### PR TITLE
feat: update vellum-avatar skill to use `assistant avatar` CLI

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -65,12 +65,10 @@ The user picks a body shape, eye style, and color. Present the options conversat
 
 ### Setting traits
 
-After the user chooses, call the render endpoint with the chosen traits. This writes `character-traits.json` and generates the static PNG in one step:
+After the user chooses, run the following command to set the character traits. This writes `character-traits.json`, generates the static PNG, and creates an ASCII representation in one step:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/avatar/render-from-traits" \
-  -H "Content-Type: application/json" \
-  -d '{"bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>"}'
+assistant avatar character update --body-shape <value> --eye-style <value> --color <value>
 ```
 
 The client will detect the traits file and render the animated character. The assistant also generates a static PNG for use as dock icon and by other clients.
@@ -134,5 +132,5 @@ The client checks for character traits first — if `character-traits.json` exis
 
 Enforcement rules:
 
-- **Setting native character traits** → call `POST /v1/avatar/render-from-traits` with `{ bodyShape, eyeStyle, color }`. This writes `character-traits.json` and auto-generates the PNG in one step.
+- **Setting native character traits** → run `assistant avatar character update --body-shape X --eye-style Y --color Z`. This writes `character-traits.json` and auto-generates the PNG in one step.
 - **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.


### PR DESCRIPTION
## Summary
- Replaced Mode 1 (native character) curl command with `assistant avatar character update --body-shape X --eye-style Y --color Z`
- Updated mutual exclusivity rule to reference the CLI command instead of the HTTP endpoint
- Mode 2 (upload) and Mode 3 (AI-generate) remain unchanged

Part of plan: ascii-avatar-renderer.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
