### PR TITLE
fix: use original caller headers for redirect re-authentication in CES HTTP executor

### DIFF
--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -225,6 +225,7 @@ export async function executeAuthenticatedHttpRequest(
       request.credentialHandle,
       deps,
       credential,
+      request.headers ?? {},
     );
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
@@ -536,8 +537,15 @@ async function performHttpRequest(
   credentialHandle: string,
   deps: HttpExecutorDeps,
   credential?: MaterialisedCredential,
+  callerHeaders?: Record<string, string>,
 ): Promise<RawHttpResponse> {
   const fetchFn = deps.fetch ?? globalThis.fetch;
+
+  // Preserve the original caller headers (before auth injection) so that
+  // redirect re-authentication starts from a clean slate on each hop.
+  // This prevents previously injected auth headers from being treated as
+  // caller headers and leaking credentials across redirect hops.
+  const originalCallerHeaders = callerHeaders ?? headers;
 
   let currentUrl = url;
   let currentMethod = method;
@@ -614,13 +622,14 @@ async function performHttpRequest(
         currentBody = undefined;
       }
 
-      // Re-apply auth injection for the redirect URL. This is necessary
-      // because query-parameter credentials are URL-specific and would be
-      // lost when the URL changes on redirect.
+      // Re-apply auth injection for the redirect URL starting from the
+      // original caller headers — not currentHeaders which already contain
+      // auth injected on the previous hop. This prevents credential leakage
+      // across multi-redirect flows.
       if (credential) {
         const reAuthenticated = buildAuthenticatedRequest(
           redirectUrl,
-          currentHeaders,
+          originalCallerHeaders,
           credential,
         );
         currentUrl = reAuthenticated.url;


### PR DESCRIPTION
Addresses Codex feedback from PR #17194. The redirect re-auth was passing currentHeaders (which contain previously injected auth headers) back into buildAuthenticatedRequest. This could leak credentials across redirect hops. Now stores the original caller headers before the first auth injection and uses those clean headers for each redirect re-auth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
