### PR TITLE
fix: move ensureGrantAuditEnabled inside try/catch in CES CLI handlers

### DIFF
--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -161,10 +161,9 @@ Examples:
     )
     .action(
       async (opts: { handle?: string; status?: string }, cmd: Command) => {
-        if (!ensureGrantAuditEnabled(cmd)) return;
-
         let cleanup: (() => Promise<void>) | undefined;
         try {
+          if (!ensureGrantAuditEnabled(cmd)) return;
           const ces = await acquireCesClient();
           cleanup = ces.cleanup;
 
@@ -225,10 +224,9 @@ Examples:
     )
     .action(
       async (grantId: string, opts: { reason?: string }, cmd: Command) => {
-        if (!ensureGrantAuditEnabled(cmd)) return;
-
         let cleanup: (() => Promise<void>) | undefined;
         try {
+          if (!ensureGrantAuditEnabled(cmd)) return;
           const ces = await acquireCesClient();
           cleanup = ces.cleanup;
 
@@ -298,10 +296,9 @@ Examples:
         opts: { handle?: string; grant?: string; limit: string },
         cmd: Command,
       ) => {
-        if (!ensureGrantAuditEnabled(cmd)) return;
-
         let cleanup: (() => Promise<void>) | undefined;
         try {
+          if (!ensureGrantAuditEnabled(cmd)) return;
           const ces = await acquireCesClient();
           cleanup = ces.cleanup;
 


### PR DESCRIPTION
Moves ensureGrantAuditEnabled() inside the existing try/catch blocks so getConfig() errors are properly handled instead of throwing unhandled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
