### PR TITLE
fix: prevent Sentry conversation_id tag overwrite for thread-scoped exports

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -71,6 +71,8 @@ enum LogExporter {
             if case .thread(let conversationId, _, _, _) = formData.scope {
                 tags["conversation_id"] = conversationId
                 tags["export_scope"] = "thread"
+            } else {
+                tags["export_scope"] = "global"
             }
             // When routing to the brain project, tag the event so it's clear
             // it originated from the macOS client (not the daemon itself).
@@ -91,7 +93,12 @@ enum LogExporter {
                     // it here enables cross-project search: find the daemon error
                     // that corresponds to a macOS log report by querying
                     // conversation_id in the vellum-assistant-brain Sentry project.
-                    tags["conversation_id"] = sessionId
+                    // For thread-scoped exports, conversation_id was already set
+                    // to the reported thread's ID above — don't overwrite it with
+                    // the active thread's session ID.
+                    if case .global = formData.scope {
+                        tags["conversation_id"] = sessionId
+                    }
                 }
             }
             var errorCategoryString: String?
@@ -108,7 +115,11 @@ enum LogExporter {
                 if let sessionId = vm.sessionId {
                     // Prefer the view model's sessionId (most up-to-date)
                     tags["session_id"] = sessionId
-                    tags["conversation_id"] = sessionId
+                    // For thread-scoped exports, conversation_id reflects the
+                    // reported thread, not the active one — skip the overwrite.
+                    if case .global = formData.scope {
+                        tags["conversation_id"] = sessionId
+                    }
                 }
             }
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {


### PR DESCRIPTION
## Summary
- When the export scope is `.thread`, the `conversation_id` Sentry tag now correctly reflects the thread being reported, not the active thread. The pre-existing active-thread tagging logic only overwrites `conversation_id` for `.global` exports.
- Added `export_scope: "global"` Sentry tag for global exports, making both scopes filterable in Sentry.

Fixes gaps 1 and 5 from plan review for thread-scoped-log-export.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
