### PR TITLE
fix: prevent adapter env from overriding PATH and LANG in CES command executor

### DIFF
--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -938,13 +938,12 @@ function buildCommandEnv(
   homeDir?: string,
 ): Record<string, string> {
   const env: Record<string, string> = {
-    // Minimal baseline environment
+    // Inject auth adapter env vars first so they cannot override protected keys
+    ...adapterEnv,
+    // PATH, LANG, and HOME are set after adapterEnv spread to prevent auth
+    // adapters from overriding baseline environment invariants.
     PATH: process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin",
     LANG: "en_US.UTF-8",
-    // Inject auth adapter env vars first so they cannot override HOME
-    ...adapterEnv,
-    // HOME is set after adapterEnv spread to prevent auth adapters declaring
-    // envVarName: "HOME" from bypassing the isolated config directory.
     HOME: homeDir ?? join(tmpdir(), `ces-home-${randomUUID()}`),
   };
 


### PR DESCRIPTION
Addresses feedback from PR #17171. Extends the HOME override protection to also protect PATH and LANG from being overridden by auth adapter environment variables when cleanConfigDirs is active.

The `...adapterEnv` spread was positioned after PATH and LANG in the object literal, meaning an auth adapter declaring `envVarName: "PATH"` or `envVarName: "LANG"` could override these baseline values. Moved all three protected keys (PATH, LANG, HOME) after the adapter spread so they always take precedence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
