### PR TITLE
fix: read CES_DATA_DIR env var matching pod template (was CES_DATA_ROOT)

### DIFF
--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -352,23 +352,46 @@ describe("CES data paths", () => {
   });
 
   test("managed mode data root defaults to /home/ces/.ces-data", () => {
-    const saved = process.env["CES_DATA_ROOT"];
+    const savedDir = process.env["CES_DATA_DIR"];
+    const savedRoot = process.env["CES_DATA_ROOT"];
+    delete process.env["CES_DATA_DIR"];
     delete process.env["CES_DATA_ROOT"];
     try {
       expect(getCesDataRoot("managed")).toBe("/home/ces/.ces-data");
     } finally {
-      if (saved !== undefined) process.env["CES_DATA_ROOT"] = saved;
+      if (savedDir !== undefined) process.env["CES_DATA_DIR"] = savedDir;
+      if (savedRoot !== undefined) process.env["CES_DATA_ROOT"] = savedRoot;
     }
   });
 
-  test("managed mode data root respects CES_DATA_ROOT env var", () => {
-    const saved = process.env["CES_DATA_ROOT"];
-    process.env["CES_DATA_ROOT"] = "/custom/ces-data";
+  test("managed mode data root respects CES_DATA_DIR env var", () => {
+    const savedDir = process.env["CES_DATA_DIR"];
+    const savedRoot = process.env["CES_DATA_ROOT"];
+    process.env["CES_DATA_DIR"] = "/custom/ces-data";
+    delete process.env["CES_DATA_ROOT"];
     try {
       expect(getCesDataRoot("managed")).toBe("/custom/ces-data");
     } finally {
-      if (saved !== undefined) {
-        process.env["CES_DATA_ROOT"] = saved;
+      if (savedDir !== undefined) {
+        process.env["CES_DATA_DIR"] = savedDir;
+      } else {
+        delete process.env["CES_DATA_DIR"];
+      }
+      if (savedRoot !== undefined) process.env["CES_DATA_ROOT"] = savedRoot;
+    }
+  });
+
+  test("managed mode data root falls back to CES_DATA_ROOT", () => {
+    const savedDir = process.env["CES_DATA_DIR"];
+    const savedRoot = process.env["CES_DATA_ROOT"];
+    delete process.env["CES_DATA_DIR"];
+    process.env["CES_DATA_ROOT"] = "/legacy/ces-data";
+    try {
+      expect(getCesDataRoot("managed")).toBe("/legacy/ces-data");
+    } finally {
+      if (savedDir !== undefined) process.env["CES_DATA_DIR"] = savedDir;
+      if (savedRoot !== undefined) {
+        process.env["CES_DATA_ROOT"] = savedRoot;
       } else {
         delete process.env["CES_DATA_ROOT"];
       }

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -12,7 +12,7 @@
  *   directory at `<rootDir>/protected/credential-executor/`.
  *
  * - **Managed**: CES private state lives at `/home/ces/.ces-data` by default
- *   (overridable via `CES_DATA_ROOT` env var). The assistant container never
+ *   (overridable via `CES_DATA_DIR` env var). The assistant container never
  *   sees this path.
  *
  * The assistant-visible data root (where workspace, embeddings, etc. live)
@@ -63,12 +63,17 @@ const DEFAULT_MANAGED_CES_DATA_ROOT = "/home/ces/.ces-data";
  * Return the CES-private data root.
  *
  * - Local: `<vellumRoot>/protected/credential-executor/`
- * - Managed: `CES_DATA_ROOT` env var, or `/home/ces/.ces-data` by default
+ * - Managed: `CES_DATA_DIR` env var (with `CES_DATA_ROOT` fallback), or
+ *   `/home/ces/.ces-data` by default
  */
 export function getCesDataRoot(mode?: CesMode): string {
   const resolvedMode = mode ?? getCesMode();
   if (resolvedMode === "managed") {
-    return process.env["CES_DATA_ROOT"] ?? DEFAULT_MANAGED_CES_DATA_ROOT;
+    return (
+      process.env["CES_DATA_DIR"] ??
+      process.env["CES_DATA_ROOT"] ??
+      DEFAULT_MANAGED_CES_DATA_ROOT
+    );
   }
   return join(getVellumRootDir(), "protected", "credential-executor");
 }


### PR DESCRIPTION
## Summary
CES reads CES_DATA_ROOT but pod template sets CES_DATA_DIR, causing managed CES to use ~/.ces-data instead of the dedicated /ces-data PVC. Updated paths.ts to prefer CES_DATA_DIR with CES_DATA_ROOT fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
