### PR TITLE
fix: align CES data root constant and docs with platform template (/ces-data)

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -249,7 +249,7 @@ Local deployments do not require image changes. Enabling `ces-tools` causes the 
 | ------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | Process-boundary credential isolation      | Strong (separate child process)                                     | Strong (separate container)                                                                                                     |
 | Credential value never in assistant memory | Strong                                                              | Strong                                                                                                                          |
-| Grant persistence survives restarts        | Strong (filesystem-backed under `~/.vellum/protected/`)             | Strong (dedicated `/home/ces/.ces-data` volume)                                                                                 |
+| Grant persistence survives restarts        | Strong (filesystem-backed under `~/.vellum/protected/`)             | Strong (dedicated `/ces-data` volume)                                                                                           |
 | Network egress enforcement via proxy       | Moderate (relies on process env vars; host networking is available) | Moderate (cooperative via env vars; per-container Calico egress restriction is a design goal but not yet enforced — see Risk 7) |
 | Secret scrubbing in HTTP responses         | Defense-in-depth only                                               | Defense-in-depth only                                                                                                           |
 | `host_bash` restriction                    | Policy-only (trust rules can deny, but the tool exists)             | Policy-only (same; managed deployments should deny `host_bash` for untrusted agents)                                            |
@@ -287,7 +287,7 @@ If the CES sidecar container causes pod scheduling issues or resource pressure:
 1. Disable `ces-tools` on all assistants first (prevents the assistant from attempting CES calls).
 2. Disable `ces-managed-sidecar` on all assistants.
 3. Remove the CES container and its volume mounts from the pod template in vembda.
-4. CES grant/audit data on the `/home/ces/.ces-data` volume is orphaned and can be cleaned up at convenience.
+4. CES grant/audit data on the `/ces-data` volume is orphaned and can be cleaned up at convenience.
 
 The assistant reverts to the pre-CES credential broker once `ces-tools` is disabled.
 
@@ -361,7 +361,7 @@ This means the helper is subject to the same cooperative egress limitation as th
 
 The following capabilities are intentionally deferred beyond v1:
 
-- **Cloud KMS/Vault integration for secret storage** — v1 reads secrets from filesystem (`~/.vellum/protected/` locally, `/home/ces/.ces-data` in managed). Moving to a dedicated secrets manager is a future enhancement.
+- **Cloud KMS/Vault integration for secret storage** — v1 reads secrets from filesystem (`~/.vellum/protected/` locally, `/ces-data` in managed). Moving to a dedicated secrets manager is a future enhancement.
 - **Multi-CES-instance support** — Each assistant pod runs exactly one CES sidecar. Horizontal scaling of CES within a pod is not supported.
 - **Cross-pod credential sharing** — CES grants are scoped to a single pod. There is no grant federation across pods or assistant instances.
 - **Browser automation through CES** — Browser form-fill with credential injection is deferred beyond initial rollout.

--- a/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
@@ -69,8 +69,8 @@ describe("managed env contract constants", () => {
     expect(CES_ASSISTANT_DATA_READONLY_MOUNT).toBe("/assistant-data-ro");
   });
 
-  test("CES_PRIVATE_DATA_DIR is /home/ces/.ces-data", () => {
-    expect(CES_PRIVATE_DATA_DIR).toBe("/home/ces/.ces-data");
+  test("CES_PRIVATE_DATA_DIR is /ces-data", () => {
+    expect(CES_PRIVATE_DATA_DIR).toBe("/ces-data");
   });
 });
 
@@ -119,11 +119,11 @@ describe("three-container pod contract", () => {
     expect(CES_ASSISTANT_DATA_READONLY_MOUNT).toBe("/assistant-data-ro");
   });
 
-  test("CES private data directory is a separate volume at /home/ces/.ces-data", () => {
+  test("CES private data directory is a separate volume at /ces-data", () => {
     // The stateful_template.yaml gives the CES sidecar its own PVC at
-    // /home/ces/.ces-data, separate from the assistant-data PVC. This ensures
+    // /ces-data, separate from the assistant-data PVC. This ensures
     // CES grant/audit data is isolated.
-    expect(CES_PRIVATE_DATA_DIR).toBe("/home/ces/.ces-data");
+    expect(CES_PRIVATE_DATA_DIR).toBe("/ces-data");
   });
 });
 

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -21,7 +21,7 @@
  * Managed env contract:
  * - CES_BOOTSTRAP_SOCKET  — Path to the bootstrap Unix socket (shared emptyDir)
  * - /assistant-data-ro     — Assistant data mounted read-only into the CES sidecar
