### PR TITLE
refactor: rename daemon ThreadType and thread-created message types to conversation

### DIFF
--- a/assistant/src/__tests__/media-visibility-policy.test.ts
+++ b/assistant/src/__tests__/media-visibility-policy.test.ts
@@ -26,8 +26,8 @@ describe("isAttachmentVisible", () => {
     isPrivate: true,
   };
 
-  describe("standard thread attachments", () => {
-    test("visible from a standard thread", () => {
+  describe("standard conversation attachments", () => {
+    test("visible from a standard conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: "conv-other",
         isPrivate: false,
@@ -35,7 +35,7 @@ describe("isAttachmentVisible", () => {
       expect(isAttachmentVisible(standardAttachment, ctx)).toBe(true);
     });
 
-    test("visible from a different standard thread", () => {
+    test("visible from a different standard conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: "conv-standard-002",
         isPrivate: false,
@@ -43,7 +43,7 @@ describe("isAttachmentVisible", () => {
       expect(isAttachmentVisible(standardAttachment, ctx)).toBe(true);
     });
 
-    test("visible from a private thread", () => {
+    test("visible from a private conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: "conv-private-xyz",
         isPrivate: true,
@@ -64,8 +64,8 @@ describe("isAttachmentVisible", () => {
     });
   });
 
-  describe("private thread attachments", () => {
-    test("visible from the same private thread", () => {
+  describe("private conversation attachments", () => {
+    test("visible from the same private conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: privateAttachmentA.conversationId,
         isPrivate: true,
@@ -73,7 +73,7 @@ describe("isAttachmentVisible", () => {
       expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(true);
     });
 
-    test("NOT visible from a different private thread", () => {
+    test("NOT visible from a different private conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: privateAttachmentB.conversationId,
         isPrivate: true,
@@ -81,7 +81,7 @@ describe("isAttachmentVisible", () => {
       expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
     });
 
-    test("NOT visible from a standard thread", () => {
+    test("NOT visible from a standard conversation", () => {
       const ctx: AttachmentContext = {
         conversationId: "conv-standard-001",
         isPrivate: false,
@@ -97,7 +97,7 @@ describe("isAttachmentVisible", () => {
       expect(isAttachmentVisible(privateAttachmentA, ctx)).toBe(false);
     });
 
-    test("NOT visible from standard thread even with same conversationId", () => {
+    test("NOT visible from standard conversation even with same conversationId", () => {
       // Edge case: same conversationId but the context is not marked as private
       const ctx: AttachmentContext = {
         conversationId: privateAttachmentA.conversationId,
@@ -151,7 +151,7 @@ describe("filterVisibleAttachments", () => {
     expect(result).toEqual([standardAtt]);
   });
 
-  test("includes matching private attachment when in same private thread", () => {
+  test("includes matching private attachment when in same private conversation", () => {
     const ctx: AttachmentContext = {
       conversationId: "conv-priv-a",
       isPrivate: true,

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -154,7 +154,7 @@ describe("notification deep-link metadata", () => {
           copy: { title: "Alert", body: "Something happened" },
           deepLinkTarget: {
             conversationId: "conv-123",
-            threadType: "notification",
+            conversationType: "notification",
           },
         },
         { channel: "vellum" },
@@ -167,7 +167,7 @@ describe("notification deep-link metadata", () => {
       expect(msg.body).toBe("Something happened");
       expect(msg.deepLinkMetadata).toEqual({
         conversationId: "conv-123",
-        threadType: "notification",
+        conversationType: "notification",
       });
     });
 
@@ -303,19 +303,19 @@ describe("notification deep-link metadata", () => {
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulates the broadcaster merging pairing.conversationId into deep-link
-      // for a newly created notification thread (start_new path)
+      // for a newly created notification conversation (start_new path)
       await adapter.send(
         {
           sourceEventName: "schedule.notify",
           copy: { title: "Reminder", body: "Take out the trash" },
-          deepLinkTarget: { conversationId: "conv-new-thread-001" },
+          deepLinkTarget: { conversationId: "conv-new-convo-001" },
         },
         { channel: "vellum" },
       );
 
       const msg = messages[0] as unknown as Record<string, unknown>;
       const metadata = msg.deepLinkMetadata as Record<string, unknown>;
-      expect(metadata.conversationId).toBe("conv-new-thread-001");
+      expect(metadata.conversationId).toBe("conv-new-convo-001");
     });
 
     test("deep-link payload includes conversationId for a reused conversation", async () => {
@@ -323,7 +323,7 @@ describe("notification deep-link metadata", () => {
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulates the broadcaster merging pairing.conversationId into deep-link
-      // for a reused notification thread (reuse_existing path)
+      // for a reused notification conversation (reuse_existing path)
       await adapter.send(
         {
           sourceEventName: "schedule.notify",
@@ -331,19 +331,19 @@ describe("notification deep-link metadata", () => {
             title: "Follow-up",
             body: "Still need to take out the trash",
           },
-          deepLinkTarget: { conversationId: "conv-reused-thread-042" },
+          deepLinkTarget: { conversationId: "conv-reused-convo-042" },
         },
         { channel: "vellum" },
       );
 
       const msg = messages[0] as unknown as Record<string, unknown>;
       const metadata = msg.deepLinkMetadata as Record<string, unknown>;
-      expect(metadata.conversationId).toBe("conv-reused-thread-042");
+      expect(metadata.conversationId).toBe("conv-reused-convo-042");
     });
 
-    // ── Reused thread deep-link stability regressions ─────────────────
+    // ── Reused conversation deep-link stability regressions ─────────────────
 
-    test("reused thread preserves the same conversationId across follow-up notifications", async () => {
+    test("reused conversation preserves the same conversationId across follow-up notifications", async () => {
       const messages: ServerMessage[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
@@ -391,7 +391,7 @@ describe("notification deep-link metadata", () => {
       expect(meta2.messageId).toBe("msg-seed-2");
     });
 
-    test("reused thread deep-link messageId changes per delivery for scroll targeting", async () => {
+    test("reused conversation deep-link messageId changes per delivery for scroll targeting", async () => {
       const messages: ServerMessage[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -33,7 +33,7 @@ import type {
   ConfirmationResponse,
   DeleteQueuedMessage,
   RegenerateRequest,
-  ReorderThreadsRequest,
+  ReorderConversationsRequest,
   SecretResponse,
   ServerMessage,
   SessionCreateRequest,
@@ -42,7 +42,7 @@ import type {
   UndoRequest,
   UsageRequest,
 } from "../message-protocol.js";
-import { normalizeThreadType } from "../message-protocol.js";
+import { normalizeConversationType } from "../message-protocol.js";
 import type { Session } from "../session.js";
 import {
   buildSessionErrorMessage,
@@ -233,7 +233,7 @@ export async function handleSessionCreate(
   msg: SessionCreateRequest,
   ctx: HandlerContext,
 ): Promise<void> {
-  const conversationType = normalizeThreadType(msg.threadType);
+  const conversationType = normalizeConversationType(msg.conversationType);
   const title =
     msg.title ?? (msg.initialMessage ? GENERATING_TITLE : "New Conversation");
   const conversation = createConversation({
@@ -257,7 +257,7 @@ export async function handleSessionCreate(
     sessionId: conversation.id,
     title: conversation.title ?? "New Conversation",
     ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
-    threadType: normalizeThreadType(conversation.conversationType),
+    conversationType: normalizeConversationType(conversation.conversationType),
   });
 
   // Auto-send the initial message if provided, kick-starting the skill.
@@ -363,7 +363,7 @@ export async function switchSession(
 ): Promise<{
   sessionId: string;
   title: string;
-  conversationType: ReturnType<typeof normalizeThreadType>;
+  conversationType: ReturnType<typeof normalizeConversationType>;
 } | null> {
   const conversation = getConversation(sessionId);
   if (!conversation) {
@@ -385,7 +385,7 @@ export async function switchSession(
   return {
     sessionId: conversation.id,
     title: conversation.title ?? "Untitled",
-    conversationType: normalizeThreadType(conversation.conversationType),
+    conversationType: normalizeConversationType(conversation.conversationType),
   };
 }
 
@@ -406,7 +406,7 @@ export async function handleSessionSwitch(
     type: "session_info",
     sessionId: result.sessionId,
     title: result.title,
-    threadType: result.conversationType,
+    conversationType: result.conversationType,
   });
 }
 
@@ -641,8 +641,8 @@ export function handleDeleteQueuedMessage(
   }
 }
 
-export function handleReorderThreads(
-  msg: ReorderThreadsRequest,
+export function handleReorderConversations(
+  msg: ReorderConversationsRequest,
   _ctx: HandlerContext,
 ): void {
   if (!Array.isArray(msg.updates)) {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -128,7 +128,7 @@ export interface SessionCreateOptions {
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
   memoryScopeId?: string;
-  isPrivateThread?: boolean;
+  isPrivateConversation?: boolean;
   strictPrivateSideEffects?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -503,7 +503,7 @@ export async function runDaemon(): Promise<void> {
       },
       (info) => {
         server.broadcast({
-          type: "schedule_thread_created",
+          type: "schedule_conversation_created",
           conversationId: info.conversationId,
           scheduleJobId: info.scheduleJobId,
           title: info.title,

--- a/assistant/src/daemon/media-visibility-policy.ts
+++ b/assistant/src/daemon/media-visibility-policy.ts
@@ -1,9 +1,9 @@
 /**
- * Centralized policy for attachment visibility across thread types.
+ * Centralized policy for attachment visibility across conversation types.
  *
- * Private-thread attachments are scoped: they are only visible when the
- * current context is the *same* private thread. Standard (non-private)
- * thread attachments are visible everywhere.
+ * Private-conversation attachments are scoped: they are only visible when the
+ * current context is the *same* private conversation. Standard (non-private)
+ * conversation attachments are visible everywhere.
  *
  * This is a pure policy module -- no IO, no database queries, just logic.
  * Actual enforcement in tools happens downstream (e.g., attachment-list
@@ -20,20 +20,20 @@ export interface AttachmentContext {
  * Determine whether a single attachment is visible from the given context.
  *
  * Rules:
- * 1. Attachments from standard (non-private) threads are always visible.
- * 2. Attachments from private threads are only visible when the current
- *    context matches the same private thread (same conversationId).
+ * 1. Attachments from standard (non-private) conversations are always visible.
+ * 2. Attachments from private conversations are only visible when the current
+ *    context matches the same private conversation (same conversationId).
  */
 export function isAttachmentVisible(
   attachment: AttachmentContext,
   currentContext: AttachmentContext,
 ): boolean {
-  // Standard thread attachments are universally visible
+  // Standard conversation attachments are universally visible
   if (!attachment.isPrivate) {
     return true;
   }
 
-  // Private thread attachments require the viewer to be in the same private thread
+  // Private conversation attachments require the viewer to be in the same private conversation
   return (
     currentContext.isPrivate === true &&
     currentContext.conversationId === attachment.conversationId
@@ -44,7 +44,7 @@ export function isAttachmentVisible(
  * Filter a list of attachments to only those visible from the current context.
  *
  * @param attachments - The full list of attachments to filter.
- * @param currentContext - The thread context from which visibility is evaluated.
+ * @param currentContext - The conversation context from which visibility is evaluated.
  * @param getContext - Extracts the conversation context from each attachment
  *   record (since the caller's attachment type may differ from AttachmentContext).
  */

--- a/assistant/src/daemon/message-types/notifications.ts
+++ b/assistant/src/daemon/message-types/notifications.ts
@@ -16,14 +16,14 @@ export interface NotificationIntent {
   targetGuardianPrincipalId?: string;
 }
 
-/** Server push — broadcast when a notification creates a new vellum conversation thread. */
-export interface NotificationThreadCreated {
-  type: "notification_thread_created";
+/** Server push — broadcast when a notification creates a new vellum conversation. */
+export interface NotificationConversationCreated {
+  type: "notification_conversation_created";
   conversationId: string;
   title: string;
   sourceEventName: string;
   /**
-   * When set, this thread was created for a guardian-sensitive notification
+   * When set, this conversation was created for a guardian-sensitive notification
    * and should only be surfaced by clients bound to this guardian identity.
    */
   targetGuardianPrincipalId?: string;
@@ -73,4 +73,4 @@ export type _NotificationsClientMessages =
 
 export type _NotificationsServerMessages =
   | NotificationIntent
-  | NotificationThreadCreated;
+  | NotificationConversationCreated;

--- a/assistant/src/daemon/message-types/sessions.ts
+++ b/assistant/src/daemon/message-types/sessions.ts
@@ -1,7 +1,7 @@
 // Session lifecycle, auth, model config, and history types.
 
 import type { ChannelId, InterfaceId } from "../../channels/types.js";
-import type { ThreadType } from "./shared.js";
+import type { ConversationType } from "./shared.js";
 import type { UserMessageAttachment } from "./shared.js";
 
 // === Client → Server ===
@@ -35,7 +35,7 @@ export interface SessionCreateRequest {
   maxResponseTokens?: number;
   correlationId?: string;
   transport?: SessionTransportMetadata;
-  threadType?: ThreadType;
+  conversationType?: ConversationType;
   /** Skill IDs to pre-activate in the new session (loaded before the first message). */
   preactivatedSkillIds?: string[];
   /** If provided, automatically sent as the first user message after session creation. */
@@ -118,8 +118,8 @@ export interface SessionsClearRequest {
   type: "sessions_clear";
 }
 
-export interface ReorderThreadsRequest {
-  type: "reorder_threads";
+export interface ReorderConversationsRequest {
+  type: "reorder_conversations";
   updates: Array<{
     sessionId: string;
     displayOrder: number | null;
@@ -155,7 +155,7 @@ export interface SessionInfo {
   sessionId: string;
   title: string;
   correlationId?: string;
-  threadType?: ThreadType;
+  conversationType?: ConversationType;
 }
 
 export interface SessionTitleUpdated {
@@ -189,7 +189,7 @@ export interface SessionListResponse {
     title: string;
     createdAt?: number;
     updatedAt: number;
-    threadType?: ThreadType;
+    conversationType?: ConversationType;
     source?: string;
     scheduleJobId?: string;
     channelBinding?: ChannelBinding;
@@ -376,9 +376,9 @@ export interface SessionErrorMessage {
   errorCategory?: string;
 }
 
-/** Server push — broadcast when a schedule creates a conversation, so the client can show it as a chat thread. */
-export interface ScheduleThreadCreated {
-  type: "schedule_thread_created";
+/** Server push — broadcast when a schedule creates a conversation. */
+export interface ScheduleConversationCreated {
+  type: "schedule_conversation_created";
   conversationId: string;
   scheduleJobId: string;
   title: string;
@@ -402,7 +402,7 @@ export type _SessionsClientMessages =
   | SessionSwitchRequest
   | SessionRenameRequest
   | SessionsClearRequest
-  | ReorderThreadsRequest;
+  | ReorderConversationsRequest;
 
 export type _SessionsServerMessages =
   | AuthResult
@@ -423,4 +423,4 @@ export type _SessionsServerMessages =
   | SessionsClearResponse
   | ConversationSearchResponse
   | MessageContentResponse
-  | ScheduleThreadCreated;
+  | ScheduleConversationCreated;

--- a/assistant/src/daemon/message-types/shared.ts
+++ b/assistant/src/daemon/message-types/shared.ts
@@ -1,11 +1,11 @@
 // Shared types used across multiple message domains.
 
-export type ThreadType = "standard" | "private";
+export type ConversationType = "standard" | "private";
 
 /** Runtime normalizer — collapses unknown/legacy DB values to 'standard'. */
-export function normalizeThreadType(
+export function normalizeConversationType(
   raw: string | null | undefined,
-): ThreadType {
+): ConversationType {
   return raw === "private" ? "private" : "standard";
 }
 

--- a/assistant/src/daemon/message-types/work-items.ts
+++ b/assistant/src/daemon/message-types/work-items.ts
@@ -206,9 +206,9 @@ export interface WorkItemStatusChanged {
   };
 }
 
-/** Server push — broadcast when a task run creates a conversation, so the client can show it as a chat thread. */
-export interface TaskRunThreadCreated {
-  type: "task_run_thread_created";
+/** Server push — broadcast when a task run creates a conversation. */
+export interface TaskRunConversationCreated {
+  type: "task_run_conversation_created";
   conversationId: string;
   workItemId: string;
   title: string;
@@ -239,5 +239,5 @@ export type _WorkItemsServerMessages =
   | WorkItemApprovePermissionsResponse
   | WorkItemCancelResponse
   | WorkItemStatusChanged
-  | TaskRunThreadCreated
+  | TaskRunConversationCreated
   | TasksChanged;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -428,7 +428,7 @@ export async function runAgentLoopImpl(
         ctx.messages.pop();
         deleteMessageById(userMessageId);
       }
-      // Replace loading placeholder so the thread isn't stuck as "Generating title..."
+      // Replace loading placeholder so the conversation isn't stuck as "Generating title..."
       const currentConv = getConversation(ctx.conversationId);
       if (
         isReplaceableTitle(currentConv?.title ?? null) &&
@@ -1285,7 +1285,7 @@ export async function runAgentLoopImpl(
             const denyText =
               "The conversation has grown too long for the model to process, " +
               "and compression was declined. Please start a new conversation " +
-              "or manually shorten the thread to continue.";
+              "or manually shorten the conversation to continue.";
             const loopChannelMeta = {
               ...provenanceFromTrustContext(ctx.trustContext),
               userMessageChannel: capturedTurnChannelContext.userMessageChannel,

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -174,7 +174,7 @@ function classifyCore(
       return {
         code: "CONTEXT_TOO_LARGE",
         userMessage:
-          "This conversation is too long. Please start a new thread.",
+          "This conversation is too long. Please start a new conversation.",
         retryable: false,
         errorCategory: "context_too_large",
       };
@@ -209,7 +209,7 @@ function classifyCore(
         return {
           code: "CONTEXT_TOO_LARGE",
           userMessage:
-            "This conversation is too long. Please start a new thread.",
+            "This conversation is too long. Please start a new conversation.",
           retryable: false,
           errorCategory: "context_too_large",
         };
@@ -286,7 +286,8 @@ function classifyByMessage(
   if (isContextTooLarge(message)) {
     return {
       code: "CONTEXT_TOO_LARGE",
-      userMessage: "This conversation is too long. Please start a new thread.",
+      userMessage:
+        "This conversation is too long. Please start a new conversation.",
       retryable: false,
       errorCategory: "context_too_large",
     };

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -74,7 +74,7 @@ function getBroadcaster(): NotificationBroadcaster {
       const broadcastFn = registeredBroadcastFn;
       broadcasterInstance.setOnConversationCreated((info) => {
         broadcastFn({
-          type: "notification_thread_created",
+          type: "notification_conversation_created",
           conversationId: info.conversationId,
           title: info.title,
           sourceEventName: info.sourceEventName,

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -710,7 +710,7 @@ export function workItemRouteDefinitions(
                   session = await getOrCreateSession(conversationId);
 
                   publishEvent({
-                    type: "task_run_thread_created",
+                    type: "task_run_conversation_created",
                     conversationId,
                     workItemId,
                     title: workItem.title,

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -155,7 +155,7 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
             session = await getOrCreateSession(conversationId);
 
             broadcast({
-              type: "task_run_thread_created",
+              type: "task_run_conversation_created",
               conversationId,
               workItemId,
               title: workItem.title,


### PR DESCRIPTION
## Summary
- Rename ThreadType → ConversationType and normalizeThreadType → normalizeConversationType
- Rename all *ThreadCreated wire message types to *ConversationCreated
- Rename ReorderThreadsRequest → ReorderConversationsRequest
- Update user-facing strings from 'thread' to 'conversation'

Part of plan: thread-to-conversation-rename.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
