### PR TITLE
refactor: extract ensureThreadAndSend helper on ThreadManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -77,19 +77,14 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
                 onInvokeSkill: { skill in
-                    if threadManager.activeViewModel == nil {
-                        threadManager.createThread()
-                    }
-                    if let viewModel = threadManager.activeViewModel {
-                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                    let vm = threadManager.ensureThreadAndSend(message: "Use the \(skill.name) skill") { vm in
+                        vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,
                             description: skill.description
                         )
-                        viewModel.inputText = "Use the \(skill.name) skill"
-                        viewModel.sendMessage()
-                        viewModel.pendingSkillInvocation = nil
                     }
+                    vm?.pendingSkillInvocation = nil
                     windowState.selection = nil
                 },
                 daemonClient: daemonClient,
@@ -124,15 +119,12 @@ extension MainWindowView {
                        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         // Ensure a thread exists so the prompt doesn't silently fail
                         // on fresh app launch before any chat thread is created.
-                        if threadManager.activeViewModel == nil {
-                            threadManager.createThread()
-                        }
-                        if let vm = threadManager.activeViewModel {
+                        threadManager.ensureThreadAndSend(
+                            message: prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                        ) { vm in
                             // Sync dock state before sending so the message is
                             // classified correctly (chat vs. workspace refinement).
                             vm.isChatDockedToSide = windowState.isChatDockOpen
-                            vm.inputText = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                            vm.sendMessage()
                         }
                         return
                     }
@@ -449,19 +441,14 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
                 onInvokeSkill: { skill in
-                    if threadManager.activeViewModel == nil {
-                        threadManager.createThread()
-                    }
-                    if let viewModel = threadManager.activeViewModel {
-                        viewModel.pendingSkillInvocation = SkillInvocationData(
+                    let vm = threadManager.ensureThreadAndSend(message: "Use the \(skill.name) skill") { vm in
+                        vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,
                             description: skill.description
                         )
-                        viewModel.inputText = "Use the \(skill.name) skill"
-                        viewModel.sendMessage()
-                        viewModel.pendingSkillInvocation = nil
                     }
+                    vm?.pendingSkillInvocation = nil
                     windowState.dismissOverlay()
                 },
                 daemonClient: daemonClient,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -231,6 +231,23 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         enterDraftMode()
     }
 
+    /// Ensures a thread exists and sends a message.
+    /// - Parameters:
+    ///   - message: The text to send.
+    ///   - configure: Optional closure to configure the view model before sending
+    ///     (e.g., set skill invocation data or dock state).
+    @discardableResult
+    func ensureThreadAndSend(message: String, configure: ((ChatViewModel) -> Void)? = nil) -> ChatViewModel? {
+        if activeViewModel == nil {
+            createThread()
+        }
+        guard let viewModel = activeViewModel else { return nil }
+        configure?(viewModel)
+        viewModel.inputText = message
+        viewModel.sendMessage()
+        return viewModel
+    }
+
     /// Ensures an active thread exists, selecting or creating one if needed.
     ///
     /// Selection priority:


### PR DESCRIPTION
## Summary
- Extract `ensureThreadAndSend(message:configure:)` method on ThreadManager to consolidate the repeated ensure-thread + set-text + send pattern
- Migrate all 3 existing inline sites in PanelCoordinator (2 skill invocations + 1 relay_prompt) to use the new helper
- Behavior is preserved: skill invocations still set/clear pendingSkillInvocation, relay_prompt still syncs dock state

Part of plan: library-empty-state-new-thread.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
