### PR TITLE
fix: update stale thread comments in db-init.ts and test variable names

### DIFF
--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -36,7 +36,7 @@ mock.module("../util/logger.js", () => ({
 
 // Mock notification emission — capture calls without running the full pipeline
 const emittedSignals: Array<Record<string, unknown>> = [];
-const mockOnThreadCreatedCallbacks: Array<
+const mockOnConversationCreatedCallbacks: Array<
   (info: {
     conversationId: string;
     title: string;
@@ -48,7 +48,7 @@ mock.module("../notifications/emit-signal.js", () => ({
     emittedSignals.push(params);
     // Capture onConversationCreated callback so tests can invoke it
     if (typeof params.onConversationCreated === "function") {
-      mockOnThreadCreatedCallbacks.push(
+      mockOnConversationCreatedCallbacks.push(
         params.onConversationCreated as (info: {
           conversationId: string;
           title: string;
@@ -157,7 +157,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
   beforeEach(() => {
     resetTables();
     emittedSignals.length = 0;
-    mockOnThreadCreatedCallbacks.length = 0;
+    mockOnConversationCreatedCallbacks.length = 0;
   });
 
   test("emits guardian.question for trusted-contact sessions", () => {
@@ -313,11 +313,11 @@ describe("bridgeConfirmationRequestToGuardian", () => {
       toolName: "bash",
     });
 
-    expect(mockOnThreadCreatedCallbacks).toHaveLength(1);
+    expect(mockOnConversationCreatedCallbacks).toHaveLength(1);
 
     // Simulate the broadcaster invoking onConversationCreated
-    mockOnThreadCreatedCallbacks[0]({
-      conversationId: "guardian-thread-1",
+    mockOnConversationCreatedCallbacks[0]({
+      conversationId: "guardian-conversation-1",
       title: "Guardian question",
       sourceEventName: "guardian.question",
     });
@@ -325,7 +325,9 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     const deliveries = listCanonicalGuardianDeliveries(canonicalRequest.id);
     expect(deliveries).toHaveLength(1);
     expect(deliveries[0].destinationChannel).toBe("vellum");
-    expect(deliveries[0].destinationConversationId).toBe("guardian-thread-1");
+    expect(deliveries[0].destinationConversationId).toBe(
+      "guardian-conversation-1",
+    );
   });
 
   test("uses custom assistantId when provided", () => {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -224,7 +224,7 @@ export function initializeDb(): void {
   // 14c3. Guardian action supersession metadata (superseded_by_request_id, superseded_at) + session lookup index
   migrateGuardianActionSupersession(database);
 
-  // 14d. Index on conversations.thread_type for frequent WHERE filters
+  // 14d. Index on conversations.conversation_type for frequent WHERE filters
   migrateConversationsThreadTypeIndex(database);
 
   // 14e. Index on guardian_action_deliveries.destination_conversation_id for conversation-based lookups
@@ -255,7 +255,7 @@ export function initializeDb(): void {
   // 22. Scoped approval grants (channel-agnostic one-time-use grants)
   createScopedApprovalGrantsTable(database);
 
-  // 23. Thread decision audit columns on notification_deliveries
+  // 23. Conversation decision audit columns on notification_deliveries
   migrateNotificationDeliveryThreadDecision(database);
 
   // 24. Canonical guardian requests and deliveries (unified cross-source guardian domain)


### PR DESCRIPTION
## Summary
- Update stale thread_type and Thread decision comments in db-init.ts
- Rename mockOnThreadCreatedCallbacks to mockOnConversationCreatedCallbacks and guardian-thread-1 to guardian-conversation-1 in test file

Part of plan: conv-rename-followup-fixes.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
