### PR TITLE
fix: strip removed metadata keys in migration script

### DIFF
--- a/scripts/skills/migrate-bundled-frontmatter.mjs
+++ b/scripts/skills/migrate-bundled-frontmatter.mjs
@@ -211,17 +211,9 @@ function migrateSkill(dirName, skillDir) {
     changes.push(`includes moved to metadata.vellum`);
   }
 
-  // credential-setup-for: only if present
-  const credSetupFor =
-    fields["credential-setup-for"] ||
-    existingMetadata?.vellum?.["credential-setup-for"];
-  if (credSetupFor) {
-    vellum["credential-setup-for"] = credSetupFor;
-    changes.push(`credential-setup-for moved to metadata.vellum`);
-  }
-
   // Preserve other existing metadata.vellum fields (feature-flag, etc.)
-  // Dead keys (cli, requires, os, primaryEnv, install) have been removed.
+  // Dead keys (cli, requires, os, primaryEnv, install, credential-setup-for,
+  // disable-model-invocation) have been removed.
   if (existingMetadata?.vellum) {
     const HANDLED_KEYS = new Set([
       "emoji",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-skill-metadata-keys.md.

**Gap:** Migration script still propagates credential-setup-for
**What was expected:** Removed metadata keys should be stripped during migration
**What was found:** credential-setup-for write block still active in migrate-bundled-frontmatter.mjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
