### PR TITLE
fix: update CLI help and tests to use slash separator in CES handles

### DIFF
--- a/assistant/src/__tests__/credential-execution-admin-cli.test.ts
+++ b/assistant/src/__tests__/credential-execution-admin-cli.test.ts
@@ -107,7 +107,7 @@ function makeGrant(
     grantId: overrides?.grantId ?? "grant-001",
     sessionId: overrides?.sessionId ?? "session-abc",
     credentialHandle:
-      overrides?.credentialHandle ?? "local_static:github:token",
+      overrides?.credentialHandle ?? "local_static:github/token",
     proposalType: overrides?.proposalType ?? "http",
     proposalHash: overrides?.proposalHash ?? "hash-abc",
     allowedPurposes: overrides?.allowedPurposes ?? [
@@ -129,7 +129,7 @@ function makeAuditRecord(
     auditId: overrides?.auditId ?? "audit-001",
     grantId: overrides?.grantId ?? "grant-001",
     credentialHandle:
-      overrides?.credentialHandle ?? "local_static:github:token",
+      overrides?.credentialHandle ?? "local_static:github/token",
     toolName: overrides?.toolName ?? "http",
     target:
       overrides?.target ??
@@ -246,7 +246,7 @@ describe("credential-execution grants list", () => {
       "grants",
       "list",
       "--handle",
-      "local_static:github:token",
+      "local_static:github/token",
       "--json",
     ]);
 
@@ -254,7 +254,7 @@ describe("credential-execution grants list", () => {
     expect(mockCallHistory[0]!.method).toBe("list_grants");
     expect(
       (mockCallHistory[0]!.request as Record<string, unknown>).credentialHandle,
-    ).toBe("local_static:github:token");
+    ).toBe("local_static:github/token");
   });
 
   test("forwards --status filter to RPC call", async () => {
@@ -403,7 +403,7 @@ describe("credential-execution audit list", () => {
       "audit",
       "list",
       "--handle",
-      "local_static:github:token",
+      "local_static:github/token",
       "--grant",
       "grant-001",
       "--json",
@@ -411,7 +411,7 @@ describe("credential-execution audit list", () => {
 
     expect(mockCallHistory).toHaveLength(1);
     const req = mockCallHistory[0]!.request as Record<string, unknown>;
-    expect(req.credentialHandle).toBe("local_static:github:token");
+    expect(req.credentialHandle).toBe("local_static:github/token");
     expect(req.grantId).toBe("grant-001");
   });
 

--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -134,7 +134,7 @@ proposal type, status, timestamps, allowed purposes).
 
 Examples:
   $ assistant credential-execution grants list
-  $ assistant credential-execution grants list --handle local_static:github:token
+  $ assistant credential-execution grants list --handle local_static:github/token
   $ assistant credential-execution grants list --status active --json`,
     )
     .action(
@@ -264,7 +264,7 @@ code, credential handle, grant ID, success/failure).
 Examples:
   $ assistant credential-execution audit list
   $ assistant credential-execution audit list --limit 50
-  $ assistant credential-execution audit list --handle local_static:github:token
+  $ assistant credential-execution audit list --handle local_static:github/token
   $ assistant credential-execution audit list --grant abc123 --json`,
     )
     .action(


### PR DESCRIPTION
Follow-up to #17043. Updates CLI help examples and admin CLI tests to use the correct `local_static:<service>/<field>` format instead of the old double-colon format.

Closes JARVIS-1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
