### PR TITLE
fix: correct OAuth DB path in local-oauth-lookup

### DIFF
--- a/credential-executor/src/materializers/local-oauth-lookup.ts
+++ b/credential-executor/src/materializers/local-oauth-lookup.ts
@@ -70,7 +70,7 @@ function rowToRecord(row: OAuthConnectionRow): OAuthConnectionRecord {
 export function createLocalOAuthLookup(
   vellumRoot: string,
 ): OAuthConnectionLookup {
-  const dbPath = join(vellumRoot, "data", "assistant.db");
+  const dbPath = join(vellumRoot, "workspace", "data", "db", "assistant.db");
 
   return {
     getById(connectionId: string): OAuthConnectionRecord | undefined {


### PR DESCRIPTION
## Summary

- Fix wrong database path in `createLocalOAuthLookup` — was `join(vellumRoot, "data", "assistant.db")`, should be `join(vellumRoot, "workspace", "data", "db", "assistant.db")` to match `getDbPath()` in `assistant/src/util/platform.ts`.
- The other two review items on #16972 (grant hash/pattern mismatch and argv patterns) were already addressed by #17008 and #16997 respectively.

## Test plan

- [ ] Verify `existsSync(dbPath)` returns `true` for the corrected path when the assistant DB exists
- [ ] Verify local OAuth connection lookups resolve successfully with a valid connection ID
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
