### PR TITLE
fix: prevent adapter env from overriding HOME when cleanConfigDirs is active

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -425,8 +425,8 @@ export async function executeAuthenticatedCommand(
   }
 
   // Generate HOME path before buildCommandEnv so we have a known-safe value
-  // for cleanup. buildCommandEnv spreads adapterEnv which could override HOME
-  // if an auth adapter declares envVarName: "HOME".
+  // for cleanup. buildCommandEnv sets HOME after spreading adapterEnv to
+  // prevent auth adapters from overriding the isolated home directory.
   const generatedHomeDir = join(tmpdir(), `ces-home-${randomUUID()}`);
 
   // Create the HOME directory and enforce cleanConfigDirs before building env
@@ -940,10 +940,12 @@ function buildCommandEnv(
   const env: Record<string, string> = {
     // Minimal baseline environment
     PATH: process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin",
-    HOME: homeDir ?? join(tmpdir(), `ces-home-${randomUUID()}`),
     LANG: "en_US.UTF-8",
-    // Inject auth adapter env vars
+    // Inject auth adapter env vars first so they cannot override HOME
     ...adapterEnv,
+    // HOME is set after adapterEnv spread to prevent auth adapters declaring
+    // envVarName: "HOME" from bypassing the isolated config directory.
+    HOME: homeDir ?? join(tmpdir(), `ces-home-${randomUUID()}`),
   };
 
   // Inject proxy env vars if the egress proxy is active


### PR DESCRIPTION
Ensures HOME cannot be overridden by auth adapter env vars when cleanConfigDirs is in use, preventing bypass of the isolated config directory security boundary.

In buildCommandEnv, adapterEnv was spread after HOME was set, meaning an auth adapter declaring envVarName: "HOME" could override the generatedHomeDir. This fix reorders the object literal so HOME is set after the adapterEnv spread, ensuring the isolated home directory always wins.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
