### PR TITLE
feat: add New Thread button to Library empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -71,6 +71,10 @@ extension MainWindowView {
                     } else {
                         windowState.selection = .app(surfaceMsg.surfaceId)
                     }
+                },
+                onNewThread: {
+                    threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                    windowState.selection = nil
                 }
             )
         case .intelligence:
@@ -266,6 +270,10 @@ extension MainWindowView {
                         } else {
                             windowState.selection = .app(surfaceMsg.surfaceId)
                         }
+                    },
+                    onNewThread: {
+                        threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                        windowState.selection = nil
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
@@ -433,6 +441,10 @@ extension MainWindowView {
                     } else {
                         windowState.selection = .app(surfaceMsg.surfaceId)
                     }
+                },
+                onNewThread: {
+                    threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                    windowState.dismissOverlay()
                 }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -9,6 +9,7 @@ struct AppsGridView: View {
     let onOpenApp: (String) -> Void
     /// Called when the user opens a shared app (needs surface-based navigation).
     var onOpenSharedApp: ((UiSurfaceShowMessage) -> Void)?
+    var onNewThread: (() -> Void)?
 
     @State private var searchText = ""
     @State private var hoveredAppId: String?
@@ -135,21 +136,14 @@ struct AppsGridView: View {
     // MARK: - Empty State
 
     private var noAppsEmptyState: some View {
-        VStack(spacing: VSpacing.xl) {
-            VIconView(.layoutGrid, size: 40)
-                .foregroundColor(VColor.contentTertiary)
-
-            VStack(spacing: VSpacing.sm) {
-                Text("Your library is empty")
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.contentSecondary)
-
-                Text("Ask your assistant to build something")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        VEmptyState(
+            title: "Your library is empty",
+            subtitle: "Ask your assistant to build something",
+            icon: VIcon.layoutGrid.rawValue,
+            actionLabel: "New Thread",
+            actionIcon: VIcon.plus.rawValue,
+            action: { onNewThread?() }
+        )
     }
 
     // MARK: - Search Bar


### PR DESCRIPTION
## Summary
- Add `onNewThread` callback to AppsGridView for creating new threads from the Library
- Replace hand-rolled empty state with `VEmptyState` component, adding a "New Thread" button with plus icon
- Wire up the callback at all 3 AppsGridView instantiation sites in PanelCoordinator using `ensureThreadAndSend` to auto-send "What kind of apps can you build?"

Part of plan: library-empty-state-new-thread.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
