### PR TITLE
fix: use consistent path canonicalization in CES publish entrypoint check

### DIFF
--- a/credential-executor/src/toolstore/publish.ts
+++ b/credential-executor/src/toolstore/publish.ts
@@ -346,8 +346,8 @@ export function publishBundle(request: PublishRequest): PublishResult {
     // Validate that the declared entrypoint resolves inside the staging
     // directory. A manifest with an absolute or `../`-traversal entrypoint
     // could make chmod (or later execution) touch files outside the bundle.
-    const extractedEntrypoint = resolve(stagingDir, secureCommandManifest.entrypoint);
     const realStagingDir = realpathSync(stagingDir);
+    const extractedEntrypoint = resolve(realStagingDir, secureCommandManifest.entrypoint);
     if (extractedEntrypoint !== realStagingDir && !extractedEntrypoint.startsWith(realStagingDir + "/")) {
       throw new Error(
         `Entrypoint "${secureCommandManifest.entrypoint}" resolves outside the bundle directory. ` +


### PR DESCRIPTION
## Summary
- Fixes path canonicalization inconsistency in CES publish entrypoint check
- Addresses feedback from PR #17262

## Test plan
- [ ] Verify CES publish entrypoint check works with various path formats
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
