### PR TITLE
fix: move GET skills/:id route after literal GET routes to prevent shadowing

### DIFF
--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -68,23 +68,6 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       },
     },
 
-    // GET /v1/skills/:id — single skill metadata
-    {
-      endpoint: "skills/:id",
-      method: "GET",
-      policyKey: "skills",
-      handler: ({ params }) => {
-        const result = getSkill(params.id, ctx());
-        if ("error" in result) {
-          if (result.status === 404) {
-            return httpError("NOT_FOUND", result.error, 404);
-          }
-          return httpError("INTERNAL_ERROR", result.error, 500);
-        }
-        return Response.json(result);
-      },
-    },
-
     // POST /v1/skills/:id/enable — enable skill
     {
       endpoint: "skills/:id/enable",
@@ -278,6 +261,25 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
               result.error,
             )
           ) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json(result);
+      },
+    },
+
+    // GET /v1/skills/:id — single skill metadata
+    // Registered after all literal-segment GET routes (search, inspect, files)
+    // to avoid shadowing them with the parametric :id match.
+    {
+      endpoint: "skills/:id",
+      method: "GET",
+      policyKey: "skills",
+      handler: ({ params }) => {
+        const result = getSkill(params.id, ctx());
+        if ("error" in result) {
+          if (result.status === 404) {
             return httpError("NOT_FOUND", result.error, 404);
           }
           return httpError("INTERNAL_ERROR", result.error, 500);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-detail-files-api.md.

**Gap:** GET skills/:id route shadows GET skills/search
**What was expected:** Literal routes like skills/search should match before parametric skills/:id
**What was found:** skills/:id was registered before skills/search, making search unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
