### PR TITLE
fix: add session scoping and soft revocation to CES persistent grants

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -211,6 +211,7 @@ function addCommandGrant(
     pattern: `${bundleId}/${profileName}`,
     scope: credentialHandle,
     createdAt: Date.now(),
+    sessionId: "test-session",
   });
 }
 

--- a/credential-executor/src/__tests__/grant-store.test.ts
+++ b/credential-executor/src/__tests__/grant-store.test.ts
@@ -40,6 +40,9 @@ function makeGrant(overrides?: Partial<PersistentGrant>): PersistentGrant {
     pattern: overrides?.pattern ?? "npm install",
     scope: overrides?.scope ?? "/project",
     createdAt: overrides?.createdAt ?? Date.now(),
+    sessionId: overrides?.sessionId ?? "test-session",
+    revokedAt: overrides?.revokedAt,
+    revokedReason: overrides?.revokedReason,
   };
 }
 

--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -319,6 +319,7 @@ describe("HTTP executor: local static secrets", () => {
       pattern: "GET https://api.github.com/repos/owner/repo",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const { fetch: fetchFn, requests } = mockFetchRecorder(
@@ -358,6 +359,7 @@ describe("HTTP executor: local static secrets", () => {
       pattern: "GET https://api.github.com/user",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Simulate API echoing back the token in response
@@ -392,6 +394,7 @@ describe("HTTP executor: local static secrets", () => {
       pattern: "GET https://api.github.com/data",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = mockFetch(200, '{"ok": true}', {
@@ -456,6 +459,7 @@ describe("HTTP executor: local OAuth", () => {
       pattern: "GET https://www.googleapis.com/calendar/v3/calendars/primary/events",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const { fetch: fetchFn, requests } = mockFetchRecorder(
@@ -496,6 +500,7 @@ describe("HTTP executor: local OAuth", () => {
       pattern: "GET https://www.googleapis.com/oauth2/v1/tokeninfo",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Simulate tokeninfo endpoint echoing the token
@@ -547,6 +552,7 @@ describe("HTTP executor: platform_oauth handles", () => {
       pattern: "GET https://api.slack.com/api/conversations.list",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Mock the platform catalog response
@@ -645,6 +651,7 @@ describe("HTTP executor: platform_oauth handles", () => {
       pattern: "GET https://api.slack.com/data",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // No managedSubjectOptions or managedMaterializerOptions
@@ -777,6 +784,7 @@ describe("HTTP executor: forbidden header rejection", () => {
       pattern: "GET https://api.github.com/user",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const { fetch: fetchFn, requests } = mockFetchRecorder(200, '{"ok": true}');
@@ -808,6 +816,7 @@ describe("HTTP executor: forbidden header rejection", () => {
       pattern: "GET https://api.github.com/user",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const { fetch: fetchFn, requests } = mockFetchRecorder(200, '{"ok": true}');
@@ -838,6 +847,7 @@ describe("HTTP executor: forbidden header rejection", () => {
       pattern: "GET https://api.github.com/user",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const deps = buildDeps(fixture, []);
@@ -887,6 +897,7 @@ describe("HTTP executor: redirect denial", () => {
       pattern: "GET https://api.github.com/repos/owner/repo",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Redirect to an evil domain
@@ -925,6 +936,7 @@ describe("HTTP executor: redirect denial", () => {
       pattern: "GET https://api.github.com/repos/owner/repo/result",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Also add a grant for the original POST endpoint
@@ -934,6 +946,7 @@ describe("HTTP executor: redirect denial", () => {
       pattern: "POST https://api.github.com/repos/owner/repo/action",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // POST -> 303 redirect to a GET-only granted endpoint
@@ -990,6 +1003,7 @@ describe("HTTP executor: redirect denial", () => {
       pattern: "GET https://api.github.com/repos/owner/repo",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     // Redirect to the same domain/path that matches the grant
@@ -1056,6 +1070,7 @@ describe("HTTP executor: filtered response behaviour", () => {
       pattern: "GET https://api.example.com/protected",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = mockFetch(401, '{"error": "unauthorized"}', {
@@ -1090,6 +1105,7 @@ describe("HTTP executor: filtered response behaviour", () => {
       pattern: "GET https://api.example.com/data",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = mockFetch(200, '{"ok": true}', {
@@ -1147,6 +1163,7 @@ describe("HTTP executor: audit summary integrity", () => {
       pattern: "GET https://api.github.com/user",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = mockFetch(200, '{"login": "octocat"}');
@@ -1180,6 +1197,7 @@ describe("HTTP executor: audit summary integrity", () => {
       pattern: "GET https://api.github.com/user",
       scope: badHandle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const deps = buildDeps(fixture, []);
@@ -1261,6 +1279,7 @@ describe("HTTP executor: network error handling", () => {
       pattern: "GET https://api.example.com/data",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = asFetch(async () => {
@@ -1294,6 +1313,7 @@ describe("HTTP executor: network error handling", () => {
       pattern: "GET https://api.example.com/data",
       scope: handle,
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const fetchFn = asFetch(async () => {

--- a/credential-executor/src/__tests__/http-policy.test.ts
+++ b/credential-executor/src/__tests__/http-policy.test.ts
@@ -413,6 +413,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "GET https://api.github.com/repos/owner/repo",
       scope: "local_static:github/api_key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -437,6 +438,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "POST https://api.example.com/data",
       scope: "local_static:svc/key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -461,6 +463,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "GET https://api.example.com/users/{:num}/posts",
       scope: "local_static:svc/key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -529,6 +532,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "GET https://api.example.com/data",
       scope: "local_static:other/key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -549,6 +553,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "GET https://api.example.com/data",
       scope: "local_static:svc/key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -570,6 +575,7 @@ describe("evaluateHttpPolicy", () => {
       pattern: "GET https://api.example.com/data",
       scope: "local_static:svc/key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
 
     const request: HttpPolicyRequest = {
@@ -951,6 +957,7 @@ describe("end-to-end: policy evaluation → response filter → audit", () => {
       pattern: "GET https://api.stripe.com/v1/charges/{:num}",
       scope: "local_static:stripe/api_key",
       createdAt: Date.now(),
+      sessionId: "test-session",
     });
     const temporaryStore = new TemporaryGrantStore();
 

--- a/credential-executor/src/grants/persistent-store.ts
+++ b/credential-executor/src/grants/persistent-store.ts
@@ -43,6 +43,12 @@ export interface PersistentGrant {
   scope: string;
   /** When the grant was created (epoch ms). */
   createdAt: number;
+  /** The agent session that created this grant. */
+  sessionId: string;
+  /** When the grant was revoked (epoch ms), or undefined if active. */
+  revokedAt?: number;
+  /** Human-readable reason for revocation. */
+  revokedReason?: string;
 }
 
 /** On-disk format for the grants file. */
@@ -97,21 +103,30 @@ export class PersistentGrantStore {
   }
 
   /**
-   * Return all persisted grants.
+   * Return all persisted grants that are not revoked.
    *
    * Returns an empty array if the store has never been initialised
    * (no file on disk). Throws if the store is corrupt.
    */
   getAll(): PersistentGrant[] {
+    return this.getAllIncludingRevoked().filter((g) => g.revokedAt == null);
+  }
+
+  /**
+   * Return all persisted grants including revoked ones.
+   *
+   * Used by the listing handler to expose the full audit trail.
+   */
+  getAllIncludingRevoked(): PersistentGrant[] {
     this.assertNotCorrupt();
     if (!existsSync(this.filePath)) return [];
     return [...this.loadFromDisk()];
   }
 
   /**
-   * Look up a grant by its canonical ID.
+   * Look up a grant by its canonical ID (active grants only).
    *
-   * Returns `undefined` if not found. Throws if the store is corrupt.
+   * Returns `undefined` if not found or revoked. Throws if the store is corrupt.
    */
   getById(id: string): PersistentGrant | undefined {
     return this.getAll().find((g) => g.id === id);
@@ -136,9 +151,11 @@ export class PersistentGrantStore {
   }
 
   /**
-   * Remove a grant by its canonical ID.
+   * Remove a grant by its canonical ID (hard delete).
    *
    * Returns `true` if the grant was found and removed, `false` otherwise.
+   *
+   * Prefer `markRevoked()` for audit-preserving revocation.
    */
   remove(id: string): boolean {
     this.assertNotCorrupt();
@@ -146,6 +163,25 @@ export class PersistentGrantStore {
     const index = grants.findIndex((g) => g.id === id);
     if (index === -1) return false;
     grants.splice(index, 1);
+    this.writeToDisk(grants);
+    return true;
+  }
+
+  /**
+   * Mark a grant as revoked by its canonical ID. The grant remains
+   * on disk for audit purposes but is excluded from `getAll()` and
+   * `getById()` lookups.
+   *
+   * Returns `true` if the grant was found and marked revoked,
+   * `false` if the grant does not exist or is already revoked.
+   */
+  markRevoked(id: string, reason?: string): boolean {
+    this.assertNotCorrupt();
+    const grants = this.loadFromDisk();
+    const grant = grants.find((g) => g.id === id);
+    if (!grant || grant.revokedAt != null) return false;
+    grant.revokedAt = Date.now();
+    grant.revokedReason = reason;
     this.writeToDisk(grants);
     return true;
   }

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -36,19 +36,13 @@ import type { RpcMethodHandler } from "../server.js";
 
 /**
  * Project a CES internal PersistentGrant into the wire-format
- * PersistentGrantRecord. The internal store uses a simpler schema;
- * the wire format includes additional status/lifecycle fields.
- *
- * Since the persistent store does not track lifecycle states (expiry,
- * revocation, consumption), all persisted grants are considered "active".
+ * PersistentGrantRecord. Maps real fields from the persistent store
+ * schema into the wire contract.
  */
-function projectGrant(
-  grant: PersistentGrant,
-  sessionId: string,
-): PersistentGrantRecord {
+function projectGrant(grant: PersistentGrant): PersistentGrantRecord {
   return {
     grantId: grant.id,
-    sessionId,
+    sessionId: grant.sessionId,
     credentialHandle: grant.scope,
     proposalType:
       grant.tool === "http" || grant.tool === "command"
@@ -56,12 +50,15 @@ function projectGrant(
         : "command",
     proposalHash: grant.id,
     allowedPurposes: [grant.pattern],
-    status: "active",
+    status: grant.revokedAt != null ? "revoked" : "active",
     grantedBy: "user",
     createdAt: new Date(grant.createdAt).toISOString(),
     expiresAt: null,
     consumedAt: null,
-    revokedAt: null,
+    revokedAt:
+      grant.revokedAt != null
+        ? new Date(grant.revokedAt).toISOString()
+        : null,
   };
 }
 
@@ -119,6 +116,7 @@ export function createRecordGrantHandler(
             : proposal.command,
         scope: proposal.credentialHandle,
         createdAt: now,
+        sessionId,
       };
       deps.persistentGrantStore.add(persistentGrant);
     }
@@ -180,23 +178,23 @@ export function createRecordGrantHandler(
 
 export interface ListGrantsHandlerDeps {
   persistentGrantStore: PersistentGrantStore;
-  /** Default session ID for grants that don't track session. */
-  sessionId: string;
 }
 
 /**
  * Create an RPC handler for the `list_grants` method.
  *
- * Lists all persistent grants, optionally filtered by session ID,
- * credential handle, or status. Returns wire-format PersistentGrantRecords
- * that never include raw secret material.
+ * Lists all persistent grants (including revoked, for audit trail),
+ * optionally filtered by session ID, credential handle, or status.
+ * Returns wire-format PersistentGrantRecords that never include raw
+ * secret material.
  */
 export function createListGrantsHandler(
   deps: ListGrantsHandlerDeps,
 ): RpcMethodHandler<ListGrants, ListGrantsResponse> {
   return (request) => {
-    const allGrants = deps.persistentGrantStore.getAll();
-    const projected = allGrants.map((g) => projectGrant(g, deps.sessionId));
+    // Include revoked grants in the listing for audit visibility.
+    const allGrants = deps.persistentGrantStore.getAllIncludingRevoked();
+    const projected = allGrants.map((g) => projectGrant(g));
 
     let filtered = projected;
 
@@ -229,22 +227,24 @@ export interface RevokeGrantHandlerDeps {
 /**
  * Create an RPC handler for the `revoke_grant` method.
  *
- * Removes a grant from the persistent store by its stable ID. Returns
- * success/failure. The reason field is logged but not persisted (the
- * persistent store does not track revocation metadata).
+ * Marks a grant as revoked in the persistent store by its stable ID,
+ * preserving the record for audit trail. Returns success/failure.
  */
 export function createRevokeGrantHandler(
   deps: RevokeGrantHandlerDeps,
 ): RpcMethodHandler<RevokeGrant, RevokeGrantResponse> {
   return (request) => {
-    const removed = deps.persistentGrantStore.remove(request.grantId);
+    const revoked = deps.persistentGrantStore.markRevoked(
+      request.grantId,
+      request.reason,
+    );
 
-    if (!removed) {
+    if (!revoked) {
       return {
         success: false,
         error: {
           code: "GRANT_NOT_FOUND",
-          message: `No grant found with ID "${request.grantId}"`,
+          message: `No grant found with ID "${request.grantId}" (or already revoked)`,
         },
       };
     }

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -225,7 +225,6 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
 
   handlers[CesRpcMethod.ListGrants] = createListGrantsHandler({
     persistentGrantStore,
-    sessionId,
   }) as typeof handlers[string];
 
   handlers[CesRpcMethod.RevokeGrant] = createRevokeGrantHandler({

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -268,7 +268,6 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
 
   handlers[CesRpcMethod.ListGrants] = createListGrantsHandler({
     persistentGrantStore,
-    sessionId,
   }) as typeof handlers[string];
 
   handlers[CesRpcMethod.RevokeGrant] = createRevokeGrantHandler({


### PR DESCRIPTION
## Summary
Extends persistent grant schema with sessionId, revokedAt, revokedReason. Revocation now soft-deletes (marks revoked) instead of hard-deleting, preserving audit trail. Grant listing returns real field values instead of fabricated ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
