### PR TITLE
fix: add missing installationId to CLI AssistantEntry construction sites

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -36,6 +36,7 @@ const makeEntry = (
   extra?: Partial<AssistantEntry>,
 ): AssistantEntry => ({
   assistantId: id,
+  installationId: `test-install-${id}`,
   runtimeUrl,
   cloud: "local",
   ...extra,

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -68,6 +68,7 @@ const makeEntry = (
   extra?: Partial<AssistantEntry>,
 ): AssistantEntry => ({
   assistantId: id,
+  installationId: `test-install-${id}`,
   runtimeUrl: `http://localhost:${DEFAULT_DAEMON_PORT}`,
   cloud,
   ...extra,

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { readFileSync } from "fs";
 import jsQR from "jsqr";
 import { hostname, userInfo } from "os";
@@ -167,6 +167,7 @@ export async function pair(): Promise<void> {
 
     const customEntry: AssistantEntry = {
       assistantId: instanceName,
+      installationId: randomUUID(),
       runtimeUrl,
       bearerToken,
       cloud: "custom",


### PR DESCRIPTION
## Summary
- Add `installationId` to test `makeEntry` helpers in `assistant-config.test.ts` and `multi-local.test.ts`
- Add `installationId: randomUUID()` to the `pair` command's `AssistantEntry` construction
- Fixes type-check failures introduced by #17105 which made `installationId` required

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23113797892/job/67135698928

🤖 Generated with [Claude Code](https://claude.com/claude-code)