### PR TITLE
fix: add tar.gz bundle extraction to CES toolstore publish

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -40,7 +40,6 @@ import { PersistentGrantStore } from "../grants/persistent-store.js";
 import { TemporaryGrantStore } from "../grants/temporary-store.js";
 import {
   publishBundle,
-  getBundleContentPath,
 } from "../toolstore/publish.js";
 import { getCesToolStoreDir, getCesDataRoot } from "../paths.js";
 import { computeDigest } from "../toolstore/integrity.js";
@@ -115,46 +114,67 @@ function buildManifest(
 /**
  * Publish a test bundle into the CES toolstore and return the digest.
  *
- * Creates a minimal shell script as the "binary" and writes it to the
- * toolstore under the computed digest.
+ * Creates a real tar.gz archive containing the entrypoint shell script
+ * at the manifest's declared entrypoint path, then publishes it through
+ * the actual publishBundle function so the extraction path is exercised.
  */
 function publishTestBundle(
   manifest: SecureCommandManifest,
   cesMode: "local" | "managed" = "local",
   scriptContent = '#!/bin/sh\necho "hello from test-cli"\n',
 ): { digest: string; manifest: SecureCommandManifest } {
-  const bundleBytes = Buffer.from(scriptContent, "utf-8");
-  const digest = computeDigest(bundleBytes);
+  // Build a tar.gz archive containing the entrypoint at the declared path
+  const archiveStagingDir = makeTempDir("ces-archive-staging");
+  try {
+    const entrypoint = manifest.entrypoint || "bin/test-cli";
+    const entrypointFullPath = join(archiveStagingDir, entrypoint);
+    mkdirSync(join(archiveStagingDir, entrypoint, ".."), { recursive: true });
+    writeFileSync(entrypointFullPath, scriptContent, { mode: 0o755 });
 
-  // Update the manifest with the computed digest
-  const fullManifest: SecureCommandManifest = {
-    ...manifest,
-    bundleDigest: digest,
-  };
+    // Create tar.gz archive
+    const archivePath = join(archiveStagingDir, "bundle.tar.gz");
+    const tarProc = Bun.spawnSync(
+      ["tar", "czf", archivePath, "-C", archiveStagingDir, entrypoint],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (tarProc.exitCode !== 0) {
+      const stderr = tarProc.stderr
+        ? new TextDecoder().decode(tarProc.stderr).trim()
+        : "unknown error";
+      throw new Error(`Failed to create test archive: ${stderr}`);
+    }
 
-  const result = publishBundle({
-    bundleBytes,
-    expectedDigest: digest,
-    bundleId: fullManifest.bundleId,
-    version: fullManifest.version,
-    sourceUrl: "https://releases.example.com/test-cli-1.0.0.tar.gz",
-    secureCommandManifest: fullManifest,
-    cesMode,
-  });
+    const bundleBytes = Buffer.from(readFileSync(archivePath));
+    const digest = computeDigest(bundleBytes);
 
-  if (!result.success) {
-    throw new Error(`Failed to publish test bundle: ${result.error}`);
+    // Update the manifest with the computed digest
+    const fullManifest: SecureCommandManifest = {
+      ...manifest,
+      bundleDigest: digest,
+    };
+
+    const result = publishBundle({
+      bundleBytes,
+      expectedDigest: digest,
+      bundleId: fullManifest.bundleId,
+      version: fullManifest.version,
+      sourceUrl: "https://releases.example.com/test-cli-1.0.0.tar.gz",
+      secureCommandManifest: fullManifest,
+      cesMode,
+    });
+
+    if (!result.success) {
+      throw new Error(`Failed to publish test bundle: ${result.error}`);
+    }
+
+    return { digest, manifest: fullManifest };
+  } finally {
+    try {
+      rmSync(archiveStagingDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
   }
-
-  // Make the entrypoint executable by creating it in the bundle dir
-  const toolstoreDir = getCesToolStoreDir(cesMode);
-  const bundleDir = join(toolstoreDir, digest);
-  const entrypointDir = join(bundleDir, "bin");
-  mkdirSync(entrypointDir, { recursive: true });
-  const entrypointPath = join(entrypointDir, "test-cli");
-  writeFileSync(entrypointPath, scriptContent, { mode: 0o755 });
-
-  return { digest, manifest: fullManifest };
 }
 
 /**

--- a/credential-executor/src/__tests__/toolstore.test.ts
+++ b/credential-executor/src/__tests__/toolstore.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 import {
   type SecureCommandManifest,
@@ -26,20 +27,42 @@ import {
 // Test fixtures
 // ---------------------------------------------------------------------------
 
-/** Sample bundle bytes (just some arbitrary content for testing). */
-const SAMPLE_BUNDLE_BYTES = Buffer.from(
-  "#!/usr/bin/env bash\necho hello\n",
-  "utf-8",
-);
+/**
+ * Create a tar.gz archive containing a shell script at the given entrypoint path.
+ * Returns the archive bytes.
+ */
+function createTestArchive(
+  entrypoint: string,
+  scriptContent = "#!/usr/bin/env bash\necho hello\n",
+): Buffer {
+  const stagingDir = join(tmpdir(), `ces-test-archive-${randomUUID()}`);
+  try {
+    const entrypointPath = join(stagingDir, entrypoint);
+    mkdirSync(join(stagingDir, entrypoint, ".."), { recursive: true });
+    writeFileSync(entrypointPath, scriptContent, { mode: 0o755 });
+
+    const archivePath = join(stagingDir, "bundle.tar.gz");
+    const proc = Bun.spawnSync(
+      ["tar", "czf", archivePath, "-C", stagingDir, entrypoint],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) {
+      throw new Error(`Failed to create test archive: ${new TextDecoder().decode(proc.stderr).trim()}`);
+    }
+    return Buffer.from(readFileSync(archivePath));
+  } finally {
+    try { rmSync(stagingDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+/** Sample bundle bytes as a valid tar.gz archive containing bin/test-cli. */
+const SAMPLE_BUNDLE_BYTES = createTestArchive("bin/test-cli");
 
 /** The correct SHA-256 digest of SAMPLE_BUNDLE_BYTES. */
 const SAMPLE_BUNDLE_DIGEST = computeDigest(SAMPLE_BUNDLE_BYTES);
 
-/** A different set of bytes to test digest mismatches. */
-const TAMPERED_BUNDLE_BYTES = Buffer.from(
-  "#!/usr/bin/env bash\nrm -rf /\n",
-  "utf-8",
-);
+/** A different archive to test digest mismatches. */
+const TAMPERED_BUNDLE_BYTES = createTestArchive("bin/test-cli", "#!/usr/bin/env bash\nrm -rf /\n");
 
 /**
  * Build a minimal valid SecureCommandManifest for testing.
@@ -350,15 +373,20 @@ describe("publishBundle — immutable and deduplicated by digest", () => {
     expect(second.bundlePath).toBe(first.bundlePath);
   });
 
-  test("published bundle content is readable and matches original bytes", () => {
+  test("published bundle contains extracted entrypoint (not raw archive)", () => {
     const result = publishBundle(buildPublishRequest());
     expect(result.success).toBe(true);
 
+    // After extraction, bundle.bin is removed and replaced by extracted contents
     const bundleContentPath = join(result.bundlePath, "bundle.bin");
-    expect(existsSync(bundleContentPath)).toBe(true);
+    expect(existsSync(bundleContentPath)).toBe(false);
 
-    const readBack = readFileSync(bundleContentPath);
-    expect(Buffer.compare(readBack, SAMPLE_BUNDLE_BYTES)).toBe(0);
+    // The entrypoint should exist and be executable
+    const entrypointPath = join(result.bundlePath, "bin", "test-cli");
+    expect(existsSync(entrypointPath)).toBe(true);
+
+    const content = readFileSync(entrypointPath, "utf-8");
+    expect(content).toContain("echo hello");
   });
 
   test("published manifest is readable and has correct fields", () => {
@@ -390,8 +418,8 @@ describe("publishBundle — immutable and deduplicated by digest", () => {
     const firstResult = publishBundle(buildPublishRequest());
     expect(firstResult.success).toBe(true);
 
-    // Publish a second, different bundle
-    const otherBytes = Buffer.from("#!/usr/bin/env bash\necho other\n", "utf-8");
+    // Publish a second, different bundle (real tar.gz archive)
+    const otherBytes = createTestArchive("bin/test-cli", "#!/usr/bin/env bash\necho other\n");
     const otherDigest = computeDigest(otherBytes);
     const otherManifest = buildSecureManifest({
       bundleDigest: otherDigest,

--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -27,7 +27,7 @@
  *    workspace directory or use non-HTTPS schemes are rejected.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getCesToolStoreDir, type CesMode } from "../paths.js";
@@ -302,9 +302,44 @@ export function publishBundle(request: PublishRequest): PublishResult {
   mkdirSync(stagingDir, { recursive: true });
 
   try {
-    // Write bundle content
+    // Write bundle content (raw archive bytes for digest verification)
     const stagingBundlePath = join(stagingDir, BUNDLE_FILENAME);
     writeFileSync(stagingBundlePath, bundleBytes, { mode: 0o444 });
+
+    // Extract the tar.gz archive into the staging directory.
+    // The archive is expected to contain the runnable bundle contents,
+    // including the entrypoint declared in the manifest.
+    const extractProc = Bun.spawnSync(
+      ["tar", "xzf", stagingBundlePath, "-C", stagingDir],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (extractProc.exitCode !== 0) {
+      const stderr = extractProc.stderr
+        ? new TextDecoder().decode(extractProc.stderr).trim()
+        : "unknown error";
+      throw new Error(
+        `Bundle extraction failed (exit code ${extractProc.exitCode}): ${stderr}`,
+      );
+    }
+
+    // Remove the raw archive — the extracted contents replace it
+    try {
+      unlinkSync(stagingBundlePath);
+    } catch {
+      // Best effort — the file may have been overwritten by extraction
+    }
+
+    // Validate that the declared entrypoint exists after extraction
+    const extractedEntrypoint = join(stagingDir, secureCommandManifest.entrypoint);
+    if (!existsSync(extractedEntrypoint)) {
+      throw new Error(
+        `Entrypoint "${secureCommandManifest.entrypoint}" not found in extracted bundle contents. ` +
+        `The archive must contain the declared entrypoint path.`,
+      );
+    }
+
+    // Make the entrypoint executable
+    chmodSync(extractedEntrypoint, 0o555);
 
     // Build and write toolstore manifest
     const toolstoreManifest: ToolstoreManifest = {


### PR DESCRIPTION
## Summary
- Add tar.gz archive extraction step to `publishBundle()` after digest verification
- Validate that the declared entrypoint exists after extraction
- Make entrypoints executable (mode 0o555)
- Update tests to create real tar.gz archives instead of manually creating files

🤖 Generated with [Claude Code](https://claude.com/claude-code)