### PR TITLE
feat: add getSkill business-logic function for single skill lookup

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -274,6 +274,48 @@ export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
   return items;
 }
 
+/** Look up a single skill by ID from the resolved catalog, returning its SkillListItem. */
+function findSkillById(
+  skillId: string,
+): { item: SkillListItem; summary: SkillSummary } | undefined {
+  const config = getConfig();
+  const catalog = loadSkillCatalog();
+  const resolved = resolveSkillStates(catalog, config);
+  const match = resolved.find((r) => r.summary.id === skillId);
+  if (!match) return undefined;
+
+  const r = match;
+  const item: SkillListItem = {
+    id: r.summary.id,
+    name: r.summary.displayName,
+    description: r.summary.description,
+    emoji: r.summary.emoji,
+    homepage: r.summary.homepage,
+    source: r.summary.source,
+    state: (r.state === "degraded" ? "enabled" : r.state) as
+      | "enabled"
+      | "disabled"
+      | "available",
+    degraded: r.degraded,
+    missingRequirements: r.missingRequirements,
+    updateAvailable: false,
+    userInvocable: r.summary.userInvocable,
+    provenance: resolveProvenance(r.summary),
+  };
+  return { item, summary: r.summary };
+}
+
+export function getSkill(
+  skillId: string,
+  _ctx: SkillOperationContext,
+): { skill: SkillListItem } | { error: string; status: number } {
+  const found = findSkillById(skillId);
+  if (!found) {
+    return { error: `Skill "${skillId}" not found`, status: 404 };
+  }
+  return { skill: found.item };
+}
+
 export function enableSkill(
   skillId: string,
   ctx: SkillOperationContext,


### PR DESCRIPTION
## Summary
- Extract `findSkillById` private helper from skill catalog lookup logic
- Add exported `getSkill` function that returns a single skill's metadata by ID
- Returns same `SkillListItem` shape as the list API, or a 404 error

Part of plan: skill-detail-files-api.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
