### PR TITLE
refactor: use `generateInstanceName` in Docker hatch

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -9,7 +9,7 @@ import type { AssistantEntry } from "./assistant-config";
 import { DEFAULT_GATEWAY_PORT } from "./constants";
 import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
-import { generateRandomSuffix } from "./random-name";
+import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
 import {
   closeLogFile,
@@ -220,7 +220,6 @@ function createLinePrefixer(
   };
 }
 
-
 export async function retireDocker(name: string): Promise<void> {
   console.log(`\u{1F5D1}\ufe0f  Stopping Docker container '${name}'...\n`);
 
@@ -269,7 +268,7 @@ export async function hatchDocker(
     throw err;
   }
 
-  const instanceName = name ?? `${species}-${generateRandomSuffix()}`;
+  const instanceName = generateInstanceName(species, name);
   const dockerfileName = watch ? "Dockerfile.development" : "Dockerfile";
   const dockerfile = join(dockerfileDir, dockerfileName);
   const dockerfilePath = join(repoRoot, dockerfile);


### PR DESCRIPTION
## Summary
- Replace inline `species-generateRandomSuffix()` pattern with unified `generateInstanceName` helper in Docker hatch
- Preserves existing explicit name passthrough behavior

Part of plan: unify-assistant-id-generation.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
