### PR TITLE
feat: accept vellum:platform_base_url as runtime credential for managed proxy activation

### DIFF
--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -9,7 +9,10 @@ const metadataDeletes: Array<{ service: string; field: string }> = [];
 
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
+const PLATFORM_BASE_URL_PATH = credentialKey("vellum", "platform_base_url");
 const MANAGED_PROVIDERS = ["anthropic", "gemini"] as const;
+
+let platformBaseUrlOverride: string | undefined;
 
 const mockConfig = {
   provider: "anthropic",
@@ -41,6 +44,9 @@ mock.module("@google/genai", () => ({
 
 mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: () => PLATFORM_BASE_URL,
+  setPlatformBaseUrl: (value: string | undefined) => {
+    platformBaseUrlOverride = value;
+  },
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -127,6 +133,7 @@ describe("secret routes managed proxy registry sync", () => {
     metadataUpserts.length = 0;
     metadataDeletes.length = 0;
     lastGeminiConstructorOpts = null;
+    platformBaseUrlOverride = undefined;
     await initializeProviders(mockConfig);
   });
 
@@ -171,5 +178,64 @@ describe("secret routes managed proxy registry sync", () => {
       { service: "vellum", field: "assistant_api_key" },
     ]);
     expect(listProviders()).toEqual([]);
+  });
+
+  test("storing vellum:platform_base_url sets override and triggers initializeProviders", async () => {
+    const res = await handleAddSecret(
+      makeAddCredentialRequest(
+        "vellum:platform_base_url",
+        "https://managed.example.com",
+      ),
+    );
+
+    expect(res.status).toBe(201);
+    expect(secureKeyStore[PLATFORM_BASE_URL_PATH]).toBe(
+      "https://managed.example.com",
+    );
+    expect(platformBaseUrlOverride).toBe("https://managed.example.com");
+    expect(metadataUpserts).toEqual([
+      { service: "vellum", field: "platform_base_url" },
+    ]);
+  });
+
+  test("storing both vellum:platform_base_url and vellum:assistant_api_key enables managed proxy", async () => {
+    expect(listProviders()).toEqual([]);
+
+    await handleAddSecret(
+      makeAddCredentialRequest(
+        "vellum:platform_base_url",
+        "https://managed.example.com",
+      ),
+    );
+    expect(platformBaseUrlOverride).toBe("https://managed.example.com");
+
+    const res = await handleAddSecret(
+      makeAddCredentialRequest("vellum:assistant_api_key", "ast-managed-key"),
+    );
+
+    expect(res.status).toBe(201);
+    const providers = listProviders();
+    expect(providers).toHaveLength(MANAGED_PROVIDERS.length);
+    for (const provider of MANAGED_PROVIDERS) {
+      expect(providers).toContain(provider);
+      expect(getProviderRoutingSource(provider)).toBe("managed-proxy");
+    }
+  });
+
+  test("deleting vellum:platform_base_url clears override and re-initializes providers", async () => {
+    // Set up: store the platform URL credential first
+    secureKeyStore[PLATFORM_BASE_URL_PATH] = "https://managed.example.com";
+    platformBaseUrlOverride = "https://managed.example.com";
+
+    const res = await handleDeleteSecret(
+      makeDeleteCredentialRequest("vellum:platform_base_url"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(secureKeyStore[PLATFORM_BASE_URL_PATH]).toBeUndefined();
+    expect(platformBaseUrlOverride).toBeUndefined();
+    expect(metadataDeletes).toEqual([
+      { service: "vellum", field: "platform_base_url" },
+    ]);
   });
 });

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -134,8 +134,14 @@ export function getOllamaBaseUrlEnv(): string | undefined {
 
 // ── Platform ─────────────────────────────────────────────────────────────────
 
+let _platformBaseUrlOverride: string | undefined;
+
+export function setPlatformBaseUrl(value: string | undefined): void {
+  _platformBaseUrlOverride = value;
+}
+
 export function getPlatformBaseUrl(): string {
-  return str("PLATFORM_BASE_URL") ?? "";
+  return str("PLATFORM_BASE_URL") ?? _platformBaseUrlOverride ?? "";
 }
 
 /**

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -1,3 +1,4 @@
+import { setPlatformBaseUrl } from "../../config/env.js";
 import {
   API_KEY_PROVIDERS,
   getConfig,
@@ -21,15 +22,14 @@ import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("runtime-http");
-const MANAGED_PROXY_CREDENTIAL = {
-  service: "vellum",
-  field: "assistant_api_key",
-};
+const MANAGED_PROXY_CREDENTIALS = [
+  { service: "vellum", field: "assistant_api_key" },
+  { service: "vellum", field: "platform_base_url" },
+] as const;
 
 function isManagedProxyCredential(service: string, field: string): boolean {
-  return (
-    service === MANAGED_PROXY_CREDENTIAL.service &&
-    field === MANAGED_PROXY_CREDENTIAL.field
+  return MANAGED_PROXY_CREDENTIALS.some(
+    (c) => c.service === service && c.field === field,
   );
 }
 
@@ -142,28 +142,33 @@ export async function handleAddSecret(
         );
       }
       upsertCredentialMetadata(service, field, {});
+      if (service === "vellum" && field === "platform_base_url") {
+        setPlatformBaseUrl(value);
+      }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());
-        // Push the API key to CES so managed credential materialization
-        // works even though the handshake ran before the key was available.
-        const cesClient = getCesClient?.();
-        if (cesClient) {
-          if (cesClient.isReady()) {
-            try {
-              await cesClient.updateAssistantApiKey(value);
-              log.info(
-                "Pushed assistant API key to CES after managed proxy credential update",
-              );
-            } catch (err) {
-              log.warn(
-                { error: err instanceof Error ? err.message : String(err) },
-                "Failed to push assistant API key to CES (non-fatal)",
-              );
+        if (service === "vellum" && field === "assistant_api_key") {
+          // Push the API key to CES so managed credential materialization
+          // works even though the handshake ran before the key was available.
+          const cesClient = getCesClient?.();
+          if (cesClient) {
+            if (cesClient.isReady()) {
+              try {
+                await cesClient.updateAssistantApiKey(value);
+                log.info(
+                  "Pushed assistant API key to CES after managed proxy credential update",
+                );
+              } catch (err) {
+                log.warn(
+                  { error: err instanceof Error ? err.message : String(err) },
+                  "Failed to push assistant API key to CES (non-fatal)",
+                );
+              }
+            } else {
+              // CES handshake is still in flight — queue the key propagation
+              // so it fires once CES becomes ready.
+              void queueApiKeyPropagation(cesClient, value);
             }
-          } else {
-            // CES handshake is still in flight — queue the key propagation
-            // so it fires once CES becomes ready.
-            void queueApiKeyPropagation(cesClient, value);
           }
         }
       }
@@ -259,6 +264,9 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
         );
       }
       deleteCredentialMetadata(service, field);
+      if (service === "vellum" && field === "platform_base_url") {
+        setPlatformBaseUrl(undefined);
+      }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());
       }


### PR DESCRIPTION
## Summary
- Add `setPlatformBaseUrl()` runtime override in env.ts so the platform URL can be injected via credential store
- Expand `isManagedProxyCredential()` in secret-routes.ts to recognize `vellum:platform_base_url` alongside `vellum:assistant_api_key`
- Add tests verifying platform URL credential triggers provider re-initialization

Part of plan: platform-sign-in.md (PR 1 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)