### PR TITLE
fix: install ces-contracts linked deps in benchmark and release CI

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install linked package dependencies
+        run: cd ../packages/ces-contracts && bun install --frozen-lockfile
+
       - name: Download previous baseline
         id: baseline
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1191,6 +1191,7 @@ jobs:
 
           # Daemon
           (cd "$ASSISTANT_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
+          (cd packages/ces-contracts && bun install --frozen-lockfile 2>/dev/null || bun install)
           mkdir -p daemon-bin
           bun build --compile "${DAEMON_FLAGS[@]}" --target=bun-darwin-x64 \
             "$ASSISTANT_SRC_DIR/src/daemon/main.ts" --outfile daemon-bin/vellum-daemon
@@ -1565,6 +1566,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
         working-directory: assistant
+
+      - name: Install linked package dependencies
+        run: cd packages/ces-contracts && bun install --frozen-lockfile
 
       - name: Lint
         run: bun run lint


### PR DESCRIPTION
## Summary
- Add missing `bun install --frozen-lockfile` step for `packages/ces-contracts` in the benchmark CI workflow and release CI workflow
- The main CI workflow (`ci-main-assistant.yaml`) already has this step, but the benchmark and release workflows were missing it, causing `Cannot find module 'zod/v4'` errors when ces-contracts is transitively imported

## Original prompt
fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/23113855399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
