### PR TITLE
fix: pass all 4 args to grantMatchesCommand in explicit grantId path

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -625,7 +625,7 @@ function checkGrant(
       grant &&
       grant.tool === "command" &&
       grant.scope === request.credentialHandle &&
-      grantMatchesCommand(grant.pattern, manifest.bundleId, profileName)
+      grantMatchesCommand(grant.pattern, request.credentialHandle, request.bundleDigest, profileName)
     ) {
       return { ok: true, grantId: grant.id };
     }


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error in `credential-executor/src/commands/executor.ts` where `grantMatchesCommand` was called with 3 arguments instead of the required 4 in the explicit `grantId` validation path
- Added missing `request.credentialHandle` and replaced `manifest.bundleId` with `request.bundleDigest` to match the function signature and the pattern used in the adjacent grant-matching loop

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23103158565/job/67107442649

🤖 Generated with [Claude Code](https://claude.com/claude-code)