### PR TITLE
fix: cancel CES startup on session dispose to prevent leaked processes

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -179,6 +179,8 @@ export class Session {
   /** @internal */ hostFileProxy?: HostFileProxy;
   /** @internal */ cesProcessManager?: CesProcessManager;
   /** @internal */ cesClient?: CesClient;
+  /** @internal */ cesInitAborted = false;
+  /** @internal */ cesInitPromise?: Promise<void>;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
@@ -334,11 +336,20 @@ export class Session {
     if (isCesToolsEnabled(config)) {
       const pm = createCesProcessManager({ assistantConfig: config });
       this.cesProcessManager = pm;
-      void (async () => {
+      this.cesInitPromise = (async () => {
         try {
           const transport = await pm.start();
+          if (this.cesInitAborted) {
+            await pm.stop();
+            return;
+          }
           const client = createCesClient(transport);
           const { accepted, reason } = await client.handshake();
+          if (this.cesInitAborted) {
+            client.close();
+            await pm.stop();
+            return;
+          }
           if (accepted) {
             this.cesClient = client;
             log.info("CES client initialized and handshake accepted");
@@ -361,6 +372,8 @@ export class Session {
               "Failed to initialize CES client — CES tools will be unavailable",
             );
           }
+          // Clean up the process manager on any init failure
+          await pm.stop().catch(() => {});
         }
       })();
     }
@@ -498,14 +511,29 @@ export class Session {
     this.hostBashProxy?.dispose();
     this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
-    // Gracefully shut down the CES client and process manager
-    if (this.cesClient) {
-      this.cesClient.close();
-      this.cesClient = undefined;
-    }
-    if (this.cesProcessManager) {
-      void this.cesProcessManager.stop();
-      this.cesProcessManager = undefined;
+    // Signal the async CES init to abort, then wait for it to finish so we
+    // don't leak a child process that completes startup after dispose().
+    this.cesInitAborted = true;
+    if (this.cesInitPromise) {
+      void this.cesInitPromise.then(() => {
+        if (this.cesClient) {
+          this.cesClient.close();
+          this.cesClient = undefined;
+        }
+        if (this.cesProcessManager) {
+          void this.cesProcessManager.stop();
+          this.cesProcessManager = undefined;
+        }
+      });
+    } else {
+      if (this.cesClient) {
+        this.cesClient.close();
+        this.cesClient = undefined;
+      }
+      if (this.cesProcessManager) {
+        void this.cesProcessManager.stop();
+        this.cesProcessManager = undefined;
+      }
     }
     disposeSession(this);
   }


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #16902 (Codex P1 + Devin BUG):

- **Race between async CES init and dispose()**: When `dispose()` runs while the fire-and-forget CES startup IIFE is in-flight, `pm.stop()` no-ops because `running` is still `false`. The IIFE then completes, spawns the child process, and sets `cesClient` on a disposed session — leaking the process permanently. Fixed by adding a `cesInitAborted` flag checked after each `await` in the init IIFE, and storing the init promise so `dispose()` chains cleanup after it resolves.
- **Handshake failure leaks process manager**: If `client.handshake()` throws, the catch block only logged but never called `pm.stop()`. Added cleanup in the catch block.

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Quick session create/dispose cycle doesn't leak CES processes
- [ ] CES handshake failure path properly stops the process manager

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
