### PR TITLE
fix: backfill installationId on recovered assistant entries

### DIFF
--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, unlinkSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -39,6 +40,8 @@ export async function recover(): Promise<void> {
 
   // 2. Read and validate metadata before any side effects
   const entry: AssistantEntry = JSON.parse(readFileSync(metadataPath, "utf-8"));
+  // Backfill installationId for archives created before the field was introduced
+  entry.installationId ??= randomUUID();
   if (!entry.resources) {
     throw new Error(
       `Retired assistant '${name}' is missing resource configuration. ` +


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for canonical-installation-id.md.

**Gap:** recover.ts passes archived entry without installationId
**What was expected:** All AssistantEntry objects written to lockfile should have installationId
**What was found:** Archives from before installationId was introduced lack the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
