### PR TITLE
fix: unique script content in CES tests to avoid digest collisions

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -1588,7 +1588,7 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
     const { digest } = publishTestBundle(
       manifest,
       "local",
-      '#!/bin/sh\necho "should not run"\n',
+      '#!/bin/sh\necho "denied-binary-test"\n',
     );
 
     // Patch the published manifest to contain the denied helperCommand.
@@ -1652,7 +1652,7 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
     const { digest } = publishTestBundle(
       manifest,
       "local",
-      '#!/bin/sh\necho "should not run"\n',
+      '#!/bin/sh\necho "metacharacter-test"\n',
     );
 
     // Patch the published manifest to contain shell metacharacters.
@@ -1720,7 +1720,7 @@ describe("executeAuthenticatedCommand — symlink escape prevention", () => {
     const { digest } = publishTestBundle(
       manifest,
       "local",
-      '#!/bin/sh\necho "should not run"\n',
+      '#!/bin/sh\necho "symlink-escape-test"\n',
     );
 
     // Tamper: replace the real entrypoint with a symlink to an external binary


### PR DESCRIPTION
## Summary
- The path traversal, credential_process defense-in-depth, and symlink escape tests all used identical script content, producing the same bundle digest
- `publishBundle` deduplicates by digest, so whichever test ran first would tamper the manifest and pollute subsequent tests with a `../../usr/bin/git` entrypoint
- Fixed by giving each test group unique script content so their archives produce distinct digests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23115976806/job/67141435838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
