### PR TITLE
refactor: use `generateInstanceName` in GCP hatch

### DIFF
--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -8,7 +8,7 @@ import type { AssistantEntry } from "./assistant-config";
 import { FIREWALL_TAG, GATEWAY_PORT } from "./constants";
 import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
-import { generateRandomSuffix } from "./random-name";
+import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
 
 export async function getActiveProject(): Promise<string> {
@@ -467,12 +467,7 @@ export async function hatchGcp(
     const project = process.env.GCP_PROJECT ?? (await getActiveProject());
     let instanceName: string;
 
-    if (name) {
-      instanceName = name;
-    } else {
-      const suffix = generateRandomSuffix();
-      instanceName = `${species}-${suffix}`;
-    }
+    instanceName = generateInstanceName(species, name);
 
     console.log(`\ud83e\udd5a Creating new assistant: ${instanceName}`);
     console.log(`   Species: ${species}`);
@@ -500,8 +495,7 @@ export async function hatchGcp(
         console.log(
           `\u26a0\ufe0f  Instance name ${instanceName} already exists, generating a new name...`,
         );
-        const suffix = generateRandomSuffix();
-        instanceName = `${species}-${suffix}`;
+        instanceName = generateInstanceName(species);
       }
     }
 
@@ -654,10 +648,7 @@ export async function hatchGcp(
       }
 
       try {
-        const tokenData = await leaseGuardianToken(
-          runtimeUrl,
-          instanceName,
-        );
+        const tokenData = await leaseGuardianToken(runtimeUrl, instanceName);
         gcpEntry.bearerToken = tokenData.accessToken;
         saveAssistantEntry(gcpEntry);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Replace inline `species-generateRandomSuffix()` pattern with unified `generateInstanceName` helper in GCP hatch
- Both initial name generation and collision retry loop now use `generateInstanceName`
- Preserves existing collision detection and retry behavior

Part of plan: unify-assistant-id-generation.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
