### PR TITLE
fix: make CES sidecar readiness probe return 200 unconditionally for dark-launch safety

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -302,11 +302,16 @@ function startHealthServer(port: number, signal: AbortSignal): ReturnType<typeof
         );
       }
       if (url.pathname === "/readyz") {
-        const ready = rpcConnected;
+        // Always return 200 — pod readiness must not depend on whether the
+        // assistant has connected.  When the CES feature flag is off the
+        // assistant never connects, and a 503 here would block pod
+        // scheduling during dark-launch.  The sidecar can't do useful work
+        // without a connection anyway, so readiness is purely about the
+        // process being up and able to accept a future connection.
         return new Response(
-          JSON.stringify({ ready, version: CES_PROTOCOL_VERSION }),
+          JSON.stringify({ ready: true, rpcConnected, version: CES_PROTOCOL_VERSION }),
           {
-            status: ready ? 200 : 503,
+            status: 200,
             headers: { "Content-Type": "application/json" },
           },
         );


### PR DESCRIPTION
## Summary
CES /readyz was 503 until the assistant connected, making dark-launch unsafe when the feature flag is off. Now returns 200 unconditionally — pod readiness is independent of the assistant's CES feature flag state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
