### PR TITLE
fix: remove overstated cwd-safety claim from CES residual risk docs

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -355,7 +355,7 @@ CES enforces isolation controls cooperatively rather than at the OS level:
 
 Both limitations stem from the same root cause: v1 relies on process-level conventions (env vars for network, cwd for filesystem) rather than OS-level enforcement primitives.
 
-**Mitigation**: The denied-binary list and manifest validation restrict which binaries can run as secure commands, reducing the surface for non-cooperating binaries. In practice, the well-known CLI tools approved as secure command entrypoints (e.g., `gh`, `aws`) respect proxy environment variables and operate within their working directory. True enforcement requires OS-level sandboxing — Linux network namespaces for mandatory proxy routing and filesystem namespaces or chroot for path isolation — which is planned for v2 when CES runs in managed containers with full namespace support.
+**Mitigation**: The denied-binary list and manifest validation restrict which binaries can run as secure commands, reducing the surface for non-cooperating binaries. In practice, the well-known CLI tools approved as secure command entrypoints (e.g., `gh`, `aws`) respect proxy environment variables. True enforcement requires OS-level sandboxing — Linux network namespaces for mandatory proxy routing and filesystem namespaces or chroot for path isolation — which is planned for v2 when CES runs in managed containers with full namespace support.
 
 ### 8. `credential_process` adapter shares cooperative egress limitation with main command
 


### PR DESCRIPTION
Addresses Codex review feedback on #17156. Removes the claim that approved CLI tools 'operate within their working directory' from Residual Risk #7 mitigation, since this overstates filesystem safety given that CES has no chroot or namespace isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
