### PR TITLE
fix: harden CES downloadBundle with SSRF protection, size limit, and timeout

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -50,6 +50,7 @@ import {
   type RpcHandlerRegistry,
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
+import { validateSourceUrl } from "./toolstore/manifest.js";
 import type { OAuthConnectionLookup } from "./subjects/local.js";
 
 // ---------------------------------------------------------------------------
@@ -174,9 +175,18 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
 
   registerManageSecureCommandToolHandler(handlers, {
     downloadBundle: async (sourceUrl: string) => {
-      const resp = await fetch(sourceUrl);
+      const urlError = validateSourceUrl(sourceUrl);
+      if (urlError) {
+        throw new Error(urlError);
+      }
+      const MAX_BUNDLE_SIZE = 100 * 1024 * 1024; // 100 MB
+      const resp = await fetch(sourceUrl, { signal: AbortSignal.timeout(60_000) });
       if (!resp.ok) {
         throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+      }
+      const contentLength = resp.headers.get("content-length");
+      if (contentLength && parseInt(contentLength, 10) > MAX_BUNDLE_SIZE) {
+        throw new Error(`Bundle too large: ${contentLength} bytes (max ${MAX_BUNDLE_SIZE})`);
       }
       return Buffer.from(await resp.arrayBuffer());
     },

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -49,6 +49,7 @@ import {
   type RpcHandlerRegistry,
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
+import { validateSourceUrl } from "./toolstore/manifest.js";
 import type { ManagedSubjectResolverOptions } from "./subjects/managed.js";
 import type { ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 
@@ -171,9 +172,18 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
 
   registerManageSecureCommandToolHandler(handlers, {
     downloadBundle: async (sourceUrl: string) => {
-      const resp = await fetch(sourceUrl);
+      const urlError = validateSourceUrl(sourceUrl);
+      if (urlError) {
+        throw new Error(urlError);
+      }
+      const MAX_BUNDLE_SIZE = 100 * 1024 * 1024; // 100 MB
+      const resp = await fetch(sourceUrl, { signal: AbortSignal.timeout(60_000) });
       if (!resp.ok) {
         throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+      }
+      const contentLength = resp.headers.get("content-length");
+      if (contentLength && parseInt(contentLength, 10) > MAX_BUNDLE_SIZE) {
+        throw new Error(`Bundle too large: ${contentLength} bytes (max ${MAX_BUNDLE_SIZE})`);
       }
       return Buffer.from(await resp.arrayBuffer());
     },


### PR DESCRIPTION
## Summary
- Validates URL scheme (HTTPS-only) via `validateSourceUrl()` **before** fetching to prevent SSRF attacks against cloud metadata endpoints (e.g. `169.254.169.254`)
- Adds 60s request timeout via `AbortSignal.timeout()` to prevent blocking on slow/hanging endpoints
- Adds 100MB `Content-Length` check to prevent OOM from oversized bundles
- Applied to both local (`main.ts`) and managed (`managed-main.ts`) CES entrypoints

Addresses review feedback on #16907 from Codex (P1: unbounded size/timeout) and Devin (BUG: SSRF risk from missing pre-download URL validation).

## Test plan
- [ ] Verify type-check passes
- [ ] Confirm non-HTTPS URLs are rejected before fetch is attempted
- [ ] Confirm oversized bundles are rejected via Content-Length check
- [ ] Confirm slow downloads are aborted after 60s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
