### PR TITLE
chore: avatar system cleanup — orphaned ASCII + rename syncTraitsToPng

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -87,10 +87,10 @@ export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
 
 /**
  * Reads character-traits.json from the avatar directory and regenerates
- * avatar-image.png to match. Kept for backward compatibility (e.g. the
- * client-side file watcher triggers this path).
+ * avatar-image.png and character-ascii.txt to match. Kept for backward
+ * compatibility (e.g. the client-side file watcher triggers this path).
  */
-export function syncTraitsToPng(): boolean {
+export function syncTraitsToAvatar(): boolean {
   const traitsPath = join(
     getWorkspaceDir(),
     "data",

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { getCharacterComponents } from "../../avatar/character-components.js";
 import {
   type CharacterTraits,
-  syncTraitsToPng,
+  syncTraitsToAvatar,
   writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { getLogger } from "../../util/logger.js";
@@ -71,7 +71,7 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
 
           success = writeTraitsAndRenderAvatar(body);
         } else {
-          success = syncTraitsToPng();
+          success = syncTraitsToAvatar();
         }
 
         if (!success) {

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -84,10 +84,11 @@ mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
 cp "<user-provided-path>" "$VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png"
 ```
 
-Then remove the character traits file, since a custom image overrides the native character:
+Then remove the native character files, since a custom image overrides the native character:
 
 ```bash
 rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
+rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-ascii.txt"
 ```
 
 Tell the user their avatar has been updated. The client will pick up the new image automatically.
@@ -102,10 +103,11 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/settings/avatar/generate" \
   -d '{"description": "<user'\''s description>"}'
 ```
 
-This generates an image using AI and saves it to `data/avatar/avatar-image.png`. After the image is generated, remove the character traits file:
+This generates an image using AI and saves it to `data/avatar/avatar-image.png`. After the image is generated, remove the native character files:
 
 ```bash
 rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
+rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-ascii.txt"
 ```
 
 The generated avatar will appear automatically in the client.
@@ -133,4 +135,4 @@ The client checks for character traits first — if `character-traits.json` exis
 Enforcement rules:
 
 - **Setting native character traits** → run `assistant avatar character update --body-shape X --eye-style Y --color Z`. This writes `character-traits.json`, auto-generates the PNG, and creates ASCII art in one step.
-- **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json`.
+- **Uploading or generating a custom image** → write `avatar-image.png` and remove `character-traits.json` and `character-ascii.txt`.


### PR DESCRIPTION
## Summary
- Add `rm -f character-ascii.txt` alongside the existing `rm -f character-traits.json` in SKILL.md Mode 2 (upload) and Mode 3 (AI-generate) flows so the ASCII sidecar doesn't get orphaned when switching to a custom image
- Rename `syncTraitsToPng` → `syncTraitsToAvatar` in traits-png-sync.ts and its caller in avatar-routes.ts to reflect that it now produces ASCII art in addition to the PNG

## Original prompt
Address remaining avatar system cleanup items: 1) In SKILL.md Mode 2 and Mode 3, add `rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-ascii.txt"` alongside the existing rm for character-traits.json. 2) Rename `syncTraitsToPng` to `syncTraitsToAvatar` in traits-png-sync.ts and update its caller in avatar-routes.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
