### PR TITLE
feat(acp): clean up ACP processes on daemon shutdown

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { disposeAcpSessionManager } from "../acp/index.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -470,6 +471,7 @@ export class DaemonServer {
 
   async stop(): Promise<void> {
     getSubagentManager().disposeAll();
+    disposeAcpSessionManager();
     this.evictor.stop();
     this.configWatcher.stop();
     if (this.unsubscribeContactChange) {


### PR DESCRIPTION
## Summary
- Add disposeAcpSessionManager() call to DaemonServer.stop() for clean shutdown
- Ensures ACP agent subprocesses are killed alongside subagent cleanup

Part of plan: acp-client-integration.md (PR 8 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
