### PR TITLE
fix: make SkillsListResponseSkill.degraded optional to match daemon response

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -104,7 +104,7 @@ struct InstalledSkillsView: View {
 
             Spacer()
 
-            if skill.degraded {
+            if skill.degraded == true {
                 VIconView(.triangleAlert, size: 14)
                     .foregroundColor(.orange)
                     .accessibilityLabel("Degraded")
@@ -112,7 +112,7 @@ struct InstalledSkillsView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Skill: \(skill.name), \(skill.state)\(skill.degraded ? ", degraded" : "")")
+        .accessibilityLabel("Skill: \(skill.name), \(skill.state)\(skill.degraded == true ? ", degraded" : "")")
         .accessibilityHint("Opens skill details")
     }
 

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -173,7 +173,7 @@ struct SkillDetailView: View {
                     .multilineTextAlignment(.center)
             }
 
-            if skill.degraded {
+            if skill.degraded == true {
                 HStack(spacing: 4) {
                     VIconView(.triangleAlert, size: 12)
                     Text("Degraded")

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3870,7 +3870,7 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let homepage: String?
     public let source: String
     public let state: String
-    public let degraded: Bool
+    public let degraded: Bool?
     public let missingRequirements: SkillsListResponseSkillMissingRequirements?
     public let installedVersion: String?
     public let latestVersion: String?
@@ -3878,7 +3878,7 @@ public struct SkillsListResponseSkill: Codable, Sendable {
     public let clawhub: SkillsListResponseSkillClawhub?
     public let provenance: SkillsListResponseSkillProvenance?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, degraded: Bool, missingRequirements: SkillsListResponseSkillMissingRequirements? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, clawhub: SkillsListResponseSkillClawhub? = nil, provenance: SkillsListResponseSkillProvenance? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, degraded: Bool? = nil, missingRequirements: SkillsListResponseSkillMissingRequirements? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, clawhub: SkillsListResponseSkillClawhub? = nil, provenance: SkillsListResponseSkillProvenance? = nil) {
         self.id = id
         self.name = name
         self.description = description


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-detail-files-api.md.

**Gap:** Swift `SkillsListResponseSkill.degraded` is non-optional but daemon no longer sends it
**What was expected:** Swift type should decode skill responses that omit `degraded` field
**What was found:** Non-optional `degraded: Bool` causes `DecodingError.keyNotFound` at runtime

### Changes
- Made `degraded` property optional (`Bool?`) in `SkillsListResponseSkill` (GeneratedAPITypes.swift)
- Updated init parameter to `degraded: Bool? = nil` for backwards compatibility
- Updated `InstalledSkillsView.swift` to use `skill.degraded == true` instead of `skill.degraded`
- Updated `SkillDetailView.swift` to use `skill.degraded == true` instead of `skill.degraded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
