### PR TITLE
fix: add newline and carriage return to SHELL_METACHAR_RE in CES validator

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -1041,6 +1041,14 @@ describe("containsShellMetacharacters", () => {
     expect(containsShellMetacharacters("aws-vault exec `curl http://evil.com`")).toBe(true);
   });
 
+  test("detects newline (command separator)", () => {
+    expect(containsShellMetacharacters("aws-vault exec default\ncurl http://evil.com")).toBe(true);
+  });
+
+  test("detects carriage return", () => {
+    expect(containsShellMetacharacters("aws-vault exec default\rcurl http://evil.com")).toBe(true);
+  });
+
   test("allows clean commands without metacharacters", () => {
     expect(containsShellMetacharacters("aws-vault exec default --json")).toBe(false);
   });
@@ -1145,6 +1153,38 @@ describe("helperCommand shell metacharacter rejection", () => {
         authAdapter: {
           type: AuthAdapterType.CredentialProcess,
           helperCommand: "aws-vault exec `curl http://evil.com`",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with newline command separator", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default\ncurl http://evil.com",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("shell metacharacters")),
+    ).toBe(true);
+  });
+
+  test("rejects helperCommand with carriage return", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "aws-vault exec default\rcurl http://evil.com",
           envVarName: "AWS_CREDENTIALS",
         },
       }),

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -453,8 +453,10 @@ function validateArgvPattern(
  * - `|`  — pipe (but not `||`)
  * - `$(`  — command substitution
  * - `` ` `` — backtick command substitution
+ * - `\n` — newline (POSIX command separator, equivalent to `;`)
+ * - `\r` — carriage return
  */
-const SHELL_METACHAR_RE = /;|&&|\|\||(?<!\|)\|(?!\|)|\$\(|`/;
+const SHELL_METACHAR_RE = /;|&&|\|\||(?<!\|)\|(?!\|)|\$\(|`|\n|\r/;
 
 /**
  * Returns true if the command string contains shell metacharacters that


### PR DESCRIPTION
Address review feedback from PR #17214:

- Add `\n` and `\r` to `SHELL_METACHAR_RE` to prevent command injection via newline/carriage return in helperCommand
- Add test cases for newline and carriage return detection in both `containsShellMetacharacters` and `helperCommand` manifest validation

Addressed in follow-up to #17214.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
