### PR TITLE
fix: plumb handshake sessionId into command audit records

### DIFF
--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -282,7 +282,7 @@ function buildDeps(
       metadataStore: fixture.metadataStore,
       oauthConnections: createOAuthLookup(oauthConnections),
     },
-    sessionId: "test-session",
+    sessionId: { current: "test-session" },
     logger: silentLogger,
     ...overrides,
     auditStore: overrides.auditStore ?? new AuditStore(fixture.tmpDir),

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -79,6 +79,7 @@ import { hashProposal, type AuditRecordSummary, type CommandGrantProposal } from
 import type { AuditStore } from "../audit/store.js";
 import type { PersistentGrantStore } from "../grants/persistent-store.js";
 import type { TemporaryGrantStore } from "../grants/temporary-store.js";
+import type { SessionIdRef } from "../server.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,8 +109,6 @@ export interface ExecuteCommandRequest {
   grantId?: string;
   /** Conversation ID for thread-scoped temporary grants. */
   conversationId?: string;
-  /** Session ID for the egress proxy. */
-  sessionId?: string;
 }
 
 /**
@@ -172,8 +171,8 @@ export interface CommandExecutorDeps {
   materializeCredential: MaterializeCredentialFn;
   /** Audit store for persisting token-free audit records. */
   auditStore?: AuditStore;
-  /** Session ID for audit records. */
-  sessionId?: string;
+  /** Mutable reference to the session ID for audit records. Updated to the handshake session ID once the RPC handshake completes. */
+  sessionId?: SessionIdRef;
   /** CES operating mode (for toolstore path resolution). */
   cesMode?: CesMode;
   /** Egress proxy session start hooks (for creating the proxy server). */
