### PR TITLE
feat: classify 402 Payment Required from managed proxy as credits_exhausted error

### DIFF
--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -187,6 +187,15 @@ function classifyCore(
         errorCategory: "provider_billing",
       };
     }
+    if (error.statusCode === 402) {
+      return {
+        code: "PROVIDER_BILLING",
+        userMessage:
+          "You've run out of credits. Add funds to continue using the assistant.",
+        retryable: false,
+        errorCategory: "credits_exhausted",
+      };
+    }
     if (error.statusCode === 429) {
       return {
         code: "PROVIDER_RATE_LIMIT",


### PR DESCRIPTION
## Summary
- Add explicit 402 status code handling in session-error.ts to classify it as PROVIDER_BILLING with credits_exhausted error category
- Returns a clear user message about running out of credits, marked as non-retryable

Part of plan: platform-sign-in.md (PR 4 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)