### PR TITLE
refactor: use `generateInstanceName` in AWS hatch

### DIFF
--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -10,7 +10,7 @@ import type { AssistantEntry } from "./assistant-config";
 import { GATEWAY_PORT } from "./constants";
 import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
-import { generateRandomSuffix } from "./random-name";
+import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
 
 const KEY_PAIR_NAME = "vellum-assistant";
@@ -384,12 +384,7 @@ export async function hatchAws(
       (await getActiveRegion().catch(() => AWS_DEFAULT_REGION));
     let instanceName: string;
 
-    if (name) {
-      instanceName = name;
-    } else {
-      const suffix = generateRandomSuffix();
-      instanceName = `${species}-${suffix}`;
-    }
+    instanceName = generateInstanceName(species, name);
 
     console.log(`\u{1F95A} Creating new assistant: ${instanceName}`);
     console.log(`   Species: ${species}`);
@@ -410,8 +405,7 @@ export async function hatchAws(
         console.log(
           `\u26a0\ufe0f  Instance name ${instanceName} already exists, generating a new name...`,
         );
-        const suffix = generateRandomSuffix();
-        instanceName = `${species}-${suffix}`;
+        instanceName = generateInstanceName(species);
       }
     }
 
@@ -537,10 +531,7 @@ export async function hatchAws(
         }
 
         try {
-          const tokenData = await leaseGuardianToken(
-            runtimeUrl,
-            instanceName,
-          );
+          const tokenData = await leaseGuardianToken(runtimeUrl, instanceName);
           awsEntry.bearerToken = tokenData.accessToken;
           saveAssistantEntry(awsEntry);
         } catch (err) {


### PR DESCRIPTION
## Summary
- Replace inline `species-generateRandomSuffix()` pattern with unified `generateInstanceName` helper in AWS hatch
- Both initial name generation and collision retry loop now use `generateInstanceName`
- Preserves existing collision detection and retry behavior

Part of plan: unify-assistant-id-generation.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
