### PR TITLE
fix: handle missing CES client and surface prompter timeouts in approval bridge

### DIFF
--- a/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
+++ b/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
@@ -356,6 +356,47 @@ describe("CES approval bridge", () => {
     });
   });
 
+  describe("prompter timeout", () => {
+    test("returns timeout outcome when prompter times out", async () => {
+      // The PermissionPrompter resolves timeouts as decision: "deny" with a
+      // decisionContext containing "timed out".
+      const prompter = makePrompter(
+        "deny",
+        'The permission prompt for the "ces:http" tool timed out. The user did not explicitly deny this request — they may have been away or busy. You may retry this tool call if it is still needed for the current task.',
+      );
+      const cesClient = makeCesClient();
+
+      const result = await bridgeCesApproval(
+        makeApprovalRequired(),
+        prompter,
+        cesClient,
+        { isInteractive: true },
+      );
+
+      expect(result.outcome).toBe("timeout");
+
+      // No record_grant RPC should have been made
+      expect(cesClient.recordGrantCalls.length).toBe(0);
+    });
+
+    test("explicit deny with no timeout context returns denied, not timeout", async () => {
+      const prompter = makePrompter("deny");
+      const cesClient = makeCesClient();
+
+      const result = await bridgeCesApproval(
+        makeApprovalRequired(),
+        prompter,
+        cesClient,
+        { isInteractive: true },
+      );
+
+      expect(result.outcome).toBe("denied");
+      if (result.outcome === "denied") {
+        expect(result.userDecision).toBe("deny");
+      }
+    });
+  });
+
   describe("non-interactive fail-closed", () => {
     test("auto-denies when isInteractive is false", async () => {
       const prompter = makePrompter("allow");

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -208,6 +208,27 @@ export async function bridgeCesApproval(
     ["allow_10m", "allow_thread"], // Offer temporary approval options
   );
 
+  // Detect prompter timeout: the PermissionPrompter resolves timeouts as
+  // decision: "deny" with a decisionContext containing "timed out". Surface
+  // this as a distinct outcome so the executor shows a timeout-specific
+  // message that encourages retrying rather than implying explicit denial.
+  const isTimeout =
+    response.decision === "deny" &&
+    typeof response.decisionContext === "string" &&
+    response.decisionContext.includes("timed out");
+
+  if (isTimeout) {
+    log.info(
+      {
+        event: "ces_approval_bridge_timeout",
+        proposalHash,
+        sessionId,
+      },
+      "CES approval bridge: prompter timed out",
+    );
+    return { outcome: "timeout" };
+  }
+
   const cesDecision = mapUserDecisionToCesDecision(response.decision);
 
   log.info(

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -221,6 +221,27 @@ export class ToolExecutor {
       // indicator, present the proposal to the guardian via the existing
       // confirmation transport, commit the decision to CES, and retry
       // the original tool invocation with the granted grantId.
+      if (execResult.cesApprovalRequired && !context.cesClient) {
+        const msg = `CES approval required for "${name}" but no CES client is available. Ensure the Credential Execution Service is running.`;
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent(context, {
+          type: "error",
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          sessionId: context.sessionId,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: "error",
+          durationMs,
+          errorMessage: msg,
+          isExpected: true,
+          errorCategory: "tool_failure",
+        });
+        return { content: msg, isError: true };
+      }
       if (execResult.cesApprovalRequired && context.cesClient) {
         const bridgeResult = await bridgeCesApproval(
           execResult.cesApprovalRequired,


### PR DESCRIPTION
## Summary

Addresses review feedback from [PR #16869](https://github.com/vellum-ai/vellum-assistant/pull/16869):

- **Codex P1 — missing CES client**: When a CES tool returns `cesApprovalRequired` but no `cesClient` is available on the context, the executor now returns an explicit error instead of silently ignoring the approval response. This prevents the CES approval flow from being non-functional at runtime when the CES process is unavailable.

- **Devin BUG — unreachable timeout outcome**: The `bridgeCesApproval` function now detects prompter timeouts (the `PermissionPrompter` resolves timeouts as `decision: "deny"` with a `decisionContext` containing "timed out") and returns `outcome: "timeout"` instead of `outcome: "denied"`. This makes the executor's timeout-specific message branch reachable, giving the agent retry-encouraging context rather than an explicit denial message.

## Test plan

- [x] Added tests for prompter timeout detection (returns `outcome: "timeout"`)
- [x] Added test confirming explicit deny still returns `outcome: "denied"` (not timeout)
- [x] All 18 existing CES approval bridge tests pass
- [x] Type-check passes (pre-existing error in unrelated file)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
