### PR TITLE
fix: replace permanent broker unavailability with cooldown-based retry

### DIFF
--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -508,4 +508,150 @@ describe("keychain-broker-client", () => {
       expect(connectionCount).toBe(1);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Cooldown-based retry
+  // -----------------------------------------------------------------------
+  describe("cooldown-based retry", () => {
+    const originalDateNow = Date.now;
+    let fakeNow: number;
+
+    beforeEach(() => {
+      fakeNow = originalDateNow.call(Date);
+      Date.now = () => fakeNow;
+      writeFileSync(TOKEN_PATH, TEST_TOKEN);
+    });
+
+    afterEach(() => {
+      Date.now = originalDateNow;
+    });
+
+    test("retries connection after cooldown period elapses", async () => {
+      // No socket file — two connection failures (first + immediate retry)
+      const client = createBrokerClient();
+      const result = await client.ping();
+      expect(result).toBeNull();
+
+      // Client should be in cooldown — isAvailable() returns false even with
+      // socket + token files present.
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      // Advance time past the first cooldown (30s)
+      fakeNow += 30_001;
+      expect(client.isAvailable()).toBe(true);
+
+      // Now start a real broker and verify the client reconnects
+      rmSync(SOCKET_PATH, { force: true });
+      const broker = createMockBroker();
+      broker.setHandler(() => ({ ok: true, result: { pong: true } }));
+      await broker.start();
+
+      const retryResult = await client.ping();
+      expect(retryResult).toEqual({ pong: true });
+
+      await broker.stop();
+    });
+
+    test("resets failure count after successful reconnection", async () => {
+      // No socket file — two connection failures
+      const client = createBrokerClient();
+      await client.ping();
+
+      // Advance past first cooldown (30s)
+      fakeNow += 30_001;
+
+      // Start broker — reconnection should succeed and reset counters
+      const broker = createMockBroker();
+      broker.setHandler(() => ({ ok: true, result: { pong: true } }));
+      await broker.start();
+
+      const result = await client.ping();
+      expect(result).toEqual({ pong: true });
+
+      // Stop broker and remove socket — simulate another disconnection
+      await broker.stop();
+      rmSync(SOCKET_PATH, { force: true });
+
+      // This new failure should start from the beginning of the cooldown
+      // schedule (30s), not escalated.
+      await client.ping();
+
+      // Verify cooldown is back to 30s (not 60s)
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      // 30s should be enough to clear cooldown
+      fakeNow += 30_001;
+      expect(client.isAvailable()).toBe(true);
+    });
+
+    test("escalates cooldown on repeated failures", async () => {
+      const client = createBrokerClient();
+
+      // First failure round: two attempts (first + immediate retry) ->
+      // consecutiveFailures=2, cooldown index = max(2-2,0) = 0 -> 30s.
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      // 30s should clear the first cooldown
+      fakeNow += 30_001;
+      expect(client.isAvailable()).toBe(true);
+
+      // Remove socket to trigger another failure. After cooldown elapses,
+      // ensureConnected clears unavailableSince and tries connect().
+      // This failure increments consecutiveFailures to 3 (no immediate retry
+      // since consecutiveFailures > 1 after increment).
+      // Cooldown index = max(3-2,0) = 1 -> 60s.
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 30_001;
+      expect(client.isAvailable()).toBe(false); // 30s not enough
+
+      fakeNow += 30_000; // total 60_001ms since this cooldown started
+      expect(client.isAvailable()).toBe(true);
+
+      // Another failure -> consecutiveFailures=4, index = max(4-2,0) = 2 -> 120s (2min)
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 60_001;
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 60_000; // total 120_001ms
+      expect(client.isAvailable()).toBe(true);
+
+      // Another failure -> consecutiveFailures=5, index = max(5-2,0) = 3 -> 300s (5min)
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 120_001;
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 180_000; // total 300_001ms
+      expect(client.isAvailable()).toBe(true);
+
+      // Another failure -> consecutiveFailures=6, index = min(max(6-2,0), 3) = 3 -> 300s (capped)
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 300_001;
+      expect(client.isAvailable()).toBe(true);
+    });
+  });
 });

--- a/assistant/src/security/keychain-broker-client.ts
+++ b/assistant/src/security/keychain-broker-client.ts
@@ -25,6 +25,9 @@ const log = getLogger("keychain-broker-client");
 
 const REQUEST_TIMEOUT_MS = 5_000;
 
