### PR TITLE
fix: remove CES_DATA_ROOT backward-compat fallback

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -44,9 +44,9 @@ function buildCredentialRefTrace(
  * - ~/.vellum/workspace/data/db/ — database files that may contain credential metadata
  * - CES bootstrap socket directory (/run/ces/ or CES_BOOTSTRAP_SOCKET_DIR) —
  *   prevents untrusted shells from connecting to the CES sidecar directly
- * - CES managed-mode data root (CES_DATA_DIR / CES_DATA_ROOT /
- *   /home/ces/.ces-data) — prevents access to CES-private state in managed
- *   deployments (local-mode is already covered by the protected/ entry)
+ * - CES managed-mode data root (CES_DATA_DIR / /home/ces/.ces-data) —
+ *   prevents access to CES-private state in managed deployments (local-mode
+ *   is already covered by the protected/ entry)
  */
 function buildCesProtectedPaths(): string[] {
   const root = getRootDir();
@@ -70,8 +70,7 @@ function buildCesProtectedPaths(): string[] {
   // CES managed-mode private data root — in managed deployments the CES
   // data lives outside the Vellum root, so it isn't covered by the
   // `protected/` entry above.
-  const cesDataDir =
-    process.env["CES_DATA_DIR"] ?? process.env["CES_DATA_ROOT"];
+  const cesDataDir = process.env["CES_DATA_DIR"];
   if (cesDataDir) {
     paths.push(cesDataDir);
   } else if (process.env["CES_MODE"] === "managed") {

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -353,22 +353,17 @@ describe("CES data paths", () => {
 
   test("managed mode data root defaults to /home/ces/.ces-data", () => {
     const savedDir = process.env["CES_DATA_DIR"];
-    const savedRoot = process.env["CES_DATA_ROOT"];
     delete process.env["CES_DATA_DIR"];
-    delete process.env["CES_DATA_ROOT"];
     try {
       expect(getCesDataRoot("managed")).toBe("/home/ces/.ces-data");
     } finally {
       if (savedDir !== undefined) process.env["CES_DATA_DIR"] = savedDir;
-      if (savedRoot !== undefined) process.env["CES_DATA_ROOT"] = savedRoot;
     }
   });
 
   test("managed mode data root respects CES_DATA_DIR env var", () => {
     const savedDir = process.env["CES_DATA_DIR"];
-    const savedRoot = process.env["CES_DATA_ROOT"];
     process.env["CES_DATA_DIR"] = "/custom/ces-data";
-    delete process.env["CES_DATA_ROOT"];
     try {
       expect(getCesDataRoot("managed")).toBe("/custom/ces-data");
     } finally {
@@ -376,24 +371,6 @@ describe("CES data paths", () => {
         process.env["CES_DATA_DIR"] = savedDir;
       } else {
         delete process.env["CES_DATA_DIR"];
-      }
-      if (savedRoot !== undefined) process.env["CES_DATA_ROOT"] = savedRoot;
-    }
-  });
-
-  test("managed mode data root falls back to CES_DATA_ROOT", () => {
-    const savedDir = process.env["CES_DATA_DIR"];
-    const savedRoot = process.env["CES_DATA_ROOT"];
-    delete process.env["CES_DATA_DIR"];
-    process.env["CES_DATA_ROOT"] = "/legacy/ces-data";
-    try {
-      expect(getCesDataRoot("managed")).toBe("/legacy/ces-data");
-    } finally {
-      if (savedDir !== undefined) process.env["CES_DATA_DIR"] = savedDir;
-      if (savedRoot !== undefined) {
-        process.env["CES_DATA_ROOT"] = savedRoot;
-      } else {
-        delete process.env["CES_DATA_ROOT"];
       }
     }
   });

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -63,15 +63,13 @@ const DEFAULT_MANAGED_CES_DATA_ROOT = "/home/ces/.ces-data";
  * Return the CES-private data root.
  *
  * - Local: `<vellumRoot>/protected/credential-executor/`
- * - Managed: `CES_DATA_DIR` env var (with `CES_DATA_ROOT` fallback), or
- *   `/home/ces/.ces-data` by default
+ * - Managed: `CES_DATA_DIR` env var, or `/home/ces/.ces-data` by default
  */
 export function getCesDataRoot(mode?: CesMode): string {
   const resolvedMode = mode ?? getCesMode();
   if (resolvedMode === "managed") {
     return (
       process.env["CES_DATA_DIR"] ??
-      process.env["CES_DATA_ROOT"] ??
       DEFAULT_MANAGED_CES_DATA_ROOT
     );
   }


### PR DESCRIPTION
Devin review on #17002 noted that the `CES_DATA_ROOT` env var fallback is backwards-compatibility code per AGENTS.md policy. Removes the fallback, keeping only the canonical `CES_DATA_DIR` env var.

Changes:
- `credential-executor/src/paths.ts`: Remove `CES_DATA_ROOT` from the fallback chain
- `credential-executor/src/__tests__/transport.test.ts`: Remove the `CES_DATA_ROOT` fallback test and clean up save/restore of the old env var from remaining tests
- `assistant/src/tools/terminal/shell.ts`: Remove `CES_DATA_ROOT` fallback from protected paths builder
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
