### PR TITLE
fix: harden egress-proxy package boundary tests

### DIFF
--- a/packages/egress-proxy/src/__tests__/package-boundary.test.ts
+++ b/packages/egress-proxy/src/__tests__/package-boundary.test.ts
@@ -48,18 +48,24 @@ const FORBIDDEN_PATTERNS = [
   /from\s+['"]@vellumai\/assistant/,
   /import\s*\(.*\/assistant\/src\//,
   /require\s*\(.*\/assistant\/src\//,
+  /import\s+['"].*\/assistant\/src\//,
+  /import\s+['"]@vellumai\/assistant/,
 
   // CES server modules (future — reserve the boundary now)
   /from\s+['"].*\/ces\/src\//,
   /from\s+['"]@vellumai\/ces/,
   /import\s*\(.*\/ces\/src\//,
   /require\s*\(.*\/ces\/src\//,
+  /import\s+['"].*\/ces\/src\//,
+  /import\s+['"]@vellumai\/ces/,
 
   // Gateway internals
   /from\s+['"].*\/gateway\/src\//,
   /from\s+['"]@vellumai\/vellum-gateway/,
   /import\s*\(.*\/gateway\/src\//,
   /require\s*\(.*\/gateway\/src\//,
+  /import\s+['"].*\/gateway\/src\//,
+  /import\s+['"]@vellumai\/vellum-gateway/,
 ];
 
 describe("package boundary", () => {
@@ -96,6 +102,7 @@ describe("package boundary", () => {
       ...pkgJson.dependencies,
       ...pkgJson.devDependencies,
       ...pkgJson.peerDependencies,
+      ...pkgJson.optionalDependencies,
     };
 
     const forbidden = [
@@ -105,10 +112,7 @@ describe("package boundary", () => {
     ];
 
     for (const dep of forbidden) {
-      expect(allDeps).not.toHaveProperty(
-        dep,
-        `package.json must not depend on ${dep}`,
-      );
+      expect(allDeps).not.toHaveProperty(dep);
     }
   });
 


### PR DESCRIPTION
Address review feedback from #16814:
- Remove incorrect second arg from not.toHaveProperty (was treated as expected value, not error message)
- Add side-effect import detection to boundary regex
- Check optionalDependencies for forbidden packages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
