### PR TITLE
feat: add installationId UUID to AssistantEntry and generate at hatch time

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -103,8 +103,7 @@ export async function buildStartupScript(
   instanceName: string,
   cloud: RemoteHost,
 ): Promise<string> {
-  const platformUrl =
-    process.env.VELLUM_PLATFORM_URL ?? "https://vellum.ai";
+  const platformUrl = process.env.VELLUM_PLATFORM_URL ?? "https://vellum.ai";
   const logPath =
     cloud === "custom"
       ? "/tmp/vellum-startup.log"
@@ -801,6 +800,7 @@ async function hatchLocal(
 
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
+    installationId: randomUUID(),
     runtimeUrl,
     localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
     bearerToken,

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -36,6 +36,7 @@ export interface LocalInstanceResources {
 
 export interface AssistantEntry {
   assistantId: string;
+  installationId?: string;
   runtimeUrl: string;
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
@@ -153,7 +154,9 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
       "share",
       "vellum",
       "assistants",
-      typeof raw.assistantId === "string" ? raw.assistantId : DAEMON_INTERNAL_ASSISTANT_ID,
+      typeof raw.assistantId === "string"
+        ? raw.assistantId
+        : DAEMON_INTERNAL_ASSISTANT_ID,
     );
     raw.resources = {
       instanceDir,
@@ -173,7 +176,9 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
         "share",
         "vellum",
         "assistants",
-        typeof raw.assistantId === "string" ? raw.assistantId : DAEMON_INTERNAL_ASSISTANT_ID,
+        typeof raw.assistantId === "string"
+          ? raw.assistantId
+          : DAEMON_INTERNAL_ASSISTANT_ID,
       );
       mutated = true;
     }

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir, userInfo } from "os";
 import { join } from "path";
@@ -512,6 +512,7 @@ export async function hatchAws(
       : `http://${instanceName}:${GATEWAY_PORT}`;
     const awsEntry: AssistantEntry = {
       assistantId: instanceName,
+      installationId: randomUUID(),
       runtimeUrl,
       cloud: "aws",
       instanceId,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn } from "child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "fs";
 import { createRequire } from "module";
 import { dirname, join } from "path";
@@ -376,6 +377,7 @@ export async function hatchDocker(
   const runtimeUrl = `http://localhost:${gatewayPort}`;
   const dockerEntry: AssistantEntry = {
     assistantId: instanceName,
+    installationId: randomUUID(),
     runtimeUrl,
     cloud: "docker",
     species,

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { unlinkSync, writeFileSync } from "fs";
 import { tmpdir, userInfo } from "os";
 import { join } from "path";
@@ -589,6 +589,7 @@ export async function hatchGcp(
       : `http://${instanceName}:${GATEWAY_PORT}`;
     const gcpEntry: AssistantEntry = {
       assistantId: instanceName,
+      installationId: randomUUID(),
       runtimeUrl,
       cloud: "gcp",
       project,


### PR DESCRIPTION
## Summary
- Add optional `installationId?: string` field to the `AssistantEntry` interface
- Generate a UUID via `randomUUID()` at hatch time in all four hatch paths (local, GCP, AWS, Docker)
- Existing lockfile entries without `installationId` continue to load correctly

Part of plan: canonical-installation-id.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
