### PR TITLE
fix: propagate conversationId through CES RPC for thread-scoped grants

### DIFF
--- a/assistant/src/tools/credential-execution/make-authenticated-request.ts
+++ b/assistant/src/tools/credential-execution/make-authenticated-request.ts
@@ -110,6 +110,7 @@ class MakeAuthenticatedRequestTool implements Tool {
         ...(headers ? { headers } : {}),
         ...(body !== undefined ? { body } : {}),
         ...(grantId ? { grantId } : {}),
+        conversationId: context.conversationId,
       });
 
       if (!response.success) {

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -147,6 +147,7 @@ class RunAuthenticatedCommandTool implements Tool {
         ...(inputs ? { inputs } : {}),
         ...(outputs ? { outputs } : {}),
         ...(grantId ? { grantId } : {}),
+        conversationId: context.conversationId,
       });
 
       if (!response.success) {

--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -138,6 +138,7 @@ export async function executeAuthenticatedHttpRequest(
       headers: request.headers,
       purpose: request.purpose,
       grantId: request.grantId,
+      conversationId: request.conversationId,
     },
     deps.persistentGrantStore,
     deps.temporaryGrantStore,

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -425,6 +425,7 @@ export function createRunAuthenticatedCommandHandler(
       outputs: request.outputs,
       purpose: request.purpose,
       grantId: request.grantId,
+      conversationId: request.conversationId,
     };
 
     const result = await executeAuthenticatedCommand(

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -70,6 +70,8 @@ export const MakeAuthenticatedRequestSchema = z.object({
   purpose: z.string(),
   /** Existing grant ID to consume, if the caller holds one. */
   grantId: z.string().optional(),
+  /** Conversation ID for thread-scoped temporary grants. */
+  conversationId: z.string().optional(),
 });
 export type MakeAuthenticatedRequest = z.infer<
   typeof MakeAuthenticatedRequestSchema
@@ -133,6 +135,8 @@ export const RunAuthenticatedCommandSchema = z.object({
   purpose: z.string(),
   /** Existing grant ID to consume, if the caller holds one. */
   grantId: z.string().optional(),
+  /** Conversation ID for thread-scoped temporary grants. */
+  conversationId: z.string().optional(),
 });
 export type RunAuthenticatedCommand = z.infer<
   typeof RunAuthenticatedCommandSchema


### PR DESCRIPTION
## Summary
Adds conversationId to CES RPC schemas and propagates it from assistant tool wrappers through to the temp grant store, enabling allow_thread grants to actually scope to the conversation.

- Add optional `conversationId` field to `MakeAuthenticatedRequestSchema` and `RunAuthenticatedCommandSchema` in `ces-contracts`
- Send `context.conversationId` from both CES tool wrappers (`make-authenticated-request`, `run-authenticated-command`)
- Forward `conversationId` in server handler for `run_authenticated_command` to the command executor
- Pass `conversationId` through to HTTP policy evaluation in the HTTP executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
