### PR TITLE
fix: reject malformed URI segments instead of matching literally

### DIFF
--- a/credential-executor/src/http/path-template.ts
+++ b/credential-executor/src/http/path-template.ts
@@ -19,15 +19,15 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Safely decode a percent-encoded path segment. Falls back to the raw
- * segment when it contains malformed escapes (e.g. bare `%` or `%zz`)
- * that would cause `decodeURIComponent` to throw a `URIError`.
+ * Safely decode a percent-encoded path segment. Returns `null` when it
+ * contains malformed escapes (e.g. bare `%` or `%zz`) so that callers
+ * can fail closed — malformed segments never match anything.
  */
-function safeDecodeSegment(segment: string): string {
+function safeDecodeSegment(segment: string): string | null {
   try {
     return decodeURIComponent(segment);
   } catch {
-    return segment;
+    return null;
   }
 }
 
@@ -167,6 +167,7 @@ export function urlMatchesTemplate(
   // safeDecodeSegment is applied to both sides so that percent-encoded bytes
   // (e.g. %20, %7B) are compared consistently and so that the URL constructor's
   // encoding of curly braces ({, }) in template placeholders is reversed.
+  // A null return means a malformed escape — fail closed immediately.
   const urlSegments = parsedUrl.pathname
     .split("/")
     .filter((s) => s.length > 0)
@@ -176,11 +177,14 @@ export function urlMatchesTemplate(
     .filter((s) => s.length > 0)
     .map(safeDecodeSegment);
 
+  if (urlSegments.some((s) => s === null)) return false;
+  if (templateSegments.some((s) => s === null)) return false;
+
   if (urlSegments.length !== templateSegments.length) return false;
 
   for (let i = 0; i < templateSegments.length; i++) {
-    const tSeg = templateSegments[i];
-    const uSeg = urlSegments[i];
+    const tSeg = templateSegments[i]!;
+    const uSeg = urlSegments[i]!;
 
     if (tSeg === "{:num}") {
       if (!NUMERIC_RE.test(uSeg)) return false;


### PR DESCRIPTION
Address review feedback from #16948:\n- safeDecodeSegment now returns null on decodeURIComponent failure\n- Callers treat null as non-match, preventing malformed escapes from matching\n- Ensures fail-closed behavior for malformed percent-encoded segments
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
