### PR TITLE
feat: add workspace migration to backfill installationId into lockfile

### DIFF
--- a/assistant/src/memory/checkpoints.ts
+++ b/assistant/src/memory/checkpoints.ts
@@ -30,6 +30,11 @@ export function setMemoryCheckpoint(key: string, value: string): void {
     .run();
 }
 
+export function deleteMemoryCheckpoint(key: string): void {
+  const db = getDb();
+  db.delete(memoryCheckpoints).where(eq(memoryCheckpoints.key, key)).run();
+}
+
 export function readMessageCursorCheckpoint(
   createdAtKey: string,
   messageIdKey: string,

--- a/assistant/src/workspace/migrations/002-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/002-backfill-installation-id.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+} from "../../memory/checkpoints.js";
+import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id.js";
+import type { WorkspaceMigration } from "./types.js";
+
+export const backfillInstallationIdMigration: WorkspaceMigration = {
+  id: "002-backfill-installation-id",
+  description:
+    "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
+  run(_workspaceDir: string): void {
+    // a. Read existing installation ID from SQLite, or generate a new one
+    const existingId = getMemoryCheckpoint("telemetry:installation_id");
+    const installationId = existingId || randomUUID();
+
+    // b. Read the lockfile from the standard path
+    const base = process.env.BASE_DATA_DIR?.trim() || homedir();
+    const lockPath = join(base, ".vellum.lock.json");
+    if (!existsSync(lockPath)) return;
+
+    let lockData: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      lockData = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // c. Find the assistant entry that corresponds to this daemon instance
+    const assistants = lockData.assistants as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (!Array.isArray(assistants)) return;
+
+    const externalId = getExternalAssistantId();
+    const entry = assistants.find((a) => a.assistantId === externalId);
+    if (!entry) return;
+
+    // d. If already has a truthy installationId, skip lockfile write (idempotent)
+    if (entry.installationId) {
+      // e is skipped for lockfile write, but still clean up SQLite
+      deleteMemoryCheckpoint("telemetry:installation_id");
+      return;
+    }
+
+    // e. Set installationId on the entry and write the lockfile back
+    entry.installationId = installationId;
+    writeFileSync(lockPath, JSON.stringify(lockData, null, 2) + "\n");
+
+    // f. Delete the stale SQLite row
+    deleteMemoryCheckpoint("telemetry:installation_id");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,4 +1,5 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
+import { backfillInstallationIdMigration } from "./002-backfill-installation-id.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -7,4 +8,5 @@ import type { WorkspaceMigration } from "./types.js";
  */
 export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
+  backfillInstallationIdMigration,
 ];


### PR DESCRIPTION
## Summary
- Add `deleteMemoryCheckpoint()` helper to `checkpoints.ts`
- Create workspace migration `002-backfill-installation-id` that reads existing `telemetry:installation_id` from SQLite, writes it to the lockfile entry as `installationId`, and cleans up the stale SQLite row
- Register the migration in `WORKSPACE_MIGRATIONS`

Part of plan: canonical-installation-id.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
