### PR TITLE
fix: rename threadTitle to conversationTitle in GuardianCopy interface

### DIFF
--- a/assistant/src/__tests__/guardian-question-copy.test.ts
+++ b/assistant/src/__tests__/guardian-question-copy.test.ts
@@ -3,19 +3,21 @@ import { describe, expect, test } from "bun:test";
 import { buildFallbackCopy } from "../calls/guardian-question-copy.js";
 
 describe("buildFallbackCopy", () => {
-  test("threadTitle starts with warning emoji", () => {
+  test("conversationTitle starts with warning emoji", () => {
     const result = buildFallbackCopy("What is the gate code?");
-    expect(result.threadTitle.startsWith("\u26A0\uFE0F")).toBe(true);
+    expect(result.conversationTitle.startsWith("\u26A0\uFE0F")).toBe(true);
   });
 
-  test('threadTitle does not start with "Guardian question:"', () => {
+  test('conversationTitle does not start with "Guardian question:"', () => {
     const result = buildFallbackCopy("What is the gate code?");
-    expect(result.threadTitle.startsWith("Guardian question:")).toBe(false);
+    expect(result.conversationTitle.startsWith("Guardian question:")).toBe(
+      false,
+    );
   });
 
-  test("threadTitle is under 80 characters for reasonable input", () => {
+  test("conversationTitle is under 80 characters for reasonable input", () => {
     const result = buildFallbackCopy("What is the gate code?");
-    expect(result.threadTitle.length).toBeLessThan(80);
+    expect(result.conversationTitle.length).toBeLessThan(80);
   });
 
   test("initialMessage contains the question text", () => {
@@ -35,12 +37,12 @@ describe("buildFallbackCopy", () => {
 
     // Title should use questionText.slice(0, 70), so the question portion is at most 70 chars
     // Plus the emoji prefix and space, should still be well under 80
-    expect(result.threadTitle.length).toBeLessThanOrEqual(
+    expect(result.conversationTitle.length).toBeLessThanOrEqual(
       "\u26A0\uFE0F ".length + 70,
     );
 
     // The full question should NOT appear in the title
-    expect(result.threadTitle).not.toContain(longQuestion);
+    expect(result.conversationTitle).not.toContain(longQuestion);
 
     // But the full question should still appear in the initial message
     expect(result.initialMessage).toContain(longQuestion);

--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -20,7 +20,7 @@ const log = getLogger("guardian-question-copy");
 const GENERATION_TIMEOUT_MS = 5_000;
 
 export interface GuardianCopy {
-  threadTitle: string;
+  conversationTitle: string;
   initialMessage: string;
 }
 
@@ -29,7 +29,7 @@ export interface GuardianCopy {
  */
 export function buildFallbackCopy(questionText: string): GuardianCopy {
   return {
-    threadTitle: `\u26A0\uFE0F ${questionText.slice(0, 70)}`,
+    conversationTitle: `\u26A0\uFE0F ${questionText.slice(0, 70)}`,
     initialMessage: [
       "Your assistant needs your input during a phone call.",
       "",
@@ -134,5 +134,5 @@ function parseGeneratedCopy(text: string): GuardianCopy | null {
     return null;
   }
 
-  return { threadTitle: title, initialMessage: message };
+  return { conversationTitle: title, initialMessage: message };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-to-conversation-rename.md.

**Gap:** GuardianCopy.threadTitle not renamed
**What was expected:** Should use conversationTitle
**What was found:** guardian-question-copy.ts still uses threadTitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
