### PR TITLE
fix: rename allow_thread to allow_conversation in CES temporary grant store

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -252,7 +252,7 @@ function addTemporaryCommandGrant(
   credentialHandle: string,
   bundleDigest: string,
   profileName: string,
-  kind: "allow_once" | "allow_10m" | "allow_thread" = "allow_once",
+  kind: "allow_once" | "allow_10m" | "allow_conversation" = "allow_once",
   conversationId?: string,
   argv: string[] = [],
   purpose: string = "Test execution",

--- a/credential-executor/src/__tests__/grant-store.test.ts
+++ b/credential-executor/src/__tests__/grant-store.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  * - Persistent store: initialization, duplicate prevention by canonical grant
  *   hash, fail-closed behavior on corrupt/unreadable files.
- * - Temporary store: allow_once consumption, allow_10m expiry, allow_thread
+ * - Temporary store: allow_once consumption, allow_10m expiry, allow_conversation
  *   scoping by conversation ID, clearConversation cleanup.
  */
 
@@ -457,35 +457,35 @@ describe("TemporaryGrantStore", () => {
     });
   });
 
-  describe("allow_thread", () => {
+  describe("allow_conversation", () => {
     test("requires conversationId", () => {
-      expect(() => store.add("allow_thread", "hash-t", {})).toThrow(
+      expect(() => store.add("allow_conversation", "hash-t", {})).toThrow(
         /conversationId/,
       );
     });
 
     test("scoped to conversation ID", () => {
-      store.add("allow_thread", "hash-t", { conversationId: "conv-1" });
+      store.add("allow_conversation", "hash-t", { conversationId: "conv-1" });
 
-      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-1")).toBe(true);
       // Different conversation should not match
-      expect(store.check("allow_thread", "hash-t", "conv-2")).toBe(false);
+      expect(store.check("allow_conversation", "hash-t", "conv-2")).toBe(false);
     });
 
     test("same proposal hash in different conversations are independent", () => {
-      store.add("allow_thread", "hash-t", { conversationId: "conv-a" });
-      store.add("allow_thread", "hash-t", { conversationId: "conv-b" });
+      store.add("allow_conversation", "hash-t", { conversationId: "conv-a" });
+      store.add("allow_conversation", "hash-t", { conversationId: "conv-b" });
 
-      expect(store.check("allow_thread", "hash-t", "conv-a")).toBe(true);
-      expect(store.check("allow_thread", "hash-t", "conv-b")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-a")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-b")).toBe(true);
     });
 
-    test("not consumed on check (persists within thread)", () => {
-      store.add("allow_thread", "hash-t", { conversationId: "conv-1" });
+    test("not consumed on check (persists within conversation)", () => {
+      store.add("allow_conversation", "hash-t", { conversationId: "conv-1" });
 
-      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
-      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
-      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_conversation", "hash-t", "conv-1")).toBe(true);
     });
   });
 
@@ -502,9 +502,9 @@ describe("TemporaryGrantStore", () => {
       expect(store.checkAny("hash-any-t")).toBe("allow_10m");
     });
 
-    test("finds allow_thread grant with conversationId", () => {
-      store.add("allow_thread", "hash-any-th", { conversationId: "conv-x" });
-      expect(store.checkAny("hash-any-th", "conv-x")).toBe("allow_thread");
+    test("finds allow_conversation grant with conversationId", () => {
+      store.add("allow_conversation", "hash-any-th", { conversationId: "conv-x" });
+      expect(store.checkAny("hash-any-th", "conv-x")).toBe("allow_conversation");
     });
 
     test("returns undefined when no grants match", () => {
@@ -532,28 +532,28 @@ describe("TemporaryGrantStore", () => {
   });
 
   describe("clearConversation", () => {
-    test("removes all thread grants for a conversation", () => {
-      store.add("allow_thread", "hash-1", { conversationId: "conv-clear" });
-      store.add("allow_thread", "hash-2", { conversationId: "conv-clear" });
-      store.add("allow_thread", "hash-3", { conversationId: "conv-keep" });
+    test("removes all conversation grants for a conversation", () => {
+      store.add("allow_conversation", "hash-1", { conversationId: "conv-clear" });
+      store.add("allow_conversation", "hash-2", { conversationId: "conv-clear" });
+      store.add("allow_conversation", "hash-3", { conversationId: "conv-keep" });
 
       store.clearConversation("conv-clear");
 
-      expect(store.check("allow_thread", "hash-1", "conv-clear")).toBe(false);
-      expect(store.check("allow_thread", "hash-2", "conv-clear")).toBe(false);
+      expect(store.check("allow_conversation", "hash-1", "conv-clear")).toBe(false);
+      expect(store.check("allow_conversation", "hash-2", "conv-clear")).toBe(false);
       // Other conversation unaffected
-      expect(store.check("allow_thread", "hash-3", "conv-keep")).toBe(true);
+      expect(store.check("allow_conversation", "hash-3", "conv-keep")).toBe(true);
     });
 
-    test("does not affect non-thread grants", () => {
-      store.add("allow_once", "hash-non-thread");
-      store.add("allow_10m", "hash-non-thread-t");
+    test("does not affect non-conversation grants", () => {
+      store.add("allow_once", "hash-non-conv");
+      store.add("allow_10m", "hash-non-conv-t");
 
       store.clearConversation("any-conv");
 
-      // Non-thread grants unaffected
-      expect(store.check("allow_once", "hash-non-thread")).toBe(true);
-      expect(store.check("allow_10m", "hash-non-thread-t")).toBe(true);
+      // Non-conversation grants unaffected
+      expect(store.check("allow_once", "hash-non-conv")).toBe(true);
+      expect(store.check("allow_10m", "hash-non-conv-t")).toBe(true);
     });
   });
 
@@ -561,7 +561,7 @@ describe("TemporaryGrantStore", () => {
     test("removes all grants", () => {
       store.add("allow_once", "h1");
       store.add("allow_10m", "h2");
-      store.add("allow_thread", "h3", { conversationId: "c1" });
+      store.add("allow_conversation", "h3", { conversationId: "c1" });
 
       store.clear();
       expect(store.size).toBe(0);
@@ -572,7 +572,7 @@ describe("TemporaryGrantStore", () => {
     test("grants do not survive new store instance", () => {
       store.add("allow_once", "hash-restart");
       store.add("allow_10m", "hash-restart-t");
-      store.add("allow_thread", "hash-restart-th", {
+      store.add("allow_conversation", "hash-restart-th", {
         conversationId: "conv-r",
       });
 

--- a/credential-executor/src/grants/index.ts
+++ b/credential-executor/src/grants/index.ts
@@ -7,7 +7,7 @@
  * - **Persistent store**: Durable grants (e.g. `always_allow`) persisted
  *   to `grants.json` inside the CES-private data root. Survives restarts.
  * - **Temporary store**: Ephemeral grants (`allow_once`, `allow_10m`,
- *   `allow_thread`) held in memory. Never survives a process restart.
+ *   `allow_conversation`) held in memory. Never survives a process restart.
  */
 
 export { PersistentGrantStore } from "./persistent-store.js";

--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -105,7 +105,7 @@ export function createRecordGrantHandler(
 
     // Only `always_allow` creates a persistent grant. All other approved
     // decisions create only a temporary grant — this prevents allow_once,
-    // allow_10m, and allow_thread from becoming effectively permanent.
+    // allow_10m, and allow_conversation from becoming effectively permanent.
     if (grantType === "always_allow") {
       let pattern: string;
       if (proposal.type === "http") {
@@ -133,8 +133,8 @@ export function createRecordGrantHandler(
     // the next policy check hits the persistent store.
     if (grantType === "allow_10m") {
       deps.temporaryGrantStore.add("allow_10m", decision.proposalHash);
-    } else if (grantType === "allow_thread") {
-      deps.temporaryGrantStore.add("allow_thread", decision.proposalHash, {
+    } else if (grantType === "allow_conversation") {
+      deps.temporaryGrantStore.add("allow_conversation", decision.proposalHash, {
         conversationId: request.conversationId ?? sessionId,
       });
     } else {

--- a/credential-executor/src/grants/temporary-store.ts
+++ b/credential-executor/src/grants/temporary-store.ts
@@ -1,7 +1,7 @@
 /**
  * CES in-memory temporary grant store.
  *
- * Manages grants for `allow_once`, `allow_10m`, and `allow_thread` decisions.
+ * Manages grants for `allow_once`, `allow_10m`, and `allow_conversation` decisions.
  * All state is in-memory — temporary grants never survive a process restart,
  * which is the desired behaviour for ephemeral approvals.
  *
@@ -9,22 +9,22 @@
  * - `allow_once`: Keyed by proposal hash. Consumed (deleted) on first use.
  * - `allow_10m`: Keyed by proposal hash. Checked for expiry on every read;
  *   expired entries are lazily purged.
- * - `allow_thread`: Keyed by proposal hash + conversation ID. Scoped to a
- *   single conversation thread.
+ * - `allow_conversation`: Keyed by proposal hash + conversation ID. Scoped to a
+ *   single conversation.
  */
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type TemporaryGrantKind = "allow_once" | "allow_10m" | "allow_thread";
+export type TemporaryGrantKind = "allow_once" | "allow_10m" | "allow_conversation";
 
 export interface TemporaryGrant {
   /** The kind of temporary grant. */
   kind: TemporaryGrantKind;
   /** Canonical proposal hash identifying the operation being granted. */
   proposalHash: string;
-  /** Conversation ID — required for `allow_thread`, ignored otherwise. */
+  /** Conversation ID — required for `allow_conversation`, ignored otherwise. */
   conversationId?: string;
   /** When the grant was created (epoch ms). */
   createdAt: number;
@@ -43,20 +43,20 @@ const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000;
  * Compute the storage key for a temporary grant.
  *
  * - `allow_once` / `allow_10m`: keyed by proposal hash alone.
- * - `allow_thread`: keyed by proposal hash + conversation ID.
+ * - `allow_conversation`: keyed by proposal hash + conversation ID.
  */
 function storageKey(
   kind: TemporaryGrantKind,
   proposalHash: string,
   conversationId?: string,
 ): string {
-  if (kind === "allow_thread") {
+  if (kind === "allow_conversation") {
     if (!conversationId) {
       throw new Error(
-        "allow_thread grants require a conversationId",
+        "allow_conversation grants require a conversationId",
       );
     }
-    return `thread:${conversationId}:${proposalHash}`;
+    return `conversation:${conversationId}:${proposalHash}`;
   }
   return `${kind}:${proposalHash}`;
 }
@@ -76,7 +76,7 @@ export class TemporaryGrantStore {
    *
    * @param kind - The type of temporary grant.
    * @param proposalHash - Canonical hash of the operation proposal.
-   * @param options - Additional options (conversationId for thread grants,
+   * @param options - Additional options (conversationId for conversation grants,
    *   custom duration for timed grants).
    */
   add(
@@ -115,7 +115,7 @@ export class TemporaryGrantStore {
    * - `allow_once`: Returns `true` and **consumes** the grant (deletes it).
    * - `allow_10m`: Returns `true` only if the grant has not expired.
    *   Expired grants are lazily purged.
-   * - `allow_thread`: Returns `true` only if a grant exists for the given
+   * - `allow_conversation`: Returns `true` only if a grant exists for the given
    *   proposal hash scoped to the specified conversation ID.
    *
    * Returns `false` if no matching grant exists.
@@ -149,7 +149,7 @@ export class TemporaryGrantStore {
       return true;
     }
 
-    // allow_thread — no expiry, just existence check
+    // allow_conversation — no expiry, just existence check
     return true;
   }
 
@@ -157,7 +157,7 @@ export class TemporaryGrantStore {
    * Check whether any kind of active temporary grant exists for the given
    * proposal hash and optional conversation ID.
    *
-   * Checks `allow_once`, `allow_10m`, and `allow_thread` in order.
+   * Checks `allow_once`, `allow_10m`, and `allow_conversation` in order.
    * Returns the kind of the matched grant, or `undefined` if none match.
    *
    * Note: If an `allow_once` grant matches, it is consumed.
@@ -172,9 +172,9 @@ export class TemporaryGrantStore {
     // Check allow_10m
     if (this.check("allow_10m", proposalHash)) return "allow_10m";
 
-    // Check allow_thread (requires conversationId)
-    if (conversationId && this.check("allow_thread", proposalHash, conversationId)) {
-      return "allow_thread";
+    // Check allow_conversation (requires conversationId)
+    if (conversationId && this.check("allow_conversation", proposalHash, conversationId)) {
+      return "allow_conversation";
     }
 
     return undefined;
@@ -197,11 +197,11 @@ export class TemporaryGrantStore {
   /**
    * Remove all temporary grants for a given conversation ID.
    *
-   * Useful when a conversation/thread ends. Only removes `allow_thread`
+   * Useful when a conversation ends. Only removes `allow_conversation`
    * grants scoped to that conversation.
    */
   clearConversation(conversationId: string): void {
-    const prefix = `thread:${conversationId}:`;
+    const prefix = `conversation:${conversationId}:`;
     for (const key of this.store.keys()) {
       if (key.startsWith(prefix)) {
         this.store.delete(key);


### PR DESCRIPTION
## Summary
- Renamed `allow_thread` to `allow_conversation` in `credential-executor/src/grants/temporary-store.ts`, `rpc-handlers.ts`, `index.ts`, and associated tests to match the updated `ces-contracts` schema
- Updated internal storage key prefix from `thread:` to `conversation:` for consistency
- Fixes TypeScript error: `types '"allow_once" | "allow_conversation" | "always_allow"' and '"allow_thread"' have no overlap`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115885762/job/67141200891

🤖 Generated with [Claude Code](https://claude.com/claude-code)