### PR TITLE
feat: add HTTPTransport methods for skill detail and skill files APIs

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Skills.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Skills.swift
@@ -69,3 +69,62 @@ extension HTTPTransport {
         }
     }
 }
+
+// MARK: - Skill Detail HTTP Methods
+
+extension HTTPTransport {
+
+    /// Fetch full metadata for a single skill via `GET /v1/skills/:id`.
+    func fetchSkillDetail(skillId: String, isRetry: Bool = false) async -> SkillDetailHTTPResponse? {
+        guard let url = buildURL(for: .skillDetail(id: skillId)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchSkillDetail(skillId: skillId, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(SkillDetailHTTPResponse.self, from: data)
+        } catch {
+            log.error("fetchSkillDetail failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch the directory contents of a skill via `GET /v1/skills/:id/files`.
+    func fetchSkillFiles(skillId: String, isRetry: Bool = false) async -> SkillDetailFilesHTTPResponse? {
+        guard let url = buildURL(for: .skillFiles(id: skillId)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchSkillFiles(skillId: skillId, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(SkillDetailFilesHTTPResponse.self, from: data)
+        } catch {
+            log.error("fetchSkillFiles failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -355,6 +355,8 @@ public final class HTTPTransport {
         case skillInspect(id: String)
         case skillsDraft
         case skillsCreate
+        case skillDetail(id: String)
+        case skillFiles(id: String)
 
         // Computer Use
         case cuWatch
@@ -744,6 +746,12 @@ public final class HTTPTransport {
             return ("/v1/skills/draft", nil)
         case .skillsCreate:
             return ("/v1/skills", nil)
+        case .skillDetail(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: Self.pathComponentAllowed) ?? id
+            return ("/v1/skills/\(encoded)", nil)
+        case .skillFiles(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: Self.pathComponentAllowed) ?? id
+            return ("/v1/skills/\(encoded)/files", nil)
         // Computer Use
         case .cuWatch:
             return ("/v1/computer-use/watch", nil)
@@ -1155,6 +1163,12 @@ public final class HTTPTransport {
             return ("\(prefix)/skills/draft/", nil)
         case .skillsCreate:
             return ("\(prefix)/skills/", nil)
+        case .skillDetail(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: Self.pathComponentAllowed) ?? id
+            return ("\(prefix)/skills/\(encoded)/", nil)
+        case .skillFiles(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: Self.pathComponentAllowed) ?? id
+            return ("\(prefix)/skills/\(encoded)/files/", nil)
         // Computer Use
         case .cuWatch:
             return ("\(prefix)/computer-use/watch/", nil)


### PR DESCRIPTION
## Summary
- Add `fetchSkillDetail(skillId:)` method to HTTPTransport for `GET /v1/skills/:id`
- Add `fetchSkillFiles(skillId:)` method to HTTPTransport for `GET /v1/skills/:id/files`
- Both methods follow existing transport patterns for URL building, auth, and JSON decoding
- Add `skillDetail` and `skillFiles` endpoint cases with routing in both runtime-flat and platform-proxy path builders

Part of plan: skill-detail-files-api.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
