### PR TITLE
fix: normalize denied flag check to catch --flag=value bypass

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -614,6 +614,45 @@ describe("validateCommand", () => {
     expect(result.reason).toContain("--unsafe-perm");
   });
 
+  test("denies --flag=value form of denied flags", () => {
+    const manifestWithDeniedFlags = buildManifest({
+      commandProfiles: {
+        "api-read": {
+          description: "Read-only GitHub API calls",
+          allowedArgvPatterns: [
+            {
+              name: "api-call",
+              tokens: ["api", "<endpoint>", "<args...>"],
+            },
+          ],
+          deniedSubcommands: [],
+          deniedFlags: ["--endpoint-url", "--exec"],
+          allowedNetworkTargets: [
+            { hostPattern: "api.github.com", protocols: ["https"] },
+          ],
+        },
+      },
+    });
+
+    // --flag=value combined form should be caught
+    const result = validateCommand(manifestWithDeniedFlags, [
+      "api",
+      "/repos",
+      "--endpoint-url=https://evil.example.com",
+    ]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("--endpoint-url");
+
+    // --flag value (separate tokens) should still be caught
+    const result2 = validateCommand(manifestWithDeniedFlags, [
+      "api",
+      "/repos",
+      "--exec",
+    ]);
+    expect(result2.allowed).toBe(false);
+    expect(result2.reason).toContain("--exec");
+  });
+
   // -- Multi-profile matching ------------------------------------------------
 
   test("matches across multiple profiles", () => {

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -531,13 +531,24 @@ export function validateCommand(
     }
   }
 
-  // Check denied flags
+  // Check denied flags — also handle --flag=value combined tokens
   for (const arg of argv) {
     if (allDeniedFlags.has(arg)) {
       return {
         allowed: false,
         reason: `Flag "${arg}" is explicitly denied.`,
       };
+    }
+
+    // Handle --flag=value form: extract the flag prefix before '='
+    if (arg.startsWith("-") && arg.includes("=")) {
+      const flagPrefix = arg.slice(0, arg.indexOf("="));
+      if (allDeniedFlags.has(flagPrefix)) {
+        return {
+          allowed: false,
+          reason: `Flag "${flagPrefix}" is explicitly denied (via "${arg}").`,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed denied flag enforcement bypass where `--flag=value` combined tokens evaded exact-match checks in CES `validateCommand`
- The denied flags check now extracts the flag prefix before `=` to properly block tokens like `--endpoint-url=https://evil.com` when `--endpoint-url` is denied
- Added test coverage for the `--flag=value` bypass scenario

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)