### PR TITLE
fix: restrict denied-binary checks to executable argv positions only

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -507,6 +507,35 @@ describe("validateManifest", () => {
     expect(result.valid).toBe(true);
   });
 
+  test("allows denied binary names in non-executable argv positions", () => {
+    // Names like "https", "exec", "http" overlap with DENIED_BINARIES but
+    // are valid argument values when not in the first (executable) position.
+    const result = validateManifest(
+      buildManifest({
+        commandProfiles: {
+          "connect": {
+            description: "Connect with scheme",
+            allowedArgvPatterns: [
+              {
+                name: "connect-https",
+                tokens: ["connect", "--scheme", "https"],
+              },
+              {
+                name: "run-mode",
+                tokens: ["run", "--mode", "exec", "<target>"],
+              },
+            ],
+            deniedSubcommands: [],
+            allowedNetworkTargets: [
+              { hostPattern: "example.com", protocols: ["https"] },
+            ],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
   // -- Auth adapter validation -----------------------------------------------
 
   test("rejects auth adapter with empty envVarName", () => {

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -433,15 +433,17 @@ function validateArgvPattern(
     }
   }
 
-  // Literal tokens must not match denied binaries — prevents smuggling
-  // denied operations through multi-call umbrella binaries (e.g. busybox wget)
-  for (const token of pattern.tokens) {
-    if (!isPlaceholder(token) && !isRestPlaceholder(token) && isDeniedBinary(token)) {
-      errors.push(
-        `${profilePrefix}: argv pattern "${pattern.name}" token "${token}" matches a denied binary. ` +
-          `Multi-call umbrella binaries and shell trampolines cannot appear in argv patterns.`,
-      );
-    }
+  // Only check denied binaries in executable positions — the first token
+  // (index 0) is the subcommand position for multi-call umbrella binaries
+  // (e.g. busybox wget). Tokens at other positions are argument values and
+  // may legitimately use names that overlap with denied binaries (e.g.
+  // "--scheme https" where "https" is an httpie alias in DENIED_BINARIES).
+  const firstToken = pattern.tokens[0];
+  if (firstToken && !isPlaceholder(firstToken) && !isRestPlaceholder(firstToken) && isDeniedBinary(firstToken)) {
+    errors.push(
+      `${profilePrefix}: argv pattern "${pattern.name}" token "${firstToken}" matches a denied binary. ` +
+        `Multi-call umbrella binaries and shell trampolines cannot appear in executable argv positions.`,
+    );
   }
 
   return errors;


### PR DESCRIPTION
Address review feedback from PR #17240:

- Only check isDeniedBinary on tokens in executable positions (first element, index 0) instead of all literal tokens
- Prevents false-positive rejections for manifests using denied binary names as argument values (e.g., '--scheme https', '--mode exec')
- Add test covering denied binary names in non-executable positions

Follow-up to #17240.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
