### PR TITLE
fix: pre-create /ces-data directory in CES Dockerfile for non-root startup

### DIFF
--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -45,6 +45,10 @@ RUN groupadd --system --gid 1001 ces && \
 # Copy built app from builder
 COPY --from=builder --chown=ces:ces /app /app
 
+# Pre-create /ces-data so the non-root ces user can write to it
+# when no PVC volume is mounted (e.g., direct docker run)
+RUN mkdir -p /ces-data && chown ces:ces /ces-data
+
 USER ces
 
 EXPOSE 8090


### PR DESCRIPTION
Adds mkdir -p /ces-data with proper ownership in the CES Dockerfile so the ces user can write to the data root when no PVC volume is mounted (matching the old behavior where /home/ces/.ces-data was writable by default).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
