### PR TITLE
fix: wire setBroadcastToAllClients in DaemonServer constructor

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { disposeAcpSessionManager } from "../acp/index.js";
+import {
+  disposeAcpSessionManager,
+  setBroadcastToAllClients,
+} from "../acp/index.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -284,6 +287,7 @@ export class DaemonServer {
     this.evictor = new SessionEvictor(this.sessions);
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
     getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
+    setBroadcastToAllClients((msg) => this.broadcast(msg));
     this.evictor.onEvict = (sessionId: string) => {
       getSubagentManager().abortAllForParent(sessionId);
     };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for acp-client-integration.md.

**Gap:** setBroadcastToAllClients never wired up
**What was expected:** ACP session events should broadcast to connected SSE clients
**What was found:** broadcastToAllClients was always null, silently dropping events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
