### PR TITLE
feat: rename approval string literals from thread to conversation

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -2,7 +2,7 @@
  * Tests for cascading approval decisions to matching pending confirmations.
  *
  * When a user resolves one confirmation with a broad decision (allow_10m,
- * allow_thread, always_allow, always_deny), other pending confirmations in
+ * allow_conversation, always_allow, always_deny), other pending confirmations in
  * the same conversation that match are auto-resolved.
  */
 import { mkdtempSync, rmSync } from "node:fs";
@@ -392,7 +392,7 @@ describe("approval cascading", () => {
     expect(resolvedIds).toEqual(["req-1", "req-2", "req-3"]);
   });
 
-  test("allow_thread cascades to all pending in same conversation", () => {
+  test("allow_conversation cascades to all pending in same conversation", () => {
     const emitted: ServerMessage[] = [];
     const session = makeSession((msg) => emitted.push(msg), CONV_ID);
 
@@ -419,7 +419,7 @@ describe("approval cascading", () => {
       makeConfirmationDetails(["bash:echo c"]),
     );
 
-    session.handleConfirmationResponse("req-a", "allow_thread");
+    session.handleConfirmationResponse("req-a", "allow_conversation");
 
     const confirmMsgs = emitted.filter(
       (m) =>

--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -10,7 +10,7 @@ describe("parseCallbackData", () => {
   test.each([
     ["apr:req-123:approve_once", "approve_once"],
     ["apr:req-123:approve_10m", "approve_10m"],
-    ["apr:req-123:approve_thread", "approve_thread"],
+    ["apr:req-123:approve_conversation", "approve_conversation"],
     ["apr:req-123:approve_always", "approve_always"],
     ["apr:req-123:reject", "reject"],
   ] as const)('parses "%s" as action "%s"', (data, expectedAction) => {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -136,7 +136,7 @@ describe("getChannelApprovalPrompt", () => {
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
       "approve_10m",
-      "approve_thread",
+      "approve_conversation",
       "approve_always",
       "reject",
     ]);
@@ -177,7 +177,7 @@ describe("getChannelApprovalPrompt", () => {
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
       "approve_10m",
-      "approve_thread",
+      "approve_conversation",
       "approve_always",
       "reject",
     ]);
@@ -194,7 +194,7 @@ describe("getChannelApprovalPrompt", () => {
     expect(result!.actions.map((a) => a.id)).toEqual([
       "approve_once",
       "approve_10m",
-      "approve_thread",
+      "approve_conversation",
       "approve_always",
       "reject",
     ]);

--- a/assistant/src/__tests__/context-overflow-approval.test.ts
+++ b/assistant/src/__tests__/context-overflow-approval.test.ts
@@ -102,8 +102,8 @@ describe("requestCompressionApproval", () => {
     expect(result).toEqual({ approved: true });
   });
 
-  test("maps allow_thread decision to approved: true", async () => {
-    const prompter = createMockPrompter("allow_thread");
+  test("maps allow_conversation decision to approved: true", async () => {
+    const prompter = createMockPrompter("allow_conversation");
     const result = await requestCompressionApproval(prompter);
     expect(result).toEqual({ approved: true });
   });

--- a/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
+++ b/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
@@ -270,9 +270,9 @@ describe("CES approval bridge", () => {
     });
   });
 
-  describe("thread-scoped grant (allow_thread)", () => {
-    test("allow_thread decision maps to approved with no TTL", async () => {
-      const prompter = makePrompter("allow_thread");
+  describe("conversation-scoped grant (allow_conversation)", () => {
+    test("allow_conversation decision maps to approved with no TTL", async () => {
+      const prompter = makePrompter("allow_conversation");
       const cesClient = makeCesClient();
 
       const result = await bridgeCesApproval(

--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -11,7 +11,7 @@ describe("isAllowDecision", () => {
   const allowDecisions: UserDecision[] = [
     "allow",
     "allow_10m",
-    "allow_thread",
+    "allow_conversation",
     "always_allow",
     "always_allow_high_risk",
     "temporary_override",

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -190,7 +190,7 @@ export function applyGuardianDecision(
   const effectiveDecision: ApprovalDecisionResult =
     decision.action === "approve_always" ||
     decision.action === "approve_10m" ||
-    decision.action === "approve_thread"
+    decision.action === "approve_conversation"
       ? { ...decision, action: "approve_once" }
       : decision;
 
@@ -321,7 +321,7 @@ export function mintCanonicalRequestGrant(params: {
 const VALID_CANONICAL_ACTIONS: ReadonlySet<ApprovalAction> = new Set([
   "approve_once",
   "approve_10m",
-  "approve_thread",
+  "approve_conversation",
   "approve_always",
   "reject",
 ]);
@@ -493,11 +493,11 @@ export async function applyCanonicalGuardianDecision(
 
   // 3. Downgrade approve_always and temporary modes to approve_once for
   // guardian-on-behalf requests. Guardians cannot grant broad allow modes
-  // (permanent, timed, or thread-scoped) on behalf of requesters.
+  // (permanent, timed, or conversation-scoped) on behalf of requesters.
   const effectiveAction: ApprovalAction =
     action === "approve_always" ||
     action === "approve_10m" ||
-    action === "approve_thread"
+    action === "approve_conversation"
       ? "approve_once"
       : action;
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -421,8 +421,8 @@ export async function startCli(): Promise<void> {
     if (req.temporaryOptionsAvailable?.includes("allow_10m")) {
       process.stdout.write(`\u2502 [t] Allow 10m\n`);
     }
-    if (req.temporaryOptionsAvailable?.includes("allow_thread")) {
-      process.stdout.write(`\u2502 [T] Allow Thread\n`);
+    if (req.temporaryOptionsAvailable?.includes("allow_conversation")) {
+      process.stdout.write(`\u2502 [T] Allow Conversation\n`);
     }
     process.stdout.write(`\u2502 [d] Deny once\n`);
     if (req.allowlistOptions.length > 0 && req.scopeOptions.length > 0) {
@@ -488,9 +488,9 @@ export async function startCli(): Promise<void> {
 
       if (
         trimmed === "T" &&
-        req.temporaryOptionsAvailable?.includes("allow_thread")
+        req.temporaryOptionsAvailable?.includes("allow_conversation")
       ) {
-        sendConfirmation(req.requestId, "allow_thread");
+        sendConfirmation(req.requestId, "allow_conversation");
         return;
       }
 

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -36,7 +36,7 @@ const log = getLogger("ces-approval-bridge");
  * Maps the existing confirmation transport decisions to CES grant semantics:
  * - `allow`          -> approved (single-use grant, no TTL)
  * - `allow_10m`      -> approved (temporary grant, 10-minute TTL)
- * - `allow_thread`   -> approved (session-scoped grant, no TTL but session-bound)
+ * - `allow_conversation` -> approved (session-scoped grant, no TTL but session-bound)
  * - `always_allow`   -> approved (persistent grant, no expiry)
  * - `deny`           -> denied
  * - `always_deny`    -> denied
@@ -50,7 +50,7 @@ export interface CesApprovalDecision {
   grantType:
     | "allow_once"
     | "allow_10m"
-    | "allow_thread"
+    | "allow_conversation"
     | "always_allow"
     | undefined;
   /** The original user decision from the confirmation transport. */
@@ -75,14 +75,14 @@ function mapUserDecisionToCesDecision(
         grantType: "allow_10m",
         userDecision: decision,
       };
-    case "allow_thread":
-      // Thread-scoped grants don't have a wall-clock TTL — they are bound
+    case "allow_conversation":
+      // Conversation-scoped grants don't have a wall-clock TTL — they are bound
       // to the session lifetime. CES handles the session binding; we pass
       // no TTL so the grant remains active until the session ends.
       return {
         grantDecision: "approved",
         ttl: undefined,
-        grantType: "allow_thread",
+        grantType: "allow_conversation",
         userDecision: decision,
       };
     case "always_allow":
@@ -225,7 +225,7 @@ export async function bridgeCesApproval(
     "host", // CES operations target the host
     false, // Persistent decisions are managed by CES, not trust.json
     options?.signal,
-    ["allow_10m", "allow_thread"], // Offer temporary approval options
+    ["allow_10m", "allow_conversation"], // Offer temporary approval options
   );
 
   // Detect prompter timeout: the PermissionPrompter resolves timeouts as

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -46,15 +46,15 @@ const APPROVAL_CONVERSATION_TOOL_SCHEMA = {
           "keep_pending",
           "approve_once",
           "approve_10m",
-          "approve_thread",
+          "approve_conversation",
           "approve_always",
           "reject",
         ],
         description:
           "The decision: keep_pending if the user is asking questions or unclear, " +
           "approve_once to approve this single request, approve_10m to approve all " +
-          "requests for 10 minutes, approve_thread to approve all requests in this " +
-          "thread, approve_always to approve this tool permanently, reject to deny the request.",
+          "requests for 10 minutes, approve_conversation to approve all requests in this " +
+          "conversation, approve_always to approve this tool permanently, reject to deny the request.",
       },
       replyText: {
         type: "string",
@@ -75,7 +75,7 @@ const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
   "keep_pending",
   "approve_once",
   "approve_10m",
-  "approve_thread",
+  "approve_conversation",
   "approve_always",
   "reject",
 ]);

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -33,7 +33,7 @@ export interface ConfirmationResponse {
   decision:
     | "allow"
     | "allow_10m"
-    | "allow_thread"
+    | "allow_conversation"
     | "always_allow"
     | "always_allow_high_risk"
     | "deny"
@@ -155,7 +155,7 @@ export interface ConfirmationRequest {
   /** When false, the client should hide "always allow" / trust-rule persistence affordances. */
   persistentDecisionsAllowed?: boolean;
   /** Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread"). */
-  temporaryOptionsAvailable?: Array<"allow_10m" | "allow_thread">;
+  temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">;
   /** The tool_use block ID for client-side correlation with specific tool calls. */
   toolUseId?: string;
 }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -463,7 +463,7 @@ export function createProxyApprovalCallback(
     }
 
     // Proxied network requests require per-invocation approval and must
-    // not be auto-approved by temporary overrides (allow_10m / allow_thread).
+    // not be auto-approved by temporary overrides (allow_10m / allow_conversation).
     // Unlike regular tool invocations, these represent outbound network
     // actions that should always receive explicit confirmation.
 

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -562,7 +562,7 @@ export class Session {
       decisionContext,
     );
 
-    // Mode activation (setTimedMode / setThreadMode) is intentionally NOT
+    // Mode activation (setTimedMode / setConversationMode) is intentionally NOT
     // done here. It is handled in permission-checker.ts where the
     // guardian trust-class and conversation context are available.
 
@@ -609,7 +609,7 @@ export class Session {
    * After resolving one confirmation, auto-resolve other pending
    * confirmations in the same conversation that match the decision.
    *
-   * - allow_10m / allow_thread → approve ALL pending in conversation
+   * - allow_10m / allow_conversation → approve ALL pending in conversation
    * - always_allow / always_allow_high_risk → approve pattern-matching pending
    * - always_deny → deny pattern-matching pending
    * - allow / deny (one-time) → no cascading
@@ -682,7 +682,7 @@ export class Session {
     details?: import("../runtime/pending-interactions.js").ConfirmationDetails,
   ): { allow: boolean } | null {
     // Temporary overrides apply to the entire conversation
-    if (decision === "allow_10m" || decision === "allow_thread") {
+    if (decision === "allow_10m" || decision === "allow_conversation") {
       return { allow: true };
     }
 

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -23,7 +23,7 @@ export interface ToolDomainEvents {
     decision:
       | "allow"
       | "allow_10m"
-      | "allow_thread"
+      | "allow_conversation"
       | "always_allow"
       | "always_allow_high_risk"
       | "deny"

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -63,7 +63,7 @@ export class PermissionPrompter {
     executionTarget?: ExecutionTarget,
     persistentDecisionsAllowed?: boolean,
     signal?: AbortSignal,
-    temporaryOptionsAvailable?: Array<"allow_10m" | "allow_thread">,
+    temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">,
     toolUseId?: string,
   ): Promise<{
     decision: UserDecision;

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -19,7 +19,7 @@ export interface TrustRule {
 export type UserDecision =
   | "allow"
   | "allow_10m"
-  | "allow_thread"
+  | "allow_conversation"
   | "always_allow"
   | "always_allow_high_risk"
   | "deny"
@@ -31,7 +31,7 @@ export function isAllowDecision(decision: UserDecision): boolean {
   return (
     decision === "allow" ||
     decision === "allow_10m" ||
-    decision === "allow_thread" ||
+    decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
     decision === "temporary_override"

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -18,7 +18,7 @@ Approvals are **orthogonal to message sending**. The assistant asks for approval
 
 - **Discovery**: Clients discover pending approvals via SSE events (`confirmation_request`, `secret_request`) which include a `requestId`.
 - **Resolution**: Clients respond via standalone endpoints keyed by `requestId`:
-  - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_thread"`, `"deny"`, `"always_allow"`, `"always_deny"`, `"always_allow_high_risk"`. For persistent decisions (`always_allow`, `always_deny`, `always_allow_high_risk`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
+  - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_conversation"`, `"deny"`, `"always_allow"`, `"always_deny"`, `"always_allow_high_risk"`. For persistent decisions (`always_allow`, `always_deny`, `always_allow_high_risk`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
   - `POST /v1/secret` — `{ requestId, value, delivery }`
   - `POST /v1/trust-rules` — `{ requestId, pattern, scope, decision, allowHighRisk? }`. Validates pattern/scope against server-provided options. Does not resolve the confirmation itself.
 - **Tracking**: The `pending-interactions` tracker (`assistant/src/runtime/pending-interactions.ts`) maps `requestId → session`. Use `register()` to track, `resolve()` to consume, `getByConversation()` to query.

--- a/assistant/src/runtime/approval-conversation-turn.ts
+++ b/assistant/src/runtime/approval-conversation-turn.ts
@@ -23,7 +23,7 @@ const VALID_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition> =
     "keep_pending",
     "approve_once",
     "approve_10m",
-    "approve_thread",
+    "approve_conversation",
     "approve_always",
     "reject",
   ]);
@@ -33,7 +33,7 @@ const DECISION_BEARING_DISPOSITIONS: ReadonlySet<ApprovalConversationDisposition
   new Set([
     "approve_once",
     "approve_10m",
-    "approve_thread",
+    "approve_conversation",
     "approve_always",
     "reject",
   ]);

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -17,7 +17,7 @@ import type { GuardianDecisionAction } from "./guardian-decision-types.js";
 export type ApprovalAction =
   | "approve_once"
   | "approve_10m"
-  | "approve_thread"
+  | "approve_conversation"
   | "approve_always"
   | "reject";
 

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -134,7 +134,7 @@ export function buildApprovalUIMetadata(
 /**
  * Map a channel-level `ApprovalAction` to the permission system's
  * `UserDecision` type. Temporary approval modes (`approve_10m`,
- * `approve_thread`) map directly to their `allow_*` counterparts so
+ * `approve_conversation`) map directly to their `allow_*` counterparts so
  * the permission pipeline can activate the appropriate override.
  */
 function mapApprovalActionToUserDecision(action: ApprovalAction): UserDecision {
@@ -143,8 +143,8 @@ function mapApprovalActionToUserDecision(action: ApprovalAction): UserDecision {
       return "deny";
     case "approve_10m":
       return "allow_10m";
-    case "approve_thread":
-      return "allow_thread";
+    case "approve_conversation":
+      return "allow_conversation";
     default:
       return "allow";
   }

--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -21,7 +21,7 @@ import type { ApprovalAction } from "./channel-approval-types.js";
 export const VALID_GUARDIAN_ACTIONS: ReadonlySet<string> = new Set<string>([
   "approve_once",
   "approve_10m",
-  "approve_thread",
+  "approve_conversation",
   "approve_always",
   "reject",
 ]);
@@ -73,7 +73,7 @@ export async function processGuardianDecision(
     return {
       ok: false,
       error: "invalid_action",
-      message: `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_thread, approve_always, reject`,
+      message: `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_conversation, approve_always, reject`,
     };
   }
 

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -48,7 +48,10 @@ export interface GuardianDecisionAction {
 export const GUARDIAN_DECISION_ACTIONS = {
   approve_once: { action: "approve_once", label: "Approve once" },
   approve_10m: { action: "approve_10m", label: "Allow 10 min" },
-  approve_thread: { action: "approve_thread", label: "Allow thread" },
+  approve_conversation: {
+    action: "approve_conversation",
+    label: "Allow conversation",
+  },
   approve_always: { action: "approve_always", label: "Approve always" },
   reject: { action: "reject", label: "Reject" },
 } as const satisfies Record<string, GuardianDecisionAction>;
@@ -62,7 +65,7 @@ export const GUARDIAN_DECISION_ACTIONS = {
  * of a requester), both `approve_always` and the temporary modes are excluded
  * since guardians cannot grant broad delegated allow modes on behalf of others.
  *
- * Temporary modes (`approve_10m`, `approve_thread`) are included for
+ * Temporary modes (`approve_10m`, `approve_conversation`) are included for
  * requester-side standard approval flows when persistent decisions are allowed.
  */
 export function buildDecisionActions(opts?: {
@@ -78,7 +81,7 @@ export function buildDecisionActions(opts?: {
     ...(showTemporary
       ? [
           GUARDIAN_DECISION_ACTIONS.approve_10m,
-          GUARDIAN_DECISION_ACTIONS.approve_thread,
+          GUARDIAN_DECISION_ACTIONS.approve_conversation,
         ]
       : []),
     ...(showAlways ? [GUARDIAN_DECISION_ACTIONS.approve_always] : []),
@@ -97,16 +100,18 @@ export function buildPlainTextFallback(
 ): string {
   const hasAlways = actions.some((a) => a.action === "approve_always");
   const has10m = actions.some((a) => a.action === "approve_10m");
-  const hasThread = actions.some((a) => a.action === "approve_thread");
+  const hasConversation = actions.some(
+    (a) => a.action === "approve_conversation",
+  );
 
-  if (hasAlways && has10m && hasThread) {
-    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", "always" to approve always, or "no" to reject.`;
+  if (hasAlways && has10m && hasConversation) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for conversation", "always" to approve always, or "no" to reject.`;
   }
   if (hasAlways) {
     return `${promptText}\n\nReply "yes" to approve once, "always" to approve always, or "no" to reject.`;
   }
-  if (has10m && hasThread) {
-    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for thread", or "no" to reject.`;
+  if (has10m && hasConversation) {
+    return `${promptText}\n\nReply "yes" to approve once, "approve for 10 minutes", "approve for conversation", or "no" to reject.`;
   }
   return `${promptText}\n\nReply "yes" to approve or "no" to reject.`;
 }

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -114,7 +114,7 @@ export interface GuardianReplyResult {
 const VALID_ACTIONS: ReadonlySet<string> = new Set([
   "approve_once",
   "approve_10m",
-  "approve_thread",
+  "approve_conversation",
   "approve_always",
   "reject",
 ]);
@@ -560,7 +560,7 @@ export async function routeGuardianReply(
     if (
       decisionAction === "approve_always" ||
       decisionAction === "approve_10m" ||
-      decisionAction === "approve_thread"
+      decisionAction === "approve_conversation"
     ) {
       decisionAction = "approve_once";
     }

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -38,7 +38,7 @@ export type ApprovalConversationDisposition =
   | "keep_pending"
   | "approve_once"
   | "approve_10m"
-  | "approve_thread"
+  | "approve_conversation"
   | "approve_always"
   | "reject";
 

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -24,7 +24,7 @@ export interface ConfirmationDetails {
   }>;
   scopeOptions: Array<{ label: string; scope: string }>;
   persistentDecisionsAllowed?: boolean;
-  temporaryOptionsAvailable?: Array<"allow_10m" | "allow_thread">;
+  temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">;
 }
 
 export interface PendingInteraction {

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -48,7 +48,7 @@ export async function handleConfirm(
   const validConfirmDecisions = [
     "allow",
     "allow_10m",
-    "allow_thread",
+    "allow_conversation",
     "deny",
     "always_allow",
     "always_deny",

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -441,7 +441,7 @@ async function handleConversationalDecision(params: {
   if (
     decisionAction === "approve_always" ||
     decisionAction === "approve_10m" ||
-    decisionAction === "approve_thread"
+    decisionAction === "approve_conversation"
   ) {
     decisionAction = "approve_once";
   }

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -30,10 +30,12 @@ export function requiredDecisionKeywords(
 ): string[] {
   const hasAlways = actions.some((action) => action.id === "approve_always");
   const has10m = actions.some((action) => action.id === "approve_10m");
-  const hasThread = actions.some((action) => action.id === "approve_thread");
+  const hasConversation = actions.some(
+    (action) => action.id === "approve_conversation",
+  );
   const keywords = ["yes", "no"];
   if (has10m) keywords.push("approve for 10 minutes");
-  if (hasThread) keywords.push("approve for thread");
+  if (hasConversation) keywords.push("approve for conversation");
   if (hasAlways) keywords.push("always");
   return keywords;
 }
@@ -45,7 +47,7 @@ export function requiredDecisionKeywords(
 const VALID_ACTIONS: ReadonlySet<string> = new Set<string>([
   "approve_once",
   "approve_10m",
-  "approve_thread",
+  "approve_conversation",
   "approve_always",
   "reject",
 ]);

--- a/assistant/src/runtime/session-approval-overrides.ts
+++ b/assistant/src/runtime/session-approval-overrides.ts
@@ -1,13 +1,13 @@
 /**
  * Per-conversation temporary approval overrides.
  *
- * When a user chooses `allow_thread` or `allow_10m`, the session records a
+ * When a user chooses `allow_conversation` or `allow_10m`, the session records a
  * temporary approval mode scoped to the conversation. Subsequent tool-use
  * confirmations within the same conversation can check this state to
  * auto-approve without prompting.
  *
  * State is in-memory only -- it does not survive daemon restarts, which is
- * the desired behavior for temporary approvals. Thread-scoped overrides
+ * the desired behavior for temporary approvals. Conversation-scoped overrides
  * persist until the session ends or the mode is explicitly cleared. Timed
  * overrides expire after their TTL (checked at read time, no background sweep).
  */

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -20,7 +20,7 @@ const log = getLogger("signal:confirm");
 const VALID_DECISIONS: ReadonlySet<string> = new Set<string>([
   "allow",
   "allow_10m",
-  "allow_thread",
+  "allow_conversation",
   "always_allow",
   "always_allow_high_risk",
   "deny",

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -176,7 +176,7 @@ export class PermissionChecker {
         }
 
         // Temporary approval override: if the guardian has enabled a
-        // conversation-scoped "allow all" mode (allow_10m or allow_thread),
+        // conversation-scoped "allow all" mode (allow_10m or allow_conversation),
         // skip the interactive prompt and auto-approve. Only applies to
         // guardian actors — untrusted actors cannot leverage this to bypass
         // guardian-required gates (those are enforced in pre-execution gates).
@@ -222,10 +222,10 @@ export class PermissionChecker {
 
         // Offer temporary approval options to guardians.
         const temporaryOptionsAvailable:
-          | Array<"allow_10m" | "allow_thread">
+          | Array<"allow_10m" | "allow_conversation">
           | undefined =
           context.trustClass === "guardian"
-            ? ["allow_10m", "allow_thread"]
+            ? ["allow_10m", "allow_conversation"]
             : undefined;
 
         emitLifecycleEvent({
@@ -402,7 +402,7 @@ export class PermissionChecker {
         }
 
         // Activate temporary approval mode when the user chooses a
-        // time-limited or thread-scoped override. Subsequent tool
+        // time-limited or conversation-scoped override. Subsequent tool
         // invocations in this conversation will auto-approve without
         // prompting (checked above in the temporary override block).
         if (response.decision === "allow_10m") {
@@ -411,11 +411,11 @@ export class PermissionChecker {
             { toolName: name, conversationId: context.conversationId },
             "Activated timed (10m) temporary approval mode",
           );
-        } else if (response.decision === "allow_thread") {
+        } else if (response.decision === "allow_conversation") {
           setThreadMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },
-            "Activated thread-scoped temporary approval mode",
+            "Activated conversation-scoped temporary approval mode",
           );
         }
 


### PR DESCRIPTION
## Summary
- Renames `allow_thread` → `allow_conversation` and `approve_thread` → `approve_conversation` across all permissions, daemon, runtime, tools, credential-execution, CLI, and test files
- Updates user-facing labels: "Allow thread" → "Allow conversation"
- Updates comments and documentation to use "conversation" terminology

Part of plan: thread-to-conversation-rename.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
