### PR TITLE
fix: enforce port and protocol restrictions in CES egress proxy

### DIFF
--- a/credential-executor/src/commands/egress-hooks.ts
+++ b/credential-executor/src/commands/egress-hooks.ts
@@ -10,7 +10,7 @@
  * auth adapters in the command environment.
  *
  * The proxy server is a plain HTTP CONNECT proxy that:
- * - Allows connections to hosts matching the session's `allowedTargets`
+ * - Allows connections matching the session's `allowedTargets` (host, port, protocol)
  * - Blocks all other outbound connections
  */
 
@@ -18,7 +18,7 @@ import { request as httpRequest, createServer, type IncomingMessage, type Server
 import { request as httpsRequest } from "node:https";
 import { connect, type Socket } from "node:net";
 
-import type { ManagedSession, SessionStartHooks } from "@vellumai/egress-proxy";
+import type { AllowedTarget, ManagedSession, SessionStartHooks } from "@vellumai/egress-proxy";
 
 // ---------------------------------------------------------------------------
 // Host-pattern matching
@@ -45,11 +45,24 @@ function matchesHostPattern(hostname: string, pattern: string): boolean {
 }
 
 /**
- * Check if a hostname is allowed by any of the provided patterns.
+ * Check if a request target is allowed by any of the provided allowed targets.
+ *
+ * Validates host, port, and protocol against each allowed target entry.
+ * - Host must match the glob pattern.
+ * - If the target specifies `ports`, the request port must be in the list.
+ * - If the target specifies `protocols`, the request protocol must be in the list.
  */
-function isHostAllowed(hostname: string, allowedTargets: string[]): boolean {
-  for (const pattern of allowedTargets) {
-    if (matchesHostPattern(hostname, pattern)) return true;
+function isTargetAllowed(
+  hostname: string,
+  port: number,
+  protocol: "http" | "https",
+  allowedTargets: AllowedTarget[],
+): boolean {
+  for (const target of allowedTargets) {
+    if (!matchesHostPattern(hostname, target.host)) continue;
+    if (target.ports && target.ports.length > 0 && !target.ports.includes(port)) continue;
+    if (target.protocols && target.protocols.length > 0 && !target.protocols.includes(protocol)) continue;
+    return true;
   }
   return false;
 }
@@ -97,13 +110,17 @@ export function buildCesEgressHooks(): SessionStartHooks {
       const allowedTargets = managed.config.allowedTargets ?? [];
 
       const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-        // Plain HTTP proxy requests — parse the absolute URL and check the host
+        // Plain HTTP proxy requests — parse the absolute URL and check host/port/protocol
         if (req.url && req.method) {
           try {
             const target = new URL(req.url);
-            if (!isHostAllowed(target.hostname, allowedTargets)) {
+            const protocol = target.protocol === "https:" ? "https" : "http" as const;
+            const port = target.port
+              ? Number(target.port)
+              : protocol === "https" ? 443 : 80;
+            if (!isTargetAllowed(target.hostname, port, protocol, allowedTargets)) {
               res.writeHead(403, { "Content-Type": "text/plain" });
-              res.end(`Blocked by CES egress policy: ${target.hostname} is not in the allowed targets list`);
+              res.end(`Blocked by CES egress policy: ${target.hostname}:${port} (${protocol}) is not in the allowed targets list`);
               return;
             }
 
@@ -149,11 +166,12 @@ export function buildCesEgressHooks(): SessionStartHooks {
           return;
         }
 
-        if (!isHostAllowed(target.host, allowedTargets)) {
+        // CONNECT is used for HTTPS tunnelling — assume "https" protocol
+        if (!isTargetAllowed(target.host, target.port, "https", allowedTargets)) {
           clientSocket.write(
             "HTTP/1.1 403 Forbidden\r\n" +
             "Content-Type: text/plain\r\n\r\n" +
-            `Blocked by CES egress policy: ${target.host} is not in the allowed targets list`,
+            `Blocked by CES egress policy: ${target.host}:${target.port} (https) is not in the allowed targets list`,
           );
           clientSocket.destroy();
           return;

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -335,7 +335,11 @@ export async function executeAuthenticatedCommand(
       // Carry the profile's allowedNetworkTargets into the session config
       // so the egress proxy can enforce the allowlist.
       const profile = manifest.commandProfiles[request.profileName];
-      const allowedTargets = profile?.allowedNetworkTargets?.map((t) => t.hostPattern);
+      const allowedTargets = profile?.allowedNetworkTargets?.map((t) => ({
+        host: t.hostPattern,
+        ...(t.ports ? { ports: t.ports } : {}),
+        ...(t.protocols ? { protocols: t.protocols } : {}),
+      }));
       const session = createSession(
         sessionStore,
         conversationId,

--- a/packages/egress-proxy/src/index.ts
+++ b/packages/egress-proxy/src/index.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 export type {
+  AllowedTarget,
   CredentialInjectionTemplate,
   CredentialInjectionType,
   PolicyCallback,

--- a/packages/egress-proxy/src/types.ts
+++ b/packages/egress-proxy/src/types.ts
@@ -33,6 +33,24 @@ export interface ProxySession {
 }
 
 // ---------------------------------------------------------------------------
+// Allowed network target
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes a network target that an egress proxy session is allowed to
+ * connect to. Carries host, port, and protocol restrictions from the
+ * secure command manifest.
+ */
+export interface AllowedTarget {
+  /** Host glob pattern (e.g. "api.github.com", "*.amazonaws.com"). */
+  host: string;
+  /** Allowed port(s). When omitted or empty, any port is allowed. */
+  ports?: number[];
+  /** Allowed protocol(s) ("http" | "https"). When omitted or empty, any protocol is allowed. */
+  protocols?: Array<"http" | "https">;
+}
+
+// ---------------------------------------------------------------------------
 // Session configuration
 // ---------------------------------------------------------------------------
 
@@ -43,12 +61,16 @@ export interface ProxySessionConfig {
   /** Maximum concurrent sessions per conversation. */
   maxSessionsPerConversation: number;
   /**
-   * Per-command network target allowlist (host glob patterns).
-   * When set, the proxy server MUST reject outbound connections to hosts
+   * Per-command network target allowlist.
+   * When set, the proxy server MUST reject outbound connections to targets
    * that do not match any entry. Used by CES egress enforcement to carry
    * manifest `allowedNetworkTargets` through to the proxy session.
+   *
+   * Each entry specifies a host glob pattern and optional port/protocol
+   * restrictions. When `ports` is omitted, any port is allowed. When
+   * `protocols` is omitted, any protocol is allowed.
    */
-  allowedTargets?: string[];
+  allowedTargets?: AllowedTarget[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extends egress proxy to enforce port and protocol restrictions from secure command manifests, not just hostnames. The plan requires 'exact allowed network targets' which means host+port+protocol.

- Introduces `AllowedTarget` type in `@vellumai/egress-proxy` with `host`, `ports?`, and `protocols?` fields, replacing the flat `string[]` in `ProxySessionConfig.allowedTargets`
- Updates `executor.ts` to pass full `{host, ports, protocols}` objects from the manifest's `allowedNetworkTargets` instead of stripping to host-only patterns
- Updates `egress-hooks.ts` to validate host AND port AND protocol when checking both CONNECT tunnels and plain HTTP proxy requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
