### PR TITLE
fix: respond to duplicate handshake requests with error instead of silently dropping

### DIFF
--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -220,7 +220,15 @@ export class CesRpcServer {
 
     if (msg.type === "handshake_request") {
       if (this.handshakeComplete) {
-        this.logger.warn("[ces-server] Duplicate handshake_request after session established; ignoring");
+        this.logger.warn("[ces-server] Duplicate handshake_request after session established; rejecting");
+        const ack: HandshakeAck = {
+          type: "handshake_ack",
+          protocolVersion: CES_PROTOCOL_VERSION,
+          sessionId: (msg as HandshakeRequest).sessionId,
+          accepted: false,
+          reason: "Session already established",
+        };
+        this.sendMessage(ack);
         return;
       }
       this.handleHandshake(msg as HandshakeRequest);


### PR DESCRIPTION
Addresses feedback from PR #17174. Instead of silently dropping duplicate handshake_request messages after session establishment, sends back a handshake_ack with accepted: false and a reason so the client doesn't hang until timeout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
