### PR TITLE
fix: exclude .env files from credential-executor and packages in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,4 +15,8 @@ assistant/build/
 assistant/.env
 assistant/.env.*
 credential-executor/node_modules/
+credential-executor/.env
+credential-executor/.env.*
 packages/*/node_modules/
+packages/*/.env
+packages/*/.env.*


### PR DESCRIPTION
Address review feedback from #16931:
- Add .env and .env.* exclusions for credential-executor/ and packages/*/
- Prevents accidental secret leakage into Docker images
- Matches existing pattern used for assistant/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
