### PR TITLE
refactor: use `generateInstanceName` in local hatch

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -47,7 +47,7 @@ import {
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
 import { detectOrphanedProcesses } from "../lib/orphan-detection";
 import { isProcessAlive, stopProcess } from "../lib/process";
-import { generateRandomSuffix } from "../lib/random-name";
+import { generateInstanceName } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
 import { archiveLogFile, resetLogFile } from "../lib/xdg-log";
 
@@ -575,10 +575,10 @@ async function hatchLocal(
     process.exit(1);
   }
 
-  const instanceName =
-    name ??
-    process.env.VELLUM_ASSISTANT_NAME ??
-    `${species}-${generateRandomSuffix()}`;
+  const instanceName = generateInstanceName(
+    species,
+    name ?? process.env.VELLUM_ASSISTANT_NAME,
+  );
 
   // Clean up stale local state: if daemon/gateway processes are running but
   // the lock file has no entries, stop them before starting fresh.


### PR DESCRIPTION
## Summary
- Replace inline `species-generateRandomSuffix()` pattern with unified `generateInstanceName` helper in local hatch command
- Preserves existing `--name` and `VELLUM_ASSISTANT_NAME` env var fallback behavior

Part of plan: unify-assistant-id-generation.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
