### PR TITLE
fix: rename managed CES test from E2E to contract test

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -1,15 +1,15 @@
 /**
- * End-to-end managed CES tests.
+ * Managed CES contract and wiring tests.
  *
- * Verifies the managed (three-container pod) CES sidecar integration:
+ * Validates the contract surface and feature-flag gating for the managed
+ * (three-container pod) CES sidecar integration:
  *
  * 1. Pod creation contract: assistant, gateway, and credential-executor
  *    containers share the bootstrap socket emptyDir and assistant-data
  *    read-only mount.
  *
- * 2. Bootstrap handshake success: the process manager connects to the
- *    managed CES sidecar via the bootstrap socket and completes the
- *    handshake, returning a functional CesClient.
+ * 2. Bootstrap handshake contract: the protocol version and session ID
+ *    fields required by the managed sidecar handshake are present.
  *
  * 3. Secure HTTP execution: make_authenticated_request RPC method is
  *    available in the CES contract for managed sidecar mode.


### PR DESCRIPTION
## Summary
- Renames credential-execution-managed-e2e.test.ts to credential-execution-managed-contract.test.ts
- Updates module docstring and describe blocks to accurately reflect these are contract/wiring tests, not E2E
- The tests mock the process manager and CES client, validating contract and wiring only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
