### PR TITLE
fix: remove stale degraded/missingRequirements from findSkillById

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -303,12 +303,7 @@ function findSkillById(
     emoji: r.summary.emoji,
     homepage: r.summary.homepage,
     source: r.summary.source,
-    state: (r.state === "degraded" ? "enabled" : r.state) as
-      | "enabled"
-      | "disabled"
-      | "available",
-    degraded: r.degraded,
-    missingRequirements: r.missingRequirements,
+    state: r.state as "enabled" | "disabled" | "available",
     updateAvailable: false,
     provenance: resolveProvenance(r.summary),
   };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-detail-files-api.md.

**Gap:** findSkillById references removed degraded and missingRequirements fields
**What was expected:** findSkillById should match current SkillListItem interface (no degraded/missingRequirements)
**What was found:** Stale field assignments from before PR #17124 removed these fields

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
