### PR TITLE
feat: add 'Send Logs for Thread' to sidebar context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -191,6 +191,15 @@ struct SidebarThreadItem: View {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
             .disabled(!canMarkUnread)
+
+            Divider()
+
+            Button {
+                AppDelegate.shared?.showLogReportWindow(scope: .thread(conversationId: thread.sessionId ?? "", threadTitle: thread.title))
+            } label: {
+                Label { Text("Send Logs for Thread") } icon: { VIconView(.upload, size: 14) }
+            }
+            .disabled(thread.sessionId == nil)
         }
         .pointerCursor()
         .onHover { hovering in


### PR DESCRIPTION
## Summary
- Add "Send Logs for Thread" button to sidebar thread context menu
- Separated from existing items by a Divider
- Disabled when thread has no sessionId (unsaved threads)
- Calls `showLogReportWindow(scope: .thread(...))` on AppDelegate

Part of plan: thread-scoped-log-export.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
