### PR TITLE
feat(acp): add ACP configuration schema to workspace config

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellumai/assistant",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.16.1",
         "@anthropic-ai/claude-agent-sdk": "^0.2.42",
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.40.0",
@@ -56,6 +57,8 @@
     },
   },
   "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.76", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -26,6 +26,7 @@
     "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.16.1",
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -1,0 +1,79 @@
+/**
+ * ACP (Agent Client Protocol) types for agent session management and configuration.
+ */
+
+// Import StopReason for use in AcpSessionState
+import type { StopReason } from "@agentclientprotocol/sdk";
+
+// Re-export relevant types from the ACP SDK for convenience
+export type {
+  AgentCapabilities,
+  ClientCapabilities,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionId,
+  SessionInfo,
+  SessionNotification,
+  SessionUpdate,
+  StopReason,
+  ToolCall,
+  ToolCallContent,
+  ToolCallId,
+  ToolCallStatus,
+} from "@agentclientprotocol/sdk";
+export {
+  AgentSideConnection,
+  ClientSideConnection,
+} from "@agentclientprotocol/sdk";
+
+/**
+ * Configuration for a single ACP agent process.
+ */
+export interface AcpAgentConfig {
+  command: string;
+  args: string[];
+  description?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Top-level ACP configuration.
+ */
+export interface AcpConfig {
+  enabled: boolean;
+  maxConcurrentSessions: number;
+  agents: Record<string, AcpAgentConfig>;
+}
+
+/**
+ * Runtime state of an ACP session.
+ */
+export interface AcpSessionState {
+  id: string;
+  agentId: string;
+  acpSessionId: string;
+  status: "initializing" | "running" | "completed" | "failed" | "cancelled";
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+  stopReason?: StopReason;
+}
+
+/**
+ * Classification of a tool call's operation kind.
+ */
+export type ToolCallKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";

--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const AcpAgentConfigSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).default([]),
+  description: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+});
+
+export const AcpConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  maxConcurrentSessions: z.number().int().positive().default(4),
+  agents: z.record(z.string(), AcpAgentConfigSchema).default({}),
+});
+
+export type AcpConfig = z.infer<typeof AcpConfigSchema>;
+export type AcpAgentConfig = z.infer<typeof AcpAgentConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { getDataDir } from "../util/platform.js";
 
 // Re-export all domain schemas
+export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
+export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
 export type {
   CallerIdentityConfig,
   CallsConfig,
@@ -164,6 +166,7 @@ export type { WorkspaceGitConfig } from "./schemas/workspace-git.js";
 export { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
 // Imports for AssistantConfigSchema composition
+import { AcpConfigSchema } from "./acp-schema.js";
 import { CallsConfigSchema } from "./schemas/calls.js";
 import {
   SlackConfigSchema,
@@ -279,6 +282,7 @@ export const AssistantConfigSchema = z
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     swarm: SwarmConfigSchema.default(SwarmConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
+    acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),
     skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),
     workspaceGit: WorkspaceGitConfigSchema.default(
       WorkspaceGitConfigSchema.parse({}),

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -13,6 +13,7 @@
  */
 
 // Re-export domain modules (all individual types remain importable)
+export * from "./message-types/acp.js";
 export * from "./message-types/apps.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
@@ -41,6 +42,7 @@ export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
+import type { _AcpServerMessages } from "./message-types/acp.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -192,6 +194,7 @@ export type ServerMessage =
   | _InboxServerMessages
   | _PairingServerMessages
   | _NotificationsServerMessages
+  | _AcpServerMessages
   | SubagentEvent;
 
 // === Contract schema ===

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -1,0 +1,61 @@
+// ACP (Agent Client Protocol) session lifecycle and communication types.
+
+// === Server → Client (streamed via SSE) ===
+
+export interface AcpSessionSpawned {
+  type: "acp_session_spawned";
+  acpSessionId: string;
+  agent: string;
+  parentSessionId: string;
+}
+
+export interface AcpSessionUpdate {
+  type: "acp_session_update";
+  acpSessionId: string;
+  updateType: "agent_message_chunk" | "tool_call" | "tool_call_update" | "plan";
+  content?: string;
+  toolCallId?: string;
+  toolTitle?: string;
+  toolKind?: string;
+  toolStatus?: string;
+}
+
+export interface AcpPermissionRequest {
+  type: "acp_permission_request";
+  acpSessionId: string;
+  requestId: string;
+  toolTitle: string;
+  toolKind: string;
+  rawInput?: unknown;
+  options: Array<{
+    optionId: string;
+    name: string;
+    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>;
+}
+
+export interface AcpSessionCompleted {
+  type: "acp_session_completed";
+  acpSessionId: string;
+  stopReason:
+    | "end_turn"
+    | "max_tokens"
+    | "max_turn_requests"
+    | "refusal"
+    | "cancelled";
+}
+
+export interface AcpSessionError {
+  type: "acp_session_error";
+  acpSessionId: string;
+  error: string;
+}
+
+// --- Domain-level union alias (consumed by message-protocol.ts) ---
+
+export type _AcpServerMessages =
+  | AcpSessionSpawned
+  | AcpSessionUpdate
+  | AcpPermissionRequest
+  | AcpSessionCompleted
+  | AcpSessionError;


### PR DESCRIPTION
## Summary
- Create assistant/src/config/acp-schema.ts with Zod schemas for ACP agent and config
- Wire AcpConfigSchema into AssistantConfigSchema in schema.ts
- Re-export types for external use

Part of plan: acp-client-integration.md (PR 2 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)