### PR TITLE
fix: replace 'daemon' with 'assistant' in avatar SKILL.md

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -82,11 +82,11 @@ cat > "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json" << 'TRAITS'
 { "bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>" }
 TRAITS
 
-# Trigger daemon-side PNG rendering from the traits
+# Trigger assistant-side PNG rendering from the traits
 curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/avatar/render-from-traits"
 ```
 
-The client will detect the traits file and render the animated character. The daemon also generates a static PNG for use as dock icon and by other clients.
+The client will detect the traits file and render the animated character. The assistant also generates a static PNG for use as dock icon and by other clients.
 
 ## Mode 2: Upload a Custom Image
 
@@ -140,12 +140,12 @@ The generated avatar will appear automatically in the client.
 
 `character-traits.json` and `avatar-image.png` represent different avatar modes:
 
-- **Native character** — `character-traits.json` is the source of truth. The daemon auto-generates `avatar-image.png` as a static representation, so both files coexist.
+- **Native character** — `character-traits.json` is the source of truth. The assistant auto-generates `avatar-image.png` as a static representation, so both files coexist.
 - **Custom image** — `avatar-image.png` is user-provided (uploaded or AI-generated). No traits file exists.
 
 The client checks for character traits first — if `character-traits.json` exists, it renders the animated character. Otherwise, it falls back to `avatar-image.png` for custom images.
 
 Enforcement rules:
 
-- **Setting native character traits** → write `character-traits.json` and call `POST /v1/avatar/render-from-traits`. The daemon auto-generates the PNG.
+- **Setting native character traits** → write `character-traits.json` and call `POST /v1/avatar/render-from-traits`. The assistant auto-generates the PNG.
 - **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.


### PR DESCRIPTION
## Summary
Replaces internal "daemon" terminology with user-facing "assistant" in the vellum-avatar SKILL.md. The word "daemon" is an internal implementation detail that shouldn't appear in skill prose.

Fixes gap identified during plan review for daemon-avatar-svg-rendering.md.

**Gap:** "daemon" used in user-facing SKILL.md prose
**What was expected:** User-facing text should say "assistant" not "daemon"
**What was found:** Four occurrences of "daemon" in skill prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
