### PR TITLE
fix: lift CES client from per-session to server-level singleton

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -13,6 +13,14 @@ import {
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
+import type { CesClient } from "../credential-execution/client.js";
+import { createCesClient } from "../credential-execution/client.js";
+import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
+import {
+  type CesProcessManager,
+  CesUnavailableError,
+  createCesProcessManager,
+} from "../credential-execution/process-manager.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
@@ -243,6 +251,12 @@ export class DaemonServer {
   // Composed subsystems
   private configWatcher = new ConfigWatcher();
 
+  // CES (Credential Execution Service) — process-level singleton.
+  // The CES sidecar accepts exactly one bootstrap connection, so we must
+  // hold that connection at the server level rather than per-session.
+  private cesProcessManager?: CesProcessManager;
+  private cesClientPromise?: Promise<CesClient | undefined>;
+
   /**
    * Logical assistant identifier used when publishing to the assistant-events hub.
    */
@@ -465,6 +479,48 @@ export class DaemonServer {
       this.broadcast({ type: "contacts_changed" });
     });
 
+    // CES lifecycle — start the CES process and perform the RPC handshake
+    // once at server level. The managed sidecar accepts exactly one bootstrap
+    // connection, so this must be a process-level singleton.
+    if (isCesToolsEnabled(config)) {
+      const pm = createCesProcessManager({ assistantConfig: config });
+      this.cesProcessManager = pm;
+      this.cesClientPromise = (async () => {
+        try {
+          const transport = await pm.start();
+          const client = createCesClient(transport);
+          const { accepted, reason } = await client.handshake();
+          if (accepted) {
+            log.info(
+              "CES client initialized and handshake accepted (server-level)",
+            );
+            return client;
+          }
+          log.warn(
+            { reason },
+            "CES handshake rejected — CES tools will be unavailable",
+          );
+          client.close();
+          await pm.stop();
+          return undefined;
+        } catch (err) {
+          if (err instanceof CesUnavailableError) {
+            log.info(
+              { reason: err.message },
+              "CES is not available — CES tools will be unavailable",
+            );
+          } else {
+            log.warn(
+              { error: err instanceof Error ? err.message : String(err) },
+              "Failed to initialize CES client — CES tools will be unavailable",
+            );
+          }
+          await pm.stop().catch(() => {});
+          return undefined;
+        }
+      })();
+    }
+
     log.info("DaemonServer started (HTTP-only mode)");
   }
 
@@ -481,6 +537,19 @@ export class DaemonServer {
       session.dispose();
     }
     this.sessions.clear();
+
+    // Tear down the server-level CES client and process manager
+    if (this.cesClientPromise) {
+      const client = await this.cesClientPromise.catch(() => undefined);
+      if (client) {
+        client.close();
+      }
+      this.cesClientPromise = undefined;
+    }
+    if (this.cesProcessManager) {
+      await this.cesProcessManager.stop().catch(() => {});
+      this.cesProcessManager = undefined;
+    }
 
     log.info("Daemon server stopped");
   }
