### PR TITLE
fix: update Swift client SessionInfo and SessionCreate to use conversationType

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -446,7 +446,7 @@ class IOSThreadStore: ObservableObject {
             return
         }
 
-        let filteredSessions = response.sessions.filter { $0.threadType != "private" }
+        let filteredSessions = response.sessions.filter { $0.conversationType != "private" }
 
         // Handle confirmed-empty first-page response: clear stale cached sessions.
         // Only clear when hasMore is explicitly false (authoritative empty result).
@@ -849,8 +849,8 @@ class IOSThreadStore: ObservableObject {
     }
 
     /// Create a new private thread with the given name. The thread is immediately
-    /// backed by a daemon session with threadType "private" so it is persisted on
-    /// the daemon side and excluded from normal thread restoration.
+    /// backed by a daemon session with conversationType "private" so it is persisted on
+    /// the daemon side and excluded from normal conversation restoration.
     @discardableResult
     func newPrivateThread(name: String = "Private Thread") -> IOSThread {
         let thread = IOSThread(title: name, isPrivate: true)
@@ -858,7 +858,7 @@ class IOSThreadStore: ObservableObject {
         // Get or create the view model after appending so activity tracking
         // can find the thread in self.threads.
         let vm = viewModel(for: thread.id)
-        vm.createSessionIfNeeded(threadType: "private")
+        vm.createSessionIfNeeded(conversationType: "private")
         save()
         return thread
     }

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -77,16 +77,16 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
     }
 
