### PR TITLE
fix: align CES bootstrap socket and health port defaults with vembda

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -139,7 +139,7 @@ Audit logs record every materialization event with: grant ID, credential ID, too
 │         ▼                   ▼            │
 │  ┌─────────────────────────────────┐    │
 │  │  shared emptyDir volume         │    │
-│  │  └── /run/ces/ces.sock          │    │
+│  │  └── /run/ces-bootstrap/ces.sock │    │
 │  └─────────────────────────────────┘    │
 │         │                               │
 │         ▼                               │
@@ -229,7 +229,7 @@ Enable flags in this order. Each flag is safe to enable independently, but later
 
 To dark-launch CES in managed deployments without user impact:
 
-1. **Deploy the CES container image** via the `credential_executor_image` field in `POST /v1/internal/assistant-image-releases/`. The warm-pool manager picks it up and includes it in pod templates. The CES container starts, binds its bootstrap socket and health port (7841), but does nothing until an assistant connects.
+1. **Deploy the CES container image** via the `credential_executor_image` field in `POST /v1/internal/assistant-image-releases/`. The warm-pool manager picks it up and includes it in pod templates. The CES container starts, binds its bootstrap socket and health port (8090), but does nothing until an assistant connects.
 
 2. **Verify sidecar health** using kubelet probes: `/healthz` (liveness) and `/readyz` (readiness, always returns 200; includes `rpcConnected` field for observability). CES reports its protocol version in both probe responses.
 

