### PR TITLE
fix: replace stale disable-model-invocation in test fixture

### DIFF
--- a/assistant/src/__tests__/frontmatter.test.ts
+++ b/assistant/src/__tests__/frontmatter.test.ts
@@ -219,7 +219,7 @@ describe("parseFrontmatterFields", () => {
       '  emoji: "\uD83D\uDD0C"',
       "  vellum:",
       '    display-name: "Test Skill"',
-      "    disable-model-invocation: true",
+      "    some-custom-field: true",
       "---",
       "Body",
     ].join("\n");
@@ -230,7 +230,7 @@ describe("parseFrontmatterFields", () => {
       emoji: "\uD83D\uDD0C",
       vellum: {
         "display-name": "Test Skill",
-        "disable-model-invocation": true,
+        "some-custom-field": true,
       },
     });
   });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-skill-metadata-keys.md.

**Gap:** Stale disable-model-invocation in test fixture YAML
**What was expected:** References to removed metadata keys cleaned from test files
**What was found:** frontmatter.test.ts uses disable-model-invocation as test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
