### PR TITLE
fix: align CES tool tests with current manage_secure_command_tool schema

### DIFF
--- a/assistant/src/__tests__/credential-execution-tools.test.ts
+++ b/assistant/src/__tests__/credential-execution-tools.test.ts
@@ -57,7 +57,7 @@ describe("CES tool schema shapes", () => {
     expect(schema.properties).toHaveProperty("version");
     expect(schema.properties).toHaveProperty("sourceUrl");
     expect(schema.properties).toHaveProperty("sha256");
-    expect(schema.properties).toHaveProperty("profiles");
+    expect(schema.properties).toHaveProperty("secureCommandManifest");
   });
 
   test("all CES tools are high risk", () => {
@@ -261,6 +261,17 @@ describe("manage_secure_command_tool input validation", () => {
         sourceUrl: "http://insecure.example.com/bundle.tar.gz",
         sha256: "abc123",
         credentialHandle: "local_static:test/key",
+        description: "test tool",
+        secureCommandManifest: {
+          schemaVersion: "1",
+          bundleDigest: "abc123",
+          bundleId: "test-bundle",
+          version: "1.0.0",
+          entrypoint: "bin/test",
+          commandProfiles: {},
+          authAdapter: { type: "env_var", envVarName: "TEST_TOKEN" },
+          egressMode: "no_network",
+        },
       },
       contextWithMockCes,
     );


### PR DESCRIPTION
## Summary
- Updated schema shape test to check for `secureCommandManifest` instead of the removed `profiles` property
- Added missing required fields (`description`, `secureCommandManifest`) to the non-HTTPS rejection test so it reaches the HTTPS validation path

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102380572/job/67105343654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
