### PR TITLE
fix: unregister secure command tool also deletes bundle from toolstore

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -55,7 +55,7 @@ import {
   type RpcHandlerRegistry,
   type SessionIdRef,
 } from "./server.js";
-import { publishBundle } from "./toolstore/publish.js";
+import { deleteBundleFromToolstore, publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
 import { buildCesEgressHooks } from "./commands/egress-hooks.js";
 
@@ -227,7 +227,12 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
     },
     publishBundle: (request) => publishBundle({ ...request, cesMode: "local" }),
     unregisterTool: (toolName: string) => {
-      return toolRegistry.delete(toolName);
+      const entry = toolRegistry.get(toolName);
+      const removed = toolRegistry.delete(toolName);
+      if (removed && entry?.bundleDigest) {
+        deleteBundleFromToolstore(entry.bundleDigest, "local");
+      }
+      return removed;
     },
     registerTool: (entry) => {
       toolRegistry.set(entry.toolName, entry);

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -49,7 +49,7 @@ import {
   type RpcHandlerRegistry,
   type SessionIdRef,
 } from "./server.js";
-import { publishBundle } from "./toolstore/publish.js";
+import { deleteBundleFromToolstore, publishBundle } from "./toolstore/publish.js";
 import { validateSourceUrl } from "./toolstore/manifest.js";
 import { buildCesEgressHooks } from "./commands/egress-hooks.js";
 import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "./subjects/managed.js";
@@ -309,7 +309,12 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
     },
     publishBundle: (request) => publishBundle({ ...request, cesMode: "managed" }),
     unregisterTool: (toolName: string) => {
-      return toolRegistry.delete(toolName);
+      const entry = toolRegistry.get(toolName);
+      const removed = toolRegistry.delete(toolName);
+      if (removed && entry?.bundleDigest) {
+        deleteBundleFromToolstore(entry.bundleDigest, "managed");
+      }
+      return removed;
     },
     registerTool: (entry) => {
       toolRegistry.set(entry.toolName, entry);

--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -472,6 +472,36 @@ export function readPublishedManifest(
 }
 
 /**
+ * Delete a published bundle from the toolstore by digest.
+ *
+ * Removes the entire content-addressed directory for the given digest.
+ * Returns true if the directory existed and was deleted, false if it
+ * did not exist (or the digest was invalid).
+ *
+ * This is used during tool unregistration to ensure that a previously
+ * published bundle cannot be executed after the tool is removed from
+ * the in-memory registry.
+ */
+export function deleteBundleFromToolstore(
+  digest: string,
+  cesMode?: CesMode,
+): boolean {
+  if (!isValidSha256Hex(digest)) {
+    return false;
+  }
+
+  const toolstoreDir = getCesToolStoreDir(cesMode);
+  const bundleDir = getBundleDir(toolstoreDir, digest);
+
+  if (!existsSync(bundleDir)) {
+    return false;
+  }
+
+  rmSync(bundleDir, { recursive: true, force: true });
+  return true;
+}
+
+/**
  * Check if a bundle with the given digest is published in the toolstore.
  *
  * Returns false if the digest is not a valid SHA-256 hex string.


### PR DESCRIPTION
## Summary
- Unregistering a secure command tool now deletes the bundle from the toolstore filesystem, not just the in-memory registry.
- Previously, a bundle remained published on disk after unregister and could still be executed via bundleDigest/profileName.
- Adds `deleteBundleFromToolstore()` helper to `toolstore/publish.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
