### PR TITLE
fix: wire egress proxy hooks for secure command execution with allowed network targets

### DIFF
--- a/credential-executor/src/commands/egress-hooks.ts
+++ b/credential-executor/src/commands/egress-hooks.ts
@@ -1,0 +1,184 @@
+/**
+ * CES egress proxy hooks.
+ *
+ * Provides a lightweight `SessionStartHooks` implementation for the
+ * credential execution service. Unlike the assistant's session-manager
+ * (which wires credential resolution, MITM interception, and policy
+ * decisions), CES only needs to enforce the manifest's
+ * `allowedNetworkTargets` allowlist. No credential injection or CA
+ * setup happens at the proxy layer — CES injects credentials through
+ * auth adapters in the command environment.
+ *
+ * The proxy server is a plain HTTP CONNECT proxy that:
+ * - Allows connections to hosts matching the session's `allowedTargets`
+ * - Blocks all other outbound connections
+ */
+
+import { request as httpRequest, createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { connect, type Socket } from "node:net";
+
+import type { ManagedSession, SessionStartHooks } from "@vellumai/egress-proxy";
+
+// ---------------------------------------------------------------------------
+// Host-pattern matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Match a hostname against a glob pattern.
+ *
+ * Supported patterns:
+ * - Exact match: `"api.github.com"` matches `"api.github.com"`
+ * - Wildcard subdomain: `"*.github.com"` matches `"api.github.com"`,
+ *   `"foo.bar.github.com"`, and also `"github.com"` (apex)
+ * - Plain `"*"` matches everything
+ */
+function matchesHostPattern(hostname: string, pattern: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern === hostname) return true;
+  if (pattern.startsWith("*.")) {
+    const suffix = pattern.slice(1); // e.g. ".github.com"
+    const apex = pattern.slice(2);   // e.g. "github.com"
+    return hostname.endsWith(suffix) || hostname === apex;
+  }
+  return false;
+}
+
+/**
+ * Check if a hostname is allowed by any of the provided patterns.
+ */
+function isHostAllowed(hostname: string, allowedTargets: string[]): boolean {
+  for (const pattern of allowedTargets) {
+    if (matchesHostPattern(hostname, pattern)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// CONNECT tunnel handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a CONNECT target of the form `host:port`.
+ */
+function parseConnectTarget(
+  url: string | undefined,
+): { host: string; port: number } | null {
+  if (!url) return null;
+  const colonIdx = url.lastIndexOf(":");
+  if (colonIdx <= 0) return null;
+  let host = url.slice(0, colonIdx);
+  const portStr = url.slice(colonIdx + 1);
+  if (!host || !portStr) return null;
+  const port = Number(portStr);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+    if (!host) return null;
+  }
+  return { host, port };
+}
+
+// ---------------------------------------------------------------------------
+// Hooks factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build `SessionStartHooks` for CES egress enforcement.
+ *
+ * The created proxy server enforces the `allowedTargets` from the
+ * session's config. If no `allowedTargets` are configured, all
+ * connections are blocked (fail-closed).
+ */
+export function buildCesEgressHooks(): SessionStartHooks {
+  return {
+    // No CA setup needed — CES does not do MITM interception
+    createServer: async (managed: ManagedSession) => {
+      const allowedTargets = managed.config.allowedTargets ?? [];
+
+      const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        // Plain HTTP proxy requests — parse the absolute URL and check the host
+        if (req.url && req.method) {
+          try {
+            const target = new URL(req.url);
+            if (!isHostAllowed(target.hostname, allowedTargets)) {
+              res.writeHead(403, { "Content-Type": "text/plain" });
+              res.end(`Blocked by CES egress policy: ${target.hostname} is not in the allowed targets list`);
+              return;
+            }
+
+            // Forward the request using the appropriate protocol
+            const doRequest = target.protocol === "https:" ? httpsRequest : httpRequest;
+            const proxyReq = doRequest(
+              req.url,
+              {
+                method: req.method,
+                headers: { ...req.headers, host: target.host },
+              },
+              (proxyRes) => {
+                res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+                proxyRes.pipe(res);
+              },
+            );
+
+            proxyReq.on("error", () => {
+              if (!res.headersSent) {
+                res.writeHead(502, { "Content-Type": "text/plain" });
+              }
+              res.end("Proxy connection error");
+            });
+
+            req.pipe(proxyReq);
+          } catch {
+            res.writeHead(400, { "Content-Type": "text/plain" });
+            res.end("Bad request");
+          }
+          return;
+        }
+
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("Bad request");
+      });
+
+      // Handle CONNECT for HTTPS tunnelling
+      server.on("connect", (req: IncomingMessage, clientSocket: Socket, head: Buffer) => {
+        const target = parseConnectTarget(req.url);
+        if (!target) {
+          clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+          clientSocket.destroy();
+          return;
+        }
+
+        if (!isHostAllowed(target.host, allowedTargets)) {
+          clientSocket.write(
+            "HTTP/1.1 403 Forbidden\r\n" +
+            "Content-Type: text/plain\r\n\r\n" +
+            `Blocked by CES egress policy: ${target.host} is not in the allowed targets list`,
+          );
+          clientSocket.destroy();
+          return;
+        }
+
+        // Tunnel to the allowed target
+        const upstream = connect(target.port, target.host, () => {
+          clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          if (head.length > 0) {
+            upstream.write(head);
+          }
+          upstream.pipe(clientSocket);
+          clientSocket.pipe(upstream);
+        });
+
+        upstream.on("error", () => {
+          clientSocket.destroy();
+        });
+
+        clientSocket.on("error", () => {
+          upstream.destroy();
+        });
+      });
+
+      return server;
+    },
+  };
+}

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -330,10 +330,15 @@ export async function executeAuthenticatedCommand(
 
     try {
       const conversationId = request.conversationId ?? `ces-cmd-${auditId}`;
+      // Carry the profile's allowedNetworkTargets into the session config
+      // so the egress proxy can enforce the allowlist.
+      const profile = manifest.commandProfiles[request.profileName];
+      const allowedTargets = profile?.allowedNetworkTargets?.map((t) => t.hostPattern);
       const session = createSession(
         sessionStore,
         conversationId,
         [request.credentialHandle],
+        { allowedTargets },
       );
       const started = await startSession(
         sessionStore,

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -54,6 +54,7 @@ import {
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
+import { buildCesEgressHooks } from "./commands/egress-hooks.js";
 
 // ---------------------------------------------------------------------------
 // Data directory bootstrap
@@ -167,6 +168,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       },
       auditStore,
       cesMode: "local",
+      egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: join(vellumRoot, "workspace"),
   });

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -50,6 +50,7 @@ import {
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
+import { buildCesEgressHooks } from "./commands/egress-hooks.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "./subjects/managed.js";
 import { materializeManagedToken, type ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 import { HandleType, parseHandle } from "@vellumai/ces-contracts";
@@ -210,6 +211,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       },
       auditStore,
       cesMode: "managed",
+      egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: "/workspace",
   });

--- a/packages/egress-proxy/src/types.ts
+++ b/packages/egress-proxy/src/types.ts
@@ -42,6 +42,13 @@ export interface ProxySessionConfig {
   idleTimeoutMs: number;
   /** Maximum concurrent sessions per conversation. */
   maxSessionsPerConversation: number;
+  /**
+   * Per-command network target allowlist (host glob patterns).
+   * When set, the proxy server MUST reject outbound connections to hosts
+   * that do not match any entry. Used by CES egress enforcement to carry
+   * manifest `allowedNetworkTargets` through to the proxy session.
+   */
+  allowedTargets?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Wires egress proxy enforcement for secure commands:
- Add allowedTargets to ProxySessionConfig
- Create CES-side egress hooks for both local and managed modes
- Pass manifest allowedNetworkTargets through to proxy session
- Commands with proxy_required no longer hard-fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
