### PR TITLE
feat: update vellum-avatar skill to trigger daemon-side PNG rendering for native characters

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -81,9 +81,12 @@ mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
 cat > "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json" << 'TRAITS'
 { "bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>" }
 TRAITS
+
+# Trigger daemon-side PNG rendering from the traits
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/avatar/render-from-traits"
 ```
 
-The client will detect the traits file and render the animated character.
+The client will detect the traits file and render the animated character. The daemon also generates a static PNG for use as dock icon and by other clients.
 
 ## Mode 2: Upload a Custom Image
 
@@ -137,12 +140,12 @@ The generated avatar will appear automatically in the client.
 
 `character-traits.json` and `avatar-image.png` represent different avatar modes:
 
-- **Native character** — `character-traits.json` is the source of truth. The client auto-generates `avatar-image.png` as a static representation, so both files coexist.
+- **Native character** — `character-traits.json` is the source of truth. The daemon auto-generates `avatar-image.png` as a static representation, so both files coexist.
 - **Custom image** — `avatar-image.png` is user-provided (uploaded or AI-generated). No traits file exists.
 
 The client checks for character traits first — if `character-traits.json` exists, it renders the animated character. Otherwise, it falls back to `avatar-image.png` for custom images.
 
 Enforcement rules:
 
-- **Setting native character traits** → write `character-traits.json` only. The client auto-generates the PNG.
+- **Setting native character traits** → write `character-traits.json` and call `POST /v1/avatar/render-from-traits`. The daemon auto-generates the PNG.
 - **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.


### PR DESCRIPTION
## Summary
- Updates vellum-avatar SKILL.md to call POST /v1/avatar/render-from-traits after writing character traits
- Daemon now generates the static PNG, removing reliance on the macOS client for PNG rendering

Part of plan: daemon-avatar-svg-rendering.md (PR 6 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
