### PR TITLE
feat: add getSkillFiles business-logic function for reading skill directory contents

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,5 +1,11 @@
-import { existsSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join, relative } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
@@ -37,6 +43,24 @@ import {
   type HandlerContext,
   log,
 } from "./shared.js";
+
+// ─── MIME detection helpers ───────────────────────────────────────────────────
+
+const TEXT_MIME_PREFIXES = [
+  "text/",
+  "application/json",
+  "application/javascript",
+  "application/typescript",
+  "application/xml",
+  "application/yaml",
+  "application/x-yaml",
+  "application/toml",
+  "application/x-sh",
+];
+function isTextMime(mimeType: string): boolean {
+  return TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
+}
+const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 // ─── Shared context for standalone functions ─────────────────────────────────
 
@@ -314,6 +338,81 @@ export function getSkill(
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
   return { skill: found.item };
+}
+
+// ─── Skill file listing ──────────────────────────────────────────────────────
+
+export interface SkillFileEntry {
+  path: string; // relative to skill directory root (e.g. "SKILL.md", "tools/foo.ts")
+  name: string; // basename
+  size: number;
+  mimeType: string;
+  isBinary: boolean;
+  content: string | null; // inline text if ≤ 2 MB and text MIME, else null
+}
+
+const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
+
+function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
+  const entries: SkillFileEntry[] = [];
+  let dirents;
+  try {
+    dirents = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return entries;
+  }
+  for (const dirent of dirents) {
+    if (dirent.name.startsWith(".")) continue;
+    const fullPath = join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      if (SKIP_DIRS.has(dirent.name)) continue;
+      entries.push(...readDirRecursive(fullPath, rootDir));
+      continue;
+    }
+    if (!dirent.isFile()) continue;
+    try {
+      const stat = statSync(fullPath);
+      const mimeType = Bun.file(fullPath).type;
+      const isText = isTextMime(mimeType);
+      let content: string | null = null;
+      if (isText && stat.size <= MAX_INLINE_SIZE) {
+        content = readFileSync(fullPath, "utf-8");
+      }
+      entries.push({
+        path: relative(rootDir, fullPath),
+        name: dirent.name,
+        size: stat.size,
+        mimeType,
+        isBinary: !isText,
+        content,
+      });
+    } catch {
+      // Skip files that can't be stat'd
+    }
+  }
+  return entries;
+}
+
+export function getSkillFiles(
+  skillId: string,
+  _ctx: SkillOperationContext,
+):
+  | { skill: SkillListItem; files: SkillFileEntry[] }
+  | { error: string; status: number } {
+  const found = findSkillById(skillId);
+  if (!found) {
+    return { error: `Skill "${skillId}" not found`, status: 404 };
+  }
+
+  const dirPath = found.summary.directoryPath;
+  if (!existsSync(dirPath)) {
+    return { error: `Skill directory not found for "${skillId}"`, status: 404 };
+  }
+
+  const files = readDirRecursive(dirPath, dirPath);
+  files.sort((a, b) => a.path.localeCompare(b.path));
+
+  return { skill: found.item, files };
 }
 
 export function enableSkill(


### PR DESCRIPTION
## Summary
- Add MIME-detection helpers and `SkillFileEntry` interface
- Add recursive directory reader that handles all file types with inline text content
- Add exported `getSkillFiles` function reusing `findSkillById` from PR 1
- Skips dotfiles, node_modules, __pycache__, and unreadable files

Part of plan: skill-detail-files-api.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
