### PR TITLE
feat: add GET /v1/skills/:id and GET /v1/skills/:id/files HTTP routes

### DIFF
--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -16,6 +16,8 @@ import {
   disableSkill,
   draftSkill,
   enableSkill,
+  getSkill,
+  getSkillFiles,
   inspectSkill,
   installSkill,
   listSkills,
@@ -46,6 +48,40 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       handler: () => {
         const skills = listSkills(ctx());
         return Response.json({ skills });
+      },
+    },
+
+    // GET /v1/skills/:id/files — skill metadata + directory contents
+    {
+      endpoint: "skills/:id/files",
+      method: "GET",
+      policyKey: "skills",
+      handler: ({ params }) => {
+        const result = getSkillFiles(params.id, ctx());
+        if ("error" in result) {
+          if (result.status === 404) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json(result);
+      },
+    },
+
+    // GET /v1/skills/:id — single skill metadata
+    {
+      endpoint: "skills/:id",
+      method: "GET",
+      policyKey: "skills",
+      handler: ({ params }) => {
+        const result = getSkill(params.id, ctx());
+        if ("error" in result) {
+          if (result.status === 404) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json(result);
       },
     },
 


### PR DESCRIPTION
## Summary
- Add GET /v1/skills/:id route returning single skill metadata
- Add GET /v1/skills/:id/files route returning skill metadata + directory contents
- Both routes use existing getSkill/getSkillFiles business logic from prior PRs

Part of plan: skill-detail-files-api.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
