### PR TITLE
fix(security): align command grant key to credentialHandle + bundleDigest + commandProfile

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -22,7 +22,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { randomUUID, createHash } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { AuthAdapterType } from "../commands/auth-adapters.js";
 import {
@@ -44,6 +44,7 @@ import {
 } from "../toolstore/publish.js";
 import { getCesToolStoreDir, getCesDataRoot } from "../paths.js";
 import { computeDigest } from "../toolstore/integrity.js";
+import { hashProposal, type CommandGrantProposal } from "@vellumai/ces-contracts";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -198,17 +199,19 @@ function buildDeps(
 
 /**
  * Add a command grant to the persistent store.
+ *
+ * Pattern uses the canonical triple: `credentialHandle:bundleDigest:profileName`.
  */
 function addCommandGrant(
   store: PersistentGrantStore,
   credentialHandle: string,
-  bundleId: string,
+  bundleDigest: string,
   profileName: string,
 ): void {
   store.add({
     id: randomUUID(),
     tool: "command",
-    pattern: `${bundleId}/${profileName}`,
+    pattern: `${credentialHandle}:${bundleDigest}:${profileName}`,
     scope: credentialHandle,
     createdAt: Date.now(),
   });
@@ -216,18 +219,29 @@ function addCommandGrant(
 
 /**
  * Add a temporary command grant.
+ *
+ * Constructs the same CommandGrantProposal shape that the executor builds
+ * and hashes it with `hashProposal` from `@vellumai/ces-contracts` so the
+ * hashes align.
  */
 function addTemporaryCommandGrant(
   store: TemporaryGrantStore,
   credentialHandle: string,
-  bundleId: string,
+  bundleDigest: string,
   profileName: string,
   kind: "allow_once" | "allow_10m" | "allow_thread" = "allow_once",
   conversationId?: string,
+  argv: string[] = [],
+  purpose: string = "Test execution",
 ): void {
-  const parts = ["command", credentialHandle, bundleId, profileName];
-  const canonical = JSON.stringify(parts);
-  const proposalHash = createHash("sha256").update(canonical, "utf8").digest("hex");
+  const proposal: CommandGrantProposal = {
+    type: "command",
+    credentialHandle,
+    command: `${bundleDigest}/${profileName}${argv.length ? " " + argv.join(" ") : ""}`,
+    purpose,
+    allowedCommandPatterns: [`${credentialHandle}:${bundleDigest}:${profileName}`],
+  };
+  const proposalHash = hashProposal(proposal);
   store.add(kind, proposalHash, { conversationId });
 }
 
@@ -320,7 +334,7 @@ describe("executeAuthenticatedCommand — profile validation", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "nonexistent",
     );
 
@@ -347,7 +361,7 @@ describe("executeAuthenticatedCommand — profile validation", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -375,7 +389,7 @@ describe("executeAuthenticatedCommand — profile validation", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -402,7 +416,7 @@ describe("executeAuthenticatedCommand — profile validation", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -476,7 +490,7 @@ describe("executeAuthenticatedCommand — grant enforcement", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -522,8 +536,12 @@ describe("executeAuthenticatedCommand — grant enforcement", () => {
     addTemporaryCommandGrant(
       deps.temporaryStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
+      "allow_once",
+      undefined,
+      ["list", "--format", "json"],
+      "Test execution",
     );
 
     const request: ExecuteCommandRequest = {
@@ -571,7 +589,7 @@ describe("executeAuthenticatedCommand — credential materialization", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -630,7 +648,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -687,7 +705,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -742,7 +760,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -782,7 +800,7 @@ describe("executeAuthenticatedCommand — egress enforcement", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -828,7 +846,7 @@ describe("executeAuthenticatedCommand — egress enforcement", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -880,7 +898,7 @@ describe("executeAuthenticatedCommand — command execution", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -926,7 +944,7 @@ describe("executeAuthenticatedCommand — command execution", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -973,7 +991,7 @@ describe("executeAuthenticatedCommand — command execution", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1027,7 +1045,7 @@ describe("executeAuthenticatedCommand — output copyback", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1117,7 +1135,7 @@ describe("executeAuthenticatedCommand — entrypoint path containment", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1170,7 +1188,7 @@ describe("executeAuthenticatedCommand — no_network enforcement", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1230,7 +1248,7 @@ describe("executeAuthenticatedCommand — credential_process stdin", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1360,7 +1378,7 @@ describe("executeAuthenticatedCommand — integration: local static secret", () 
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1420,7 +1438,7 @@ describe("executeAuthenticatedCommand — integration: local OAuth", () => {
     addCommandGrant(
       deps.persistentStore,
       "local_oauth:integration:google/conn-123",
-      manifest.bundleId,
+      digest,
       "list",
     );
 
@@ -1478,7 +1496,7 @@ describe("executeAuthenticatedCommand — integration: managed OAuth", () => {
     addCommandGrant(
       deps.persistentStore,
       "platform_oauth:platform-conn-456",
-      manifest.bundleId,
+      digest,
       "list",
     );
 

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -38,7 +38,7 @@
  * violations all result in command rejection before or after execution.
  */
 
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { mkdirSync, writeFileSync, unlinkSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -68,7 +68,7 @@ import {
   type WorkspaceOutput,
   type CopybackResult,
 } from "./workspace.js";
-import type { AuditRecordSummary } from "@vellumai/ces-contracts";
+import { hashProposal, type AuditRecordSummary, type CommandGrantProposal } from "@vellumai/ces-contracts";
 
 import type { AuditStore } from "../audit/store.js";
 import type { PersistentGrantStore } from "../grants/persistent-store.js";
@@ -132,6 +132,7 @@ export interface ExecuteCommandResult {
   approvalRequired?: {
     credentialHandle: string;
     bundleId: string;
+    bundleDigest: string;
     profileName: string;
     command: string;
     purpose: string;
@@ -248,6 +249,7 @@ export async function executeAuthenticatedCommand(
       approvalRequired: {
         credentialHandle: request.credentialHandle,
         bundleId: manifest.bundleId,
+        bundleDigest: request.bundleDigest,
         profileName: request.profileName,
         command: `${request.bundleDigest}/${request.profileName} ${request.argv.join(" ")}`.trim(),
         purpose: request.purpose,
@@ -622,18 +624,23 @@ function checkGrant(
     if (
       grant.tool === "command" &&
       grant.scope === request.credentialHandle &&
-      grantMatchesCommand(grant.pattern, manifest.bundleId, profileName)
+      grantMatchesCommand(grant.pattern, request.credentialHandle, request.bundleDigest, profileName)
     ) {
       return { ok: true, grantId: grant.id };
     }
   }
 
-  // Check temporary grants
-  const proposalHash = computeCommandProposalHash(
-    request.credentialHandle,
-    manifest.bundleId,
-    profileName,
-  );
+  // Check temporary grants — build the same proposal shape that the
+  // approval bridge produces, then hash with the canonical algorithm
+  // from `@vellumai/ces-contracts` so the hashes align.
+  const tempProposal: CommandGrantProposal = {
+    type: "command",
+    credentialHandle: request.credentialHandle,
+    command: `${request.bundleDigest}/${profileName} ${request.argv.join(" ")}`.trim(),
+    purpose: request.purpose,
+    allowedCommandPatterns: [`${request.credentialHandle}:${request.bundleDigest}:${profileName}`],
+  };
+  const proposalHash = hashProposal(tempProposal);
   const tempKind = temporaryStore.checkAny(
     proposalHash,
     request.conversationId,
@@ -653,28 +660,17 @@ function checkGrant(
 /**
  * Check if a persistent grant pattern matches a command invocation.
  *
- * Grant patterns for commands use the format: `<bundleId>/<profileName>`.
+ * Grant patterns for commands use the format: `<credentialHandle>:<bundleDigest>:<profileName>`.
  */
 function grantMatchesCommand(
   pattern: string,
-  bundleId: string,
+  credentialHandle: string,
+  bundleDigest: string,
   profileName: string,
 ): boolean {
-  return pattern === `${bundleId}/${profileName}`;
+  return pattern === `${credentialHandle}:${bundleDigest}:${profileName}`;
 }
 
-/**
- * Compute a deterministic hash for temporary grant lookup.
- */
-function computeCommandProposalHash(
-  credentialHandle: string,
-  bundleId: string,
-  profileName: string,
-): string {
-  const parts = ["command", credentialHandle, bundleId, profileName];
-  const canonical = JSON.stringify(parts);
-  return createHash("sha256").update(canonical, "utf8").digest("hex");
-}
 
 // ---------------------------------------------------------------------------
 // Internal: Auth adapter environment construction

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -110,13 +110,16 @@ export function createRecordGrantHandler(
     // decisions create only a temporary grant — this prevents allow_once,
     // allow_10m, and allow_thread from becoming effectively permanent.
     if (grantType === "always_allow") {
+      let pattern: string;
+      if (proposal.type === "http") {
+        pattern = `${proposal.method} ${proposal.url}`;
+      } else {
+        pattern = proposal.allowedCommandPatterns?.[0] ?? proposal.command;
+      }
       const persistentGrant: PersistentGrant = {
         id: grantId,
         tool: proposal.type,
-        pattern:
-          proposal.type === "http"
-            ? `${proposal.method} ${proposal.url}`
-            : proposal.command,
+        pattern,
         scope: proposal.credentialHandle,
         createdAt: now,
       };

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -434,7 +434,7 @@ export function createRunAuthenticatedCommandHandler(
     // APPROVAL_REQUIRED response with the proposal so the approval
     // bridge can activate.
     if (!result.success && result.approvalRequired) {
-      const { credentialHandle, bundleId, profileName, command, purpose } =
+      const { credentialHandle, bundleDigest, profileName, command, purpose } =
         result.approvalRequired;
 
       const proposal: CommandGrantProposal = {
@@ -442,7 +442,7 @@ export function createRunAuthenticatedCommandHandler(
         credentialHandle,
         command,
         purpose,
-        allowedCommandPatterns: [`${bundleId}/${profileName}`],
+        allowedCommandPatterns: [`${credentialHandle}:${bundleDigest}:${profileName}`],
       };
 
       return {


### PR DESCRIPTION
## Summary
P0 fix: Command grants now key on the full credentialHandle + bundleDigest + commandProfile triple as the plan requires. Aligned proposal construction, grant storage, persistent grant matching, and temp-grant hash computation.

- **Proposal construction** (server.ts): allowedCommandPatterns now uses `credentialHandle:bundleDigest:profileName` instead of `bundleId/profileName`
- **Grant storage** (rpc-handlers.ts): Persistent command grants store the canonical triple from `allowedCommandPatterns[0]` instead of the raw `proposal.command` string
- **Grant matching** (executor.ts): Persistent grant check matches against `credentialHandle:bundleDigest:profileName` instead of `bundleId/profileName`
- **Temp-grant hash** (executor.ts): Uses `hashProposal()` from `@vellumai/ces-contracts` instead of a custom hash, ensuring temp grants minted by the approval bridge match when the executor checks them

🤖 Generated with [Claude Code](https://claude.com/claude-code)