+/** Cooldown periods (ms) after consecutive connection failures: 30s, 60s, 2min, 5min, then cap at 5min. */
+const RECONNECT_COOLDOWN_MS = [30_000, 60_000, 120_000, 300_000];
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -89,10 +92,12 @@ export function createBrokerClient(): KeychainBrokerClient {
   let socket: Socket | null = null;
   /** Promise that resolves when the in-flight connect() completes. */
   let connectPromise: Promise<Socket> | null = null;
-  let permanentlyUnavailable = false;
+  /** Timestamp when the broker became unavailable, or null if available. */
+  let unavailableSince: number | null = null;
+  /** Number of consecutive connection failures (drives cooldown escalation). */
+  let consecutiveFailures = 0;
   /** Cached token string, or undefined if not yet successfully read. */
   let cachedToken: string | undefined;
-  let hasTriedReconnect = false;
 
   /** Buffer for incoming data — responses are newline-delimited JSON. */
   let inBuffer = "";
@@ -188,7 +193,8 @@ export function createBrokerClient(): KeychainBrokerClient {
 
       sock.on("connect", () => {
         socket = sock;
-        hasTriedReconnect = false;
+        consecutiveFailures = 0;
+        unavailableSince = null;
         resolve(sock);
       });
 
@@ -206,8 +212,26 @@ export function createBrokerClient(): KeychainBrokerClient {
     });
   }
 
+  /** Compute the cooldown duration for the current failure count. The first
+   *  two failures (initial + immediate retry) map to index 0 (30s). */
+  function getCooldownMs(): number {
+    const idx = Math.min(
+      Math.max(consecutiveFailures - 2, 0),
+      RECONNECT_COOLDOWN_MS.length - 1,
+    );
+    return RECONNECT_COOLDOWN_MS[idx];
+  }
+
   async function ensureConnected(): Promise<Socket | null> {
-    if (permanentlyUnavailable) return null;
+    // If in cooldown, check whether the cooldown period has elapsed.
+    if (unavailableSince != null) {
+      if (Date.now() - unavailableSince < getCooldownMs()) {
+        return null;
+      }
+      // Cooldown elapsed — clear and attempt reconnection below.
+      unavailableSince = null;
+    }
+
     if (socket && !socket.destroyed) return socket;
 
     // If a connect() is already in flight, wait for it instead of returning
@@ -225,24 +249,31 @@ export function createBrokerClient(): KeychainBrokerClient {
       const sock = await connectPromise;
       return sock;
     } catch {
-      // First connection failed — try once more
-      if (!hasTriedReconnect) {
-        hasTriedReconnect = true;
+      consecutiveFailures++;
+
+      // First failure triggers one immediate retry (preserves the original
+      // "try once more" behavior).
+      if (consecutiveFailures === 1) {
         connectPromise = connect();
         try {
           return await connectPromise;
         } catch {
-          // Reconnect also failed — mark unavailable
+          consecutiveFailures++;
+          unavailableSince = Date.now();
           log.warn(
-            "Keychain broker reconnect failed, marking unavailable for this process",
+            `Keychain broker reconnect failed, will retry in ${getCooldownMs() / 1000}s`,
           );
-          permanentlyUnavailable = true;
           return null;
         } finally {
           connectPromise = null;
         }
       }
-      permanentlyUnavailable = true;
+
+      // Subsequent failures — enter cooldown.
+      unavailableSince = Date.now();
+      log.warn(
+        `Keychain broker connection failed (attempt ${consecutiveFailures}), will retry in ${getCooldownMs() / 1000}s`,
+      );
       return null;
     } finally {
       connectPromise = null;
@@ -334,7 +365,9 @@ export function createBrokerClient(): KeychainBrokerClient {
 
   return {
     isAvailable(): boolean {
-      if (permanentlyUnavailable) return false;
+      if (unavailableSince != null) {
+        if (Date.now() - unavailableSince < getCooldownMs()) return false;
+      }
       if (!pathExists(getSocketPath())) return false;
       return pathExists(getTokenPath());
     },


### PR DESCRIPTION
## Summary
- Replace the permanent `permanentlyUnavailable` flag in the keychain broker client with a cooldown-based retry mechanism
- Cooldown escalates on repeated failures: 30s -> 60s -> 2min -> 5min (capped), resets on successful reconnection
- Add tests covering cooldown, escalation, and reset behavior

Part of plan: keychain-broker-resilience.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
