### PR TITLE
feat: make showLogReportWindow thread-aware with scope parameter

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -490,7 +490,7 @@ extension AppDelegate {
         }
     }
 
-    private func showLogReportWindow() {
+    func showLogReportWindow(scope: LogExportScope = .global) {
         let dismiss: () -> Void = { [weak self] in
             self?.dismissLogReportWindow()
         }
@@ -498,6 +498,8 @@ extension AppDelegate {
         let view = LogReportFormView(
             onSend: { [weak self] formData in
                 self?.dismissLogReportWindow()
+                var formData = formData
+                formData.scope = scope
                 LogExporter.sendLogsToSentry(formData: formData)
             },
             onCancel: dismiss
@@ -511,7 +513,12 @@ extension AppDelegate {
             defer: false
         )
         window.contentViewController = hostingController
-        window.title = "Send Logs to Vellum"
+        switch scope {
+        case .global:
+            window.title = "Send Logs to Vellum"
+        case .thread:
+            window.title = "Send Logs for Thread"
+        }
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
         window.center()


### PR DESCRIPTION
## Summary
- Add `scope: LogExportScope = .global` parameter to `showLogReportWindow`
- Set `formData.scope` from the parameter before calling `sendLogsToSentry`
- Set window title to "Send Logs for Thread" vs "Send Logs to Vellum" based on scope
- Existing callers unaffected (default `.global`)

Part of plan: thread-scoped-log-export.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
