### PR TITLE
fix: update shell lockdown fallback path from /run/ces to /run/ces-bootstrap

### DIFF
--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -56,7 +56,7 @@ function buildCesProtectedPaths(): string[] {
   // CES bootstrap socket directory — block access to the Unix socket that
   // accepts RPC commands from the assistant process.
   const bootstrapSocketDir =
-    process.env["CES_BOOTSTRAP_SOCKET_DIR"] || "/run/ces";
+    process.env["CES_BOOTSTRAP_SOCKET_DIR"] || "/run/ces-bootstrap";
   paths.push(bootstrapSocketDir);
 
   // If a full socket path override is set (without the dir env var), block


### PR DESCRIPTION
Updates buildCesProtectedPaths() fallback from /run/ces to /run/ces-bootstrap to match the socket directory rename in PR #17092. Without this fix, the shell lockdown blocks the old path while leaving the actual CES bootstrap socket unprotected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
