### PR TITLE
fix: move CES lockdown forcePromptSideEffects before grantConsumed sh…

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -83,23 +83,25 @@ export class ToolExecutor {
     const tool = gateResult.tool;
 
     try {
+      // CES shell lockdown: set forcePromptSideEffects BEFORE both the
+      // grantConsumed short-circuit and the permission check. This ensures
+      // the flag is visible to all downstream consumers regardless of
+      // whether a scoped grant was consumed. Previously this was nested
+      // inside the `!grantConsumed` block, meaning untrusted host_bash
+      // calls that arrived with a consumed guardian-approval grant would
+      // skip this assignment entirely — defeating the lockdown.
+      if (
+        name === "host_bash" &&
+        isCesShellLockdownEnabled(getConfig()) &&
+        isUntrustedTrustClass(context.trustClass)
+      ) {
+        context.forcePromptSideEffects = true;
+      }
+
       // A consumed scoped grant is a complete authorization — skip the
       // interactive permission/prompt flow so non-interactive sessions
       // don't auto-deny prompt-gated tools and burn the one-time grant.
       if (!gateResult.grantConsumed) {
-        // CES shell lockdown: set forcePromptSideEffects BEFORE the
-        // permission check so the PermissionChecker sees it and promotes
-        // any "allow" trust-rule decision to "prompt". Previously this
-        // flag was set inside host-shell.ts execute(), which runs AFTER
-        // the permission check and therefore had no effect.
-        if (
-          name === "host_bash" &&
-          isCesShellLockdownEnabled(getConfig()) &&
-          isUntrustedTrustClass(context.trustClass)
-        ) {
-          context.forcePromptSideEffects = true;
-        }
-
         // Check permissions via the extracted PermissionChecker
         const permResult = await this.permissionChecker.checkPermission(
           name,


### PR DESCRIPTION
…ort-circuit

The forcePromptSideEffects assignment was nested inside the `if (!gateResult.grantConsumed)` block, but untrusted host_bash executions arrive with grantConsumed=true (from guardian approval grant consumption), causing the entire block to be skipped. This left the lockdown flag unset for the exact scenario it was meant to protect.

Move the assignment before the grantConsumed check so the flag is always set for untrusted host_bash under CES lockdown, regardless of grant state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
