### PR TITLE
fix: remove stale setPreactivatedSkillIds cleanup in server.ts

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1049,17 +1049,11 @@ export class DaemonServer {
     const resolvedContent = slashResult.content;
 
     const requestId = crypto.randomUUID();
-    let messageId: string;
-    try {
-      messageId = await session.persistUserMessage(
-        resolvedContent,
-        attachments,
-        requestId,
-      );
-    } catch (err) {
-      session.setPreactivatedSkillIds(undefined);
-      throw err;
-    }
+    const messageId = await session.persistUserMessage(
+      resolvedContent,
+      attachments,
+      requestId,
+    );
 
     // Register pending interactions so channel approval interception can
     // find the session by requestId when confirmation/secret events fire.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-skill-metadata-keys.md.

**Gap:** Stale setPreactivatedSkillIds(undefined) in server.ts catch block
**What was expected:** The catch block cleanup should have been removed when slash command rewrite logic was deleted
**What was found:** session.setPreactivatedSkillIds(undefined) still exists but the corresponding setter was removed

Removed the stale `session.setPreactivatedSkillIds(undefined)` call and the now-pointless try/catch wrapper around `persistUserMessage`, since the catch block only existed to run that cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
