### PR TITLE
fix: narrow ParsedHandle union in CES contract tests

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -150,7 +150,9 @@ describe("local_static handle rejection in managed mode", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.handle.type).toBe(HandleType.PlatformOAuth);
-      expect(result.handle.connectionId).toBe("conn_abc123");
+      if (result.handle.type === HandleType.PlatformOAuth) {
+        expect(result.handle.connectionId).toBe("conn_abc123");
+      }
     }
   });
 
@@ -419,7 +421,9 @@ describe("managed OAuth materialization through CES sidecar", () => {
     expect(parsed.ok).toBe(true);
     if (parsed.ok) {
       expect(parsed.handle.type).toBe(HandleType.PlatformOAuth);
-      expect(parsed.handle.connectionId).toBe("conn_abc123");
+      if (parsed.handle.type === HandleType.PlatformOAuth) {
+        expect(parsed.handle.connectionId).toBe("conn_abc123");
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- Added type narrowing (`handle.type === HandleType.PlatformOAuth`) before accessing `connectionId` on `ParsedHandle` in two test cases
- Fixes TS2339 errors where `connectionId` doesn't exist on `LocalStaticHandle` variant of the union

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23118785620/job/67148945361

🤖 Generated with [Claude Code](https://claude.com/claude-code)