### PR TITLE
fix: scope allow_once fallback grant for allow_thread decisions

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -26,7 +26,7 @@ import type {
 } from "@vellumai/ces-contracts";
 
 import type { PersistentGrantStore, PersistentGrant } from "./persistent-store.js";
-import type { TemporaryGrantStore } from "./temporary-store.js";
+import { type TemporaryGrantStore, DEFAULT_ONCE_FALLBACK_TTL_MS } from "./temporary-store.js";
 import type { AuditStore } from "../audit/store.js";
 import type { RpcMethodHandler } from "../server.js";
 
@@ -140,8 +140,11 @@ export function createRecordGrantHandler(
       // Also add an allow_once fallback: the HTTP executor doesn't pass
       // conversationId, so the thread-scoped grant alone is unreachable
       // for HTTP requests. The allow_once ensures the immediate retry
-      // succeeds regardless of executor type.
-      deps.temporaryGrantStore.add("allow_once", decision.proposalHash);
+      // succeeds regardless of executor type. TTL-scoped to prevent
+      // cross-thread consumption outside the immediate retry window.
+      deps.temporaryGrantStore.add("allow_once", decision.proposalHash, {
+        durationMs: DEFAULT_ONCE_FALLBACK_TTL_MS,
+      });
     } else {
       // allow_once and always_allow both get a single-use temp grant
       // for immediate retry.

--- a/credential-executor/src/grants/temporary-store.ts
+++ b/credential-executor/src/grants/temporary-store.ts
@@ -28,12 +28,15 @@ export interface TemporaryGrant {
   conversationId?: string;
   /** When the grant was created (epoch ms). */
   createdAt: number;
-  /** When the grant expires (epoch ms). Only set for `allow_10m`. */
+  /** When the grant expires (epoch ms). Set for `allow_10m`; optionally set for `allow_once` (e.g. TTL-scoped fallback grants). */
   expiresAt?: number;
 }
 
 /** Default TTL for timed grants (10 minutes). */
 const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000;
+
+/** Default TTL for allow_once fallback grants (30 seconds). */
+export const DEFAULT_ONCE_FALLBACK_TTL_MS = 30 * 1000;
 
 // ---------------------------------------------------------------------------
 // Store implementation
@@ -102,6 +105,8 @@ export class TemporaryGrantStore {
     if (kind === "allow_10m") {
       grant.expiresAt =
         Date.now() + (options?.durationMs ?? DEFAULT_TIMED_DURATION_MS);
+    } else if (kind === "allow_once" && options?.durationMs !== undefined) {
+      grant.expiresAt = Date.now() + options.durationMs;
     }
 
     this.store.set(key, grant);
@@ -128,6 +133,11 @@ export class TemporaryGrantStore {
     if (!grant) return false;
 
     if (grant.kind === "allow_once") {
+      // Check TTL if set (e.g. fallback grants for allow_thread)
+      if (grant.expiresAt !== undefined && Date.now() >= grant.expiresAt) {
+        this.store.delete(key);
+        return false;
+      }
       // Consume on first use
       this.store.delete(key);
       return true;


### PR DESCRIPTION
Codex and Devin reviews on #16993 noted the allow_once fallback for allow_thread was globally unscoped. Adds a 30-second TTL to the fallback allow_once grant so it expires quickly after the immediate retry window, preventing cross-thread authorization while preserving the HTTP executor's ability to consume the grant on immediate retry.

Changes:
- Add TTL/expiry support for allow_once grants in TemporaryGrantStore
- Check expiry before consuming allow_once grants
- Apply 30s TTL to allow_once fallback created for allow_thread decisions
- Export DEFAULT_ONCE_FALLBACK_TTL_MS constant for the fallback TTL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
