### PR TITLE
refactor: use `generateInstanceName` in pair command

### DIFF
--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -7,7 +7,7 @@ import { PNG } from "pngjs";
 import { saveAssistantEntry } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import type { Species } from "../lib/constants";
-import { generateRandomSuffix } from "../lib/random-name";
+import { generateInstanceName } from "../lib/random-name";
 
 interface QRPairingPayload {
   type: string;
@@ -119,7 +119,7 @@ export async function pair(): Promise<void> {
       throw new Error("QR code does not contain valid Vellum pairing data.");
     }
 
-    const instanceName = `${species}-${generateRandomSuffix()}`;
+    const instanceName = generateInstanceName(species);
     const runtimeUrl = payload.g;
     const deviceId = getDeviceId();
     const deviceName = hostname();


### PR DESCRIPTION
## Summary
- Replace inline `species-generateRandomSuffix()` pattern with unified `generateInstanceName` helper in pair command

Part of plan: unify-assistant-id-generation.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
