### PR TITLE
fix: remove duplicate isManagedAssistant from SidebarThreadItem

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -38,11 +38,6 @@ struct SidebarThreadItem: View {
             thread.latestAssistantMessageAt != nil
     }
 
-    private var isManagedAssistant: Bool {
-        guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return false }
-        return LockfileAssistant.loadByName(id)?.isManaged == true
-    }
-
     var body: some View {
         // Always reserve 20pt leading slot so text never shifts.
         // Use a tap gesture instead of Button so .draggable() can coexist —
@@ -205,7 +200,7 @@ struct SidebarThreadItem: View {
             } label: {
                 Label { Text("Send Logs for Thread") } icon: { VIconView(.upload, size: 14) }
             }
-            .disabled(thread.sessionId == nil || isManagedAssistant)
+            .disabled(thread.sessionId == nil || LogExporter.isManagedAssistant)
         }
         .pointerCursor()
         .onHover { hovering in


### PR DESCRIPTION
## Summary
- Remove the duplicate `isManagedAssistant` computed property from `SidebarThreadItem`
- Use `LogExporter.isManagedAssistant` instead for the `.disabled` modifier
- Reduces duplication — `LogExporter` already has the same logic

Part of plan: dedup-managed-check.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
