### PR TITLE
fix: allow /dev/null writes in macOS sandbox profile

### DIFF
--- a/assistant/src/__tests__/terminal-sandbox.test.ts
+++ b/assistant/src/__tests__/terminal-sandbox.test.ts
@@ -205,6 +205,12 @@ describe("terminal sandbox — macOS sandbox-exec behavior", () => {
     const profileContent = writeFileSyncMock.mock.calls[0]?.[1] as string;
     expect(profileContent).toContain('bad\\"dir');
   });
+
+  test("SBPL profile allows writes to /dev/null", () => {
+    wrapCommand("git status", "/tmp/project", nativeConfig());
+    const profileContent = writeFileSyncMock.mock.calls[0]?.[1] as string;
+    expect(profileContent).toContain('(literal "/dev/null")');
+  });
 });
 
 describe("terminal sandbox — backend selection", () => {

--- a/assistant/src/tools/terminal/backends/native.ts
+++ b/assistant/src/tools/terminal/backends/native.ts
@@ -59,6 +59,7 @@ ${denyReadRules}
 
 ;; Allow write access to the working directory and its children
 (allow file-write*
+  (literal "/dev/null")
   (subpath "__WORKING_DIR__")
   (subpath "/private/tmp")
   (subpath "/tmp")


### PR DESCRIPTION
## Summary
- Add `(literal "/dev/null")` to the `file-write*` allow rule in the macOS sandbox SBPL profile, fixing git and other CLI tools that open `/dev/null` for writing
- Add test verifying the SBPL profile includes the `/dev/null` write permission

Part of plan: sandbox-devnull-write.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
