### PR TITLE
fix: harden entropy lifecycle for managed CES key derivation

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -21,6 +21,7 @@ import { chmodSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { ensureDir, pathExists } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import { getPlatformName, getRootDir } from "../util/platform.js";
@@ -162,8 +163,13 @@ const ENTROPY_FILENAME = "entropy.key";
 /**
  * Persist the current machine entropy next to the key store so the managed
  * CES sidecar can read it and derive the same decryption key.
+ *
+ * Only writes in containerized (managed) mode — in local mode, CES runs on
+ * the same machine and derives the same entropy natively, so the file is
+ * unnecessary and would weaken offline security by persisting entropy to disk.
  */
 function persistEntropy(protectedDir: string): void {
+  if (!getIsContainerized()) return;
   try {
     const entropyPath = join(protectedDir, ENTROPY_FILENAME);
     const tmpPath = entropyPath + `.tmp.${process.pid}`;
@@ -171,8 +177,25 @@ function persistEntropy(protectedDir: string): void {
     chmodSync(tmpPath, 0o600);
     renameSync(tmpPath, entropyPath);
   } catch {
-    // Best-effort — local mode doesn't need this file, and managed mode
-    // will log a clear error if it's missing.
+    // Best-effort — managed mode will log a clear error if it's missing.
+  }
+}
+
+/**
+ * Backfill `entropy.key` for existing encrypted stores that predate the
+ * entropy persistence feature. If the store file exists but `entropy.key`
+ * does not, write it now so the managed CES sidecar can derive the key.
+ */
+function backfillEntropyIfMissing(): void {
+  if (!getIsContainerized()) return;
+  try {
+    const protectedDir = dirname(getStorePath());
+    const entropyPath = join(protectedDir, ENTROPY_FILENAME);
+    if (!pathExists(entropyPath)) {
+      persistEntropy(protectedDir);
+    }
+  } catch {
+    // Best-effort — don't break reads if backfill fails.
   }
 }
 
@@ -252,6 +275,10 @@ export function getKey(account: string): string | undefined {
   try {
     const store = readStore();
     if (!store) return undefined;
+
+    // Backfill entropy.key for existing stores that were created before
+    // entropy persistence was added. Only needed in managed mode.
+    backfillEntropyIfMissing();
 
     const entry = store.entries[account];
     if (!entry) return undefined;

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -142,20 +142,31 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
   // the CES sidecar can derive the same AES decryption key. Without this,
   // key derivation would use the sidecar's own hostname/user/homedir which
   // differ from the assistant container's values.
-  let assistantEntropy: string | undefined;
+  //
+  // Use a lazy getter instead of a one-shot read: the entropy file may not
+  // exist at CES boot (e.g. the assistant hasn't written it yet). A lazy
+  // re-read on each get() call handles this startup race gracefully.
   const entropyPath = join(mountedVellumRoot, "protected", "entropy.key");
-  try {
-    assistantEntropy = readFileSync(entropyPath, "utf-8");
-    log(`Read assistant entropy from ${entropyPath}`);
-  } catch {
+  const readAssistantEntropy = (): string | undefined => {
+    try {
+      return readFileSync(entropyPath, "utf-8");
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Attempt an eager read for logging — but the getter handles misses.
+  if (readAssistantEntropy()) {
+    log(`Assistant entropy available at ${entropyPath}`);
+  } else {
     warn(
-      `Could not read assistant entropy from ${entropyPath}. ` +
-        "local_static credential decryption may fail if machine entropy differs.",
+      `Assistant entropy not yet available at ${entropyPath}. ` +
+        "Will re-read lazily on each credential access.",
     );
   }
 
   const secureKeyBackend = createLocalSecureKeyBackend(mountedVellumRoot, {
-    entropyOverride: assistantEntropy,
+    entropyGetter: readAssistantEntropy,
   });
   const localMaterialiser = new LocalMaterialiser({ secureKeyBackend });
 

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -139,13 +139,18 @@ function readStore(storePath: string): StoreFile | null {
  *   runs in a different container with a different hostname/user, so it
  *   must use the assistant's entropy (read from the shared data mount)
  *   to derive the same AES key.
+ * @param options.entropyGetter - If provided, called on each `get()` to
+ *   lazily resolve entropy. This handles the startup race where the
+ *   entropy file may not exist at construction time but appears later.
+ *   Takes precedence over `entropyOverride`.
  */
 export function createLocalSecureKeyBackend(
   vellumRoot: string,
-  options?: { entropyOverride?: string },
+  options?: { entropyOverride?: string; entropyGetter?: () => string | undefined },
 ): SecureKeyBackend {
   const storePath = join(vellumRoot, "protected", "keys.enc");
-  const entropy = options?.entropyOverride;
+  const staticEntropy = options?.entropyOverride;
+  const entropyGetter = options?.entropyGetter;
 
   return {
     async get(key: string): Promise<string | undefined> {
@@ -155,6 +160,9 @@ export function createLocalSecureKeyBackend(
 
         const entry = store.entries[key];
         if (!entry) return undefined;
+
+        // Lazy re-read: prefer getter (handles startup race) over static value.
+        const entropy = entropyGetter?.() ?? staticEntropy;
 
         const salt = Buffer.from(store.salt, "hex");
         const derivedKey = deriveKey(salt, entropy);


### PR DESCRIPTION
Addresses feedback from PR #17177. Three fixes:

1. **Backfill entropy.key for existing stores**: Assistants with an existing `protected/keys.enc` that never mutate credentials would never generate the entropy file. Added `backfillEntropyIfMissing()` called during `getKey()` that writes `entropy.key` if the store exists but the entropy file doesn't.

2. **Lazy re-read entropy in managed CES**: Replaced the one-shot `readFileSync` at handler construction with an `entropyGetter` function that re-reads on each `get()` call. This handles the startup race where the entropy file may not exist when the CES sidecar boots but appears later when the assistant writes it.

3. **Mode-conditional entropy persistence**: `persistEntropy()` now checks `getIsContainerized()` and returns early in local mode. In local mode, CES derives entropy natively from the same machine, so persisting it to disk is unnecessary and weakens offline security.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
