### PR TITLE
fix: use single-char ESCAPE in turn-events-store SQL LIKE clauses

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -28,8 +28,8 @@ export function queryUnreportedTurnEvents(
         // system-generated and should not count as user turns.
         // Use ESCAPE '\\' so underscores are matched literally, not as
         // single-character wildcards.
-        sql`${messages.content} NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\\\'`,
-        sql`${messages.content} NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\\\'`,
+        sql`${messages.content} NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'`,
+        sql`${messages.content} NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'`,
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),


### PR DESCRIPTION
Fixes the ESCAPE clause in turn-events-store.ts to use 2 backslashes in source (producing 1 backslash in SQL) matching the pattern in conversation-queries.ts. The previous 4 backslashes produced a 2-char ESCAPE string which SQLite rejects.

Follows up on #17072.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
