### PR TITLE
fix: make render-from-traits endpoint write traits file atomically

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -8,21 +8,75 @@ import { renderCharacterPng } from "./png-renderer.js";
 
 const log = getLogger("traits-png-sync");
 
-interface CharacterTraits {
+export interface CharacterTraits {
   bodyShape: string;
   eyeStyle: string;
   color: string;
 }
 
 /**
- * Reads character-traits.json from the avatar directory and regenerates
- * avatar-image.png to match. Called after traits are written to disk.
- * Returns true if PNG was generated, false if traits file is missing/invalid.
+ * Writes character-traits.json and regenerates avatar-image.png in one
+ * atomic operation.  Accepts the trait values directly so callers don't
+ * need to touch the filesystem first.
+ *
+ * Returns true if both the traits file and PNG were written successfully.
  */
-export function syncTraitsToPng(): boolean {
+export function writeTraitsAndRenderPng(traits: CharacterTraits): boolean {
+  if (!traits.bodyShape || !traits.eyeStyle || !traits.color) {
+    log.warn({ traits }, "Invalid character traits — missing required fields");
+    return false;
+  }
+
   const avatarDir = join(getWorkspaceDir(), "data", "avatar");
   const traitsPath = join(avatarDir, "character-traits.json");
   const pngPath = join(avatarDir, "avatar-image.png");
+
+  try {
+    mkdirSync(avatarDir, { recursive: true });
+
+    // Write traits file atomically
+    const traitsJson = JSON.stringify(traits, null, 2);
+    const traitsTmp = `${traitsPath}.${randomUUID()}.tmp`;
+    writeFileSync(traitsTmp, traitsJson);
+    renameSync(traitsTmp, traitsPath);
+
+    // Render and write PNG atomically
+    const pngBuffer = renderCharacterPng(
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
+    );
+    const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
+    writeFileSync(pngTmp, pngBuffer);
+    renameSync(pngTmp, pngPath);
+
+    log.info(
+      {
+        bodyShape: traits.bodyShape,
+        eyeStyle: traits.eyeStyle,
+        color: traits.color,
+      },
+      "Wrote character traits and regenerated avatar PNG",
+    );
+    return true;
+  } catch (err) {
+    log.error({ err }, "Failed to write traits / render avatar PNG");
+    return false;
+  }
+}
+
+/**
+ * Reads character-traits.json from the avatar directory and regenerates
+ * avatar-image.png to match. Kept for backward compatibility (e.g. the
+ * client-side file watcher triggers this path).
+ */
+export function syncTraitsToPng(): boolean {
+  const traitsPath = join(
+    getWorkspaceDir(),
+    "data",
+    "avatar",
+    "character-traits.json",
+  );
 
   let traits: CharacterTraits;
   try {
@@ -32,38 +86,5 @@ export function syncTraitsToPng(): boolean {
     return false;
   }
 
-  if (
-    !traits ||
-    typeof traits !== "object" ||
-    !traits.bodyShape ||
-    !traits.eyeStyle ||
-    !traits.color
-  ) {
-    log.warn({ traits }, "Invalid character traits — missing required fields");
-    return false;
-  }
-
-  try {
-    const pngBuffer = renderCharacterPng(
-      traits.bodyShape,
-      traits.eyeStyle,
-      traits.color,
-    );
-    mkdirSync(avatarDir, { recursive: true });
-    const tmpPath = `${pngPath}.${randomUUID()}.tmp`;
-    writeFileSync(tmpPath, pngBuffer);
-    renameSync(tmpPath, pngPath);
-    log.info(
-      {
-        bodyShape: traits.bodyShape,
-        eyeStyle: traits.eyeStyle,
-        color: traits.color,
-      },
-      "Regenerated avatar PNG from character traits",
-    );
-    return true;
-  } catch (err) {
-    log.error({ err }, "Failed to render avatar PNG from traits");
-    return false;
-  }
+  return writeTraitsAndRenderPng(traits);
 }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -1,7 +1,11 @@
 import { join } from "node:path";
 
 import { getCharacterComponents } from "../../avatar/character-components.js";
-import { syncTraitsToPng } from "../../avatar/traits-png-sync.js";
+import {
+  type CharacterTraits,
+  syncTraitsToPng,
+  writeTraitsAndRenderPng,
+} from "../../avatar/traits-png-sync.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -11,6 +15,25 @@ import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("avatar-routes");
+
+function publishAvatarUpdated(): void {
+  const avatarPath = join(
+    getWorkspaceDir(),
+    "data",
+    "avatar",
+    "avatar-image.png",
+  );
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "avatar_updated",
+        avatarPath,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish avatar_updated event");
+    });
+}
 
 export function avatarRouteDefinitions(): RouteDefinition[] {
   return [
@@ -22,34 +45,44 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
     {
       endpoint: "avatar/render-from-traits",
       method: "POST",
-      handler: () => {
-        const success = syncTraitsToPng();
+      handler: async ({ req }) => {
+        let success: boolean;
+
+        // If the request includes a JSON body with traits, write the traits
+        // file and render the PNG in one atomic operation.  Otherwise fall
+        // back to reading the existing character-traits.json from disk
+        // (backward-compat path).
+        const contentType = req.headers.get("content-type") ?? "";
+        if (contentType.includes("application/json")) {
+          let body: CharacterTraits;
+          try {
+            body = (await req.json()) as CharacterTraits;
+          } catch {
+            return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+          }
+
+          if (!body.bodyShape || !body.eyeStyle || !body.color) {
+            return httpError(
+              "BAD_REQUEST",
+              "Missing required fields: bodyShape, eyeStyle, color",
+              400,
+            );
+          }
+
+          success = writeTraitsAndRenderPng(body);
+        } else {
+          success = syncTraitsToPng();
+        }
+
         if (!success) {
           return httpError(
             "BAD_REQUEST",
-            "No valid character-traits.json found",
+            "Failed to render avatar from traits",
             400,
           );
         }
 
-        // Notify connected clients to reload avatar
-        const avatarPath = join(
-          getWorkspaceDir(),
-          "data",
-          "avatar",
-          "avatar-image.png",
-        );
-        assistantEventHub
-          .publish(
-            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
-              type: "avatar_updated",
-              avatarPath,
-            }),
-          )
-          .catch((err) => {
-            log.warn({ err }, "Failed to publish avatar_updated event");
-          });
-
+        publishAvatarUpdated();
         return Response.json({ ok: true });
       },
     },

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -65,24 +65,12 @@ The user picks a body shape, eye style, and color. Present the options conversat
 
 ### Setting traits
 
-After the user chooses, write the selection to `data/avatar/character-traits.json` (relative to the workspace root):
-
-```json
-{
-  "bodyShape": "<chosen-body-shape>",
-  "eyeStyle": "<chosen-eye-style>",
-  "color": "<chosen-color>"
-}
-```
+After the user chooses, call the render endpoint with the chosen traits. This writes `character-traits.json` and generates the static PNG in one step:
 
 ```bash
-mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
-cat > "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json" << 'TRAITS'
-{ "bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>" }
-TRAITS
-
-# Trigger assistant-side PNG rendering from the traits
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/avatar/render-from-traits"
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/avatar/render-from-traits" \
+  -H "Content-Type: application/json" \
+  -d '{"bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>"}'
 ```
 
 The client will detect the traits file and render the animated character. The assistant also generates a static PNG for use as dock icon and by other clients.
@@ -146,5 +134,5 @@ The client checks for character traits first — if `character-traits.json` exis
 
 Enforcement rules:
 
-- **Setting native character traits** → write `character-traits.json` and call `POST /v1/avatar/render-from-traits`. The assistant auto-generates the PNG.
+- **Setting native character traits** → call `POST /v1/avatar/render-from-traits` with `{ bodyShape, eyeStyle, color }`. This writes `character-traits.json` and auto-generates the PNG in one step.
 - **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.


### PR DESCRIPTION
## Summary
- The `POST /v1/avatar/render-from-traits` endpoint now accepts an optional JSON body with `{ bodyShape, eyeStyle, color }` and writes both `character-traits.json` and `avatar-image.png` atomically
- Added `writeTraitsAndRenderPng()` to `traits-png-sync.ts` that handles the full write-traits-then-render-PNG flow in one step
- Simplified the vellum-avatar skill to use a single `curl` call instead of a two-step bash-then-curl flow, fixing the bug where `avatar-image.png` wasn't always updated

## Original prompt
ship a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
