### PR TITLE
docs: remove stale slash command references from comments and diagrams

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1192,7 +1192,6 @@ The following capabilities ship as bundled skills in `assistant/src/config/bundl
 ```mermaid
 graph TB
     subgraph "Activation Sources"
-        SLASH["Slash command<br/>/skill-id → preactivate"]
         MARKER["&lt;loaded_skill id=&quot;...&quot; /&gt;<br/>marker in conversation history"]
         CONFIG["Config / session<br/>preactivatedSkillIds"]
     end
@@ -1214,7 +1213,6 @@ graph TB
         PROVIDER["LLM Provider<br/>receives full tool list"]
     end
 
-    SLASH --> CONFIG
     MARKER --> DERIVE
     CONFIG --> UNION
     DERIVE --> UNION
@@ -1229,7 +1227,7 @@ graph TB
     RESOLVE --> PROVIDER
 ```
 
-**Internal preactivation**: Some bundled skills are preactivated programmatically rather than by user slash commands or model discovery. For example, desktop sessions set `preactivatedSkillIds: ['computer-use']`, causing `projectSkillTools()` to load the 11 `computer_use_*` tool definitions from the bundled skill's `TOOLS.json` on the first turn. These proxy tools forward actions to the connected macOS client via `HostCuProxy`.
+**Internal preactivation**: Some bundled skills are preactivated programmatically rather than by model discovery. For example, desktop sessions set `preactivatedSkillIds: ['computer-use']`, causing `projectSkillTools()` to load the 11 `computer_use_*` tool definitions from the bundled skill's `TOOLS.json` on the first turn. These proxy tools forward actions to the connected macOS client via `HostCuProxy`.
 
 ### Skill Tool Execution
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -94,7 +94,7 @@ export interface ProcessSessionContext {
   currentPage?: string;
   /** Cumulative token usage stats for the session. */
   readonly usageStats: UsageStats;
-  /** Request-scoped skill IDs preactivated via slash resolution. */
+  /** Request-scoped skill IDs preactivated via config or programmatic injection. */
   preactivatedSkillIds?: string[];
   /** Add a skill ID to the preactivated set without replacing existing entries. */
   addPreactivatedSkillId(id: string): void;

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -2,7 +2,7 @@
  * Session-time projection of active skill tools.
  *
  * On each agent turn the conversation history (and any pre-activated IDs from
- * config or slash commands) determine which skills are "active".  This module
+ * config or programmatic injection) determine which skills are "active".  This module
  * computes the union, loads tool manifests, registers new skill tools, tears
  * down tools for skills that are no longer active, and returns the projected
  * tool definitions so the agent loop can include them in the next request.

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -345,7 +345,7 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
 }
 
 /**
- * Resolve slash commands against the current skill catalog.
+ * Resolve built-in slash commands (/model, /status, /commands, /pair, provider shortcuts).
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
  */
 export async function resolveSlash(


### PR DESCRIPTION
## Summary
- Remove 5 stale comments/docs referencing the removed skill-based slash command system
- Update ARCHITECTURE.md Mermaid diagram to remove the `/skill-id → preactivate` activation source node and edge
- Update JSDoc comments in session-slash.ts, session-skill-tools.ts, and session-process.ts to reflect that preactivation comes from config or programmatic injection, not slash resolution

## Original prompt
Fix 5 stale comments referencing removed skill-based slash commands:
1. session-slash.ts:348 — "against the current skill catalog" → "built-in slash commands"
2. ARCHITECTURE.md:1195 — Remove SLASH node from Mermaid diagram
3. ARCHITECTURE.md:1232 — Remove "user slash commands" reference
4. session-skill-tools.ts:5 — "config or slash commands" → "config or programmatic injection"
5. session-process.ts:97 — "via slash resolution" → "via config or programmatic injection"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
