### PR TITLE
fix: update stale comments about hardcoded avatar data

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -126,8 +126,9 @@ final class AvatarAppearanceManager {
 
         // Fire-and-forget: fetch character component definitions from the
         // daemon and populate AvatarComponentStore.shared so downstream
-        // code can look up definitions by ID. The app still works with
-        // hardcoded enums if the daemon is unreachable.
+        // code can look up definitions by ID. Avatar rendering requires
+        // the component store to be populated; safe defaults are used
+        // during the pre-fetch window.
         Task { [weak self] in
             await self?.fetchComponentsFromDaemon()
         }
@@ -158,7 +159,7 @@ final class AvatarAppearanceManager {
 
     /// Fetches the canonical character component definitions from the daemon
     /// and populates `AvatarComponentStore.shared` for O(1) lookups.
-    /// Fails silently — the client continues to work with hardcoded enums.
+    /// Fails silently — avatar rendering uses safe defaults until the store is populated.
     private func fetchComponentsFromDaemon() async {
         guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
               let assistant = LockfileAssistant.loadByName(assistantId) else {

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
@@ -65,7 +65,7 @@ final class AvatarComponentService {
 
     /// Fetches character components from the daemon. Returns `nil` on any
     /// failure (network error, non-200 status, decode error) so callers
-    /// can fall back to hardcoded enums.
+    /// can use safe defaults until the component store is populated.
     static func fetch(port: Int) async -> ComponentsResponse? {
         guard let url = URL(string: "http://localhost:\(port)/v1/avatar/character-components") else {
             log.warning("Invalid URL for character-components endpoint")


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-client-cutover.md.

**Gap:** Stale comment claims hardcoded fallbacks still exist
**What was expected:** Comments accurately reflect that avatar data comes from AvatarComponentStore
**What was found:** Comments in AvatarAppearanceManager.swift and AvatarComponentService.swift still referenced hardcoded enums as a fallback, even though the hardcoded SVG data was removed in the avatar client cutover.

**Changes:**
- Updated comment in `start()` method (AvatarAppearanceManager.swift) to say avatar rendering requires the component store to be populated with safe defaults during the pre-fetch window
- Updated doc comment on `fetchComponentsFromDaemon()` to reference safe defaults instead of hardcoded enums
- Updated doc comment on `AvatarComponentService.fetch()` to reference safe defaults instead of hardcoded enums

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
