### PR TITLE
fix: rename setThreadMode to setConversationMode in session-approval-overrides

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -155,12 +155,12 @@ In addition to persistent trust rules (`always_allow` / `always_deny`), the appr
 
 **Key source files:**
 
-| File                                        | Purpose                                                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `src/runtime/session-approval-overrides.ts` | In-memory store: `setThreadMode`, `setTimedMode`, `getEffectiveMode`, `clearMode`, `hasActiveOverride`, `clearAll` |
-| `src/permissions/types.ts`                  | `UserDecision` type (includes `allow_10m`, `allow_thread`, `temporary_override`), `isAllowDecision()` helper       |
-| `src/runtime/guardian-decision-types.ts`    | `buildDecisionActions()` — controls which temporary options appear in approval prompts                             |
-| `src/tools/permission-checker.ts`           | Permission pipeline integration — checks temporary overrides before prompting                                      |
+| File                                        | Purpose                                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/runtime/session-approval-overrides.ts` | In-memory store: `setConversationMode`, `setTimedMode`, `getEffectiveMode`, `clearMode`, `hasActiveOverride`, `clearAll` |
+| `src/permissions/types.ts`                  | `UserDecision` type (includes `allow_10m`, `allow_thread`, `temporary_override`), `isAllowDecision()` helper             |
+| `src/runtime/guardian-decision-types.ts`    | `buildDecisionActions()` — controls which temporary options appear in approval prompts                                   |
+| `src/tools/permission-checker.ts`           | Permission pipeline integration — checks temporary overrides before prompting                                            |
 
 ### Canonical Guardian Request System
 

--- a/assistant/src/__tests__/session-approval-overrides.test.ts
+++ b/assistant/src/__tests__/session-approval-overrides.test.ts
@@ -7,7 +7,7 @@ import {
   clearMode,
   getEffectiveMode,
   hasActiveOverride,
-  setThreadMode,
+  setConversationMode,
   setTimedMode,
 } from "../runtime/session-approval-overrides.js";
 
@@ -21,24 +21,24 @@ describe("session-approval-overrides", () => {
   });
 
   // -----------------------------------------------------------------------
-  // setThreadMode / getEffectiveMode
+  // setConversationMode / getEffectiveMode
   // -----------------------------------------------------------------------
-  describe("thread mode", () => {
-    test("setThreadMode stores a thread override", () => {
-      setThreadMode("conv-1");
+  describe("conversation mode", () => {
+    test("setConversationMode stores a conversation override", () => {
+      setConversationMode("conv-1");
       const mode = getEffectiveMode("conv-1");
       expect(mode).not.toBeUndefined();
-      expect(mode!.kind).toBe("thread");
+      expect(mode!.kind).toBe("conversation");
     });
 
-    test("thread mode persists across multiple reads", () => {
-      setThreadMode("conv-1");
+    test("conversation mode persists across multiple reads", () => {
+      setConversationMode("conv-1");
       expect(getEffectiveMode("conv-1")).not.toBeUndefined();
       expect(getEffectiveMode("conv-1")).not.toBeUndefined();
     });
 
-    test("thread mode is scoped to a specific conversationId", () => {
-      setThreadMode("conv-1");
+    test("conversation mode is scoped to a specific conversationId", () => {
+      setConversationMode("conv-1");
       expect(getEffectiveMode("conv-1")).not.toBeUndefined();
       expect(getEffectiveMode("conv-2")).toBeUndefined();
     });
@@ -102,8 +102,8 @@ describe("session-approval-overrides", () => {
   // Mode replacement
   // -----------------------------------------------------------------------
   describe("mode replacement", () => {
-    test("setTimedMode replaces an existing thread mode", () => {
-      setThreadMode("conv-1");
+    test("setTimedMode replaces an existing conversation mode", () => {
+      setConversationMode("conv-1");
       setTimedMode("conv-1", 60_000);
 
       const mode = getEffectiveMode("conv-1");
@@ -111,13 +111,13 @@ describe("session-approval-overrides", () => {
       expect(mode!.kind).toBe("timed");
     });
 
-    test("setThreadMode replaces an existing timed mode", () => {
+    test("setConversationMode replaces an existing timed mode", () => {
       setTimedMode("conv-1", 60_000);
-      setThreadMode("conv-1");
+      setConversationMode("conv-1");
 
       const mode = getEffectiveMode("conv-1");
       expect(mode).not.toBeUndefined();
-      expect(mode!.kind).toBe("thread");
+      expect(mode!.kind).toBe("conversation");
     });
   });
 
@@ -125,8 +125,8 @@ describe("session-approval-overrides", () => {
   // clearMode
   // -----------------------------------------------------------------------
   describe("clearMode", () => {
-    test("clearMode removes a thread override", () => {
-      setThreadMode("conv-1");
+    test("clearMode removes a conversation override", () => {
+      setConversationMode("conv-1");
       clearMode("conv-1");
       expect(getEffectiveMode("conv-1")).toBeUndefined();
     });
@@ -152,8 +152,8 @@ describe("session-approval-overrides", () => {
       expect(hasActiveOverride("conv-1")).toBe(false);
     });
 
-    test("returns true for active thread override", () => {
-      setThreadMode("conv-1");
+    test("returns true for active conversation override", () => {
+      setConversationMode("conv-1");
       expect(hasActiveOverride("conv-1")).toBe(true);
     });
 
@@ -169,7 +169,7 @@ describe("session-approval-overrides", () => {
     });
 
     test("returns false after clearMode", () => {
-      setThreadMode("conv-1");
+      setConversationMode("conv-1");
       clearMode("conv-1");
       expect(hasActiveOverride("conv-1")).toBe(false);
     });
@@ -180,9 +180,9 @@ describe("session-approval-overrides", () => {
   // -----------------------------------------------------------------------
   describe("clearAll", () => {
     test("clearAll removes all overrides", () => {
-      setThreadMode("conv-1");
+      setConversationMode("conv-1");
       setTimedMode("conv-2", 60_000);
-      setThreadMode("conv-3");
+      setConversationMode("conv-3");
 
       clearAll();
 

--- a/assistant/src/runtime/session-approval-overrides.ts
+++ b/assistant/src/runtime/session-approval-overrides.ts
@@ -13,7 +13,7 @@
  */
 
 export type TemporaryApprovalMode =
-  | { kind: "thread" }
+  | { kind: "conversation" }
   | { kind: "timed"; expiresAt: number };
 
 const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000; // 10 minutes
@@ -25,8 +25,8 @@ const store = new Map<string, TemporaryApprovalMode>();
  * Remains active until explicitly cleared or session ends.
  * Replaces any existing mode for the conversation.
  */
-export function setThreadMode(conversationId: string): void {
-  store.set(conversationId, { kind: "thread" });
+export function setConversationMode(conversationId: string): void {
+  store.set(conversationId, { kind: "conversation" });
 }
 
 /**

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -10,7 +10,7 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
 import {
   getEffectiveMode,
-  setThreadMode,
+  setConversationMode,
   setTimedMode,
 } from "../runtime/session-approval-overrides.js";
 import { getLogger } from "../util/logger.js";
@@ -412,7 +412,7 @@ export class PermissionChecker {
             "Activated timed (10m) temporary approval mode",
           );
         } else if (response.decision === "allow_conversation") {
-          setThreadMode(context.conversationId);
+          setConversationMode(context.conversationId);
           log.info(
             { toolName: name, conversationId: context.conversationId },
             "Activated conversation-scoped temporary approval mode",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-to-conversation-rename.md.

**Gap:** setThreadMode and kind: thread not renamed
**What was expected:** Should use Conversation terminology
**What was found:** session-approval-overrides.ts still uses Thread/thread terminology

- Renamed `setThreadMode()` to `setConversationMode()` in `session-approval-overrides.ts`
- Changed `kind: "thread"` to `kind: "conversation"` in the `TemporaryApprovalMode` type
- Updated the import and call site in `permission-checker.ts`
- Updated all test references in `session-approval-overrides.test.ts`
- Updated `ARCHITECTURE.md` function reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
