### PR TITLE
fix: map conversationType to threadType in switch endpoint HTTP response

### DIFF
--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -83,7 +83,12 @@ export function sessionManagementRouteDefinitions(
         if (body.conversationKey && typeof body.conversationKey === "string") {
           setConversationKeyIfAbsent(body.conversationKey, conversationId);
         }
-        return Response.json(result);
+        return Response.json({
+          sessionId: result.sessionId,
+          title: result.title,
+          threadType:
+            result.conversationType === "private" ? "private" : "standard",
+        });
       },
     },
     {


### PR DESCRIPTION
## Summary
- Fix the switch endpoint to return threadType instead of leaking internal conversationType field
- Makes POST /v1/conversations/:id/switch consistent with GET endpoints

Part of plan: conv-rename-followup-fixes.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
