### PR TITLE
feat: add GET /v1/avatar/character-components endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -100,6 +100,7 @@ import { handleServePage } from "./routes/app-routes.js";
 import { appRouteDefinitions } from "./routes/app-routes.js";
 import { approvalRouteDefinitions } from "./routes/approval-routes.js";
 import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
+import { avatarRouteDefinitions } from "./routes/avatar-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
 import { btwRouteDefinitions } from "./routes/btw-routes.js";
 import { callRouteDefinitions } from "./routes/call-routes.js";
@@ -731,6 +732,7 @@ export class RuntimeHttpServer {
       ...workspaceRouteDefinitions(),
       ...memoryItemRouteDefinitions(),
       ...settingsRouteDefinitions(),
+      ...avatarRouteDefinitions(),
       ...scheduleRouteDefinitions({
         sendMessageDeps: this.sendMessageDeps,
       }),

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -1,0 +1,12 @@
+import { getCharacterComponents } from "../../avatar/character-components.js";
+import type { RouteDefinition } from "../http-router.js";
+
+export function avatarRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "avatar/character-components",
+      method: "GET",
+      handler: () => Response.json(getCharacterComponents()),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Creates assistant/src/runtime/routes/avatar-routes.ts with character-components GET endpoint
- Registers the route in http-server.ts buildRouteTable()
- Returns full character component data (body shapes, eye styles, colors, face center overrides) as JSON

Part of plan: daemon-avatar-svg-rendering.md (PR 4 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
