### PR TITLE
fix: prevent keychain broker test timeout from stale socket race

### DIFF
--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -569,8 +569,12 @@ describe("keychain-broker-client", () => {
       const result = await client.ping();
       expect(result).toEqual({ pong: true });
 
-      // Stop broker and remove socket — simulate another disconnection
+      // Stop broker and remove socket — simulate another disconnection.
+      // Yield after stop so the client socket receives the close event
+      // before the next ping (otherwise ensureConnected returns the stale
+      // socket and sendRequest waits REQUEST_TIMEOUT_MS for a response).
       await broker.stop();
+      await new Promise((r) => setTimeout(r, 50));
       rmSync(SOCKET_PATH, { force: true });
 
       // This new failure should start from the beginning of the cooldown
@@ -584,7 +588,7 @@ describe("keychain-broker-client", () => {
       // 30s should be enough to clear cooldown
       fakeNow += 30_001;
       expect(client.isAvailable()).toBe(true);
-    });
+    }, 15_000);
 
     test("escalates cooldown on repeated failures", async () => {
       const client = createBrokerClient();


### PR DESCRIPTION
## Summary
- Add a 50ms yield after `broker.stop()` in the "resets failure count after successful reconnection" test so the client socket receives the close event before the next `ping()` call
- Bump the test timeout from the default 5s to 15s as a safety net — the default exactly matched `REQUEST_TIMEOUT_MS`, leaving zero margin if the race still occurs

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23113780457/job/67135654344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
