### PR TITLE
fix: add symlink escape protection to readDirRecursive

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,7 +1,9 @@
 import {
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
 } from "node:fs";
@@ -339,6 +341,27 @@ export interface SkillFileEntry {
 
 const SKIP_DIRS = new Set(["node_modules", "__pycache__", ".git"]);
 
+/**
+ * Returns true if `filePath` is a symlink whose resolved real path escapes
+ * `rootDir`. Symlinks that stay within `rootDir` are allowed; only those that
+ * point outside are considered unsafe. Dangling symlinks are treated as escaping.
+ */
+function isEscapingSymlink(filePath: string, rootDir: string): boolean {
+  try {
+    if (!lstatSync(filePath).isSymbolicLink()) return false;
+    const real = realpathSync(filePath);
+    const normalizedRoot = realpathSync(rootDir);
+    return (
+      real !== normalizedRoot &&
+      !real.startsWith(normalizedRoot + "/") &&
+      !real.startsWith(normalizedRoot + "\\")
+    );
+  } catch {
+    // If we can't resolve (e.g. dangling symlink), treat as escaping.
+    return true;
+  }
+}
+
 function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
   const entries: SkillFileEntry[] = [];
   let dirents;
@@ -350,6 +373,8 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
   for (const dirent of dirents) {
     if (dirent.name.startsWith(".")) continue;
     const fullPath = join(dir, dirent.name);
+    // Skip symlinks that escape the skill directory root
+    if (isEscapingSymlink(fullPath, rootDir)) continue;
     if (dirent.isDirectory()) {
       if (SKIP_DIRS.has(dirent.name)) continue;
       entries.push(...readDirRecursive(fullPath, rootDir));


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-detail-files-api.md.

**Gap:** readDirRecursive follows symlinks without escape protection
**What was expected:** Symlinks should be checked to ensure they don't escape the skill directory root
**What was found:** No symlink validation, allowing potential exfiltration via malicious symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
