### PR TITLE
fix: use assistant-sourced entropy for managed CES key derivation

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -76,7 +76,7 @@ export function _setStorePath(path: string | null): void {
 // Machine entropy for key derivation
 // ---------------------------------------------------------------------------
 
-function getMachineEntropy(): string {
+export function getMachineEntropy(): string {
   const parts: string[] = [];
   try {
     parts.push(hostname());
@@ -152,9 +152,34 @@ function readStore(): StoreFile | null {
   }
 }
 
+/**
+ * Well-known filename for the persisted machine entropy.
+ * Written alongside `keys.enc` so the CES sidecar (which mounts the
+ * assistant data volume read-only) can derive the same AES key.
+ */
+const ENTROPY_FILENAME = "entropy.key";
+
+/**
+ * Persist the current machine entropy next to the key store so the managed
+ * CES sidecar can read it and derive the same decryption key.
+ */
+function persistEntropy(protectedDir: string): void {
+  try {
+    const entropyPath = join(protectedDir, ENTROPY_FILENAME);
+    const tmpPath = entropyPath + `.tmp.${process.pid}`;
+    writeFileSync(tmpPath, getMachineEntropy(), { mode: 0o600 });
+    chmodSync(tmpPath, 0o600);
+    renameSync(tmpPath, entropyPath);
+  } catch {
+    // Best-effort — local mode doesn't need this file, and managed mode
+    // will log a clear error if it's missing.
+  }
+}
+
 function writeStore(store: StoreFile): void {
   const path = getStorePath();
-  ensureDir(dirname(path));
+  const protectedDir = dirname(path);
+  ensureDir(protectedDir);
   // Atomic write: write to temp file then rename to avoid partial/corrupt writes.
   // Use pid suffix to prevent cross-process collisions while ensuring same-process
   // retries overwrite the stale temp file (avoids orphaned temp files on failure).
@@ -162,6 +187,9 @@ function writeStore(store: StoreFile): void {
   writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 });
   chmodSync(tmpPath, 0o600);
   renameSync(tmpPath, path);
+
+  // Keep entropy.key in sync so the managed CES sidecar can decrypt.
+  persistEntropy(protectedDir);
 }
 
 function getOrCreateStore(): StoreFile {

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -17,7 +17,7 @@
  * All RPC traffic flows exclusively over the accepted Unix socket stream.
  */
 
-import { mkdirSync, unlinkSync } from "node:fs";
+import { mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { createServer as createNetServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { Readable, Writable } from "node:stream";
@@ -137,7 +137,25 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
     process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
   const mountedVellumRoot = join(assistantDataMount, ".vellum");
 
-  const secureKeyBackend = createLocalSecureKeyBackend(mountedVellumRoot);
+  // The assistant writes its machine entropy to `protected/entropy.key` so
+  // the CES sidecar can derive the same AES decryption key. Without this,
+  // key derivation would use the sidecar's own hostname/user/homedir which
+  // differ from the assistant container's values.
+  let assistantEntropy: string | undefined;
+  const entropyPath = join(mountedVellumRoot, "protected", "entropy.key");
+  try {
+    assistantEntropy = readFileSync(entropyPath, "utf-8");
+    log(`Read assistant entropy from ${entropyPath}`);
+  } catch {
+    warn(
+      `Could not read assistant entropy from ${entropyPath}. ` +
+        "local_static credential decryption may fail if machine entropy differs.",
+    );
+  }
+
+  const secureKeyBackend = createLocalSecureKeyBackend(mountedVellumRoot, {
+    entropyOverride: assistantEntropy,
+  });
   const localMaterialiser = new LocalMaterialiser({ secureKeyBackend });
 
   const credentialMetadataPath = join(

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -12,8 +12,10 @@
  * enforce this invariant.
  *
  * The encrypted store uses AES-256-GCM with a key derived from machine-
- * specific entropy via PBKDF2. Since CES runs on the same machine as the
- * same user, the derived key is identical.
+ * specific entropy via PBKDF2. In local mode, CES runs on the same machine
+ * as the same user so the derived key is identical. In managed mode, CES
+ * runs in a separate container with different hostname/user/homedir, so
+ * the caller must supply the assistant's entropy via `entropyOverride`.
  */
 
 import {
@@ -81,8 +83,8 @@ function getMachineEntropy(): string {
   return parts.join(":");
 }
 
-function deriveKey(salt: Buffer): Buffer {
-  const entropy = getMachineEntropy();
+function deriveKey(salt: Buffer, entropyOverride?: string): Buffer {
+  const entropy = entropyOverride ?? getMachineEntropy();
   return pbkdf2Sync(entropy, salt, PBKDF2_ITERATIONS, KEY_LENGTH, "sha512");
 }
 
@@ -132,11 +134,18 @@ function readStore(storePath: string): StoreFile | null {
  * encrypted key store.
  *
  * @param vellumRoot - The Vellum root directory (e.g. `~/.vellum`).
+ * @param options.entropyOverride - If provided, used instead of local
+ *   machine entropy for key derivation. In managed mode the CES sidecar
+ *   runs in a different container with a different hostname/user, so it
+ *   must use the assistant's entropy (read from the shared data mount)
+ *   to derive the same AES key.
  */
 export function createLocalSecureKeyBackend(
   vellumRoot: string,
+  options?: { entropyOverride?: string },
 ): SecureKeyBackend {
   const storePath = join(vellumRoot, "protected", "keys.enc");
+  const entropy = options?.entropyOverride;
 
   return {
     async get(key: string): Promise<string | undefined> {
@@ -148,7 +157,7 @@ export function createLocalSecureKeyBackend(
         if (!entry) return undefined;
 
         const salt = Buffer.from(store.salt, "hex");
-        const derivedKey = deriveKey(salt);
+        const derivedKey = deriveKey(salt, entropy);
         return decrypt(entry, derivedKey);
       } catch {
         return undefined;


### PR DESCRIPTION
Fixes local_static credential materialisation in managed CES mode by using entropy from the assistant container (via shared mount) rather than the CES sidecar's own machine entropy, which differs due to different hostname/user.

The assistant now persists its machine entropy to `protected/entropy.key` alongside `keys.enc` whenever the encrypted store is written. The managed CES sidecar reads this file from the read-only assistant data mount and uses it for AES key derivation, ensuring the same decryption key is derived regardless of container differences.

Closes #17087
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
