### PR TITLE
fix: accept 'thread' as voice approval synonym for backward compatibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -511,7 +511,9 @@ final class VoiceModeManager: ObservableObject {
         }
 
         // "allow for this conversation" / "this conversation" / "for the conversation"
-        let conversationPatterns = ["this conversation", "the conversation", "for conversation", "allow conversation"]
+        // Also accept "thread" as a legacy synonym for backward compatibility.
+        let conversationPatterns = ["this conversation", "the conversation", "for conversation", "allow conversation",
+                                    "this thread", "the thread", "for thread", "allow thread"]
         if conversationPatterns.contains(where: { lower.contains($0) }) && !hasNegative {
             return .allowConversation
         }


### PR DESCRIPTION
Address review feedback from PR #17234:

- Add "thread" as a legacy synonym for "conversation" in voice approval pattern matching so utterances like "allow for this thread" correctly map to `allowConversation` instead of falling through to the generic `allow` path.
- Documentation already uses `allow_conversation` — no doc changes needed.

Follow-up to #17234.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
