### PR TITLE
test: add deterministic concurrent git mutex test

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -480,6 +480,59 @@ describe("WorkspaceGitService — abort signal propagation", () => {
     const status = await service.getStatus();
     expect(status.clean).toBe(true);
   });
+
+  test("concurrent git operations are serialized by the mutex", async () => {
+    const { WorkspaceGitService, _resetGitServiceRegistry } =
+      await import("../workspace/git-service.js");
+
+    _resetGitServiceRegistry();
+    const service = new WorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // Track the order of execution to prove serialization.
+    const executionLog: string[] = [];
+
+    // Create a deferred promise so we can explicitly control when the first
+    // mutex holder releases. This guarantees the second operation is queued
+    // behind the first — no timing dependency.
+    let releaseFirst!: () => void;
+    const firstBlocks = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+
+    // Operation A: acquire the mutex, signal it's holding, then wait for
+    // our explicit release before finishing.
+    let opAQueued!: () => void;
+    const opAIsHolding = new Promise<void>((r) => {
+      opAQueued = r;
+    });
+
+    const opA = service.runWithMutex(async (exec) => {
+      executionLog.push("A:start");
+      opAQueued(); // signal that A holds the lock
+      await firstBlocks; // wait until we explicitly release
+      await exec(["status"]);
+      executionLog.push("A:end");
+    });
+
+    // Wait until A is definitely holding the lock before starting B.
+    await opAIsHolding;
+
+    // Operation B: a normal commitChanges that must wait for A to finish.
+    writeFileSync(join(testDir, "concurrent.txt"), "data");
+    const opB = service.commitChanges("concurrent commit").then(() => {
+      executionLog.push("B:done");
+    });
+
+    // At this point B is queued behind A in the mutex. Release A.
+    releaseFirst();
+
+    // Both operations should complete without errors.
+    await Promise.all([opA, opB]);
+
+    // A must have fully completed before B started — that's the mutex guarantee.
+    expect(executionLog).toEqual(["A:start", "A:end", "B:done"]);
+  });
 });
 
 // ── 4. Shell tool (sandboxed) — abort signal ─────────────────────────────────


### PR DESCRIPTION
Follow-up to #17069. Adds a new deterministic test that exercises the git mutex concurrent serialization path without relying on timing-dependent race conditions.

The test uses explicit synchronization (deferred promises) to guarantee operation A holds the mutex when operation B is started, then verifies that A completes before B runs — proving the mutex serializes concurrent git operations correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
