### PR TITLE
fix: use process.pid for credential store temp file suffix

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -156,8 +156,9 @@ function writeStore(store: StoreFile): void {
   const path = getStorePath();
   ensureDir(dirname(path));
   // Atomic write: write to temp file then rename to avoid partial/corrupt writes.
-  // Use a unique suffix per write to prevent collisions under concurrent writes.
-  const tmpPath = path + `.tmp.${randomBytes(6).toString("hex")}`;
+  // Use pid suffix to prevent cross-process collisions while ensuring same-process
+  // retries overwrite the stale temp file (avoids orphaned temp files on failure).
+  const tmpPath = path + `.tmp.${process.pid}`;
   writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 });
   chmodSync(tmpPath, 0o600);
   renameSync(tmpPath, path);


### PR DESCRIPTION
Address review feedback from #16927:
- Replace randomBytes(6) with process.pid for temp file suffix
- Follows codebase convention (trust-store, pairing-store, etc.)
- Prevents orphaned temp files on write failure while still avoiding cross-process collisions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
