### PR TITLE
fix: use lowercase alphanumeric nanoid alphabet for cloud-safe instance names

### DIFF
--- a/cli/src/__tests__/random-name.test.ts
+++ b/cli/src/__tests__/random-name.test.ts
@@ -7,7 +7,7 @@ import {
 describe("generateRandomSuffix", () => {
   test("returns a string in adjective-noun-nanoid format", () => {
     const result = generateRandomSuffix();
-    expect(result).toMatch(/^[a-z]+-[a-z]+-[A-Za-z0-9_-]{6}$/);
+    expect(result).toMatch(/^[a-z]+-[a-z]+-[a-z0-9]{6}$/);
   });
 
   test("produces varying results across multiple calls", () => {
@@ -28,11 +28,11 @@ describe("generateInstanceName", () => {
 
   test("generates species-prefixed name when no explicit name", () => {
     const result = generateInstanceName("vellum");
-    expect(result).toMatch(/^vellum-[a-z]+-[a-z]+-[A-Za-z0-9_-]{6}$/);
+    expect(result).toMatch(/^vellum-[a-z]+-[a-z]+-[a-z0-9]{6}$/);
   });
 
   test("treats null as no explicit name", () => {
     const result = generateInstanceName("openclaw", null);
-    expect(result).toMatch(/^openclaw-[a-z]+-[a-z]+-[A-Za-z0-9_-]{6}$/);
+    expect(result).toMatch(/^openclaw-[a-z]+-[a-z]+-[a-z0-9]{6}$/);
   });
 });

--- a/cli/src/lib/random-name.ts
+++ b/cli/src/lib/random-name.ts
@@ -1,4 +1,6 @@
-import { nanoid } from "nanoid";
+import { customAlphabet } from "nanoid";
+
+const nanoidLower = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789", 6);
 
 const ADJECTIVES = [
   "brave",
@@ -131,7 +133,7 @@ function randomElement<T>(arr: T[]): T {
 }
 
 export function generateRandomSuffix(): string {
-  return `${randomElement(ADJECTIVES)}-${randomElement(NOUNS)}-${nanoid(6)}`;
+  return `${randomElement(ADJECTIVES)}-${randomElement(NOUNS)}-${nanoidLower()}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-assistant-id-generation.md.

**Gap:** nanoid default alphabet produces characters illegal in GCP instance names
**What was expected:** Suffix should only contain lowercase alphanumeric characters
**What was found:** `nanoid(6)` uses `A-Za-z0-9_-` which includes uppercase and underscores that GCP rejects

Uses `customAlphabet` from nanoid restricted to `abcdefghijklmnopqrstuvwxyz0123456789` to ensure generated names are valid across all cloud providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
