### PR TITLE
fix: accept 'thread' as voice approval synonym for backward compatibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -511,7 +511,9 @@ final class VoiceModeManager: ObservableObject {
         }
 
         // "allow for this conversation" / "this conversation" / "for the conversation"
-        let conversationPatterns = ["this conversation", "the conversation", "for conversation", "allow conversation"]
+        // Also accept "thread" as a legacy synonym for backward compatibility.
+        let conversationPatterns = ["this conversation", "the conversation", "for conversation", "allow conversation",
+                                    "this thread", "the thread", "for thread", "allow thread"]
         if conversationPatterns.contains(where: { lower.contains($0) }) && !hasNegative {
             return .allowConversation
         }


### PR DESCRIPTION
## Summary
- Accepts 'thread' as a synonym for voice approval for backward compatibility
- Addresses feedback from PR #17274

## Test plan
- [ ] Verify 'thread' is accepted as voice approval synonym
- [ ] Verify existing voice approval flows still work
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
