### PR TITLE
fix: backfill legacy grant sessionId and add reactivation tests

### DIFF
--- a/credential-executor/src/__tests__/grant-store.test.ts
+++ b/credential-executor/src/__tests__/grant-store.test.ts
@@ -136,6 +136,121 @@ describe("PersistentGrantStore", () => {
     });
   });
 
+  describe("reactivation of revoked grants", () => {
+    test("adding a grant with same ID as revoked returns true and reactivates", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grant = makeGrant({ id: "revoke-reactivate" });
+      store.add(grant);
+      store.markRevoked("revoke-reactivate", "test revocation");
+
+      // Revoked grant should not appear in getAll
+      expect(store.getAll()).toHaveLength(0);
+
+      // Re-add with same ID — should reactivate
+      const reactivated = store.add(
+        makeGrant({ id: "revoke-reactivate", pattern: "bun install" }),
+      );
+      expect(reactivated).toBe(true);
+    });
+
+    test("reactivated grant appears in getAll()", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "revoke-visible" }));
+      store.markRevoked("revoke-visible");
+      store.add(makeGrant({ id: "revoke-visible" }));
+
+      const all = store.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe("revoke-visible");
+      expect(all[0].revokedAt).toBeUndefined();
+      expect(all[0].revokedReason).toBeUndefined();
+    });
+
+    test("reactivated grant fields are updated from the new grant", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(
+        makeGrant({
+          id: "revoke-update",
+          tool: "host_bash",
+          pattern: "npm install",
+          scope: "/old-project",
+          sessionId: "session-1",
+        }),
+      );
+      store.markRevoked("revoke-update", "no longer needed");
+
+      const newGrant = makeGrant({
+        id: "revoke-update",
+        tool: "command",
+        pattern: "bun install",
+        scope: "/new-project",
+        sessionId: "session-2",
+      });
+      store.add(newGrant);
+
+      const result = store.getById("revoke-update");
+      expect(result).toBeDefined();
+      expect(result!.tool).toBe("command");
+      expect(result!.pattern).toBe("bun install");
+      expect(result!.scope).toBe("/new-project");
+      expect(result!.sessionId).toBe("session-2");
+      expect(result!.revokedAt).toBeUndefined();
+      expect(result!.revokedReason).toBeUndefined();
+    });
+
+    test("reactivated grant round-trips through serialization", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "revoke-persist" }));
+      store.markRevoked("revoke-persist", "reason");
+      store.add(makeGrant({ id: "revoke-persist", pattern: "bun test" }));
+
+      // Load from a fresh store instance to verify serialization
+      const store2 = new PersistentGrantStore(tmpDir);
+      const grants = store2.getAll();
+      expect(grants).toHaveLength(1);
+      expect(grants[0].id).toBe("revoke-persist");
+      expect(grants[0].pattern).toBe("bun test");
+      expect(grants[0].revokedAt).toBeUndefined();
+      expect(grants[0].revokedReason).toBeUndefined();
+    });
+  });
+
+  describe("legacy sessionId migration", () => {
+    test("backfills sessionId on legacy grants during init", () => {
+      // Write a grants file with a grant missing sessionId (legacy format)
+      const legacyGrant = {
+        id: "legacy-grant",
+        tool: "host_bash",
+        pattern: "npm install",
+        scope: "/project",
+        createdAt: Date.now(),
+      };
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ version: 1, grants: [legacyGrant] }, null, 2),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grants = store.getAll();
+      expect(grants).toHaveLength(1);
+      expect(grants[0].sessionId).toBe("unknown");
+
+      // Verify it was persisted
+      const raw = JSON.parse(readFileSync(join(tmpDir, "grants.json"), "utf-8"));
+      expect(raw.grants[0].sessionId).toBe("unknown");
+    });
+  });
+
   describe("getById and has", () => {
     test("returns grant by ID", () => {
       const store = new PersistentGrantStore(tmpDir);

--- a/credential-executor/src/grants/persistent-store.ts
+++ b/credential-executor/src/grants/persistent-store.ts
@@ -44,7 +44,7 @@ export interface PersistentGrant {
   scope: string;
   /** When the grant was created (epoch ms). */
   createdAt: number;
-  /** The agent session that created this grant. May be absent on legacy grants. */
+  /** The agent session that created this grant. Backfilled to "unknown" on legacy grants. */
   sessionId: string;
   /** When the grant was revoked (epoch ms), or undefined if active. */
   revokedAt?: number;
@@ -100,7 +100,19 @@ export class PersistentGrantStore {
 
     // Validate the existing file is readable and well-formed.
     // If it isn't, mark corrupt and throw (fail closed).
-    this.loadFromDisk();
+    const grants = this.loadFromDisk();
+
+    // Migration: backfill sessionId on legacy grants that pre-date the field.
+    let migrated = false;
+    for (const grant of grants) {
+      if (grant.sessionId == null) {
+        (grant as { sessionId: string }).sessionId = "unknown";
+        migrated = true;
+      }
+    }
+    if (migrated) {
+      this.writeToDisk(grants);
+    }
   }
 
   /**

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -42,7 +42,7 @@ import type { RpcMethodHandler } from "../server.js";
 function projectGrant(grant: PersistentGrant): PersistentGrantRecord {
   return {
     grantId: grant.id,
-    sessionId: grant.sessionId ?? "unknown",
+    sessionId: grant.sessionId,
     credentialHandle: grant.scope,
     proposalType:
       grant.tool === "http" || grant.tool === "command"


### PR DESCRIPTION
Follow-up to #17062. Adds migration to backfill sessionId on legacy grants (removing the \?\? fallback adapter), and adds test coverage for grant reactivation after revocation.

Closes the two actionable review items:
1. Type/runtime mismatch: sessionId migration in init() ensures the string type holds true
2. Missing test coverage: reactivation-of-revoked-grants tests added
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
