### PR TITLE
refactor: telemetry reporter reads installationId from lockfile instead of SQLite

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -55,6 +55,12 @@ mock.module("../config/env.js", () => ({
   bool: () => false,
 }));
 
+const mockGetInstallationId = mock(() => "test-installation-id");
+
+mock.module("../runtime/auth/installation-id.js", () => ({
+  getInstallationId: mockGetInstallationId,
+}));
+
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -111,6 +117,8 @@ beforeEach(() => {
   mockResolveManagedProxyContext.mockReset();
   mockGetTelemetryPlatformUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
+  mockGetInstallationId.mockReset();
+  mockGetInstallationId.mockReturnValue("test-installation-id");
 
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
@@ -236,17 +244,7 @@ describe("UsageTelemetryReporter", () => {
     expect(watermarkCalls.length).toBe(0);
   });
 
-  test("installation ID generated on first flush, reused thereafter", async () => {
-    let storedInstallId: string | null = null;
-
-    mockGetMemoryCheckpoint.mockImplementation((key: string) => {
-      if (key === "telemetry:installation_id") return storedInstallId;
-      return null;
-    });
-    mockSetMemoryCheckpoint.mockImplementation((key: string, value: string) => {
-      if (key === "telemetry:installation_id") storedInstallId = value;
-    });
-
+  test("installation ID comes from lockfile-based resolver", async () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
     mockFetch.mockImplementation(() =>
@@ -255,25 +253,22 @@ describe("UsageTelemetryReporter", () => {
 
     const reporter = new UsageTelemetryReporter();
 
-    // First flush — should generate and store a new installation ID
+    // First flush — should use the lockfile-based installation ID
     await reporter.flush();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body1 = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(body1.installation_id).toBeTruthy();
-    expect(typeof body1.installation_id).toBe("string");
+    expect(body1.installation_id).toBe("test-installation-id");
 
-    // Second flush
+    // Second flush — should use the same value
     mockQueryUnreportedUsageEvents.mockReturnValue([makeUsageEvent()]);
     await reporter.flush();
     expect(mockFetch).toHaveBeenCalledTimes(2);
     const body2 = JSON.parse(
       (mockFetch.mock.calls[1] as [string, RequestInit])[1].body as string,
     );
-
-    // Both flushes should use the same installation ID
-    expect(body2.installation_id).toBe(body1.installation_id);
+    expect(body2.installation_id).toBe("test-installation-id");
   });
 
   test("empty batch makes no HTTP call", async () => {
@@ -348,7 +343,7 @@ describe("UsageTelemetryReporter", () => {
     );
 
     // Top-level: installation_id and events array
-    expect(typeof body.installation_id).toBe("string");
+    expect(body.installation_id).toBe("test-installation-id");
     expect(Array.isArray(body.events)).toBe(true);
     expect(body.events.length).toBe(1);
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -9,8 +9,6 @@
  * - Anonymous: X-Telemetry-Token static token from env
  */
 
-import { v4 as uuid } from "uuid";
-
 import {
   getTelemetryAppToken,
   getTelemetryPlatformUrl,
@@ -22,6 +20,7 @@ import {
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { getInstallationId } from "../runtime/auth/installation-id.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("usage-telemetry");
@@ -34,24 +33,10 @@ const CHECKPOINT_KEY_WATERMARK = "telemetry:usage:last_reported_at";
 const CHECKPOINT_KEY_WATERMARK_ID = "telemetry:usage:last_reported_id";
 const CHECKPOINT_KEY_TURN_WATERMARK = "telemetry:turns:last_reported_at";
 const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
-const CHECKPOINT_KEY_INSTALL_ID = "telemetry:installation_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
 const TELEMETRY_PATH = "/v1/assistants/self-hosted-local/telemetry/usage/";
-
-// ---------------------------------------------------------------------------
-// Installation ID
-// ---------------------------------------------------------------------------
-
-function getOrCreateInstallationId(): string {
-  const existing = getMemoryCheckpoint(CHECKPOINT_KEY_INSTALL_ID);
-  if (existing) return existing;
-
-  const id = uuid();
-  setMemoryCheckpoint(CHECKPOINT_KEY_INSTALL_ID, id);
-  return id;
-}
 
 // ---------------------------------------------------------------------------
 // Reporter
@@ -144,7 +129,7 @@ export class UsageTelemetryReporter {
 
       // Build payload
       const payload = {
-        installation_id: getOrCreateInstallationId(),
+        installation_id: getInstallationId(),
         events: events.map((e) => ({
           daemon_event_id: e.id,
           provider: e.provider,


### PR DESCRIPTION
## Summary
- Replace `getOrCreateInstallationId()` (SQLite-based) with `getInstallationId()` (lockfile-based) in the telemetry reporter
- Remove `CHECKPOINT_KEY_INSTALL_ID` constant and the `getOrCreateInstallationId()` function
- Update tests to mock the new lockfile-based resolver instead of SQLite checkpoint operations

Part of plan: canonical-installation-id.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
