### PR TITLE
fix: remove cross-thread allow_once fallback from allow_thread grants

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -26,7 +26,7 @@ import type {
 } from "@vellumai/ces-contracts";
 
 import type { PersistentGrantStore, PersistentGrant } from "./persistent-store.js";
-import { type TemporaryGrantStore, DEFAULT_ONCE_FALLBACK_TTL_MS } from "./temporary-store.js";
+import type { TemporaryGrantStore } from "./temporary-store.js";
 import type { AuditStore } from "../audit/store.js";
 import type { RpcMethodHandler } from "../server.js";
 
@@ -136,13 +136,6 @@ export function createRecordGrantHandler(
     } else if (grantType === "allow_thread") {
       deps.temporaryGrantStore.add("allow_thread", decision.proposalHash, {
         conversationId: request.conversationId ?? sessionId,
-      });
-      // Also add an allow_once fallback as defense-in-depth: ensures the
-      // immediate retry succeeds even if conversationId is missing or
-      // mismatched. TTL-scoped to prevent cross-thread consumption outside
-      // the immediate retry window.
-      deps.temporaryGrantStore.add("allow_once", decision.proposalHash, {
-        durationMs: DEFAULT_ONCE_FALLBACK_TTL_MS,
       });
     } else {
       // allow_once and always_allow both get a single-use temp grant


### PR DESCRIPTION
## Summary
- Removes the allow_once fallback grant that was created alongside allow_thread grants
- The fallback was keyed by proposal hash only (no conversationId), creating a 30-second window where another thread could consume the approval
- allow_thread grants should be strictly thread-scoped; if the immediate retry fails due to missing conversationId, that's a caller bug to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
