### PR TITLE
chore: remove credential-setup-for skill metadata key

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -69,7 +69,6 @@ const VellumMetadataSchema = z
     "user-invocable": z.union([z.boolean(), z.string()]).optional(),
     "disable-model-invocation": z.union([z.boolean(), z.string()]).optional(),
     includes: z.array(z.string()).optional(),
-    "credential-setup-for": z.string().optional(),
     "feature-flag": z.string().optional(),
   })
   .passthrough();
@@ -136,8 +135,6 @@ export interface SkillSummary {
   toolManifest?: SkillToolManifestMeta;
   /** IDs of child skills that this skill includes (metadata-only, not auto-activated). */
   includes?: string[];
-  /** Declares which credential this skill sets up (e.g. "vercel:api_token"). */
-  credentialSetupFor?: string;
   /** Feature flag ID declared in frontmatter. Only skills with this field are subject to feature flag gating. */
   featureFlag?: string;
 }
@@ -341,7 +338,6 @@ interface ParsedFrontmatter {
   disableModelInvocation: boolean;
   metadata?: VellumMetadata;
   includes?: string[];
-  credentialSetupFor?: string;
   featureFlag?: string;
 }
 
@@ -475,11 +471,6 @@ function parseFrontmatter(
     includes = normalized.length > 0 ? normalized : undefined;
   }
 
-  const credentialSetupFor =
-    typeof vellum?.["credential-setup-for"] === "string"
-      ? vellum["credential-setup-for"]
-      : undefined;
-
   const featureFlag =
     typeof vellum?.["feature-flag"] === "string"
       ? vellum["feature-flag"]
@@ -499,7 +490,6 @@ function parseFrontmatter(
     disableModelInvocation,
     metadata,
     includes,
-    credentialSetupFor,
     featureFlag,
   };
 }
@@ -654,7 +644,6 @@ function readSkillFromDirectory(
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
       includes: parsed.includes,
-      credentialSetupFor: parsed.credentialSetupFor,
       featureFlag: parsed.featureFlag,
     };
   } catch (err) {
@@ -705,7 +694,6 @@ function readBundledSkillFromDirectory(
       metadata: parsed.metadata,
       toolManifest: detectToolManifest(directoryPath),
       includes: parsed.includes,
-      credentialSetupFor: parsed.credentialSetupFor,
       featureFlag: parsed.featureFlag,
     };
   } catch (err) {
@@ -764,7 +752,6 @@ function loadBundledSkills(): SkillSummary[] {
       metadata: skill.metadata,
       toolManifest: skill.toolManifest,
       includes: skill.includes,
-      credentialSetupFor: skill.credentialSetupFor,
       featureFlag: skill.featureFlag,
     });
   }
@@ -902,7 +889,6 @@ function skillSummaryFromDefinition(
     metadata: skill.metadata,
     toolManifest: skill.toolManifest,
     includes: skill.includes,
-    credentialSetupFor: skill.credentialSetupFor,
     featureFlag: skill.featureFlag,
   };
 }
@@ -955,7 +941,6 @@ export function loadSkillCatalog(
             metadata: parsed.metadata,
             toolManifest: detectToolManifest(directory),
             includes: parsed.includes,
-            credentialSetupFor: parsed.credentialSetupFor,
             featureFlag: parsed.featureFlag,
           });
         } catch (err) {
@@ -1052,7 +1037,6 @@ export function loadSkillCatalog(
           metadata: parsed.metadata,
           toolManifest: detectToolManifest(directory),
           includes: parsed.includes,
-          credentialSetupFor: parsed.credentialSetupFor,
           featureFlag: parsed.featureFlag,
         };
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1040,11 +1040,8 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
         ? escapeXml(getMcpSetupDescription())
         : escapeXml(skill.description);
     const locAttr = escapeXml(skill.directoryPath);
-    const credAttr = skill.credentialSetupFor
-      ? ` credential-setup-for="${escapeXml(skill.credentialSetupFor)}"`
-      : "";
     lines.push(
-      `<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}"${credAttr} />`,
+      `<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}" />`,
     );
   }
   lines.push("</available_skills>");
