### PR TITLE
feat: add duplicate migration ID detection and crash recovery marker

### DIFF
--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -8,7 +8,10 @@ import type { WorkspaceMigration } from "./types.js";
 const log = getLogger("workspace-migrations");
 
 export type CheckpointFile = {
-  applied: Record<string, { appliedAt: string }>;
+  applied: Record<
+    string,
+    { appliedAt: string; status?: "started" | "completed" }
+  >;
 };
 
 export function getCheckpointPath(workspaceDir: string): string {
@@ -53,7 +56,24 @@ export function runWorkspaceMigrations(
   workspaceDir: string,
   migrations: WorkspaceMigration[],
 ): void {
+  const seen = new Set<string>();
+  for (const m of migrations) {
+    if (seen.has(m.id)) {
+      throw new Error(`Duplicate workspace migration id: "${m.id}"`);
+    }
+    seen.add(m.id);
+  }
+
   const checkpoints = loadCheckpoints(workspaceDir);
+
+  for (const [id, entry] of Object.entries(checkpoints.applied)) {
+    if (entry.status === "started") {
+      log.warn(
+        `Workspace migration "${id}" was interrupted during a previous run; will re-run`,
+      );
+      delete checkpoints.applied[id];
+    }
+  }
 
   for (const migration of migrations) {
     if (checkpoints.applied[migration.id]) {
@@ -63,6 +83,13 @@ export function runWorkspaceMigrations(
     log.info(
       `Running workspace migration: ${migration.id} — ${migration.description}`,
     );
+
+    // Mark as started before execution (for crash recovery observability)
+    checkpoints.applied[migration.id] = {
+      appliedAt: new Date().toISOString(),
+      status: "started",
+    };
+    saveCheckpoints(workspaceDir, checkpoints);
 
     try {
       migration.run(workspaceDir);
@@ -74,8 +101,10 @@ export function runWorkspaceMigrations(
       throw error;
     }
 
+    // Mark as completed
     checkpoints.applied[migration.id] = {
       appliedAt: new Date().toISOString(),
+      status: "completed",
     };
     saveCheckpoints(workspaceDir, checkpoints);
   }

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -1,5 +1,6 @@
 export interface WorkspaceMigration {
-  /** Unique identifier, e.g. "001-avatar-rename". Used as the checkpoint key. */
+  /** Unique identifier, e.g. "001-avatar-rename". Used as the checkpoint key.
+   *  Must be unique across all registered migrations — the runner validates this at startup. */
   id: string;
   /** Human-readable description for logging. */
   description: string;


### PR DESCRIPTION
## Summary
- Add duplicate ID validation that throws on registration of migrations with the same id
- Add 'started'/'completed' status markers to checkpoint entries for crash recovery observability
- On startup, detect and clear 'started' entries so interrupted migrations re-run

Part of plan: ws-migration-hardening.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
