### PR TITLE
fix: enforce credential allowedTools/allowedDomains policies in CES

### DIFF
--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -40,6 +40,7 @@ import type { TemporaryGrantStore } from "../grants/temporary-store.js";
 import type { LocalMaterialiser, MaterialisedCredential } from "../materializers/local.js";
 import { materializeManagedToken, type ManagedMaterializerOptions } from "../materializers/managed-platform.js";
 import { resolveLocalSubject, type LocalSubjectResolverDeps } from "../subjects/local.js";
+import { checkCredentialPolicy } from "../subjects/policy.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "../subjects/managed.js";
 import type { SessionIdRef } from "../server.js";
 
@@ -308,6 +309,19 @@ async function materialiseCredential(
       const subjectResult = resolveLocalSubject(rawHandle, deps.localSubjectDeps);
       if (!subjectResult.ok) {
         return { ok: false, error: subjectResult.error };
+      }
+
+      // Enforce credential-level policies for local static handles.
+      // OAuth connections don't carry allowedTools/allowedDomains in the
+      // same way, so policy checks are skipped for OAuth.
+      if (subjectResult.subject.type === HandleType.LocalStatic) {
+        const policyCheck = checkCredentialPolicy(
+          subjectResult.subject.metadata,
+          "make_authenticated_request",
+        );
+        if (!policyCheck.ok) {
+          return { ok: false, error: policyCheck.error! };
+        }
       }
 
       // Materialise through the local materialiser

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -39,6 +39,7 @@ import { LocalMaterialiser } from "./materializers/local.js";
 import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
 import { createLocalOAuthLookup } from "./materializers/local-oauth-lookup.js";
 import { resolveLocalSubject } from "./subjects/local.js";
+import { checkCredentialPolicy } from "./subjects/policy.js";
 import {
   getCesAuditDir,
   getCesDataRoot,
@@ -157,6 +158,18 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
         if (!subjectResult.ok) {
           return { ok: false as const, error: subjectResult.error };
         }
+
+        // Enforce credential-level policies for local static handles
+        if (subjectResult.subject.type === "local_static") {
+          const policyCheck = checkCredentialPolicy(
+            subjectResult.subject.metadata,
+            "run_authenticated_command",
+          );
+          if (!policyCheck.ok) {
+            return { ok: false as const, error: policyCheck.error! };
+          }
+        }
+
         const matResult = await localMaterialiser.materialise(subjectResult.subject);
         if (!matResult.ok) {
           return { ok: false as const, error: matResult.error };

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -56,6 +56,7 @@ import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
 import { buildCesEgressHooks } from "./commands/egress-hooks.js";
 import { resolveLocalSubject } from "./subjects/local.js";
+import { checkCredentialPolicy } from "./subjects/policy.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "./subjects/managed.js";
 import { materializeManagedToken, type ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 import { HandleType, parseHandle } from "@vellumai/ces-contracts";
@@ -191,6 +192,18 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
             if (!subjectResult.ok) {
               return { ok: false as const, error: subjectResult.error };
             }
+
+            // Enforce credential-level policies for local static handles
+            if (subjectResult.subject.type === HandleType.LocalStatic) {
+              const policyCheck = checkCredentialPolicy(
+                subjectResult.subject.metadata,
+                "run_authenticated_command",
+              );
+              if (!policyCheck.ok) {
+                return { ok: false as const, error: policyCheck.error! };
+              }
+            }
+
             const matResult = await localMaterialiser.materialise(
               subjectResult.subject,
             );

--- a/credential-executor/src/subjects/policy.ts
+++ b/credential-executor/src/subjects/policy.ts
@@ -1,0 +1,75 @@
+/**
+ * CES credential policy enforcement.
+ *
+ * Enforces credential-level policies (allowedTools, allowedDomains) that were
+ * previously only checked by the pre-CES broker in the assistant daemon.
+ * Without these checks, CES would materialise credentials that the broker
+ * would have rejected — a security regression.
+ *
+ * Policy rules:
+ * - **allowedDomains** — credentials with domain restrictions are scoped to
+ *   browser use on those domains and cannot be used server-side by CES.
+ * - **allowedTools** — if set, only the listed tools may consume the
+ *   credential. CES tool names ("make_authenticated_request",
+ *   "run_authenticated_command") must be in the list.
+ */
+
+import type { StaticCredentialRecord } from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export interface CredentialPolicyCheckResult {
+  ok: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Policy check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check credential-level policies before materialisation.
+ *
+ * Returns `{ ok: true }` if the credential may be materialised for the
+ * given CES tool, or `{ ok: false, error }` with a human-readable
+ * rejection message.
+ *
+ * @param metadata  Non-secret metadata record for a local static credential.
+ * @param cesToolName  The CES tool requesting materialisation
+ *   (e.g. "make_authenticated_request" or "run_authenticated_command").
+ */
+export function checkCredentialPolicy(
+  metadata: StaticCredentialRecord,
+  cesToolName: string,
+): CredentialPolicyCheckResult {
+  // -- allowedDomains -------------------------------------------------------
+  // Credentials with domain restrictions are scoped to browser use on those
+  // domains. They cannot be used for server-side operations through CES.
+  if (metadata.allowedDomains && metadata.allowedDomains.length > 0) {
+    return {
+      ok: false,
+      error:
+        `Credential ${metadata.service}/${metadata.field} has domain restrictions ` +
+        `(${metadata.allowedDomains.join(", ")}) and cannot be used for server-side ` +
+        `operations through CES. Remove domain restrictions or use a separate credential.`,
+    };
+  }
+
+  // -- allowedTools ---------------------------------------------------------
+  // If set, the CES tool must be in the allowed list.
+  if (metadata.allowedTools && metadata.allowedTools.length > 0) {
+    if (!metadata.allowedTools.includes(cesToolName)) {
+      return {
+        ok: false,
+        error:
+          `Tool "${cesToolName}" is not allowed to use credential ` +
+          `${metadata.service}/${metadata.field}. ` +
+          `Allowed tools: ${metadata.allowedTools.join(", ")}.`,
+      };
+    }
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- Adds shared credential policy check helper (`credential-executor/src/subjects/policy.ts`) that enforces `allowedTools` and `allowedDomains` from credential metadata
- Wires policy checks into HTTP executor, local command executor, and managed command executor materialization paths
- Matches pre-CES broker behavior: domain-restricted credentials are rejected for server-side use, tool-restricted credentials require the CES tool name in the allowed list

## Test plan
- [ ] Verify that a credential with `allowedDomains` set is rejected when used through `make_authenticated_request`
- [ ] Verify that a credential with `allowedTools` not including `make_authenticated_request` is rejected for HTTP requests
- [ ] Verify that a credential with `allowedTools` not including `run_authenticated_command` is rejected for command execution
- [ ] Verify that credentials without restrictions continue to work normally
- [ ] Verify that OAuth credentials (which don't carry these policies) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
