### PR TITLE
feat: pass ASSISTANT_API_KEY to CES sidecar via bootstrap handshake

### DIFF
--- a/assistant/src/credential-execution/client.ts
+++ b/assistant/src/credential-execution/client.ts
@@ -80,12 +80,24 @@ const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 // Client interface
 // ---------------------------------------------------------------------------
 
+export interface CesClientHandshakeOptions {
+  /**
+   * Optional assistant API key to pass to CES during the handshake.
+   * In managed (sidecar) mode the API key is provisioned after hatch,
+   * so the assistant forwards it here so CES can use it for platform
+   * credential materialisation without relying on env vars.
+   */
+  assistantApiKey?: string;
+}
+
 export interface CesClient {
   /**
    * Perform the handshake with CES. Must be called before any RPC calls.
    * Returns true if the handshake was accepted, false otherwise.
    */
-  handshake(): Promise<{ accepted: boolean; reason?: string }>;
+  handshake(
+    options?: CesClientHandshakeOptions,
+  ): Promise<{ accepted: boolean; reason?: string }>;
 
   /**
    * Send a typed RPC request and wait for the response.
@@ -185,7 +197,9 @@ export function createCesClient(
   // -------------------------------------------------------------------------
 
   return {
-    async handshake(): Promise<{ accepted: boolean; reason?: string }> {
+    async handshake(
+      options?: CesClientHandshakeOptions,
+    ): Promise<{ accepted: boolean; reason?: string }> {
       if (ready) return { accepted: true };
 
       const ackPromise = new Promise<HandshakeAck>((resolve, reject) => {
@@ -210,6 +224,9 @@ export function createCesClient(
           type: "handshake_request",
           protocolVersion: CES_PROTOCOL_VERSION,
           sessionId,
+          ...(options?.assistantApiKey
+            ? { assistantApiKey: options.assistantApiKey }
+            : {}),
         });
       } catch (err) {
         const entry = pending.get("handshake");

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -37,6 +37,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import {
   getFailoverProvider,
@@ -497,7 +498,16 @@ export class DaemonServer {
           }
           const client = createCesClient(transport);
           this.cesClientRef = client;
-          const { accepted, reason } = await client.handshake();
+          // Resolve the assistant API key so CES can use it for platform
+          // credential materialisation. In managed mode the key is provisioned
+          // after hatch and stored in the credential store — CES can't read
+          // the env var, so we pass it via the handshake.
+          const proxyCtx = await resolveManagedProxyContext();
+          const { accepted, reason } = await client.handshake(
+            proxyCtx.assistantApiKey
+              ? { assistantApiKey: proxyCtx.assistantApiKey }
+              : undefined,
+          );
           if (abortController.signal.aborted) {
             client.close();
             throw new Error("CES initialization aborted during shutdown");

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -86,7 +86,16 @@ function ensureDataDirs(): void {
 // Build RPC handler registry (managed mode)
 // ---------------------------------------------------------------------------
 
-function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
+/**
+ * Mutable reference to the assistant API key. Allows the handshake callback
+ * to inject the key provisioned at runtime (which arrives after handlers are
+ * built). Handlers read `.current` at call time, not at registration time.
+ */
+interface ApiKeyRef {
+  current: string;
+}
+
+function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHandlerRegistry {
   // -- Grant stores ----------------------------------------------------------
   const persistentGrantStore = new PersistentGrantStore(
     getCesGrantsDir("managed"),
@@ -101,26 +110,45 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
 
   // -- Managed credential options --------------------------------------------
   // In managed mode, credentials are obtained from the platform via its
-  // token-materialization endpoint. The platform URL, API key, and assistant
-  // ID are provided through environment variables set by the orchestration layer.
+  // token-materialization endpoint. The platform URL and assistant ID come
+  // from environment variables. The API key may come from the env var OR
+  // from the bootstrap handshake (the assistant forwards it after hatch).
+  // We use a lazy getter so the handshake-provided key takes effect even
+  // though handlers are built before the handshake completes.
   const platformBaseUrl = process.env["PLATFORM_BASE_URL"] ?? "";
-  const assistantApiKey = process.env["ASSISTANT_API_KEY"] ?? "";
   const assistantId = process.env["PLATFORM_ASSISTANT_ID"] ?? "";
 
-  const managedSubjectOptions: ManagedSubjectResolverOptions | undefined =
-    platformBaseUrl && assistantApiKey && assistantId
-      ? { platformBaseUrl, assistantApiKey, assistantId }
-      : undefined;
+  /**
+   * Resolve the current API key. Prefers the handshake-provided key
+   * (via apiKeyRef) over the env var, since in managed mode the env var
+   * may not be set (chicken-and-egg: key is provisioned after hatch).
+   */
+  const getAssistantApiKey = (): string =>
+    apiKeyRef.current || process.env["ASSISTANT_API_KEY"] || "";
 
-  const managedMaterializerOptions: ManagedMaterializerOptions | undefined =
-    platformBaseUrl && assistantApiKey && assistantId
-      ? { platformBaseUrl, assistantApiKey, assistantId }
+  /**
+   * Build managed options lazily at call time so the handshake-provided
+   * API key is available even though handlers are registered before
+   * the handshake completes.
+   */
+  const getManagedSubjectOptions = (): ManagedSubjectResolverOptions | undefined => {
+    const key = getAssistantApiKey();
+    return platformBaseUrl && key && assistantId
+      ? { platformBaseUrl, assistantApiKey: key, assistantId }
       : undefined;
+  };
 
-  if (!managedSubjectOptions) {
+  const getManagedMaterializerOptions = (): ManagedMaterializerOptions | undefined => {
+    const key = getAssistantApiKey();
+    return platformBaseUrl && key && assistantId
+      ? { platformBaseUrl, assistantApiKey: key, assistantId }
+      : undefined;
+  };
+
+  if (!platformBaseUrl || !assistantId) {
     warn(
-      "PLATFORM_BASE_URL, ASSISTANT_API_KEY, and/or PLATFORM_ASSISTANT_ID not set. " +
-        "Managed credential materialisation will not be available.",
+      "PLATFORM_BASE_URL and/or PLATFORM_ASSISTANT_ID not set. " +
+        "Managed credential materialisation will depend on the handshake-provided API key.",
     );
   }
 
@@ -154,18 +182,20 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
     oauthConnections: { getById: () => undefined },
   };
 
-  const handlers = buildHandlersWithHttp(
-    {
-      persistentGrantStore,
-      temporaryGrantStore,
-      localMaterialiser: localMaterialiserStub as any,
-      localSubjectDeps: localSubjectDepsStub,
-      managedSubjectOptions,
-      managedMaterializerOptions,
-      auditStore,
-      sessionId: sessionIdRef,
-    },
-  );
+  // Use a deps object with getters so the handshake-provided API key
+  // is resolved lazily at RPC call time (after the handshake completes).
+  const httpDeps = {
+    persistentGrantStore,
+    temporaryGrantStore,
+    localMaterialiser: localMaterialiserStub as any,
+    localSubjectDeps: localSubjectDepsStub,
+    get managedSubjectOptions() { return getManagedSubjectOptions(); },
+    get managedMaterializerOptions() { return getManagedMaterializerOptions(); },
+    auditStore,
+    sessionId: sessionIdRef,
+  };
+
+  const handlers = buildHandlersWithHttp(httpDeps);
 
   // Register run_authenticated_command handler with managed platform materializer
   registerCommandExecutionHandler(handlers, {
@@ -192,7 +222,9 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
 
           // -- Platform OAuth: materialise via the platform endpoint ----------
           case HandleType.PlatformOAuth: {
-            if (!managedMaterializerOptions) {
+            const matOpts = getManagedMaterializerOptions();
+            const subOpts = getManagedSubjectOptions();
+            if (!matOpts || !subOpts) {
               return {
                 ok: false as const,
                 error:
@@ -203,7 +235,7 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
 
             const subjectResult = await resolveManagedSubject(
               handle,
-              managedSubjectOptions!,
+              subOpts,
             );
             if (!subjectResult.ok) {
               return { ok: false as const, error: subjectResult.error.message };
@@ -211,7 +243,7 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
 
             const matResult = await materializeManagedToken(
               subjectResult.subject,
-              managedMaterializerOptions,
+              matOpts,
             );
             if (!matResult.ok) {
               return { ok: false as const, error: matResult.error.message };
@@ -491,10 +523,11 @@ async function main(): Promise<void> {
   rpcConnected = true;
 
   // Build the handler registry with all available RPC implementations.
-  // Use a mutable ref so audit records capture the handshake session ID
-  // once it's negotiated (the handshake completes before any RPC call).
+  // Use mutable refs so the handshake-provided session ID and API key
+  // are available to handlers at call time (after the handshake completes).
   const sessionIdRef: SessionIdRef = { current: `ces-managed-${Date.now()}` };
-  const handlers = buildHandlers(sessionIdRef);
+  const apiKeyRef: ApiKeyRef = { current: "" };
+  const handlers = buildHandlers(sessionIdRef, apiKeyRef);
 
   const server = new CesRpcServer({
     input: connection.readable,
@@ -509,8 +542,12 @@ async function main(): Promise<void> {
         process.stderr.write(`[ces-managed] ERROR: ${msg} ${args.map(String).join(" ")}\n`),
     },
     signal: controller.signal,
-    onHandshakeComplete: (hsSessionId) => {
+    onHandshakeComplete: (hsSessionId, hsApiKey) => {
       sessionIdRef.current = hsSessionId;
+      if (hsApiKey) {
+        apiKeyRef.current = hsApiKey;
+        log(`Received assistant API key via handshake`);
+      }
     },
   });
 

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -88,8 +88,8 @@ export interface CesServerOptions {
   logger?: Pick<Console, "log" | "warn" | "error">;
   /** Optional abort signal to shut down the server. */
   signal?: AbortSignal;
-  /** Callback invoked when the handshake completes with the negotiated session ID. */
-  onHandshakeComplete?: (sessionId: string) => void;
+  /** Callback invoked when the handshake completes with the negotiated session ID and optional API key. */
+  onHandshakeComplete?: (sessionId: string, assistantApiKey?: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +102,7 @@ export class CesRpcServer {
   private readonly handlers: RpcHandlerRegistry;
   private readonly logger: Pick<Console, "log" | "warn" | "error">;
   private readonly signal?: AbortSignal;
-  private readonly onHandshakeComplete?: (sessionId: string) => void;
+  private readonly onHandshakeComplete?: (sessionId: string, assistantApiKey?: string) => void;
 
   private handshakeComplete = false;
   private sessionId: string | null = null;
@@ -255,7 +255,7 @@ export class CesRpcServer {
       this.handshakeComplete = true;
       this.sessionId = req.sessionId;
       this.logger.log(`[ces-server] Handshake accepted for session ${req.sessionId}`);
-      this.onHandshakeComplete?.(req.sessionId);
+      this.onHandshakeComplete?.(req.sessionId, req.assistantApiKey);
     } else {
       this.logger.warn(
         `[ces-server] Handshake rejected: version mismatch (got ${req.protocolVersion}, expected ${CES_PROTOCOL_VERSION})`,

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -26,6 +26,13 @@ export const HandshakeRequestSchema = z.object({
   protocolVersion: z.string(),
   /** Opaque session identifier chosen by the initiator. */
   sessionId: z.string(),
+  /**
+   * Optional assistant API key passed from the assistant runtime.
+   * In managed (sidecar) mode the API key is provisioned after hatch,
+   * so the assistant forwards it during the bootstrap handshake so CES
+   * can use it for platform credential materialisation.
+   */
+  assistantApiKey: z.string().optional(),
 });
 export type HandshakeRequest = z.infer<typeof HandshakeRequestSchema>;
 


### PR DESCRIPTION
## Summary
- Extends CES handshake schema with optional `assistantApiKey` field
- Assistant resolves its API key from the credential store and includes it in the bootstrap handshake payload
- Managed CES sidecar extracts the key via `onHandshakeComplete` callback and stores it in a mutable ref
- Managed credential materialisation uses the handshake-provided key (falling back to `ASSISTANT_API_KEY` env var)
- Fixes chicken-and-egg problem: API key is provisioned after hatch but CES needs it at startup for credential materialisation

## Test plan
- [x] `bunx tsc --noEmit` passes in `credential-executor/`, `assistant/`
- [x] CES client tests pass (`credential-execution-client.test.ts`)
- [x] CES contracts tests pass (`contracts.test.ts`)
- [x] CES transport tests pass (`transport.test.ts`)
- [x] CES admin CLI tests pass (`credential-execution-admin-cli.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
