### PR TITLE
fix: log broker errors distinctly from key-not-found in credential backend

### DIFF
--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -4,9 +4,12 @@
  * (macOS Keychain, encrypted file store, etc.) is in use.
  */
 
+import { getLogger } from "../util/logger.js";
 import * as encryptedStore from "./encrypted-store.js";
 import type { KeychainBrokerClient } from "./keychain-broker-client.js";
 import { createBrokerClient } from "./keychain-broker-client.js";
+
+const log = getLogger("credential-backend");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,9 +58,17 @@ export class KeychainBackend implements CredentialBackend {
   async get(account: string): Promise<string | undefined> {
     try {
       const result = await this.client.get(account);
-      if (result == null || !result.found) return undefined;
+      if (result == null) {
+        log.warn(
+          { account },
+          "Keychain broker unreachable during get — falling back",
+        );
+        return undefined;
+      }
+      if (!result.found) return undefined;
       return result.value;
-    } catch {
+    } catch (err) {
+      log.warn({ err, account }, "Keychain get threw unexpectedly");
       return undefined;
     }
   }
@@ -65,8 +76,20 @@ export class KeychainBackend implements CredentialBackend {
   async set(account: string, value: string): Promise<boolean> {
     try {
       const result = await this.client.set(account, value);
-      return result.status === "ok";
-    } catch {
+      if (result.status === "ok") return true;
+      log.warn(
+        {
+          account,
+          status: result.status,
+          ...(result.status === "rejected"
+            ? { code: result.code, message: result.message }
+            : {}),
+        },
+        "Keychain broker set failed",
+      );
+      return false;
+    } catch (err) {
+      log.warn({ err, account }, "Keychain set threw unexpectedly");
       return false;
     }
   }
@@ -85,7 +108,8 @@ export class KeychainBackend implements CredentialBackend {
   async list(): Promise<string[]> {
     try {
       return await this.client.list();
-    } catch {
+    } catch (err) {
+      log.warn({ err }, "Keychain list threw unexpectedly");
       return [];
     }
   }


### PR DESCRIPTION
## Summary
- Add structured logging to KeychainBackend to distinguish broker unreachable errors from genuine key-not-found results
- Log broker set failures with status, code, and message details for diagnostics
- Log unexpected exceptions in get, set, and list methods with error objects

Part of plan: keychain-broker-resilience.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
