### PR TITLE
feat(acp): add HTTP route handlers for ACP session lifecycle

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -95,6 +95,7 @@ import {
   TWILIO_WEBHOOK_RE,
   validateTwilioWebhook,
 } from "./middleware/twilio-validation.js";
+import { acpRouteDefinitions } from "./routes/acp-routes.js";
 import { appManagementRouteDefinitions } from "./routes/app-management-routes.js";
 import { handleServePage } from "./routes/app-routes.js";
 import { appRouteDefinitions } from "./routes/app-routes.js";
@@ -752,6 +753,7 @@ export class RuntimeHttpServer {
             }
           : undefined,
       ),
+      ...acpRouteDefinitions(),
       ...subagentRouteDefinitions(),
       ...sessionQueryRouteDefinitions({
         getModelSetContext: this.getModelSetContext,

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -1,0 +1,142 @@
+/**
+ * Route handlers for ACP (Agent Communication Protocol) session lifecycle.
+ *
+ * Exposes spawn, steer, cancel, close, sessions, and permission operations
+ * over HTTP.
+ */
+import {
+  broadcastToAllClients,
+  getAcpSessionManager,
+} from "../../acp/index.js";
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("acp-routes");
+
+export function acpRouteDefinitions(): RouteDefinition[] {
+  return [
+    // POST /v1/acp/spawn
+    {
+      endpoint: "acp/spawn",
+      method: "POST",
+      policyKey: "acp/spawn",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          agent?: string;
+          task?: string;
+          sessionId?: string;
+          cwd?: string;
+        };
+        if (!body.agent || !body.task || !body.sessionId) {
+          return httpError(
+            "BAD_REQUEST",
+            "agent, task, and sessionId are required",
+            400,
+          );
+        }
+        const config = getConfig();
+        if (!config.acp.enabled) {
+          return httpError("BAD_REQUEST", "ACP is not enabled", 400);
+        }
+        const agentConfig = config.acp.agents[body.agent];
+        if (!agentConfig) {
+          const available = Object.keys(config.acp.agents).join(", ") || "none";
+          return httpError(
+            "BAD_REQUEST",
+            `Unknown agent "${body.agent}". Available: ${available}`,
+            400,
+          );
+        }
+        const manager = getAcpSessionManager();
+        const sendToVellum =
+          broadcastToAllClients ?? ((_msg) => log.warn("No broadcast fn set"));
+        const acpSessionId = await manager.spawn(
+          body.agent,
+          agentConfig,
+          body.task,
+          body.cwd ?? process.cwd(),
+          body.sessionId,
+          sendToVellum,
+        );
+        return Response.json({ acpSessionId, agent: body.agent });
+      },
+    },
+
+    // POST /v1/acp/:id/steer
+    {
+      endpoint: "acp/:id/steer",
+      method: "POST",
+      policyKey: "acp/steer",
+      handler: async ({ req, params }) => {
+        const body = (await req.json()) as { instruction?: string };
+        if (!body.instruction) {
+          return httpError("BAD_REQUEST", "instruction is required", 400);
+        }
+        const manager = getAcpSessionManager();
+        await manager.steer(params.id, body.instruction);
+        return Response.json({ acpSessionId: params.id, steered: true });
+      },
+    },
+
+    // POST /v1/acp/:id/cancel
+    {
+      endpoint: "acp/:id/cancel",
+      method: "POST",
+      policyKey: "acp/cancel",
+      handler: async ({ params }) => {
+        const manager = getAcpSessionManager();
+        await manager.cancel(params.id);
+        return Response.json({ acpSessionId: params.id, cancelled: true });
+      },
+    },
+
+    // POST /v1/acp/:id/close
+    {
+      endpoint: "acp/:id/close",
+      method: "POST",
+      policyKey: "acp/close",
+      handler: async ({ params }) => {
+        const manager = getAcpSessionManager();
+        manager.close(params.id);
+        return Response.json({ acpSessionId: params.id, closed: true });
+      },
+    },
+
+    // GET /v1/acp/sessions
+    {
+      endpoint: "acp/sessions",
+      method: "GET",
+      policyKey: "acp",
+      handler: () => {
+        const manager = getAcpSessionManager();
+        const sessions = manager.getStatus();
+        return Response.json({ sessions });
+      },
+    },
+
+    // POST /v1/acp/permission
+    {
+      endpoint: "acp/permission",
+      method: "POST",
+      policyKey: "acp/permission",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          requestId?: string;
+          optionId?: string;
+        };
+        if (!body.requestId || !body.optionId) {
+          return httpError(
+            "BAD_REQUEST",
+            "requestId and optionId are required",
+            400,
+          );
+        }
+        const manager = getAcpSessionManager();
+        manager.resolvePermission(body.requestId, body.optionId);
+        return Response.json({ resolved: true });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Create acp-routes.ts with spawn, steer, cancel, close, sessions, and permission endpoints
- Register routes in http-server.ts alongside subagent routes
- Input validation and error handling following subagents-routes.ts pattern

Part of plan: acp-client-integration.md (PR 7 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
