### PR TITLE
fix: ensure workspace-origin check runs even when URI decoding fails

### DIFF
--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -185,15 +185,34 @@ export function publishBundle(request: PublishRequest): PublishResult {
   // -- Reject workspace-origin paths in the URL ---------------------------
   try {
     const parsedUrl = new URL(sourceUrl);
-    const decodedPathname = decodeURIComponent(parsedUrl.pathname);
-    if (isWorkspaceOriginPath(decodedPathname)) {
+    const rawPathname = parsedUrl.pathname;
+
+    // Always check the raw pathname — this must not be skipped.
+    if (isWorkspaceOriginPath(rawPathname)) {
       return {
         success: false,
         deduplicated: false,
         bundlePath: "",
-        error: `Source URL path "${decodedPathname}" appears to be a workspace-origin path. ` +
+        error: `Source URL path "${rawPathname}" appears to be a workspace-origin path. ` +
           `Workspace-origin binaries are never publishable.`,
       };
+    }
+
+    // Also check the decoded pathname for percent-encoded traversals.
+    try {
+      const decodedPathname = decodeURIComponent(rawPathname);
+      if (decodedPathname !== rawPathname && isWorkspaceOriginPath(decodedPathname)) {
+        return {
+          success: false,
+          deduplicated: false,
+          bundlePath: "",
+          error: `Source URL path "${decodedPathname}" (decoded from "${rawPathname}") appears to be a workspace-origin path. ` +
+            `Workspace-origin binaries are never publishable.`,
+        };
+      }
+    } catch {
+      // decodeURIComponent threw URIError on malformed sequences (e.g. %C0%AF).
+      // The raw pathname was already checked above, so we're safe.
     }
   } catch {
     // URL parsing already validated above


### PR DESCRIPTION
Address review feedback from #16940:
- decodeURIComponent failure no longer silently skips workspace-origin validation
- Checks raw pathname first, then decoded pathname separately
- Falls back safely when decoding throws URIError on malformed sequences (e.g., %C0%AF)
- Prevents bypass via malformed percent-encoded URLs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
