### PR TITLE
refactor: rename assistant_inbox_thread_state → assistant_inbox_conversation_state

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -82,6 +82,7 @@ import {
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameGuardianVerificationValues,
+  migrateRenameInboxThreadStateTable,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
@@ -395,6 +396,9 @@ export function initializeDb(): void {
 
   // 65. Convert guardian timestamps from ISO 8601 text to epoch ms integers
   migrateGuardianTimestampsEpochMs(database);
+
+  // 66. Rename assistant_inbox_thread_state → assistant_inbox_conversation_state
+  migrateRenameInboxThreadStateTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -67,7 +67,7 @@ const PRUNE_BATCH_LIMIT = 100;
  *
  * Tables with onDelete cascade on conversation FK (memory_segments,
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
- * external_conversation_bindings, assistant_inbox_thread_state) are handled
+ * external_conversation_bindings, assistant_inbox_conversation_state) are handled
  * automatically. Tables without cascade (messages, tool_invocations,
  * llm_request_logs) are deleted explicitly before removing the conversation row.
  */

--- a/assistant/src/memory/migrations/165-rename-inbox-thread-state-table.ts
+++ b/assistant/src/memory/migrations/165-rename-inbox-thread-state-table.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Rename assistant_inbox_thread_state -> assistant_inbox_conversation_state
+ * as part of the thread -> conversation terminology unification.
+ */
+export function migrateRenameInboxThreadStateTable(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE assistant_inbox_thread_state RENAME TO assistant_inbox_conversation_state`,
+    );
+  } catch {
+    /* already renamed */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -104,6 +104,7 @@ export { migrateDropContactInteractionColumns } from "./159-drop-contact-interac
 export { migrateDropLoopbackPortColumn } from "./160-drop-loopback-port-column.js";
 export { migrateDropOrphanedMediaTables } from "./161-drop-orphaned-media-tables.js";
 export { migrateGuardianTimestampsEpochMs } from "./162-guardian-timestamps-epoch-ms.js";
+export { migrateRenameInboxThreadStateTable } from "./165-rename-inbox-thread-state-table.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -93,8 +93,8 @@ export const assistantIngressInvites = sqliteTable(
   },
 );
 
-export const assistantInboxThreadState = sqliteTable(
-  "assistant_inbox_thread_state",
+export const assistantInboxConversationState = sqliteTable(
+  "assistant_inbox_conversation_state",
   {
     conversationId: text("conversation_id")
       .primaryKey()


### PR DESCRIPTION
## Summary
- Add DB migration to rename `assistant_inbox_thread_state` → `assistant_inbox_conversation_state`
- Update Drizzle schema export name and table string
- Update all imports and references across the codebase

Part of plan: thread-to-conversation-rename.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
