### PR TITLE
fix: persist audit records in HTTP and command executors

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -68,6 +68,9 @@ import {
   type WorkspaceOutput,
   type CopybackResult,
 } from "./workspace.js";
+import type { AuditRecordSummary } from "@vellumai/ces-contracts";
+
+import type { AuditStore } from "../audit/store.js";
 import type { PersistentGrantStore } from "../grants/persistent-store.js";
 import type { TemporaryGrantStore } from "../grants/temporary-store.js";
 
@@ -148,6 +151,8 @@ export interface CommandExecutorDeps {
   temporaryStore: TemporaryGrantStore;
   /** Credential materializer function. */
   materializeCredential: MaterializeCredentialFn;
+  /** Audit store for persisting token-free audit records. */
+  auditStore?: AuditStore;
   /** CES operating mode (for toolstore path resolution). */
   cesMode?: CesMode;
   /** Egress proxy session start hooks (for creating the proxy server). */
@@ -425,6 +430,22 @@ export async function executeAuthenticatedCommand(
   }
 
   cleanupAll(scratchDir, tempFilePath, commandEnv["HOME"]);
+
+  // -- 12. Persist audit record -----------------------------------------------
+  if (deps.auditStore) {
+    const auditRecord: AuditRecordSummary = {
+      auditId,
+      grantId: grantResult.grantId ?? "unknown",
+      credentialHandle: request.credentialHandle,
+      toolName: "command",
+      target: `${request.bundleDigest}/${request.profileName} ${request.argv.join(" ")}`.trim(),
+      sessionId: request.sessionId ?? "unknown",
+      success: execResult.success,
+      ...(execResult.error ? { errorMessage: execResult.error } : {}),
+      timestamp: new Date().toISOString(),
+    };
+    try { deps.auditStore.append(auditRecord); } catch { /* audit persistence must not block execution */ }
+  }
 
   return execResult;
 }

--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -33,6 +33,7 @@ import { evaluateHttpPolicy, type PolicyResult } from "./policy.js";
 import { filterHttpResponse, type RawHttpResponse } from "./response-filter.js";
 import { generateHttpAuditSummary } from "./audit.js";
 
+import type { AuditStore } from "../audit/store.js";
 import type { PersistentGrantStore } from "../grants/persistent-store.js";
 import type { TemporaryGrantStore } from "../grants/temporary-store.js";
 
@@ -75,6 +76,8 @@ export interface HttpExecutorDeps {
   managedSubjectOptions?: ManagedSubjectResolverOptions;
   /** Options for managed token materialisation (null if managed mode is unavailable). */
   managedMaterializerOptions?: ManagedMaterializerOptions;
+  /** Audit store for persisting token-free audit records. */
+  auditStore: AuditStore;
   /** Session ID for audit records. */
   sessionId: string;
   /** Optional custom fetch implementation (for testing). */
@@ -185,6 +188,8 @@ export async function executeAuthenticatedHttpRequest(
       errorMessage: materialiseResult.error,
     });
 
+    try { deps.auditStore.append(audit); } catch { /* audit persistence must not block execution */ }
+
     return {
       success: false,
       error: {
@@ -230,6 +235,8 @@ export async function executeAuthenticatedHttpRequest(
       errorMessage: safeError,
     });
 
+    try { deps.auditStore.append(audit); } catch { /* audit persistence must not block execution */ }
+
     return {
       success: false,
       error: {
@@ -243,7 +250,7 @@ export async function executeAuthenticatedHttpRequest(
   // 6. Filter the response through the sanitisation pipeline
   const filtered = filterHttpResponse(rawResponse, secrets);
 
-  // 7. Generate audit summary
+  // 7. Generate and persist audit summary
   const audit = generateHttpAuditSummary({
     credentialHandle: request.credentialHandle,
     grantId,
@@ -253,6 +260,8 @@ export async function executeAuthenticatedHttpRequest(
     success: true,
     statusCode: rawResponse.statusCode,
   });
+
+  try { deps.auditStore.append(audit); } catch { /* audit persistence must not block execution */ }
 
   logger.log(
     `[ces-http] ${request.method} ${request.url} -> ${rawResponse.statusCode} (grant=${grantId})`,

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -149,6 +149,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         metadataStore,
         oauthConnections,
       },
+      auditStore,
       sessionId,
     },
   );
@@ -164,6 +165,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
           "CES local credential materialisation not yet available. " +
           "A CES-native secure-key backend must be configured.",
       }),
+      auditStore,
       cesMode: "local",
     },
     defaultWorkspaceDir: join(vellumRoot, "workspace"),

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -147,6 +147,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       },
       managedSubjectOptions,
       managedMaterializerOptions,
+      auditStore,
       sessionId,
     },
   );
@@ -161,6 +162,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         error:
           "Command credential materialisation in managed mode is not yet available.",
       }),
+      auditStore,
       cesMode: "managed",
     },
     defaultWorkspaceDir: "/workspace",


### PR DESCRIPTION
## Summary
Wire AuditStore into both HTTP and command executors so audit records are actually persisted. Previously, audit summaries were generated but discarded, leaving the audit inspection CLI surfaces empty.

- Add `auditStore` to `HttpExecutorDeps` and call `auditStore.append()` after every `generateHttpAuditSummary()` call (materialisation failure, HTTP request failure, and success paths)
- Add `auditStore` to `CommandExecutorDeps` and persist a `command`-type audit record after execution completes
- Pass `auditStore` through `main.ts` and `managed-main.ts` to both handler factories

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
