### PR TITLE
fix: add route policies for avatar endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -400,6 +400,8 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Settings (voice, avatar, client settings)
   { endpoint: "settings/voice", scopes: ["settings.write"] },
   { endpoint: "settings/avatar/generate", scopes: ["settings.write"] },
+  { endpoint: "avatar/character-components", scopes: ["settings.read"] },
+  { endpoint: "avatar/render-from-traits", scopes: ["settings.write"] },
   { endpoint: "settings/client", scopes: ["settings.write"] },
 
   // Schedules


### PR DESCRIPTION
## Summary
Adds missing route policy registrations for the two new avatar endpoints (`avatar/character-components` and `avatar/render-from-traits`) introduced by the daemon-avatar-svg-rendering plan. Without these, the endpoints bypass auth enforcement.

Fixes gap identified during plan review for daemon-avatar-svg-rendering.md.

**Gap:** Missing route policies for avatar endpoints
**What was expected:** Both endpoints should have route policies registered
**What was found:** No registerPolicy() entries for the new avatar endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
