### PR TITLE
fix: add CES init retry on failure and fast shutdown abort

### DIFF
--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -97,6 +97,13 @@ export interface CesProcessManager {
   /** Gracefully stop the CES process (local) or disconnect (managed). */
   stop(): Promise<void>;
 
+  /**
+   * Force-stop the CES process even if start() hasn't finished yet.
+   * Unlike stop(), this works regardless of the `running` state — it kills
+   * any child process or destroys any managed socket immediately.
+   */
+  forceStop(): Promise<void>;
+
   /** The discovery result from the last start() call, or null if not started. */
   getDiscoveryResult(): DiscoveryResult | null;
 
@@ -170,6 +177,22 @@ export function createCesProcessManager(
 
       running = false;
       log.info("CES process manager stopped");
+    },
+
+    async forceStop(): Promise<void> {
+      if (childProcess) {
+        childProcess.kill("SIGKILL");
+        await childProcess.exited.catch(() => {});
+        childProcess = null;
+      }
+
+      if (managedSocket) {
+        managedSocket.destroy();
+        managedSocket = null;
+      }
+
+      running = false;
+      log.info("CES process manager force-stopped");
     },
 
     getDiscoveryResult(): DiscoveryResult | null {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -256,6 +256,7 @@ export class DaemonServer {
   // hold that connection at the server level rather than per-session.
   private cesProcessManager?: CesProcessManager;
   private cesClientPromise?: Promise<CesClient | undefined>;
+  private cesInitAbortController?: AbortController;
 
   /**
    * Logical assistant identifier used when publishing to the assistant-events hub.
@@ -485,11 +486,20 @@ export class DaemonServer {
     if (isCesToolsEnabled(config)) {
       const pm = createCesProcessManager({ assistantConfig: config });
       this.cesProcessManager = pm;
+      const abortController = new AbortController();
+      this.cesInitAbortController = abortController;
       this.cesClientPromise = (async () => {
         try {
           const transport = await pm.start();
+          if (abortController.signal.aborted) {
+            throw new Error("CES initialization aborted during shutdown");
+          }
           const client = createCesClient(transport);
           const { accepted, reason } = await client.handshake();
+          if (abortController.signal.aborted) {
+            client.close();
+            throw new Error("CES initialization aborted during shutdown");
+          }
           if (accepted) {
             log.info(
               "CES client initialized and handshake accepted (server-level)",
@@ -502,6 +512,8 @@ export class DaemonServer {
           );
           client.close();
           await pm.stop();
+          // Reset so next session can retry initialization
+          this.cesClientPromise = undefined;
           return undefined;
         } catch (err) {
           if (err instanceof CesUnavailableError) {
@@ -516,6 +528,8 @@ export class DaemonServer {
             );
           }
           await pm.stop().catch(() => {});
+          // Reset so next session can retry initialization
+          this.cesClientPromise = undefined;
           return undefined;
         }
       })();
@@ -538,7 +552,18 @@ export class DaemonServer {
     }
     this.sessions.clear();
 
-    // Tear down the server-level CES client and process manager
+    // Abort any in-flight CES initialization so it fails fast instead of
+    // blocking shutdown for up to ~15s (socket connect + handshake timeouts).
+    if (this.cesInitAbortController) {
+      this.cesInitAbortController.abort();
+      this.cesInitAbortController = undefined;
+    }
+    // Force-stop the CES process immediately — forceStop() works even if
+    // start() hasn't finished (unlike stop() which is a no-op when !running).
+    if (this.cesProcessManager) {
+      await this.cesProcessManager.forceStop().catch(() => {});
+    }
+    // Now await the init promise (which should settle quickly due to abort/kill).
     if (this.cesClientPromise) {
       const client = await this.cesClientPromise.catch(() => undefined);
       if (client) {
@@ -547,7 +572,6 @@ export class DaemonServer {
       this.cesClientPromise = undefined;
     }
     if (this.cesProcessManager) {
-      await this.cesProcessManager.stop().catch(() => {});
       this.cesProcessManager = undefined;
     }
 


### PR DESCRIPTION
Resets cesClientPromise on initialization failure so subsequent sessions can retry. Adds an abort mechanism so server shutdown causes in-flight CES init to fail fast instead of blocking ~15s.

- Reset cesClientPromise to undefined in both the catch and rejection paths of the CES init IIFE, so the next session triggers a fresh initialization attempt
- Add AbortController to the CES init IIFE; stop() aborts it before awaiting the promise
- Add forceStop() to CesProcessManager that kills child process / destroys socket regardless of running state (unlike stop() which is a no-op during in-progress start())
- Reorder stop() to: abort signal -> forceStop -> await promise (settles quickly)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
