### PR TITLE
fix: resolve TS2454 in credential-executor validateContainedPath

### DIFF
--- a/credential-executor/src/commands/workspace.ts
+++ b/credential-executor/src/commands/workspace.ts
@@ -175,7 +175,7 @@ export function validateContainedPath(
 ): string | undefined {
   // Resolve symlinks when path exists; fall back to lexical resolve
   let normalizedRoot: string;
-  let normalizedPath: string;
+  let normalizedPath: string = resolve(resolvedPath);
   try {
     normalizedRoot = realpathSync(rootDir);
   } catch {


### PR DESCRIPTION
## Summary
- Initialize `normalizedPath` with `resolve(resolvedPath)` at declaration to satisfy TypeScript's definite assignment analysis (TS2454)
- The while loop in the outer catch block always assigns `normalizedPath`, but TypeScript's control flow analysis can't prove it — giving it the same fallback value used at the end of the ancestor walk fixes the error without changing runtime behavior

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23112508722/job/67132349601

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
