### PR TITLE
fix: update daemon HTTP endpoints to use conversationType on wire

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -850,7 +850,7 @@ export class RuntimeHttpServer {
                 title: c.title ?? "Untitled",
                 createdAt: c.createdAt,
                 updatedAt: c.updatedAt,
-                threadType:
+                conversationType:
                   c.conversationType === "private" ? "private" : "standard",
                 source: c.source ?? "user",
                 ...(c.scheduleJobId ? { scheduleJobId: c.scheduleJobId } : {}),
@@ -1028,7 +1028,7 @@ export class RuntimeHttpServer {
               title: conversation.title ?? "Untitled",
               createdAt: conversation.createdAt,
               updatedAt: conversation.updatedAt,
-              threadType:
+              conversationType:
                 conversation.conversationType === "private"
                   ? "private"
                   : "standard",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -555,7 +555,7 @@ export async function handleSendMessage(
     attachmentIds?: string[];
     sourceChannel?: string;
     interface?: string;
-    threadType?: string;
+    conversationType?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -655,7 +655,7 @@ export async function handleSendMessage(
   }
 
   const conversationType =
-    body.threadType === "private" ? ("private" as const) : undefined;
+    body.conversationType === "private" ? ("private" as const) : undefined;
   const mapping = getOrCreateConversation(conversationKey, {
     conversationType,
   });

--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -86,7 +86,7 @@ export function sessionManagementRouteDefinitions(
         return Response.json({
           sessionId: result.sessionId,
           title: result.title,
-          threadType:
+          conversationType:
             result.conversationType === "private" ? "private" : "standard",
         });
       },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-rename-followup-fixes.md.

**Gap:** HTTP wire mismatch — daemon sends threadType but Swift client now sends/decodes conversationType
**What was expected:** Daemon HTTP endpoints should use conversationType to match the updated Swift client
**What was found:** GET /v1/conversations, GET /v1/conversations/:id, POST /v1/conversations/:id/switch, and POST /v1/messages all used threadType on the wire while the client sends/expects conversationType

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
