### PR TITLE
refactor: remove installationId generation from Swift ensureManagedEntry

### DIFF
--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -38,9 +38,6 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(assistants[0]["cloud"] as? String, "vellum")
         XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://platform.vellum.ai")
         XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-01-01T00:00:00Z")
-        let installationId = assistants[0]["installationId"] as? String
-        XCTAssertNotNil(installationId, "installationId should be generated on insert")
-        XCTAssertFalse(installationId!.isEmpty, "installationId should not be empty")
     }
 
     func testEnsureInsertsIntoEmptyLockfile() {
@@ -91,33 +88,6 @@ final class LockfileAssistantManagedTests: XCTestCase {
         // Original values preserved, NOT overwritten.
         XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://old.example.com")
         XCTAssertEqual(assistants[0]["hatchedAt"] as? String, "2024-01-01T00:00:00Z")
-    }
-
-    func testEnsurePreservesInstallationIdOnRepeatCall() {
-        LockfileAssistant.ensureManagedEntry(
-            assistantId: "test-id",
-            runtimeUrl: "https://example.com",
-            hatchedAt: "2024-01-01T00:00:00Z",
-            lockfilePath: lockfilePath
-        )
-
-        let data1 = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
-        let json1 = try! JSONSerialization.jsonObject(with: data1) as! [String: Any]
-        let assistants1 = json1["assistants"] as! [[String: Any]]
-        let originalInstallationId = assistants1[0]["installationId"] as! String
-
-        // Second call with same assistantId — should be no-op.
-        LockfileAssistant.ensureManagedEntry(
-            assistantId: "test-id",
-            runtimeUrl: "https://different.example.com",
-            hatchedAt: "2024-06-01T00:00:00Z",
-            lockfilePath: lockfilePath
-        )
-
-        let data2 = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
-        let json2 = try! JSONSerialization.jsonObject(with: data2) as! [String: Any]
-        let assistants2 = json2["assistants"] as! [[String: Any]]
-        XCTAssertEqual(assistants2[0]["installationId"] as? String, originalInstallationId, "installationId must survive repeat calls")
     }
 
     // MARK: - ensureManagedEntry: preserves other entries

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -173,7 +173,6 @@ public struct LockfileAssistant {
             "runtimeUrl": runtimeUrl,
             "cloud": "vellum",
             "hatchedAt": hatchedAt,
-            "installationId": UUID().uuidString.lowercased(),
         ]
         assistants.append(newEntry)
 


### PR DESCRIPTION
## Summary
- Remove `installationId` generation from `ensureManagedEntry` in `LockfileAssistant.swift`
- Remove `installationId` assertions from managed entry tests
- Delete `testEnsurePreservesInstallationIdOnRepeatCall` test (no longer relevant)

Part of plan: unify-device-id.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
