### PR TITLE
fix: remove macOS-only guard from DeviceIdStore for iOS build

### DIFF
--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -1,4 +1,3 @@
-#if os(macOS)
 import Foundation
 
 /// Reads or creates a per-device UUID stored at ~/.vellum/device.json.
@@ -73,4 +72,3 @@ public enum DeviceIdStore {
         return deviceId
     }
 }
-#endif


### PR DESCRIPTION
## Summary
- Removed `#if os(macOS)` / `#endif` conditional compilation guard from `DeviceIdStore.swift`
- The file only uses Foundation APIs (FileManager, UserDefaults, JSONSerialization) available on all Apple platforms
- Fixes iOS CI build failure: `cannot find 'DeviceIdStore' in scope` in `LocalAssistantBootstrapService.swift`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23120130651/job/67152541557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
