### PR TITLE
fix: add path containment, error handling, and validation for cleanConfigDirs

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -431,8 +431,24 @@ export async function executeAuthenticatedCommand(
   const generatedHomeDir = join(tmpdir(), `ces-home-${randomUUID()}`);
 
   // Create the HOME directory and enforce cleanConfigDirs before building env
-  mkdirSync(generatedHomeDir, { recursive: true });
-  enforceCleanConfigDirs(manifest, generatedHomeDir);
+  try {
+    mkdirSync(generatedHomeDir, { recursive: true });
+    enforceCleanConfigDirs(manifest, generatedHomeDir);
+  } catch (err) {
+    if (proxySessionId) {
+      try {
+        await stopSession(proxySessionId, sessionStore);
+      } catch {
+        // Best-effort proxy cleanup
+      }
+    }
+    cleanupAll(scratchDir, tempFilePath, generatedHomeDir);
+    return {
+      success: false,
+      error: `Clean config dirs setup failed: ${err instanceof Error ? err.message : String(err)}`,
+      auditId,
+    };
+  }
 
   const commandEnv = buildCommandEnv(
     adapterEnv,
@@ -978,7 +994,11 @@ function enforceCleanConfigDirs(
     // Only handle ~/‑prefixed paths for v1
     if (dirPath.startsWith("~/")) {
       const relativePath = dirPath.slice(2); // strip "~/"
-      const resolvedPath = join(homeDir, relativePath);
+      const resolvedPath = resolve(homeDir, relativePath);
+      // Containment check: resolved path must stay inside homeDir
+      if (!resolvedPath.startsWith(homeDir + "/") && resolvedPath !== homeDir) {
+        continue; // Skip paths that escape the home directory
+      }
       mkdirSync(resolvedPath, { recursive: true });
     } else if (dirPath === "~") {
       // "~" alone is just the home dir itself, already created

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -118,6 +118,23 @@ export function validateManifest(
     }
   }
 
+  // -- cleanConfigDirs key validation (defense-in-depth against path traversal)
+  if (manifest.cleanConfigDirs) {
+    for (const key of Object.keys(manifest.cleanConfigDirs)) {
+      if (key.includes("..")) {
+        errors.push(
+          `cleanConfigDirs key "${key}" contains path traversal sequence "..". ` +
+            `This is not allowed.`,
+        );
+      }
+      if (key.trim().length === 0) {
+        errors.push(
+          `cleanConfigDirs contains an empty key.`,
+        );
+      }
+    }
+  }
+
   // -- Command profiles (must have at least one)
   if (
     !manifest.commandProfiles ||


### PR DESCRIPTION
Follow-up to #17059. Adds path traversal protection in enforceCleanConfigDirs, wraps mkdir/enforce calls in try/catch with cleanup, and adds manifest-level validation for cleanConfigDirs keys.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
