### PR TITLE
fix: escape underscores in SQL LIKE pattern for telemetry

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, notLike, or } from "drizzle-orm";
+import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 
 import { getDb } from "./db.js";
 import { messages } from "./schema.js";
@@ -26,8 +26,10 @@ export function queryUnreportedTurnEvents(
         eq(messages.role, "user"),
         // Exclude tool-result rows persisted with role "user" — these are
         // system-generated and should not count as user turns.
-        notLike(messages.content, '%"type":"tool_result"%'),
-        notLike(messages.content, '%"type":"web_search_tool_result"%'),
+        // Use ESCAPE '\' so underscores are matched literally, not as
+        // single-character wildcards.
+        sql`${messages.content} NOT LIKE '%"type":"tool\_result"%' ESCAPE '\'`,
+        sql`${messages.content} NOT LIKE '%"type":"web\_search\_tool\_result"%' ESCAPE '\'`,
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),


### PR DESCRIPTION
Codex review on #16975 noted that `_` is a single-character wildcard in SQL LIKE, so the `web_search_tool_result` and `tool_result` patterns could match unintended strings. Escapes underscores with an ESCAPE clause for exact matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
