### PR TITLE
fix: sanitize audit target and fix sessionId in command executor

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -166,6 +166,8 @@ export interface CommandExecutorDeps {
   materializeCredential: MaterializeCredentialFn;
   /** Audit store for persisting token-free audit records. */
   auditStore?: AuditStore;
+  /** Session ID for audit records. */
+  sessionId?: string;
   /** CES operating mode (for toolstore path resolution). */
   cesMode?: CesMode;
   /** Egress proxy session start hooks (for creating the proxy server). */
@@ -482,8 +484,8 @@ export async function executeAuthenticatedCommand(
       grantId: grantResult.grantId ?? "unknown",
       credentialHandle: request.credentialHandle,
       toolName: "command",
-      target: `${request.bundleDigest}/${request.profileName} ${request.argv.join(" ")}`.trim(),
-      sessionId: request.sessionId ?? "unknown",
+      target: `${request.bundleDigest}/${request.profileName}`,
+      sessionId: deps.sessionId ?? "unknown",
       success: execResult.success,
       ...(execResult.error ? { errorMessage: execResult.error } : {}),
       timestamp: new Date().toISOString(),

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -167,6 +167,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         };
       },
       auditStore,
+      sessionId,
       cesMode: "local",
       egressHooks: buildCesEgressHooks(),
     },

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -210,6 +210,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         };
       },
       auditStore,
+      sessionId,
       cesMode: "managed",
       egressHooks: buildCesEgressHooks(),
     },


### PR DESCRIPTION
Codex and Devin reviews on #16964 noted two issues:

1. **Audit target leaking secrets** — raw `argv` was persisted in the audit record `target` field, which can leak tokens, passwords, or sensitive IDs into `audit.jsonl`. Now persists only the sanitized `bundleDigest/profileName` summary.

2. **sessionId always "unknown"** — `request.sessionId` is never populated by the RPC handler in `server.ts`, so every command audit record had `sessionId: "unknown"`. Now sources sessionId from `deps` (matching the HTTP executor pattern) and passes it through in both local and managed main entry points.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
