### PR TITLE
fix: parenthesize find predicates in credential-executor CI

### DIFF
--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Test
         run: |
-          if [ -n "$(find src/ -name '*.test.*' -o -name '*.spec.*' -print -quit)" ]; then
+          if [ -n "$(find src/ \( -name '*.test.*' -o -name '*.spec.*' \) -print -quit)" ]; then
             bun run test
           else
             echo "No test files found, skipping"

--- a/.github/workflows/pr-credential-executor.yaml
+++ b/.github/workflows/pr-credential-executor.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test
         run: |
-          if [ -n "$(find src/ -name '*.test.*' -o -name '*.spec.*' -print -quit)" ]; then
+          if [ -n "$(find src/ \( -name '*.test.*' -o -name '*.spec.*' \) -print -quit)" ]; then
             bun run test
           else
             echo "No test files found, skipping"


### PR DESCRIPTION
Address review feedback from #16929:
- Add parentheses around -o expression in find command
- Without parens, -print -quit only applied to *.spec.* branch
- Since credential-executor only has *.test.* files, CI was silently skipping all tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
