### PR TITLE
fix: CES executor — path containment, no_network enforcement, credential stdin, cleanup

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -1086,6 +1086,173 @@ describe("executeAuthenticatedCommand — banned binaries", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Entrypoint path containment tests
+// ---------------------------------------------------------------------------
+
+describe("executeAuthenticatedCommand — entrypoint path containment", () => {
+  test("rejects entrypoint that escapes the bundle directory via path traversal", async () => {
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      entrypoint: "../../usr/bin/git",
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "should not run"\n',
+    );
+
+    const deps = buildDeps();
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      manifest.bundleId,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test path traversal",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("resolves outside the bundle directory");
+    expect(result.error).toContain("Path traversal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no_network enforcement tests
+// ---------------------------------------------------------------------------
+
+describe("executeAuthenticatedCommand — no_network enforcement", () => {
+  test("injects blocking proxy env vars in no_network mode", async () => {
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    // Script that checks for proxy env vars
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "HTTP_PROXY=$HTTP_PROXY"\necho "HTTPS_PROXY=$HTTPS_PROXY"\n',
+    );
+
+    const deps = buildDeps();
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      manifest.bundleId,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test no_network proxy injection",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    expect(result.exitCode).toBe(0);
+    // The proxy vars should point at a dead address to block outbound connections
+    expect(result.stdout).toContain("HTTP_PROXY=http://127.0.0.1:0");
+    expect(result.stdout).toContain("HTTPS_PROXY=http://127.0.0.1:0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// credential_process stdin tests
+// ---------------------------------------------------------------------------
+
+describe("executeAuthenticatedCommand — credential_process stdin", () => {
+  test("credential_process helper receives credential value on stdin", async () => {
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      authAdapter: {
+        type: AuthAdapterType.CredentialProcess,
+        helperCommand: "cat",  // cat echoes stdin to stdout
+        envVarName: "TRANSFORMED_CRED",
+      },
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "$TRANSFORMED_CRED"\n',
+    );
+
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("my-raw-credential"),
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      manifest.bundleId,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test credential_process stdin",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    // cat should have echoed the credential value via stdin, which then
+    // gets injected into TRANSFORMED_CRED for the command to use
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout?.trim()).toBe("my-raw-credential");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // RPC handler command string parsing tests
 // ---------------------------------------------------------------------------
 

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -39,7 +39,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { mkdirSync, writeFileSync, unlinkSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
@@ -328,17 +328,41 @@ export async function executeAuthenticatedCommand(
     }
   }
 
+  // For no_network mode, block all outbound by pointing proxy vars at a
+  // non-existent address. This prevents subprocesses from making direct
+  // connections even without a running egress proxy.
+  let noNetworkEnv: Record<string, string> | undefined;
+  if (manifest.egressMode === EgressMode.NoNetwork) {
+    const blockedProxy = "http://127.0.0.1:0";
+    noNetworkEnv = {
+      HTTP_PROXY: blockedProxy,
+      HTTPS_PROXY: blockedProxy,
+      http_proxy: blockedProxy,
+      https_proxy: blockedProxy,
+      NO_PROXY: "",
+      no_proxy: "",
+    };
+  }
+
   // -- 8. Build the execution environment -----------------------------------
-  const entrypointPath = join(
-    getBundleContentPath(toolstoreDir, request.bundleDigest),
-    "..",
-    manifest.entrypoint,
-  );
+  const bundleDir = dirname(getBundleContentPath(toolstoreDir, request.bundleDigest));
+  const entrypointPath = resolve(bundleDir, manifest.entrypoint);
+
+  // Containment check: entrypoint must resolve inside the bundle directory
+  if (!entrypointPath.startsWith(bundleDir + "/") && entrypointPath !== bundleDir) {
+    cleanupAll(scratchDir, tempFilePath);
+    return {
+      success: false,
+      error: `Entrypoint "${manifest.entrypoint}" resolves outside the bundle directory. ` +
+        `Path traversal is not allowed.`,
+      auditId,
+    };
+  }
 
   const commandEnv = buildCommandEnv(
     adapterEnv,
     proxyEnv,
-    manifest.cleanConfigDirs,
+    noNetworkEnv,
   );
 
   // -- 9. Execute the command -----------------------------------------------
@@ -400,7 +424,7 @@ export async function executeAuthenticatedCommand(
     }
   }
 
-  cleanupAll(scratchDir, tempFilePath);
+  cleanupAll(scratchDir, tempFilePath, commandEnv["HOME"]);
 
   return execResult;
 }
@@ -677,7 +701,7 @@ async function buildAuthAdapterEnv(
  */
 async function runCredentialProcess(
   helperCommand: string,
-  _credentialValue: string,
+  credentialValue: string,
   timeoutMs: number,
 ): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
   try {
@@ -688,12 +712,20 @@ async function runCredentialProcess(
       env: {}, // Clean environment — no secrets leaked
     });
 
-    // Close stdin immediately — the helper reads only from its argv/config
+    // Write the credential value to stdin for the helper to consume
+    proc.stdin.write(credentialValue);
     proc.stdin.end();
 
     const timeoutSignal = AbortSignal.timeout(timeoutMs);
-    const exitCode = await Promise.race([
-      proc.exited,
+
+    // Consume stdout/stderr concurrently with waiting for exit to avoid
+    // pipe buffer deadlocks when the helper produces large output.
+    const [exitCode, stdout, stderr] = await Promise.race([
+      Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]),
       new Promise<never>((_, reject) => {
         timeoutSignal.addEventListener("abort", () => {
           proc.kill();
@@ -701,9 +733,6 @@ async function runCredentialProcess(
         });
       }),
     ]);
-
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
 
     if (exitCode !== 0) {
       return {
@@ -740,7 +769,7 @@ async function runCredentialProcess(
 function buildCommandEnv(
   adapterEnv: Record<string, string>,
   proxyEnv?: ProxyEnvVars,
-  _cleanConfigDirs?: Record<string, string>,
+  noNetworkEnv?: Record<string, string>,
 ): Record<string, string> {
   const env: Record<string, string> = {
     // Minimal baseline environment
@@ -765,6 +794,12 @@ function buildCommandEnv(
     if (proxyEnv.SSL_CERT_FILE) {
       env["SSL_CERT_FILE"] = proxyEnv.SSL_CERT_FILE;
     }
+  }
+
+  // For no_network mode, inject proxy vars pointing at a dead address to
+  // block direct outbound connections from the subprocess.
+  if (noNetworkEnv) {
+    Object.assign(env, noNetworkEnv);
   }
 
   return env;
@@ -795,11 +830,14 @@ async function runCommand(
     stderr: "pipe",
   });
 
-  const exitCode = await proc.exited;
-
-  // Capture stdout and stderr with size limits
-  const stdoutRaw = await new Response(proc.stdout).text();
-  const stderrRaw = await new Response(proc.stderr).text();
+  // Consume stdout/stderr concurrently with waiting for exit to avoid
+  // pipe buffer deadlocks when the command produces output exceeding the
+  // OS pipe buffer size (~64KB).
+  const [exitCode, stdoutRaw, stderrRaw] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
 
   const stdout = stdoutRaw.length > maxOutputBytes
     ? stdoutRaw.slice(0, maxOutputBytes) + "\n[output truncated]"
@@ -823,13 +861,22 @@ async function runCommand(
 // Internal: Cleanup helpers
 // ---------------------------------------------------------------------------
 
-function cleanupAll(scratchDir: string, tempFilePath?: string): void {
+function cleanupAll(scratchDir: string, tempFilePath?: string, homeDir?: string): void {
   // Clean up temp auth file
   if (tempFilePath) {
     try {
       unlinkSync(tempFilePath);
       // Also remove the parent temp directory
       rmSync(dirname(tempFilePath), { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  // Clean up per-execution HOME temp directory
+  if (homeDir) {
+    try {
+      rmSync(homeDir, { recursive: true, force: true });
     } catch {
       // Best-effort cleanup
     }


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #16876 (Codex and Devin automated reviews):

- **P1: Restrict entrypoint path to bundle directory** — `resolve()` + `startsWith` containment check prevents `../../`-style path traversal in manifest entrypoints that could escape the bundle integrity boundary and run host binaries
- **P1: Enforce `no_network` egress mode** — Injects proxy env vars pointing at `127.0.0.1:0` to block direct outbound connections when manifest declares `no_network`, preventing credential-bearing commands from exfiltrating data
- **BUG: Write credential to stdin in `runCredentialProcess`** — The `credentialValue` parameter was unused (prefixed with `_`) and stdin was closed immediately without writing. `credential_process` helpers that rely on stdin input would receive EOF and fail
- **Cleanup: HOME temp directory leak** — `cleanupAll` now removes the per-execution `ces-home-*` temp directory that was created by `buildCommandEnv` but never cleaned up
- **Deadlock: Concurrent stdout/stderr consumption** — Both `runCommand` and `runCredentialProcess` now use `Promise.all` to consume stdout/stderr concurrently with `proc.exited`, preventing pipe buffer deadlocks when output exceeds ~64KB

## Test plan
- [x] New test: entrypoint path traversal (`../../usr/bin/git`) is rejected
- [x] New test: `no_network` mode injects blocking proxy env vars
- [x] New test: `credential_process` helper receives credential value on stdin (uses `cat` to echo)
- [x] All 29 existing + new tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
