### PR TITLE
fix: remove duplicate secureCommandManifest declaration in CES server

### DIFF
--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -643,31 +643,6 @@ export function createManageSecureCommandToolHandler(
       request.secureCommandManifest as unknown as import("./commands/profiles.js").SecureCommandManifest;
 
     // Publish into the immutable toolstore (includes digest verification)
-    // TODO: extract the full manifest from the downloaded bundle rather
-    // than constructing a stub here. The bundle should embed a manifest
-    // with precise argv patterns, network targets, and auth config.
-    const secureCommandManifest: import("./commands/profiles.js").SecureCommandManifest = {
-      schemaVersion: "1",
-      bundleDigest: request.sha256!,
-      bundleId: request.bundleId!,
-      version: request.version!,
-      entrypoint: `bin/${request.toolName}`,
-      commandProfiles: Object.fromEntries(
-        (request.profiles ?? []).map((p: string) => [
-          p,
-          {
-            description: `Profile "${p}" for ${request.toolName}`,
-            allowedArgvPatterns: [
-              { name: `${p}-default`, tokens: ["<subcmd>", "<args...>"] },
-            ],
-            deniedSubcommands: [],
-          } satisfies import("./commands/profiles.js").CommandProfile,
-        ]),
-      ),
-      authAdapter: { type: "env_var", envVarName: `${request.toolName.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_TOKEN` },
-      egressMode: "no_network",
-    };
-
     const publishResult = deps.publishBundle({
       bundleBytes,
       expectedDigest: request.sha256!,


### PR DESCRIPTION
## Summary
- Removed duplicate `const secureCommandManifest` declaration in `credential-executor/src/server.ts` that caused TS2451 (redeclare) and TS2339 (`request.profiles` does not exist) type errors
- The stale stub was superseded when `request.secureCommandManifest` was added to the RPC payload — the cast on line 642 is the correct path

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23102681472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
