### PR TITLE
fix: walk to nearest existing ancestor in validateContainedPath

### DIFF
--- a/credential-executor/src/commands/workspace.ts
+++ b/credential-executor/src/commands/workspace.ts
@@ -184,15 +184,28 @@ export function validateContainedPath(
   try {
     normalizedPath = realpathSync(resolvedPath);
   } catch {
-    // Path doesn't exist yet — resolve its closest existing ancestor via
-    // realpathSync so that symlinks in parent dirs (e.g. /tmp → /private/tmp)
-    // are resolved consistently with the root directory.
-    const parent = dirname(resolvedPath);
-    const child = basename(resolvedPath);
-    try {
-      normalizedPath = join(realpathSync(parent), child);
-    } catch {
-      normalizedPath = resolve(resolvedPath);
+    // Path doesn't exist yet — walk up to the nearest existing ancestor and
+    // resolve it via realpathSync so that symlinks in parent dirs (e.g.
+    // /tmp → /private/tmp on macOS) are resolved consistently with the root
+    // directory. A single dirname call isn't enough for multi-level
+    // non-existent paths like "reports/output.json" where "reports/" also
+    // doesn't exist.
+    let current = resolvedPath;
+    let resolved = false;
+    while (!resolved) {
+      const ancestor = dirname(current);
+      const tail = current.slice(ancestor.length);
+      try {
+        normalizedPath = realpathSync(ancestor) + tail;
+        resolved = true;
+      } catch {
+        if (ancestor === current) {
+          // Reached filesystem root without finding an existing ancestor
+          normalizedPath = resolve(resolvedPath);
+          resolved = true;
+        }
+        current = ancestor;
+      }
     }
   }
 


### PR DESCRIPTION
Codex and Devin reviews on #16992 noted the realpath fallback only walked up one level. For multi-level non-existent paths, symlink resolution was skipped, causing false containment rejections on macOS (/tmp → /private/tmp). Now walks up to the nearest existing ancestor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
