### PR TITLE
fix: enforce cleanConfigDirs by creating empty dirs under temp HOME

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -407,6 +407,10 @@ export async function executeAuthenticatedCommand(
   // if an auth adapter declares envVarName: "HOME".
   const generatedHomeDir = join(tmpdir(), `ces-home-${randomUUID()}`);
 
+  // Create the HOME directory and enforce cleanConfigDirs before building env
+  mkdirSync(generatedHomeDir, { recursive: true });
+  enforceCleanConfigDirs(manifest, generatedHomeDir);
+
   const commandEnv = buildCommandEnv(
     adapterEnv,
     proxyEnv,
@@ -872,6 +876,42 @@ function buildCommandEnv(
   }
 
   return env;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Clean config dirs enforcement
+// ---------------------------------------------------------------------------
+
+/**
+ * Enforce the manifest's `cleanConfigDirs` contract by creating empty
+ * directories under the temp HOME directory.
+ *
+ * For each entry in `cleanConfigDirs`:
+ * - `~/`-prefixed paths are resolved relative to the temp HOME dir and
+ *   created as empty directories. This ensures the command finds an empty
+ *   config directory instead of reading host config that might contain secrets.
+ * - Absolute paths (not `~/`-prefixed) are skipped for v1 — they would
+ *   require filesystem-level isolation (bind mounts, overlayfs).
+ */
+function enforceCleanConfigDirs(
+  manifest: SecureCommandManifest,
+  homeDir: string,
+): void {
+  const dirs = manifest.cleanConfigDirs;
+  if (!dirs) return;
+
+  for (const dirPath of Object.keys(dirs)) {
+    // Only handle ~/‑prefixed paths for v1
+    if (dirPath.startsWith("~/")) {
+      const relativePath = dirPath.slice(2); // strip "~/"
+      const resolvedPath = join(homeDir, relativePath);
+      mkdirSync(resolvedPath, { recursive: true });
+    } else if (dirPath === "~") {
+      // "~" alone is just the home dir itself, already created
+      continue;
+    }
+    // Absolute paths are skipped — would require filesystem-level isolation
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements the cleanConfigDirs manifest field that was previously a no-op.
For each ~/‑prefixed path in cleanConfigDirs, creates an empty directory
under the temp HOME so the command binary finds an empty config directory
instead of potentially reading host config with secrets.

Absolute paths are skipped for v1 (would require filesystem-level isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
