### PR TITLE
refactor: delegate AvatarColor.nsColor to component store

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
@@ -5,20 +5,8 @@ enum AvatarColor: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var nsColor: NSColor {
-        switch self {
-        case .green: // color-literal-ok
-            return NSColor(srgbRed: 0x4C / 255.0, green: 0x9B / 255.0, blue: 0x50 / 255.0, alpha: 1)
-        case .orange: // color-literal-ok
-            return NSColor(srgbRed: 0xE9 / 255.0, green: 0x64 / 255.0, blue: 0x2F / 255.0, alpha: 1)
-        case .pink:
-            return NSColor(srgbRed: 0xDB / 255.0, green: 0x4B / 255.0, blue: 0x77 / 255.0, alpha: 1)
-        case .purple:
-            return NSColor(srgbRed: 0xA6 / 255.0, green: 0x65 / 255.0, blue: 0xC9 / 255.0, alpha: 1)
-        case .teal:
-            return NSColor(srgbRed: 0x0E / 255.0, green: 0x9B / 255.0, blue: 0x8B / 255.0, alpha: 1)
-        case .yellow: // color-literal-ok
-            return NSColor(srgbRed: 0xE9 / 255.0, green: 0xC9 / 255.0, blue: 0x1A / 255.0, alpha: 1)
-        }
+    @MainActor var nsColor: NSColor {
+        guard let def = AvatarComponentStore.shared.color(id: rawValue) else { return .clear }
+        return AvatarComponentStore.hexToNSColor(def.hex)
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded nsColor switch with AvatarComponentStore lookup and hex conversion
- Remove all inline color definitions from AvatarColors.swift
- Returns .clear when store is not yet loaded

Part of plan: avatar-client-cutover.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
