### PR TITLE
fix: update CES data root test to match /home/ces/.ces-data default

### DIFF
--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -351,8 +351,8 @@ describe("CES data paths", () => {
     expect(root).toMatch(/protected[/\\]credential-executor$/);
   });
 
-  test("managed mode data root is /ces-data", () => {
-    expect(getCesDataRoot("managed")).toBe("/ces-data");
+  test("managed mode data root is /home/ces/.ces-data", () => {
+    expect(getCesDataRoot("managed")).toBe("/home/ces/.ces-data");
   });
 
   test("local data root is under the Vellum root, not the workspace", () => {


### PR DESCRIPTION
## Summary
- Updated the `managed mode data root` test assertion from `/ces-data` to `/home/ces/.ces-data` to match the actual default in `paths.ts`
- The default was changed to `/home/ces/.ces-data` so the non-root `ces` user can write without extra chown/mkdir, but the test wasn't updated

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102596158/job/67105958562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
