### PR TITLE
fix: document health endpoint mock limitations in managed CES test

### DIFF
--- a/credential-executor/src/__tests__/managed-integration.test.ts
+++ b/credential-executor/src/__tests__/managed-integration.test.ts
@@ -328,6 +328,23 @@ describe("managed CES integration (real Unix socket)", () => {
     controller = new AbortController();
 
     // -- Start health server ---------------------------------------------------
+    // NOTE: This uses a local Bun.serve mock rather than the production
+    // `startHealthServer()` from managed-main.ts. The production function is
+    // not exported and depends on module-level mutable state (the
+    // `rpcConnected` flag) that cannot be controlled from tests.
+    //
+    // What this covers:
+    //   - The health endpoint contract (/healthz, /readyz response shapes)
+    //     that Kubernetes probes and the assistant runtime depend on.
+    //   - End-to-end socket + RPC + health plumbing in one integration flow.
+    //
+    // What this does NOT cover:
+    //   - The actual `startHealthServer()` implementation in managed-main.ts,
+    //     including the `rpcConnected` field in the /readyz response. If the
+    //     production health handler drifts (changes routes, status codes, or
+    //     response shape), this test will not catch it. To close that gap,
+    //     extract `startHealthServer` into an importable module so this test
+    //     can exercise the real code path.
     healthServer = Bun.serve({
       port: healthPort,
       fetch(req) {


### PR DESCRIPTION
## Summary
- Add detailed comment documenting why the health endpoint test uses a local Bun.serve mock rather than the production `startHealthServer()` from `managed-main.ts`
- Explains what the mock covers (endpoint contract, response shapes) vs what it doesn't cover (production implementation, `rpcConnected` field drift)
- The socket readiness retry was already addressed in #17230

Addressed in follow-up to #17216.

## Test plan
- [ ] Verify comment is present and accurate
- [ ] No functional changes — comment-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
