### PR TITLE
fix: improve skill detail page UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -246,7 +246,6 @@ struct AgentPanelContent: View {
                 ) {
                     withAnimation(VAnimation.fast) {
                         selectedInstalledSkillId = skill.id
-                        skillsManager.fetchSkillBody(skillId: skill.id)
                     }
                 }
             }
@@ -262,7 +261,7 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private func installedSkillDetailView(_ skill: SkillInfo) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
 
             // Back button
             Button(action: {
@@ -365,24 +364,23 @@ struct AgentPanelContent: View {
                 }
             }
 
-            // Skill body content
-            ScrollView {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    skillBody(for: skill.id)
-                }
-                .padding(VSpacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxHeight: 300)
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.borderBase, lineWidth: 1)
-            )
+            // Two-pane content: file list + file content viewer
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                // Left: file list
+                skillFilesSection
+                    .frame(width: expandedFilePath != nil ? 280 : nil, alignment: .topLeading)
+                    .frame(maxWidth: expandedFilePath != nil ? 280 : .infinity, alignment: .topLeading)
 
-            // Skill files
-            skillFilesSection
+                // Right: file content viewer
+                if let selectedPath = expandedFilePath,
+                   let filesResponse = skillsManager.selectedSkillFiles,
+                   let file = filesResponse.files.first(where: { $0.path == selectedPath }),
+                   !file.isBinary,
+                   let content = file.content {
+                    skillFileContentPane(file: file, content: content)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
         }
         .onAppear {
@@ -456,17 +454,42 @@ struct AgentPanelContent: View {
     }
 
     @ViewBuilder
-    private func skillBody(for skillId: String) -> some View {
-        if let body = skillsManager.loadedBodies[skillId] {
-            Text(body)
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
-                .textSelection(.enabled)
-        } else {
-            ProgressView()
-                .controlSize(.small)
-                .padding(.vertical, VSpacing.sm)
+    private func skillFileContentPane(file: SkillFileEntry, content: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // File header
+            HStack(spacing: VSpacing.sm) {
+                VIconView(fileIcon(for: file.mimeType), size: 12)
+                    .foregroundColor(VColor.primaryBase)
+                Text(file.path)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.contentDefault)
+                Spacer()
+                Text(formatFileSize(file.size))
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+
+            Divider().background(VColor.borderBase)
+
+            // File content
+            ScrollView([.vertical, .horizontal]) {
+                Text(content)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentSecondary)
+                    .textSelection(.enabled)
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
     }
 
     @ViewBuilder
@@ -528,56 +551,38 @@ struct AgentPanelContent: View {
     @ViewBuilder
     private func skillFileRow(_ file: SkillFileEntry) -> some View {
         let isText = !file.isBinary && file.content != nil
-        let isExpanded = expandedFilePath == file.path
+        let isSelected = expandedFilePath == file.path
 
-        VStack(alignment: .leading, spacing: 0) {
-            Button {
-                if isText {
-                    withAnimation(VAnimation.fast) {
-                        expandedFilePath = isExpanded ? nil : file.path
-                    }
+        Button {
+            if isText {
+                withAnimation(VAnimation.fast) {
+                    expandedFilePath = isSelected ? nil : file.path
                 }
-            } label: {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(fileIcon(for: file.mimeType), size: 12)
-                        .foregroundColor(VColor.primaryBase)
-                        .frame(width: 20)
-
-                    Text(file.path)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentDefault)
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Text(formatFileSize(file.size))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.contentTertiary)
-
-                    if isText {
-                        VIconView(isExpanded ? .chevronUp : .chevronDown, size: 9)
-                            .foregroundColor(VColor.contentTertiary)
-                    }
-                }
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.sm)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .disabled(!isText)
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(fileIcon(for: file.mimeType), size: 12)
+                    .foregroundColor(VColor.primaryBase)
+                    .frame(width: 20)
 
-            if isExpanded, let content = file.content {
-                ScrollView(.horizontal, showsIndicators: true) {
-                    Text(content)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.contentSecondary)
-                        .textSelection(.enabled)
-                        .padding(VSpacing.md)
-                }
-                .frame(maxHeight: 300)
-                .background(VColor.surfaceBase)
+                Text(file.path)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(formatFileSize(file.size))
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
             }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .contentShape(Rectangle())
+            .background(isSelected ? VColor.surfaceActive : Color.clear)
         }
+        .buttonStyle(.plain)
+        .disabled(!isText)
     }
 
     private func fileIcon(for mimeType: String) -> VIcon {


### PR DESCRIPTION
## Summary
- Reduced excessive vertical spacing in the skill detail header by changing stack spacing from `VSpacing.lg` to `VSpacing.sm`
- Removed the skill body section that caused an infinite loading spinner (it used an unreliable WebSocket-based `fetchSkillBody` that never responded; the same content is available via SKILL.md in the files section)
- Replaced inline file content expansion with a two-pane layout: file list on the left with selection highlighting, file content viewer on the right — matching the Workspace tab pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
