### PR TITLE
fix: update threadType to conversationType in documentation files

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -688,7 +688,7 @@ graph LR
 
     subgraph "~/.vellum/workspace/data/db/assistant.db (SQLite + WAL)"
         direction TB
-        CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>thread_type: 'standard' | 'private'<br/>memory_scope_id: 'default' | 'private:&lt;uuid&gt;'"]
+        CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>conversation_type: 'standard' | 'private'<br/>memory_scope_id: 'default' | 'private:&lt;uuid&gt;'"]
         MSG["messages<br/>───────────────<br/>id, conversation_id (FK)<br/>role: user | assistant<br/>content: JSON array<br/>created_at"]
         TOOL["tool_invocations<br/>───────────────<br/>tool_name, input, result<br/>decision, risk_level<br/>duration_ms"]
         SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -312,16 +312,16 @@ When the embedding backend or Qdrant is unavailable:
 
 ## Private Threads — Isolated Memory and Strict Side-Effect Controls
 
-Private threads provide per-conversation memory isolation and stricter tool execution controls. When a conversation is created with `threadType: 'private'`, the daemon assigns it a unique memory scope and enforces additional safeguards to prevent unintended side effects.
+Private threads provide per-conversation memory isolation and stricter tool execution controls. When a conversation is created with `conversationType: 'private'`, the daemon assigns it a unique memory scope and enforces additional safeguards to prevent unintended side effects.
 
 ### Schema Columns
 
 Two columns on the `conversations` table drive the feature:
 
-| Column            | Type                               | Values                                                                   | Purpose                                                                                                                        |
-| ----------------- | ---------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `thread_type`     | `text NOT NULL DEFAULT 'standard'` | `'standard'` or `'private'`                                              | Determines whether the conversation uses shared or isolated memory and permission policies                                     |
-| `memory_scope_id` | `text NOT NULL DEFAULT 'default'`  | `'default'` for standard threads; `'private:<uuid>'` for private threads | Scopes all memory writes (items, segments) to this namespace; embeddings are isolated indirectly via their parent item/segment |
+| Column              | Type                               | Values                                                                   | Purpose                                                                                                                        |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `conversation_type` | `text NOT NULL DEFAULT 'standard'` | `'standard'` or `'private'`                                              | Determines whether the conversation uses shared or isolated memory and permission policies                                     |
+| `memory_scope_id`   | `text NOT NULL DEFAULT 'default'`  | `'default'` for standard threads; `'private:<uuid>'` for private threads | Scopes all memory writes (items, segments) to this namespace; embeddings are isolated indirectly via their parent item/segment |
 
 ### Memory Isolation
 
@@ -355,7 +355,7 @@ graph TB
 
 ### SessionMemoryPolicy
 
-The daemon derives a `SessionMemoryPolicy` from the conversation's `thread_type` and `memory_scope_id` when creating or restoring a session:
+The daemon derives a `SessionMemoryPolicy` from the conversation's `conversation_type` and `memory_scope_id` when creating or restoring a session:
 
 ```typescript
 interface SessionMemoryPolicy {
@@ -388,7 +388,7 @@ This ensures that file writes, bash commands, host operations, and other mutatin
 
 | File                                         | Role                                                                                       |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `assistant/src/memory/schema.ts`             | `conversations` table: `threadType` and `memoryScopeId` column definitions                 |
+| `assistant/src/memory/schema.ts`             | `conversations` table: `conversationType` and `memoryScopeId` column definitions           |
 | `assistant/src/daemon/session.ts`            | `SessionMemoryPolicy` interface and `DEFAULT_MEMORY_POLICY` constant                       |
 | `assistant/src/daemon/server.ts`             | `deriveMemoryPolicy()` — maps thread type to memory policy                                 |
 | `assistant/src/daemon/session-tool-setup.ts` | Propagates `memoryPolicy.strictSideEffects` as `forcePromptSideEffects` into `ToolContext` |

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -121,7 +121,7 @@ When the decision engine selects `reuse_existing` for a channel with a valid can
 
 ### New Conversation Path (`start_new` / default)
 
-- **`start_new_conversation`**: Creates a new conversation with `threadType: 'standard'` and `source: 'notification'`, plus an assistant message containing the conversation seed. Memory indexing is skipped on the seed message to prevent notification copy from polluting conversational recall. The result has `createdNewConversation: true`.
+- **`start_new_conversation`**: Creates a new conversation with `conversationType: 'standard'` and `source: 'notification'`, plus an assistant message containing the conversation seed. Memory indexing is skipped on the seed message to prevent notification copy from polluting conversational recall. The result has `createdNewConversation: true`.
 - **`continue_existing_conversation`**: Looks up a previously bound conversation by binding key (`sourceChannel` + `externalChatId` via `getBindingByChannelChat()`). When a valid bound conversation with `source: 'notification'` exists, the seed message is appended to it and the binding timestamp is refreshed. When no binding exists or the bound conversation is stale/invalid, a new conversation is created and the binding is upserted for future reuse. The result has `createdNewConversation: false` on reuse, `true` on fresh creation.
 - **`not_deliverable`**: Returns `{ conversationId: null, messageId: null }`.
 

--- a/assistant/src/tasks/SPEC.md
+++ b/assistant/src/tasks/SPEC.md
@@ -83,7 +83,7 @@ conversations (see `conversation-crud.ts`), extended to a new `task:` namespace.
 
 ## 3. Run Surface
 
-Each task run creates a new background conversation with `threadType: 'background'`.
+Each task run creates a new background conversation with `conversationType: 'background'`.
 
 ### Lifecycle
 
@@ -103,7 +103,7 @@ Each task run creates a new background conversation with `threadType: 'backgroun
    list (existing behavior in `conversation-crud.ts`). Clients can query for
    them explicitly to surface task results in a dedicated UI.
 
-**Why background conversations:** Reuses the existing `threadType: 'background'`
+**Why background conversations:** Reuses the existing `conversationType: 'background'`
 infrastructure. Task runs don't interrupt the user's current conversation, and
 clients can choose how and when to display results (toast, panel, separate
 tab).


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-to-conversation-rename.md.

**Gap:** threadType references remain in documentation
**What was expected:** All doc references should use conversationType
**What was found:** README.md and SPEC.md still reference threadType

Updates all threadType/thread_type references to conversationType/conversation_type in:
- assistant/src/notifications/README.md
- assistant/src/tasks/SPEC.md
- assistant/docs/architecture/memory.md
- assistant/ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
