### PR TITLE
feat: forward skill files state and methods through SkillsManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -13,6 +13,9 @@ final class SkillsManager: ObservableObject {
     @Published var isLoading = false
     @Published var uninstallResult: SkillsStore.UninstallResult?
     @Published var isUninstalling = false
+    @Published var selectedSkillFiles: SkillDetailFilesHTTPResponse?
+    @Published var isLoadingSkillFiles = false
+    @Published var skillFilesError: String?
 
     // Kept for source compatibility with existing macOS views.
     typealias UninstallResult = SkillsStore.UninstallResult
@@ -29,6 +32,9 @@ final class SkillsManager: ObservableObject {
         skillsStore.$isLoading.assign(to: &$isLoading)
         skillsStore.$uninstallResult.assign(to: &$uninstallResult)
         skillsStore.$isUninstalling.assign(to: &$isUninstalling)
+        skillsStore.$selectedSkillFiles.assign(to: &$selectedSkillFiles)
+        skillsStore.$isLoadingSkillFiles.assign(to: &$isLoadingSkillFiles)
+        skillsStore.$skillFilesError.assign(to: &$skillFilesError)
     }
 
     // MARK: - Delegated Operations
@@ -43,5 +49,13 @@ final class SkillsManager: ObservableObject {
 
     func uninstallSkill(id: String) {
         skillsStore.uninstallSkill(id: id)
+    }
+
+    func fetchSkillFiles(skillId: String) {
+        skillsStore.fetchSkillFiles(skillId: skillId)
+    }
+
+    func clearSkillDetail() {
+        skillsStore.clearSkillDetail()
     }
 }


### PR DESCRIPTION
## Summary
- Add published properties for selectedSkillFiles, isLoadingSkillFiles, skillFilesError to SkillsManager
- Bind all three to SkillsStore via Combine
- Add delegated fetchSkillFiles(skillId:) and clearSkillDetail() methods

Part of plan: skill-detail-view.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
