### PR TITLE
docs: fix allow_thread grant lifetime claim in CES ADR

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -89,7 +89,7 @@ CES has two grant tiers:
 
 - **Persistent grants** (`always_allow`): Stored in the CES grant table and scoped to the entire assistant — not to a specific session. These are analogous to trust rules: once a user approves `always_allow` for a credential+purpose pair, any session on that assistant can use the grant. The `session_id` field on persistent grants records which session created the grant (audit metadata), but is not used as an enforcement filter during grant matching.
 
-- **Temporary grants** (`allow_once`, `allow_10m`, `allow_thread`): Held in-memory by the CES process and scoped to the session or thread that created them. These grants are not persisted and do not survive CES restarts. `allow_once` is consumed immediately after a single use; `allow_10m` expires after 10 minutes; `allow_thread` lasts for the lifetime of the originating agent thread.
+- **Temporary grants** (`allow_once`, `allow_10m`, `allow_thread`): Held in-memory by the CES process and scoped to the session or thread that created them. These grants are not persisted and do not survive CES restarts. `allow_once` is consumed immediately after a single use; `allow_10m` expires after 10 minutes; `allow_thread` is scoped to the originating conversation via key matching but remains in memory until the CES process restarts (there is no automatic cleanup on thread end).
 
 ### Persistent grant table
 


### PR DESCRIPTION
Corrects the allow_thread grant documentation to reflect actual behavior: grants are scoped to the originating conversation via key matching but held in memory until CES restarts (clearConversation is not called in production).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
