### PR TITLE
fix: validate cwd for workspace staging and surface copyback errors

### DIFF
--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -198,6 +198,27 @@ class RunAuthenticatedCommandTool implements Tool {
         };
       }
 
+      // Surface copyback errors — CES may report success (command exited
+      // normally) but populate response.error with copyback failures.
+      if (response.error) {
+        const copybackMsg = response.error.message ?? "Output copyback failed";
+        log.warn(
+          { credentialHandle, command, error: copybackMsg },
+          "CES command succeeded but reported copyback error",
+        );
+
+        const parts: string[] = [];
+        if (response.stdout) {
+          parts.push(response.stdout);
+        }
+        parts.push(`Warning: ${copybackMsg}`);
+
+        return {
+          content: parts.join("\n\n"),
+          isError: true,
+        };
+      }
+
       // Build a human-readable result
       const parts: string[] = [];
       if (response.exitCode !== undefined) {

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -34,11 +34,15 @@ import {
   TransportMessageSchema,
 } from "@vellumai/ces-contracts";
 
+import { resolve } from "node:path";
+
 import {
   executeAuthenticatedCommand,
   type CommandExecutorDeps,
   type ExecuteCommandRequest,
 } from "./commands/executor.js";
+
+import { validateContainedPath } from "./commands/workspace.js";
 
 import {
   executeAuthenticatedHttpRequest,
@@ -415,12 +419,41 @@ export function createRunAuthenticatedCommandHandler(
       };
     }
 
+    // Validate cwd when inputs or outputs are present — the workspace
+    // staging/copyback pipeline resolves paths relative to workspaceDir,
+    // so an unvalidated cwd could let a caller read/write outside the
+    // assistant workspace.
+    const workspaceDir = request.cwd ?? options.defaultWorkspaceDir;
+    const hasWorkspaceIO =
+      (request.inputs && request.inputs.length > 0) ||
+      (request.outputs && request.outputs.length > 0);
+
+    if (hasWorkspaceIO && request.cwd) {
+      const resolvedCwd = resolve(request.cwd);
+      const cwdError = validateContainedPath(
+        resolvedCwd,
+        options.defaultWorkspaceDir,
+        "Command cwd",
+      );
+      if (cwdError) {
+        return {
+          success: false,
+          error: {
+            code: "INVALID_CWD",
+            message:
+              `cwd cannot be used with inputs/outputs when it resolves outside ` +
+              `the workspace directory: ${cwdError}`,
+          },
+        };
+      }
+    }
+
     const execRequest: ExecuteCommandRequest = {
       bundleDigest: parseResult.bundleDigest,
       profileName: parseResult.profileName,
       credentialHandle: request.credentialHandle,
       argv: parseResult.argv,
-      workspaceDir: request.cwd ?? options.defaultWorkspaceDir,
+      workspaceDir,
       inputs: request.inputs,
       outputs: request.outputs,
       purpose: request.purpose,


### PR DESCRIPTION
Codex review on #17007 noted two issues: (1) workspace inputs/outputs reachable with unvalidated cwd — adds validation that cwd is contained within defaultWorkspaceDir when inputs/outputs are present, (2) output copyback failures not surfaced to the tool when command exits 0 — now checks response.error even when response.success is true.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
