### PR TITLE
fix: update stale /ces-data path references

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -241,7 +241,7 @@ Local deployments do not require image changes. Enabling `ces-tools` causes the 
 | ------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Process-boundary credential isolation      | Strong (separate child process)                                     | Strong (separate container)                                                          |
 | Credential value never in assistant memory | Strong                                                              | Strong                                                                               |
-| Grant persistence survives restarts        | Strong (filesystem-backed under `~/.vellum/protected/`)             | Strong (dedicated `/ces-data` volume)                                                |
+| Grant persistence survives restarts        | Strong (filesystem-backed under `~/.vellum/protected/`)             | Strong (dedicated `/home/ces/.ces-data` volume)                                      |
 | Network egress enforcement via proxy       | Moderate (relies on process env vars; host networking is available) | Strong (Calico network policy enforces sandbox egress rules)                         |
 | Secret scrubbing in HTTP responses         | Defense-in-depth only                                               | Defense-in-depth only                                                                |
 | `host_bash` restriction                    | Policy-only (trust rules can deny, but the tool exists)             | Policy-only (same; managed deployments should deny `host_bash` for untrusted agents) |
@@ -279,7 +279,7 @@ If the CES sidecar container causes pod scheduling issues or resource pressure:
 1. Disable `ces-tools` on all assistants first (prevents the assistant from attempting CES calls).
 2. Disable `ces-managed-sidecar` on all assistants.
 3. Remove the CES container and its volume mounts from the pod template in vembda.
-4. CES grant/audit data on the `/ces-data` volume is orphaned and can be cleaned up at convenience.
+4. CES grant/audit data on the `/home/ces/.ces-data` volume is orphaned and can be cleaned up at convenience.
 
 The assistant reverts to the pre-CES credential broker once `ces-tools` is disabled.
 
@@ -351,7 +351,7 @@ The `credential_process` auth adapter executes `sh -c <helperCommand>` with the 
 
 The following capabilities are intentionally deferred beyond v1:
 
-- **Cloud KMS/Vault integration for secret storage** — v1 reads secrets from filesystem (`~/.vellum/protected/` locally, `/ces-data` in managed). Moving to a dedicated secrets manager is a future enhancement.
+- **Cloud KMS/Vault integration for secret storage** — v1 reads secrets from filesystem (`~/.vellum/protected/` locally, `/home/ces/.ces-data` in managed). Moving to a dedicated secrets manager is a future enhancement.
 - **Multi-CES-instance support** — Each assistant pod runs exactly one CES sidecar. Horizontal scaling of CES within a pod is not supported.
 - **Cross-pod credential sharing** — CES grants are scoped to a single pod. There is no grant federation across pods or assistant instances.
 - **Browser automation through CES** — Browser form-fill with credential injection is deferred beyond initial rollout.

--- a/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
@@ -69,8 +69,8 @@ describe("managed env contract constants", () => {
     expect(CES_ASSISTANT_DATA_READONLY_MOUNT).toBe("/assistant-data-ro");
   });
 
-  test("CES_PRIVATE_DATA_DIR is /ces-data", () => {
-    expect(CES_PRIVATE_DATA_DIR).toBe("/ces-data");
+  test("CES_PRIVATE_DATA_DIR is /home/ces/.ces-data", () => {
+    expect(CES_PRIVATE_DATA_DIR).toBe("/home/ces/.ces-data");
   });
 });
 
@@ -119,11 +119,11 @@ describe("three-container pod contract", () => {
     expect(CES_ASSISTANT_DATA_READONLY_MOUNT).toBe("/assistant-data-ro");
   });
 
-  test("CES private data directory is a separate volume at /ces-data", () => {
+  test("CES private data directory is a separate volume at /home/ces/.ces-data", () => {
     // The stateful_template.yaml gives the CES sidecar its own PVC at
-    // /ces-data, separate from the assistant-data PVC. This ensures
+    // /home/ces/.ces-data, separate from the assistant-data PVC. This ensures
     // CES grant/audit data is isolated.
-    expect(CES_PRIVATE_DATA_DIR).toBe("/ces-data");
+    expect(CES_PRIVATE_DATA_DIR).toBe("/home/ces/.ces-data");
   });
 });
 

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -21,7 +21,7 @@
  * Managed env contract:
  * - CES_BOOTSTRAP_SOCKET  — Path to the bootstrap Unix socket (shared emptyDir)
  * - /assistant-data-ro     — Assistant data mounted read-only into the CES sidecar
- * - /ces-data              — CES private data directory (separate PVC)
+ * - /home/ces/.ces-data    — CES private data directory (separate PVC)
  * - CES_HEALTH_PORT        — Health check port exposed by the CES sidecar
  */
 
@@ -61,7 +61,7 @@ export const CES_ASSISTANT_DATA_READONLY_MOUNT = "/assistant-data-ro";
  * Private data directory for the CES sidecar (separate PVC).
  * CES stores grants, audit logs, and credential material here.
  */
-export const CES_PRIVATE_DATA_DIR = "/ces-data";
+export const CES_PRIVATE_DATA_DIR = "/home/ces/.ces-data";
 
 // ---------------------------------------------------------------------------
 // Process manager configuration


### PR DESCRIPTION
Devin review on #16986 identified stale `/ces-data` references remaining after the default changed to `/home/ces/.ces-data`. Updates the constant in process-manager, test assertions, JSDoc comments, and documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
