### PR TITLE
fix: remove non-functional local_static support from managed CES sidecar

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -60,11 +60,13 @@ The existing `host_bash` tool executes commands on the host machine without any 
 
 **Implication**: `host_bash` represents a weaker security tier. Agents that require the strong secrecy guarantee must use `run_authenticated_command` instead. Trust rules and permission policies should reflect this distinction — managed deployments may deny `host_bash` entirely for untrusted agents while allowing `run_authenticated_command`.
 
-### 2. Managed static secrets remain on the assistant data volume for v1
+### 2. Local static secrets are local-mode only for v1
 
-For the initial implementation, managed static secrets (API keys, tokens stored via the credential store) remain on the assistant's data volume (`~/.vellum/protected/`). CES reads them at materialization time via a read-only volume mount (managed) or direct filesystem access (local).
+For the initial implementation, local static secrets (API keys, tokens stored via the credential store in `~/.vellum/protected/`) are only accessible to CES in **local mode**, where CES runs as a child process of the assistant as the same OS user. CES reads them at materialization time via direct filesystem access.
 
-This is a pragmatic v1 decision. Future iterations may move secret storage to a dedicated secret manager (e.g., cloud KMS, Vault) with CES as the only authorized reader.
+In **managed mode**, `local_static` handles are not supported. The encrypted key store uses PBKDF2 key derivation from user identity (username, homedir), and the assistant and CES containers run as different users, producing different derived keys. Managed deployments must use `platform_oauth` handles exclusively.
+
+Future iterations may move secret storage to a dedicated secret manager (e.g., cloud KMS, Vault) with CES as the only authorized reader, which would enable static secrets in managed mode.
 
 ### 3. Platform OAuth materialization stays on the platform
 
@@ -367,6 +369,7 @@ This means the helper is subject to the same cooperative egress limitation as th
 
 The following capabilities are intentionally deferred beyond v1:
 
+- **`local_static` handles in managed mode** — The encrypted key store (`keys.enc`) uses PBKDF2 key derivation from machine-specific entropy that includes `userInfo().username` and `userInfo().homedir`. In managed deployments, the assistant container runs as `root` while the CES sidecar runs as `ces` (uid 1001). This produces different derived AES keys, making `local_static` decryption silently fail across container boundaries. Managed mode returns a clear error for any `local_static` handle and requires `platform_oauth` handles exclusively. The `local-secure-key-backend.ts` module is restricted to local mode where CES runs as the same OS user as the assistant.
 - **Cloud KMS/Vault integration for secret storage** — v1 reads secrets from filesystem (`~/.vellum/protected/` locally, `/ces-data` in managed). Moving to a dedicated secrets manager is a future enhancement.
 - **Multi-CES-instance support** — Each assistant pod runs exactly one CES sidecar. Horizontal scaling of CES within a pod is not supported.
 - **Cross-pod credential sharing** — CES grants are scoped to a single pod. There is no grant federation across pods or assistant instances.

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -17,13 +17,12 @@
  * All RPC traffic flows exclusively over the accepted Unix socket stream.
  */
 
