### PR TITLE
fix: null-safety guard in syncTraitsToPng

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -32,7 +32,13 @@ export function syncTraitsToPng(): boolean {
     return false;
   }
 
-  if (!traits.bodyShape || !traits.eyeStyle || !traits.color) {
+  if (
+    !traits ||
+    typeof traits !== "object" ||
+    !traits.bodyShape ||
+    !traits.eyeStyle ||
+    !traits.color
+  ) {
     log.warn({ traits }, "Invalid character traits — missing required fields");
     return false;
   }


### PR DESCRIPTION
## Summary
Adds a null/typeof guard in `syncTraitsToPng()` to handle malformed `character-traits.json` content (e.g., `null`, arrays, primitives). Previously, `JSON.parse("null")` would succeed but then `traits.bodyShape` would throw an uncaught TypeError.

Fixes gap identified during plan review for daemon-avatar-svg-rendering.md.

**Gap:** Null-safety bug in syncTraitsToPng
**What was expected:** Graceful handling of non-object JSON in traits file
**What was found:** `JSON.parse("null")` causes uncaught TypeError on property access

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
