### PR TITLE
fix: use OS-assigned port in call-routes-http tests to prevent EADDRINUSE

### DIFF
--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -191,9 +191,9 @@ describe("runtime call routes — HTTP layer", () => {
   });
 
   async function startServer(): Promise<void> {
-    port = 19000 + Math.floor(Math.random() * 1000);
-    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
+    server = new RuntimeHttpServer({ port: 0, bearerToken: TEST_TOKEN });
     await server.start();
+    port = server.actualPort;
   }
 
   async function stopServer(): Promise<void> {


### PR DESCRIPTION
## Summary
- Changed `startServer()` in `call-routes-http.test.ts` to use port `0` (OS-assigned) instead of a random port from a small range
- Reads the actual port from `server.actualPort` after start, eliminating port collision failures in CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23119148819/job/67149890772

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
