### PR TITLE
fix: lazily read CES_DATA_ROOT env var in getCesDataRoot

### DIFF
--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -351,8 +351,28 @@ describe("CES data paths", () => {
     expect(root).toMatch(/protected[/\\]credential-executor$/);
   });
 
-  test("managed mode data root is /ces-data", () => {
-    expect(getCesDataRoot("managed")).toBe("/ces-data");
+  test("managed mode data root defaults to /home/ces/.ces-data", () => {
+    const saved = process.env["CES_DATA_ROOT"];
+    delete process.env["CES_DATA_ROOT"];
+    try {
+      expect(getCesDataRoot("managed")).toBe("/home/ces/.ces-data");
+    } finally {
+      if (saved !== undefined) process.env["CES_DATA_ROOT"] = saved;
+    }
+  });
+
+  test("managed mode data root respects CES_DATA_ROOT env var", () => {
+    const saved = process.env["CES_DATA_ROOT"];
+    process.env["CES_DATA_ROOT"] = "/custom/ces-data";
+    try {
+      expect(getCesDataRoot("managed")).toBe("/custom/ces-data");
+    } finally {
+      if (saved !== undefined) {
+        process.env["CES_DATA_ROOT"] = saved;
+      } else {
+        delete process.env["CES_DATA_ROOT"];
+      }
+    }
   });
 
   test("local data root is under the Vellum root, not the workspace", () => {

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -11,9 +11,9 @@
  * - **Local**: CES private state lives under the Vellum root's `protected/`
  *   directory at `<rootDir>/protected/credential-executor/`.
  *
- * - **Managed**: CES private state lives at `/ces-data`, a dedicated volume
- *   mounted only into the CES container. The assistant container never sees
- *   this volume.
+ * - **Managed**: CES private state lives at `/home/ces/.ces-data` by default
+ *   (overridable via `CES_DATA_ROOT` env var). The assistant container never
+ *   sees this path.
  *
  * The assistant-visible data root (where workspace, embeddings, etc. live)
  * is a separate path and must never be used for CES-private writes.
@@ -52,24 +52,23 @@ function getVellumRootDir(): string {
 }
 
 /**
- * Well-known managed CES data root.
+ * Default managed CES data root.
  *
  * Defaults to `/home/ces/.ces-data` so the non-root `ces` user (uid 1001)
- * can write without extra chown/mkdir in the Dockerfile. Can be overridden
- * via `CES_DATA_ROOT` for custom volume mounts.
+ * can write without extra chown/mkdir in the Dockerfile.
  */
-const MANAGED_CES_DATA_ROOT = process.env["CES_DATA_ROOT"] ?? "/home/ces/.ces-data";
+const DEFAULT_MANAGED_CES_DATA_ROOT = "/home/ces/.ces-data";
 
 /**
  * Return the CES-private data root.
  *
  * - Local: `<vellumRoot>/protected/credential-executor/`
- * - Managed: `/ces-data`
+ * - Managed: `CES_DATA_ROOT` env var, or `/home/ces/.ces-data` by default
  */
 export function getCesDataRoot(mode?: CesMode): string {
   const resolvedMode = mode ?? getCesMode();
   if (resolvedMode === "managed") {
-    return MANAGED_CES_DATA_ROOT;
+    return process.env["CES_DATA_ROOT"] ?? DEFAULT_MANAGED_CES_DATA_ROOT;
   }
   return join(getVellumRootDir(), "protected", "credential-executor");
 }


### PR DESCRIPTION
Address review feedback from #16943:
- Move CES_DATA_ROOT env read from module scope into getCesDataRoot()
- Matches lazy-evaluation pattern of all other env reads in paths.ts
- Fixes tests that couldn't override the env var after module load
- Add test for CES_DATA_ROOT env var override in managed mode
- Update docstrings to reflect new default path

Closes #16943
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
