### PR TITLE
fix: align grant scope validation with stored grant format

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -684,7 +684,14 @@ function checkGrant(
 /**
  * Check if a persistent grant pattern matches a command invocation.
  *
- * Grant patterns for commands use the format: `<credentialHandle>:<bundleDigest>:<profileName>`.
+ * Grant patterns for commands can be stored in two formats:
+ * 1. Canonical: `<credentialHandle>:<bundleDigest>:<profileName>` (from allowedCommandPatterns)
+ * 2. Legacy:    `<bundleDigest>/<profileName> <argv...>` (from proposal.command fallback)
+ *
+ * The legacy format exists because older grants were persisted using
+ * `proposal.command` before `allowedCommandPatterns` was introduced.
+ * Credential scope is already verified by the caller (`grant.scope === credentialHandle`),
+ * so for legacy patterns we only need to confirm the bundleDigest/profileName match.
  */
 function grantMatchesCommand(
   pattern: string,
@@ -692,7 +699,19 @@ function grantMatchesCommand(
   bundleDigest: string,
   profileName: string,
 ): boolean {
-  return pattern === `${credentialHandle}:${bundleDigest}:${profileName}`;
+  // Canonical format: <credentialHandle>:<bundleDigest>:<profileName>
+  if (pattern === `${credentialHandle}:${bundleDigest}:${profileName}`) {
+    return true;
+  }
+
+  // Legacy format: <bundleDigest>/<profileName> <argv...>
+  // The pattern starts with "<bundleDigest>/<profileName>" followed by a space or end-of-string.
+  const legacyPrefix = `${bundleDigest}/${profileName}`;
+  if (pattern === legacyPrefix || pattern.startsWith(`${legacyPrefix} `)) {
+    return true;
+  }
+
+  return false;
 }
 
 


### PR DESCRIPTION
Codex review on #17005 noted that grantMatchesCommand rejects grants from the approval pipeline because the stored pattern format differs from what the matcher expects. Aligns the formats by supporting both the canonical format (credentialHandle:bundleDigest:profileName) and the legacy command format (bundleDigest/profileName argv) that record_grant may persist when allowedCommandPatterns is absent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
