### PR TITLE
fix: add shotgun command to CLI_HELP_REFERENCE snapshot

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -33,5 +33,6 @@ Commands:
   skills                                   Browse and install skills from the Vellum catalog
   browser                                  Browser automation, extension relay, and Chrome CDP management
   usage                                    Query LLM token usage and cost data
+  shotgun                                  Start and monitor screen-watch (shotgun) sessions via IPC
   sequence [options]                       Manage email sequences
 `;


### PR DESCRIPTION
## Summary
- Added the `shotgun` CLI subcommand to the `CLI_HELP_REFERENCE` constant so it matches the actual `buildCliProgram().helpInformation()` output
- Fixes the `cli-help-reference-sync.test.ts` CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102197856/job/67104833708

🤖 Generated with [Claude Code](https://claude.com/claude-code)