### PR TITLE
fix: use hard expiry check for non-refreshable OAuth tokens

### DIFF
--- a/credential-executor/src/materializers/local.ts
+++ b/credential-executor/src/materializers/local.ts
@@ -181,15 +181,22 @@ export class LocalMaterialiser {
     }
 
     // 2. Check if the token is expired and needs refresh
-    if (isTokenExpired(connection.expiresAt)) {
-      if (connection.hasRefreshToken) {
+    if (connection.hasRefreshToken) {
+      // For refreshable tokens, use the proactive buffer so we can refresh
+      // before the token actually expires.
+      if (isTokenExpired(connection.expiresAt)) {
         return this.refreshAndMaterialise(subject, connectionId);
       }
-      return {
-        ok: false,
-        error: `Token for OAuth connection "${connectionId}" is expired and no refresh ` +
-          `token is available. Re-authorization required.`,
-      };
+    } else {
+      // For non-refreshable tokens, check against the hard expiry — use
+      // every valid second rather than the 5-minute proactive buffer.
+      if (connection.expiresAt && Date.now() >= connection.expiresAt) {
+        return {
+          ok: false,
+          error: `Token for OAuth connection "${connectionId}" is expired and no refresh ` +
+            `token is available. Re-authorization required.`,
+        };
+      }
     }
 
     // 3. Token is valid — return it


### PR DESCRIPTION
Address review feedback from #16950:
- Check actual expiresAt for non-refreshable tokens instead of isTokenExpired()
- isTokenExpired includes a 5-minute proactive buffer meant for triggering refresh
- Non-refreshable tokens should use every valid second before rejecting
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
