### PR TITLE
fix: only delete bundle from toolstore when no other tools reference the same digest

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -230,7 +230,10 @@ function buildHandlers(sessionIdRef: SessionIdRef): RpcHandlerRegistry {
       const entry = toolRegistry.get(toolName);
       const removed = toolRegistry.delete(toolName);
       if (removed && entry?.bundleDigest) {
-        deleteBundleFromToolstore(entry.bundleDigest, "local");
+        const stillInUse = Array.from(toolRegistry.values()).some(t => t.bundleDigest === entry.bundleDigest);
+        if (!stillInUse) {
+          deleteBundleFromToolstore(entry.bundleDigest, "local");
+        }
       }
       return removed;
     },

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -312,7 +312,10 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
       const entry = toolRegistry.get(toolName);
       const removed = toolRegistry.delete(toolName);
       if (removed && entry?.bundleDigest) {
-        deleteBundleFromToolstore(entry.bundleDigest, "managed");
+        const stillInUse = Array.from(toolRegistry.values()).some(t => t.bundleDigest === entry.bundleDigest);
+        if (!stillInUse) {
+          deleteBundleFromToolstore(entry.bundleDigest, "managed");
+        }
       }
       return removed;
     },


### PR DESCRIPTION
Address review feedback from PR #17250: add reference counting before deleting a bundle on tool unregistration. Multiple tools can share a bundleDigest, so we now check if any remaining registry entry references the same digest before removing it from disk. Applied to both local (main.ts) and managed (managed-main.ts) CES modes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