-import { mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { mkdirSync, unlinkSync } from "node:fs";
 import { createServer as createNetServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { Readable, Writable } from "node:stream";
 
 import { CES_PROTOCOL_VERSION, CesRpcMethod } from "@vellumai/ces-contracts";
-import { StaticCredentialMetadataStore } from "@vellumai/credential-storage";
 
 import { AuditStore } from "./audit/store.js";
 import { PersistentGrantStore } from "./grants/persistent-store.js";
@@ -34,8 +33,6 @@ import {
   createRevokeGrantHandler,
 } from "./grants/rpc-handlers.js";
 import { TemporaryGrantStore } from "./grants/temporary-store.js";
-import { LocalMaterialiser } from "./materializers/local.js";
-import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
 import {
   getBootstrapSocketPath,
   getCesAuditDir,
@@ -55,8 +52,6 @@ import {
 import { publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
 import { buildCesEgressHooks } from "./commands/egress-hooks.js";
-import { resolveLocalSubject } from "./subjects/local.js";
-import { checkCredentialPolicy } from "./subjects/policy.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "./subjects/managed.js";
 import { materializeManagedToken, type ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 import { HandleType, parseHandle } from "@vellumai/ces-contracts";
@@ -129,58 +124,42 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
     );
   }
 
-  // -- Local credential backend via read-only assistant data mount -----------
-  // In managed mode, the platform mounts the assistant data volume read-only
-  // into the CES sidecar at CES_ASSISTANT_DATA_MOUNT (default /assistant-data-ro).
-  // This allows CES to read local static secrets from the assistant's encrypted
-  // key store on the shared volume, supporting v1 local_static handles.
+  // -- Workspace root for command execution cwd ------------------------------
   const assistantDataMount =
     process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
   const mountedVellumRoot = join(assistantDataMount, ".vellum");
 
-  // The assistant writes its machine entropy to `protected/entropy.key` so
-  // the CES sidecar can derive the same AES decryption key. Without this,
-  // key derivation would use the sidecar's own hostname/user/homedir which
-  // differ from the assistant container's values.
-  let assistantEntropy: string | undefined;
-  const entropyPath = join(mountedVellumRoot, "protected", "entropy.key");
-  try {
-    assistantEntropy = readFileSync(entropyPath, "utf-8");
-    log(`Read assistant entropy from ${entropyPath}`);
-  } catch {
-    warn(
-      `Could not read assistant entropy from ${entropyPath}. ` +
-        "local_static credential decryption may fail if machine entropy differs.",
-    );
-  }
-
-  const secureKeyBackend = createLocalSecureKeyBackend(mountedVellumRoot, {
-    entropyOverride: assistantEntropy,
-  });
-  const localMaterialiser = new LocalMaterialiser({ secureKeyBackend });
-
-  const credentialMetadataPath = join(
-    mountedVellumRoot,
-    "workspace",
-    "data",
-    "credentials",
-    "metadata.json",
-  );
-  const metadataStore = new StaticCredentialMetadataStore(credentialMetadataPath);
-
   // -- Build handler registry ------------------------------------------------
+  // NOTE: local_static credential handles are NOT supported in managed mode.
+  // The encrypted key store uses PBKDF2 key derivation from user identity
+  // (username, homedir), but the assistant container runs as root while CES
+  // runs as ces — different derived keys make decryption silently fail.
+  // Managed deployments must use platform_oauth handles exclusively.
+  //
+  // We provide error-returning stubs for localMaterialiser/localSubjectDeps
+  // so the HTTP handler compiles but any local_static request gets a clear
+  // error message rather than a silent decryption failure.
+
+  const localMaterialiserStub = {
+    materialise: async () => ({
+      ok: false as const,
+      error:
+        "local_static credential handles are not supported in managed mode. " +
+        "Use platform_oauth handles for managed deployments.",
+    }),
+  };
+
+  const localSubjectDepsStub = {
+    metadataStore: { getById: () => undefined, list: () => [] } as any,
+    oauthConnections: { getById: () => undefined },
+  };
 
   const handlers = buildHandlersWithHttp(
     {
       persistentGrantStore,
       temporaryGrantStore,
-      localMaterialiser,
-      localSubjectDeps: {
-        metadataStore,
-        // OAuth connections are not available via the read-only mount — only
-        // local_static handles are supported. Return undefined for any lookup.
-        oauthConnections: { getById: () => undefined },
-      },
+      localMaterialiser: localMaterialiserStub as any,
+      localSubjectDeps: localSubjectDepsStub,
       managedSubjectOptions,
       managedMaterializerOptions,
       auditStore,
@@ -201,37 +180,13 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
         }
 
         switch (parseResult.handle.type) {
-          // -- Local static: read from the mounted assistant data volume ------
+          // -- Local static: NOT supported in managed mode -------------------
           case HandleType.LocalStatic: {
-            const subjectResult = resolveLocalSubject(handle, {
-              metadataStore,
-              oauthConnections: { getById: () => undefined },
-            });
-            if (!subjectResult.ok) {
-              return { ok: false as const, error: subjectResult.error };
-            }
-
-            // Enforce credential-level policies for local static handles
-            if (subjectResult.subject.type === HandleType.LocalStatic) {
-              const policyCheck = checkCredentialPolicy(
-                subjectResult.subject.metadata,
-                "run_authenticated_command",
-              );
-              if (!policyCheck.ok) {
-                return { ok: false as const, error: policyCheck.error! };
-              }
-            }
-
-            const matResult = await localMaterialiser.materialise(
-              subjectResult.subject,
-            );
-            if (!matResult.ok) {
-              return { ok: false as const, error: matResult.error };
-            }
             return {
-              ok: true as const,
-              value: matResult.credential.value,
-              handleType: HandleType.LocalStatic,
+              ok: false as const,
+              error:
+                "local_static credential handles are not supported in managed mode. " +
+                "Use platform_oauth handles for managed deployments.",
             };
           }
 
@@ -273,7 +228,7 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
             return {
               ok: false as const,
               error: `Handle type "${parseResult.handle.type}" is not supported in managed mode. ` +
-                `Supported types: local_static, platform_oauth.`,
+                `Supported types: platform_oauth.`,
             };
         }
       },

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -1,9 +1,9 @@
 /**
- * CES-native read-only SecureKeyBackend for local mode.
+ * CES-native read-only SecureKeyBackend for **local mode only**.
  *
  * In local mode, CES runs as a child process of the assistant on the same
- * machine and can read the assistant's encrypted key store file at
- * `<vellumRoot>/protected/keys.enc`.
+ * machine as the same user and can read the assistant's encrypted key store
+ * file at `<vellumRoot>/protected/keys.enc`.
  *
  * This implementation replicates the decryption logic from the assistant's
  * `encrypted-store.ts` without importing assistant-internal modules. It is
@@ -12,10 +12,15 @@
  * enforce this invariant.
  *
  * The encrypted store uses AES-256-GCM with a key derived from machine-
- * specific entropy via PBKDF2. In local mode, CES runs on the same machine
- * as the same user so the derived key is identical. In managed mode, CES
- * runs in a separate container with different hostname/user/homedir, so
- * the caller must supply the assistant's entropy via `entropyOverride`.
+ * specific entropy via PBKDF2. The derivation includes `userInfo().username`
+ * and `userInfo().homedir`, so the key is only correct when CES runs as the
+ * same OS user as the assistant.
+ *
+ * **This backend must NOT be used in managed mode.** In managed (sidecar)
+ * deployments, the assistant container runs as `root` while the CES
+ * container runs as `ces` (uid 1001). The different user identity produces
+ * a different PBKDF2-derived key, causing silent decryption failures.
+ * Managed deployments must use `platform_oauth` handles exclusively.
  */
 
 import {


### PR DESCRIPTION
## Summary
- Remove local_static credential handle support from managed CES sidecar (managed-main.ts)
- The encrypted key store's PBKDF2 derivation uses user identity (username, homedir), but assistant runs as root and CES as ces — different derived keys make decryption silently fail
- Managed deployments should use platform_oauth handles exclusively
- Document this as a deliberate v1 boundary in the CES ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)