### PR TITLE
fix: remove dead sessionId field from ExecuteCommandRequest

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -108,8 +108,6 @@ export interface ExecuteCommandRequest {
   grantId?: string;
   /** Conversation ID for thread-scoped temporary grants. */
   conversationId?: string;
-  /** Session ID for the egress proxy. */
-  sessionId?: string;
 }
 
 /**

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -465,7 +465,6 @@ export function createRunAuthenticatedCommandHandler(
       purpose: request.purpose,
       grantId: request.grantId,
       conversationId: request.conversationId,
-      sessionId: options.sessionId,
     };
 
     const result = await executeAuthenticatedCommand(


### PR DESCRIPTION
Follow-up to #17058. Removes the unused sessionId field from ExecuteCommandRequest since audit records now use deps.sessionId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
