### PR TITLE
fix: add missing auditStore to http-executor test buildDeps

### DIFF
--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -43,6 +43,7 @@ import { PersistentGrantStore } from "../grants/persistent-store.js";
 import { TemporaryGrantStore } from "../grants/temporary-store.js";
 import { LocalMaterialiser } from "../materializers/local.js";
 import type { OAuthConnectionLookup, LocalSubjectResolverDeps } from "../subjects/local.js";
+import { AuditStore } from "../audit/store.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -284,6 +285,7 @@ function buildDeps(
     sessionId: "test-session",
     logger: silentLogger,
     ...overrides,
+    auditStore: overrides.auditStore ?? new AuditStore(fixture.tmpDir),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `AuditStore` to the `buildDeps` helper in `http-executor.test.ts` to fix a type error after `auditStore` was made a required field on `HttpExecutorDeps`
- Placed after the `...overrides` spread to ensure the required field is always defined while still allowing test overrides

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102399429/job/67105393057

🤖 Generated with [Claude Code](https://claude.com/claude-code)