### PR TITLE
feat: auto-render avatar-image.png when character traits are loaded

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -261,6 +261,28 @@ final class AvatarAppearanceManager {
         characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
         characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
         characterColor = AvatarColor(rawValue: components.color)
+        renderAndSaveCharacterPNG()
+    }
+
+    /// Renders the current character traits to a static PNG and saves it to
+    /// avatar-image.png. This ensures a static representation always exists
+    /// alongside the traits file — used by the dock icon, chat avatar image,
+    /// and other clients (iOS, Telegram) that don't have the animated renderer.
+    private func renderAndSaveCharacterPNG() {
+        guard let body = characterBodyShape,
+              let eyes = characterEyeStyle,
+              let color = characterColor else { return }
+        let rendered = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
+        let url = customAvatarURL
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        guard let tiffData = rendered.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
+        try? pngData.write(to: url)
+        cachedChatAvatar = nil
+        customAvatarImage = rendered
+        updateDockIcon()
     }
 
     // MARK: - File Watching


### PR DESCRIPTION
## Summary
- Add `renderAndSaveCharacterPNG()` method that uses `AvatarCompositor.render()` to generate a 512x512 static PNG from character traits
- Call it at the end of `loadAvatarComponents()` so that whenever traits are loaded (at startup, from file watcher, or daemon event), a matching PNG is automatically written to `avatar-image.png`
- Sets `customAvatarImage` and updates the dock icon so all static avatar contexts reflect the character

Part of plan: avatar-png-from-traits.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
