### PR TITLE
fix: make CES tool response success variant strict

### DIFF
--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -91,11 +91,13 @@ export type ToolRequestBase = z.infer<typeof ToolRequestBaseSchema>;
  * payloads (e.g. `success: false` without `error`, or `success: true`
  * with `error`) are rejected at parse time.
  */
-const ToolResponseSuccessSchema = z.object({
-  success: z.literal(true),
-  /** Tool output. */
-  result: z.unknown().optional(),
-});
+const ToolResponseSuccessSchema = z
+  .object({
+    success: z.literal(true),
+    /** Tool output. */
+    result: z.unknown().optional(),
+  })
+  .strict();
 
 const ToolResponseErrorSchema = z.object({
   success: z.literal(false),


### PR DESCRIPTION
Address review feedback from #16920:\n- Add .strict() to ToolResponseSuccessSchema to reject payloads with contradictory fields\n- Prevents { success: true, error: {...} } from silently passing validation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
