### PR TITLE
fix: harden stopAllSessions against throwing onError callbacks

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -460,6 +460,6 @@ export function getSessionsForConversation(
  */
 export async function stopAllSessions(): Promise<void> {
   return coreStopAllSessions(store, (id, err) => {
-    log.debug({ err, id }, "session shutdown error");
+    log.warn({ err, id }, "session shutdown error");
   });
 }

--- a/packages/egress-proxy/src/session-core.ts
+++ b/packages/egress-proxy/src/session-core.ts
@@ -454,7 +454,11 @@ export async function stopAllSessions(
   await Promise.all(
     ids.map((id) =>
       stopSession(id, store).catch((err) => {
-        onError?.(id, err);
+        try {
+          onError?.(id, err);
+        } catch {
+          // swallow – never let a throwing callback break Promise.all
+        }
       }),
     ),
   );


### PR DESCRIPTION
Address review feedback from #16921:
- Wrap onError callback in try-catch to prevent store.sessions.clear() from being skipped
- Upgrade shutdown error logging from debug to warn level
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
