### PR TITLE
feat: add 'Send Logs for Current Thread' to status menu

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -306,6 +306,12 @@ extension AppDelegate {
         sendLogsItem.image = VIcon.upload.nsImage
         menu.addItem(sendLogsItem)
 
+        let sendThreadLogsItem = NSMenuItem(title: "Send Logs for Current Thread", action: #selector(sendCurrentThreadLogsToSentry), keyEquivalent: "")
+        sendThreadLogsItem.target = self
+        sendThreadLogsItem.image = VIcon.upload.nsImage
+        sendThreadLogsItem.isEnabled = mainWindow?.threadManager.activeThread?.sessionId != nil
+        menu.addItem(sendThreadLogsItem)
+
         if MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items") {
             menu.addItem(NSMenuItem.separator())
 
@@ -487,6 +493,24 @@ extension AppDelegate {
         // otherwise macOS can swallow the makeKeyAndOrderFront during menu teardown.
         DispatchQueue.main.async { [weak self] in
             self?.showLogReportWindow()
+        }
+    }
+
+    @objc func sendCurrentThreadLogsToSentry() {
+        guard let thread = mainWindow?.threadManager.activeThread,
+              let sessionId = thread.sessionId else { return }
+
+        // If the window is already showing, just bring it forward.
+        if let existing = logReportWindow, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        // Defer window creation until after the status menu finishes dismissing,
+        // otherwise macOS can swallow the makeKeyAndOrderFront during menu teardown.
+        DispatchQueue.main.async { [weak self] in
+            self?.showLogReportWindow(scope: .thread(conversationId: sessionId, threadTitle: thread.title))
         }
     }
 


### PR DESCRIPTION
## Summary
- Add "Send Logs for Current Thread" NSMenuItem to the status menu
- Reads active thread from `mainWindow?.threadManager.activeThread`
- Disabled when no active thread has a sessionId
- Uses same upload icon as existing "Send Logs to Vellum" item

Part of plan: thread-scoped-log-export.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
