### PR TITLE
fix: align allow_thread grant storage and lookup identifiers

### DIFF
--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -173,7 +173,13 @@ export async function bridgeCesApproval(
     signal?: AbortSignal;
   },
 ): Promise<CesApprovalBridgeResult> {
-  const { proposal, renderedProposal, proposalHash, sessionId } = approval;
+  const {
+    proposal,
+    renderedProposal,
+    proposalHash,
+    sessionId,
+    conversationId,
+  } = approval;
 
   // Non-interactive sessions have no client to respond — fail closed.
   if (options?.isInteractive === false) {
@@ -277,6 +283,7 @@ export async function bridgeCesApproval(
           grantType: cesDecision.grantType,
         },
         sessionId,
+        conversationId,
       },
     );
 

--- a/assistant/src/tools/credential-execution/make-authenticated-request.ts
+++ b/assistant/src/tools/credential-execution/make-authenticated-request.ts
@@ -140,6 +140,7 @@ class MakeAuthenticatedRequestTool implements Tool {
               proposalHash: (details.proposalHash as string) ?? "",
               renderedProposal: renderProposal(proposal),
               sessionId: context.sessionId,
+              conversationId: context.conversationId,
             };
           } else {
             log.warn(

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -177,6 +177,7 @@ class RunAuthenticatedCommandTool implements Tool {
               proposalHash: (details.proposalHash as string) ?? "",
               renderedProposal: renderProposal(proposal),
               sessionId: context.sessionId,
+              conversationId: context.conversationId,
             };
           } else {
             log.warn(

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -135,13 +135,12 @@ export function createRecordGrantHandler(
       deps.temporaryGrantStore.add("allow_10m", decision.proposalHash);
     } else if (grantType === "allow_thread") {
       deps.temporaryGrantStore.add("allow_thread", decision.proposalHash, {
-        conversationId: sessionId,
+        conversationId: request.conversationId ?? sessionId,
       });
-      // Also add an allow_once fallback: the HTTP executor doesn't pass
-      // conversationId, so the thread-scoped grant alone is unreachable
-      // for HTTP requests. The allow_once ensures the immediate retry
-      // succeeds regardless of executor type. TTL-scoped to prevent
-      // cross-thread consumption outside the immediate retry window.
+      // Also add an allow_once fallback as defense-in-depth: ensures the
+      // immediate retry succeeds even if conversationId is missing or
+      // mismatched. TTL-scoped to prevent cross-thread consumption outside
+      // the immediate retry window.
       deps.temporaryGrantStore.add("allow_once", decision.proposalHash, {
         durationMs: DEFAULT_ONCE_FALLBACK_TTL_MS,
       });

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -291,6 +291,8 @@ export const ApprovalRequiredSchema = z.object({
   renderedProposal: z.string(),
   /** The agent session requesting approval. */
   sessionId: z.string(),
+  /** The conversation/thread ID for thread-scoped grants. */
+  conversationId: z.string().optional(),
 });
 export type ApprovalRequired = z.infer<typeof ApprovalRequiredSchema>;
 
@@ -311,6 +313,8 @@ export const RecordGrantSchema = z.object({
   decision: TemporaryGrantDecisionSchema,
   /** The agent session this grant applies to. */
   sessionId: z.string(),
+  /** The conversation/thread ID for thread-scoped grants. */
+  conversationId: z.string().optional(),
 });
 export type RecordGrant = z.infer<typeof RecordGrantSchema>;
 


### PR DESCRIPTION
Devin review on #17018 noted that allow_thread grants are stored by sessionId but checked by conversationId, making thread-scoped grants unfindable. Aligns the identifiers so allow_thread grants work correctly for the HTTP executor.

## Changes

- Add conversationId to ApprovalRequiredSchema and RecordGrantSchema in ces-contracts
- Pass context.conversationId through the approval flow (make-authenticated-request, run-authenticated-command, approval-bridge)
- Use request.conversationId (falling back to sessionId) when storing allow_thread grants in the RPC handler
- Update stale comment about HTTP executor not passing conversationId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
