### PR TITLE
fix: make system prompt handle teaching mode-aware for managed deployments

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -851,7 +851,13 @@ export function buildCliReferenceSection(): string {
     "   - `assistant credentials list` — lists local credentials with their service:field identifiers",
     "   - `assistant oauth connections list` — lists OAuth connections with provider keys",
     "   - `assistant credentials list --search <query>` — filter by service, field, or description",
-    "   For local credentials, construct the CES handle as `local_static:<service>/<field>` from the listed identifiers. For local OAuth connections, the handle is `local_oauth:<providerKey>/<connectionId>` (shown in the `handle` field of `assistant oauth connections list`). Platform-managed entries use `platform_oauth:<connectionId>` handles, also shown in their `handle` field.",
+    ...(getIsContainerized()
+      ? [
+          "   In managed deployments, credential handles use the `platform_oauth:<connectionId>` format (shown in the `handle` field of `assistant oauth connections list`). Local credential handles (`local_static`, `local_oauth`) are not available in managed mode.",
+        ]
+      : [
+          "   For local credentials, construct the CES handle as `local_static:<service>/<field>` from the listed identifiers. For local OAuth connections, the handle is `local_oauth:<providerKey>/<connectionId>` (shown in the `handle` field of `assistant oauth connections list`). Platform-managed entries use `platform_oauth:<connectionId>` handles, also shown in their `handle` field.",
+        ]),
     "",
     "2. **Use CES tools** with the handle to perform authenticated work:",
     "   - `make_authenticated_request` — authenticated HTTP requests (API calls, webhooks). CES injects the credential and returns the response; the assistant never sees raw secrets.",


### PR DESCRIPTION
## Summary
- System prompt now conditionally teaches credential handles based on deployment mode
- Managed mode: teaches platform_oauth only, notes local handles are unavailable
- Local mode: unchanged, teaches all three handle formats

Part of plan: untrusted-agent-credential-arch.md (R16 review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
