### PR TITLE
fix: update Swift clients to decode conversation-created SSE event types

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -285,7 +285,7 @@ class IOSThreadStore: ObservableObject {
         daemon.onMessageContentResponse = { [weak self] response in
             self?.handleMessageContentResponse(response)
         }
-        daemon.onScheduleThreadCreated = { [weak self] msg in
+        daemon.onScheduleConversationCreated = { [weak self] msg in
             guard let self else { return }
             // Avoid duplicates
             guard !self.threads.contains(where: { $0.sessionId == msg.conversationId }) else { return }
@@ -295,7 +295,7 @@ class IOSThreadStore: ObservableObject {
                 scheduleJobId: msg.scheduleJobId
             )
             // Remove the empty placeholder thread if it's still present (race:
-            // schedule_thread_created can arrive before the first session_list_response).
+            // schedule_conversation_created can arrive before the first session_list_response).
             if self.threads.count == 1,
                self.threads[0].sessionId == nil,
                self.viewModels[self.threads[0].id]?.messages.isEmpty ?? true,
@@ -385,7 +385,7 @@ class IOSThreadStore: ObservableObject {
             oldDaemon.onHistoryResponse = nil
             oldDaemon.onSubagentDetailResponse = nil
             oldDaemon.onMessageContentResponse = nil
-            oldDaemon.onScheduleThreadCreated = nil
+            oldDaemon.onScheduleConversationCreated = nil
         }
 
         daemonClient = newClient

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -207,9 +207,9 @@ extension AppDelegate {
             )
         }
 
-        // Automatically surface threads created by scheduled task runs so
+        // Automatically surface conversations created by scheduled task runs so
         // the user sees them in the sidebar without restarting the app.
-        daemonClient.onTaskRunThreadCreated = { [weak self] msg in
+        daemonClient.onTaskRunConversationCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.threadManager.createTaskRunThread(
@@ -219,8 +219,8 @@ extension AppDelegate {
             )
         }
 
-        // Schedule threads — created when the scheduler fires and creates a conversation.
-        daemonClient.onScheduleThreadCreated = { [weak self] msg in
+        // Schedule conversations — created when the scheduler fires and creates a conversation.
+        daemonClient.onScheduleConversationCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.threadManager.createScheduleThread(
@@ -230,11 +230,11 @@ extension AppDelegate {
             )
         }
 
-        // Notification threads — created when the notification pipeline delivers
+        // Notification conversations — created when the notification pipeline delivers
         // to the vellum channel with start_new_conversation strategy.
-        daemonClient.onNotificationThreadCreated = { [weak self] msg in
+        daemonClient.onNotificationConversationCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
-            self.handleNotificationThreadCreated(msg)
+            self.handleNotificationConversationCreated(msg)
         }
 
         // Forward dictation responses from the daemon to VoiceInputManager

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -81,20 +81,20 @@ extension AppDelegate {
         ])
     }
 
-    /// Handles notification permission when a notification thread arrives while
+    /// Handles notification permission when a notification conversation arrives while
     /// the app is active. This provides user-visible context for the OS prompt
     /// and gives an immediate recovery path when the app is already denied.
-    func maybePromptNotificationAuthorizationForThreadCreated() {
+    func maybePromptNotificationAuthorizationForConversationCreated() {
         Task { @MainActor in
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             switch settings.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
                 return
             case .notDetermined:
-                guard !hasRequestedNotificationAuthorizationFromThreadSignal else { return }
-                hasRequestedNotificationAuthorizationFromThreadSignal = true
-                log.info("Requesting notification authorization from notification_thread_created signal")
-                requestNotificationAuthorization(trigger: "notification_thread_created", showDeniedToast: true)
+                guard !hasRequestedNotificationAuthorizationFromConversationSignal else { return }
+                hasRequestedNotificationAuthorizationFromConversationSignal = true
+                log.info("Requesting notification authorization from notification_conversation_created signal")
+                requestNotificationAuthorization(trigger: "notification_conversation_created", showDeniedToast: true)
             case .denied:
                 showNotificationPermissionSettingsToastIfNeeded()
             @unknown default:
@@ -361,7 +361,7 @@ extension AppDelegate {
         )
     }
 
-    /// Schedules a fallback local notification for any notification_thread_created
+    /// Schedules a fallback local notification for any notification_conversation_created
     /// event. If the corresponding notification_intent event arrives within the
     /// delay window, the fallback is cancelled (preventing duplicates). Guardian
     /// questions use a specific body; all other event types use a generic body.

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -54,15 +54,15 @@ extension AppDelegate {
     /// Guardian questions are time-sensitive, so they are foregrounded when the
     /// app is active. All notification types get a fallback native alert when
     /// backgrounded to guarantee delivery if the notification_intent event is late.
-    func handleNotificationThreadCreated(_ msg: NotificationThreadCreated) {
-        // Guardian scoping: skip thread creation for notifications targeted at
+    func handleNotificationConversationCreated(_ msg: NotificationConversationCreated) {
+        // Guardian scoping: skip conversation creation for notifications targeted at
         // a different guardian identity. When the local principal is nil (not yet
         // bootstrapped), pass through all notifications so urgent prompts aren't
         // silently missed during startup.
         if let target = msg.targetGuardianPrincipalId {
             let localId = ActorTokenManager.getGuardianPrincipalId()
             if let localId, localId != target {
-                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId)")
+                log.info("Skipping notification_conversation_created for guardian \(target) — local guardian is \(localId)")
                 return
             }
         }
@@ -75,7 +75,7 @@ extension AppDelegate {
         )
 
         if NSApp.isActive {
-            maybePromptNotificationAuthorizationForThreadCreated()
+            maybePromptNotificationAuthorizationForConversationCreated()
         }
 
         // Guardian questions get foregrounded immediately when the app is active.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -123,8 +123,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// inside a short window is treated as a duplicate and suppressed.
     var fallbackDeliveredAtMs: [String: Double] = [:]
     /// Guard to avoid repeatedly re-requesting notification authorization when
-    /// multiple notification threads are created in quick succession.
-    var hasRequestedNotificationAuthorizationFromThreadSignal = false
+    /// multiple notification conversations are created in quick succession.
+    var hasRequestedNotificationAuthorizationFromConversationSignal = false
     /// Last time we surfaced the denied-notification permission toast.
     var lastNotificationPermissionToastAtMs: Double = 0
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -428,7 +428,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Create a visible thread bound to an existing task run conversation.
-    /// Called when the daemon broadcasts `task_run_thread_created` so the user
+    /// Called when the daemon broadcasts `task_run_conversation_created` so the user
     /// can see task execution messages streaming in real-time.
     func createTaskRunThread(conversationId: String, workItemId: String, title: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
@@ -459,7 +459,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Create a visible thread bound to a schedule-created conversation.
-    /// Called when the daemon broadcasts `schedule_thread_created` so the user
+    /// Called when the daemon broadcasts `schedule_conversation_created` so the user
     /// sees scheduled threads in the sidebar without a full refresh.
     func createScheduleThread(conversationId: String, scheduleJobId: String, title: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
@@ -487,7 +487,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Create a visible thread bound to a notification-created conversation.
-    /// Called when the daemon broadcasts `notification_thread_created` so the user
+    /// Called when the daemon broadcasts `notification_conversation_created` so the user
     /// can see notification threads and deep-link into them.
     func createNotificationThread(conversationId: String, title: String, sourceEventName: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
@@ -502,7 +502,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.sessionId = conversationId
         // Do NOT set isHistoryLoaded here — notification threads have a
         // pre-existing seed message persisted by conversation-pairing before
-        // the notification_thread_created event is emitted. Leaving
+        // the notification_conversation_created event is emitted. Leaving
         // isHistoryLoaded false allows ThreadSessionRestorer.loadHistoryIfNeeded
         // to fetch that seed message when the thread is first selected.
         // The handleAssistantMessageArrival guard dropping updates is correct

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -351,8 +351,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon emits a generic `notification_intent` payload.
     public var onNotificationIntent: ((NotificationIntentMessage) -> Void)?
 
-    /// Called when a notification delivery creates a new vellum conversation thread.
-    public var onNotificationThreadCreated: ((NotificationThreadCreated) -> Void)?
+    /// Called when a notification delivery creates a new vellum conversation.
+    public var onNotificationConversationCreated: ((NotificationConversationCreated) -> Void)?
 
     /// Called when the daemon sends a `trust_rules_list_response` message.
     public var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
@@ -520,10 +520,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onError: ((ErrorMessage) -> Void)?
 
     /// Called when a task run creates a conversation so the client can show it as a visible chat thread.
-    public var onTaskRunThreadCreated: ((TaskRunThreadCreated) -> Void)?
+    public var onTaskRunConversationCreated: ((TaskRunConversationCreated) -> Void)?
 
     /// Called when a schedule creates a conversation so the client can show it as a visible chat thread.
-    public var onScheduleThreadCreated: ((ScheduleThreadCreated) -> Void)?
+    public var onScheduleConversationCreated: ((ScheduleConversationCreated) -> Void)?
 
     /// Called when the daemon requests pairing approval from macOS.
     public var onPairingApprovalRequest: ((PairingApprovalRequestMessage) -> Void)?

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -90,8 +90,8 @@ extension DaemonClient {
             onDictationResponse?(msg)
         case .notificationIntent(let msg):
             onNotificationIntent?(msg)
-        case .notificationThreadCreated(let msg):
-            onNotificationThreadCreated?(msg)
+        case .notificationConversationCreated(let msg):
+            onNotificationConversationCreated?(msg)
         case .trustRulesListResponse(let msg):
             onTrustRulesListResponse?(msg.rules)
         case .toolPermissionSimulateResponse(let msg):
@@ -230,10 +230,10 @@ extension DaemonClient {
             onWorkItemApprovePermissionsResponse?(msg)
         case .workItemCancelResponse(let msg):
             onWorkItemCancelResponse?(msg)
-        case .taskRunThreadCreated(let msg):
-            onTaskRunThreadCreated?(msg)
-        case .scheduleThreadCreated(let msg):
-            onScheduleThreadCreated?(msg)
+        case .taskRunConversationCreated(let msg):
+            onTaskRunConversationCreated?(msg)
+        case .scheduleConversationCreated(let msg):
+            onScheduleConversationCreated?(msg)
         case .subagentSpawned(let msg):
             onSubagentSpawned?(msg)
         case .subagentStatusChanged(let msg):

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2735,13 +2735,13 @@ public struct NotificationIntentResult: Codable, Sendable {
     }
 }
 
-/// Server push — broadcast when a notification creates a new vellum conversation thread.
-public struct NotificationThreadCreated: Codable, Sendable {
+/// Server push — broadcast when a notification creates a new vellum conversation.
+public struct NotificationConversationCreated: Codable, Sendable {
     public let type: String
     public let conversationId: String
     public let title: String
     public let sourceEventName: String
-    /// When set, this thread was created for a guardian-sensitive notification
+    /// When set, this conversation was created for a guardian-sensitive notification
     /// and should only be surfaced by clients bound to this guardian identity.
     public let targetGuardianPrincipalId: String?
 
@@ -3194,7 +3194,7 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
 }
 
 /// Server push — broadcast when a schedule creates a conversation, so the client can show it as a chat thread.
-public struct ScheduleThreadCreated: Codable, Sendable {
+public struct ScheduleConversationCreated: Codable, Sendable {
     public let type: String
     public let conversationId: String
     public let scheduleJobId: String
@@ -4195,7 +4195,7 @@ public struct SurfaceAction: Codable, Sendable {
 }
 
 /// Server push — broadcast when a task run creates a conversation, so the client can show it as a chat thread.
-public struct TaskRunThreadCreated: Codable, Sendable {
+public struct TaskRunConversationCreated: Codable, Sendable {
     public let type: String
     public let conversationId: String
     public let workItemId: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2115,7 +2115,7 @@ public enum ServerMessage: Decodable, Sendable {
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
     case notificationIntent(NotificationIntentMessage)
-    case notificationThreadCreated(NotificationThreadCreated)
+    case notificationConversationCreated(NotificationConversationCreated)
     case watchStarted(WatchStartedMessage)
     case watchCompleteRequest(WatchCompleteRequestMessage)
     case traceEvent(TraceEventMessage)
@@ -2175,8 +2175,8 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemPreflightResponse(WorkItemPreflightResponse)
     case workItemApprovePermissionsResponse(WorkItemApprovePermissionsResponse)
     case workItemCancelResponse(WorkItemCancelResponse)
-    case taskRunThreadCreated(TaskRunThreadCreated)
-    case scheduleThreadCreated(ScheduleThreadCreated)
+    case taskRunConversationCreated(TaskRunConversationCreated)
+    case scheduleConversationCreated(ScheduleConversationCreated)
     case subagentSpawned(SubagentSpawned)
     case subagentStatusChanged(SubagentStatusChanged)
     indirect case subagentEvent(SubagentEventMessage)
@@ -2365,9 +2365,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "notification_intent":
             let message = try NotificationIntentMessage(from: decoder)
             self = .notificationIntent(message)
-        case "notification_thread_created":
-            let message = try NotificationThreadCreated(from: decoder)
-            self = .notificationThreadCreated(message)
+        case "notification_conversation_created":
+            let message = try NotificationConversationCreated(from: decoder)
+            self = .notificationConversationCreated(message)
         case "watch_started":
             let message = try WatchStartedMessage(from: decoder)
             self = .watchStarted(message)
@@ -2530,12 +2530,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "work_item_cancel_response":
             let message = try WorkItemCancelResponse(from: decoder)
             self = .workItemCancelResponse(message)
-        case "task_run_thread_created":
-            let message = try TaskRunThreadCreated(from: decoder)
-            self = .taskRunThreadCreated(message)
-        case "schedule_thread_created":
-            let message = try ScheduleThreadCreated(from: decoder)
-            self = .scheduleThreadCreated(message)
+        case "task_run_conversation_created":
+            let message = try TaskRunConversationCreated(from: decoder)
+            self = .taskRunConversationCreated(message)
+        case "schedule_conversation_created":
+            let message = try ScheduleConversationCreated(from: decoder)
+            self = .scheduleConversationCreated(message)
         case "subagent_spawned":
             let message = try SubagentSpawned(from: decoder)
             self = .subagentSpawned(message)


### PR DESCRIPTION
## Summary
- Rename SSE event type strings from notification_thread_created/task_run_thread_created/schedule_thread_created to conversation variants
- Update all struct types, enum cases, callbacks, and handler methods across shared/macOS/iOS Swift code
- Fixes critical bug where server-initiated conversations were silently dropped by clients

Part of plan: conv-rename-followup-fixes.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
