### PR TITLE
feat: include assistant_id in telemetry usage payload

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -20,6 +20,7 @@ import {
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getInstallationId } from "../runtime/auth/installation-id.js";
 import { getLogger } from "../util/logger.js";
 
@@ -130,6 +131,7 @@ export class UsageTelemetryReporter {
       // Build payload
       const payload = {
         installation_id: getInstallationId(),
+        assistant_id: getExternalAssistantId(),
         events: events.map((e) => ({
           daemon_event_id: e.id,
           provider: e.provider,


### PR DESCRIPTION
## Summary
- Adds `assistant_id` (the human-readable assistant name like "vellum-true-eel") to the telemetry usage payload alongside `installation_id`
- Uses the existing `getExternalAssistantId()` resolver which reads from the lockfile and caches in memory

## Original prompt
In `assistant/src/telemetry/usage-telemetry-reporter.ts`:

1. Add import for `getExternalAssistantId` from `../runtime/auth/external-assistant-id.js` (next to the existing `getInstallationId` import on line 23).

2. Add `assistant_id: getExternalAssistantId()` to the payload object at line 132, right after the `installation_id` field.

That's it — two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
