### PR TITLE
fix: normalize legacy tool values before setting proposalType

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -50,7 +50,10 @@ function projectGrant(
     grantId: grant.id,
     sessionId,
     credentialHandle: grant.scope,
-    proposalType: grant.tool as "http" | "command",
+    proposalType:
+      grant.tool === "http" || grant.tool === "command"
+        ? grant.tool
+        : "command",
     proposalHash: grant.id,
     allowedPurposes: [grant.pattern],
     status: "active",


### PR DESCRIPTION
## Summary
- Fixes P1 feedback on #16910: `projectGrant()` was casting `grant.tool` directly to `"http" | "command"`, but legacy grants (persisted before #16910) may have stored the credential handle (e.g. `local_static:...`) in the `tool` field instead.
- Now validates `grant.tool` against the expected enum values and falls back to `"command"` for unrecognized legacy entries, preventing `PersistentGrantRecordSchema` validation failures on `list_grants`.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit` — no new errors in `rpc-handlers.ts`)
- [ ] Verify `list_grants` returns valid records for stores with legacy grant entries
- [ ] Verify newly created grants still project correctly with `"http"` or `"command"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
