### PR TITLE
fix: align managed OAuth URLs and response parsing with platform API contract

### DIFF
--- a/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
+++ b/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
@@ -23,6 +23,7 @@ mock.module("../util/logger.js", () => ({
 
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey: string | null = null;
+let mockPlatformAssistantId = "";
 
 /** Simulated platform catalog responses keyed by URL. */
 let mockFetchResponses: Map<string, { status: number; body: unknown }> =
@@ -30,6 +31,7 @@ let mockFetchResponses: Map<string, { status: number; body: unknown }> =
 
 mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
+  getPlatformAssistantId: () => mockPlatformAssistantId,
 }));
 
 mock.module("../security/secure-keys.js", () => ({
@@ -88,6 +90,7 @@ describe("fetchManagedCatalog", () => {
   beforeEach(() => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
+    mockPlatformAssistantId = "";
     mockFetchResponses = new Map();
   });
 
@@ -119,31 +122,45 @@ describe("fetchManagedCatalog", () => {
     expect(result.descriptors).toEqual([]);
   });
 
+  test("returns empty descriptors when assistant ID is missing", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "";
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toEqual([]);
+  });
+
   test("parses platform catalog response into descriptors with correct handles", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
-    mockFetchResponses.set("https://platform.example.com/v1/ces/catalog", {
-      status: 200,
-      body: {
-        connections: [
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/",
+      {
+        status: 200,
+        body: [
           {
-            id: "conn_google_123",
+            handle: "platform_oauth:conn_google_123",
+            connection_id: "conn_google_123",
             provider: "google",
-            account_info: "user@gmail.com",
-            granted_scopes: ["email", "calendar"],
+            account_label: "user@gmail.com",
+            scopes_granted: ["email", "calendar"],
             status: "active",
           },
           {
-            id: "conn_slack_456",
+            handle: "platform_oauth:conn_slack_456",
+            connection_id: "conn_slack_456",
             provider: "slack",
-            account_info: "workspace-bot",
-            granted_scopes: ["chat:write"],
+            account_label: "workspace-bot",
+            scopes_granted: ["chat:write"],
             status: "active",
           },
         ],
       },
-    });
+    );
 
     const result = await fetchManagedCatalog();
     expect(result.ok).toBe(true);
@@ -166,11 +183,15 @@ describe("fetchManagedCatalog", () => {
   test("handles empty connections list from platform", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
-    mockFetchResponses.set("https://platform.example.com/v1/ces/catalog", {
-      status: 200,
-      body: { connections: [] },
-    });
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/",
+      {
+        status: 200,
+        body: [],
+      },
+    );
 
     const result = await fetchManagedCatalog();
     expect(result.ok).toBe(true);
@@ -180,11 +201,15 @@ describe("fetchManagedCatalog", () => {
   test("handles platform returning HTTP error gracefully", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
-    mockFetchResponses.set("https://platform.example.com/v1/ces/catalog", {
-      status: 500,
-      body: { detail: "Internal server error" },
-    });
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/",
+      {
+        status: 500,
+        body: { detail: "Internal server error" },
+      },
+    );
 
     const result = await fetchManagedCatalog();
     expect(result.ok).toBe(false);
@@ -195,11 +220,15 @@ describe("fetchManagedCatalog", () => {
   test("handles platform returning unexpected format gracefully", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
-    mockFetchResponses.set("https://platform.example.com/v1/ces/catalog", {
-      status: 200,
-      body: { unexpected: "shape" },
-    });
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/",
+      {
+        status: 200,
+        body: { unexpected: "shape" },
+      },
+    );
 
     const result = await fetchManagedCatalog();
     expect(result.ok).toBe(false);
@@ -209,19 +238,22 @@ describe("fetchManagedCatalog", () => {
   test("defaults missing optional fields in catalog entries", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
-    mockFetchResponses.set("https://platform.example.com/v1/ces/catalog", {
-      status: 200,
-      body: {
-        connections: [
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/",
+      {
+        status: 200,
+        body: [
           {
-            id: "conn_minimal",
+            handle: "platform_oauth:conn_minimal",
+            connection_id: "conn_minimal",
             provider: "github",
-            // account_info, granted_scopes, status all omitted
+            // account_label, scopes_granted, status all omitted
           },
         ],
       },
-    });
+    );
 
     const result = await fetchManagedCatalog();
     expect(result.ok).toBe(true);
@@ -237,13 +269,14 @@ describe("fetchManagedCatalog", () => {
   test("error messages never contain API key values", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-super-secret-key-12345";
+    mockPlatformAssistantId = "ast-uuid-1234";
 
     // Simulate a network error
     const savedFetch = globalThis.fetch;
     const errorFetch: typeof fetch = Object.assign(
       async () => {
         throw new Error(
-          "Connect failed to https://platform.example.com/v1/ces/catalog with Api-Key sk-super-secret-key-12345",
+          "Connect failed to https://platform.example.com/v1/assistants/ast-uuid-1234/oauth/managed/catalog/ with Api-Key sk-super-secret-key-12345",
         );
       },
       { preconnect: savedFetch.preconnect },

--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -11,6 +11,7 @@
 
 import { platformOAuthHandle } from "@vellumai/ces-contracts";
 
+import { getPlatformAssistantId } from "../config/env.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { getLogger } from "../util/logger.js";
 
@@ -44,17 +45,17 @@ export interface ManagedCredentialDescriptor {
 /**
  * Shape of a single connection entry in the platform catalog response.
  * Only non-secret fields are parsed; token values are never included.
+ *
+ * Field names match the platform's ManagedConnectionCatalogEntrySerializer:
+ *   handle, connection_id, provider, account_label, scopes_granted, status
  */
 interface PlatformCatalogEntry {
-  id: string;
+  handle: string;
+  connection_id: string;
   provider: string;
-  account_info?: string | null;
-  granted_scopes?: string[];
+  account_label?: string | null;
+  scopes_granted?: string[];
   status?: string;
-}
-
-interface PlatformCatalogResponse {
-  connections: PlatformCatalogEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +85,13 @@ export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> 
     return { ok: true, descriptors: [] };
   }
 
-  const url = `${ctx.platformBaseUrl}/v1/ces/catalog`;
+  const assistantId = getPlatformAssistantId();
+  if (!assistantId) {
+    log.warn("PLATFORM_ASSISTANT_ID not set; cannot fetch managed catalog");
+    return { ok: true, descriptors: [] };
+  }
+
+  const url = `${ctx.platformBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/oauth/managed/catalog/`;
 
   try {
     const response = await fetch(url, {
@@ -97,7 +104,9 @@ export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> 
 
     if (!response.ok) {
       const statusText = response.statusText || `HTTP ${response.status}`;
-      log.warn(`Platform CES catalog returned ${response.status}: ${statusText}`);
+      log.warn(
+        `Platform CES catalog returned ${response.status}: ${statusText}`,
+      );
       return {
         ok: false,
         descriptors: [],
@@ -105,9 +114,11 @@ export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> 
       };
     }
 
-    const body = (await response.json()) as PlatformCatalogResponse;
+    // The platform returns a flat JSON array of catalog entries
+    // (serialized with many=True), not a wrapper object.
+    const body = (await response.json()) as PlatformCatalogEntry[];
 
-    if (!body.connections || !Array.isArray(body.connections)) {
+    if (!Array.isArray(body)) {
       return {
         ok: false,
         descriptors: [],
@@ -115,24 +126,25 @@ export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> 
       };
     }
 
-    const descriptors: ManagedCredentialDescriptor[] = body.connections.map(
-      (entry) => ({
-        handle: platformOAuthHandle(entry.id),
-        source: "platform" as const,
-        provider: entry.provider,
-        connectionId: entry.id,
-        accountInfo: entry.account_info ?? null,
-        grantedScopes: entry.granted_scopes ?? [],
-        status: entry.status ?? "unknown",
-      }),
-    );
+    const descriptors: ManagedCredentialDescriptor[] = body.map((entry) => ({
+      handle: platformOAuthHandle(entry.connection_id),
+      source: "platform" as const,
+      provider: entry.provider,
+      connectionId: entry.connection_id,
+      accountInfo: entry.account_label ?? null,
+      grantedScopes: entry.scopes_granted ?? [],
+      status: entry.status ?? "unknown",
+    }));
 
     return { ok: true, descriptors };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Ensure the error message does not leak secrets — strip any URL params
     // that might contain tokens (defensive, since we use Api-Key header).
-    const safeMessage = message.replace(/Api-Key\s+\S+/gi, "Api-Key [REDACTED]");
+    const safeMessage = message.replace(
+      /Api-Key\s+\S+/gi,
+      "Api-Key [REDACTED]",
+    );
     log.warn(`Failed to fetch managed CES catalog: ${safeMessage}`);
     return {
       ok: false,

--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -555,30 +555,31 @@ describe("HTTP executor: platform_oauth handles", () => {
       const urlStr = url.toString();
 
       // Platform catalog
-      if (urlStr.includes("/v1/ces/catalog")) {
+      if (urlStr.includes("/oauth/managed/catalog")) {
         return new Response(
-          JSON.stringify({
-            connections: [
-              {
-                id: "conn-platform-1",
-                provider: "slack",
-                account_info: "workspace@slack.com",
-                granted_scopes: ["channels:read"],
-                status: "active",
-              },
-            ],
-          }),
+          JSON.stringify([
+            {
+              handle: "platform_oauth:conn-platform-1",
+              connection_id: "conn-platform-1",
+              provider: "slack",
+              account_label: "workspace@slack.com",
+              scopes_granted: ["channels:read"],
+              status: "active",
+            },
+          ]),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
       }
 
       // Platform token materialization
-      if (urlStr.includes("/v1/ces/connections/conn-platform-1/materialize")) {
+      if (urlStr.includes("/oauth/managed/materialize")) {
         return new Response(
           JSON.stringify({
             access_token: "xoxp-platform-token-12345678",
             token_type: "Bearer",
-            expires_in: 3600,
+            expires_at: new Date(Date.now() + 3600_000).toISOString(),
+            provider: "slack",
+            handle: "platform_oauth:conn-platform-1",
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
@@ -603,11 +604,13 @@ describe("HTTP executor: platform_oauth handles", () => {
       managedSubjectOptions: {
         platformBaseUrl: "https://api.vellum.ai",
         assistantApiKey: "test-api-key",
+        assistantId: "test-assistant-id",
         fetch: platformCatalogFetch,
       },
       managedMaterializerOptions: {
         platformBaseUrl: "https://api.vellum.ai",
         assistantApiKey: "test-api-key",
+        assistantId: "test-assistant-id",
         fetch: platformCatalogFetch,
       },
     });

--- a/credential-executor/src/__tests__/managed-materializers.test.ts
+++ b/credential-executor/src/__tests__/managed-materializers.test.ts
@@ -35,28 +35,35 @@ import {
 
 const TEST_PLATFORM_URL = "https://api.test-platform.vellum.ai";
 const TEST_API_KEY = "test-api-key-abc123";
+const TEST_ASSISTANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 
 /**
- * Build a mock catalog response with the given entries.
+ * Build a mock catalog response matching the platform's flat-array format.
+ * The platform serializes with many=True, returning a JSON array directly.
  */
 function buildCatalogResponse(
   entries: PlatformCatalogEntry[],
-): { connections: PlatformCatalogEntry[] } {
-  return { connections: entries };
+): PlatformCatalogEntry[] {
+  return entries;
 }
 
 /**
- * Build a mock platform token response.
+ * Build a mock platform token response matching
+ * ManagedTokenMaterializeResponseSerializer.
  */
 function buildTokenResponse(overrides: {
   access_token?: string;
   token_type?: string;
-  expires_in?: number | null;
+  expires_at?: string | null;
+  provider?: string;
+  handle?: string;
 } = {}) {
   return {
     access_token: overrides.access_token ?? "mat_token_abc123",
     token_type: overrides.token_type ?? "Bearer",
-    expires_in: overrides.expires_in ?? 3600,
+    expires_at: overrides.expires_at ?? new Date(Date.now() + 3600_000).toISOString(),
+    provider: overrides.provider ?? "google",
+    handle: overrides.handle ?? "platform_oauth:conn_test123",
   };
 }
 
@@ -78,12 +85,12 @@ function createMockFetch(handlers: {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
 
-    if (url.includes("/v1/ces/catalog")) {
+    if (url.includes("/oauth/managed/catalog")) {
       if (handlers.catalog?.error) {
         throw handlers.catalog.error;
       }
       return new Response(
-        JSON.stringify(handlers.catalog?.body ?? { connections: [] }),
+        JSON.stringify(handlers.catalog?.body ?? []),
         {
           status: handlers.catalog?.status ?? 200,
           headers: { "Content-Type": "application/json" },
@@ -91,7 +98,7 @@ function createMockFetch(handlers: {
       );
     }
 
-    if (url.includes("/materialize")) {
+    if (url.includes("/oauth/managed/materialize")) {
       if (handlers.materialize?.error) {
         throw handlers.materialize.error;
       }
@@ -138,10 +145,11 @@ describe("resolveManagedSubject", () => {
         status: 200,
         body: buildCatalogResponse([
           {
-            id: "conn_abc123",
+            handle: "platform_oauth:conn_abc123",
+            connection_id: "conn_abc123",
             provider: "google",
-            account_info: "user@example.com",
-            granted_scopes: ["email", "calendar"],
+            account_label: "user@example.com",
+            scopes_granted: ["email", "calendar"],
             status: "active",
           },
         ]),
@@ -151,6 +159,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -172,15 +181,16 @@ describe("resolveManagedSubject", () => {
       catalog: {
         status: 200,
         body: buildCatalogResponse([
-          { id: "conn_first", provider: "slack" },
+          { handle: "platform_oauth:conn_first", connection_id: "conn_first", provider: "slack" },
           {
-            id: "conn_second",
+            handle: "platform_oauth:conn_second",
+            connection_id: "conn_second",
             provider: "github",
-            account_info: "dev@github.com",
-            granted_scopes: ["repo", "read:org"],
+            account_label: "dev@github.com",
+            scopes_granted: ["repo", "read:org"],
             status: "active",
           },
-          { id: "conn_third", provider: "google" },
+          { handle: "platform_oauth:conn_third", connection_id: "conn_third", provider: "google" },
         ]),
       },
     });
@@ -188,6 +198,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -203,7 +214,7 @@ describe("resolveManagedSubject", () => {
       catalog: {
         status: 200,
         body: buildCatalogResponse([
-          { id: "conn_minimal", provider: "slack" },
+          { handle: "platform_oauth:conn_minimal", connection_id: "conn_minimal", provider: "slack" },
         ]),
       },
     });
@@ -211,6 +222,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -229,6 +241,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject("not-a-valid-handle", {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
@@ -240,6 +253,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject("local_static:github/api_key", {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
@@ -254,6 +268,7 @@ describe("resolveManagedSubject", () => {
       {
         platformBaseUrl: TEST_PLATFORM_URL,
         assistantApiKey: TEST_API_KEY,
+        assistantId: TEST_ASSISTANT_ID,
       },
     );
 
@@ -273,7 +288,7 @@ describe("resolveManagedSubject", () => {
       catalog: {
         status: 200,
         body: buildCatalogResponse([
-          { id: "conn_other", provider: "slack" },
+          { handle: "platform_oauth:conn_other", connection_id: "conn_other", provider: "slack" },
         ]),
       },
     });
@@ -281,6 +296,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -303,6 +319,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -321,6 +338,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -338,6 +356,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -355,6 +374,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -373,6 +393,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: "",
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
@@ -386,11 +407,26 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: "",
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("MISSING_PLATFORM_URL");
+  });
+
+  test("fails when assistant ID is missing", async () => {
+    const handle = platformOAuthHandle("conn_test");
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      assistantId: "",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_ASSISTANT_ID");
   });
 
   // -------------------------------------------------------------------------
@@ -409,6 +445,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -432,6 +469,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -457,6 +495,7 @@ describe("resolveManagedSubject", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -473,20 +512,21 @@ describe("resolveManagedSubject", () => {
 describe("materializeManagedToken", () => {
   test("materializes a token successfully", async () => {
     const subject = buildManagedSubject();
+    const futureExpiry = new Date(Date.now() + 1_800_000).toISOString();
     const mockFetch = createMockFetch({
       materialize: {
         status: 200,
         body: buildTokenResponse({
           access_token: "fresh_token_xyz",
-          expires_in: 1800,
+          expires_at: futureExpiry,
         }),
       },
     });
 
-    const before = Date.now();
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -497,12 +537,10 @@ describe("materializeManagedToken", () => {
     expect(result.token.tokenType).toBe("Bearer");
     expect(result.token.provider).toBe("google");
     expect(result.token.connectionId).toBe("conn_test123");
-    // expires_in: 1800 seconds = 1,800,000 ms from now
+    // expires_at is parsed from ISO datetime
     expect(result.token.expiresAt).not.toBeNull();
-    expect(result.token.expiresAt!).toBeGreaterThanOrEqual(before + 1_799_000);
-    expect(result.token.expiresAt!).toBeLessThanOrEqual(
-      Date.now() + 1_801_000,
-    );
+    const expectedMs = new Date(futureExpiry).getTime();
+    expect(result.token.expiresAt!).toBe(expectedMs);
   });
 
   test("defaults token_type to Bearer when not provided", async () => {
@@ -510,13 +548,14 @@ describe("materializeManagedToken", () => {
     const mockFetch = createMockFetch({
       materialize: {
         status: 200,
-        body: { access_token: "tok_no_type" },
+        body: { access_token: "tok_no_type", expires_at: null },
       },
     });
 
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -539,6 +578,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -557,6 +597,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -574,6 +615,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -592,6 +634,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -610,6 +653,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: "",
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
@@ -623,11 +667,26 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: "",
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("MISSING_PLATFORM_URL");
+  });
+
+  test("fails when assistant ID is missing", async () => {
+    const subject = buildManagedSubject();
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      assistantId: "",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_ASSISTANT_ID");
   });
 
   // -------------------------------------------------------------------------
@@ -646,6 +705,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -669,6 +729,7 @@ describe("materializeManagedToken", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -687,13 +748,14 @@ describe("materializeManagedToken", () => {
     const mockFetch = createMockFetch({
       materialize: {
         status: 200,
-        body: { token_type: "Bearer", expires_in: 3600 },
+        body: { token_type: "Bearer", expires_at: new Date(Date.now() + 3600_000).toISOString() },
       },
     });
 
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -717,14 +779,14 @@ describe("materializeManagedToken", () => {
     ) => {
       callCount++;
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("/materialize")) {
+      if (url.includes("/oauth/managed/materialize")) {
         // Each call returns a different token to prove we got a fresh one
         return Promise.resolve(
           new Response(
             JSON.stringify(
               buildTokenResponse({
                 access_token: `fresh_token_${callCount}`,
-                expires_in: 3600,
+                expires_at: new Date(Date.now() + 3600_000).toISOString(),
               }),
             ),
             {
@@ -740,6 +802,7 @@ describe("materializeManagedToken", () => {
     const opts: ManagedMaterializerOptions = {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     };
 
@@ -771,10 +834,11 @@ describe("uniform subject interface", () => {
         status: 200,
         body: buildCatalogResponse([
           {
-            id: "conn_uniform",
+            handle: "platform_oauth:conn_uniform",
+            connection_id: "conn_uniform",
             provider: "github",
-            account_info: "dev@example.com",
-            granted_scopes: ["repo"],
+            account_label: "dev@example.com",
+            scopes_granted: ["repo"],
             status: "active",
           },
         ]),
@@ -784,6 +848,7 @@ describe("uniform subject interface", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -804,7 +869,7 @@ describe("uniform subject interface", () => {
       catalog: {
         status: 200,
         body: buildCatalogResponse([
-          { id: "conn_branch", provider: "slack" },
+          { handle: "platform_oauth:conn_branch", connection_id: "conn_branch", provider: "slack" },
         ]),
       },
     });
@@ -812,6 +877,7 @@ describe("uniform subject interface", () => {
     const result = await resolveManagedSubject(handle, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -850,6 +916,7 @@ describe("token non-persistence invariant", () => {
     const result = await materializeManagedToken(subject, {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     });
 
@@ -918,10 +985,11 @@ describe("end-to-end resolve and materialize", () => {
         status: 200,
         body: buildCatalogResponse([
           {
-            id: "conn_e2e",
+            handle: "platform_oauth:conn_e2e",
+            connection_id: "conn_e2e",
             provider: "google",
-            account_info: "e2e@example.com",
-            granted_scopes: ["drive"],
+            account_label: "e2e@example.com",
+            scopes_granted: ["drive"],
             status: "active",
           },
         ]),
@@ -930,7 +998,7 @@ describe("end-to-end resolve and materialize", () => {
         status: 200,
         body: buildTokenResponse({
           access_token: "e2e_access_token",
-          expires_in: 7200,
+          expires_at: new Date(Date.now() + 7200_000).toISOString(),
         }),
       },
     });
@@ -938,6 +1006,7 @@ describe("end-to-end resolve and materialize", () => {
     const opts = {
       platformBaseUrl: TEST_PLATFORM_URL,
       assistantApiKey: TEST_API_KEY,
+      assistantId: TEST_ASSISTANT_ID,
       fetch: mockFetch,
     };
 

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -97,24 +97,25 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
 
   // -- Managed credential options --------------------------------------------
   // In managed mode, credentials are obtained from the platform via its
-  // token-materialization endpoint. The platform URL and API key are provided
-  // through environment variables set by the orchestration layer.
+  // token-materialization endpoint. The platform URL, API key, and assistant
+  // ID are provided through environment variables set by the orchestration layer.
   const platformBaseUrl = process.env["PLATFORM_BASE_URL"] ?? "";
   const assistantApiKey = process.env["ASSISTANT_API_KEY"] ?? "";
+  const assistantId = process.env["PLATFORM_ASSISTANT_ID"] ?? "";
 
   const managedSubjectOptions: ManagedSubjectResolverOptions | undefined =
-    platformBaseUrl && assistantApiKey
-      ? { platformBaseUrl, assistantApiKey }
+    platformBaseUrl && assistantApiKey && assistantId
+      ? { platformBaseUrl, assistantApiKey, assistantId }
       : undefined;
 
   const managedMaterializerOptions: ManagedMaterializerOptions | undefined =
-    platformBaseUrl && assistantApiKey
-      ? { platformBaseUrl, assistantApiKey }
+    platformBaseUrl && assistantApiKey && assistantId
+      ? { platformBaseUrl, assistantApiKey, assistantId }
       : undefined;
 
   if (!managedSubjectOptions) {
     warn(
-      "PLATFORM_BASE_URL and/or ASSISTANT_API_KEY not set. " +
+      "PLATFORM_BASE_URL, ASSISTANT_API_KEY, and/or PLATFORM_ASSISTANT_ID not set. " +
         "Managed credential materialisation will not be available.",
     );
   }

--- a/credential-executor/src/materializers/managed-platform.ts
+++ b/credential-executor/src/materializers/managed-platform.ts
@@ -70,6 +70,9 @@ export class MaterializationError extends Error {
 /**
  * Shape of the platform's CES token-materialization response.
  *
+ * Field names match the platform's ManagedTokenMaterializeResponseSerializer:
+ *   access_token, token_type, expires_at, provider, handle
+ *
  * The platform issues a short-lived access token for the specified
  * connection. The token is pre-authorized for the scopes granted on
  * the connection.
@@ -77,8 +80,10 @@ export class MaterializationError extends Error {
 interface PlatformTokenResponse {
   access_token: string;
   token_type?: string;
-  /** Seconds until the token expires. */
-  expires_in?: number | null;
+  /** ISO-8601 datetime when the token expires (null if no expiry). */
+  expires_at?: string | null;
+  provider?: string;
+  handle?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +100,11 @@ export interface ManagedMaterializerOptions {
    */
   assistantApiKey: string;
   /**
+   * Platform-assigned assistant UUID. Required for building the
+   * platform materialize URL: /v1/assistants/<id>/oauth/managed/materialize/
+   */
+  assistantId: string;
+  /**
    * Optional custom fetch implementation (for testing).
    */
   fetch?: typeof globalThis.fetch;
@@ -109,7 +119,9 @@ export interface ManagedMaterializerOptions {
  * by calling the platform's token-materialization endpoint.
  *
  * The endpoint is:
- *   POST {platformBaseUrl}/v1/ces/connections/{connectionId}/materialize
+ *   POST {platformBaseUrl}/v1/assistants/{assistantId}/oauth/managed/materialize/
+ *
+ * The request body contains `{ connection_id: <uuid> }`.
  *
  * The platform validates the assistant API key, checks that the connection
  * is active, and returns a fresh access token (refreshing upstream if
@@ -120,7 +132,7 @@ export interface ManagedMaterializerOptions {
  */
 export async function materializeManagedToken(
   subject: ManagedSubject,
-  options: ManagedMaterializerOptions,
+  options: ManagedMaterializerOptions
 ): Promise<MaterializeResult> {
   // -- Validate prerequisites -----------------------------------------------
   if (!options.platformBaseUrl) {
@@ -128,7 +140,7 @@ export async function materializeManagedToken(
       ok: false,
       error: new MaterializationError(
         "MISSING_PLATFORM_URL",
-        "Platform base URL is required for managed token materialization",
+        "Platform base URL is required for managed token materialization"
       ),
     };
   }
@@ -138,15 +150,28 @@ export async function materializeManagedToken(
       ok: false,
       error: new MaterializationError(
         "MISSING_API_KEY",
-        "Assistant API key is required for managed token materialization",
+        "Assistant API key is required for managed token materialization"
+      ),
+    };
+  }
+
+  if (!options.assistantId) {
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "MISSING_ASSISTANT_ID",
+        "Assistant ID is required for managed token materialization"
       ),
     };
   }
 
   // -- Call platform token endpoint -----------------------------------------
   const fetchFn = options.fetch ?? globalThis.fetch;
-  const materializeUrl =
-    `${options.platformBaseUrl}/v1/ces/connections/${encodeURIComponent(subject.connectionId)}/materialize`;
+  const materializeUrl = `${
+    options.platformBaseUrl
+  }/v1/assistants/${encodeURIComponent(
+    options.assistantId
+  )}/oauth/managed/materialize/`;
 
   let response: Response;
   try {
@@ -157,7 +182,7 @@ export async function materializeManagedToken(
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ connection_id: subject.connectionId }),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -165,7 +190,7 @@ export async function materializeManagedToken(
       ok: false,
       error: new MaterializationError(
         "PLATFORM_UNREACHABLE",
-        `Failed to reach platform token endpoint: ${sanitizeError(message)}`,
+        `Failed to reach platform token endpoint: ${sanitizeError(message)}`
       ),
     };
   }
@@ -187,7 +212,7 @@ export async function materializeManagedToken(
       ok: false,
       error: new MaterializationError(
         "INVALID_TOKEN_RESPONSE",
-        "Platform token endpoint returned invalid JSON",
+        "Platform token endpoint returned invalid JSON"
       ),
     };
   }
@@ -197,13 +222,13 @@ export async function materializeManagedToken(
       ok: false,
       error: new MaterializationError(
         "INVALID_TOKEN_RESPONSE",
-        "Platform token response missing access_token",
+        "Platform token response missing access_token"
       ),
     };
   }
 
   // -- Build materialized token ---------------------------------------------
-  const expiresAt = computeExpiresAt(body.expires_in);
+  const expiresAt = parseExpiresAt(body.expires_at);
 
   const token: MaterializedToken = {
     accessToken: body.access_token,
@@ -225,41 +250,41 @@ export async function materializeManagedToken(
  */
 function mapPlatformError(
   status: number,
-  connectionId: string,
+  connectionId: string
 ): MaterializationError {
   switch (status) {
     case 401:
       return new MaterializationError(
         "PLATFORM_AUTH_FAILED",
-        "Assistant API key is invalid or expired (HTTP 401)",
+        "Assistant API key is invalid or expired (HTTP 401)"
       );
     case 403:
       return new MaterializationError(
         "PLATFORM_FORBIDDEN",
-        "Assistant is not authorized to materialize this connection (HTTP 403)",
+        "Assistant is not authorized to materialize this connection (HTTP 403)"
       );
     case 404:
       return new MaterializationError(
         "CONNECTION_NOT_FOUND",
-        `Connection ${connectionId} not found on the platform (HTTP 404)`,
+        `Connection ${connectionId} not found on the platform (HTTP 404)`
       );
     default:
       return new MaterializationError(
         `PLATFORM_HTTP_${status}`,
-        `Platform token endpoint returned HTTP ${status}`,
+        `Platform token endpoint returned HTTP ${status}`
       );
   }
 }
 
 /**
- * Compute the absolute expiry timestamp from an `expires_in` seconds value.
- * Returns null if the value is missing or zero.
+ * Parse an ISO-8601 `expires_at` datetime string into epoch milliseconds.
+ * Returns null if the value is missing or invalid.
  */
-function computeExpiresAt(
-  expiresIn: number | null | undefined,
-): number | null {
-  if (expiresIn == null || expiresIn <= 0) return null;
-  return Date.now() + expiresIn * 1000;
+function parseExpiresAt(expiresAt: string | null | undefined): number | null {
+  if (expiresAt == null) return null;
+  const ts = new Date(expiresAt).getTime();
+  if (Number.isNaN(ts)) return null;
+  return ts;
 }
 
 /**

--- a/credential-executor/src/subjects/managed.ts
+++ b/credential-executor/src/subjects/managed.ts
@@ -83,12 +83,16 @@ export interface ManagedSubject extends ResolvedSubject {
 /**
  * Shape of a single connection entry in the platform catalog response.
  * Only non-secret fields are parsed; token values are never included.
+ *
+ * Field names match the platform's ManagedConnectionCatalogEntrySerializer:
+ *   handle, connection_id, provider, account_label, scopes_granted, status
  */
 export interface PlatformCatalogEntry {
-  id: string;
+  handle: string;
+  connection_id: string;
   provider: string;
-  account_info?: string | null;
-  granted_scopes?: string[];
+  account_label?: string | null;
+  scopes_granted?: string[];
   status?: string;
 }
 
@@ -120,6 +124,11 @@ export interface ManagedSubjectResolverOptions {
    * Assistant API key for authenticating with the platform.
    */
   assistantApiKey: string;
+  /**
+   * Platform-assigned assistant UUID. Required for building the
+   * platform catalog URL: /v1/assistants/<id>/oauth/managed/catalog/
+   */
+  assistantId: string;
   /**
    * Optional custom fetch implementation (for testing).
    */
@@ -191,9 +200,19 @@ export async function resolveManagedSubject(
     };
   }
 
+  if (!options.assistantId) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "MISSING_ASSISTANT_ID",
+        "Assistant ID is required for managed subject resolution",
+      ),
+    };
+  }
+
   // -- Fetch catalog entry --------------------------------------------------
   const fetchFn = options.fetch ?? globalThis.fetch;
-  const catalogUrl = `${options.platformBaseUrl}/v1/ces/catalog`;
+  const catalogUrl = `${options.platformBaseUrl}/v1/assistants/${encodeURIComponent(options.assistantId)}/oauth/managed/catalog/`;
 
   let response: Response;
   try {
@@ -226,9 +245,11 @@ export async function resolveManagedSubject(
   }
 
   // -- Parse response -------------------------------------------------------
-  let body: { connections?: PlatformCatalogEntry[] };
+  // The platform returns a flat JSON array of catalog entries
+  // (serialized with many=True), not a wrapper object.
+  let entries: PlatformCatalogEntry[];
   try {
-    body = (await response.json()) as { connections?: PlatformCatalogEntry[] };
+    entries = (await response.json()) as PlatformCatalogEntry[];
   } catch {
     return {
       ok: false,
@@ -239,7 +260,7 @@ export async function resolveManagedSubject(
     };
   }
 
-  if (!body.connections || !Array.isArray(body.connections)) {
+  if (!Array.isArray(entries)) {
     return {
       ok: false,
       error: new SubjectResolutionError(
@@ -250,8 +271,8 @@ export async function resolveManagedSubject(
   }
 
   // -- Find matching connection ---------------------------------------------
-  const entry = body.connections.find(
-    (c) => c.id === platformHandle.connectionId,
+  const entry = entries.find(
+    (c) => c.connection_id === platformHandle.connectionId,
   );
 
   if (!entry) {
@@ -269,9 +290,9 @@ export async function resolveManagedSubject(
     source: "managed",
     handle,
     provider: entry.provider,
-    connectionId: entry.id,
-    accountInfo: entry.account_info ?? null,
-    grantedScopes: entry.granted_scopes ?? [],
+    connectionId: entry.connection_id,
+    accountInfo: entry.account_label ?? null,
+    grantedScopes: entry.scopes_granted ?? [],
     status: entry.status ?? "unknown",
   };
 


### PR DESCRIPTION
## Summary
Aligns assistant/CES managed OAuth integration with actual platform API:
- Fix URL paths to match platform's /v1/assistants/<id>/oauth/managed/ routes
- Fix response field name parsing to match platform serializers (connection_id, account_label, scopes_granted, expires_at)
- Platform PR adds PLATFORM_BASE_URL, ASSISTANT_API_KEY, and PLATFORM_ASSISTANT_ID to CES sidecar: https://github.com/vellum-ai/vellum-assistant-platform/pull/2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)