@@ -606,6 +675,10 @@ export class DaemonServer {
         const maxTokens = storedOptions?.maxResponseTokens ?? config.maxTokens;
 
         const memoryPolicy = this.deriveMemoryPolicy(conversationId);
+        // Resolve the shared CES client (may still be initializing).
+        const sharedCesClient = this.cesClientPromise
+          ? await this.cesClientPromise
+          : undefined;
         const newSession = new Session(
           conversationId,
           provider,
@@ -615,6 +688,7 @@ export class DaemonServer {
           workingDir,
           (msg) => this.broadcast(msg),
           memoryPolicy,
+          sharedCesClient,
         );
         newSession.updateClient(sendToClient, true);
         await newSession.loadFromDb();

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -24,13 +24,6 @@ import type {
 import { getConfig } from "../config/loader.js";
 import { ContextWindowManager } from "../context/window-manager.js";
 import type { CesClient } from "../credential-execution/client.js";
-import { createCesClient } from "../credential-execution/client.js";
-import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
-import {
-  type CesProcessManager,
-  CesUnavailableError,
-  createCesProcessManager,
-} from "../credential-execution/process-manager.js";
 import { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
@@ -56,7 +49,6 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
-import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
 import type { CuObservationResult } from "./host-cu-proxy.js";
@@ -125,8 +117,6 @@ export interface SessionMemoryPolicy {
   strictSideEffects: boolean;
 }
 
-const log = getLogger("session");
-
 export const DEFAULT_MEMORY_POLICY: Readonly<SessionMemoryPolicy> =
   Object.freeze({
     scopeId: "default",
@@ -177,10 +167,7 @@ export class Session {
   /** @internal */ hostBashProxy?: HostBashProxy;
   /** @internal */ hostCuProxy?: HostCuProxy;
   /** @internal */ hostFileProxy?: HostFileProxy;
-  /** @internal */ cesProcessManager?: CesProcessManager;
   /** @internal */ cesClient?: CesClient;
-  /** @internal */ cesInitAborted = false;
-  /** @internal */ cesInitPromise?: Promise<void>;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
@@ -248,6 +235,7 @@ export class Session {
     workingDir: string,
     broadcastToAllClients?: (msg: ServerMessage) => void,
     memoryPolicy?: SessionMemoryPolicy,
+    sharedCesClient?: CesClient,
   ) {
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
@@ -328,55 +316,11 @@ export class Session {
     const config = getConfig();
     this.streamThinking = config.thinking.streamThinking ?? false;
 
-    // CES (Credential Execution Service) lifecycle — conditionally start the
-    // CES process and perform the RPC handshake when CES tools are enabled.
-    // The initialization is async; cesClient is set once the handshake
-    // completes. Tools reading context.cesClient tolerate it being undefined
-    // until then (they return a graceful error).
-    if (isCesToolsEnabled(config)) {
-      const pm = createCesProcessManager({ assistantConfig: config });
-      this.cesProcessManager = pm;
-      this.cesInitPromise = (async () => {
-        try {
-          const transport = await pm.start();
-          if (this.cesInitAborted) {
-            await pm.stop();
-            return;
-          }
-          const client = createCesClient(transport);
-          const { accepted, reason } = await client.handshake();
-          if (this.cesInitAborted) {
-            client.close();
-            await pm.stop();
-            return;
-          }
-          if (accepted) {
-            this.cesClient = client;
-            log.info("CES client initialized and handshake accepted");
-          } else {
-            log.warn(
-              { reason },
-              "CES handshake rejected — CES tools will be unavailable",
-            );
-            client.close();
-            await pm.stop();
-          }
-        } catch (err) {
-          if (err instanceof CesUnavailableError) {
-            log.info(
-              { reason: err.message },
-              "CES is not available — CES tools will be unavailable",
-            );
-          } else {
-            log.warn(
-              { error: err instanceof Error ? err.message : String(err) },
-              "Failed to initialize CES client — CES tools will be unavailable",
-            );
-          }
-          // Clean up the process manager on any init failure
-          await pm.stop().catch(() => {});
-        }
-      })();
+    // CES (Credential Execution Service) — use the shared server-level client.
+    // The CES sidecar accepts exactly one bootstrap connection, so the
+    // client is owned by DaemonServer and passed in here.
+    if (sharedCesClient) {
+      this.cesClient = sharedCesClient;
     }
 
     const resolveTools = createResolveToolsCallback(toolDefs, this);
@@ -512,29 +456,9 @@ export class Session {
     this.hostBashProxy?.dispose();
     this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
-    // Signal the async CES init to abort and stop the process manager
-    // immediately so we don't keep the child process alive for the full
-    // handshake timeout window. The deferred .then() handles client cleanup
-    // once the init promise settles.
-    this.cesInitAborted = true;
-    if (this.cesClient) {
-      this.cesClient.close();
-      this.cesClient = undefined;
-    }
-    if (this.cesProcessManager) {
-      void this.cesProcessManager.stop();
-      this.cesProcessManager = undefined;
-    }
-    if (this.cesInitPromise) {
-      void this.cesInitPromise.then(() => {
-        // Client may have been set between our immediate cleanup and the
-        // promise settling — close it if so.
-        if (this.cesClient) {
-          this.cesClient.close();
-          this.cesClient = undefined;
-        }
-      });
-    }
+    // CES client is owned by DaemonServer — just drop the reference.
+    // Do NOT close it here; the server manages the CES lifecycle.
+    this.cesClient = undefined;
     disposeSession(this);
   }
 


### PR DESCRIPTION
## Summary
Managed CES accepts exactly one bootstrap connection then unlinks the
socket. Each Session was creating its own CES client, so the first
conversation consumed the only connection and all subsequent sessions
lost CES entirely.

- Moves CES process manager and client creation from Session to DaemonServer
- Sessions receive the shared client reference instead of creating their own
- CES connection now lasts the lifetime of the daemon process

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
