### PR TITLE
fix: add @MainActor to avatar enum properties accessing component store

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarBodyShapes.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarBodyShapes.swift
@@ -5,19 +5,19 @@ enum AvatarBodyShape: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var viewBox: CGSize {
+    @MainActor var viewBox: CGSize {
         guard let def = AvatarComponentStore.shared.bodyShape(id: rawValue) else { return .zero }
         return CGSize(width: def.viewBox.width, height: def.viewBox.height)
     }
 
     /// Point within the viewBox where eyes should be centered — derived from each body's
     /// native eye style placement. Ninja has no native eye style so uses a manual estimate.
-    var faceCenter: CGPoint {
+    @MainActor var faceCenter: CGPoint {
         guard let def = AvatarComponentStore.shared.bodyShape(id: rawValue) else { return .zero }
         return CGPoint(x: def.faceCenter.x, y: def.faceCenter.y)
     }
 
-    var svgPath: String {
+    @MainActor var svgPath: String {
         AvatarComponentStore.shared.bodyShape(id: rawValue)?.svgPath ?? ""
     }
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarEyeStyles.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarEyeStyles.swift
@@ -10,19 +10,19 @@ enum AvatarEyeStyle: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var sourceViewBox: CGSize {
+    @MainActor var sourceViewBox: CGSize {
         guard let def = AvatarComponentStore.shared.eyeStyle(id: rawValue) else { return .zero }
         return CGSize(width: def.sourceViewBox.width, height: def.sourceViewBox.height)
     }
 
     /// Approximate center of the combined eye paths' bounding box within sourceViewBox coordinates.
     /// Used by AvatarCompositor to align eyes to each body shape's face center.
-    var eyeCenter: CGPoint {
+    @MainActor var eyeCenter: CGPoint {
         guard let def = AvatarComponentStore.shared.eyeStyle(id: rawValue) else { return .zero }
         return CGPoint(x: def.eyeCenter.x, y: def.eyeCenter.y)
     }
 
-    var paths: [AvatarEyePath] {
+    @MainActor var paths: [AvatarEyePath] {
         guard let def = AvatarComponentStore.shared.eyeStyle(id: rawValue) else { return [] }
         return def.paths.map { path in
             AvatarEyePath(

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
@@ -39,7 +39,7 @@ enum AvatarTransforms {
     /// Resolves the face center for a body/eye combination, checking the
     /// component store for per-combo overrides before falling back to the
     /// body's default.
-    static func resolveFaceCenter(
+    @MainActor static func resolveFaceCenter(
         bodyShape: AvatarBodyShape,
         eyeStyle: AvatarEyeStyle
     ) -> CGPoint {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-client-cutover.md.

**Gap:** Missing @MainActor annotations on enum computed properties
**What was expected:** All properties accessing @MainActor-isolated AvatarComponentStore.shared should have @MainActor annotation
**What was found:** AvatarColors.nsColor had it, but AvatarBodyShapes, AvatarEyeStyles, and AvatarTransforms did not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
