### PR TITLE
feat: add LogExportScope enum and scope field to LogReportFormData

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -36,10 +36,20 @@ enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
+/// Determines what data the log export should include.
+enum LogExportScope: Sendable {
+    /// Full global export — all threads, all data.
+    case global
+    /// Scoped to a single thread/conversation.
+    case thread(conversationId: String, threadTitle: String,
+                startTime: Date? = nil, endTime: Date? = nil)
+}
+
 /// Aggregated form data collected from the log report sheet.
 struct LogReportFormData: Sendable {
     var reason: LogReportReason
     var name: String
     var message: String
     var email: String  // Required — used for follow-up via Sentry Feedback
+    var scope: LogExportScope = .global
 }


### PR DESCRIPTION
## Summary
- Add `LogExportScope` enum with `.global` and `.thread(conversationId:threadTitle:startTime:endTime:)` cases
- Add `scope: LogExportScope = .global` field to `LogReportFormData`
- Backwards-compatible — existing callers compile without changes

Part of plan: thread-scoped-log-export.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
