### PR TITLE
fix: stop CES process manager when handshake throws

### DIFF
--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -46,12 +46,17 @@ async function acquireCesClient(): Promise<{
   const pm = createCesProcessManager({ assistantConfig: getConfig() });
   const transport = await pm.start();
   const client = createCesClient(transport);
-  const hs = await client.handshake();
 
-  if (!hs.accepted) {
+  try {
+    const hs = await client.handshake();
+
+    if (!hs.accepted) {
+      throw new Error(`CES handshake rejected: ${hs.reason ?? "unknown"}`);
+    }
+  } catch (err) {
     client.close();
     await pm.stop();
-    throw new Error(`CES handshake rejected: ${hs.reason ?? "unknown"}`);
+    throw err;
   }
 
   return {


### PR DESCRIPTION
## Summary
- Fixes a resource leak in `acquireCesClient()` where a thrown exception from `client.handshake()` (e.g. transport timeout, connection broken) would orphan the CES child process (local mode) or leak a socket connection (managed mode).
- Wraps the handshake + acceptance check in try/catch so both thrown exceptions and rejected handshakes clean up the client and process manager before re-throwing.

Addresses review feedback from PR #16883 (Devin BUG: CES process manager leaked when handshake throws).

Note: The Codex P1 comment on #16883 ("register CES admin RPC methods before exposing CLI commands") is a **false positive** — the handlers are correctly registered in both `main.ts` and `managed-main.ts` via direct assignment to the `handlers` registry object, which is passed to `CesRpcServer`. The `rg` search in the review only looked for registration call sites in `server.ts`, missing the registration in the entrypoint files.

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes (pre-existing unrelated error in test file)
- [ ] Confirm handshake timeout/failure no longer leaks CES child process
- [ ] Confirm rejected handshake still throws with proper cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
