### PR TITLE
fix: correct managed CES defaultWorkspaceDir to /assistant-data-ro/.vellum/workspace

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -251,7 +251,7 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
       cesMode: "managed",
       egressHooks: buildCesEgressHooks(),
     },
-    defaultWorkspaceDir: "/workspace",
+    defaultWorkspaceDir: join(mountedVellumRoot, "workspace"),
   });
 
   // Register manage_secure_command_tool handler


### PR DESCRIPTION
## Summary
- Fixes managed CES sidecar defaultWorkspaceDir from hardcoded "/workspace" to the correct path derived from the assistant data mount
- Uses join(mountedVellumRoot, "workspace") which resolves to /assistant-data-ro/.vellum/workspace
- Aligns with how the assistant stores its workspace at /data/.vellum/workspace (visible to CES via read-only mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)