### PR TITLE
fix: address review feedback on SecureCommandManifest tool

### DIFF
--- a/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
+++ b/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
@@ -168,13 +168,46 @@ class ManageSecureCommandToolImpl implements Tool {
               authAdapter: {
                 type: "object",
                 description:
-                  "Auth adapter configuration describing how credentials are injected.",
+                  "Auth adapter configuration describing how credentials are injected. " +
+                  "Use type=env_var to set an environment variable, type=temp_file to write " +
+                  "credentials to a temporary file, or type=credential_process to run a helper command.",
                 properties: {
                   type: {
                     type: "string",
                     enum: ["env_var", "temp_file", "credential_process"],
+                    description:
+                      "Adapter type: env_var, temp_file, or credential_process.",
                   },
-                  envVarName: { type: "string" },
+                  envVarName: {
+                    type: "string",
+                    description:
+                      "Environment variable name for credential injection (required for all types).",
+                  },
+                  valuePrefix: {
+                    type: "string",
+                    description:
+                      'Optional prefix prepended to the credential value (env_var only, e.g. "Bearer ").',
+                  },
+                  fileExtension: {
+                    type: "string",
+                    description:
+                      'Optional file extension for the temp file (temp_file only, e.g. ".json").',
+                  },
+                  fileMode: {
+                    type: "number",
+                    description:
+                      "Optional file mode/permissions for the temp file (temp_file only, e.g. 0o600).",
+                  },
+                  helperCommand: {
+                    type: "string",
+                    description:
+                      "Command to run to obtain credentials (credential_process only, required for that type).",
+                  },
+                  timeoutMs: {
+                    type: "number",
+                    description:
+                      "Timeout in milliseconds for the helper command (credential_process only).",
+                  },
                 },
                 required: ["type", "envVarName"],
               },
@@ -260,10 +293,18 @@ class ManageSecureCommandToolImpl implements Tool {
       }
 
       // Reject non-HTTPS source URLs to prevent insecure downloads
-      if (sourceUrl && !sourceUrl.startsWith("https://")) {
+      try {
+        const parsed = new URL(sourceUrl!);
+        if (parsed.protocol !== "https:") {
+          return {
+            content:
+              "Error: sourceUrl must use HTTPS for secure bundle downloads.",
+            isError: true,
+          };
+        }
+      } catch {
         return {
-          content:
-            "Error: sourceUrl must use HTTPS for secure bundle downloads.",
+          content: "Error: sourceUrl is not a valid URL.",
           isError: true,
         };
       }

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -616,12 +616,23 @@ export function createManageSecureCommandToolHandler(
 
     // Validate HTTPS before downloading — CES is the security boundary
     // and must not rely on the caller for URL scheme validation.
-    if (!request.sourceUrl!.startsWith("https://")) {
+    try {
+      const parsed = new URL(request.sourceUrl!);
+      if (parsed.protocol !== "https:") {
+        return {
+          success: false,
+          error: {
+            code: "INVALID_SOURCE_URL",
+            message: "sourceUrl must use HTTPS for secure bundle downloads.",
+          },
+        };
+      }
+    } catch {
       return {
         success: false,
         error: {
           code: "INVALID_SOURCE_URL",
-          message: "sourceUrl must use HTTPS for secure bundle downloads.",
+          message: "sourceUrl is not a valid URL.",
         },
       };
     }


### PR DESCRIPTION
Addresses Codex and Devin feedback on #16961: uses URL parsing for HTTPS validation instead of case-sensitive startsWith, and completes the authAdapter schema with all adapter variants (valuePrefix for env_var, fileExtension/fileMode for temp_file, helperCommand/timeoutMs for credential_process).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
