### PR TITLE
fix: rename allow_thread to allow_conversation in CES approval bridge

### DIFF
--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -50,7 +50,7 @@ export interface CesApprovalDecision {
   grantType:
     | "allow_once"
     | "allow_10m"
-    | "allow_thread"
+    | "allow_conversation"
     | "always_allow"
     | undefined;
   /** The original user decision from the confirmation transport. */
@@ -82,7 +82,7 @@ function mapUserDecisionToCesDecision(
       return {
         grantDecision: "approved",
         ttl: undefined,
-        grantType: "allow_thread",
+        grantType: "allow_conversation",
         userDecision: decision,
       };
     case "always_allow":


### PR DESCRIPTION
## Summary
- Rename `allow_thread` to `allow_conversation` in the `CesGrantDecision` type and the `allow_conversation` case mapping in `approval-bridge.ts`
- Aligns with the CES contracts schema which was already updated to use `allow_conversation`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115885822/job/67141201009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
