### PR TITLE
fix: remove skill.degraded references from iOS views

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -104,15 +104,10 @@ struct InstalledSkillsView: View {
 
             Spacer()
 
-            if skill.degraded == true {
-                VIconView(.triangleAlert, size: 14)
-                    .foregroundColor(.orange)
-                    .accessibilityLabel("Degraded")
-            }
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Skill: \(skill.name), \(skill.state)\(skill.degraded == true ? ", degraded" : "")")
+        .accessibilityLabel("Skill: \(skill.name), \(skill.state)")
         .accessibilityHint("Opens skill details")
     }
 

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -173,17 +173,6 @@ struct SkillDetailView: View {
                     .multilineTextAlignment(.center)
             }
 
-            if skill.degraded == true {
-                HStack(spacing: 4) {
-                    VIconView(.triangleAlert, size: 12)
-                    Text("Degraded")
-                        .font(VFont.caption)
-                }
-                .foregroundColor(.orange)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Skill is degraded")
-            }
-
             if skill.updateAvailable {
                 HStack(spacing: 4) {
                     VIconView(.circleArrowUp, size: 12)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-skill-metadata-keys.md.

**Gap:** skill.degraded references in iOS views cause Swift compile error
**What was expected:** View-layer references removed after struct field was removed
**What was found:** SkillDetailView.swift and InstalledSkillsView.swift still reference skill.degraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
