### PR TITLE
feat(acp): add ACP message types to message protocol

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -13,6 +13,7 @@
  */
 
 // Re-export domain modules (all individual types remain importable)
+export * from "./message-types/acp.js";
 export * from "./message-types/apps.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
@@ -41,6 +42,7 @@ export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
+import type { _AcpServerMessages } from "./message-types/acp.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -192,6 +194,7 @@ export type ServerMessage =
   | _InboxServerMessages
   | _PairingServerMessages
   | _NotificationsServerMessages
+  | _AcpServerMessages
   | SubagentEvent;
 
 // === Contract schema ===

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -1,0 +1,61 @@
+// ACP (Agent Client Protocol) session lifecycle and communication types.
+
+// === Server → Client (streamed via SSE) ===
+
+export interface AcpSessionSpawned {
+  type: "acp_session_spawned";
+  acpSessionId: string;
+  agent: string;
+  parentSessionId: string;
+}
+
+export interface AcpSessionUpdate {
+  type: "acp_session_update";
+  acpSessionId: string;
+  updateType: "agent_message_chunk" | "tool_call" | "tool_call_update" | "plan";
+  content?: string;
+  toolCallId?: string;
+  toolTitle?: string;
+  toolKind?: string;
+  toolStatus?: string;
+}
+
+export interface AcpPermissionRequest {
+  type: "acp_permission_request";
+  acpSessionId: string;
+  requestId: string;
+  toolTitle: string;
+  toolKind: string;
+  rawInput?: unknown;
+  options: Array<{
+    optionId: string;
+    name: string;
+    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>;
+}
+
+export interface AcpSessionCompleted {
+  type: "acp_session_completed";
+  acpSessionId: string;
+  stopReason:
+    | "end_turn"
+    | "max_tokens"
+    | "max_turn_requests"
+    | "refusal"
+    | "cancelled";
+}
+
+export interface AcpSessionError {
+  type: "acp_session_error";
+  acpSessionId: string;
+  error: string;
+}
+
+// --- Domain-level union alias (consumed by message-protocol.ts) ---
+
+export type _AcpServerMessages =
+  | AcpSessionSpawned
+  | AcpSessionUpdate
+  | AcpPermissionRequest
+  | AcpSessionCompleted
+  | AcpSessionError;


### PR DESCRIPTION
## Summary
- Create assistant/src/daemon/message-types/acp.ts with Server→Client SSE event types
- Wire ACP server messages into the ServerMessage union in message-protocol.ts
- Types follow existing subagents.ts pattern

Part of plan: acp-client-integration.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
