### PR TITLE
feat: make workspace migration run() signature async-compatible

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -144,7 +144,7 @@ export async function runDaemon(): Promise<void> {
     await initLogfire();
 
     ensureDataDir();
-    runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
+    await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
 
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -58,10 +58,10 @@ export function saveCheckpoints(
   renameSync(tmpPath, path);
 }
 
-export function runWorkspaceMigrations(
+export async function runWorkspaceMigrations(
   workspaceDir: string,
   migrations: WorkspaceMigration[],
-): void {
+): Promise<void> {
   const seen = new Set<string>();
   for (const m of migrations) {
     if (seen.has(m.id)) {
@@ -98,7 +98,7 @@ export function runWorkspaceMigrations(
     saveCheckpoints(workspaceDir, checkpoints);
 
     try {
-      migration.run(workspaceDir);
+      await migration.run(workspaceDir);
     } catch (error) {
       log.error(
         { migrationId: migration.id, error },

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -5,6 +5,7 @@ export interface WorkspaceMigration {
   /** Human-readable description for logging. */
   description: string;
   /** The migration function. Receives the workspace directory path.
-   *  Must be idempotent — safe to re-run if it was interrupted. */
-  run(workspaceDir: string): void;
+   *  Must be idempotent — safe to re-run if it was interrupted.
+   *  Both synchronous and asynchronous migrations are supported. */
+  run(workspaceDir: string): void | Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Change WorkspaceMigration.run() to accept void | Promise<void>
- Make runWorkspaceMigrations async with await on each migration
- Add await to lifecycle.ts call site

Part of plan: ws-migration-hardening.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
