### PR TITLE
fix: correct CES local credential metadata path

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -100,8 +100,10 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
   const vellumRoot = getVellumRootDir();
   const credentialMetadataPath = join(
     vellumRoot,
+    "workspace",
     "data",
-    "credential-metadata.json",
+    "credentials",
+    "metadata.json",
   );
   const metadataStore = new StaticCredentialMetadataStore(
     credentialMetadataPath,


### PR DESCRIPTION
## Summary
- Fixes the credential metadata file path in CES local mode (`main.ts`) to match where the assistant actually writes it: `<root>/workspace/data/credentials/metadata.json` instead of `<root>/data/credential-metadata.json`.
- Without this fix, `resolveLocalSubject` cannot find existing local static credentials, so `make_authenticated_request` fails with missing-credential errors even when credentials are configured.

Addresses Codex P1 feedback on #16903.

## Test plan
- [x] Verified the assistant writes metadata via `join(getDataDir(), "credentials", "metadata.json")` where `getDataDir()` = `<root>/workspace/data`
- [x] Confirmed the path in CES `main.ts` now matches exactly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
