### PR TITLE
fix: path traversal test writes outside staging dir in CI

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -40,6 +40,7 @@ import { PersistentGrantStore } from "../grants/persistent-store.js";
 import { TemporaryGrantStore } from "../grants/temporary-store.js";
 import {
   publishBundle,
+  getBundleManifestPath,
 } from "../toolstore/publish.js";
 import { getCesToolStoreDir, getCesDataRoot } from "../paths.js";
 import { computeDigest } from "../toolstore/integrity.js";
@@ -1130,9 +1131,14 @@ describe("executeAuthenticatedCommand — banned binaries", () => {
 
 describe("executeAuthenticatedCommand — entrypoint path containment", () => {
   test("rejects entrypoint that escapes the bundle directory via path traversal", async () => {
-    const manifest = buildManifest({
+    // Publish a valid bundle with a safe entrypoint, then patch the
+    // toolstore manifest to inject a traversal path. This simulates a
+    // tampered manifest — publishBundle correctly rejects traversal
+    // entrypoints during extraction, so the containment check in the
+    // executor is a defense-in-depth layer.
+    const safeManifest = buildManifest({
       egressMode: EgressMode.NoNetwork,
-      entrypoint: "../../usr/bin/git",
+      entrypoint: "bin/test-cli",
       commandProfiles: {
         "list": {
           description: "List resources",
@@ -1147,10 +1153,19 @@ describe("executeAuthenticatedCommand — entrypoint path containment", () => {
       },
     });
     const { digest } = publishTestBundle(
-      manifest,
+      safeManifest,
       "local",
       '#!/bin/sh\necho "should not run"\n',
     );
+
+    // Patch the toolstore manifest to inject a traversal entrypoint.
+    // The manifest is published as read-only (0o444), so chmod first.
+    const toolstoreDir = getCesToolStoreDir("local");
+    const manifestPath = getBundleManifestPath(toolstoreDir, digest);
+    chmodSync(manifestPath, 0o644);
+    const storedManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    storedManifest.secureCommandManifest.entrypoint = "../../usr/bin/git";
+    writeFileSync(manifestPath, JSON.stringify(storedManifest, null, 2) + "\n");
 
     const deps = buildDeps();
     addCommandGrant(


### PR DESCRIPTION
## Summary
- Fixed CES path traversal test that failed in CI with `EACCES: permission denied, open '/usr/bin/git'`
- `publishTestBundle` used `join(stagingDir, '../../usr/bin/git')` which resolved to `/usr/bin/git`, escaping the temp directory
- Now publishes a valid bundle with a safe entrypoint, then patches the toolstore manifest to inject the traversal path — correctly modeling a tampered-manifest scenario

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115370296/job/67139889426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
