### PR TITLE
docs: expand CES Residual Risk #7 to cover filesystem path escape

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -343,11 +343,17 @@ When a credential is rotated (e.g., an API key is regenerated), existing CES gra
 
 **Mitigation**: Grants have TTL-based expiry. Operators can force-revoke grants via the grant revocation RPC. Future iterations may integrate with credential-rotation webhooks to auto-revoke affected grants.
 
-### 7. Cooperative egress enforcement via environment variables
+### 7. Cooperative isolation for both network egress and filesystem access
 
-CES enforces egress controls by injecting `HTTP_PROXY`/`HTTPS_PROXY` environment variables into the subprocess environment. This is cooperative — a binary that ignores proxy environment variables, implements its own HTTP stack, or opens raw sockets can bypass CES egress controls entirely. Risk #3 above documents this limitation for both local and managed deployments. In managed deployments specifically, current network policies allow public egress from all containers in the pod, so a non-cooperating binary in the CES container can reach the internet without going through the egress proxy.
+CES enforces isolation controls cooperatively rather than at the OS level:
 
-**Mitigation**: The denied-binary list and manifest validation restrict which binaries can run as secure commands, reducing the surface for non-cooperating binaries. In practice, the well-known CLI tools approved as secure command entrypoints (e.g., `gh`, `aws`) respect proxy environment variables. Future work could add per-container network policies (e.g., Calico rules that restrict the CES container's egress to the proxy sidecar only) or use network namespace isolation to make the proxy mandatory at the network level rather than relying on process-level cooperation.
+- **Network egress**: CES injects `HTTP_PROXY`/`HTTPS_PROXY` environment variables into the subprocess environment. A binary that ignores proxy environment variables, implements its own HTTP stack, or opens raw sockets can bypass CES egress controls entirely. Risk #3 above documents this limitation for both local and managed deployments. In managed deployments specifically, current network policies allow public egress from all containers in the pod, so a non-cooperating binary in the CES container can reach the internet without going through the egress proxy.
+
+- **Filesystem access**: CES commands run with `cwd` set to a CES-private scratch directory, but this is cooperative — commands can use absolute paths to read or write arbitrary locations on the host filesystem. There is no chroot, filesystem namespace, or bind-mount isolation restricting file access. A command that resolves `..` paths or uses absolute paths can escape the scratch directory to access any file readable/writable by the CES process user.
+
+Both limitations stem from the same root cause: v1 relies on process-level conventions (env vars for network, cwd for filesystem) rather than OS-level enforcement primitives.
+
+**Mitigation**: The denied-binary list and manifest validation restrict which binaries can run as secure commands, reducing the surface for non-cooperating binaries. In practice, the well-known CLI tools approved as secure command entrypoints (e.g., `gh`, `aws`) respect proxy environment variables and operate within their working directory. True enforcement requires OS-level sandboxing — Linux network namespaces for mandatory proxy routing and filesystem namespaces or chroot for path isolation — which is planned for v2 when CES runs in managed containers with full namespace support.
 
 ### 8. `credential_process` adapter shares cooperative egress limitation with main command
 


### PR DESCRIPTION
## Summary
- Expands Residual Risk #7 in the CES ADR to explicitly document that filesystem isolation is also cooperative (cwd-based, not namespace-based)
- Documents that commands can use absolute paths to bypass scratch directory isolation
- Notes OS-level sandboxing (namespaces, chroot) as the v2 solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)