### PR TITLE
fix: mock conversation-key-store in unread route test

### DIFF
--- a/assistant/src/__tests__/conversation-unread-route.test.ts
+++ b/assistant/src/__tests__/conversation-unread-route.test.ts
@@ -46,6 +46,10 @@ mock.module("../memory/conversation-attention-store.js", () => ({
   markConversationUnread: mockMarkConversationUnread,
 }));
 
+mock.module("../memory/conversation-key-store.js", () => ({
+  resolveConversationId: (id: string) => id,
+}));
+
 import { getPolicy } from "../runtime/auth/route-policy.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { UserError } from "../util/errors.js";


### PR DESCRIPTION
## Summary
- Add missing `conversation-key-store.js` mock in `conversation-unread-route.test.ts` — the route handler calls `resolveConversationId()` which hits the `conversations` DB table, but the test never initialized the database schema, causing a `SQLiteError: no such table: conversations` and two test failures (500 instead of 200/422)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23117108134/job/67144486300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
