### PR TITLE
fix: expose workspace inputs/outputs in run_authenticated_command RPC schema

### DIFF
--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -57,6 +57,43 @@ class RunAuthenticatedCommandTool implements Tool {
             description:
               "Human-readable purpose for this command, shown in audit logs and approval prompts.",
           },
+          inputs: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                workspacePath: {
+                  type: "string",
+                  description:
+                    "Relative path within the assistant workspace to stage as a read-only input.",
+                },
+              },
+              required: ["workspacePath"],
+            },
+            description:
+              "Workspace files to stage as read-only inputs in the CES scratch directory before command execution.",
+          },
+          outputs: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                scratchPath: {
+                  type: "string",
+                  description:
+                    "Relative path within the scratch directory where the command writes output.",
+                },
+                workspacePath: {
+                  type: "string",
+                  description:
+                    "Relative path within the assistant workspace where the output is copied after execution.",
+                },
+              },
+              required: ["scratchPath", "workspacePath"],
+            },
+            description:
+              "Workspace files to copy back from the CES scratch directory after command execution.",
+          },
           grantId: {
             type: "string",
             description:
@@ -94,6 +131,10 @@ class RunAuthenticatedCommandTool implements Tool {
     const purpose = input.purpose as string;
     const envMappings = input.envMappings as Record<string, string> | undefined;
     const cwd = input.cwd as string | undefined;
+    const inputs = input.inputs as Array<{ workspacePath: string }> | undefined;
+    const outputs = input.outputs as
+      | Array<{ scratchPath: string; workspacePath: string }>
+      | undefined;
     const grantId = input.grantId as string | undefined;
 
     try {
@@ -103,6 +144,8 @@ class RunAuthenticatedCommandTool implements Tool {
         purpose,
         ...(envMappings ? { envMappings } : {}),
         ...(cwd ? { cwd } : {}),
+        ...(inputs ? { inputs } : {}),
+        ...(outputs ? { outputs } : {}),
         ...(grantId ? { grantId } : {}),
       });
 

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -421,6 +421,8 @@ export function createRunAuthenticatedCommandHandler(
       credentialHandle: request.credentialHandle,
       argv: parseResult.argv,
       workspaceDir: request.cwd ?? options.defaultWorkspaceDir,
+      inputs: request.inputs,
+      outputs: request.outputs,
       purpose: request.purpose,
       grantId: request.grantId,
     };

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -97,6 +97,25 @@ export type MakeAuthenticatedRequestResponse = z.infer<
 // run_authenticated_command
 // ---------------------------------------------------------------------------
 
+/**
+ * A file to stage from the assistant workspace into the CES scratch directory.
+ */
+const WorkspaceInputSchema = z.object({
+  /** Relative path within the assistant workspace directory. */
+  workspacePath: z.string(),
+});
+
+/**
+ * A file the command produces in the scratch directory that should be
+ * copied back to the assistant workspace after execution.
+ */
+const WorkspaceOutputSchema = z.object({
+  /** Relative path within the scratch directory where the command writes output. */
+  scratchPath: z.string(),
+  /** Relative path within the assistant workspace where the output is copied. */
+  workspacePath: z.string(),
+});
+
 export const RunAuthenticatedCommandSchema = z.object({
   /** CES credential handle to use for environment injection. */
   credentialHandle: z.string(),
@@ -106,6 +125,10 @@ export const RunAuthenticatedCommandSchema = z.object({
   envMappings: z.record(z.string(), z.string()).optional(),
   /** Optional working directory. */
   cwd: z.string().optional(),
+  /** Workspace files to stage as read-only inputs in the CES scratch directory. */
+  inputs: z.array(WorkspaceInputSchema).optional(),
+  /** Workspace files to copy back from the CES scratch directory after execution. */
+  outputs: z.array(WorkspaceOutputSchema).optional(),
   /** Human-readable purpose for audit logging. */
   purpose: z.string(),
   /** Existing grant ID to consume, if the caller holds one. */


### PR DESCRIPTION
## Summary
Adds inputs and outputs fields to RunAuthenticatedCommandSchema so the staged workspace I/O from PR 23 is reachable from the assistant tool wrapper through the CES RPC contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)