### PR TITLE
fix: sort imports in notification test files

### DIFF
--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -7,12 +7,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { NotificationSignal } from "../notifications/signal.js";
 import {
   composeConversationSeed,
   isConversationSeedSane,
   resolveVerbosity,
 } from "../notifications/conversation-seed-composer.js";
+import type { NotificationSignal } from "../notifications/signal.js";
 import type {
   NotificationChannel,
   RenderedChannelCopy,
@@ -123,7 +123,9 @@ describe("resolveVerbosity", () => {
 
 describe("isConversationSeedSane", () => {
   test("accepts a normal string", () => {
-    expect(isConversationSeedSane("This is a valid thread seed message.")).toBe(true);
+    expect(isConversationSeedSane("This is a valid thread seed message.")).toBe(
+      true,
+    );
   });
 
   test("rejects empty string", () => {

--- a/assistant/src/__tests__/notification-conversation-candidate-validation.test.ts
+++ b/assistant/src/__tests__/notification-conversation-candidate-validation.test.ts
@@ -8,19 +8,21 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { validateConversationActions } from "../notifications/decision-engine.js";
 import type {
   ConversationCandidate,
   ConversationCandidateSet,
 } from "../notifications/conversation-candidates.js";
+import { validateConversationActions } from "../notifications/decision-engine.js";
 import type {
-  NotificationChannel,
   ConversationAction,
+  NotificationChannel,
 } from "../notifications/types.js";
 
 // -- Helpers -----------------------------------------------------------------
 
-function makeCandidate(overrides?: Partial<ConversationCandidate>): ConversationCandidate {
+function makeCandidate(
+  overrides?: Partial<ConversationCandidate>,
+): ConversationCandidate {
   return {
     conversationId: "conv-default",
     title: "Test Thread",


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `conversation-seed-composer.test.ts` and `notification-conversation-candidate-validation.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115335420/job/67139798048

🤖 Generated with [Claude Code](https://claude.com/claude-code)