### PR TITLE
fix: revert ces-contracts zod imports to zod/v4

### DIFF
--- a/packages/ces-contracts/src/grants.ts
+++ b/packages/ces-contracts/src/grants.ts
@@ -9,7 +9,7 @@
  * - Audit record summaries (materialization events)
  */
 
-import { z } from "zod";
+import { z } from "zod/v4";
 
 // ---------------------------------------------------------------------------
 // Grant proposal types

--- a/packages/ces-contracts/src/handles.ts
+++ b/packages/ces-contracts/src/handles.ts
@@ -20,7 +20,7 @@
  *    is the platform-assigned connection identifier.
  */
 
-import { z } from "zod";
+import { z } from "zod/v4";
 
 // ---------------------------------------------------------------------------
 // Handle type discriminator

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -7,7 +7,7 @@
  * module so that both sides can depend on it without circular references.
  */
 
-import { z } from "zod";
+import { z } from "zod/v4";
 import { RpcErrorSchema } from "./error.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -24,7 +24,7 @@
  * - `list_audit_records` — List audit records for inspection
  */
 
-import { z } from "zod";
+import { z } from "zod/v4";
 import {
   AuditRecordSummarySchema,
   GrantProposalSchema,


### PR DESCRIPTION
## Summary
- Reverts the `import { z } from "zod"` changes from #16851 back to `import { z } from "zod/v4"` in `grants.ts`, `handles.ts`, `index.ts`, and `rpc.ts`
- The ces-contracts package uses zod v4-native APIs (`.check(z.refine(...))` in handles.ts) that are not available on the v3-compat `"zod"` entry point
- Aligns all files with `error.ts` which was already correctly using `"zod/v4"`

## Context
PR #16851 mechanically changed `"zod/v4"` to `"zod"` but missed that:
1. `error.ts` was left unchanged, creating mixed API surfaces in the same schema definitions
2. `handles.ts:206-213` uses `.check(z.refine(...))` which is a v4-only API pattern — this would cause a runtime `TypeError` with the v3-compat layer

## Test plan
- [x] `bunx tsc --noEmit` in `packages/ces-contracts/` — no new errors (pre-existing test narrowing issues remain)
- [x] `bunx tsc --noEmit` in `assistant/` — no new errors (pre-existing unrelated error remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
