### PR TITLE
fix: parse credential_process helperCommand with shell semantics before denylist check

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -11,6 +11,7 @@ import {
   validateManifest,
   validateCommand,
   matchesArgvPattern,
+  extractShellBinary,
 } from "../commands/validator.js";
 
 // ---------------------------------------------------------------------------
@@ -779,6 +780,163 @@ describe("credential_process helperCommand denied binary validation", () => {
     );
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  // -- Shell semantics bypass prevention ------------------------------------
+
+  test("rejects single-quoted denied binary ('curl')", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "'curl' https://example.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"curl"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects double-quoted denied binary (\"curl\")", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: '"curl" https://example.com',
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"curl"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects denied binary after env var assignment (AWS_PROFILE=x curl)", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "AWS_PROFILE=x curl https://example.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"curl"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects denied binary after multiple env var assignments", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "AWS_PROFILE=default FOO=bar python3 script.py",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"python3"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects denied binary with env assignment and quotes combined", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "AWS_PROFILE='prod' 'bash' -c 'echo creds'",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("credential_process") &&
+          e.includes("denied binary") &&
+          e.includes('"bash"'),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractShellBinary
+// ---------------------------------------------------------------------------
+
+describe("extractShellBinary", () => {
+  test("extracts plain binary name", () => {
+    expect(extractShellBinary("curl https://example.com")).toBe("curl");
+  });
+
+  test("extracts absolute path binary", () => {
+    expect(extractShellBinary("/usr/bin/python3 script.py")).toBe("/usr/bin/python3");
+  });
+
+  test("strips single quotes from binary", () => {
+    expect(extractShellBinary("'curl' https://example.com")).toBe("curl");
+  });
+
+  test("strips double quotes from binary", () => {
+    expect(extractShellBinary('"curl" https://example.com')).toBe("curl");
+  });
+
+  test("skips single env var assignment", () => {
+    expect(extractShellBinary("AWS_PROFILE=x curl https://example.com")).toBe("curl");
+  });
+
+  test("skips multiple env var assignments", () => {
+    expect(extractShellBinary("AWS_PROFILE=default FOO=bar curl https://example.com")).toBe("curl");
+  });
+
+  test("skips env var assignment with quoted value", () => {
+    expect(extractShellBinary("AWS_PROFILE='prod' curl https://example.com")).toBe("curl");
+  });
+
+  test("skips env var assignment with double-quoted value", () => {
+    expect(extractShellBinary('AWS_PROFILE="prod account" curl https://example.com')).toBe("curl");
+  });
+
+  test("handles env assignment + quoted binary combined", () => {
+    expect(extractShellBinary("AWS_PROFILE='prod' 'bash' -c 'echo test'")).toBe("bash");
+  });
+
+  test("handles binary with no arguments", () => {
+    expect(extractShellBinary("aws-vault")).toBe("aws-vault");
+  });
+
+  test("handles leading whitespace", () => {
+    expect(extractShellBinary("  curl https://example.com")).toBe("curl");
   });
 });
 

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -123,7 +123,7 @@ export function validateManifest(
     if (manifest.authAdapter.type === AuthAdapterType.CredentialProcess) {
       const helper = manifest.authAdapter.helperCommand;
       if (helper && helper.trim().length > 0) {
-        const firstWord = helper.trim().split(/\s+/)[0]!;
+        const firstWord = extractShellBinary(helper);
         const basename = pathBasename(firstWord);
         if (isDeniedBinary(firstWord)) {
           errors.push(
@@ -422,6 +422,62 @@ function validateArgvPattern(
   }
 
   return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Shell binary extraction (for helperCommand denylist checks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex matching shell variable assignments (KEY=VALUE) at the start of a
+ * command. These are environment overrides and not the binary. Handles
+ * bare values, single-quoted values, and double-quoted values.
+ */
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\S*)\s+/;
+
+/**
+ * Extract the actual binary name from a shell command string, accounting for
+ * leading env-var assignments (KEY=VALUE prefixes) and shell quoting around
+ * the binary token. This is necessary because helperCommand is executed via
+ * `sh -c`, so the shell resolves assignments and quotes before execution.
+ *
+ * Examples:
+ *   "curl https://..."                → "curl"
+ *   "'curl' https://..."              → "curl"
+ *   "AWS_PROFILE=x curl ..."          → "curl"
+ *   "AWS_PROFILE=x FOO=bar curl ..." → "curl"
+ *   "/usr/bin/python3 script.py"      → "/usr/bin/python3"
+ */
+export function extractShellBinary(command: string): string {
+  let remaining = command.trim();
+
+  // Strip leading KEY=VALUE assignments
+  let match: RegExpExecArray | null;
+  while ((match = ENV_ASSIGNMENT_RE.exec(remaining)) !== null) {
+    remaining = remaining.slice(match[0].length);
+  }
+
+  // Extract the first whitespace-delimited token
+  const firstToken = remaining.split(/\s+/)[0] ?? remaining;
+
+  // Strip surrounding quotes (single or double)
+  return stripShellQuotes(firstToken);
+}
+
+/**
+ * Remove surrounding single or double quotes from a token.
+ * Only strips matching pairs at the boundaries (e.g., `'curl'` → `curl`).
+ */
+function stripShellQuotes(token: string): string {
+  if (token.length >= 2) {
+    if (
+      (token.startsWith("'") && token.endsWith("'")) ||
+      (token.startsWith('"') && token.endsWith('"'))
+    ) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses Codex review feedback on #17186. The simple whitespace-split approach could be bypassed via shell quoting (`'curl'`) or env var assignments (`AWS_PROFILE=x curl`). Now strips quotes and skips KEY=VALUE prefixes before extracting the binary for denylist validation.

Changes:
- Added `extractShellBinary()` helper that strips leading `KEY=VALUE` env assignments and surrounding quotes before extracting the binary token
- Updated helperCommand validation to use `extractShellBinary()` instead of naive `.split(/\s+/)[0]`
- Added tests for quoting bypass, env var assignment bypass, and combined scenarios
- Added direct unit tests for `extractShellBinary()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
