### PR TITLE
fix: prevent single-use socket test timeout on slow CI

### DIFF
--- a/credential-executor/src/__tests__/managed-integration.test.ts
+++ b/credential-executor/src/__tests__/managed-integration.test.ts
@@ -601,9 +601,11 @@ describe("managed CES integration (real Unix socket)", () => {
     const conn = await connectionPromise;
 
     // Socket file should be unlinked after the first connection,
-    // so a second connection attempt should fail
+    // so a second connection attempt should fail.
+    // Use maxRetries: 0 so the ENOENT rejects immediately instead of
+    // retrying for ~10 s (which exceeds the 5 s test timeout on slow CI).
     await expect(
-      connectToSocket(socketPath),
+      connectToSocket(socketPath, { maxRetries: 0 }),
     ).rejects.toThrow();
 
     // Clean up


### PR DESCRIPTION
## Summary
- The "socket is single-use" integration test was timing out on CI because `connectToSocket` retries `ENOENT` errors up to 20 times with exponential backoff (~10s total), exceeding the 5s test timeout
- Pass `maxRetries: 0` to the second `connectToSocket` call so the expected `ENOENT` rejects immediately instead of retrying

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23116173321/job/67141958410

🤖 Generated with [Claude Code](https://claude.com/claude-code)