### PR TITLE
fix: build valid SecureCommandManifest before publishing

### DIFF
--- a/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
+++ b/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
@@ -15,6 +15,8 @@
  * verification, and installation inside the CES sandbox.
  */
 
+import type { ManageSecureCommandTool } from "@vellumai/ces-contracts/rpc";
+
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -69,12 +71,6 @@ class ManageSecureCommandToolImpl implements Tool {
             description:
               "SHA-256 hash of the bundle for integrity verification (required for register).",
           },
-          profiles: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              'Declared credential profiles the bundle requires (e.g. ["aws", "github"]). Shown to the guardian during approval.',
-          },
           credentialHandle: {
             type: "string",
             description:
@@ -84,6 +80,126 @@ class ManageSecureCommandToolImpl implements Tool {
             type: "string",
             description:
               "Human-readable description of what the secure command tool does (required for register).",
+          },
+          secureCommandManifest: {
+            type: "object",
+            description:
+              "Full secure command manifest for the bundle (required for register). " +
+              "Contains entrypoint, command profiles, auth adapter, egress mode, etc. " +
+              "CES validates this manifest before publishing the bundle.",
+            properties: {
+              schemaVersion: {
+                type: "string",
+                description: 'Manifest schema version. Must be "1".',
+              },
+              bundleDigest: {
+                type: "string",
+                description: "SHA-256 hex digest of the command bundle.",
+              },
+              bundleId: {
+                type: "string",
+                description: "Unique identifier for the command bundle.",
+              },
+              version: {
+                type: "string",
+                description: "Semantic version of the bundle.",
+              },
+              entrypoint: {
+                type: "string",
+                description:
+                  'Path to the executable entrypoint within the bundle (e.g. "bin/gh").',
+              },
+              commandProfiles: {
+                type: "object",
+                description:
+                  "Named command profiles. Each profile defines a narrow execution boundary.",
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    description: { type: "string" },
+                    allowedArgvPatterns: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          name: { type: "string" },
+                          tokens: {
+                            type: "array",
+                            items: { type: "string" },
+                          },
+                        },
+                        required: ["name", "tokens"],
+                      },
+                    },
+                    deniedSubcommands: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    deniedFlags: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    allowedNetworkTargets: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          hostPattern: { type: "string" },
+                          ports: {
+                            type: "array",
+                            items: { type: "number" },
+                          },
+                          protocols: {
+                            type: "array",
+                            items: { type: "string" },
+                          },
+                        },
+                        required: ["hostPattern"],
+                      },
+                    },
+                  },
+                  required: [
+                    "description",
+                    "allowedArgvPatterns",
+                    "deniedSubcommands",
+                  ],
+                },
+              },
+              authAdapter: {
+                type: "object",
+                description:
+                  "Auth adapter configuration describing how credentials are injected.",
+                properties: {
+                  type: {
+                    type: "string",
+                    enum: ["env_var", "temp_file", "credential_process"],
+                  },
+                  envVarName: { type: "string" },
+                },
+                required: ["type", "envVarName"],
+              },
+              egressMode: {
+                type: "string",
+                enum: ["proxy_required", "no_network"],
+                description: "Network egress enforcement mode.",
+              },
+              cleanConfigDirs: {
+                type: "object",
+                description:
+                  "Config directories to mount as empty tmpfs during execution.",
+                additionalProperties: { type: "string" },
+              },
+            },
+            required: [
+              "schemaVersion",
+              "bundleDigest",
+              "bundleId",
+              "version",
+              "entrypoint",
+              "commandProfiles",
+              "authAdapter",
+              "egressMode",
+            ],
           },
         },
         required: ["action", "toolName"],
