### PR TITLE
fix: reload character traits in reloadAvatar and directory watcher

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -209,6 +209,7 @@ final class AvatarAppearanceManager {
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
         loadCustomAvatar()
+        loadAvatarComponents()
     }
 
     func clearCustomAvatar() {
@@ -314,6 +315,7 @@ final class AvatarAppearanceManager {
         source.setEventHandler { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                self.loadAvatarComponents()
                 if FileManager.default.fileExists(atPath: self.customAvatarURL.path) {
                     self.loadCustomAvatar()
                     self.watchAvatarFile()


### PR DESCRIPTION
## Summary
- Add `loadAvatarComponents()` call to `reloadAvatar()` so daemon `avatar_updated` events also reload character traits
- Add `loadAvatarComponents()` call to `watchAvatarDirectory()` handler so directory-level changes trigger trait reload even when avatar-image.png doesn't exist

Part of plan: fix-avatar-traits-watcher.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
