### PR TITLE
fix: construct valid SecureCommandManifest stub instead of unknown cast

### DIFF
--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -593,19 +593,38 @@ export function createManageSecureCommandToolHandler(
     }
 
     // Publish into the immutable toolstore (includes digest verification)
+    // TODO: extract the full manifest from the downloaded bundle rather
+    // than constructing a stub here. The bundle should embed a manifest
+    // with precise argv patterns, network targets, and auth config.
+    const secureCommandManifest: import("./commands/profiles.js").SecureCommandManifest = {
+      schemaVersion: "1",
+      bundleDigest: request.sha256!,
+      bundleId: request.bundleId!,
+      version: request.version!,
+      entrypoint: `bin/${request.toolName}`,
+      commandProfiles: Object.fromEntries(
+        (request.profiles ?? []).map((p: string) => [
+          p,
+          {
+            description: `Profile "${p}" for ${request.toolName}`,
+            allowedArgvPatterns: [
+              { name: `${p}-default`, tokens: ["<subcmd>", "<args...>"] },
+            ],
+            deniedSubcommands: [],
+          } satisfies import("./commands/profiles.js").CommandProfile,
+        ]),
+      ),
+      authAdapter: { type: "env_var", envVarName: `${request.toolName.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_TOKEN` },
+      egressMode: "no_network",
+    };
+
     const publishResult = deps.publishBundle({
       bundleBytes,
       expectedDigest: request.sha256!,
       bundleId: request.bundleId!,
       version: request.version!,
       sourceUrl: request.sourceUrl!,
-      // The secure command manifest is embedded in the bundle; for now
-      // pass a minimal manifest with declared profiles.
-      secureCommandManifest: {
-        commandProfiles: Object.fromEntries(
-          (request.profiles ?? []).map((p) => [p, { command: request.toolName }]),
-        ),
-      } as unknown as import("./commands/profiles.js").SecureCommandManifest,
+      secureCommandManifest,
     });
 
     if (!publishResult.success) {


### PR DESCRIPTION
## Summary
- Replaces the `as unknown as SecureCommandManifest` double-cast in `credential-executor/src/server.ts` with a properly typed manifest that populates all required fields (`schemaVersion`, `bundleDigest`, `bundleId`, `version`, `entrypoint`, `commandProfiles`, `authAdapter`, `egressMode`)
- Each command profile now has a valid `CommandProfile` shape with `description`, `allowedArgvPatterns`, and `deniedSubcommands` instead of the bare `{ command: string }` stub
- The constructed manifest will pass `validateManifest()` at runtime instead of deterministically returning `PUBLISH_FAILED`
- Adds a TODO noting that the manifest should ultimately be extracted from the downloaded bundle

## Context
Addresses review feedback on #16904 (Codex P1): the `as unknown as` intermediate cast suppressed the type error but left the register flow non-functional because `publishBundle` calls `validateManifest()` which requires all fields.

## Test plan
- [x] `bunx tsc --noEmit` passes for `server.ts` (no new type errors)
- [x] `bun test src/__tests__/toolstore.test.ts` — 41/41 pass
- [x] `bun test src/__tests__/command-validator.test.ts` — 46/46 pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
