### PR TITLE
chore: remove dead skill metadata keys (requires, primaryEnv, install)

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -831,8 +831,6 @@ describe("YAML metadata round-trip", () => {
         '    display-name: "YAML Nested Skill"',
         "    user-invocable: false",
         "    disable-model-invocation: true",
-        "    os:",
-        `      - "${process.platform}"`,
         "    includes:",
         '      - "child-a"',
         '      - "child-b"',
@@ -855,9 +853,5 @@ describe("YAML metadata round-trip", () => {
     expect(skill!.disableModelInvocation).toBe(true);
     expect(skill!.emoji).toBe("🧪");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
-
-    // Verify os is parsed into metadata
-    expect(skill!.metadata).toBeDefined();
-    expect(skill!.metadata!.os).toEqual([process.platform]);
   });
 });

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -37,7 +37,6 @@ let mockVersionHashErrors: Set<string> = new Set();
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
-  checkSkillRequirements: () => ({ eligible: true, missing: {} }),
 }));
 
 mock.module("../skills/active-skill-tools.js", () => {

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -179,7 +179,6 @@ mock.module("../config/skill-state.js", () => ({
     catalog.map((s) => ({
       summary: s,
       state: "enabled",
-      degraded: false,
     })),
 }));
 

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -165,7 +165,6 @@ mock.module("../config/skill-state.js", () => ({
     catalog.map((s) => ({
       summary: s,
       state: "enabled",
-      degraded: false,
     })),
 }));
 

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -184,7 +184,6 @@ mock.module("../config/skill-state.js", () => ({
     catalog.map((s) => ({
       summary: s,
       state: "enabled",
-      degraded: false,
     })),
 }));
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -30,7 +30,6 @@ const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
 
 mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
-  checkSkillRequirements: () => ({ satisfied: true, missing: [] }),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -56,8 +56,6 @@ mock.module("../config/skills.js", () => ({
       bundled: false,
       userInvocable: false,
     })),
-  // Needed by transitive deps (skill-state.ts imports this)
-  checkSkillRequirements: () => ({ eligible: true, missing: {} }),
   getSkillsDir: () => "/tmp/fake-skills",
   getBundledSkillsDir: () => "/tmp/fake-bundled-skills",
   resolveSkillSelector: () => ({ found: false }),

--- a/assistant/src/__tests__/slash-commands-catalog.test.ts
+++ b/assistant/src/__tests__/slash-commands-catalog.test.ts
@@ -28,7 +28,6 @@ function makeResolved(
   return {
     summary: skill,
     state,
-    degraded: state === "degraded",
   };
 }
 
@@ -64,10 +63,10 @@ describe("buildInvocableSlashCatalog", () => {
     expect(entry!.name).toBe("Start the Day");
   });
 
-  test("includes degraded invocable skill", () => {
-    const skill = makeSkill("degraded-skill");
+  test("includes available invocable skill", () => {
+    const skill = makeSkill("available-skill");
     const catalog = [skill];
-    const resolved = [makeResolved(skill, "degraded")];
+    const resolved = [makeResolved(skill, "available")];
 
     const result = buildInvocableSlashCatalog(catalog, resolved);
     expect(result.size).toBe(1);

--- a/assistant/src/__tests__/slash-commands-resolver.test.ts
+++ b/assistant/src/__tests__/slash-commands-resolver.test.ts
@@ -33,7 +33,6 @@ function makeResolved(
   return {
     summary: skill,
     state,
-    degraded: state === "degraded",
   };
 }
 

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -1,15 +1,12 @@
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig, SkillEntryConfig } from "./schema.js";
 import type { SkillSummary } from "./skills.js";
-import { checkSkillRequirements } from "./skills.js";
 
-export type SkillState = "enabled" | "disabled" | "degraded" | "available";
+export type SkillState = "enabled" | "disabled" | "available";
 
 export interface ResolvedSkill {
   summary: SkillSummary;
   state: SkillState;
-  degraded: boolean;
-  missingRequirements?: { bins?: string[]; env?: string[] };
   configEntry?: SkillEntryConfig;
 }
 
@@ -67,55 +64,17 @@ export function resolveSkillStates(
       results.push({
         summary: skill,
         state: "disabled",
-        degraded: false,
         configEntry: entry,
       });
       continue;
     }
 
-    // Check requirements for enabled skills
-    const envOverrides = buildEnvOverrides(skill, entry);
-    const reqCheck = checkSkillRequirements(skill, envOverrides);
-
-    if (!reqCheck.eligible) {
-      results.push({
-        summary: skill,
-        state: "degraded",
-        degraded: true,
-        missingRequirements: reqCheck.missing,
-        configEntry: entry,
-      });
-    } else {
-      results.push({
-        summary: skill,
-        state: "enabled",
-        degraded: false,
-        configEntry: entry,
-      });
-    }
+    results.push({
+      summary: skill,
+      state: "enabled",
+      configEntry: entry,
+    });
   }
 
   return results;
-}
-
-function buildEnvOverrides(
-  skill: SkillSummary,
-  entry?: SkillEntryConfig,
-): Record<string, string> | undefined {
-  if (!entry) return undefined;
-  const overrides: Record<string, string> = {};
-
-  // Map apiKey to primaryEnv
-  if (entry.apiKey && skill.metadata?.primaryEnv) {
-    overrides[skill.metadata.primaryEnv] = entry.apiKey;
-  }
-
-  // Add explicit env overrides
-  if (entry.env) {
-    for (const [key, value] of Object.entries(entry.env)) {
-      overrides[key] = value;
-    }
-  }
-
-  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -39,32 +39,6 @@ const log = getLogger("skills");
 const VellumMetadataSchema = z
   .object({
     emoji: z.string().optional(),
-    os: z.array(z.string()).optional(),
-    requires: z
-      .object({
-        bins: z.array(z.string()).optional(),
-        anyBins: z.array(z.string()).optional(),
-        env: z.array(z.string()).optional(),
-        config: z.array(z.string()).optional(),
-      })
-      .optional(),
-    primaryEnv: z.string().optional(),
-    install: z
-      .array(
-        z
-          .object({
-            id: z.string(),
-            kind: z.enum(["brew", "node", "go", "uv", "download"]),
-          })
-          .passthrough(),
-      )
-      .optional(),
-    cli: z
-      .object({
-        command: z.string(),
-        entry: z.string(),
-      })
-      .optional(),
     "display-name": z.string().optional(),
     "user-invocable": z.union([z.boolean(), z.string()]).optional(),
     "disable-model-invocation": z.union([z.boolean(), z.string()]).optional(),
@@ -83,34 +57,8 @@ const SkillMetadataSchema = z
 
 // ─── New interfaces for extended skill metadata ──────────────────────────────
 
-export interface SkillCliSpec {
-  /** CLI command name (e.g. "doordash"). Used as the launcher script name in ~/.vellum/bin/. */
-  command: string;
-  /** Entry point filename relative to the skill directory (e.g. "doordash-entry.ts"). */
-  entry: string;
-}
-
 export interface VellumMetadata {
   emoji?: string;
-  os?: string[];
-  requires?: SkillRequirements;
-  primaryEnv?: string;
-  install?: InstallerSpec[];
-  /** Declares a standalone CLI entry point for this skill. */
-  cli?: SkillCliSpec;
-}
-
-export interface SkillRequirements {
-  bins?: string[];
-  anyBins?: string[];
-  env?: string[];
-  config?: string[];
-}
-
-export interface InstallerSpec {
-  id: string;
-  kind: "brew" | "node" | "go" | "uv" | "download";
-  [key: string]: unknown;
 }
 
 export type SkillSource = "bundled" | "managed" | "workspace" | "extra";
@@ -215,90 +163,6 @@ export interface SkillToolManifestMeta {
    * during catalog load.
    */
   versionHash?: string;
-}
-
-// ─── Requirements check ──────────────────────────────────────────────────────
-
-export interface RequirementsCheckResult {
-  eligible: boolean;
-  missing: {
-    bins?: string[];
-    env?: string[];
-  };
-}
-
-export function checkSkillRequirements(
-  skill: SkillSummary,
-  envOverrides?: Record<string, string>,
-): RequirementsCheckResult {
-  const vellum = skill.metadata;
-  if (!vellum) {
-    return { eligible: true, missing: {} };
-  }
-
-  const missingBins: string[] = [];
-  const missingEnv: string[] = [];
-
-  // OS check
-  if (vellum.os && vellum.os.length > 0) {
-    if (!vellum.os.includes(process.platform)) {
-      return {
-        eligible: false,
-        missing: {
-          bins: [
-            `(unsupported platform: ${
-              process.platform
-            }, requires: ${vellum.os.join(", ")})`,
-          ],
-        },
-      };
-    }
-  }
-
-  const requires = vellum.requires;
-  if (!requires) {
-    return { eligible: true, missing: {} };
-  }
-
-  // bins: all must exist
-  if (requires.bins) {
-    for (const bin of requires.bins) {
-      if (!Bun.which(bin)) {
-        missingBins.push(bin);
-      }
-    }
-  }
-
-  // anyBins: at least one must exist
-  if (requires.anyBins && requires.anyBins.length > 0) {
-    const hasAny = requires.anyBins.some((bin) => Bun.which(bin) != null);
-    if (!hasAny) {
-      missingBins.push(`(one of: ${requires.anyBins.join(", ")})`);
-    }
-  }
-
-  // env: check process.env or envOverrides
-  if (requires.env) {
-    const env = envOverrides
-      ? { ...process.env, ...envOverrides }
-      : process.env;
-    for (const key of requires.env) {
-      if (!env[key]) {
-        missingEnv.push(key);
-      }
-    }
-  }
-
-  // config: skip for now (needs config integration from M2)
-
-  const missing: RequirementsCheckResult["missing"] = {};
-  if (missingBins.length > 0) missing.bins = missingBins;
-  if (missingEnv.length > 0) missing.env = missingEnv;
-
-  return {
-    eligible: missingBins.length === 0 && missingEnv.length === 0,
-    missing,
-  };
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -417,24 +281,6 @@ function parseFrontmatter(
         vellum = raw?.vellum as z.infer<typeof VellumMetadataSchema>;
         if (raw?.vellum && typeof raw.vellum === "object") {
           const vellumRaw = raw.vellum as Record<string, unknown>;
-
-          // Coerce `os` to string[] — a bare string is wrapped in an array.
-          if (vellumRaw.os !== undefined) {
-            vellumRaw.os = Array.isArray(vellumRaw.os)
-              ? vellumRaw.os
-              : [vellumRaw.os];
-          }
-
-          // Coerce `requires` sub-fields to arrays.
-          if (vellumRaw.requires && typeof vellumRaw.requires === "object") {
-            const req = vellumRaw.requires as Record<string, unknown>;
-            for (const key of ["bins", "anyBins", "env", "config"] as const) {
-              if (req[key] !== undefined && !Array.isArray(req[key])) {
-                req[key] = typeof req[key] === "string" ? [req[key]] : [];
-              }
-            }
-          }
-
           metadata = vellumRaw as unknown as VellumMetadata;
         }
       }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -220,12 +220,6 @@ export interface SkillListItem {
   homepage?: string;
   source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
   state: "enabled" | "disabled" | "available";
-  degraded: boolean;
-  missingRequirements?: {
-    bins?: string[];
-    env?: string[];
-    permissions?: string[];
-  };
   updateAvailable: boolean;
   userInvocable: boolean;
   provenance: SkillProvenance;
@@ -251,12 +245,7 @@ export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
     emoji: r.summary.emoji,
     homepage: r.summary.homepage,
     source: r.summary.source,
-    state: (r.state === "degraded" ? "enabled" : r.state) as
-      | "enabled"
-      | "disabled"
-      | "available",
-    degraded: r.degraded,
-    missingRequirements: r.missingRequirements,
+    state: r.state as "enabled" | "disabled" | "available",
     updateAvailable: false,
     userInvocable: r.summary.userInvocable,
     provenance: resolveProvenance(r.summary),

--- a/assistant/src/daemon/install-cli-launchers.ts
+++ b/assistant/src/daemon/install-cli-launchers.ts
@@ -6,11 +6,6 @@
  * Each launcher is a shell script that hardcodes absolute paths to `bun`
  * and the CLI entrypoint, forwarding all arguments to the appropriate
  * subcommand.
- *
- * Commands are split into two categories:
- * - CORE_COMMANDS: always installed, dispatched via the main CLI entrypoint
- * - Skill CLI launchers: dynamically discovered from installed skills that
- *   declare a `cli` entry in their SKILL.md frontmatter metadata
  */
 
 import { execSync } from "node:child_process";
@@ -18,7 +13,6 @@ import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { loadSkillCatalog } from "../config/skills.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("install-cli-launchers");
@@ -75,12 +69,8 @@ function hasSystemConflict(name: string, binDir: string): boolean {
  *
  * For each integration command, generates a shell script that execs
  * bun with the appropriate entrypoint.
- * Uses the short name by default (e.g. `doordash`), falling back to
- * `vellum-<name>` if the short name conflicts with an existing system binary.
- *
- * Skill CLI launchers are discovered dynamically: any installed skill whose
- * SKILL.md frontmatter declares `metadata.vellum.cli` will get a launcher
- * pointing to the declared entry file within the skill directory.
+ * Uses the short name by default, falling back to `vellum-<name>` if the
+ * short name conflicts with an existing system binary.
  */
 export function installCliLaunchers(): void {
   const binDir = join(homedir(), ".vellum", "bin");
@@ -127,43 +117,6 @@ exec "${bunPath}" "${mainEntrypoint}" ${name} "$@"
     chmodSync(launcherPath, 0o755);
     installed.push(launcherName);
     log.debug({ launcherName, launcherPath }, "Installed core CLI launcher");
-  }
-
-  // Discover and install skill CLI launchers from the skill catalog
-  try {
-    const catalog = loadSkillCatalog();
-    for (const skill of catalog) {
-      const cli = skill.metadata?.cli;
-      if (!cli?.command || !cli?.entry) continue;
-
-      const entrypoint = join(skill.directoryPath, cli.entry);
-      if (!existsSync(entrypoint)) {
-        log.debug(
-          { skillId: skill.id, entrypoint },
-          "Skill CLI entry point not found — skipping",
-        );
-        continue;
-      }
-
-      const launcherName = hasSystemConflict(cli.command, binDir)
-        ? `vellum-${cli.command}`
-        : cli.command;
-      const launcherPath = join(binDir, launcherName);
-
-      const script = `#!/bin/bash
-exec "${bunPath}" "${entrypoint}" "$@"
-`;
-
-      writeFileSync(launcherPath, script);
-      chmodSync(launcherPath, 0o755);
-      installed.push(launcherName);
-      log.debug(
-        { launcherName, launcherPath, skillId: skill.id },
-        "Installed skill CLI launcher",
-      );
-    }
-  } catch (err) {
-    log.warn({ err }, "Failed to discover skill CLI launchers");
   }
 
   log.info({ binDir, commands: installed }, "CLI launchers installed");

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -88,12 +88,6 @@ export interface SkillsListResponse {
     homepage?: string;
     source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
     state: "enabled" | "disabled" | "available";
-    degraded: boolean;
-    missingRequirements?: {
-      bins?: string[];
-      env?: string[];
-      permissions?: string[];
-    };
     installedVersion?: string;
     latestVersion?: string;
     updateAvailable: boolean;

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1022,13 +1022,8 @@ function getMcpSetupDescription(): string {
 }
 
 function formatSkillsCatalog(skills: SkillSummary[]): string {
-  // Filter out skills with disableModelInvocation or unsupported OS
-  const visible = skills.filter((s) => {
-    if (s.disableModelInvocation) return false;
-    const os = s.metadata?.os;
-    if (os && os.length > 0 && !os.includes(process.platform)) return false;
-    return true;
-  });
+  // Filter out skills with disableModelInvocation
+  const visible = skills.filter((s) => !s.disableModelInvocation);
   if (visible.length === 0) return "";
 
   const lines = ["<available_skills>"];

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3874,8 +3874,6 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let homepage: String?
     public let source: String
     public let state: String
-    public let degraded: Bool
-    public let missingRequirements: SkillsListResponseSkillMissingRequirements?
     public let installedVersion: String?
     public let latestVersion: String?
     public let updateAvailable: Bool
@@ -3883,7 +3881,7 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let clawhub: SkillsListResponseSkillClawhub?
     public let provenance: SkillsListResponseSkillProvenance?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, degraded: Bool, missingRequirements: SkillsListResponseSkillMissingRequirements? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, userInvocable: Bool, clawhub: SkillsListResponseSkillClawhub? = nil, provenance: SkillsListResponseSkillProvenance? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, userInvocable: Bool, clawhub: SkillsListResponseSkillClawhub? = nil, provenance: SkillsListResponseSkillProvenance? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -3891,8 +3889,6 @@ public struct SkillsListResponseSkill: Codable, Sendable {
         self.homepage = homepage
         self.source = source
         self.state = state
-        self.degraded = degraded
-        self.missingRequirements = missingRequirements
         self.installedVersion = installedVersion
         self.latestVersion = latestVersion
         self.updateAvailable = updateAvailable
@@ -3915,18 +3911,6 @@ public struct SkillsListResponseSkillClawhub: Codable, Sendable {
         self.installs = installs
         self.reports = reports
         self.publishedAt = publishedAt
-    }
-}
-
-public struct SkillsListResponseSkillMissingRequirements: Codable, Sendable {
-    public let bins: [String]?
-    public let env: [String]?
-    public let permissions: [String]?
-
-    public init(bins: [String]? = nil, env: [String]? = nil, permissions: [String]? = nil) {
-        self.bins = bins
-        self.env = env
-        self.permissions = permissions
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -911,10 +911,6 @@ public typealias AppDataResponseMessage = AppDataResponse
 /// Backed by generated `SkillsListResponseSkillClawhub`.
 public typealias ClawhubInfo = SkillsListResponseSkillClawhub
 
-/// Missing requirements preventing a skill from full operation.
-/// Backed by generated `SkillsListResponseSkillMissingRequirements`.
-public typealias MissingRequirements = SkillsListResponseSkillMissingRequirements
-
 /// Provenance metadata indicating whether a skill is first-party, third-party, or local.
 /// Backed by generated `SkillsListResponseSkillProvenance`.
 public typealias SkillProvenance = SkillsListResponseSkillProvenance
@@ -928,7 +924,7 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `state`, preserving all other fields including `id`.
     public func withState(_ newState: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, degraded: degraded, missingRequirements: missingRequirements, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub, provenance: provenance)
+        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, userInvocable: userInvocable, clawhub: clawhub, provenance: provenance)
     }
 }
 

--- a/scripts/skills/migrate-bundled-frontmatter.mjs
+++ b/scripts/skills/migrate-bundled-frontmatter.mjs
@@ -244,18 +244,26 @@ function migrateSkill(dirName, skillDir) {
     changes.push(`credential-setup-for moved to metadata.vellum`);
   }
 
-  // Preserve other existing metadata.vellum fields (cli, requires, os, primaryEnv, install, etc.)
+  // Preserve other existing metadata.vellum fields (feature-flag, etc.)
+  // Dead keys (cli, requires, os, primaryEnv, install) have been removed.
   if (existingMetadata?.vellum) {
+    const HANDLED_KEYS = new Set([
+      "emoji",
+      "display-name",
+      "user-invocable",
+      "disable-model-invocation",
+      "includes",
+      "credential-setup-for",
+      // Dead keys — strip during migration
+      "cli",
+      "requires",
+      "os",
+      "primaryEnv",
+      "install",
+    ]);
     for (const [key, val] of Object.entries(existingMetadata.vellum)) {
-      if (
-        key === "emoji" ||
-        key === "display-name" ||
-        key === "user-invocable" ||
-        key === "disable-model-invocation" ||
-        key === "includes" ||
-        key === "credential-setup-for"
-      ) {
-        continue; // Already handled above
+      if (HANDLED_KEYS.has(key)) {
+        continue;
       }
       vellum[key] = val;
     }


### PR DESCRIPTION
## Summary
- Remove `requires`, `primaryEnv`, `install`, `cli`, and `os` fields from `VellumMetadata` schema/interface
- Delete `SkillRequirements`, `InstallerSpec`, `SkillCliSpec` interfaces, `checkSkillRequirements()` function, `buildEnvOverrides()`, and all associated metadata parsing
- Remove `degraded` skill state and `missingRequirements` from skill list responses, Swift client types, and test fixtures
- Update `migrate-bundled-frontmatter.mjs` to strip dead keys during migration

Part of plan: rm-skill-metadata-keys.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
