### PR TITLE
fix: Library "New Thread" now starts a fresh thread via `openThread(forceNew:)`

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -73,7 +73,7 @@ extension MainWindowView {
                     }
                 },
                 onNewThread: {
-                    threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                    threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
                     windowState.selection = nil
                 }
             )
@@ -81,7 +81,7 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
                 onInvokeSkill: { skill in
-                    let vm = threadManager.ensureThreadAndSend(message: "Use the \(skill.name) skill") { vm in
+                    let vm = threadManager.openThread(message: "Use the \(skill.name) skill") { vm in
                         vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,
@@ -123,7 +123,7 @@ extension MainWindowView {
                        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         // Ensure a thread exists so the prompt doesn't silently fail
                         // on fresh app launch before any chat thread is created.
-                        threadManager.ensureThreadAndSend(
+                        threadManager.openThread(
                             message: prompt.trimmingCharacters(in: .whitespacesAndNewlines)
                         ) { vm in
                             // Sync dock state before sending so the message is
@@ -272,7 +272,7 @@ extension MainWindowView {
                         }
                     },
                     onNewThread: {
-                        threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                        threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
                         windowState.selection = nil
                     }
                 )
@@ -443,7 +443,7 @@ extension MainWindowView {
                     }
                 },
                 onNewThread: {
-                    threadManager.ensureThreadAndSend(message: "What kind of apps can you build?")
+                    threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
                     windowState.dismissOverlay()
                 }
             )
@@ -453,7 +453,7 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
                 onInvokeSkill: { skill in
-                    let vm = threadManager.ensureThreadAndSend(message: "Use the \(skill.name) skill") { vm in
+                    let vm = threadManager.openThread(message: "Use the \(skill.name) skill") { vm in
                         vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -231,23 +231,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         enterDraftMode()
     }
 
-    /// Ensures a thread exists and sends a message.
-    /// - Parameters:
-    ///   - message: The text to send.
-    ///   - configure: Optional closure to configure the view model before sending
-    ///     (e.g., set skill invocation data or dock state).
-    @discardableResult
-    func ensureThreadAndSend(message: String, configure: ((ChatViewModel) -> Void)? = nil) -> ChatViewModel? {
-        if activeViewModel == nil {
-            createThread()
-        }
-        guard let viewModel = activeViewModel else { return nil }
-        configure?(viewModel)
-        viewModel.inputText = message
-        viewModel.sendMessage()
-        return viewModel
-    }
-
     /// Opens a thread for interaction, optionally creating a new one and/or sending a message.
     ///
     /// - Parameters:


### PR DESCRIPTION
## Summary
- Fix Library empty state "New Thread" button: now always creates a fresh thread via `openThread(forceNew: true)` instead of continuing an existing one
- Migrate all 6 `ensureThreadAndSend` call sites in PanelCoordinator to use `openThread`
- Remove the old `ensureThreadAndSend` method from ThreadManager

Part of plan: thread-open-refactor.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
