### PR TITLE
fix: add dedicated file watcher for character-traits.json

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -78,6 +78,7 @@ final class AvatarAppearanceManager {
     static let shared = AvatarAppearanceManager()
 
     private var fileMonitor: DispatchSourceFileSystemObject?
+    private var traitsFileMonitor: DispatchSourceFileSystemObject?
     private var identityObserver: NSObjectProtocol?
 
     /// Workspace path for custom avatar -- canonical storage location.
@@ -118,6 +119,7 @@ final class AvatarAppearanceManager {
         loadCustomAvatar()
         loadAvatarComponents()
         watchAvatarFile()
+        watchTraitsFile()
 
         // Refresh assistantName and invalidate cached fallback avatars when
         // the user renames their assistant so the initial-letter avatar
@@ -314,6 +316,10 @@ final class AvatarAppearanceManager {
         source.setEventHandler { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                if FileManager.default.fileExists(atPath: self.avatarComponentsURL.path) {
+                    self.loadAvatarComponents()
+                    self.watchTraitsFile()
+                }
                 if FileManager.default.fileExists(atPath: self.customAvatarURL.path) {
                     self.loadCustomAvatar()
                     self.watchAvatarFile()
@@ -326,6 +332,43 @@ final class AvatarAppearanceManager {
         }
 
         fileMonitor = source
+        source.resume()
+    }
+
+    /// Watch character-traits.json for external changes (e.g. assistant writes new traits).
+    private func watchTraitsFile() {
+        traitsFileMonitor?.cancel()
+        traitsFileMonitor = nil
+
+        let path = avatarComponentsURL.path
+        let fd = open(path, O_EVTONLY)
+
+        if fd < 0 {
+            // File doesn't exist yet — directory watcher will pick up creation
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            let flags = source.data
+            Task { @MainActor [weak self] in
+                self?.loadAvatarComponents()
+                if flags.contains(.delete) || flags.contains(.rename) {
+                    self?.watchTraitsFile()
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        traitsFileMonitor = source
         source.resume()
     }
 


### PR DESCRIPTION
## Summary
- Add `traitsFileMonitor` DispatchSource property to watch `character-traits.json` for write/delete/rename events
- Add `watchTraitsFile()` method mirroring the existing `watchAvatarFile()` pattern
- Call `watchTraitsFile()` in `start()` alongside `watchAvatarFile()`
- Update `watchAvatarDirectory()` handler to detect traits file creation and start dedicated watcher

Part of plan: fix-avatar-traits-watcher.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
