### PR TITLE
fix: store both transfer tasks and avoid success-path cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -62,7 +62,7 @@ struct AssistantTransferSection: View {
         .alert("Transfer to Cloud", isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Transfer", role: .destructive) {
-                Task { await transferLocalToManaged() }
+                transferTask = Task { await transferLocalToManaged() }
             }
         } message: {
             Text("This will move all conversations, memory, and settings to a cloud-hosted assistant, then retire the local one. This cannot be undone.")
@@ -164,6 +164,7 @@ struct AssistantTransferSection: View {
                 throw TransferError.managedEntryNotFound
             }
             AppDelegate.shared?.performSwitchAssistant(to: managedAssistant)
+            transferTask = nil
             onClose()
 
             // Step 5 — Retire local assistant (fire-and-forget)
@@ -310,6 +311,7 @@ struct AssistantTransferSection: View {
 
             // Step 7 — Switch to local assistant now that import succeeded
             AppDelegate.shared?.performSwitchAssistant(to: resolvedLocal)
+            transferTask = nil
             onClose()
 
             // Step 8 — Retire managed assistant (fire-and-forget with pre-saved auth)


### PR DESCRIPTION
Address review feedback from #16938:
- Store transferLocalToManaged task in transferTask for proper cancellation on view disappear
- Nil out transferTask before onClose in both transfer paths to prevent success-path view dismissal from cancelling the in-flight retirement request
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
