### PR TITLE
fix: validate credential_process helperCommand against denied binary list

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -700,6 +700,89 @@ describe("validateCommand", () => {
 });
 
 // ---------------------------------------------------------------------------
+// credential_process helperCommand denied binary validation
+// ---------------------------------------------------------------------------
+
+describe("credential_process helperCommand denied binary validation", () => {
+  test("rejects helperCommand starting with curl", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "curl http://example.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"curl"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with absolute path to denied binary (python3)", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "/usr/bin/python3 script.py",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"python3"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand starting with bash", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "bash -c 'echo test'",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"bash"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("accepts helperCommand with allowed binary (aws-vault)", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default --json",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Comprehensive denied binary coverage
 // ---------------------------------------------------------------------------
 

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -23,6 +23,7 @@
 
 import {
   validateAuthAdapterConfig,
+  AuthAdapterType,
 } from "./auth-adapters.js";
 import {
   type SecureCommandManifest,
@@ -116,6 +117,21 @@ export function validateManifest(
     const adapterErrors = validateAuthAdapterConfig(manifest.authAdapter);
     for (const e of adapterErrors) {
       errors.push(`authAdapter: ${e}`);
+    }
+
+    // -- credential_process helperCommand denied binary check
+    if (manifest.authAdapter.type === AuthAdapterType.CredentialProcess) {
+      const helper = manifest.authAdapter.helperCommand;
+      if (helper && helper.trim().length > 0) {
+        const firstWord = helper.trim().split(/\s+/)[0]!;
+        const basename = pathBasename(firstWord);
+        if (isDeniedBinary(firstWord)) {
+          errors.push(
+            `authAdapter: credential_process helperCommand starts with denied binary "${basename}". ` +
+              `Generic HTTP clients, interpreters, and shell trampolines cannot be used as credential helpers.`,
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Parse first word of credential_process helperCommand and validate against denied binary list
- Catches `curl`, `python3`, `bash`, etc. as helper commands while allowing purpose-built binaries like `aws-vault`
- Add test coverage for denied and allowed helper commands
- Makes the code match the ADR's claim that denied binaries cover helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
