### PR TITLE
fix: thread handshake sessionId into command audit records

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -172,6 +172,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: join(vellumRoot, "workspace"),
+    sessionId,
   });
 
   // Register manage_secure_command_tool handler

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -215,6 +215,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: "/workspace",
+    sessionId,
   });
 
   // Register manage_secure_command_tool handler

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -387,6 +387,12 @@ export interface RunAuthenticatedCommandHandlerOptions {
    * Typically the assistant's workspace root.
    */
   defaultWorkspaceDir: string;
+  /**
+   * Session ID to attach to audit records. In local mode this is a
+   * static string generated at startup; in managed mode it comes from
+   * the RPC handshake.
+   */
+  sessionId?: string;
 }
 
 /**
@@ -426,6 +432,7 @@ export function createRunAuthenticatedCommandHandler(
       purpose: request.purpose,
       grantId: request.grantId,
       conversationId: request.conversationId,
+      sessionId: options.sessionId,
     };
 
     const result = await executeAuthenticatedCommand(


### PR DESCRIPTION
## Summary
Command audit records were always written with sessionId "unknown" because
the RPC handler never forwarded the handshake session ID to the command
executor. Now the session ID from the handshake is threaded through the
handler options so audit records correctly identify the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
