### PR TITLE
fix: store templated URL pattern in persistent HTTP grants for reusable capability

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -109,7 +109,11 @@ export function createRecordGrantHandler(
     if (grantType === "always_allow") {
       let pattern: string;
       if (proposal.type === "http") {
-        pattern = `${proposal.method} ${proposal.url}`;
+        // Use the templated allowedUrlPatterns (e.g. "https://api.example.com/repos/{:uuid}/pulls")
+        // so the persistent grant covers future requests with different IDs but the same URL structure.
+        // Falls back to the exact URL only if allowedUrlPatterns is missing.
+        const urlPattern = proposal.allowedUrlPatterns?.[0] ?? proposal.url;
+        pattern = `${proposal.method} ${urlPattern}`;
       } else {
         pattern = proposal.allowedCommandPatterns?.[0] ?? proposal.command;
       }


### PR DESCRIPTION
## Summary
Persistent HTTP grants now store the templated allowedUrlPatterns from the approved proposal instead of the exact URL from the first request. This preserves the minimal reusable capability the guardian approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
