### PR TITLE
fix: replace upsertManagedEntry with insert-only ensureManagedEntry

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -275,7 +275,7 @@ struct OnboardingFlowView: View {
             isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             let hatchedAt = isoFormatter.string(from: Date())
 
-            let success = LockfileAssistant.upsertManagedEntry(
+            let success = LockfileAssistant.ensureManagedEntry(
                 assistantId: assistant.id,
                 runtimeUrl: runtimeUrl,
                 hatchedAt: hatchedAt

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -145,7 +145,7 @@ struct AssistantTransferSection: View {
             case .createdNew(let assistant):
                 platformAssistant = assistant
             }
-            let lockfileSuccess = LockfileAssistant.upsertManagedEntry(
+            let lockfileSuccess = LockfileAssistant.ensureManagedEntry(
                 assistantId: platformAssistant.id,
                 runtimeUrl: AuthService.shared.baseURL,
                 hatchedAt: platformAssistant.created_at ?? ISO8601DateFormatter().string(from: Date())

--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -19,10 +19,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - upsertManagedEntry: insert when absent
+    // MARK: - ensureManagedEntry: insert when absent
 
-    func testUpsertInsertsWhenLockfileDoesNotExist() {
-        let result = LockfileAssistant.upsertManagedEntry(
+    func testEnsureInsertsWhenLockfileDoesNotExist() {
+        let result = LockfileAssistant.ensureManagedEntry(
             assistantId: "test-id",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-01-01T00:00:00Z",
@@ -38,15 +38,18 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(assistants[0]["cloud"] as? String, "vellum")
         XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://platform.vellum.ai")
         XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-01-01T00:00:00Z")
+        let installationId = assistants[0]["installationId"] as? String
+        XCTAssertNotNil(installationId, "installationId should be generated on insert")
+        XCTAssertFalse(installationId!.isEmpty, "installationId should not be empty")
     }
 
-    func testUpsertInsertsIntoEmptyLockfile() {
+    func testEnsureInsertsIntoEmptyLockfile() {
         // Pre-create an empty lockfile object.
         let empty: [String: Any] = [:]
         let data = try! JSONSerialization.data(withJSONObject: empty)
         try! data.write(to: URL(fileURLWithPath: lockfilePath))
 
-        let result = LockfileAssistant.upsertManagedEntry(
+        let result = LockfileAssistant.ensureManagedEntry(
             assistantId: "new-id",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-03-01T00:00:00Z",
@@ -61,19 +64,19 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(assistants[0]["assistantId"] as? String, "new-id")
     }
 
-    // MARK: - upsertManagedEntry: update existing
+    // MARK: - ensureManagedEntry: no-op when entry exists
 
-    func testUpsertUpdatesExistingEntryBySameAssistantId() {
+    func testEnsureSkipsWhenEntryAlreadyExists() {
         // Insert first entry.
-        LockfileAssistant.upsertManagedEntry(
+        LockfileAssistant.ensureManagedEntry(
             assistantId: "test-id",
             runtimeUrl: "https://old.example.com",
             hatchedAt: "2024-01-01T00:00:00Z",
             lockfilePath: lockfilePath
         )
 
-        // Update the same assistantId with new values.
-        let result = LockfileAssistant.upsertManagedEntry(
+        // Call again with the same assistantId but different values.
+        let result = LockfileAssistant.ensureManagedEntry(
             assistantId: "test-id",
             runtimeUrl: "https://new.example.com",
             hatchedAt: "2024-06-01T00:00:00Z",
@@ -84,14 +87,42 @@ final class LockfileAssistantManagedTests: XCTestCase {
         let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
         let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
         let assistants = json["assistants"] as! [[String: Any]]
-        XCTAssertEqual(assistants.count, 1, "Should have exactly 1 entry after update, not 2")
-        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://new.example.com")
-        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-06-01T00:00:00Z")
+        XCTAssertEqual(assistants.count, 1, "Should have exactly 1 entry — second call is a no-op")
+        // Original values preserved, NOT overwritten.
+        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://old.example.com")
+        XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-01-01T00:00:00Z")
     }
 
-    // MARK: - upsertManagedEntry: preserves other entries
+    func testEnsurePreservesInstallationIdOnRepeatCall() {
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://example.com",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
 
-    func testUpsertPreservesOtherAssistantEntries() {
+        let data1 = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json1 = try! JSONSerialization.jsonObject(with: data1) as! [String: Any]
+        let assistants1 = json1["assistants"] as! [[String: Any]]
+        let originalInstallationId = assistants1[0]["installationId"] as! String
+
+        // Second call with same assistantId — should be no-op.
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "test-id",
+            runtimeUrl: "https://different.example.com",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        let data2 = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json2 = try! JSONSerialization.jsonObject(with: data2) as! [String: Any]
+        let assistants2 = json2["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants2[0]["installationId"] as? String, originalInstallationId, "installationId must survive repeat calls")
+    }
+
+    // MARK: - ensureManagedEntry: preserves other entries
+
+    func testEnsurePreservesOtherAssistantEntries() {
         // Pre-populate with a local entry.
         let existing: [String: Any] = [
             "assistants": [
@@ -107,7 +138,7 @@ final class LockfileAssistantManagedTests: XCTestCase {
         try! data.write(to: URL(fileURLWithPath: lockfilePath))
 
         // Add a managed entry.
-        let result = LockfileAssistant.upsertManagedEntry(
+        let result = LockfileAssistant.ensureManagedEntry(
             assistantId: "managed-id",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-06-01T00:00:00Z",
@@ -123,7 +154,7 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertTrue(assistants.contains(where: { ($0["assistantId"] as? String) == "managed-id" }))
     }
 
-    func testUpsertPreservesNonAssistantLockfileKeys() {
+    func testEnsurePreservesNonAssistantLockfileKeys() {
         // Pre-populate with extra top-level keys.
         let existing: [String: Any] = [
             "version": 1,
@@ -132,7 +163,7 @@ final class LockfileAssistantManagedTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: existing)
         try! data.write(to: URL(fileURLWithPath: lockfilePath))
 
-        LockfileAssistant.upsertManagedEntry(
+        LockfileAssistant.ensureManagedEntry(
             assistantId: "test-id",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-01-01T00:00:00Z",
@@ -144,10 +175,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(json["version"] as? Int, 1, "Non-assistant keys should be preserved")
     }
 
-    // MARK: - upsertManagedEntry: always sets cloud to "vellum"
+    // MARK: - ensureManagedEntry: always sets cloud to "vellum"
 
-    func testUpsertAlwaysSetsCloudToVellum() {
-        LockfileAssistant.upsertManagedEntry(
+    func testEnsureAlwaysSetsCloudToVellum() {
+        LockfileAssistant.ensureManagedEntry(
             assistantId: "test-id",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-01-01T00:00:00Z",
@@ -395,16 +426,16 @@ final class LockfileAssistantManagedTests: XCTestCase {
         }
     }
 
-    // MARK: - upsertManagedEntry: multiple different assistants
+    // MARK: - ensureManagedEntry: multiple different assistants
 
-    func testUpsertMultipleDifferentAssistants() {
-        LockfileAssistant.upsertManagedEntry(
+    func testEnsureMultipleDifferentAssistants() {
+        LockfileAssistant.ensureManagedEntry(
             assistantId: "assistant-1",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-01-01T00:00:00Z",
             lockfilePath: lockfilePath
         )
-        LockfileAssistant.upsertManagedEntry(
+        LockfileAssistant.ensureManagedEntry(
             assistantId: "assistant-2",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-02-01T00:00:00Z",

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -130,11 +130,8 @@ public struct LockfileAssistant {
         loadAll().first { $0.assistantId == name }
     }
 
-    /// Inserts or updates a managed (cloud = "vellum") entry in the lockfile.
-    ///
-    /// If an entry with the same `assistantId` already exists, it is updated
-    /// in place. Otherwise a new entry is appended. All other entries are
-    /// preserved unchanged.
+    /// Creates a managed entry if no entry with the same `assistantId` exists.
+    /// If one already exists, returns `true` without modifying it.
     ///
     /// - Parameters:
     ///   - assistantId: The platform-assigned assistant UUID string.
@@ -142,7 +139,7 @@ public struct LockfileAssistant {
     ///   - hatchedAt: ISO-8601 timestamp of when the assistant was created.
     ///   - lockfilePath: Override for tests; defaults to `LockfilePaths.primaryPath`.
     @discardableResult
-    public static func upsertManagedEntry(
+    public static func ensureManagedEntry(
         assistantId: String,
         runtimeUrl: String,
         hatchedAt: String,
@@ -166,19 +163,19 @@ public struct LockfileAssistant {
 
         var assistants = lockfile["assistants"] as? [[String: Any]] ?? []
 
+        // If an entry with this assistantId already exists, no-op.
+        if assistants.contains(where: { ($0["assistantId"] as? String) == assistantId }) {
+            return true
+        }
+
         let newEntry: [String: Any] = [
             "assistantId": assistantId,
             "runtimeUrl": runtimeUrl,
             "cloud": "vellum",
             "hatchedAt": hatchedAt,
+            "installationId": UUID().uuidString.lowercased(),
         ]
-
-        // Find existing entry with the same assistantId and update, or append.
-        if let existingIndex = assistants.firstIndex(where: { ($0["assistantId"] as? String) == assistantId }) {
-            assistants[existingIndex] = newEntry
-        } else {
-            assistants.append(newEntry)
-        }
+        assistants.append(newEntry)
 
         lockfile["assistants"] = assistants
 


### PR DESCRIPTION
## Summary
- Renamed `upsertManagedEntry` to `ensureManagedEntry` with insert-only semantics (no-op if entry exists)
- Generates `installationId` (lowercased UUID) on new entry creation
- Prevents accidental wiping of immutable fields like `installationId`, `bearerToken`, `resources`

Part of plan: swift-ensure-managed-entry.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
