### PR TITLE
fix: prevent symlink escape in CES bundle entrypoints

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, chmodSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, chmodSync, symlinkSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -41,6 +41,7 @@ import { TemporaryGrantStore } from "../grants/temporary-store.js";
 import {
   publishBundle,
   getBundleManifestPath,
+  getBundleDir,
 } from "../toolstore/publish.js";
 import { getCesToolStoreDir, getCesDataRoot } from "../paths.js";
 import { computeDigest } from "../toolstore/integrity.js";
@@ -1584,8 +1585,6 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
       },
     });
 
-    // Publish the bundle by directly writing the manifest to bypass the validator.
-    // We need to simulate a scenario where a tampered manifest somehow got published.
     const { digest } = publishTestBundle(
       manifest,
       "local",
@@ -1689,5 +1688,72 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("shell metacharacters");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entrypoint symlink escape tests (defense-in-depth)
+// ---------------------------------------------------------------------------
+
+describe("executeAuthenticatedCommand — symlink escape prevention", () => {
+  test("rejects entrypoint that is a symlink resolving outside the bundle directory", async () => {
+    // Publish a valid bundle first, then tamper with the on-disk entrypoint
+    // by replacing it with a symlink. This tests the executor's defense-in-depth
+    // check — the publisher should also reject symlink entrypoints, but the
+    // executor must independently verify.
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      entrypoint: "bin/test-cli",
+      commandProfiles: {
+        "list": {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "should not run"\n',
+    );
+
+    // Tamper: replace the real entrypoint with a symlink to an external binary
+    const toolstoreDir = getCesToolStoreDir("local");
+    const bundleDir = getBundleDir(toolstoreDir, digest);
+    const entrypointPath = join(bundleDir, "bin/test-cli");
+
+    // The published entrypoint is read-only (0o555), need to make writable to tamper
+    chmodSync(entrypointPath, 0o755);
+    unlinkSync(entrypointPath);
+    symlinkSync("/usr/bin/env", entrypointPath);
+
+    const deps = buildDeps();
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const request: ExecuteCommandRequest = {
+      bundleDigest: digest,
+      profileName: "list",
+      credentialHandle: "local_static:test/api_key",
+      argv: ["list", "--format", "json"],
+      workspaceDir: testWorkspaceDir,
+      purpose: "Test symlink escape prevention",
+    };
+
+    const result = await executeAuthenticatedCommand(request, deps);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("symlink");
+    expect(result.error).toContain("outside the bundle directory");
   });
 });

--- a/credential-executor/src/__tests__/toolstore.test.ts
+++ b/credential-executor/src/__tests__/toolstore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -48,6 +48,37 @@ function createTestArchive(
     );
     if (proc.exitCode !== 0) {
       throw new Error(`Failed to create test archive: ${new TextDecoder().decode(proc.stderr).trim()}`);
+    }
+    return Buffer.from(readFileSync(archivePath));
+  } finally {
+    try { rmSync(stagingDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+/**
+ * Create a tar.gz archive containing a symlink entrypoint that points to an external path.
+ * This simulates a malicious bundle that attempts symlink escape.
+ */
+function createSymlinkArchive(
+  entrypoint: string,
+  symlinkTarget: string,
+): Buffer {
+  const stagingDir = join(tmpdir(), `ces-test-symlink-archive-${randomUUID()}`);
+  try {
+    const entrypointPath = join(stagingDir, entrypoint);
+    mkdirSync(join(stagingDir, entrypoint, ".."), { recursive: true });
+    // Create a symlink at the entrypoint path pointing to the external target
+    symlinkSync(symlinkTarget, entrypointPath);
+
+    const archivePath = join(stagingDir, "bundle.tar.gz");
+    // Use -h flag to follow symlinks during archive creation would defeat the
+    // purpose; instead we archive the symlink itself using default tar behavior
+    const proc = Bun.spawnSync(
+      ["tar", "czf", archivePath, "-C", stagingDir, entrypoint],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) {
+      throw new Error(`Failed to create symlink test archive: ${new TextDecoder().decode(proc.stderr).trim()}`);
     }
     return Buffer.from(readFileSync(archivePath));
   } finally {
@@ -562,5 +593,136 @@ describe("publishBundle — manifest validation", () => {
     );
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid secure command manifest");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Publisher: symlink escape prevention
+// ---------------------------------------------------------------------------
+
+describe("publishBundle — symlink escape prevention", () => {
+  test("rejects bundle with symlink entrypoint pointing outside bundle", () => {
+    // Create a tar.gz with a symlink entrypoint: bin/test-cli -> /usr/bin/curl
+    const symlinkBytes = createSymlinkArchive("bin/test-cli", "/usr/bin/curl");
+    const symlinkDigest = computeDigest(symlinkBytes);
+
+    const manifest = buildSecureManifest({
+      bundleDigest: symlinkDigest,
+    });
+
+    const result = publishBundle({
+      bundleBytes: symlinkBytes,
+      expectedDigest: symlinkDigest,
+      bundleId: "test-cli",
+      version: "1.0.0",
+      sourceUrl: "https://releases.example.com/test-cli/v1.0.0/bundle.tar.gz",
+      secureCommandManifest: manifest,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("symlink");
+  });
+
+  test("rejects bundle with non-entrypoint symlink pointing outside bundle", () => {
+    // Create an archive where a non-entrypoint file is a symlink to an external path.
+    // The entrypoint itself is a real file, but the bundle contains a sneaky symlink.
+    const stagingDir = join(tmpdir(), `ces-test-mixed-symlink-${randomUUID()}`);
+    try {
+      // Create a real entrypoint
+      const entrypointPath = join(stagingDir, "bin/test-cli");
+      mkdirSync(join(stagingDir, "bin"), { recursive: true });
+      writeFileSync(entrypointPath, "#!/usr/bin/env bash\necho hello\n", { mode: 0o755 });
+
+      // Create a symlink that escapes
+      symlinkSync("/etc/passwd", join(stagingDir, "bin/evil-link"));
+
+      const archivePath = join(stagingDir, "bundle.tar.gz");
+      const proc = Bun.spawnSync(
+        ["tar", "czf", archivePath, "-C", stagingDir, "bin"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      expect(proc.exitCode).toBe(0);
+
+      const bundleBytes = Buffer.from(readFileSync(archivePath));
+      const digest = computeDigest(bundleBytes);
+
+      const manifest = buildSecureManifest({
+        bundleDigest: digest,
+      });
+
+      const result = publishBundle({
+        bundleBytes,
+        expectedDigest: digest,
+        bundleId: "test-cli",
+        version: "1.0.0",
+        sourceUrl: "https://releases.example.com/test-cli/v1.0.0/bundle.tar.gz",
+        secureCommandManifest: manifest,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("symlink");
+      expect(result.error).toContain("outside the bundle directory");
+    } finally {
+      try { rmSync(stagingDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  test("accepts bundle with internal symlinks (not escaping)", () => {
+    // Create an archive with a symlink that points within the bundle
+    const stagingDir = join(tmpdir(), `ces-test-internal-symlink-${randomUUID()}`);
+    try {
+      mkdirSync(join(stagingDir, "bin"), { recursive: true });
+      writeFileSync(join(stagingDir, "bin/test-cli"), "#!/usr/bin/env bash\necho hello\n", { mode: 0o755 });
+      // Create a symlink within the bundle: bin/alias -> test-cli (relative)
+      symlinkSync("test-cli", join(stagingDir, "bin/alias"));
+
+      const archivePath = join(stagingDir, "bundle.tar.gz");
+      const proc = Bun.spawnSync(
+        ["tar", "czf", archivePath, "-C", stagingDir, "bin"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      expect(proc.exitCode).toBe(0);
+
+      const bundleBytes = Buffer.from(readFileSync(archivePath));
+      const digest = computeDigest(bundleBytes);
+
+      const manifest = buildSecureManifest({
+        bundleDigest: digest,
+      });
+
+      const result = publishBundle({
+        bundleBytes,
+        expectedDigest: digest,
+        bundleId: "test-cli",
+        version: "1.0.0",
+        sourceUrl: "https://releases.example.com/test-cli/v1.0.0/bundle.tar.gz",
+        secureCommandManifest: manifest,
+      });
+
+      expect(result.success).toBe(true);
+    } finally {
+      try { rmSync(stagingDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  test("no files are left in toolstore when symlink escape is detected", () => {
+    const symlinkBytes = createSymlinkArchive("bin/test-cli", "/usr/bin/curl");
+    const symlinkDigest = computeDigest(symlinkBytes);
+
+    const manifest = buildSecureManifest({
+      bundleDigest: symlinkDigest,
+    });
+
+    publishBundle({
+      bundleBytes: symlinkBytes,
+      expectedDigest: symlinkDigest,
+      bundleId: "test-cli",
+      version: "1.0.0",
+      sourceUrl: "https://releases.example.com/test-cli/v1.0.0/bundle.tar.gz",
+      secureCommandManifest: manifest,
+    });
+
+    // The bundle should not be published
+    expect(isBundlePublished(symlinkDigest)).toBe(false);
   });
 });

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -46,7 +46,7 @@
 
 import { randomUUID } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
-import { mkdirSync, writeFileSync, unlinkSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, unlinkSync, rmSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
   SessionStore,
@@ -406,6 +406,7 @@ export async function executeAuthenticatedCommand(
   const entrypointPath = resolve(bundleDir, manifest.entrypoint);
 
   // Containment check: entrypoint must resolve inside the bundle directory
+  // (lexical check for path traversal via ../)
   if (!entrypointPath.startsWith(bundleDir + "/") && entrypointPath !== bundleDir) {
     // Stop the proxy session before returning — it may already be running
     if (proxySessionId) {
@@ -420,6 +421,46 @@ export async function executeAuthenticatedCommand(
       success: false,
       error: `Entrypoint "${manifest.entrypoint}" resolves outside the bundle directory. ` +
         `Path traversal is not allowed.`,
+      auditId,
+    };
+  }
+
+  // Symlink escape check: follow symlinks and verify the real path is
+  // still inside the bundle directory. A symlink entrypoint like
+  // `bin/tool -> /usr/bin/curl` passes the lexical check above but
+  // executes outside the bundle boundary.
+  let realEntrypointPath: string;
+  try {
+    realEntrypointPath = realpathSync(entrypointPath);
+  } catch {
+    // realpathSync fails if the file doesn't exist or is a broken symlink
+    if (proxySessionId) {
+      try {
+        await stopSession(proxySessionId, sessionStore);
+      } catch {
+        // Best-effort proxy cleanup
+      }
+    }
+    cleanupAll(scratchDir, tempFilePath);
+    return {
+      success: false,
+      error: `Entrypoint "${manifest.entrypoint}" could not be resolved (broken symlink or missing file).`,
+      auditId,
+    };
+  }
+  if (!realEntrypointPath.startsWith(bundleDir + "/") && realEntrypointPath !== bundleDir) {
+    if (proxySessionId) {
+      try {
+        await stopSession(proxySessionId, sessionStore);
+      } catch {
+        // Best-effort proxy cleanup
+      }
+    }
+    cleanupAll(scratchDir, tempFilePath);
+    return {
+      success: false,
+      error: `Entrypoint "${manifest.entrypoint}" is a symlink that resolves to "${realEntrypointPath}", ` +
+        `which is outside the bundle directory. Symlink escape is not allowed.`,
       auditId,
     };
   }

--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -27,8 +27,8 @@
  *    workspace directory or use non-HTTPS schemes are rejected.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, realpathSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import { getCesToolStoreDir, type CesMode } from "../paths.js";
 import type { SecureCommandManifest } from "../commands/profiles.js";
@@ -329,8 +329,36 @@ export function publishBundle(request: PublishRequest): PublishResult {
       // Best effort — the file may have been overwritten by extraction
     }
 
+    // Scan for symlinks that escape the bundle directory.
+    // A symlink pointing outside the staging directory could allow the
+    // entrypoint to execute arbitrary binaries on the host.
+    const escapingSymlinks = findEscapingSymlinks(stagingDir);
+    if (escapingSymlinks.length > 0) {
+      throw new Error(
+        `Bundle contains symlinks that point outside the bundle directory: ${escapingSymlinks.join(", ")}. ` +
+        `Symlink escape is not allowed.`,
+      );
+    }
+
     // Validate that the declared entrypoint exists after extraction
     const extractedEntrypoint = join(stagingDir, secureCommandManifest.entrypoint);
+
+    // Check that the entrypoint itself is not a symlink (use lstat to avoid following)
+    try {
+      const entrypointStat = lstatSync(extractedEntrypoint);
+      if (entrypointStat.isSymbolicLink()) {
+        throw new Error(
+          `Entrypoint "${secureCommandManifest.entrypoint}" is a symbolic link. ` +
+          `Symlink entrypoints are not allowed — the entrypoint must be a regular file.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("Symlink entrypoints")) {
+        throw err;
+      }
+      // lstat failed — the file doesn't exist, fall through to existsSync check
+    }
+
     if (!existsSync(extractedEntrypoint)) {
       throw new Error(
         `Entrypoint "${secureCommandManifest.entrypoint}" not found in extracted bundle contents. ` +
@@ -448,4 +476,54 @@ export function isBundlePublished(
   const bundleDir = getBundleDir(toolstoreDir, digest);
   const manifestPath = getBundleManifestPath(toolstoreDir, digest);
   return existsSync(bundleDir) && existsSync(manifestPath);
+}
+
+// ---------------------------------------------------------------------------
+// Symlink escape detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively scan a directory for symlinks that point outside of it.
+ *
+ * Returns an array of relative paths (from `rootDir`) of symlinks whose
+ * resolved target falls outside `rootDir`.
+ */
+function findEscapingSymlinks(rootDir: string): string[] {
+  const escaping: string[] = [];
+  const realRoot = realpathSync(rootDir);
+
+  function walk(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = lstatSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isSymbolicLink()) {
+        // Resolve the symlink target relative to its parent directory
+        const linkTarget = readlinkSync(fullPath);
+        const resolvedTarget = resolve(dir, linkTarget);
+        // Check if the resolved target is outside the root directory
+        if (!resolvedTarget.startsWith(realRoot + "/") && resolvedTarget !== realRoot) {
+          const relativePath = fullPath.slice(realRoot.length + 1);
+          escaping.push(relativePath);
+        }
+      } else if (stat.isDirectory()) {
+        walk(fullPath);
+      }
+    }
+  }
+
+  walk(realRoot);
+  return escaping;
 }


### PR DESCRIPTION
## Summary
- Rejects bundles with symlinks pointing outside the bundle directory during publish
- Uses realpathSync() in executor containment check to follow symlinks before verifying
- Adds tests for symlink escape attempts in both publish and execution paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
