### PR TITLE
fix: log retire failures in AssistantTransferSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -1,6 +1,9 @@
 import Foundation
+import os
 import SwiftUI
 import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AssistantTransfer")
 
 /// Transfer UI for moving an assistant between local and cloud (managed) hosting.
 ///
@@ -166,7 +169,11 @@ struct AssistantTransferSection: View {
             // Step 5 — Retire local assistant (fire-and-forget)
             currentStep = "Cleaning up..."
             let localName = assistant.assistantId
-            try? await AppDelegate.shared?.assistantCli.retire(name: localName)
+            do {
+                try await AppDelegate.shared?.assistantCli.retire(name: localName)
+            } catch {
+                log.error("[transfer] Failed to retire local assistant \(localName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         } catch {
             errorMessage = "Transfer failed: \(error.localizedDescription)"
         }
@@ -317,8 +324,18 @@ struct AssistantTransferSection: View {
                     if let orgId = savedOrgId {
                         retireRequest.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
                     }
-                    _ = try? await URLSession.shared.data(for: retireRequest)
+                    let retireResult = try? await URLSession.shared.data(for: retireRequest)
+                    if let (_, retireResponse) = retireResult,
+                       let httpRetire = retireResponse as? HTTPURLResponse,
+                       (200..<300).contains(httpRetire.statusCode) {
+                        log.info("[transfer] Retired managed assistant \(managedAssistantId, privacy: .public)")
+                    } else {
+                        let statusCode = (retireResult?.1 as? HTTPURLResponse)?.statusCode ?? 0
+                        log.error("[transfer] Failed to retire managed assistant \(managedAssistantId, privacy: .public): HTTP \(statusCode, privacy: .public)")
+                    }
                 }
+            } else {
+                log.warning("[transfer] Skipping managed assistant retire — no session token available for \(managedAssistantId, privacy: .public)")
             }
         } catch {
             errorMessage = "Transfer failed: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary
- Addresses Devin review feedback on PR #16818: silent retire failures could leave orphaned managed assistants with no diagnostic trail
- Adds `os.Logger` logging for retire outcomes in both `transferLocalToManaged()` and `transferManagedToLocal()` so failures are visible in Console.app
- Logs success/failure for managed assistant retire (with HTTP status code on failure) and catches + logs errors for local assistant retire

## Test plan
- [ ] Verify `AssistantTransferSection.swift` compiles without errors
- [ ] Transfer managed-to-local with network connectivity — confirm info log appears in Console.app
- [ ] Transfer managed-to-local with simulated retire failure — confirm error log appears in Console.app
- [ ] Transfer local-to-managed with retire failure — confirm error log appears in Console.app

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
