### PR TITLE
fix: add directory-level fallback to watchTraitsFile when traits file missing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -345,7 +345,36 @@ final class AvatarAppearanceManager {
         let fd = open(path, O_EVTONLY)
 
         if fd < 0 {
-            // File doesn't exist yet — directory watcher will pick up creation
+            // File doesn't exist yet — fall back to watching the directory for its creation.
+            // This mirrors the watchAvatarFile() → watchAvatarDirectory() pattern.
+            // We store the directory watcher in traitsFileMonitor (not fileMonitor) to
+            // avoid clobbering the avatar file/directory watcher.
+            let dirPath = (avatarComponentsURL.path as NSString).deletingLastPathComponent
+            let dirFd = open(dirPath, O_EVTONLY)
+            guard dirFd >= 0 else { return }
+
+            let dirSource = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: dirFd,
+                eventMask: .write,
+                queue: .global(qos: .utility)
+            )
+
+            dirSource.setEventHandler { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    if FileManager.default.fileExists(atPath: self.avatarComponentsURL.path) {
+                        self.loadAvatarComponents()
+                        self.watchTraitsFile()
+                    }
+                }
+            }
+
+            dirSource.setCancelHandler {
+                close(dirFd)
+            }
+
+            traitsFileMonitor = dirSource
+            dirSource.resume()
             return
         }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-avatar-traits-watcher.md.

**Gap:** watchTraitsFile() needs directory-level fallback when traits file doesn't exist
**What was expected:** When character-traits.json doesn't exist, the traits watcher should fall back to directory watching for file creation
**What was found:** watchTraitsFile() returned early with no fallback, leaving traits creation undetected when avatar-image.png already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
