### PR TITLE
feat: fetch avatar character components from daemon endpoint

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -1,6 +1,9 @@
 import AppKit
 import Foundation
 import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AvatarAppearanceManager")
 
 /// Manages the assistant's avatar image. Provides a custom avatar when uploaded,
 /// or falls back to a colored circle with the assistant's initial letter.
@@ -77,6 +80,12 @@ final class AvatarAppearanceManager {
 
     static let shared = AvatarAppearanceManager()
 
+    /// Character component definitions fetched from the daemon on launch.
+    /// Used to validate trait selections against the daemon's source of truth.
+    /// nil until the first successful fetch; the client still works with
+    /// hardcoded enums as fallback.
+    private var daemonComponents: AvatarComponentService.ComponentsResponse?
+
     private var fileMonitor: DispatchSourceFileSystemObject?
     private var traitsFileMonitor: DispatchSourceFileSystemObject?
     private var identityObserver: NSObjectProtocol?
@@ -121,6 +130,14 @@ final class AvatarAppearanceManager {
         watchAvatarFile()
         watchTraitsFile()
 
+        // Fire-and-forget: fetch character component definitions from the
+        // daemon so future PRs can validate trait selections against the
+        // daemon's source of truth. The app still works with hardcoded
+        // enums if the daemon is unreachable.
+        Task { [weak self] in
+            await self?.fetchComponentsFromDaemon()
+        }
+
         // Refresh assistantName and invalidate cached fallback avatars when
         // the user renames their assistant so the initial-letter avatar
         // reflects the new name.
@@ -141,6 +158,22 @@ final class AvatarAppearanceManager {
                 self.cachedFullFallbackName = nil
             }
         }
+    }
+
+    // MARK: - Daemon Component Fetch
+
+    /// Fetches the canonical character component definitions from the daemon.
+    /// On success, stores them in `daemonComponents` for future validation.
+    /// Fails silently — the client continues to work with hardcoded enums.
+    private func fetchComponentsFromDaemon() async {
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              let assistant = LockfileAssistant.loadByName(assistantId) else {
+            log.info("No connected assistant — skipping daemon component fetch")
+            return
+        }
+
+        let port = assistant.resolvedDaemonPort()
+        daemonComponents = await AvatarComponentService.fetch(port: port)
     }
 
     // MARK: - Custom Avatar

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
@@ -1,0 +1,100 @@
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AvatarComponentService")
+
+/// Fetches character component definitions from the daemon's
+/// `/v1/avatar/character-components` endpoint. The response provides the
+/// canonical set of body shapes, eye styles, colors, and face-center
+/// overrides so the client can validate trait selections against the
+/// daemon's source of truth.
+@MainActor
+final class AvatarComponentService {
+
+    // MARK: - Response Model
+
+    struct ComponentsResponse: Codable {
+        let bodyShapes: [BodyShapeDef]
+        let eyeStyles: [EyeStyleDef]
+        let colors: [ColorDef]
+        let faceCenterOverrides: [FaceCenterOverrideDef]
+    }
+
+    struct BodyShapeDef: Codable {
+        let id: String
+        let viewBox: SizeDef
+        let faceCenter: PointDef
+        let svgPath: String
+    }
+
+    struct EyeStyleDef: Codable {
+        let id: String
+        let sourceViewBox: SizeDef
+        let eyeCenter: PointDef
+        let paths: [EyePathDef]
+    }
+
+    struct EyePathDef: Codable {
+        let svgPath: String
+        let color: String
+    }
+
+    struct ColorDef: Codable {
+        let id: String
+        let hex: String
+    }
+
+    struct FaceCenterOverrideDef: Codable {
+        let bodyShape: String
+        let eyeStyle: String
+        let faceCenter: PointDef
+    }
+
+    struct SizeDef: Codable {
+        let width: Double
+        let height: Double
+    }
+
+    struct PointDef: Codable {
+        let x: Double
+        let y: Double
+    }
+
+    // MARK: - Fetch
+
+    /// Fetches character components from the daemon. Returns `nil` on any
+    /// failure (network error, non-200 status, decode error) so callers
+    /// can fall back to hardcoded enums.
+    static func fetch(port: Int) async -> ComponentsResponse? {
+        guard let url = URL(string: "http://localhost:\(port)/v1/avatar/character-components") else {
+            log.warning("Invalid URL for character-components endpoint")
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 10
+
+        if let token = ActorTokenManager.getToken(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                log.warning("character-components fetch failed with status \(statusCode)")
+                return nil
+            }
+
+            let decoded = try JSONDecoder().decode(ComponentsResponse.self, from: data)
+            log.info("Fetched character components: \(decoded.bodyShapes.count) body shapes, \(decoded.eyeStyles.count) eye styles, \(decoded.colors.count) colors")
+            return decoded
+        } catch {
+            log.warning("Failed to fetch character components: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Creates AvatarComponentService.swift with Codable structs to decode daemon's character-components JSON
- Adds fetchComponentsFromDaemon() to AvatarAppearanceManager
- Fetches component data on app launch (fire-and-forget, graceful fallback)

Part of plan: daemon-avatar-svg-rendering.md (PR 8 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