@@ -122,6 +238,10 @@ class ManageSecureCommandToolImpl implements Tool {
       const sourceUrl = input.sourceUrl as string | undefined;
       const sha256 = input.sha256 as string | undefined;
       const credentialHandle = input.credentialHandle as string | undefined;
+      const description = input.description as string | undefined;
+      const secureCommandManifest = input.secureCommandManifest as
+        | Record<string, unknown>
+        | undefined;
 
       const missing: string[] = [];
       if (!bundleId) missing.push("bundleId");
@@ -129,6 +249,8 @@ class ManageSecureCommandToolImpl implements Tool {
       if (!sourceUrl) missing.push("sourceUrl");
       if (!sha256) missing.push("sha256");
       if (!credentialHandle) missing.push("credentialHandle");
+      if (!description) missing.push("description");
+      if (!secureCommandManifest) missing.push("secureCommandManifest");
 
       if (missing.length > 0) {
         return {
@@ -165,9 +287,8 @@ class ManageSecureCommandToolImpl implements Tool {
               version: input.version as string,
               sourceUrl: input.sourceUrl as string,
               sha256: input.sha256 as string,
-              ...(input.profiles
-                ? { profiles: input.profiles as string[] }
-                : {}),
+              secureCommandManifest:
+                input.secureCommandManifest as ManageSecureCommandTool["secureCommandManifest"],
             }
           : {}),
       });

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -568,12 +568,26 @@ export function createManageSecureCommandToolHandler(
     if (!request.sourceUrl) missing.push("sourceUrl");
     if (!request.sha256) missing.push("sha256");
     if (!request.credentialHandle) missing.push("credentialHandle");
+    if (!request.description) missing.push("description");
+    if (!request.secureCommandManifest) missing.push("secureCommandManifest");
     if (missing.length > 0) {
       return {
         success: false,
         error: {
           code: "MISSING_FIELDS",
           message: `Register action requires: ${missing.join(", ")}`,
+        },
+      };
+    }
+
+    // Validate HTTPS before downloading — CES is the security boundary
+    // and must not rely on the caller for URL scheme validation.
+    if (!request.sourceUrl!.startsWith("https://")) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_SOURCE_URL",
+          message: "sourceUrl must use HTTPS for secure bundle downloads.",
         },
       };
     }
@@ -592,6 +606,11 @@ export function createManageSecureCommandToolHandler(
       };
     }
 
