### PR TITLE
fix: add allow_once fallback for allow_thread HTTP grants

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -132,6 +132,11 @@ export function createRecordGrantHandler(
       deps.temporaryGrantStore.add("allow_thread", decision.proposalHash, {
         conversationId: sessionId,
       });
+      // Also add an allow_once fallback: the HTTP executor doesn't pass
+      // conversationId, so the thread-scoped grant alone is unreachable
+      // for HTTP requests. The allow_once ensures the immediate retry
+      // succeeds regardless of executor type.
+      deps.temporaryGrantStore.add("allow_once", decision.proposalHash);
     } else {
       // allow_once and always_allow both get a single-use temp grant
       // for immediate retry.


### PR DESCRIPTION
Address review feedback from #16963:
- When grant type is allow_thread, also create an allow_once grant
- HTTP executor doesn't pass conversationId, so allow_thread alone is unreachable
- The allow_once fallback ensures the immediate retry succeeds
- Thread-scoped grant is still created for command executors with conversationId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
