### PR TITLE
fix: wire OAuth token refresh callback into local CES materialiser

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -38,6 +38,7 @@ import { TemporaryGrantStore } from "./grants/temporary-store.js";
 import { LocalMaterialiser } from "./materializers/local.js";
 import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
 import { createLocalOAuthLookup } from "./materializers/local-oauth-lookup.js";
+import { createLocalTokenRefreshFn } from "./materializers/local-token-refresh.js";
 import { resolveLocalSubject } from "./subjects/local.js";
 import { checkCredentialPolicy } from "./subjects/policy.js";
 import {
@@ -125,6 +126,7 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
 
   const localMaterialiser = new LocalMaterialiser({
     secureKeyBackend,
+    tokenRefreshFn: createLocalTokenRefreshFn(vellumRoot, secureKeyBackend),
   });
 
   // -- Build handler registry ------------------------------------------------

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -1,15 +1,16 @@
 /**
- * CES-native read-only SecureKeyBackend for **local mode only**.
+ * CES-native SecureKeyBackend for **local mode only**.
  *
  * In local mode, CES runs as a child process of the assistant on the same
- * machine as the same user and can read the assistant's encrypted key store
- * file at `<vellumRoot>/protected/keys.enc`.
+ * machine as the same user and can read/write the assistant's encrypted key
+ * store file at `<vellumRoot>/protected/keys.enc`.
  *
- * This implementation replicates the decryption logic from the assistant's
- * `encrypted-store.ts` without importing assistant-internal modules. It is
- * intentionally **read-only** — CES never writes or deletes keys in the
- * assistant's key store. The `set` and `delete` methods return failure to
- * enforce this invariant.
+ * This implementation replicates the encryption/decryption logic from the
+ * assistant's `encrypted-store.ts` without importing assistant-internal
+ * modules. Writes are needed for OAuth token refresh — when CES refreshes
+ * an expired access token, the new token must be persisted back to the
+ * encrypted store so subsequent reads (by both CES and the assistant)
+ * see the updated value.
  *
  * The encrypted store uses AES-256-GCM with a key derived from machine-
  * specific entropy via PBKDF2. The derivation includes `userInfo().username`
@@ -24,12 +25,14 @@
  */
 
 import {
+  createCipheriv,
   createDecipheriv,
   pbkdf2Sync,
+  randomBytes,
 } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type {
   SecureKeyBackend,
@@ -42,6 +45,7 @@ import type {
 
 const ALGORITHM = "aes-256-gcm";
 const KEY_LENGTH = 32; // bytes (256 bits)
+const IV_LENGTH = 16; // bytes (128 bits)
 const AUTH_TAG_LENGTH = 16; // bytes
 const PBKDF2_ITERATIONS =
   process.env.BUN_TEST === "1" ? 1 : 100_000;
@@ -109,6 +113,37 @@ function decrypt(entry: EncryptedEntry, key: Buffer): string {
   return decrypted.toString("utf-8");
 }
 
+function encrypt(plaintext: string, key: Buffer): EncryptedEntry {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf-8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return {
+    iv: iv.toString("hex"),
+    tag: tag.toString("hex"),
+    data: encrypted.toString("hex"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store writer
+// ---------------------------------------------------------------------------
+
+function writeStore(store: StoreFile, storePath: string): void {
+  const protectedDir = dirname(storePath);
+  mkdirSync(protectedDir, { recursive: true });
+  // Atomic write: write to temp file then rename to avoid partial/corrupt writes.
+  const tmpPath = storePath + `.tmp.${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 });
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, storePath);
+}
+
 // ---------------------------------------------------------------------------
 // Store reader
 // ---------------------------------------------------------------------------
@@ -135,8 +170,11 @@ function readStore(storePath: string): StoreFile | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a read-only SecureKeyBackend that reads from the assistant's
- * encrypted key store.
+ * Create a SecureKeyBackend backed by the assistant's encrypted key store.
+ *
+ * Supports `get` and `set` operations. `set` is needed for persisting
+ * refreshed OAuth tokens. `delete` remains unsupported (returns "error")
+ * because CES never needs to remove keys.
  *
  * @param vellumRoot - The Vellum root directory (e.g. `~/.vellum`).
  * @param options.entropyOverride - If provided, used instead of local
@@ -144,8 +182,8 @@ function readStore(storePath: string): StoreFile | null {
  *   runs in a different container with a different hostname/user, so it
  *   must use the assistant's entropy (read from the shared data mount)
  *   to derive the same AES key.
- * @param options.entropyGetter - If provided, called on each `get()` to
- *   lazily resolve entropy. This handles the startup race where the
+ * @param options.entropyGetter - If provided, called on each `get()`/`set()`
+ *   to lazily resolve entropy. This handles the startup race where the
  *   entropy file may not exist at construction time but appears later.
  *   Takes precedence over `entropyOverride`.
  */
@@ -177,12 +215,23 @@ export function createLocalSecureKeyBackend(
       }
     },
 
-    // CES never writes to the assistant's key store — read-only backend.
-    async set(_key: string, _value: string): Promise<boolean> {
-      return false;
+    async set(key: string, value: string): Promise<boolean> {
+      try {
+        const store = readStore(storePath);
+        if (!store) return false;
+
+        const entropy = entropyGetter?.() ?? staticEntropy;
+        const salt = Buffer.from(store.salt, "hex");
+        const derivedKey = deriveKey(salt, entropy);
+        store.entries[key] = encrypt(value, derivedKey);
+        writeStore(store, storePath);
+        return true;
+      } catch {
+        return false;
+      }
     },
 
-    // CES never deletes from the assistant's key store — read-only backend.
+    // CES never deletes keys — only reads and writes (for token refresh).
     async delete(_key: string): Promise<SecureKeyDeleteResult> {
       return "error";
     },

--- a/credential-executor/src/materializers/local-token-refresh.ts
+++ b/credential-executor/src/materializers/local-token-refresh.ts
@@ -1,0 +1,263 @@
+/**
+ * OAuth token refresh implementation for CES local mode.
+ *
+ * Performs the actual OAuth2 token refresh by:
+ * 1. Looking up the connection's provider and app configuration from the
+ *    assistant's SQLite database (read-only).
+ * 2. Retrieving the client secret from the secure-key backend.
+ * 3. Calling the provider's token endpoint with the refresh token.
+ * 4. Returning a `TokenRefreshResult` for the `LocalMaterialiser` to persist.
+ *
+ * This module does NOT import any assistant-internal modules. It queries
+ * the SQLite database directly (like `local-oauth-lookup.ts`) and performs
+ * the HTTP refresh call inline (replicating the logic from the assistant's
+ * `security/oauth2.ts:refreshOAuth2Token`).
+ */
+
+import Database from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  computeExpiresAt,
+  oauthAppClientSecretPath,
+  type SecureKeyBackend,
+  type TokenRefreshResult,
+} from "@vellumai/credential-storage";
+
+import type { TokenRefreshFn } from "./local.js";
+
+// ---------------------------------------------------------------------------
+// SQLite row shapes (match assistant schema without importing Drizzle)
+// ---------------------------------------------------------------------------
+
+interface OAuthConnectionRow {
+  id: string;
+  oauth_app_id: string;
+  provider_key: string;
+}
+
+interface OAuthAppRow {
+  id: string;
+  provider_key: string;
+  client_id: string;
+  client_secret_credential_path: string;
+}
+
+interface OAuthProviderRow {
+  provider_key: string;
+  token_url: string;
+  token_endpoint_auth_method: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Token endpoint auth method (matches assistant/src/security/oauth2.ts)
+// ---------------------------------------------------------------------------
+
+type TokenEndpointAuthMethod = "client_secret_basic" | "client_secret_post";
+
+// ---------------------------------------------------------------------------
+// Refresh config resolution
+// ---------------------------------------------------------------------------
+
+interface RefreshConfig {
+  tokenUrl: string;
+  clientId: string;
+  clientSecret?: string;
+  authMethod: TokenEndpointAuthMethod;
+}
+
+/**
+ * Resolve the OAuth refresh configuration for a connection by querying
+ * the assistant's SQLite database (read-only) and the secure-key backend.
+ */
+async function resolveRefreshConfig(
+  dbPath: string,
+  connectionId: string,
+  secureKeyBackend: SecureKeyBackend,
+): Promise<RefreshConfig | { error: string }> {
+  if (!existsSync(dbPath)) {
+    return { error: `Database not found at ${dbPath}` };
+  }
+
+  let db: Database | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true });
+
+    // 1. Look up the connection to get oauth_app_id and provider_key
+    const conn = db
+      .query<OAuthConnectionRow, [string, string]>(
+        `SELECT id, oauth_app_id, provider_key FROM oauth_connections WHERE id = ? AND status = ? LIMIT 1`,
+      )
+      .get(connectionId, "active");
+
+    if (!conn) {
+      return { error: `No active OAuth connection found for "${connectionId}"` };
+    }
+
+    // 2. Look up the app to get client_id and client_secret_credential_path
+    const app = db
+      .query<OAuthAppRow, [string]>(
+        `SELECT id, provider_key, client_id, client_secret_credential_path FROM oauth_apps WHERE id = ? LIMIT 1`,
+      )
+      .get(conn.oauth_app_id);
+
+    if (!app) {
+      return { error: `No OAuth app found for connection "${connectionId}"` };
+    }
+
+    // 3. Look up the provider to get token_url and auth method
+    const provider = db
+      .query<OAuthProviderRow, [string]>(
+        `SELECT provider_key, token_url, token_endpoint_auth_method FROM oauth_providers WHERE provider_key = ? LIMIT 1`,
+      )
+      .get(conn.provider_key);
+
+    if (!provider) {
+      return { error: `No OAuth provider found for "${conn.provider_key}"` };
+    }
+
+    if (!provider.token_url || !app.client_id) {
+      return { error: `Missing OAuth2 refresh config for "${conn.provider_key}"` };
+    }
+
+    // 4. Retrieve the client secret from secure storage
+    const clientSecret = await secureKeyBackend.get(
+      app.client_secret_credential_path,
+    );
+
+    const authMethod = (provider.token_endpoint_auth_method as TokenEndpointAuthMethod | null) ?? "client_secret_post";
+
+    return {
+      tokenUrl: provider.token_url,
+      clientId: app.client_id,
+      clientSecret,
+      authMethod,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `Failed to resolve refresh config: ${msg}` };
+  } finally {
+    db?.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP token refresh (replicates assistant/src/security/oauth2.ts logic)
+// ---------------------------------------------------------------------------
+
+interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
+
+async function performTokenRefresh(
+  config: RefreshConfig,
+  refreshToken: string,
+): Promise<RefreshTokenResponse> {
+  const body: Record<string, string> = {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  };
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+
+  if (config.clientSecret && config.authMethod === "client_secret_basic") {
+    const credentials = Buffer.from(
+      `${config.clientId}:${config.clientSecret}`,
+    ).toString("base64");
+    headers["Authorization"] = `Basic ${credentials}`;
+  } else {
+    body.client_id = config.clientId;
+    if (config.clientSecret) {
+      body.client_secret = config.clientSecret;
+    }
+  }
+
+  const resp = await fetch(config.tokenUrl, {
+    method: "POST",
+    headers,
+    body: new URLSearchParams(body),
+  });
+
+  if (!resp.ok) {
+    const rawBody = await resp.text().catch(() => "");
+    let errorCode = "";
+    try {
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+      if (parsed.error) {
+        errorCode = String(parsed.error);
+      }
+    } catch {
+      // non-JSON response
+    }
+    const detail = errorCode
+      ? `HTTP ${resp.status}: ${errorCode}`
+      : `HTTP ${resp.status}`;
+    throw new Error(`OAuth2 token refresh failed (${detail})`);
+  }
+
+  const data = (await resp.json()) as Record<string, unknown>;
+
+  return {
+    accessToken: data.access_token as string,
+    refreshToken: (data.refresh_token as string | undefined) ?? refreshToken,
+    expiresIn: data.expires_in as number | undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a `TokenRefreshFn` for CES local mode.
+ *
+ * The returned function looks up OAuth configuration from the assistant's
+ * SQLite database (read-only) and performs the HTTP token refresh call.
+ * Token persistence is handled by the `LocalMaterialiser` after this
+ * function returns.
+ *
+ * @param vellumRoot - The Vellum root directory (e.g. `~/.vellum`).
+ * @param secureKeyBackend - Backend for retrieving the OAuth client secret.
+ */
+export function createLocalTokenRefreshFn(
+  vellumRoot: string,
+  secureKeyBackend: SecureKeyBackend,
+): TokenRefreshFn {
+  const dbPath = join(vellumRoot, "workspace", "data", "db", "assistant.db");
+
+  return async (
+    connectionId: string,
+    refreshToken: string,
+  ): Promise<TokenRefreshResult> => {
+    // 1. Resolve the refresh config from SQLite + secure storage
+    const config = await resolveRefreshConfig(
+      dbPath,
+      connectionId,
+      secureKeyBackend,
+    );
+
+    if ("error" in config) {
+      return { success: false, error: config.error };
+    }
+
+    // 2. Perform the HTTP token refresh
+    try {
+      const result = await performTokenRefresh(config, refreshToken);
+      const expiresAt = computeExpiresAt(result.expiresIn ?? null);
+
+      return {
+        success: true,
+        accessToken: result.accessToken,
+        expiresAt,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: message };
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Implements `tokenRefreshFn` for local CES that resolves OAuth provider/app config from SQLite (read-only) and performs the HTTP token refresh call
- Adds write support (`set` method) to the local secure key backend so refreshed tokens can be persisted back to the encrypted store
- Passes the refresh callback to `LocalMaterialiser` in `main.ts` so expired OAuth tokens with refresh tokens can now be refreshed in local CES mode

## Test plan
- [ ] Verify type-checking passes (only pre-existing zod/v4 errors in ces-contracts)
- [ ] Test OAuth token refresh flow with an expired token that has a refresh token
- [ ] Verify the encrypted store round-trips correctly (CES writes are readable by both CES and assistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
