### PR TITLE
fix: surface local_oauth handles in CLI output and system prompt

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -1,3 +1,4 @@
+import { localOAuthHandle } from "@vellumai/ces-contracts/handles";
 import type { Command } from "commander";
 
 import {
@@ -90,6 +91,7 @@ function formatConnectionRow(row: ReturnType<typeof getConnection>) {
   const parsed = row.metadata ? JSON.parse(row.metadata) : null;
   return {
     ...row,
+    handle: localOAuthHandle(row.providerKey, row.id),
     grantedScopes: row.grantedScopes ? JSON.parse(row.grantedScopes) : [],
     metadata: parsed ? redactMetadata(parsed) : null,
     hasRefreshToken: row.hasRefreshToken === 1,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -851,7 +851,7 @@ export function buildCliReferenceSection(): string {
     "   - `assistant credentials list` — lists local credentials with their service:field identifiers",
     "   - `assistant oauth connections list` — lists OAuth connections with provider keys",
     "   - `assistant credentials list --search <query>` — filter by service, field, or description",
-    "   For local credentials, construct the CES handle as `local_static:<service>/<field>` from the listed identifiers. Platform-managed entries include a `handle` field directly.",
+    "   For local credentials, construct the CES handle as `local_static:<service>/<field>` from the listed identifiers. For local OAuth connections, the handle is `local_oauth:<providerKey>/<connectionId>` (shown in the `handle` field of `assistant oauth connections list`). Platform-managed entries use `platform_oauth:<connectionId>` handles, also shown in their `handle` field.",
     "",
     "2. **Use CES tools** with the handle to perform authenticated work:",
     "   - `make_authenticated_request` — authenticated HTTP requests (API calls, webhooks). CES injects the credential and returns the response; the assistant never sees raw secrets.",


### PR DESCRIPTION
## Summary
- Adds synthesized handle field to local OAuth connections in CLI list output.
- Updates system prompt to teach all three CES handle formats (local_static, local_oauth, platform_oauth).
- Makes handle discovery consistent between local and managed connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
