### PR TITLE
fix: add width validation and update SKILL.md enforcement rules

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -248,11 +248,20 @@ Examples:
         return;
       }
 
+      const width = parseInt(opts.width, 10);
+      if (!Number.isFinite(width) || width < 1) {
+        log.error(
+          `Invalid width: "${opts.width}". Must be a positive integer.`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const asciiArt = renderCharacterAscii(
         traits.bodyShape,
         traits.eyeStyle,
         traits.color,
-        parseInt(opts.width, 10),
+        width,
       );
 
       process.stdout.write(asciiArt + "\n");

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -132,5 +132,5 @@ The client checks for character traits first — if `character-traits.json` exis
 
 Enforcement rules:
 
-- **Setting native character traits** → run `assistant avatar character update --body-shape X --eye-style Y --color Z`. This writes `character-traits.json` and auto-generates the PNG in one step.
+- **Setting native character traits** → run `assistant avatar character update --body-shape X --eye-style Y --color Z`. This writes `character-traits.json`, auto-generates the PNG, and creates ASCII art in one step.
 - **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ascii-avatar-renderer.md.

- Added NaN/non-positive validation for --width option in the CLI ascii command
- Updated SKILL.md enforcement rules to mention ASCII art alongside traits JSON and PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
