### PR TITLE
feat: add POST /v1/avatar/render-from-traits endpoint

### DIFF
--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -1,5 +1,16 @@
+import { join } from "node:path";
+
 import { getCharacterComponents } from "../../avatar/character-components.js";
+import { syncTraitsToPng } from "../../avatar/traits-png-sync.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("avatar-routes");
 
 export function avatarRouteDefinitions(): RouteDefinition[] {
   return [
@@ -7,6 +18,40 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
       endpoint: "avatar/character-components",
       method: "GET",
       handler: () => Response.json(getCharacterComponents()),
+    },
+    {
+      endpoint: "avatar/render-from-traits",
+      method: "POST",
+      handler: () => {
+        const success = syncTraitsToPng();
+        if (!success) {
+          return httpError(
+            "BAD_REQUEST",
+            "No valid character-traits.json found",
+            400,
+          );
+        }
+
+        // Notify connected clients to reload avatar
+        const avatarPath = join(
+          getWorkspaceDir(),
+          "data",
+          "avatar",
+          "avatar-image.png",
+        );
+        assistantEventHub
+          .publish(
+            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+              type: "avatar_updated",
+              avatarPath,
+            }),
+          )
+          .catch((err) => {
+            log.warn({ err }, "Failed to publish avatar_updated event");
+          });
+
+        return Response.json({ ok: true });
+      },
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Adds POST /v1/avatar/render-from-traits endpoint to avatar-routes.ts
- Reads character-traits.json, renders PNG via daemon-side SVG rendering, publishes avatar_updated event
- Returns 400 if no valid traits file exists

Part of plan: daemon-avatar-svg-rendering.md (PR 7 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
