### PR TITLE
feat(acp): add ACP SDK dependency and types module

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellumai/assistant",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.16.1",
         "@anthropic-ai/claude-agent-sdk": "^0.2.42",
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.40.0",
@@ -56,6 +57,8 @@
     },
   },
   "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.76", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -26,6 +26,7 @@
     "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.16.1",
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -1,0 +1,79 @@
+/**
+ * ACP (Agent Client Protocol) types for agent session management and configuration.
+ */
+
+// Import StopReason for use in AcpSessionState
+import type { StopReason } from "@agentclientprotocol/sdk";
+
+// Re-export relevant types from the ACP SDK for convenience
+export type {
+  AgentCapabilities,
+  ClientCapabilities,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionId,
+  SessionInfo,
+  SessionNotification,
+  SessionUpdate,
+  StopReason,
+  ToolCall,
+  ToolCallContent,
+  ToolCallId,
+  ToolCallStatus,
+} from "@agentclientprotocol/sdk";
+export {
+  AgentSideConnection,
+  ClientSideConnection,
+} from "@agentclientprotocol/sdk";
+
+/**
+ * Configuration for a single ACP agent process.
+ */
+export interface AcpAgentConfig {
+  command: string;
+  args: string[];
+  description?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Top-level ACP configuration.
+ */
+export interface AcpConfig {
+  enabled: boolean;
+  maxConcurrentSessions: number;
+  agents: Record<string, AcpAgentConfig>;
+}
+
+/**
+ * Runtime state of an ACP session.
+ */
+export interface AcpSessionState {
+  id: string;
+  agentId: string;
+  acpSessionId: string;
+  status: "initializing" | "running" | "completed" | "failed" | "cancelled";
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+  stopReason?: StopReason;
+}
+
+/**
+ * Classification of a tool call's operation kind.
+ */
+export type ToolCallKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";


### PR DESCRIPTION
## Summary
- Add `@agentclientprotocol/sdk` dependency to `assistant/package.json`
- Create `assistant/src/acp/types.ts` with ACP config, session state, and protocol types
- Re-export relevant SDK types for convenience

Part of plan: acp-client-integration.md (PR 1 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
