### PR TITLE
fix: clean up run_authenticated_command schema to match manifest-driven contract

### DIFF
--- a/assistant/src/__tests__/credential-execution-tools.test.ts
+++ b/assistant/src/__tests__/credential-execution-tools.test.ts
@@ -38,7 +38,6 @@ describe("CES tool schema shapes", () => {
     expect(schema.required).toContain("command");
     expect(schema.required).toContain("purpose");
     // Should include optional fields
-    expect(schema.properties).toHaveProperty("envMappings");
     expect(schema.properties).toHaveProperty("cwd");
     expect(schema.properties).toHaveProperty("grantId");
   });

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -40,17 +40,13 @@ class RunAuthenticatedCommandTool implements Tool {
           },
           command: {
             type: "string",
-            description: "The command to execute.",
-          },
-          envMappings: {
-            type: "object",
-            additionalProperties: { type: "string" },
             description:
-              "Optional mapping of environment variable names to credential field paths for injection.",
+              "Secure command reference in format '<bundleDigest>/<profileName> [argv...]'. Only manifest-driven secure commands are supported.",
           },
           cwd: {
             type: "string",
-            description: "Optional working directory for command execution.",
+            description:
+              "Optional path used for resolving workspace input/output staging, not as the actual execution working directory (CES always runs commands in the scratch directory).",
           },
           purpose: {
             type: "string",
@@ -129,7 +125,6 @@ class RunAuthenticatedCommandTool implements Tool {
     const credentialHandle = input.credentialHandle as string;
     const command = input.command as string;
     const purpose = input.purpose as string;
-    const envMappings = input.envMappings as Record<string, string> | undefined;
     const cwd = input.cwd as string | undefined;
     const inputs = input.inputs as Array<{ workspacePath: string }> | undefined;
     const outputs = input.outputs as
@@ -142,7 +137,6 @@ class RunAuthenticatedCommandTool implements Tool {
         credentialHandle,
         command,
         purpose,
-        ...(envMappings ? { envMappings } : {}),
         ...(cwd ? { cwd } : {}),
         ...(inputs ? { inputs } : {}),
         ...(outputs ? { outputs } : {}),

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -121,11 +121,9 @@ const WorkspaceOutputSchema = z.object({
 export const RunAuthenticatedCommandSchema = z.object({
   /** CES credential handle to use for environment injection. */
   credentialHandle: z.string(),
-  /** The command to execute. */
+  /** Secure command reference in format '<bundleDigest>/<profileName> [argv...]'. Only manifest-driven secure commands are supported. */
   command: z.string(),
-  /** Optional environment variable name mappings for credential injection. */
-  envMappings: z.record(z.string(), z.string()).optional(),
-  /** Optional working directory. */
+  /** Optional path used for resolving workspace input/output staging, not as the actual execution working directory (CES always runs commands in the scratch directory). */
   cwd: z.string().optional(),
   /** Workspace files to stage as read-only inputs in the CES scratch directory. */
   inputs: z.array(WorkspaceInputSchema).optional(),


### PR DESCRIPTION
## Summary
- Updates command description to specify the bundleDigest/profileName format.
- Removes dead envMappings parameter (was silently dropped by CES).
- Clarifies cwd description to explain its role in workspace IO resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)