### PR TITLE
refactor: remove per-assistant installationId from AssistantEntry and CLI

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -36,7 +36,6 @@ const makeEntry = (
   extra?: Partial<AssistantEntry>,
 ): AssistantEntry => ({
   assistantId: id,
-  installationId: `test-install-${id}`,
   runtimeUrl,
   cloud: "local",
   ...extra,

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -68,7 +68,6 @@ const makeEntry = (
   extra?: Partial<AssistantEntry>,
 ): AssistantEntry => ({
   assistantId: id,
-  installationId: `test-install-${id}`,
   runtimeUrl: `http://localhost:${DEFAULT_DAEMON_PORT}`,
   cloud,
   ...extra,

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -9,7 +9,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { randomUUID } from "node:crypto";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -675,7 +674,6 @@ async function hatchLocal(
 
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
-    installationId: randomUUID(),
     runtimeUrl,
     localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
     cloud: "local",

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "crypto";
+import { createHash } from "crypto";
 import { readFileSync } from "fs";
 import jsQR from "jsqr";
 import { hostname, userInfo } from "os";
@@ -167,7 +167,6 @@ export async function pair(): Promise<void> {
 
     const customEntry: AssistantEntry = {
       assistantId: instanceName,
-      installationId: randomUUID(),
       runtimeUrl,
       bearerToken,
       cloud: "custom",

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, unlinkSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -40,8 +39,6 @@ export async function recover(): Promise<void> {
 
   // 2. Read and validate metadata before any side effects
   const entry: AssistantEntry = JSON.parse(readFileSync(metadataPath, "utf-8"));
-  // Backfill installationId for archives created before the field was introduced
-  entry.installationId ??= randomUUID();
   if (!entry.resources) {
     throw new Error(
       `Retired assistant '${name}' is missing resource configuration. ` +

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -37,7 +36,6 @@ export interface LocalInstanceResources {
 
 export interface AssistantEntry {
   assistantId: string;
-  installationId: string;
   runtimeUrl: string;
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
@@ -215,13 +213,6 @@ function readAssistants(): AssistantEntry[] {
   let migrated = false;
   for (const entry of entries) {
     if (migrateLegacyEntry(entry)) {
-      migrated = true;
-    }
-  }
-
-  for (const entry of entries) {
-    if (typeof entry.installationId !== "string") {
-      entry.installationId = randomUUID();
       migrated = true;
     }
   }

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir, userInfo } from "os";
 import { join } from "path";
@@ -483,7 +482,6 @@ export async function hatchAws(
       : `http://${instanceName}:${GATEWAY_PORT}`;
     const awsEntry: AssistantEntry = {
       assistantId: instanceName,
-      installationId: randomUUID(),
       runtimeUrl,
       cloud: "aws",
       instanceId,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1,5 +1,4 @@
 import { spawn as nodeSpawn } from "child_process";
-import { randomUUID } from "node:crypto";
 import { existsSync } from "fs";
 import { createRequire } from "module";
 import { dirname, join } from "path";
@@ -351,7 +350,6 @@ export async function hatchDocker(
   const runtimeUrl = `http://localhost:${gatewayPort}`;
   const dockerEntry: AssistantEntry = {
     assistantId: instanceName,
-    installationId: randomUUID(),
     runtimeUrl,
     cloud: "docker",
     species,

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { unlinkSync, writeFileSync } from "fs";
 import { tmpdir, userInfo } from "os";
 import { join } from "path";
@@ -581,7 +580,6 @@ export async function hatchGcp(
       : `http://${instanceName}:${GATEWAY_PORT}`;
     const gcpEntry: AssistantEntry = {
       assistantId: instanceName,
-      installationId: randomUUID(),
       runtimeUrl,
       cloud: "gcp",
       project,


### PR DESCRIPTION
## Summary
- Remove `installationId: string` from `AssistantEntry` interface
- Remove `installationId` generation from all CLI creation sites (hatch, pair, recover, aws, gcp, docker)
- Remove the `readAssistants()` backfill loop and `randomUUID` imports
- Update test helpers to remove `installationId`

Part of plan: unify-device-id.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
