### PR TITLE
fix: add avatar subcommand to CLI_HELP_REFERENCE snapshot

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -19,6 +19,7 @@ Commands:
   trust                                    Manage trust rules
   memory                                   Manage long-term memory indexing/retrieval
   audit [options]                          Show recent tool invocations
+  avatar                                   Manage the assistant's avatar
   doctor                                   Run diagnostic checks
   hooks                                    Manage hooks
   mcp                                      Manage MCP (Model Context Protocol) servers


### PR DESCRIPTION
## Summary
- Add the `avatar` subcommand entry to `CLI_HELP_REFERENCE` in `assistant/src/cli/reference.ts`, fixing the `cli-help-reference-sync` test that fails because `buildCliProgram()` now includes the avatar command but the static snapshot was not updated.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23120152624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
