### PR TITLE
fix: stop proxy on containment failure and protect HOME cleanup path

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -374,6 +374,14 @@ export async function executeAuthenticatedCommand(
 
   // Containment check: entrypoint must resolve inside the bundle directory
   if (!entrypointPath.startsWith(bundleDir + "/") && entrypointPath !== bundleDir) {
+    // Stop the proxy session before returning — it may already be running
+    if (proxySessionId) {
+      try {
+        await stopSession(proxySessionId, sessionStore);
+      } catch {
+        // Best-effort proxy cleanup
+      }
+    }
     cleanupAll(scratchDir, tempFilePath);
     return {
       success: false,
@@ -383,10 +391,16 @@ export async function executeAuthenticatedCommand(
     };
   }
 
+  // Generate HOME path before buildCommandEnv so we have a known-safe value
+  // for cleanup. buildCommandEnv spreads adapterEnv which could override HOME
+  // if an auth adapter declares envVarName: "HOME".
+  const generatedHomeDir = join(tmpdir(), `ces-home-${randomUUID()}`);
+
   const commandEnv = buildCommandEnv(
     adapterEnv,
     proxyEnv,
     noNetworkEnv,
+    generatedHomeDir,
   );
 
   // -- 9. Execute the command -----------------------------------------------
@@ -448,7 +462,7 @@ export async function executeAuthenticatedCommand(
     }
   }
 
-  cleanupAll(scratchDir, tempFilePath, commandEnv["HOME"]);
+  cleanupAll(scratchDir, tempFilePath, generatedHomeDir);
 
   // -- 12. Persist audit record -----------------------------------------------
   if (deps.auditStore) {
@@ -810,11 +824,12 @@ function buildCommandEnv(
   adapterEnv: Record<string, string>,
   proxyEnv?: ProxyEnvVars,
   noNetworkEnv?: Record<string, string>,
+  homeDir?: string,
 ): Record<string, string> {
   const env: Record<string, string> = {
     // Minimal baseline environment
     PATH: process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin",
-    HOME: join(tmpdir(), `ces-home-${randomUUID()}`),
+    HOME: homeDir ?? join(tmpdir(), `ces-home-${randomUUID()}`),
     LANG: "en_US.UTF-8",
     // Inject auth adapter env vars
     ...adapterEnv,


### PR DESCRIPTION
Address review feedback from #16956:\n- Stop egress proxy session before returning on entrypoint containment failure\n- Track generated HOME dir separately from commandEnv HOME for safe cleanup\n- Prevents proxy session leaks and arbitrary path deletion via envVarName override
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
