### PR TITLE
fix: mock ces-grant-audit feature gate in admin CLI tests

### DIFF
--- a/assistant/src/__tests__/credential-execution-admin-cli.test.ts
+++ b/assistant/src/__tests__/credential-execution-admin-cli.test.ts
@@ -56,6 +56,10 @@ mock.module("../credential-execution/process-manager.js", () => ({
   }),
 }));
 
+mock.module("../credential-execution/feature-gates.js", () => ({
+  isCesGrantAuditEnabled: () => true,
+}));
+
 mock.module("../credential-execution/client.js", () => ({
   createCesClient: () => ({
     handshake: async () => ({


### PR DESCRIPTION
## Summary

- The `ces-grant-audit` feature flag defaults to `false` in the registry, causing all credential-execution CLI commands to early-return without making RPC calls
- Added `mock.module` for `feature-gates.js` so `isCesGrantAuditEnabled` always returns `true` in tests, matching the intent of the test suite
- All 17 tests now pass (were 17/17 failing)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23103118872/job/67107336467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
