### PR TITLE
fix: add workaround for GCP OAuth client secret race condition

### DIFF
--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -151,7 +151,7 @@ Open: `https://console.cloud.google.com/auth/clients/create?project=PROJECT_ID`
 
 A modal should appear with the **Client ID** and **Client Secret**. Tell the user to keep it open.
 
-If the secret doesn't appear, guide them to click the credential name on the Credentials page to find it.
+> **Heads up:** Google sometimes has a slight delay, so the modal may only show your Client ID without the Client Secret. If that happens, don't worry — click the **Download JSON** button (downward arrow icon) on the modal. Open the downloaded file and you'll find your `client_secret` in there. It's a little annoying, but it works every time.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds user-facing guidance in the Google OAuth setup skill (Step 6) for when the client secret doesn't appear in the creation modal due to a GCP race condition
- Directs users to the Download JSON button as a reliable fallback

## Test plan
- [ ] Run through the Google OAuth setup skill and verify the guidance appears at Step 6
- [ ] Confirm the Download JSON workaround works when the secret is missing from the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
