### PR TITLE
fix: rename allow_thread to allow_conversation in Swift client code

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -477,7 +477,7 @@ final class VoiceModeManager: ObservableObject {
     enum PermissionDecision {
         case allow
         case allowTenMinutes
-        case allowThread
+        case allowConversation
         case alwaysAllow
         case denied
         case ambiguous
@@ -487,7 +487,7 @@ final class VoiceModeManager: ObservableObject {
             switch self {
             case .allow: return "allow"
             case .allowTenMinutes: return "allow_10m"
-            case .allowThread: return "allow_thread"
+            case .allowConversation: return "allow_conversation"
             case .alwaysAllow: return "always_allow"
             case .denied: return "deny"
             case .ambiguous: return "deny"
@@ -510,10 +510,10 @@ final class VoiceModeManager: ObservableObject {
             return .allowTenMinutes
         }
 
-        // "allow for this thread" / "this thread" / "for the thread"
-        let threadPatterns = ["this thread", "the thread", "for thread", "allow thread"]
-        if threadPatterns.contains(where: { lower.contains($0) }) && !hasNegative {
-            return .allowThread
+        // "allow for this conversation" / "this conversation" / "for the conversation"
+        let conversationPatterns = ["this conversation", "the conversation", "for conversation", "allow conversation"]
+        if conversationPatterns.contains(where: { lower.contains($0) }) && !hasNegative {
+            return .allowConversation
         }
 
         // "always allow" / "always approve"
@@ -544,7 +544,7 @@ final class VoiceModeManager: ObservableObject {
         }
 
         switch decision {
-        case .allow, .allowTenMinutes, .allowThread, .alwaysAllow:
+        case .allow, .allowTenMinutes, .allowConversation, .alwaysAllow:
             log.info("Voice mode: permissions \(decision.decisionString, privacy: .public) via voice")
             for requestId in pendingPermissionIds {
                 chatViewModel.respondToConfirmation(requestId: requestId, decision: decision.decisionString)
@@ -564,7 +564,7 @@ final class VoiceModeManager: ObservableObject {
             log.info("Voice mode: unclear permission response — \(text, privacy: .public)")
             state = .speaking
             voiceService.resetStreamingTTS()
-            voiceService.feedTextDelta("Sorry, I didn't quite catch that. You can say yes, no, allow for 10 minutes, allow for this thread, or always allow.")
+            voiceService.feedTextDelta("Sorry, I didn't quite catch that. You can say yes, no, allow for 10 minutes, allow for this conversation, or always allow.")
             voiceService.finishTextStream { [weak self] in
                 guard let self else { return }
                 self.voiceService.stopBargeInMonitor()

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -42,12 +42,12 @@ public struct ToolConfirmationData: Equatable {
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
-    /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_thread").
+    /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_conversation").
     public let temporaryOptionsAvailable: [String]
     /// The tool_use block ID for client-side correlation with specific tool calls.
     public let toolUseId: String?
     public var state: ToolConfirmationState = .pending
-    /// The decision string that was used to approve (e.g. "allow", "allow_10m", "allow_thread", "always_allow").
+    /// The decision string that was used to approve (e.g. "allow", "allow_10m", "allow_conversation", "always_allow").
     /// Set when the state transitions to `.approved`.
     public var approvedDecision: String?
     /// When set, `toolCategory` returns this instead of deriving from `toolName`.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2222,7 +2222,7 @@ public final class ChatViewModel: ObservableObject {
         }
         // Send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
-            let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_thread"
+            let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_conversation"
             messages[index].confirmation?.state = isApproval ? .approved : .denied
             if isApproval {
                 messages[index].confirmation?.approvedDecision = decision
@@ -2272,7 +2272,7 @@ public final class ChatViewModel: ObservableObject {
     public func updateConfirmationState(requestId: String, decision: String) {
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             switch decision {
-            case "allow", "allow_10m", "allow_thread":
+            case "allow", "allow_10m", "allow_conversation":
                 messages[index].confirmation?.state = .approved
                 messages[index].confirmation?.approvedDecision = decision
             case "deny":

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -57,8 +57,8 @@ public struct ToolConfirmationBubble: View {
         confirmation.temporaryOptionsAvailable.contains("allow_10m")
     }
 
-    private var hasAllowThread: Bool {
-        confirmation.temporaryOptionsAvailable.contains("allow_thread")
+    private var hasAllowConversation: Bool {
+        confirmation.temporaryOptionsAvailable.contains("allow_conversation")
     }
 
     /// The decision value to send when "Always Allow" is clicked.
@@ -81,8 +81,8 @@ public struct ToolConfirmationBubble: View {
             switch confirmation.approvedDecision {
             case "allow_10m":
                 return "\(confirmation.toolCategory) allowed for 10 minutes"
-            case "allow_thread":
-                return "\(confirmation.toolCategory) allowed for this thread"
+            case "allow_conversation":
+                return "\(confirmation.toolCategory) allowed for this conversation"
             default:
                 return "\(confirmation.toolCategory) allowed"
             }
@@ -346,7 +346,7 @@ public struct ToolConfirmationBubble: View {
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
         if hasAllow10m { actions.append(.allow10m) }
-        if hasAllowThread { actions.append(.allowThread) }
+        if hasAllowConversation { actions.append(.allowConversation) }
         actions.append(.allowOnce)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
@@ -356,7 +356,7 @@ public struct ToolConfirmationBubble: View {
     }
 
     private var hasTemporaryOptions: Bool {
-        hasAllow10m || hasAllowThread
+        hasAllow10m || hasAllowConversation
     }
 
     @ViewBuilder
@@ -378,13 +378,13 @@ public struct ToolConfirmationBubble: View {
                                 isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
                             ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
                         }
-                        if hasAllowThread {
+                        if hasAllowConversation {
                             confirmationButton(
-                                "Allow for this thread",
+                                "Allow for this conversation",
                                 isPrimary: true,
                                 isDanger: false,
-                                isKeyboardSelected: keyboardModel?.selectedAction == .allowThread
-                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_thread") }
+                                isKeyboardSelected: keyboardModel?.selectedAction == .allowConversation
+                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_conversation") }
                         }
                     }
                 }
@@ -631,8 +631,8 @@ public struct ToolConfirmationBubble: View {
             onAllow()
         case .allow10m:
             onTemporaryAllow?(confirmation.requestId, "allow_10m")
-        case .allowThread:
-            onTemporaryAllow?(confirmation.requestId, "allow_thread")
+        case .allowConversation:
+            onTemporaryAllow?(confirmation.requestId, "allow_conversation")
         case .alwaysAllow:
             if confirmation.allowlistOptions.count > 1 {
                 withAnimation(VAnimation.fast) {

--- a/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationKeyboardModel.swift
@@ -11,7 +11,7 @@ struct ToolConfirmationKeyboardModel {
     enum Action: Equatable {
         case allowOnce
         case allow10m
-        case allowThread
+        case allowConversation
         case alwaysAllow
         case dontAllow
     }


### PR DESCRIPTION
## Summary
- Update all Swift client string literals from `allow_thread` to `allow_conversation` to match the daemon's `UserDecision` type
- Rename Swift identifiers (`allowThread` → `allowConversation`, `hasAllowThread` → `hasAllowConversation`)
- Update user-facing labels: "Allow for this thread" → "Allow for this conversation"
- Update voice recognition patterns to match "conversation" instead of "thread"

Completes the rename started in #17224 (approval bridge) and #17225 (CES grant store).

Addressed in follow-up to #17224.

## Test plan
- [ ] Verify tool confirmation bubble shows "Allow for this conversation" button
- [ ] Verify collapsed label shows "allowed for this conversation"
- [ ] Verify voice mode recognizes "allow for this conversation"
- [ ] Verify confirmation responses send `allow_conversation` to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
