### PR TITLE
refactor: remove client-side PNG rendering on traits reload, rely on daemon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -294,28 +294,6 @@ final class AvatarAppearanceManager {
         characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
         characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
         characterColor = AvatarColor(rawValue: components.color)
-        renderAndSaveCharacterPNG()
-    }
-
-    /// Renders the current character traits to a static PNG and saves it to
-    /// avatar-image.png. This ensures a static representation always exists
-    /// alongside the traits file — used by the dock icon, chat avatar image,
-    /// and other clients (iOS, Telegram) that don't have the animated renderer.
-    private func renderAndSaveCharacterPNG() {
-        guard let body = characterBodyShape,
-              let eyes = characterEyeStyle,
-              let color = characterColor else { return }
-        let rendered = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
-        let url = customAvatarURL
-        let dir = url.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        guard let tiffData = rendered.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let pngData = bitmap.representation(using: .png, properties: [:]) else { return }
-        try? pngData.write(to: url)
-        cachedChatAvatar = nil
-        customAvatarImage = rendered
-        updateDockIcon()
     }
 
     // MARK: - File Watching


### PR DESCRIPTION
## Summary
- Removes renderAndSaveCharacterPNG() method from AvatarAppearanceManager
- Removes the call to it from loadAvatarComponents()
- Daemon now handles PNG generation via POST /v1/avatar/render-from-traits

Part of plan: daemon-avatar-svg-rendering.md (PR 9 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
