### PR TITLE
feat: expose provider routing sources (user-key vs managed-proxy) in debug endpoint

### DIFF
--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -164,6 +164,7 @@ export interface ProviderDebugStatus {
   registeredProviders: string[];
   failoverHealth: ProviderHealthStatus[] | null;
   overallHealth: "healthy" | "degraded" | "down";
+  routingSources: Record<string, "user-key" | "managed-proxy">;
 }
 
 export function getProviderDebugStatus(
@@ -199,6 +200,7 @@ export function getProviderDebugStatus(
     registeredProviders: registered,
     failoverHealth,
     overallHealth,
+    routingSources: Object.fromEntries(routingSources),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add routingSources field to ProviderDebugStatus interface showing which providers use user-key vs managed-proxy routing
- Populate from the existing routingSources Map in getProviderDebugStatus()
- Exposed automatically via GET /v1/debug endpoint

Part of plan: platform-sign-in.md (PR 5 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
