### PR TITLE
fix: include stderr and auditId in copyback error response path

### DIFF
--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -208,10 +208,19 @@ class RunAuthenticatedCommandTool implements Tool {
         );
 
         const parts: string[] = [];
+        if (response.exitCode !== undefined) {
+          parts.push(`Exit code: ${response.exitCode}`);
+        }
         if (response.stdout) {
           parts.push(response.stdout);
         }
+        if (response.stderr) {
+          parts.push(`stderr:\n${response.stderr}`);
+        }
         parts.push(`Warning: ${copybackMsg}`);
+        if (response.auditId) {
+          parts.push(`[audit: ${response.auditId}]`);
+        }
 
         return {
           content: parts.join("\n\n"),


### PR DESCRIPTION
Follow-up to #17067. Ensures the copyback error path includes response.exitCode, response.stderr, and response.auditId, matching the normal success path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
