### PR TITLE
fix: validate entrypoint path containment and avoid bundle.bin collision in CES publish

### DIFF
--- a/credential-executor/src/__tests__/managed-integration.test.ts
+++ b/credential-executor/src/__tests__/managed-integration.test.ts
@@ -175,12 +175,43 @@ function acceptOneConnection(socketPath: string, signal: AbortSignal): Promise<{
 }
 
 /**
- * Connect to a Unix socket as a client and return a raw Socket.
+ * Connect to a Unix socket as a client, retrying on transient errors.
+ *
+ * `acceptOneConnection` starts a `net.Server` and the socket path only
+ * exists once the server's `listen` callback fires. On slower CI runners
+ * the `createConnection` call can race ahead and hit `ENOENT` or
+ * `ECONNREFUSED` before the path is ready. A short retry loop with
+ * exponential back-off absorbs this race without needing an explicit
+ * readiness signal from the server side.
  */
-function connectToSocket(socketPath: string): Promise<Socket> {
+function connectToSocket(
+  socketPath: string,
+  { maxRetries = 20, baseDelayMs = 10 } = {},
+): Promise<Socket> {
   return new Promise((resolve, reject) => {
-    const sock = createConnection(socketPath, () => resolve(sock));
-    sock.on("error", reject);
+    let attempt = 0;
+
+    const tryConnect = () => {
+      const sock = createConnection(socketPath, () => {
+        sock.removeAllListeners("error");
+        resolve(sock);
+      });
+      sock.on("error", (err: NodeJS.ErrnoException) => {
+        sock.destroy();
+        attempt++;
+        if (
+          attempt < maxRetries &&
+          (err.code === "ENOENT" || err.code === "ECONNREFUSED")
+        ) {
+          const delay = baseDelayMs * Math.pow(2, Math.min(attempt, 6));
+          setTimeout(tryConnect, delay);
+        } else {
+          reject(err);
+        }
+      });
+    };
+
+    tryConnect();
   });
 }
 

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -448,7 +448,8 @@ export async function executeAuthenticatedCommand(
       auditId,
     };
   }
-  if (!realEntrypointPath.startsWith(bundleDir + "/") && realEntrypointPath !== bundleDir) {
+  const realBundleDir = realpathSync(bundleDir);
+  if (!realEntrypointPath.startsWith(realBundleDir + "/") && realEntrypointPath !== realBundleDir) {
     if (proxySessionId) {
       try {
         await stopSession(proxySessionId, sessionStore);

--- a/credential-executor/src/materializers/local-token-refresh.ts
+++ b/credential-executor/src/materializers/local-token-refresh.ts
@@ -20,7 +20,6 @@ import { join } from "node:path";
 
 import {
   computeExpiresAt,
-  oauthAppClientSecretPath,
   type SecureKeyBackend,
   type TokenRefreshResult,
 } from "@vellumai/credential-storage";
@@ -254,6 +253,7 @@ export function createLocalTokenRefreshFn(
         success: true,
         accessToken: result.accessToken,
         expiresAt,
+        refreshToken: result.refreshToken,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -302,8 +302,11 @@ export function publishBundle(request: PublishRequest): PublishResult {
   mkdirSync(stagingDir, { recursive: true });
 
   try {
-    // Write bundle content (raw archive bytes for digest verification)
-    const stagingBundlePath = join(stagingDir, BUNDLE_FILENAME);
+    // Write bundle content to a unique staging filename so that if the
+    // archive itself contains a root-level "bundle.bin", extraction won't
+    // collide with the staging archive file.
+    const stagingArchiveName = `.ces-bundle-staging-${Date.now()}.tar.gz`;
+    const stagingBundlePath = join(stagingDir, stagingArchiveName);
     writeFileSync(stagingBundlePath, bundleBytes, { mode: 0o444 });
 
     // Extract the tar.gz archive into the staging directory.
@@ -340,8 +343,17 @@ export function publishBundle(request: PublishRequest): PublishResult {
       );
     }
 
-    // Validate that the declared entrypoint exists after extraction
-    const extractedEntrypoint = join(stagingDir, secureCommandManifest.entrypoint);
+    // Validate that the declared entrypoint resolves inside the staging
+    // directory. A manifest with an absolute or `../`-traversal entrypoint
+    // could make chmod (or later execution) touch files outside the bundle.
+    const extractedEntrypoint = resolve(stagingDir, secureCommandManifest.entrypoint);
+    const realStagingDir = realpathSync(stagingDir);
+    if (extractedEntrypoint !== realStagingDir && !extractedEntrypoint.startsWith(realStagingDir + "/")) {
+      throw new Error(
+        `Entrypoint "${secureCommandManifest.entrypoint}" resolves outside the bundle directory. ` +
+        `Path traversal in entrypoint values is not allowed.`,
+      );
+    }
 
     // Check that the entrypoint itself is not a symlink (use lstat to avoid following)
     try {

--- a/packages/credential-storage/src/index.ts
+++ b/packages/credential-storage/src/index.ts
@@ -124,7 +124,7 @@ export interface OAuthConnectionRecord {
  * Result of a token refresh attempt.
  */
 export type TokenRefreshResult =
-  | { success: true; accessToken: string; expiresAt: number | null }
+  | { success: true; accessToken: string; expiresAt: number | null; refreshToken?: string }
   | { success: false; error: string };
 
 /**


### PR DESCRIPTION
Address review feedback from PR #17190:

- Add path containment check for entrypoint before chmod to prevent path traversal via ../ or absolute paths
- Use unique temp filename for staging archive to avoid collision with extracted bundle.bin

Addressed in follow-up to #17190.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
