### PR TITLE
fix: force per-invocation approval for manage_secure_command_tool

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -98,6 +98,14 @@ export class ToolExecutor {
         context.forcePromptSideEffects = true;
       }
 
+      // Secure command tool installation always requires fresh per-invocation
+      // approval — no persistent grants. This is unconditional (not gated on
+      // CES lockdown or trust class) because installing secure tools is
+      // inherently high-impact.
+      if (name === "manage_secure_command_tool") {
+        context.forcePromptSideEffects = true;
+      }
+
       // A consumed scoped grant is a complete authorization — skip the
       // interactive permission/prompt flow so non-interactive sessions
       // don't auto-deny prompt-gated tools and burn the one-time grant.


### PR DESCRIPTION
## Summary
manage_secure_command_tool must require fresh approval every invocation per the CES plan. Added it to the forcePromptSideEffects block in the tool executor, matching the host_bash pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
