### PR TITLE
fix: isolate ASCII sidecar write and update error log

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -51,16 +51,24 @@ export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
     writeFileSync(pngTmp, pngBuffer);
     renameSync(pngTmp, pngPath);
 
-    // Render and write ASCII art atomically
-    const asciiPath = join(avatarDir, "character-ascii.txt");
-    const asciiArt = renderCharacterAscii(
-      traits.bodyShape,
-      traits.eyeStyle,
-      traits.color,
-    );
-    const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
-    writeFileSync(asciiTmp, asciiArt);
-    renameSync(asciiTmp, asciiPath);
+    // Render and write ASCII art atomically — isolated so a failure here
+    // doesn't cause the primary operation (traits JSON + PNG) to report failure.
+    try {
+      const asciiPath = join(avatarDir, "character-ascii.txt");
+      const asciiArt = renderCharacterAscii(
+        traits.bodyShape,
+        traits.eyeStyle,
+        traits.color,
+      );
+      const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
+      writeFileSync(asciiTmp, asciiArt);
+      renameSync(asciiTmp, asciiPath);
+    } catch (asciiErr) {
+      log.warn(
+        { err: asciiErr },
+        "Failed to write ASCII sidecar — primary files still written",
+      );
+    }
 
     log.info(
       {
@@ -72,7 +80,7 @@ export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
     );
     return true;
   } catch (err) {
-    log.error({ err }, "Failed to write traits / render avatar PNG");
+    log.error({ err }, "Failed to write traits / render avatar");
     return false;
   }
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ascii-avatar-renderer.md.

- Wrapped ASCII art write in its own try/catch so failures don't cause the primary operation to report failure
- Updated the outer catch error log to reflect the function's current scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
