### PR TITLE
fix: make CesProcessManagerConfig.assistantConfig optional

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
@@ -197,7 +197,7 @@ describe("process manager config wiring", () => {
       }),
     };
     // The managed path should be gated
-    expect(isCesManagedSidecarEnabled(config.assistantConfig)).toBe(false);
+    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(false);
   });
 });
 

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -71,9 +71,10 @@ export interface CesProcessManagerConfig {
   /**
    * Assistant configuration for feature-flag checks.
    * The managed sidecar path is gated behind the `ces-managed-sidecar`
-   * feature flag via this config.
+   * feature flag via this config.  When omitted (e.g. CLI / admin
+   * callers), managed mode is allowed unconditionally.
    */
-  assistantConfig: AssistantConfig;
+  assistantConfig?: AssistantConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,7 +126,9 @@ export function createCesProcessManager(
       // managed discovery entirely. This ensures rollback safety —
       // disabling the flag leaves existing non-agent platform consumers
       // intact.
-      const managedAllowed = isCesManagedSidecarEnabled(config.assistantConfig);
+      const managedAllowed = config.assistantConfig
+        ? isCesManagedSidecarEnabled(config.assistantConfig)
+        : true; // No config → allow managed mode unconditionally (CLI/admin callers)
 
       if (managedAllowed) {
         discoveryResult = await discoverCes();


### PR DESCRIPTION
## Summary
- Make `assistantConfig` optional in `CesProcessManagerConfig` interface to match the backward-compat test's intent
- Handle `undefined` in the process manager by defaulting to allowing managed mode (for CLI/admin callers)
- Add non-null assertion in test where `assistantConfig` is definitely assigned

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102197856/job/67104833713

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
