### PR TITLE
feat: auto-generate avatar PNG when character traits are written by daemon

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { renderCharacterPng } from "./png-renderer.js";
+
+const log = getLogger("traits-png-sync");
+
+interface CharacterTraits {
+  bodyShape: string;
+  eyeStyle: string;
+  color: string;
+}
+
+/**
+ * Reads character-traits.json from the avatar directory and regenerates
+ * avatar-image.png to match. Called after traits are written to disk.
+ * Returns true if PNG was generated, false if traits file is missing/invalid.
+ */
+export function syncTraitsToPng(): boolean {
+  const avatarDir = join(getWorkspaceDir(), "data", "avatar");
+  const traitsPath = join(avatarDir, "character-traits.json");
+  const pngPath = join(avatarDir, "avatar-image.png");
+
+  let traits: CharacterTraits;
+  try {
+    const raw = readFileSync(traitsPath, "utf-8");
+    traits = JSON.parse(raw) as CharacterTraits;
+  } catch {
+    return false;
+  }
+
+  if (!traits.bodyShape || !traits.eyeStyle || !traits.color) {
+    log.warn({ traits }, "Invalid character traits — missing required fields");
+    return false;
+  }
+
+  try {
+    const pngBuffer = renderCharacterPng(
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
+    );
+    mkdirSync(avatarDir, { recursive: true });
+    const tmpPath = `${pngPath}.${randomUUID()}.tmp`;
+    writeFileSync(tmpPath, pngBuffer);
+    renameSync(tmpPath, pngPath);
+    log.info(
+      {
+        bodyShape: traits.bodyShape,
+        eyeStyle: traits.eyeStyle,
+        color: traits.color,
+      },
+      "Regenerated avatar PNG from character traits",
+    );
+    return true;
+  } catch (err) {
+    log.error({ err }, "Failed to render avatar PNG from traits");
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Creates assistant/src/avatar/traits-png-sync.ts with syncTraitsToPng() function
- Reads character-traits.json and regenerates avatar-image.png using daemon-side rendering
- Uses atomic write (tmp + rename) for safety, returns false on missing/invalid traits

Part of plan: daemon-avatar-svg-rendering.md (PR 5 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
