### PR TITLE
fix: remove body.cancel() on locked ReadableStream

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -202,8 +202,6 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       for await (const chunk of body) {
         totalBytes += chunk.byteLength;
         if (totalBytes > MAX_BUNDLE_SIZE) {
-          // Cancel the stream to free resources
-          await body.cancel();
           throw new Error(`Bundle too large: received >${MAX_BUNDLE_SIZE} bytes (max ${MAX_BUNDLE_SIZE})`);
         }
         chunks.push(chunk);

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -245,8 +245,6 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       for await (const chunk of body) {
         totalBytes += chunk.byteLength;
         if (totalBytes > MAX_BUNDLE_SIZE) {
-          // Cancel the stream to free resources
-          await body.cancel();
           throw new Error(`Bundle too large: received >${MAX_BUNDLE_SIZE} bytes (max ${MAX_BUNDLE_SIZE})`);
         }
         chunks.push(chunk);


### PR DESCRIPTION
Codex and Devin reviews on #16994 noted that `await body.cancel()` throws TypeError when called inside a `for await...of` loop because the stream is locked. Removes the redundant cancel call — throwing inside the loop automatically triggers stream cleanup via the async iterator protocol.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
