### PR TITLE
fix: cancel in-flight CES handshake on daemon shutdown for fast teardown

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -257,6 +257,7 @@ export class DaemonServer {
   private cesProcessManager?: CesProcessManager;
   private cesClientPromise?: Promise<CesClient | undefined>;
   private cesInitAbortController?: AbortController;
+  private cesClientRef?: CesClient;
 
   /**
    * Logical assistant identifier used when publishing to the assistant-events hub.
@@ -495,6 +496,7 @@ export class DaemonServer {
             throw new Error("CES initialization aborted during shutdown");
           }
           const client = createCesClient(transport);
+          this.cesClientRef = client;
           const { accepted, reason } = await client.handshake();
           if (abortController.signal.aborted) {
             client.close();
@@ -511,6 +513,7 @@ export class DaemonServer {
             "CES handshake rejected — CES tools will be unavailable",
           );
           client.close();
+          this.cesClientRef = undefined;
           await pm.stop();
           // Reset so next session can retry initialization
           this.cesClientPromise = undefined;
@@ -529,6 +532,7 @@ export class DaemonServer {
           }
           await pm.stop().catch(() => {});
           // Reset so next session can retry initialization
+          this.cesClientRef = undefined;
           this.cesClientPromise = undefined;
           return undefined;
         }
@@ -563,12 +567,17 @@ export class DaemonServer {
     if (this.cesProcessManager) {
       await this.cesProcessManager.forceStop().catch(() => {});
     }
-    // Now await the init promise (which should settle quickly due to abort/kill).
+    // Cancel in-flight handshake/RPC timers by closing the client directly.
+    // Without this, the handshake setTimeout (~10s) keeps the init promise
+    // pending even after the transport is killed.
+    if (this.cesClientRef) {
+      this.cesClientRef.close();
+      this.cesClientRef = undefined;
+    }
+    // Now await the init promise (which should settle immediately since we
+    // killed the transport and cancelled pending timers above).
     if (this.cesClientPromise) {
-      const client = await this.cesClientPromise.catch(() => undefined);
-      if (client) {
-        client.close();
-      }
+      await this.cesClientPromise.catch(() => undefined);
       this.cesClientPromise = undefined;
     }
     if (this.cesProcessManager) {


### PR DESCRIPTION
Addresses feedback from PR #17176. Makes the CES client close() method accessible from the shutdown path via a cesClientRef field so daemon stop() can cancel in-flight handshake timers instead of waiting up to 10s for the timeout.

The core issue: forceStop() kills the transport but doesn't cancel the handshake setTimeout inside the CES client. client.close() does cancel all pending timers, but the client was only a local variable inside the init IIFE. Now the client reference is stored on the DaemonServer instance as soon as it's created, allowing stop() to call close() before awaiting the init promise.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
