### PR TITLE
fix: use double backslashes for SQL LIKE escape in turn-events-store

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -26,10 +26,10 @@ export function queryUnreportedTurnEvents(
         eq(messages.role, "user"),
         // Exclude tool-result rows persisted with role "user" — these are
         // system-generated and should not count as user turns.
-        // Use ESCAPE '\' so underscores are matched literally, not as
+        // Use ESCAPE '\\' so underscores are matched literally, not as
         // single-character wildcards.
-        sql`${messages.content} NOT LIKE '%"type":"tool\_result"%' ESCAPE '\'`,
-        sql`${messages.content} NOT LIKE '%"type":"web\_search\_tool\_result"%' ESCAPE '\'`,
+        sql`${messages.content} NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\\\'`,
+        sql`${messages.content} NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\\\'`,
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),


### PR DESCRIPTION
Follow-up to #17044. Fixes the backslash escaping in template literals so that underscore wildcards are properly escaped in SQL LIKE patterns.

Single backslashes in JS template literals are consumed by string escaping rules (\`\_\` becomes just \`_\`), making the LIKE ESCAPE clause ineffective. Uses double backslashes to match the existing pattern in conversation-queries.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
