### PR TITLE
fix: resolve SSE event tagging, dead code, unread endpoint, and JSDoc for conversation keys

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -33,7 +33,6 @@ import { HostFileProxy } from "../host-file-proxy.js";
 import type {
   ConfirmationResponse,
   DeleteQueuedMessage,
-  RegenerateRequest,
   ReorderConversationsRequest,
   SecretResponse,
   ServerMessage,
@@ -45,10 +44,6 @@ import type {
 } from "../message-protocol.js";
 import { normalizeConversationType } from "../message-protocol.js";
 import type { Session } from "../session.js";
-import {
-  buildSessionErrorMessage,
-  classifySessionError,
-} from "../session-error.js";
 import {
   type HandlerContext,
   log,
@@ -542,39 +537,6 @@ export async function regenerateResponse(
     throw err;
   }
   return { requestId };
-}
-
-export async function handleRegenerate(
-  msg: RegenerateRequest,
-  ctx: HandlerContext,
-): Promise<void> {
-  if (!getConversation(msg.sessionId)) {
-    ctx.send({ type: "error", message: "No active session" });
-    return;
-  }
-  const session = await ctx.getOrCreateSession(msg.sessionId);
-
-  const regenerateChannel =
-    parseChannelId(session.getTurnChannelContext()?.assistantMessageChannel) ??
-    "vellum";
-  const sendEvent = makeEventSender({
-    ctx,
-    session,
-    conversationId: msg.sessionId,
-    sourceChannel: regenerateChannel,
-  });
-
-  try {
-    await regenerateResponse(msg.sessionId, ctx, sendEvent);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    ctx.send({
-      type: "error",
-      message: `Failed to regenerate: ${message}`,
-    });
-    const classified = classifySessionError(err, { phase: "regenerate" });
-    ctx.send(buildSessionErrorMessage(msg.sessionId, classified));
-  }
 }
 
 export function handleUsageRequest(

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,6 +32,7 @@ import {
   getMessages,
   purgePrivateConversations,
 } from "../memory/conversation-crud.js";
+import { resolveConversationId } from "../memory/conversation-key-store.js";
 import { initializeDb } from "../memory/db.js";
 import {
   selectEmbeddingBackend,
@@ -577,12 +578,15 @@ export async function runDaemon(): Promise<void> {
         undoLastMessage: (sessionId) =>
           undoLastMessage(sessionId, server.getHandlerContext()),
         regenerateResponse: (sessionId) => {
+          // Resolve conversation key up front so SSE events are tagged with
+          // the internal conversation ID, not the raw client key.
+          const resolvedId = resolveConversationId(sessionId) ?? sessionId;
           let hubChain: Promise<void> = Promise.resolve();
           const sendEvent = (event: ServerMessage) => {
             const ae = buildAssistantEvent(
               DAEMON_INTERNAL_ASSISTANT_ID,
               event,
-              sessionId,
+              resolvedId,
             );
             hubChain = (async () => {
               await hubChain;

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -94,13 +94,6 @@ export function setConversationKeyIfAbsent(
 }
 
 /**
- * Get or create a conversation for the given conversationKey.
- *
- * If a mapping already exists, returns the existing conversation ID.
- * Otherwise, creates a new conversation and mapping atomically within a
- * single transaction to prevent race conditions and orphaned rows.
- */
-/**
  * Resolve a value that may be either a conversation ID or a conversation key
  * to the daemon's internal conversation ID.
  *
@@ -128,6 +121,13 @@ export function resolveConversationId(idOrKey: string): string | null {
   return mapping?.conversationId ?? null;
 }
 
+/**
+ * Get or create a conversation for the given conversationKey.
+ *
+ * If a mapping already exists, returns the existing conversation ID.
+ * Otherwise, creates a new conversation and mapping atomically within a
+ * single transaction to prevent race conditions and orphaned rows.
+ */
 export function getOrCreateConversation(
   conversationKey: string,
   opts?: { conversationType?: "standard" | "private" },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -937,9 +937,16 @@ export class RuntimeHttpServer {
         method: "POST",
         handler: async ({ req }) => {
           const body = (await req.json()) as Record<string, unknown>;
-          const conversationId = body.conversationId as string | undefined;
-          if (!conversationId)
+          const rawConversationId = body.conversationId as string | undefined;
+          if (!rawConversationId)
             return httpError("BAD_REQUEST", "Missing conversationId", 400);
+          const conversationId = resolveConversationId(rawConversationId);
+          if (!conversationId)
+            return httpError(
+              "NOT_FOUND",
+              `Unknown conversation: ${rawConversationId}`,
+              404,
+            );
           try {
             markConversationUnread(conversationId);
             return Response.json({ ok: true });


### PR DESCRIPTION
Address review feedback from PR #17229:

- Resolve conversation key to internal ID in lifecycle.ts SSE event tagging for regenerate
- Remove dead code handleRegenerate function from sessions.ts
- Add resolveConversationId to conversations/unread endpoint in http-server.ts
- Fix stale JSDoc attribution in conversation-key-store.ts

Follow-up to #17229.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
