### PR TITLE
fix: load character traits when avatar PNG is deleted

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -290,6 +290,8 @@ final class AvatarAppearanceManager {
                 self?.loadCustomAvatar()
                 if flags.contains(.delete) || flags.contains(.rename) {
                     self?.watchAvatarFile()
+                    self?.loadAvatarComponents()
+                    self?.watchTraitsFile()
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-avatar-traits-watcher.md.

**Gap:** PNG delete handler doesn't load traits at transition
**What was expected:** When the avatar PNG file watcher detects deletion and transitions to directory watching, it should also load character-traits.json
**What was found:** The delete handler only called loadCustomAvatar() and watchAvatarFile(), missing the traits file entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
