### PR TITLE
fix: reject duplicate handshake requests after session is established

### DIFF
--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -219,6 +219,10 @@ export class CesRpcServer {
     const msg = msgResult.data as TransportMessage;
 
     if (msg.type === "handshake_request") {
+      if (this.handshakeComplete) {
+        this.logger.warn("[ces-server] Duplicate handshake_request after session established; ignoring");
+        return;
+      }
       this.handleHandshake(msg as HandshakeRequest);
     } else if (msg.type === "rpc") {
       this.handleRpcEnvelope(msg as unknown as RpcEnvelope).catch((err) => {


### PR DESCRIPTION
Adds an early return guard in CES server handleLine to ignore handshake_request messages after the initial handshake is complete, preventing sessionIdRef from being overwritten.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
