### PR TITLE
refactor: make installationId required on AssistantEntry with CLI-side backfill

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -36,7 +37,7 @@ export interface LocalInstanceResources {
 
 export interface AssistantEntry {
   assistantId: string;
-  installationId?: string;
+  installationId: string;
   runtimeUrl: string;
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
@@ -214,6 +215,13 @@ function readAssistants(): AssistantEntry[] {
   let migrated = false;
   for (const entry of entries) {
     if (migrateLegacyEntry(entry)) {
+      migrated = true;
+    }
+  }
+
+  for (const entry of entries) {
+    if (typeof entry.installationId !== "string") {
+      entry.installationId = randomUUID();
       migrated = true;
     }
   }


### PR DESCRIPTION
## Summary
- Make `installationId` non-optional on `AssistantEntry` interface (`string` instead of `string?`)
- Add CLI-side backfill in `readAssistants()` that generates a UUID for any lockfile entry missing `installationId`
- Ensures all code paths that return `AssistantEntry` guarantee the field is present

Part of plan: canonical-installation-id.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
