### PR TITLE
fix: update tests for threadType → conversationType rename

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -175,7 +175,7 @@ describe("pairDeliveryWithConversation", () => {
       string,
       unknown
     >;
-    expect(callArgs.threadType).toBe("standard");
+    expect(callArgs.conversationType).toBe("standard");
   });
 
   test("uses threadTitle for conversation title when available", async () => {
@@ -312,7 +312,7 @@ describe("pairDeliveryWithConversation", () => {
       string,
       unknown
     >;
-    expect(callArgs.threadType).toBe("background");
+    expect(callArgs.conversationType).toBe("background");
   });
 
   // ── Binding-key reuse (continue_existing + bindingContext) ────────

--- a/assistant/src/__tests__/task-management-tools.test.ts
+++ b/assistant/src/__tests__/task-management-tools.test.ts
@@ -115,7 +115,7 @@ function createTestConversation(id: string): string {
   const now = Date.now();
   raw
     .query(
-      `INSERT INTO conversations (id, title, created_at, updated_at, thread_type, memory_scope_id) VALUES (?, 'Test', ?, ?, 'standard', 'default')`,
+      `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, memory_scope_id) VALUES (?, 'Test', ?, ?, 'standard', 'default')`,
     )
     .run(id, now, now);
   return id;


### PR DESCRIPTION
## Summary
- Update `createTestConversation` in `task-management-tools.test.ts` to use the renamed `conversation_type` DB column instead of `thread_type`
- Update `conversation-pairing.test.ts` assertions to check `conversationType` instead of `threadType`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23114915182/job/67138675070

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
