### PR TITLE
fix: exclude web_search_tool_result from turn telemetry count

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -27,6 +27,7 @@ export function queryUnreportedTurnEvents(
         // Exclude tool-result rows persisted with role "user" — these are
         // system-generated and should not count as user turns.
         notLike(messages.content, '%"type":"tool_result"%'),
+        notLike(messages.content, '%"type":"web_search_tool_result"%'),
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),


### PR DESCRIPTION
Address review feedback from #16924:
- Add notLike filter for web_search_tool_result messages
- Aligns with other places in codebase that check for both tool_result types