### PR TITLE
feat: write character-ascii.txt alongside avatar-image.png

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
+import { renderCharacterAscii } from "./ascii-renderer.js";
 import { renderCharacterPng } from "./png-renderer.js";
 
 const log = getLogger("traits-png-sync");
@@ -15,13 +16,13 @@ export interface CharacterTraits {
 }
 
 /**
- * Writes character-traits.json and regenerates avatar-image.png in one
- * atomic operation.  Accepts the trait values directly so callers don't
- * need to touch the filesystem first.
+ * Writes character-traits.json, regenerates avatar-image.png, and updates
+ * character-ascii.txt in one atomic operation.  Accepts the trait values
+ * directly so callers don't need to touch the filesystem first.
  *
- * Returns true if both the traits file and PNG were written successfully.
+ * Returns true if all files were written successfully.
  */
-export function writeTraitsAndRenderPng(traits: CharacterTraits): boolean {
+export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
   if (!traits.bodyShape || !traits.eyeStyle || !traits.color) {
     log.warn({ traits }, "Invalid character traits — missing required fields");
     return false;
@@ -50,13 +51,24 @@ export function writeTraitsAndRenderPng(traits: CharacterTraits): boolean {
     writeFileSync(pngTmp, pngBuffer);
     renameSync(pngTmp, pngPath);
 
+    // Render and write ASCII art atomically
+    const asciiPath = join(avatarDir, "character-ascii.txt");
+    const asciiArt = renderCharacterAscii(
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
+    );
+    const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
+    writeFileSync(asciiTmp, asciiArt);
+    renameSync(asciiTmp, asciiPath);
+
     log.info(
       {
         bodyShape: traits.bodyShape,
         eyeStyle: traits.eyeStyle,
         color: traits.color,
       },
-      "Wrote character traits and regenerated avatar PNG",
+      "Wrote character traits, regenerated avatar PNG, and updated ASCII art",
     );
     return true;
   } catch (err) {
@@ -86,5 +98,5 @@ export function syncTraitsToPng(): boolean {
     return false;
   }
 
-  return writeTraitsAndRenderPng(traits);
+  return writeTraitsAndRenderAvatar(traits);
 }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -4,7 +4,7 @@ import { getCharacterComponents } from "../../avatar/character-components.js";
 import {
   type CharacterTraits,
   syncTraitsToPng,
-  writeTraitsAndRenderPng,
+  writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -69,7 +69,7 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
             );
           }
 
-          success = writeTraitsAndRenderPng(body);
+          success = writeTraitsAndRenderAvatar(body);
         } else {
           success = syncTraitsToPng();
         }


### PR DESCRIPTION
## Summary
- Renamed `writeTraitsAndRenderPng` → `writeTraitsAndRenderAvatar` to reflect it now produces three outputs
- Added atomic `character-ascii.txt` write after the PNG generation step using `renderCharacterAscii()`
- Updated all call sites in `avatar-routes.ts` and `syncTraitsToPng()`

Part of plan: ascii-avatar-renderer.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