+    // The caller provides the full secure command manifest via the RPC
+    // payload. Cast to the internal type — publishBundle() validates it.
+    const secureCommandManifest =
+      request.secureCommandManifest as unknown as import("./commands/profiles.js").SecureCommandManifest;
+
     // Publish into the immutable toolstore (includes digest verification)
     const publishResult = deps.publishBundle({
       bundleBytes,
@@ -599,13 +618,7 @@ export function createManageSecureCommandToolHandler(
       bundleId: request.bundleId!,
       version: request.version!,
       sourceUrl: request.sourceUrl!,
-      // The secure command manifest is embedded in the bundle; for now
-      // pass a minimal manifest with declared profiles.
-      secureCommandManifest: {
-        commandProfiles: Object.fromEntries(
-          (request.profiles ?? []).map((p) => [p, { command: request.toolName }]),
-        ),
-      } as unknown as import("./commands/profiles.js").SecureCommandManifest,
+      secureCommandManifest,
     });
 
     if (!publishResult.success) {
@@ -622,7 +635,7 @@ export function createManageSecureCommandToolHandler(
     deps.registerTool({
       toolName: request.toolName,
       credentialHandle: request.credentialHandle!,
-      description: request.description ?? "",
+      description: request.description!,
       bundleDigest: request.sha256!,
     });
 

--- a/packages/ces-contracts/src/__tests__/grants.test.ts
+++ b/packages/ces-contracts/src/__tests__/grants.test.ts
@@ -539,14 +539,30 @@ describe("RPC schemas", () => {
       version: "2.15.0",
       sourceUrl: "https://bundles.example.com/aws-cli-2.15.0.vbundle",
       sha256: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-      profiles: ["aws"],
+      secureCommandManifest: {
+        schemaVersion: "1",
+        bundleDigest: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        bundleId: "aws-cli",
+        version: "2.15.0",
+        entrypoint: "bin/aws",
+        commandProfiles: {
+          aws: {
+            description: "AWS CLI access",
+            allowedArgvPatterns: [{ name: "any", tokens: ["<cmd...>"] }],
+            deniedSubcommands: [],
+          },
+        },
+        authAdapter: { type: "env_var" as const, envVarName: "AWS_ACCESS_KEY_ID" },
+        egressMode: "proxy_required" as const,
+      },
     });
     expect(result.action).toBe("register");
     expect(result.bundleId).toBe("aws-cli");
     expect(result.version).toBe("2.15.0");
     expect(result.sourceUrl).toBe("https://bundles.example.com/aws-cli-2.15.0.vbundle");
     expect(result.sha256).toBe("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
-    expect(result.profiles).toEqual(["aws"]);
+    expect(result.secureCommandManifest).toBeDefined();
+    expect(result.secureCommandManifest!.entrypoint).toBe("bin/aws");
   });
 
   test("ManageSecureCommandToolSchema parses unregister action", () => {

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -145,6 +145,74 @@ export const ManageSecureCommandToolAction = {
 export type ManageSecureCommandToolAction =
   (typeof ManageSecureCommandToolAction)[keyof typeof ManageSecureCommandToolAction];
 
+/**
+ * Zod schema for allowed argv patterns within a command profile.
+ */
+const AllowedArgvPatternSchema = z.object({
+  name: z.string(),
+  tokens: z.array(z.string()),
+});
+
+/**
+ * Zod schema for allowed network targets within a command profile.
+ */
+const AllowedNetworkTargetSchema = z.object({
+  hostPattern: z.string(),
+  ports: z.array(z.number()).optional(),
+  protocols: z.array(z.enum(["http", "https"])).optional(),
+});
+
+/**
+ * Zod schema for a single command profile within a secure command manifest.
+ */
+const CommandProfileSchema = z.object({
+  description: z.string(),
+  allowedArgvPatterns: z.array(AllowedArgvPatternSchema),
+  deniedSubcommands: z.array(z.string()),
+  deniedFlags: z.array(z.string()).optional(),
+  allowedNetworkTargets: z.array(AllowedNetworkTargetSchema).optional(),
+});
+
+/**
+ * Zod schema for auth adapter configuration (discriminated union on `type`).
+ */
+const AuthAdapterConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("env_var"),
+    envVarName: z.string(),
+    valuePrefix: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("temp_file"),
+    envVarName: z.string(),
+    fileExtension: z.string().optional(),
+    fileMode: z.number().optional(),
+  }),
+  z.object({
+    type: z.literal("credential_process"),
+    envVarName: z.string(),
+    helperCommand: z.string(),
+    timeoutMs: z.number().optional(),
+  }),
+]);
+
+/**
+ * Zod schema for the full secure command manifest passed during register.
+ * This mirrors the {@link SecureCommandManifest} interface in
+ * `credential-executor/src/commands/profiles.ts`.
+ */
+export const SecureCommandManifestSchema = z.object({
+  schemaVersion: z.string(),
+  bundleDigest: z.string(),
+  bundleId: z.string(),
+  version: z.string(),
+  entrypoint: z.string(),
+  commandProfiles: z.record(z.string(), CommandProfileSchema),
+  authAdapter: AuthAdapterConfigSchema,
+  egressMode: z.enum(["proxy_required", "no_network"]),
+  cleanConfigDirs: z.record(z.string(), z.string()).optional(),
+});
+
 export const ManageSecureCommandToolSchema = z.object({
   /** Whether to register or unregister the tool. */
   action: z.enum(["register", "unregister"]),
@@ -162,8 +230,12 @@ export const ManageSecureCommandToolSchema = z.object({
   sourceUrl: z.string().optional(),
   /** SHA-256 hex digest of the bundle for integrity verification (required for register). */
   sha256: z.string().optional(),
-  /** Declared credential profiles the bundle requires (e.g. ["aws", "github"]). */
-  profiles: z.array(z.string()).optional(),
+  /**
+   * Full secure command manifest for the bundle (required for register).
+   * Contains entrypoint, command profiles, auth adapter, egress mode, etc.
+   * CES validates this manifest before publishing the bundle.
+   */
+  secureCommandManifest: SecureCommandManifestSchema.optional(),
 });
 export type ManageSecureCommandTool = z.infer<
   typeof ManageSecureCommandToolSchema


### PR DESCRIPTION
## Summary
- The `manage_secure_command_tool` RPC handler was constructing a placeholder `SecureCommandManifest` with only `commandProfiles` containing `{ command: toolName }` — missing `schemaVersion`, `bundleDigest`, `entrypoint`, `authAdapter`, `egressMode`, and properly shaped `CommandProfile` entries. The `as unknown as` cast hid this at compile time, but `publishBundle()` -> `validateManifest()` rejected it at runtime, causing every register action to fail with `PUBLISH_FAILED`.
- Adds a `secureCommandManifest` field to the RPC schema (with full Zod validation) so the caller provides the complete manifest, which CES passes through to `publishBundle()` for validation.
- Adds HTTPS validation on `sourceUrl` in the CES handler before download (defense in depth — CES is the security boundary and should not rely on the caller).
- Enforces `description` as required for register actions (was documented as required but not validated).
- Removes the unused `profiles` field (superseded by `secureCommandManifest.commandProfiles`).

Addresses feedback on #16901 (Codex P1 + Devin BUG).

## Test plan
- [x] `packages/ces-contracts` type-checks cleanly
- [x] `credential-executor` type-checks cleanly
- [x] `assistant` type-checks cleanly (pre-existing unrelated error only)
- [x] `bun test src/__tests__/grants.test.ts` — all 53 tests pass
- [x] `bun test src/__tests__/toolstore.test.ts` — all 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
