### PR TITLE
fix: remove dead cache field from CES persistent grant store

### DIFF
--- a/credential-executor/src/grants/persistent-store.ts
+++ b/credential-executor/src/grants/persistent-store.ts
@@ -60,7 +60,6 @@ const GRANTS_FILENAME = "grants.json";
 
 export class PersistentGrantStore {
   private readonly filePath: string;
-  private cache: PersistentGrant[] | null = null;
   /** Set to true when the store detects corruption; blocks all operations. */
   private corrupt = false;
 
@@ -209,7 +208,6 @@ export class PersistentGrantStore {
         throw new Error("CES grants file is malformed: grants is not an array");
       }
 
-      this.cache = file.grants;
       return [...file.grants];
     } catch (err) {
       if (this.corrupt) throw err;
@@ -240,7 +238,5 @@ export class PersistentGrantStore {
     // Enforce owner-only permissions even if the file already existed
     // with wider permissions.
     chmodSync(this.filePath, 0o600);
-
-    this.cache = grants;
   }
 }


### PR DESCRIPTION
Address review feedback from #16936:
- Remove write-only cache property and its two write sites
- Field became dead code after removing the cache read in #16936
- Per AGENTS.md dead code removal policy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
