### PR TITLE
fix: preserve full path suffix in validateContainedPath ancestor walk

### DIFF
--- a/credential-executor/src/commands/workspace.ts
+++ b/credential-executor/src/commands/workspace.ts
@@ -194,7 +194,7 @@ export function validateContainedPath(
     let resolved = false;
     while (!resolved) {
       const ancestor = dirname(current);
-      const tail = current.slice(ancestor.length);
+      const tail = resolvedPath.slice(ancestor.length);
       try {
         normalizedPath = realpathSync(ancestor) + tail;
         resolved = true;


### PR DESCRIPTION
Follow-up to #17046. Fixes the ancestor walk to use resolvedPath instead of current when computing the tail, so that all path segments are preserved when multiple levels don't exist.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
