### PR TITLE
fix: stop CES process manager immediately on session dispose and handshake rejection

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -359,6 +359,7 @@ export class Session {
               "CES handshake rejected — CES tools will be unavailable",
             );
             client.close();
+            await pm.stop();
           }
         } catch (err) {
           if (err instanceof CesUnavailableError) {
@@ -511,29 +512,28 @@ export class Session {
     this.hostBashProxy?.dispose();
     this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
-    // Signal the async CES init to abort, then wait for it to finish so we
-    // don't leak a child process that completes startup after dispose().
+    // Signal the async CES init to abort and stop the process manager
+    // immediately so we don't keep the child process alive for the full
+    // handshake timeout window. The deferred .then() handles client cleanup
+    // once the init promise settles.
     this.cesInitAborted = true;
+    if (this.cesClient) {
+      this.cesClient.close();
+      this.cesClient = undefined;
+    }
+    if (this.cesProcessManager) {
+      void this.cesProcessManager.stop();
+      this.cesProcessManager = undefined;
+    }
     if (this.cesInitPromise) {
       void this.cesInitPromise.then(() => {
+        // Client may have been set between our immediate cleanup and the
+        // promise settling — close it if so.
         if (this.cesClient) {
           this.cesClient.close();
           this.cesClient = undefined;
         }
-        if (this.cesProcessManager) {
-          void this.cesProcessManager.stop();
-          this.cesProcessManager = undefined;
-        }
       });
-    } else {
-      if (this.cesClient) {
-        this.cesClient.close();
-        this.cesClient = undefined;
-      }
-      if (this.cesProcessManager) {
-        void this.cesProcessManager.stop();
-        this.cesProcessManager = undefined;
-      }
     }
     disposeSession(this);
   }


### PR DESCRIPTION
Address review feedback from #16958:
- Stop CES process manager immediately in dispose() instead of deferring to the .then() handler, preventing a 10s handshake timeout window where the child process stays alive
- Add pm.stop() after rejected handshake to prevent leaked child processes
- Keep deferred .then() only for client cleanup in case it was set between immediate cleanup and promise settling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
