### PR TITLE
chore: remove os skill metadata key and platform filtering

### DIFF
--- a/assistant/src/__tests__/frontmatter.test.ts
+++ b/assistant/src/__tests__/frontmatter.test.ts
@@ -242,13 +242,13 @@ describe("parseFrontmatterFields", () => {
       'description: "A test skill"',
       "metadata:",
       "  vellum:",
-      "    os:",
-      "      - darwin",
-      "      - linux",
       "    requires:",
       "      bins:",
       "        - node",
       "        - npm",
+      "      env:",
+      "        - API_KEY",
+      "        - SECRET",
       "---",
       "Body",
     ].join("\n");
@@ -256,8 +256,10 @@ describe("parseFrontmatterFields", () => {
     expect(result).not.toBeNull();
     const meta = result!.fields.metadata as Record<string, unknown>;
     const vellum = meta.vellum as Record<string, unknown>;
-    expect(vellum.os).toEqual(["darwin", "linux"]);
-    expect(vellum.requires).toEqual({ bins: ["node", "npm"] });
+    expect(vellum.requires).toEqual({
+      bins: ["node", "npm"],
+      env: ["API_KEY", "SECRET"],
+    });
   });
 
   test("returns null for invalid YAML frontmatter", () => {

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -831,8 +831,6 @@ describe("YAML metadata round-trip", () => {
         '    display-name: "YAML Nested Skill"',
         "    user-invocable: false",
         "    disable-model-invocation: true",
-        "    os:",
-        `      - "${process.platform}"`,
         "    includes:",
         '      - "child-a"',
         '      - "child-b"',
@@ -856,8 +854,6 @@ describe("YAML metadata round-trip", () => {
     expect(skill!.emoji).toBe("🧪");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
 
-    // Verify os is parsed into metadata
     expect(skill!.metadata).toBeDefined();
-    expect(skill!.metadata!.os).toEqual([process.platform]);
   });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -39,7 +39,6 @@ const log = getLogger("skills");
 const VellumMetadataSchema = z
   .object({
     emoji: z.string().optional(),
-    os: z.array(z.string()).optional(),
     requires: z
       .object({
         bins: z.array(z.string()).optional(),
@@ -92,7 +91,6 @@ export interface SkillCliSpec {
 
 export interface VellumMetadata {
   emoji?: string;
-  os?: string[];
   requires?: SkillRequirements;
   primaryEnv?: string;
   install?: InstallerSpec[];
@@ -238,22 +236,6 @@ export function checkSkillRequirements(
 
   const missingBins: string[] = [];
   const missingEnv: string[] = [];
-
-  // OS check
-  if (vellum.os && vellum.os.length > 0) {
-    if (!vellum.os.includes(process.platform)) {
-      return {
-        eligible: false,
-        missing: {
-          bins: [
-            `(unsupported platform: ${
-              process.platform
-            }, requires: ${vellum.os.join(", ")})`,
-          ],
-        },
-      };
-    }
-  }
 
   const requires = vellum.requires;
   if (!requires) {
@@ -417,13 +399,6 @@ function parseFrontmatter(
         vellum = raw?.vellum as z.infer<typeof VellumMetadataSchema>;
         if (raw?.vellum && typeof raw.vellum === "object") {
           const vellumRaw = raw.vellum as Record<string, unknown>;
-
-          // Coerce `os` to string[] — a bare string is wrapped in an array.
-          if (vellumRaw.os !== undefined) {
-            vellumRaw.os = Array.isArray(vellumRaw.os)
-              ? vellumRaw.os
-              : [vellumRaw.os];
-          }
 
           // Coerce `requires` sub-fields to arrays.
           if (vellumRaw.requires && typeof vellumRaw.requires === "object") {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1022,13 +1022,8 @@ function getMcpSetupDescription(): string {
 }
 
 function formatSkillsCatalog(skills: SkillSummary[]): string {
-  // Filter out skills with disableModelInvocation or unsupported OS
-  const visible = skills.filter((s) => {
-    if (s.disableModelInvocation) return false;
-    const os = s.metadata?.os;
-    if (os && os.length > 0 && !os.includes(process.platform)) return false;
-    return true;
-  });
+  // Filter out skills with disableModelInvocation
+  const visible = skills.filter((s) => !s.disableModelInvocation);
   if (visible.length === 0) return "";
 
   const lines = ["<available_skills>"];

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -331,10 +331,7 @@
         "emoji": "🍎",
         "vellum": {
           "display-name": "macOS Automation",
-          "user-invocable": "false",
-          "os": [
-            "darwin"
-          ]
+          "user-invocable": "false"
         }
       },
       "compatibility": "Designed for Vellum personal assistants"
@@ -435,10 +432,7 @@
       "metadata": {
         "emoji": "🎬",
         "vellum": {
-          "display-name": "Screen Recording",
-          "os": [
-            "darwin"
-          ]
+          "display-name": "Screen Recording"
         }
       },
       "compatibility": "Designed for Vellum personal assistants"
@@ -678,9 +672,6 @@
         "vellum": {
           "display-name": "Voice Setup",
           "user-invocable": "true",
-          "os": [
-            "darwin"
-          ],
           "includes": [
             "elevenlabs-voice"
           ]

--- a/skills/macos-automation/SKILL.md
+++ b/skills/macos-automation/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "macOS Automation"
     user-invocable: false
-    os: ["darwin"]
 ---
 
 Use this skill to interact with native macOS apps and system-level features via `osascript` (AppleScript) through `host_bash`. Always prefer osascript over browser automation or computer-use for anything involving a native macOS app.

--- a/skills/screen-recording/SKILL.md
+++ b/skills/screen-recording/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   emoji: "🎬"
   vellum:
     display-name: "Screen Recording"
-    os: ["darwin"]
 ---
 
 Capture screen recordings as video files attached to the conversation.

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Voice Setup"
     user-invocable: true
-    os: ["darwin"]
     includes: ["elevenlabs-voice"]
 ---
 


### PR DESCRIPTION
## Summary
- Remove `os` field from VellumMetadataSchema, VellumMetadata interface, and parseFrontmatter fallback
- Remove platform-based filtering from formatSkillsCatalog() in system-prompt.ts
- Remove OS check from checkSkillRequirements() in skills.ts
- Remove `os: ["darwin"]` from screen-recording, voice-setup, and macos-automation SKILL.md files
- Regenerate catalog.json
- Update tests that referenced metadata.os

Part of plan: rm-skill-metadata-keys.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