--- a/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
@@ -275,7 +275,7 @@ describe("non-CES internal consumers intact when flag is off", () => {
   test("existing non-agent flows are unaffected by managed sidecar flag", () => {
     // When the flag is off, the process manager never touches the managed
     // path. This means:
-    // 1. No socket connection attempts to /run/ces/ces.sock
+    // 1. No socket connection attempts to /run/ces-bootstrap/ces.sock
     // 2. No managed transport creation
     // 3. Local mode works identically to before the flag existed
     const config = makeConfig({

--- a/assistant/src/credential-execution/executable-discovery.ts
+++ b/assistant/src/credential-execution/executable-discovery.ts
@@ -30,7 +30,7 @@ const log = getLogger("ces-discovery");
 // ---------------------------------------------------------------------------
 
 /** Default directory for the bootstrap socket shared volume. */
-const DEFAULT_BOOTSTRAP_SOCKET_DIR = "/run/ces";
+const DEFAULT_BOOTSTRAP_SOCKET_DIR = "/run/ces-bootstrap";
 
 /** Bootstrap socket filename. */
 const BOOTSTRAP_SOCKET_NAME = "ces.sock";
@@ -41,7 +41,7 @@ const BOOTSTRAP_SOCKET_NAME = "ces.sock";
  * Priority:
  * 1. `CES_BOOTSTRAP_SOCKET_DIR` env var (directory) — appends `ces.sock`
  * 2. `CES_BOOTSTRAP_SOCKET` env var (full file path override)
- * 3. Hardcoded default: `/run/ces/ces.sock`
+ * 3. Hardcoded default: `/run/ces-bootstrap/ces.sock`
  *
  * The pod template exports `CES_BOOTSTRAP_SOCKET_DIR`; the full-path
  * override is kept for local testing convenience.

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -42,7 +42,7 @@ function buildCredentialRefTrace(
  * - ~/.vellum/protected/ — credential store secrets (also covers local-mode
  *   CES data root at ~/.vellum/protected/credential-executor/)
  * - ~/.vellum/workspace/data/db/ — database files that may contain credential metadata
- * - CES bootstrap socket directory (/run/ces/ or CES_BOOTSTRAP_SOCKET_DIR) —
+ * - CES bootstrap socket directory (/run/ces-bootstrap/ or CES_BOOTSTRAP_SOCKET_DIR) —
  *   prevents untrusted shells from connecting to the CES sidecar directly
  * - CES managed-mode data root (CES_DATA_DIR, or /ces-data when
  *   CES_MANAGED_MODE is set) — prevents access to CES-private state in

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -47,9 +47,9 @@ COPY --from=builder --chown=ces:ces /app /app
 
 USER ces
 
-EXPOSE 7841
+EXPOSE 8090
 
 ENV CES_MODE=managed
-ENV CES_HEALTH_PORT=7841
+ENV CES_HEALTH_PORT=8090
 
 CMD ["bun", "run", "src/managed-main.ts"]

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -163,12 +163,12 @@ describe("health probes", () => {
     expect(src).toMatch(/startHealthServer\(healthPort/);
   });
 
-  test("getHealthPort defaults to 7841", () => {
+  test("getHealthPort defaults to 8090", () => {
     // Save and clear env
     const saved = process.env["CES_HEALTH_PORT"];
     delete process.env["CES_HEALTH_PORT"];
     try {
-      expect(getHealthPort()).toBe(7841);
+      expect(getHealthPort()).toBe(8090);
     } finally {
       if (saved !== undefined) process.env["CES_HEALTH_PORT"] = saved;
     }
@@ -382,11 +382,11 @@ describe("CES data paths", () => {
     expect(root).not.toMatch(/workspace/);
   });
 
-  test("getBootstrapSocketPath defaults to /run/ces/ces.sock", () => {
+  test("getBootstrapSocketPath defaults to /run/ces-bootstrap/ces.sock", () => {
     const saved = process.env["CES_BOOTSTRAP_SOCKET"];
     delete process.env["CES_BOOTSTRAP_SOCKET"];
     try {
-      expect(getBootstrapSocketPath()).toBe("/run/ces/ces.sock");
+      expect(getBootstrapSocketPath()).toBe("/run/ces-bootstrap/ces.sock");
     } finally {
       if (saved !== undefined) process.env["CES_BOOTSTRAP_SOCKET"] = saved;
     }

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -100,7 +100,7 @@ export function getCesToolStoreDir(mode?: CesMode): string {
 // ---------------------------------------------------------------------------
 
 /** Default directory for the bootstrap Unix socket shared volume. */
-const BOOTSTRAP_SOCKET_DIR = "/run/ces";
+const BOOTSTRAP_SOCKET_DIR = "/run/ces-bootstrap";
 
 /** Default bootstrap socket filename. */
 const BOOTSTRAP_SOCKET_NAME = "ces.sock";
@@ -115,7 +115,7 @@ const BOOTSTRAP_SOCKET_NAME = "ces.sock";
  * Priority:
  * 1. `CES_BOOTSTRAP_SOCKET_DIR` env var (directory) — appends `ces.sock`
  * 2. `CES_BOOTSTRAP_SOCKET` env var (full file path override)
- * 3. Hardcoded default: `/run/ces/ces.sock`
+ * 3. Hardcoded default: `/run/ces-bootstrap/ces.sock`
  *
  * The pod template exports `CES_BOOTSTRAP_SOCKET_DIR`; the full-path
  * override is kept for local testing convenience.
@@ -136,7 +136,7 @@ export function getBootstrapSocketPath(): string {
 // ---------------------------------------------------------------------------
 
 /** Default health probe port for managed CES. */
-const DEFAULT_HEALTH_PORT = 7841;
+const DEFAULT_HEALTH_PORT = 8090;
 
 /**
  * Return the health probe port for managed mode.


### PR DESCRIPTION
## Summary
CES and assistant code defaulted to /run/ces and port 7841 while Vembda
(the orchestrator) defaults to /run/ces-bootstrap and port 8090. Both
sides read from env vars so production works, but the hardcoded defaults
should agree. Aligns CES/assistant defaults to match Vembda.

- `credential-executor/src/paths.ts`: bootstrap dir `/run/ces` -> `/run/ces-bootstrap`, health port `7841` -> `8090`
- `assistant/src/credential-execution/executable-discovery.ts`: bootstrap dir `/run/ces` -> `/run/ces-bootstrap`
- `credential-executor/Dockerfile`: EXPOSE and ENV for health port `7841` -> `8090`
- Updated tests, docs, and comments referencing the old values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