@@ -510,7 +509,7 @@ export async function executeAuthenticatedCommand(
       credentialHandle: request.credentialHandle,
       toolName: "command",
       target: `${request.bundleDigest}/${request.profileName}`,
-      sessionId: deps.sessionId ?? "unknown",
+      sessionId: deps.sessionId?.current ?? "unknown",
       success: execResult.success,
       ...(execResult.error ? { errorMessage: execResult.error } : {}),
       timestamp: new Date().toISOString(),

--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -41,6 +41,7 @@ import type { LocalMaterialiser, MaterialisedCredential } from "../materializers
 import { materializeManagedToken, type ManagedMaterializerOptions } from "../materializers/managed-platform.js";
 import { resolveLocalSubject, type LocalSubjectResolverDeps } from "../subjects/local.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "../subjects/managed.js";
+import type { SessionIdRef } from "../server.js";
 
 // ---------------------------------------------------------------------------
 // Auth injection constants
@@ -78,8 +79,8 @@ export interface HttpExecutorDeps {
   managedMaterializerOptions?: ManagedMaterializerOptions;
   /** Audit store for persisting token-free audit records. */
   auditStore: AuditStore;
-  /** Session ID for audit records. */
-  sessionId: string;
+  /** Mutable reference to the session ID for audit records. Updated to the handshake session ID once the RPC handshake completes. */
+  sessionId: SessionIdRef;
   /** Optional custom fetch implementation (for testing). */
   fetch?: typeof globalThis.fetch;
   /** Optional logger. */
@@ -182,7 +183,7 @@ export async function executeAuthenticatedHttpRequest(
     const audit = generateHttpAuditSummary({
       credentialHandle: request.credentialHandle,
       grantId,
-      sessionId: deps.sessionId,
+      sessionId: deps.sessionId.current,
       method: request.method,
       url: request.url,
       success: false,
@@ -229,7 +230,7 @@ export async function executeAuthenticatedHttpRequest(
     const audit = generateHttpAuditSummary({
       credentialHandle: request.credentialHandle,
       grantId,
-      sessionId: deps.sessionId,
+      sessionId: deps.sessionId.current,
       method: request.method,
       url: request.url,
       success: false,
@@ -255,7 +256,7 @@ export async function executeAuthenticatedHttpRequest(
   const audit = generateHttpAuditSummary({
     credentialHandle: request.credentialHandle,
     grantId,
-    sessionId: deps.sessionId,
+    sessionId: deps.sessionId.current,
     method: request.method,
     url: request.url,
     success: true,

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -29,6 +29,7 @@ export type {
   RpcHandlerRegistry,
   RpcMethodHandler,
   RunAuthenticatedCommandHandlerOptions,
+  SessionIdRef,
 } from "./server.js";
 
 export {

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -51,6 +51,7 @@ import {
   registerCommandExecutionHandler,
   registerManageSecureCommandToolHandler,
   type RpcHandlerRegistry,
+  type SessionIdRef,
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
@@ -85,7 +86,7 @@ function getVellumRootDir(): string {
 // Build RPC handler registry
 // ---------------------------------------------------------------------------
 
-function buildHandlers(sessionId: string): RpcHandlerRegistry {
+function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
   // -- Grant stores ----------------------------------------------------------
   const persistentGrantStore = new PersistentGrantStore(
     getCesGrantsDir("local"),
@@ -138,7 +139,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         oauthConnections,
       },
       auditStore,
-      sessionId,
+      sessionId: sessionIdRef,
     },
   );
 
@@ -167,12 +168,11 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         };
       },
       auditStore,
-      sessionId,
+      sessionId: sessionIdRef,
       cesMode: "local",
       egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: join(vellumRoot, "workspace"),
-    sessionId,
   });
 
   // Register manage_secure_command_tool handler
@@ -263,9 +263,11 @@ async function main(): Promise<void> {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
-  // Build the handler registry with all available RPC implementations
-  const sessionId = `ces-local-${Date.now()}`;
-  const handlers = buildHandlers(sessionId);
+  // Build the handler registry with all available RPC implementations.
+  // Use a mutable ref so audit records capture the handshake session ID
+  // once it's negotiated (the handshake completes before any RPC call).
+  const sessionIdRef: SessionIdRef = { current: `ces-local-${Date.now()}` };
+  const handlers = buildHandlers(sessionIdRef);
 
   const server = new CesRpcServer({
     input: process.stdin,
@@ -280,6 +282,9 @@ async function main(): Promise<void> {
         process.stderr.write(`[ces-local] ERROR: ${msg} ${args.map(String).join(" ")}\n`),
     },
     signal: controller.signal,
+    onHandshakeComplete: (hsSessionId) => {
+      sessionIdRef.current = hsSessionId;
+    },
   });
 
   await server.serve();

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -47,6 +47,7 @@ import {
   registerCommandExecutionHandler,
   registerManageSecureCommandToolHandler,
   type RpcHandlerRegistry,
+  type SessionIdRef,
 } from "./server.js";
 import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
@@ -85,7 +86,7 @@ function ensureDataDirs(): void {
 // Build RPC handler registry (managed mode)
 // ---------------------------------------------------------------------------
 
-function buildHandlers(sessionId: string): RpcHandlerRegistry {
+function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
   // -- Grant stores ----------------------------------------------------------
   const persistentGrantStore = new PersistentGrantStore(
     getCesGrantsDir("managed"),
@@ -152,7 +153,7 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       managedSubjectOptions,
       managedMaterializerOptions,
       auditStore,
-      sessionId,
+      sessionId: sessionIdRef,
     },
   );
 
@@ -210,12 +211,11 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
         };
       },
       auditStore,
-      sessionId,
+      sessionId: sessionIdRef,
       cesMode: "managed",
       egressHooks: buildCesEgressHooks(),
     },
     defaultWorkspaceDir: "/workspace",
-    sessionId,
   });
 
   // Register manage_secure_command_tool handler
@@ -468,9 +468,11 @@ async function main(): Promise<void> {
 
   rpcConnected = true;
 
-  // Build the handler registry with all available RPC implementations
-  const sessionId = `ces-managed-${Date.now()}`;
-  const handlers = buildHandlers(sessionId);
+  // Build the handler registry with all available RPC implementations.
+  // Use a mutable ref so audit records capture the handshake session ID
+  // once it's negotiated (the handshake completes before any RPC call).
+  const sessionIdRef: SessionIdRef = { current: `ces-managed-${Date.now()}` };
+  const handlers = buildHandlers(sessionIdRef);
 
   const server = new CesRpcServer({
     input: connection.readable,
@@ -485,6 +487,9 @@ async function main(): Promise<void> {
         process.stderr.write(`[ces-managed] ERROR: ${msg} ${args.map(String).join(" ")}\n`),
     },
     signal: controller.signal,
+    onHandshakeComplete: (hsSessionId) => {
+      sessionIdRef.current = hsSessionId;
+    },
   });
 
   await server.serve();

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -54,6 +54,15 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
+ * Mutable reference to the current session ID. Allows handlers that are
+ * registered before the RPC handshake to read the actual handshake session
+ * ID at call time (after the handshake completes and sets `.current`).
+ */
+export interface SessionIdRef {
+  current: string;
+}
+
+/**
  * Handler function for a single RPC method. Receives the validated
  * request payload and returns the response payload (or throws).
  */
@@ -79,6 +88,8 @@ export interface CesServerOptions {
   logger?: Pick<Console, "log" | "warn" | "error">;
   /** Optional abort signal to shut down the server. */
   signal?: AbortSignal;
+  /** Callback invoked when the handshake completes with the negotiated session ID. */
+  onHandshakeComplete?: (sessionId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +102,7 @@ export class CesRpcServer {
   private readonly handlers: RpcHandlerRegistry;
   private readonly logger: Pick<Console, "log" | "warn" | "error">;
   private readonly signal?: AbortSignal;
+  private readonly onHandshakeComplete?: (sessionId: string) => void;
 
   private handshakeComplete = false;
   private sessionId: string | null = null;
@@ -103,6 +115,7 @@ export class CesRpcServer {
     this.handlers = options.handlers;
     this.logger = options.logger ?? console;
     this.signal = options.signal;
+    this.onHandshakeComplete = options.onHandshakeComplete;
   }
 
   /**
@@ -230,6 +243,7 @@ export class CesRpcServer {
       this.handshakeComplete = true;
       this.sessionId = req.sessionId;
       this.logger.log(`[ces-server] Handshake accepted for session ${req.sessionId}`);
+      this.onHandshakeComplete?.(req.sessionId);
     } else {
       this.logger.warn(
         `[ces-server] Handshake rejected: version mismatch (got ${req.protocolVersion}, expected ${CES_PROTOCOL_VERSION})`,
@@ -391,12 +405,6 @@ export interface RunAuthenticatedCommandHandlerOptions {
    * Typically the assistant's workspace root.
    */
   defaultWorkspaceDir: string;
-  /**
-   * Session ID to attach to audit records. In local mode this is a
-   * static string generated at startup; in managed mode it comes from
-   * the RPC handshake.
-   */
-  sessionId?: string;
 }
 
 /**
@@ -465,7 +473,6 @@ export function createRunAuthenticatedCommandHandler(
       purpose: request.purpose,
       grantId: request.grantId,
       conversationId: request.conversationId,
-      sessionId: options.sessionId,
     };
 
     const result = await executeAuthenticatedCommand(


### PR DESCRIPTION
Follow-up to #17064. Plumbs the actual RPC handshake sessionId into executor deps for audit correlation, removes dead request.sessionId field, and fixes inaccurate JSDoc.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