- * - /home/ces/.ces-data    — CES private data directory (separate PVC)
+ * - /ces-data              — CES private data directory (separate PVC)
  * - CES_HEALTH_PORT        — Health check port exposed by the CES sidecar
  */
 
@@ -61,7 +61,7 @@ export const CES_ASSISTANT_DATA_READONLY_MOUNT = "/assistant-data-ro";
  * Private data directory for the CES sidecar (separate PVC).
  * CES stores grants, audit logs, and credential material here.
  */
-export const CES_PRIVATE_DATA_DIR = "/home/ces/.ces-data";
+export const CES_PRIVATE_DATA_DIR = "/ces-data";
 
 // ---------------------------------------------------------------------------
 // Process manager configuration

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -44,7 +44,7 @@ function buildCredentialRefTrace(
  * - ~/.vellum/workspace/data/db/ — database files that may contain credential metadata
  * - CES bootstrap socket directory (/run/ces/ or CES_BOOTSTRAP_SOCKET_DIR) —
  *   prevents untrusted shells from connecting to the CES sidecar directly
- * - CES managed-mode data root (CES_DATA_DIR, or /home/ces/.ces-data when
+ * - CES managed-mode data root (CES_DATA_DIR, or /ces-data when
  *   CES_MANAGED_MODE is set) — prevents access to CES-private state in
  *   managed deployments (local-mode is already covered by the protected/
  *   entry)
@@ -75,7 +75,7 @@ function buildCesProtectedPaths(): string[] {
   if (cesDataDir) {
     paths.push(cesDataDir);
   } else if (process.env["CES_MANAGED_MODE"]) {
-    paths.push("/home/ces/.ces-data");
+    paths.push("/ces-data");
   }
 
   return paths;

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -351,11 +351,11 @@ describe("CES data paths", () => {
     expect(root).toMatch(/protected[/\\]credential-executor$/);
   });
 
-  test("managed mode data root defaults to /home/ces/.ces-data", () => {
+  test("managed mode data root defaults to /ces-data", () => {
     const savedDir = process.env["CES_DATA_DIR"];
     delete process.env["CES_DATA_DIR"];
     try {
-      expect(getCesDataRoot("managed")).toBe("/home/ces/.ces-data");
+      expect(getCesDataRoot("managed")).toBe("/ces-data");
     } finally {
       if (savedDir !== undefined) process.env["CES_DATA_DIR"] = savedDir;
     }

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -11,7 +11,7 @@
  * - **Local**: CES private state lives under the Vellum root's `protected/`
  *   directory at `<rootDir>/protected/credential-executor/`.
  *
- * - **Managed**: CES private state lives at `/home/ces/.ces-data` by default
+ * - **Managed**: CES private state lives at `/ces-data` by default
  *   (overridable via `CES_DATA_DIR` env var). The assistant container never
  *   sees this path.
  *
@@ -54,16 +54,16 @@ function getVellumRootDir(): string {
 /**
  * Default managed CES data root.
  *
- * Defaults to `/home/ces/.ces-data` so the non-root `ces` user (uid 1001)
- * can write without extra chown/mkdir in the Dockerfile.
+ * Defaults to `/ces-data` — the platform template provisions this path
+ * via the `CES_DATA_DIR` env var and a dedicated PVC.
  */
-const DEFAULT_MANAGED_CES_DATA_ROOT = "/home/ces/.ces-data";
+const DEFAULT_MANAGED_CES_DATA_ROOT = "/ces-data";
 
 /**
  * Return the CES-private data root.
  *
  * - Local: `<vellumRoot>/protected/credential-executor/`
- * - Managed: `CES_DATA_DIR` env var, or `/home/ces/.ces-data` by default
+ * - Managed: `CES_DATA_DIR` env var, or `/ces-data` by default
  */
 export function getCesDataRoot(mode?: CesMode): string {
   const resolvedMode = mode ?? getCesMode();


### PR DESCRIPTION
## Summary
The assistant-side CES constant and docs referenced /home/ces/.ces-data
but the platform template actually provisions /ces-data via CES_DATA_DIR.
Updates process-manager.ts constant, credential-executor paths.ts default,
shell.ts protected paths, tests, and credential-execution-service.md
to match the deployed contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
