### PR TITLE
fix: gate manage_secure_command_tool behind ces-secure-install flag

### DIFF
--- a/assistant/src/tools/credential-execution/make-authenticated-request.ts
+++ b/assistant/src/tools/credential-execution/make-authenticated-request.ts
@@ -173,7 +173,10 @@ class MakeAuthenticatedRequestTool implements Tool {
       }
 
       return {
-        content: parts.join("\n\n"),
+        content:
+          parts.length > 0
+            ? parts.join("\n\n")
+            : "Request completed successfully.",
         isError: false,
       };
     } catch (err) {

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -169,7 +169,10 @@ class RunAuthenticatedCommandTool implements Tool {
       }
 
       return {
-        content: parts.join("\n\n"),
+        content:
+          parts.length > 0
+            ? parts.join("\n\n")
+            : "Command completed successfully.",
         isError: response.exitCode !== undefined && response.exitCode !== 0,
       };
     } catch (err) {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -7,7 +7,10 @@
  */
 
 import { getConfig } from "../config/loader.js";
-import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
+import {
+  isCesSecureInstallEnabled,
+  isCesToolsEnabled,
+} from "../credential-execution/feature-gates.js";
 import { assetMaterializeTool } from "./assets/materialize.js";
 import { assetSearchTool } from "./assets/search.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
@@ -112,7 +115,12 @@ export function getCesToolsIfEnabled(): Tool[] {
   try {
     const config = getConfig();
     if (isCesToolsEnabled(config)) {
-      return cesTools;
+      // manage_secure_command_tool is additionally gated behind the
+      // ces-secure-install flag so it can be rolled out independently.
+      const secureInstallEnabled = isCesSecureInstallEnabled(config);
+      return cesTools.filter(
+        (t) => t.name !== "manage_secure_command_tool" || secureInstallEnabled,
+      );
     }
   } catch {
     // Config not yet loaded (e.g. during test setup) — CES tools stay off.


### PR DESCRIPTION
## Summary

Addresses valid review feedback from PR #16882:

- **Feature flag gating**: `manage_secure_command_tool` is now additionally gated behind the `ces-secure-install` feature flag via `isCesSecureInstallEnabled()` in `getCesToolsIfEnabled()`. This allows secure bundle installation to be rolled out independently from the other two CES tools (`make_authenticated_request`, `run_authenticated_command`).

- **Empty response fallback**: Both `make_authenticated_request` and `run_authenticated_command` now return a default success message ("Request completed successfully." / "Command completed successfully.") when the CES response contains no body/status/auditId, preventing empty string content that downstream consumers might misinterpret.

### Feedback triage

| Feedback | Source | Action |
|----------|--------|--------|
| P1: Read CES approval payload from error.details | Codex | Already fixed in prior commit (current code reads from `response.error.details`) |
| Tool name mismatches vs AGENTS.md | Devin | Invalid — AGENTS.md files consistently use `run_authenticated_command`, `make_authenticated_request`, `manage_secure_command_tool`. The names `ces_run_command`, `ces_authenticated_http`, `ces_browser_fill` do not appear anywhere in the codebase. |
| `manage_secure_command_tool` not approved | Devin | Invalid — explicitly listed in `assistant/src/tools/AGENTS.md:35` and `assistant/docs/credential-execution-service.md:45` |
| Feature flag gating for secure install | Devin | **Fixed** in this PR |
| Empty response fallback | Devin | **Fixed** in this PR |

## Test plan

- [x] `bun test src/__tests__/credential-execution-tools.test.ts` — all 16 tests pass
- [x] Prettier and ESLint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
