### PR TITLE
fix: rename allow_thread to allow_conversation in CES contracts Zod enum

### DIFF
--- a/packages/ces-contracts/src/grants.ts
+++ b/packages/ces-contracts/src/grants.ts
@@ -91,12 +91,12 @@ export const TemporaryGrantDecisionSchema = z.object({
    * The type of grant to create. Determines persistence behaviour:
    * - `allow_once`: Temporary single-use grant (consumed after one use)
    * - `allow_10m`: Temporary timed grant (10-minute TTL)
-   * - `allow_thread`: Temporary thread-scoped grant (lives for session)
+   * - `allow_conversation`: Temporary conversation-scoped grant (lives for session)
    * - `always_allow`: Persistent grant (survives restart)
    *
    * When omitted, defaults to `always_allow` for backwards compatibility.
    */
-  grantType: z.enum(["allow_once", "allow_10m", "allow_thread", "always_allow"]).optional(),
+  grantType: z.enum(["allow_once", "allow_10m", "allow_conversation", "always_allow"]).optional(),
 });
 export type TemporaryGrantDecision = z.infer<
   typeof TemporaryGrantDecisionSchema


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-to-conversation-rename.md.

**Gap:** CES contracts Zod enum still has allow_thread
**What was expected:** allow_thread should be allow_conversation
**What was found:** packages/ces-contracts/src/grants.ts Zod enum rejects the new allow_conversation value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
