### PR TITLE
fix: remove unused DEFAULT_ONCE_FALLBACK_TTL_MS and stale fallback comments

### DIFF
--- a/credential-executor/src/grants/temporary-store.ts
+++ b/credential-executor/src/grants/temporary-store.ts
@@ -28,15 +28,12 @@ export interface TemporaryGrant {
   conversationId?: string;
   /** When the grant was created (epoch ms). */
   createdAt: number;
-  /** When the grant expires (epoch ms). Set for `allow_10m`; optionally set for `allow_once` (e.g. TTL-scoped fallback grants). */
+  /** When the grant expires (epoch ms). Set for `allow_10m`; optionally set for `allow_once`. */
   expiresAt?: number;
 }
 
 /** Default TTL for timed grants (10 minutes). */
 const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000;
-
-/** Default TTL for allow_once fallback grants (30 seconds). */
-export const DEFAULT_ONCE_FALLBACK_TTL_MS = 30 * 1000;
 
 // ---------------------------------------------------------------------------
 // Store implementation
@@ -133,7 +130,7 @@ export class TemporaryGrantStore {
     if (!grant) return false;
 
     if (grant.kind === "allow_once") {
-      // Check TTL if set (e.g. fallback grants for allow_thread)
+      // Check TTL if set
       if (grant.expiresAt !== undefined && Date.now() >= grant.expiresAt) {
         this.store.delete(key);
         return false;


### PR DESCRIPTION
Addresses feedback from PR #17158. Removes the orphaned DEFAULT_ONCE_FALLBACK_TTL_MS export and updates stale comments that referenced the removed cross-thread allow_once fallback pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
