### PR TITLE
fix: reject expired OAuth tokens without refresh capability in CES

### DIFF
--- a/credential-executor/src/__tests__/local-materializers.test.ts
+++ b/credential-executor/src/__tests__/local-materializers.test.ts
@@ -432,6 +432,40 @@ describe("OAuth token materialisation", () => {
     expect(result.error).toMatch(/disconnected/);
   });
 
+  test("fails when token is expired and hasRefreshToken is false", async () => {
+    const conn = buildOAuthConnection({
+      id: "conn-expired-no-refresh",
+      providerKey: "integration:google",
+      // Token expired 10 minutes ago
+      expiresAt: Date.now() - 10 * 60 * 1000,
+      hasRefreshToken: false,
+    });
+    const deps = createResolverDeps({ oauthConnections: [conn] });
+    const handle = localOAuthHandle(
+      "integration:google",
+      "conn-expired-no-refresh",
+    );
+
+    const resolved = resolveLocalSubject(handle, deps);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    const backend = createMemoryBackend({
+      [oauthConnectionAccessTokenPath("conn-expired-no-refresh")]:
+        "old-expired-token",
+    });
+    const materialiser = new LocalMaterialiser({
+      secureKeyBackend: backend,
+    });
+
+    const result = await materialiser.materialise(resolved.subject);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/expired/);
+    expect(result.error).toMatch(/no refresh.*token.*available/i);
+  });
+
   test("materialises a token with null expiresAt (no expiry info)", async () => {
     const conn = buildOAuthConnection({
       id: "conn-noexpiry",

--- a/credential-executor/src/materializers/local.ts
+++ b/credential-executor/src/materializers/local.ts
@@ -181,11 +181,15 @@ export class LocalMaterialiser {
     }
 
     // 2. Check if the token is expired and needs refresh
-    if (
-      isTokenExpired(connection.expiresAt) &&
-      connection.hasRefreshToken
-    ) {
-      return this.refreshAndMaterialise(subject, connectionId);
+    if (isTokenExpired(connection.expiresAt)) {
+      if (connection.hasRefreshToken) {
+        return this.refreshAndMaterialise(subject, connectionId);
+      }
+      return {
+        ok: false,
+        error: `Token for OAuth connection "${connectionId}" is expired and no refresh ` +
+          `token is available. Re-authorization required.`,
+      };
     }
 
     // 3. Token is valid — return it


### PR DESCRIPTION
## Summary
- Fix expired OAuth tokens being returned as successful when `hasRefreshToken` is false
- The `materialiseOAuth` method now checks expiry first, then branches on refresh availability — returning a fail-closed error when refresh is not possible
- Add test covering the expired-token-without-refresh-token case

Addresses review feedback from PR #16866:
- **Codex P1**: reject expired OAuth tokens without refresh support
- **Devin BUG**: expired token returned as success when `hasRefreshToken` is false

## Test plan
- [x] New test: "fails when token is expired and hasRefreshToken is false"
- [x] All 25 existing local materializer tests pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
