### PR TITLE
fix: only persist grants for always_allow decisions, use temp grants for allow/allow_10m/allow_thread

### DIFF
--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -46,6 +46,13 @@ export interface CesApprovalDecision {
   grantDecision: "approved" | "denied";
   /** ISO-8601 duration for temporary grants. Undefined for single-use or persistent. */
   ttl: string | undefined;
+  /** The type of grant to create (controls persistence behaviour in CES). */
+  grantType:
+    | "allow_once"
+    | "allow_10m"
+    | "allow_thread"
+    | "always_allow"
+    | undefined;
   /** The original user decision from the confirmation transport. */
   userDecision: UserDecision;
 }
@@ -58,12 +65,14 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "approved",
         ttl: undefined,
+        grantType: "allow_once",
         userDecision: decision,
       };
     case "allow_10m":
       return {
         grantDecision: "approved",
         ttl: "PT10M",
+        grantType: "allow_10m",
         userDecision: decision,
       };
     case "allow_thread":
@@ -73,6 +82,7 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "approved",
         ttl: undefined,
+        grantType: "allow_thread",
         userDecision: decision,
       };
     case "always_allow":
@@ -81,6 +91,7 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "approved",
         ttl: undefined,
+        grantType: "always_allow",
         userDecision: decision,
       };
     case "deny":
@@ -88,12 +99,14 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "denied",
         ttl: undefined,
+        grantType: undefined,
         userDecision: decision,
       };
     case "temporary_override":
       return {
         grantDecision: "approved",
         ttl: undefined,
+        grantType: "allow_once",
         userDecision: decision,
       };
     default: {
@@ -102,6 +115,7 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "denied",
         ttl: undefined,
+        grantType: undefined,
         userDecision: decision,
       };
     }
@@ -260,6 +274,7 @@ export async function bridgeCesApproval(
           decidedAt: new Date().toISOString(),
           reason: response.decisionContext,
           ttl: cesDecision.ttl,
+          grantType: cesDecision.grantType,
         },
         sessionId,
       },

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -94,30 +94,44 @@ export function createRecordGrantHandler(
       return { success: true };
     }
 
-    // Build a PersistentGrant from the decision.
     const proposal = decision.proposal;
     const now = Date.now();
     const grantId = decision.proposalHash;
 
-    const persistentGrant: PersistentGrant = {
-      id: grantId,
-      tool: proposal.type,
-      pattern:
-        proposal.type === "http"
-          ? `${proposal.method} ${proposal.url}`
-          : proposal.command,
-      scope: proposal.credentialHandle,
-      createdAt: now,
-    };
+    // Determine the grant type. When omitted (backwards compat), default
+    // to `always_allow` so existing callers that don't send `grantType`
+    // continue to create persistent grants.
+    const grantType = decision.grantType ?? "always_allow";
 
-    // Persist the grant.
-    deps.persistentGrantStore.add(persistentGrant);
+    // Only `always_allow` creates a persistent grant. All other approved
+    // decisions create only a temporary grant — this prevents allow_once,
+    // allow_10m, and allow_thread from becoming effectively permanent.
+    if (grantType === "always_allow") {
+      const persistentGrant: PersistentGrant = {
+        id: grantId,
+        tool: proposal.type,
+        pattern:
+          proposal.type === "http"
+            ? `${proposal.method} ${proposal.url}`
+            : proposal.command,
+        scope: proposal.credentialHandle,
+        createdAt: now,
+      };
+      deps.persistentGrantStore.add(persistentGrant);
+    }
 
-    // Also record a temporary grant so the caller can use it immediately.
-    // Map TTL to the appropriate temporary grant kind.
-    if (decision.ttl === "PT10M") {
+    // Record a temporary grant so the caller can use it immediately.
+    // For `always_allow`, an `allow_once` temp grant bridges the gap until
+    // the next policy check hits the persistent store.
+    if (grantType === "allow_10m") {
       deps.temporaryGrantStore.add("allow_10m", decision.proposalHash);
+    } else if (grantType === "allow_thread") {
+      deps.temporaryGrantStore.add("allow_thread", decision.proposalHash, {
+        conversationId: sessionId,
+      });
     } else {
+      // allow_once and always_allow both get a single-use temp grant
+      // for immediate retry.
       deps.temporaryGrantStore.add("allow_once", decision.proposalHash);
     }
 

--- a/packages/ces-contracts/src/grants.ts
+++ b/packages/ces-contracts/src/grants.ts
@@ -87,6 +87,16 @@ export const TemporaryGrantDecisionSchema = z.object({
   reason: z.string().optional(),
   /** How long the grant should remain valid (ISO-8601 duration, e.g. "PT1H"). */
   ttl: z.string().optional(),
+  /**
+   * The type of grant to create. Determines persistence behaviour:
+   * - `allow_once`: Temporary single-use grant (consumed after one use)
+   * - `allow_10m`: Temporary timed grant (10-minute TTL)
+   * - `allow_thread`: Temporary thread-scoped grant (lives for session)
+   * - `always_allow`: Persistent grant (survives restart)
+   *
+   * When omitted, defaults to `always_allow` for backwards compatibility.
+   */
+  grantType: z.enum(["allow_once", "allow_10m", "allow_thread", "always_allow"]).optional(),
 });
 export type TemporaryGrantDecision = z.infer<
   typeof TemporaryGrantDecisionSchema


### PR DESCRIPTION
## Summary
Only always_allow creates a persistent grant. allow_once, allow_10m, and allow_thread now correctly create only temporary grants, fixing the bug where all approval types became permanent.

- Added `grantType` field to `TemporaryGrantDecisionSchema` to convey grant durability from approval bridge to CES handler
- Updated `approval-bridge.ts` to map each user decision to the correct `grantType`
- Updated `createRecordGrantHandler` to only call `persistentGrantStore.add()` for `always_allow`; all other types get only the appropriate temporary grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
