### PR TITLE
fix: make forcePromptSideEffects effective for CES tool registration

### DIFF
--- a/assistant/src/tools/side-effects.ts
+++ b/assistant/src/tools/side-effects.ts
@@ -26,6 +26,7 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "schedule_create",
   "schedule_update",
   "schedule_delete",
+  "manage_secure_command_tool",
 ]);
 
 /**


### PR DESCRIPTION
Codex and Devin reviews on #17001 noted that `forcePromptSideEffects` doesn't affect `manage_secure_command_tool` because it's not classified as a side-effect tool. The promotion logic in `permission-checker.ts` only promotes allow→prompt when `isSideEffectTool()` returns true, and the grant consumption gate in `tool-approval-handler.ts` also checks `isSideEffectTool()`. Adding `manage_secure_command_tool` to the `SIDE_EFFECT_TOOLS` set fixes both paths.

Closes #17001 review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
