### PR TITLE
fix: write starting sentinel in startDaemonWatchFromSource before spawn

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -372,6 +372,10 @@ async function startDaemonWatchFromSource(
     delete env.QDRANT_URL;
   }
 
+  // Write a sentinel PID file before spawning so concurrent hatch() calls
+  // detect the in-progress spawn and wait instead of racing.
+  writeFileSync(pidFile, "starting", "utf-8");
+
   const daemonLogFd = openLogFile("hatch.log");
   const child = spawn("bun", ["--watch", "run", mainPath], {
     detached: true,
@@ -382,8 +386,13 @@ async function startDaemonWatchFromSource(
   child.unref();
   const daemonPid = child.pid;
 
+  // Overwrite sentinel with real PID, or clean up on spawn failure.
   if (daemonPid) {
     writeFileSync(pidFile, String(daemonPid), "utf-8");
+  } else {
+    try {
+      unlinkSync(pidFile);
+    } catch {}
   }
 
   console.log("   Assistant started in watch mode (bun --watch)");


### PR DESCRIPTION
Address review feedback from #16925:
- Add missing 'starting' sentinel write in startDaemonWatchFromSource
- Matches the pattern in startDaemonFromSource and startLocalDaemon
- Prevents race condition with concurrent hatch --watch invocations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
