### PR TITLE
fix: gate credential-execution CLI behind ces-grant-audit feature flag

### DIFF
--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -27,6 +27,7 @@ import {
   type CesClient,
   createCesClient,
 } from "../../credential-execution/client.js";
+import { isCesGrantAuditEnabled } from "../../credential-execution/feature-gates.js";
 import { createCesProcessManager } from "../../credential-execution/process-manager.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
@@ -139,6 +140,10 @@ Examples:
     )
     .action(
       async (opts: { handle?: string; status?: string }, cmd: Command) => {
+        if (!isCesGrantAuditEnabled(getConfig())) {
+          log.info("credential-execution commands are not enabled");
+          return;
+        }
         let cleanup: (() => Promise<void>) | undefined;
         try {
           const ces = await acquireCesClient();
@@ -201,6 +206,10 @@ Examples:
     )
     .action(
       async (grantId: string, opts: { reason?: string }, cmd: Command) => {
+        if (!isCesGrantAuditEnabled(getConfig())) {
+          log.info("credential-execution commands are not enabled");
+          return;
+        }
         let cleanup: (() => Promise<void>) | undefined;
         try {
           const ces = await acquireCesClient();
@@ -272,6 +281,10 @@ Examples:
         opts: { handle?: string; grant?: string; limit: string },
         cmd: Command,
       ) => {
+        if (!isCesGrantAuditEnabled(getConfig())) {
+          log.info("credential-execution commands are not enabled");
+          return;
+        }
         let cleanup: (() => Promise<void>) | undefined;
         try {
           const ces = await acquireCesClient();

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -1,5 +1,7 @@
 import { Command } from "commander";
 
+import { getConfig } from "../config/loader.js";
+import { isCesGrantAuditEnabled } from "../credential-execution/feature-gates.js";
 import { registerHooksCommand } from "../hooks/cli.js";
 import { APP_VERSION } from "../version.js";
 import { registerAuditCommand } from "./commands/audit.js";
@@ -42,7 +44,9 @@ export function buildCliProgram(): Command {
   registerConfigCommand(program);
   registerKeysCommand(program);
   registerCredentialsCommand(program);
-  registerCredentialExecutionCommand(program);
+  if (isCesGrantAuditEnabled(getConfig())) {
+    registerCredentialExecutionCommand(program);
+  }
   registerTrustCommand(program);
   registerMemoryCommand(program);
   registerAuditCommand(program);

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -15,7 +15,6 @@ Commands:
   config                                   Manage configuration
   keys                                     Manage API keys in secure storage
   credentials [options]                    Manage credentials in the encrypted vault (API keys, tokens, passwords)
-  credential-execution [options]           Inspect and manage Credential Execution Service (CES) grants and audit records
   trust                                    Manage trust rules
   memory                                   Manage long-term memory indexing/retrieval
   audit [options]                          Show recent tool invocations


### PR DESCRIPTION
## Summary
The credential-execution CLI was always registered regardless of the ces-grant-audit feature flag. Now conditionally registered and action handlers check the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