@@ -1052,7 +1049,6 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
   return [
     "## Available Skills",
     "The following skills are available. Before executing one, call `skill_load` to load the full instructions, then use `skill_execute` to invoke the skill's tools.",
-    "When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill.",
     "",
     lines.join("\n"),
     "",

--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -173,7 +173,6 @@ const STANDARD_FIELDS = new Set([
 const VELLUM_EXTENSION_FIELDS = new Set([
   "user-invocable",
   "user_invocable",
-  "credential-setup-for",
   "disable-model-invocation",
 ]);
 

--- a/scripts/skills/migrate-bundled-frontmatter.mjs
+++ b/scripts/skills/migrate-bundled-frontmatter.mjs
@@ -235,15 +235,6 @@ function migrateSkill(dirName, skillDir) {
     changes.push(`includes moved to metadata.vellum`);
   }
 
-  // credential-setup-for: only if present
-  const credSetupFor =
-    fields["credential-setup-for"] ||
-    existingMetadata?.vellum?.["credential-setup-for"];
-  if (credSetupFor) {
-    vellum["credential-setup-for"] = credSetupFor;
-    changes.push(`credential-setup-for moved to metadata.vellum`);
-  }
-
   // Preserve other existing metadata.vellum fields (cli, requires, os, primaryEnv, install, etc.)
   if (existingMetadata?.vellum) {
     for (const [key, val] of Object.entries(existingMetadata.vellum)) {
@@ -252,8 +243,7 @@ function migrateSkill(dirName, skillDir) {
         key === "display-name" ||
         key === "user-invocable" ||
         key === "disable-model-invocation" ||
-        key === "includes" ||
-        key === "credential-setup-for"
+        key === "includes"
       ) {
         continue; // Already handled above
       }

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Airtable OAuth Setup"
     user-invocable: true
-    credential-setup-for: "airtable"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Asana OAuth Setup"
     user-invocable: true
-    credential-setup-for: "asana"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -24,7 +24,6 @@
         "vellum": {
           "display-name": "Airtable OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "airtable",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -67,7 +66,6 @@
         "vellum": {
           "display-name": "Asana OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "asana",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -121,7 +119,6 @@
         "vellum": {
           "display-name": "Discord OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "discord",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -168,7 +165,6 @@
         "vellum": {
           "display-name": "Dropbox OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "dropbox",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -212,7 +208,6 @@
         "vellum": {
           "display-name": "Figma OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "figma",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -238,7 +233,6 @@
         "vellum": {
           "display-name": "GitHub OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "github",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -255,7 +249,6 @@
         "vellum": {
           "display-name": "Google OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "gmail",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -285,7 +278,6 @@
         "vellum": {
           "display-name": "HubSpot OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "hubspot",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -315,7 +307,6 @@
         "vellum": {
           "display-name": "Linear OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "linear",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -374,7 +365,6 @@
         "vellum": {
           "display-name": "Notion OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "notion",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -511,7 +501,6 @@
         "vellum": {
           "display-name": "Slack OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "slack",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -528,7 +517,6 @@
         "vellum": {
           "display-name": "Spotify OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "spotify",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -586,7 +574,6 @@
         "vellum": {
           "display-name": "Todoist OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "todoist",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -619,7 +606,6 @@
         "vellum": {
           "display-name": "Twitter / X OAuth Setup",
           "user-invocable": "true",
-          "credential-setup-for": "twitter",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -663,8 +649,7 @@
           "display-name": "Vercel Token Setup",
           "includes": [
             "browser"
-          ],
-          "credential-setup-for": "vercel:api_token"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Discord OAuth Setup"
     user-invocable: true
-    credential-setup-for: "discord"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Dropbox OAuth Setup"
     user-invocable: true
-    credential-setup-for: "dropbox"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Figma OAuth Setup"
     user-invocable: true
-    credential-setup-for: "figma"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "GitHub OAuth Setup"
     user-invocable: true
-    credential-setup-for: "github"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Google OAuth Setup"
     user-invocable: true
-    credential-setup-for: "gmail"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "HubSpot OAuth Setup"
     user-invocable: true
-    credential-setup-for: "hubspot"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Linear OAuth Setup"
     user-invocable: true
-    credential-setup-for: "linear"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Notion OAuth Setup"
     user-invocable: true
-    credential-setup-for: "notion"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -40,9 +40,9 @@ If no config is found, tell the user this service doesn't have a pre-configured 
 
 ## Step 2: Check for a dedicated setup skill
 
-Check if there is a skill with `credential-setup-for` matching this service name. If so, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
+Check the available skills catalog for a dedicated `<service>-oauth-setup` skill matching this service name. If one exists, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
 
-Well-known services with dedicated setup skills: `gmail`, `slack`, `notion`, `twitter`, `github`, `linear`, `spotify`, `todoist`, `discord`, `dropbox`, `asana`, `airtable`, `hubspot`, `figma`.
+Well-known services with dedicated setup skills: `gmail` (google-oauth-applescript), `slack`, `notion`, `twitter`, `github`, `linear`, `spotify`, `todoist`, `discord`, `dropbox`, `asana`, `airtable`, `hubspot`, `figma`.
 
 ## Step 3: Choose the flow based on setup metadata
 

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Slack OAuth Setup"
     user-invocable: true
-    credential-setup-for: "slack"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Spotify OAuth Setup"
     user-invocable: true
-    credential-setup-for: "spotify"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Todoist OAuth Setup"
     user-invocable: true
-    credential-setup-for: "todoist"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Twitter / X OAuth Setup"
     user-invocable: true
-    credential-setup-for: "twitter"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Vercel Token Setup"
     includes: ["browser"]
-    credential-setup-for: "vercel:api_token"
 ---
 
 You are helping your user set up a Vercel API token so they can publish apps to the web.

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -31,6 +31,7 @@ Tell the user:
 > **Setting up Vercel API Token**
 >
 > Since I can't automate the browser from here, I'll walk you through each step with direct links. You'll need:
+>
 > 1. A Vercel account (free tier works)
 > 2. About 2 minutes
 >
@@ -130,6 +131,7 @@ Tell the user:
 > **Setting up your Vercel API token so we can publish your app...**
 >
 > Here's what will happen:
+>
 > 1. **A browser opens** to your Vercel account settings
 > 2. **You sign in** (if not already signed in)
 > 3. **I create the token** — you just watch
@@ -146,6 +148,7 @@ If the user declines, acknowledge and stop. No further confirmations are needed 
 Navigate to `https://vercel.com/account/tokens`.
 
 Take a screenshot and snapshot to check the page state:
+
 - **Sign-in page:** Tell the user: "Please sign in to your Vercel account in the browser." Then auto-detect sign-in completion by polling screenshots every 5-10 seconds. Check if the current URL has moved away from the login/sign-in page to the tokens page. Do NOT ask the user to "let me know when you're done" — detect it automatically. Once sign-in is detected, tell the user: "Signed in! Creating your API token now..."
 - **Already signed in:** Tell the user: "Already signed in — creating your API token now..." and continue immediately.
 
@@ -158,6 +161,7 @@ Take a screenshot and snapshot to check the page state:
 Take a screenshot and snapshot. Find and click the button to create a new token (typically labeled "Create" or "Create Token").
 
 On the creation form:
+
 - Token name: **"Vellum Assistant"**
 - Scope: Select **"Full Account"** (or the broadest scope available)
 - Expiration: Select the longest option available, or **"No Expiration"** if offered
@@ -178,6 +182,7 @@ After token creation, Vercel shows the token value **once**. You MUST follow thi
 3. Wait for the user to paste the token.
 
 **Absolute prohibitions during this step:**
+
 - Do NOT try to read the token value from the screenshot. It must come from the user via secure prompt to ensure accuracy.
 - Do NOT navigate away from the page until the user has pasted the token.
 - Do NOT click any download or copy buttons.


### PR DESCRIPTION
## Summary
- Remove `credential-setup-for` from VellumMetadataSchema, SkillSummary, and ParsedFrontmatter
- Remove credential-setup-for XML attribute and routing instruction from system prompt catalog
- Strip `credential-setup-for` from 15 OAuth setup SKILL.md frontmatter files
- Regenerate catalog.json and clean up lint/migration scripts

Part of plan: rm-skill-metadata-keys.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
