### PR TITLE
fix: update test assertions for thread→conversation rename

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -421,7 +421,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       context,
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("private thread");
+    expect(result.content).toContain("private conversation");
     expect(result.content).toContain("cannot be accessed");
   });
 
@@ -456,7 +456,7 @@ describe("AssetMaterializeTool visibility policy", () => {
     // Should mention the filename so the user knows which file
     expect(result.content).toContain("confidential.pdf");
     // Should explain how to access it
-    expect(result.content).toContain("from within the private thread");
+    expect(result.content).toContain("from within the private conversation");
   });
 
   test("materializing from a different private thread is REJECTED", async () => {
@@ -490,7 +490,7 @@ describe("AssetMaterializeTool visibility policy", () => {
       context,
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("private thread");
+    expect(result.content).toContain("private conversation");
   });
 
   test("attachment linked to both private and standard threads can be materialized from anywhere", async () => {

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -564,7 +564,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("private thread");
+    expect(result.content).toContain("private conversation");
     expect(result.content).toContain("cannot be accessed");
   });
 
@@ -647,7 +647,7 @@ describe("Private-thread variant: cross-thread media blocking", () => {
       context,
     );
     expect(materializeResult.isError).toBe(true);
-    expect(materializeResult.content).toContain("private thread");
+    expect(materializeResult.content).toContain("private conversation");
   });
 
   test("visibility policy unit check: private attachment blocked from standard context", () => {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -571,7 +571,7 @@ describe("ToolExecutor lifecycle events", () => {
       throw new Error("Expected permission_prompt event");
     expect(promptEvent.toolName).toBe("file_edit");
     expect(promptEvent.reason).toBe(
-      "Private thread: side-effect tools require explicit approval",
+      "Private conversation: side-effect tools require explicit approval",
     );
   });
 
@@ -600,7 +600,7 @@ describe("ToolExecutor lifecycle events", () => {
       throw new Error("Expected permission_prompt event");
     expect(promptEvent.toolName).toBe("bash");
     expect(promptEvent.reason).toBe(
-      "Private thread: side-effect tools require explicit approval",
+      "Private conversation: side-effect tools require explicit approval",
     );
     expect(promptEvent.sandboxed).toBe(true);
   });
@@ -660,7 +660,7 @@ describe("ToolExecutor lifecycle events", () => {
       throw new Error("Expected permission_prompt event");
     expect(promptEvent.toolName).toBe("file_edit");
     expect(promptEvent.reason).toBe(
-      "Private thread: side-effect tools require explicit approval",
+      "Private conversation: side-effect tools require explicit approval",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Update test string assertions in 3 test files to match the source code rename from "private thread" to "private conversation"
- Fixes `tool-executor-lifecycle-events.test.ts`, `media-reuse-story.e2e.test.ts`, and `asset-materialize-tool.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115593360/job/67140474561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