-    func testCreateSessionWithThreadTypeSetsThreadType() {
+    func testCreateSessionWithConversationTypeSetsConversationType() {
         let vm = ChatViewModel(daemonClient: mockClient)
-        vm.createSessionIfNeeded(threadType: "private")
+        vm.createSessionIfNeeded(conversationType: "private")
 
-        XCTAssertEqual(vm.threadType, "private")
+        XCTAssertEqual(vm.conversationType, "private")
     }
 
-    func testCreateSessionWithThreadTypeSendsThreadType() {
+    func testCreateSessionWithConversationTypeSendsConversationType() {
         let vm = ChatViewModel(daemonClient: mockClient)
-        vm.createSessionIfNeeded(threadType: "private")
+        vm.createSessionIfNeeded(conversationType: "private")
 
         let expectation = XCTestExpectation(description: "session_create sent")
         var cancelled = false
@@ -103,7 +103,7 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         cancelled = true
 
         let sessionCreates = mockClient.sentMessages.compactMap { $0 as? SessionCreateMessage }
-        XCTAssertEqual(sessionCreates.first?.threadType, "private")
+        XCTAssertEqual(sessionCreates.first?.conversationType, "private")
     }
 
     // MARK: - Session Info Backfill (Thread Session Assignment)

--- a/clients/ios/Views/Settings/PrivateThreadsSection.swift
+++ b/clients/ios/Views/Settings/PrivateThreadsSection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Manages private (temporary) threads on iOS, mirroring the macOS private thread
-/// workflow. Private threads are backed by daemon sessions with threadType "private"
+/// workflow. Private threads are backed by daemon sessions with conversationType "private"
 /// so they are excluded from normal session restoration and the main thread list.
 struct PrivateThreadsSection: View {
     /// Shared with the main ThreadListView so both views read from and write to the

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -399,7 +399,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         // Immediately create a daemon session so the thread is persisted
         // before the user sends any messages.
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
 
         log.info("Created private thread \(thread.id)")
     }
@@ -682,7 +682,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         serverOffset += response.sessions.count
 
         let recentSessions = response.sessions.filter {
-            $0.threadType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
         // Compute the next pinnedOrder based on existing pinned threads AND
@@ -720,7 +720,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 pinnedOrder: isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil,
                 displayOrder: session.displayOrder.map { Int($0) },
                 lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
-                kind: session.threadType == "private" ? .private : .standard,
+                kind: session.conversationType == "private" ? .private : .standard,
                 source: session.source,
                 scheduleJobId: session.scheduleJobId,
                 hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
@@ -813,7 +813,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         // Don't insert external-channel or private threads into the main sidebar
-        if session.threadType == "private" || session.channelBinding?.sourceChannel != nil {
+        if session.conversationType == "private" || session.channelBinding?.sourceChannel != nil {
             return false
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -181,7 +181,7 @@ final class ThreadSessionRestorer {
         // (e.g. Telegram). External channel-bound sessions belong to their own
         // lane and should not appear in the desktop conversation list.
         let recentSessions = response.sessions.filter {
-            $0.threadType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
         let defaultThreadIsEmpty = delegate.threads.count == 1
@@ -210,7 +210,7 @@ final class ThreadSessionRestorer {
                 continue
             }
 
-            let kind: ThreadKind = session.threadType == "private" ? .private : .standard
+            let kind: ThreadKind = session.conversationType == "private" ? .private : .standard
 
             // Preserve user-set titles: if a thread with this session already
             // exists locally and has a non-default title, keep it instead of

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2369,17 +2369,17 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - createSessionIfNeeded (Message-less Session Create)
 
     func testCreateSessionIfNeededSetsBootstrapping() {
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         XCTAssertFalse(viewModel.isSending, "Message-less session creates should not set isSending")
         XCTAssertFalse(viewModel.isThinking, "Should not show thinking for message-less session create")
         XCTAssertNotNil(viewModel.bootstrapCorrelationId, "Should set correlation ID")
-        XCTAssertEqual(viewModel.threadType, "private")
+        XCTAssertEqual(viewModel.conversationType, "private")
         XCTAssertTrue(viewModel.isBootstrapping)
     }
 
     func testCreateSessionIfNeededNoOpWhenSessionExists() {
         viewModel.sessionId = "existing-session"
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         XCTAssertNil(viewModel.bootstrapCorrelationId, "Should not bootstrap when session already exists")
     }
 
@@ -2391,12 +2391,12 @@ final class ChatViewModelTests: XCTestCase {
         let originalCorrelationId = viewModel.bootstrapCorrelationId
 
         // Calling createSessionIfNeeded should be a no-op
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         XCTAssertEqual(viewModel.bootstrapCorrelationId, originalCorrelationId, "Should not overwrite existing bootstrap")
     }
 
     func testCreateSessionIfNeededSessionInfoResetsState() {
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         let correlationId = viewModel.bootstrapCorrelationId!
 
         // Simulate daemon responding with session_info
@@ -2416,7 +2416,7 @@ final class ChatViewModelTests: XCTestCase {
             callbackSessionId = sessionId
         }
 
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         let correlationId = viewModel.bootstrapCorrelationId!
 
         let info = SessionInfoMessage(sessionId: "callback-session", title: "Test", correlationId: correlationId)
@@ -2425,13 +2425,13 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(callbackSessionId, "callback-session", "Should fire onSessionCreated callback")
     }
 
-    func testCreateSessionIfNeededSendsThreadTypeInMessage() {
+    func testCreateSessionIfNeededSendsConversationTypeInMessage() {
         var capturedMessages: [Any] = []
         daemonClient.sendOverride = { msg in
             capturedMessages.append(msg)
         }
 
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
 
         // Allow the async Task in bootstrapSession to execute
         let expectation = XCTestExpectation(description: "session_create sent")
@@ -2442,24 +2442,24 @@ final class ChatViewModelTests: XCTestCase {
 
         let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
         XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
-        XCTAssertEqual(sessionCreates.first?.threadType, "private", "session_create should include threadType")
+        XCTAssertEqual(sessionCreates.first?.conversationType, "private", "session_create should include conversationType")
         XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
     }
 
-    func testCreateSessionIfNeededWithoutThreadType() {
+    func testCreateSessionIfNeededWithoutConversationType() {
         viewModel.createSessionIfNeeded()
         XCTAssertFalse(viewModel.isSending, "Message-less session creates should not set isSending")
-        XCTAssertNil(viewModel.threadType, "threadType should remain nil when not specified")
+        XCTAssertNil(viewModel.conversationType, "conversationType should remain nil when not specified")
     }
 
-    func testThreadTypePassedThroughNormalSend() {
+    func testConversationTypePassedThroughNormalSend() {
         var capturedMessages: [Any] = []
         daemonClient.sendOverride = { msg in
             capturedMessages.append(msg)
         }
 
-        // Set threadType before sending
-        viewModel.threadType = "private"
+        // Set conversationType before sending
+        viewModel.conversationType = "private"
         viewModel.inputText = "Hello"
         viewModel.sendMessage()
 
@@ -2472,12 +2472,12 @@ final class ChatViewModelTests: XCTestCase {
 
         let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
         XCTAssertEqual(sessionCreates.count, 1)
-        XCTAssertEqual(sessionCreates.first?.threadType, "private", "Normal send should also pass threadType")
+        XCTAssertEqual(sessionCreates.first?.conversationType, "private", "Normal send should also pass conversationType")
     }
 
     func testCreateSessionThenSendMessageUsesClaimedSession() {
         // Create session without message
-        viewModel.createSessionIfNeeded(threadType: "private")
+        viewModel.createSessionIfNeeded(conversationType: "private")
         let correlationId = viewModel.bootstrapCorrelationId!
 
         // Daemon responds with session_info

--- a/clients/macos/vellum-assistantTests/PrivateThreadPersistenceTests.swift
+++ b/clients/macos/vellum-assistantTests/PrivateThreadPersistenceTests.swift
@@ -49,7 +49,7 @@ struct PrivateThreadPersistenceTests {
         #expect(updatedThread.kind == .private)
 
         // Now simulate a fresh restore: build a session list response
-        // that includes this session with threadType "private", and verify
+        // that includes this session with conversationType "private", and verify
         // the restorer creates it with .private kind.
         let restorer = ThreadSessionRestorer(daemonClient: dc)
         let delegate = MockThreadRestorerDelegate(daemonClient: dc)
@@ -67,7 +67,7 @@ struct PrivateThreadPersistenceTests {
                     "title": "Private Thread",
                     "createdAt": 4000,
                     "updatedAt": 5000,
-                    "threadType": "private"
+                    "conversationType": "private"
                 ]
             ]
         ]
@@ -110,7 +110,7 @@ struct PrivateThreadPersistenceTests {
                     "title": "Standard Thread",
                     "createdAt": 2000,
                     "updatedAt": 3000,
-                    "threadType": "standard"
+                    "conversationType": "standard"
                 ]
             ]
         ]
@@ -141,9 +141,9 @@ struct PrivateThreadPersistenceTests {
         let sessionListJSON: [String: Any] = [
             "type": "session_list_response",
             "sessions": [
-                ["id": "s-private-1", "title": "Private A", "createdAt": 4000, "updatedAt": 5000, "threadType": "private"],
-                ["id": "s-standard-1", "title": "Standard B", "createdAt": 3000, "updatedAt": 4000, "threadType": "standard"],
-                ["id": "s-private-2", "title": "Private C", "createdAt": 2000, "updatedAt": 3000, "threadType": "private"],
+                ["id": "s-private-1", "title": "Private A", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
+                ["id": "s-standard-1", "title": "Standard B", "createdAt": 3000, "updatedAt": 4000, "conversationType": "standard"],
+                ["id": "s-private-2", "title": "Private C", "createdAt": 2000, "updatedAt": 3000, "conversationType": "private"],
             ]
         ]
         let data = try! JSONSerialization.data(withJSONObject: sessionListJSON)
@@ -158,10 +158,10 @@ struct PrivateThreadPersistenceTests {
 
     // MARK: - Legacy Daemon Payload Fallback
 
-    /// Older daemon versions do not include the threadType field in session
+    /// Older daemon versions do not include the conversationType field in session
     /// list responses. Verify that these sessions default to .standard.
     @Test @MainActor
-    func legacyPayloadWithoutThreadTypeDefaultsToStandard() {
+    func legacyPayloadWithoutConversationTypeDefaultsToStandard() {
         let dc = DaemonClient()
         let restorer = ThreadSessionRestorer(daemonClient: dc)
         let delegate = MockThreadRestorerDelegate(daemonClient: dc)
@@ -171,7 +171,7 @@ struct PrivateThreadPersistenceTests {
         delegate.threads = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
-        // JSON with no threadType key at all — simulates an older daemon
+        // JSON with no conversationType key at all — simulates an older daemon
         let legacyJSON: [String: Any] = [
             "type": "session_list_response",
             "sessions": [
@@ -187,8 +187,8 @@ struct PrivateThreadPersistenceTests {
         #expect(delegate.threads[0].sessionId == "legacy-1")
     }
 
-    /// Verifies that a session list mixing legacy (no threadType) and modern
-    /// (with threadType) sessions restores correctly.
+    /// Verifies that a session list mixing legacy (no conversationType) and modern
+    /// (with conversationType) sessions restores correctly.
     @Test @MainActor
     func mixedLegacyAndModernPayloadsRestoreCorrectly() {
         let dc = DaemonClient()
@@ -200,9 +200,9 @@ struct PrivateThreadPersistenceTests {
         delegate.threads = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
-        // Build sessions array manually: first has threadType, second doesn't
+        // Build sessions array manually: first has conversationType, second doesn't
         let sessions: [[String: Any]] = [
-            ["id": "modern-1", "title": "Modern Private", "createdAt": 4000, "updatedAt": 5000, "threadType": "private"],
+            ["id": "modern-1", "title": "Modern Private", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
             ["id": "legacy-1", "title": "Legacy Chat", "createdAt": 3000, "updatedAt": 4000],
         ]
         let dict: [String: Any] = ["type": "session_list_response", "sessions": sessions]
@@ -219,7 +219,7 @@ struct PrivateThreadPersistenceTests {
     // MARK: - ThreadManager.createPrivateThread Immediate Persistence
 
     /// Verifies that createPrivateThread() immediately sends a session_create
-    /// with threadType "private" — the thread is persisted on the daemon side
+    /// with conversationType "private" — the thread is persisted on the daemon side
     /// before the user sends any messages.
     @Test @MainActor
     func privateThreadPersistsImmediatelyViaSessionCreate() {
@@ -235,10 +235,10 @@ struct PrivateThreadPersistenceTests {
 
         let vm = manager.activeViewModel!
         #expect(vm.isBootstrapping)
-        #expect(vm.threadType == "private")
+        #expect(vm.conversationType == "private")
 
         // The session_create is dispatched asynchronously via Task; the
-        // correlation ID and threadType are set synchronously, confirming
+        // correlation ID and conversationType are set synchronously, confirming
         // the intent to persist immediately.
         #expect(vm.bootstrapCorrelationId != nil)
     }

--- a/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerPrivateThreadTests.swift
@@ -53,7 +53,7 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
         let vm = threadManager.activeViewModel!
         XCTAssertTrue(vm.isSending, "Should be in sending state from createSessionIfNeeded bootstrap")
         XCTAssertTrue(vm.isBootstrapping, "Should be bootstrapping a session")
-        XCTAssertEqual(vm.threadType, "private", "threadType should be set to private")
+        XCTAssertEqual(vm.conversationType, "private", "conversationType should be set to private")
     }
 
     func testCreatePrivateThreadSendsSessionCreate() {
@@ -68,7 +68,7 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
 
         let sessionCreates = capturedMessages.compactMap { $0 as? SessionCreateMessage }
         XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
-        XCTAssertEqual(sessionCreates.first?.threadType, "private", "session_create should include private threadType")
+        XCTAssertEqual(sessionCreates.first?.conversationType, "private", "session_create should include private conversationType")
         XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
     }
 

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -94,11 +94,11 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 // MARK: - Helpers
 
 /// Build a SessionListResponseMessage via JSON round-trip.
-private func makeSessionListResponse(sessions: [(id: String, title: String, createdAt: Int, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
+private func makeSessionListResponse(sessions: [(id: String, title: String, createdAt: Int, updatedAt: Int, conversationType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
     let sessionDicts = sessions.map { session -> [String: Any] in
         var dict: [String: Any] = ["id": session.id, "title": session.title, "createdAt": session.createdAt, "updatedAt": session.updatedAt]
-        if let threadType = session.threadType {
-            dict["threadType"] = threadType
+        if let conversationType = session.conversationType {
+            dict["conversationType"] = conversationType
         }
         if let channelBinding = session.channelBinding {
             dict["channelBinding"] = channelBinding
@@ -121,17 +121,17 @@ private func makeSessionListResponse(
     return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
 }
 
-/// Convenience overload with threadType and optional channelBinding.
-private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
-    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, $0.channelBinding) })
+/// Convenience overload with conversationType and optional channelBinding.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, conversationType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.conversationType, $0.channelBinding) })
 }
 
-/// Convenience overload with threadType but no channelBinding.
-private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?)]) -> SessionListResponseMessage {
-    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, nil) })
+/// Convenience overload with conversationType but no channelBinding.
+private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, conversationType: String?)]) -> SessionListResponseMessage {
+    makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.conversationType, nil) })
 }
 
-/// Convenience overload without threadType for existing tests.
+/// Convenience overload without conversationType for existing tests.
 private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int)]) -> SessionListResponseMessage {
     makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, nil, nil) })
 }
@@ -510,7 +510,7 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Private Chat", updatedAt: 2000, threadType: "private"),
+            (id: "s1", title: "Private Chat", updatedAt: 2000, conversationType: "private"),
         ])
         restorer.handleSessionListResponse(response)
 
@@ -521,7 +521,7 @@ struct ThreadSessionRestorerTests {
     }
 
     @Test @MainActor
-    func nilThreadTypeRestoresAsStandardKind() {
+    func nilConversationTypeRestoresAsStandardKind() {
         let dc = DaemonClient()
         let restorer = ThreadSessionRestorer(daemonClient: dc)
         let delegate = MockThreadRestorerDelegate(daemonClient: dc)
@@ -532,7 +532,7 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Regular Chat", updatedAt: 2000, threadType: nil),
+            (id: "s1", title: "Regular Chat", updatedAt: 2000, conversationType: nil),
         ])
         restorer.handleSessionListResponse(response)
 
@@ -541,7 +541,7 @@ struct ThreadSessionRestorerTests {
     }
 
     @Test @MainActor
-    func standardThreadTypeRestoresAsStandardKind() {
+    func standardConversationTypeRestoresAsStandardKind() {
         let dc = DaemonClient()
         let restorer = ThreadSessionRestorer(daemonClient: dc)
         let delegate = MockThreadRestorerDelegate(daemonClient: dc)
@@ -552,7 +552,7 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Standard Chat", updatedAt: 2000, threadType: "standard"),
+            (id: "s1", title: "Standard Chat", updatedAt: 2000, conversationType: "standard"),
         ])
         restorer.handleSessionListResponse(response)
 
@@ -574,7 +574,7 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Telegram Chat", updatedAt: 2000, threadType: nil,
+            (id: "s1", title: "Telegram Chat", updatedAt: 2000, conversationType: nil,
              channelBinding: ["sourceChannel": "telegram", "externalChatId": "123456"]),
         ])
         restorer.handleSessionListResponse(response)
@@ -598,7 +598,7 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Voice Call", updatedAt: 2000, threadType: nil,
+            (id: "s1", title: "Voice Call", updatedAt: 2000, conversationType: nil,
              channelBinding: ["sourceChannel": "phone", "externalChatId": "call-123"]),
         ])
         restorer.handleSessionListResponse(response)
@@ -622,12 +622,12 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Desktop Chat", updatedAt: 4000, threadType: nil, channelBinding: nil),
-            (id: "s2", title: "Telegram Chat", updatedAt: 3000, threadType: nil,
+            (id: "s1", title: "Desktop Chat", updatedAt: 4000, conversationType: nil, channelBinding: nil),
+            (id: "s2", title: "Telegram Chat", updatedAt: 3000, conversationType: nil,
              channelBinding: ["sourceChannel": "telegram", "externalChatId": "789"]),
-            (id: "s3", title: "Voice Call", updatedAt: 2000, threadType: nil,
+            (id: "s3", title: "Voice Call", updatedAt: 2000, conversationType: nil,
              channelBinding: ["sourceChannel": "phone", "externalChatId": "call-456"]),
-            (id: "s4", title: "Another Desktop Chat", updatedAt: 1000, threadType: nil, channelBinding: nil),
+            (id: "s4", title: "Another Desktop Chat", updatedAt: 1000, conversationType: nil, channelBinding: nil),
         ])
         restorer.handleSessionListResponse(response)
 
@@ -652,10 +652,10 @@ struct ThreadSessionRestorerTests {
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeSessionListResponse(sessions: [
-            (id: "s1", title: "Desktop Chat", updatedAt: 3000, threadType: nil, channelBinding: nil),
-            (id: "s2", title: "Telegram Chat", updatedAt: 2000, threadType: nil,
+            (id: "s1", title: "Desktop Chat", updatedAt: 3000, conversationType: nil, channelBinding: nil),
+            (id: "s2", title: "Telegram Chat", updatedAt: 2000, conversationType: nil,
              channelBinding: ["sourceChannel": "telegram", "externalChatId": "789"]),
-            (id: "s3", title: "Another Desktop Chat", updatedAt: 1000, threadType: nil, channelBinding: nil),
+            (id: "s3", title: "Another Desktop Chat", updatedAt: 1000, conversationType: nil, channelBinding: nil),
         ])
         restorer.handleSessionListResponse(response)
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -384,10 +384,10 @@ public final class ChatViewModel: ObservableObject {
     /// Nonce sent with `session_create` and echoed back in `session_info`.
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
-    /// Thread type sent with `session_create` (e.g. "private").
-    /// Set by `createSessionIfNeeded(threadType:)` and included in the
-    /// message so the daemon can persist the correct thread kind.
-    public var threadType: String?
+    /// Conversation type sent with `session_create` (e.g. "private").
+    /// Set by `createSessionIfNeeded(conversationType:)` and included in the
+    /// message so the daemon can persist the correct conversation kind.
+    public var conversationType: String?
     /// Skill IDs to pre-activate in the session. Included in the
     /// `session_create` request for deterministic skill activation.
     public var preactivatedSkillIds: [String]?
@@ -1278,7 +1278,7 @@ public final class ChatViewModel: ObservableObject {
 
             // Send session_create with correlation ID and thread type
             do {
-                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, threadType: self.threadType, preactivatedSkillIds: self.preactivatedSkillIds))
+                try daemonClient.send(SessionCreateMessage(title: nil, correlationId: correlationId, conversationType: self.conversationType, preactivatedSkillIds: self.preactivatedSkillIds))
                 // Clear one-shot preactivated skills so they don't leak into a
                 // later session if this bootstrap is interrupted before completion.
                 self.preactivatedSkillIds = nil
@@ -1515,10 +1515,10 @@ public final class ChatViewModel: ObservableObject {
     /// Used by private threads that need a persistent session ID right away
     /// (e.g. to store the thread in the database before the user types anything).
     /// No-op if a session already exists or a bootstrap is already in flight.
-    public func createSessionIfNeeded(threadType: String? = nil) {
+    public func createSessionIfNeeded(conversationType: String? = nil) {
         guard sessionId == nil, !isBootstrapping else { return }
-        if let threadType {
-            self.threadType = threadType
+        if let conversationType {
+            self.conversationType = conversationType
         }
         bootstrapSession(userMessage: nil, attachments: nil)
     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3301,20 +3301,20 @@ public struct SessionCreateRequest: Codable, Sendable {
     public let correlationId: String?
     /// Lightweight session transport metadata for channel identity and natural-language guidance.
     public let transport: SessionTransportMetadata?
-    public let threadType: String?
+    public let conversationType: String?
     /// Skill IDs to pre-activate in the new session (loaded before the first message).
     public let preactivatedSkillIds: [String]?
     /// If provided, automatically sent as the first user message after session creation.
     public let initialMessage: String?
 
-    public init(type: String, title: String? = nil, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: SessionTransportMetadata? = nil, threadType: String? = nil, preactivatedSkillIds: [String]? = nil, initialMessage: String? = nil) {
+    public init(type: String, title: String? = nil, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: SessionTransportMetadata? = nil, conversationType: String? = nil, preactivatedSkillIds: [String]? = nil, initialMessage: String? = nil) {
         self.type = type
         self.title = title
         self.systemPromptOverride = systemPromptOverride
         self.maxResponseTokens = maxResponseTokens
         self.correlationId = correlationId
         self.transport = transport
-        self.threadType = threadType
+        self.conversationType = conversationType
         self.preactivatedSkillIds = preactivatedSkillIds
         self.initialMessage = initialMessage
     }
@@ -3325,14 +3325,14 @@ public struct SessionInfo: Codable, Sendable {
     public let sessionId: String
     public let title: String
     public let correlationId: String?
-    public let threadType: String?
+    public let conversationType: String?
 
-    public init(type: String, sessionId: String, title: String, correlationId: String? = nil, threadType: String? = nil) {
+    public init(type: String, sessionId: String, title: String, correlationId: String? = nil, conversationType: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.title = title
         self.correlationId = correlationId
-        self.threadType = threadType
+        self.conversationType = conversationType
     }
 }
 
@@ -3368,7 +3368,7 @@ public struct SessionListResponseSession: Codable, Sendable {
     public let title: String
     public let createdAt: Int?
     public let updatedAt: Int
-    public let threadType: String?
+    public let conversationType: String?
     public let source: String?
     public let scheduleJobId: String?
     /// Channel binding metadata exposed in session/conversation list APIs.
@@ -3380,12 +3380,12 @@ public struct SessionListResponseSession: Codable, Sendable {
     public let displayOrder: Double?
     public let isPinned: Bool?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, threadType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-        self.threadType = threadType
+        self.conversationType = conversationType
         self.source = source
         self.scheduleJobId = scheduleJobId
         self.channelBinding = channelBinding

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -30,8 +30,8 @@ extension HTTPTransport {
                 // acts as the session. Emit a synthetic session_info so ChatViewModel
                 // records the session ID.
                 let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
-                // Remember private sessions so sendMessage can pass threadType to the backend.
-                if msg.threadType == "private" {
+                // Remember private sessions so sendMessage can pass conversationType to the backend.
+                if msg.conversationType == "private" {
                     self.privateSessionIds.insert(sessionId)
                 }
                 let info = ServerMessage.sessionInfo(

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -27,7 +27,7 @@ public struct ConversationsListResponse: Decodable {
         public let title: String
         public let createdAt: Int?
         public let updatedAt: Int
-        public let threadType: String?
+        public let conversationType: String?
         public let source: String?
         public let scheduleJobId: String?
         public let channelBinding: ChannelBinding?
@@ -187,7 +187,7 @@ public final class HTTPTransport {
     /// Host tool requests are only executed for these session IDs.
     private var locallyOwnedSessionIds: Set<String> = []
     /// Session IDs that belong to private (temporary) threads.
-    /// Populated when a session_create with threadType "private" is handled locally.
+    /// Populated when a session_create with conversationType "private" is handled locally.
     var privateSessionIds: Set<String> = []
 
     let decoder = JSONDecoder()
@@ -1716,7 +1716,7 @@ public final class HTTPTransport {
             body["attachmentIds"] = attachmentIds
         }
         if privateSessionIds.contains(sessionId) {
-            body["threadType"] = "private"
+            body["conversationType"] = "private"
         }
 
         do {
@@ -2935,7 +2935,7 @@ public final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    SessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, scheduleJobId: $0.scheduleJobId, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention, displayOrder: $0.displayOrder, isPinned: $0.isPinned)
+                    SessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, conversationType: $0.conversationType, source: $0.source, scheduleJobId: $0.scheduleJobId, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention, displayOrder: $0.displayOrder, isPinned: $0.isPinned)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -199,8 +199,8 @@ extension SessionCreateRequest {
         #endif
     }
 
-    public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: SessionTransportMetadata? = nil, threadType: String? = nil, preactivatedSkillIds: [String]? = nil, initialMessage: String? = nil) {
-        self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, threadType: threadType, preactivatedSkillIds: preactivatedSkillIds, initialMessage: initialMessage)
+    public init(title: String?, systemPromptOverride: String? = nil, maxResponseTokens: Int? = nil, correlationId: String? = nil, transport: SessionTransportMetadata? = nil, conversationType: String? = nil, preactivatedSkillIds: [String]? = nil, initialMessage: String? = nil) {
+        self.init(type: "session_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, conversationType: conversationType, preactivatedSkillIds: preactivatedSkillIds, initialMessage: initialMessage)
     }
 
     public init(
@@ -225,7 +225,7 @@ extension SessionCreateRequest {
                 hints: transportHints,
                 uxBrief: transportUxBrief
             ),
-            threadType: nil,
+            conversationType: nil,
             preactivatedSkillIds: nil,
             initialMessage: nil
         )
@@ -683,8 +683,8 @@ extension MessageComplete {
 public typealias SessionInfoMessage = SessionInfo
 
 extension SessionInfo {
-    public init(sessionId: String, title: String, correlationId: String? = nil, threadType: String? = nil) {
-        self.init(type: "session_info", sessionId: sessionId, title: title, correlationId: correlationId, threadType: threadType)
+    public init(sessionId: String, title: String, correlationId: String? = nil, conversationType: String? = nil) {
+        self.init(type: "session_info", sessionId: sessionId, title: title, correlationId: correlationId, conversationType: conversationType)
     }
 }
 


### PR DESCRIPTION
## Summary
- Rename threadType property to conversationType in SessionCreateRequest, SessionInfo, and SessionListResponseSession structs
- Update all convenience initializers and call sites in Swift code
- Ensures client session types match daemon wire format

Part of plan: conv-rename-followup-fixes.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
