### PR TITLE
fix: add warning log when workspace migration checkpoint file is malformed

### DIFF
--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -31,8 +31,14 @@ export function loadCheckpoints(workspaceDir: string): CheckpointFile {
     ) {
       return data as CheckpointFile;
     }
+    log.warn(
+      "Workspace migration checkpoint file has unexpected structure; treating as fresh state",
+    );
     return { applied: {} };
   } catch {
+    log.warn(
+      "Workspace migration checkpoint file is malformed; treating as fresh state",
+    );
     return { applied: {} };
   }
 }


### PR DESCRIPTION
## Summary
- Add log.warn when the checkpoint JSON is malformed (unparseable)
- Add log.warn when the checkpoint JSON has an unexpected structure (missing 'applied' key)

Part of plan: ws-migration-hardening.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
