### PR TITLE
feat: add Swift types for skill detail and skill files API responses

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3944,6 +3944,46 @@ public struct SkillsListResponseSkillProvenance: Codable, Sendable {
     }
 }
 
+// MARK: - Skill Detail Response (GET /v1/skills/:id)
+
+public struct SkillDetailHTTPResponse: Codable, Sendable {
+    public let skill: SkillsListResponseSkill
+
+    public init(skill: SkillsListResponseSkill) {
+        self.skill = skill
+    }
+}
+
+// MARK: - Skill Detail Files Response (GET /v1/skills/:id/files)
+
+public struct SkillDetailFilesHTTPResponse: Codable, Sendable {
+    public let skill: SkillsListResponseSkill
+    public let files: [SkillFileEntry]
+
+    public init(skill: SkillsListResponseSkill, files: [SkillFileEntry]) {
+        self.skill = skill
+        self.files = files
+    }
+}
+
+public struct SkillFileEntry: Codable, Sendable {
+    public let path: String
+    public let name: String
+    public let size: Int
+    public let mimeType: String
+    public let isBinary: Bool
+    public let content: String?
+
+    public init(path: String, name: String, size: Int, mimeType: String, isBinary: Bool, content: String? = nil) {
+        self.path = path
+        self.name = name
+        self.size = size
+        self.mimeType = mimeType
+        self.isBinary = isBinary
+        self.content = content
+    }
+}
+
 public struct SkillsOperationResponse: Codable, Sendable {
     public let type: String
     public let operation: String


### PR DESCRIPTION
## Summary
- Add `SkillDetailHTTPResponse` type for GET /v1/skills/:id
- Add `SkillDetailFilesHTTPResponse` and `SkillFileEntry` types for GET /v1/skills/:id/files
- Reuses existing `SkillsListResponseSkill` for the skill metadata field
- Named with `HTTP` suffix to avoid conflict with existing `SkillDetailResponse` WebSocket message type

Part of plan: skill-detail-files-api.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
