### PR TITLE
fix: remove calendar_id account inference to prevent cross-account access

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
@@ -15,7 +15,7 @@ export async function run(
   const calendarIds = (input.calendar_ids as string[]) ?? ["primary"];
   const timezone = input.timezone as string | undefined;
 
-  const connection = await getCalendarConnection(account, calendarIds[0]);
+  const connection = await getCalendarConnection(account);
   const result = await calendar.freeBusy(connection, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
@@ -41,7 +41,7 @@ export async function run(
     eventBody.attendees = attendees.map((email) => ({ email }));
   }
 
-  const connection = await getCalendarConnection(account, calendarId);
+  const connection = await getCalendarConnection(account);
   const event = await calendar.createEvent(connection, eventBody, calendarId);
   const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
   return ok(`Event created (ID: ${event.id}).${link}`);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
@@ -13,7 +13,7 @@ export async function run(
   const eventId = input.event_id as string;
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = await getCalendarConnection(account, calendarId);
+  const connection = await getCalendarConnection(account);
   const event = await calendar.getEvent(connection, eventId, calendarId);
   return ok(JSON.stringify(event, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
@@ -18,7 +18,7 @@ export async function run(
   const singleEvents = (input.single_events as boolean) ?? true;
   const orderBy = input.order_by as "startTime" | "updated" | undefined;
 
-  const connection = await getCalendarConnection(account, calendarId);
+  const connection = await getCalendarConnection(account);
   const result = await calendar.listEvents(connection, calendarId, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
@@ -14,7 +14,7 @@ export async function run(
   const response = input.response as "accepted" | "declined" | "tentative";
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = await getCalendarConnection(account, calendarId);
+  const connection = await getCalendarConnection(account);
 
   // First get the event to find the user's attendee entry
   const event = await calendar.getEvent(connection, eventId, calendarId);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -12,10 +12,6 @@ export function ok(content: string): ToolExecutionResult {
  */
 export async function getCalendarConnection(
   account?: string,
-  calendarId?: string,
 ): Promise<OAuthConnection> {
-  // If no explicit account but calendar_id looks like an email, use it as the account hint
-  const resolved =
-    account ?? (calendarId?.includes("@") ? calendarId : undefined);
-  return resolveOAuthConnection("integration:google", resolved);
+  return resolveOAuthConnection("integration:google", account);
 }


### PR DESCRIPTION
## Summary
- Removed the `calendarId` parameter from `getCalendarConnection` — account selection now requires the explicit `account` parameter only
- Previously, any `calendar_id` containing `@` was used as an OAuth account hint when `account` was omitted, enabling attacker-influenced inputs to pivot to a different connected Google account
- Updated all 5 calendar tool callers (`list-events`, `create-event`, `get-event`, `rsvp`, `check-availability`) to pass only `account`

## Original prompt
Fix the calendar account inference security issue: remove the calendar_id-as-account-hint logic from getCalendarConnection in shared.ts. The function should only use the explicit `account` parameter for OAuth account selection, never infer it from calendar_id. Update all callers to only pass `account`. This prevents prompt injection from steering which OAuth account is used for calendar operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
