### PR TITLE
fix(security): validate grant scope when accepting grantId in command executor

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -607,13 +607,22 @@ function checkGrant(
   persistentStore: PersistentGrantStore,
   temporaryStore: TemporaryGrantStore,
 ): GrantCheckResult {
-  // If an explicit grantId is provided, check it directly
+  // If an explicit grantId is provided, check it directly — but verify
+  // that the grant's scope matches the current request. Without this
+  // check, an agent with a valid grant for one command/credential could
+  // reuse the grantId for a different command/credential (authorization
+  // bypass).
   if (request.grantId) {
     const grant = persistentStore.getById(request.grantId);
-    if (grant) {
+    if (
+      grant &&
+      grant.tool === "command" &&
+      grant.scope === request.credentialHandle &&
+      grantMatchesCommand(grant.pattern, manifest.bundleId, profileName)
+    ) {
       return { ok: true, grantId: grant.id };
     }
-    // Explicit grant not found — fall through to pattern matching
+    // Explicit grant not found or does not match this request — fall through to pattern matching
   }
 
   // Check persistent grants for a matching command grant


### PR DESCRIPTION
## Summary
P0 security fix: when a `grantId` is explicitly provided in the command executor's `checkGrant()` function, the lookup now validates that the grant's tool type (`command`), scope (credential handle), and pattern (bundleId/profileName) all match the current request. Previously, any valid grant ID was accepted without scope checks, allowing a potential authorization bypass where an agent could reuse a grant ID from one command/credential pair for a different one.

The HTTP executor's policy layer (`http/policy.ts`) already performed these validations correctly, so no changes were needed there.

- Closes the grantId authorization bypass in `credential-executor/src/commands/executor.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
