### PR TITLE
fix: treat blank config values as undefined in getNumber

### DIFF
--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -91,7 +91,7 @@ export class ConfigFileCache {
   ): number | undefined {
     const raw = this.getRaw(section, field, opts);
     if (typeof raw === "number" && Number.isFinite(raw)) return raw;
-    if (typeof raw === "string") {
+    if (typeof raw === "string" && raw.trim() !== "") {
       const n = Number(raw);
       return Number.isFinite(n) ? n : undefined;
     }


### PR DESCRIPTION
Address review feedback from #16917:
- Add blank-string guard to getNumber to match getString behavior
- Empty/whitespace-only config values now return undefined instead of 0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
