### PR TITLE
fix: allow make_authenticated_request in HTTP executor test fixtures

### DIFF
--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -90,7 +90,7 @@ function buildStaticRecord(
     credentialId: overrides.credentialId ?? "cred-uuid-1",
     service: overrides.service ?? "github",
     field: overrides.field ?? "api_key",
-    allowedTools: overrides.allowedTools ?? [],
+    allowedTools: overrides.allowedTools ?? ["make_authenticated_request"],
     allowedDomains: overrides.allowedDomains ?? [],
     createdAt: overrides.createdAt ?? Date.now(),
     updatedAt: overrides.updatedAt ?? Date.now(),


### PR DESCRIPTION
## Summary
- After the fail-closed policy change (#17191), empty `allowedTools: []` correctly denies all CES tools
- The `buildStaticRecord()` test helper defaulted `allowedTools` to `[]`, causing 11 HTTP executor tests to fail with "Credential example/key does not allow any tools."
- Updated the default to `["make_authenticated_request"]` since that's the tool being tested

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115497001/job/67140224607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
