### PR TITLE
fix: use NSHomeDirectory() in DeviceIdStore for iOS compatibility

### DIFF
--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -27,7 +27,7 @@ public enum DeviceIdStore {
 
         if let cached { return cached }
 
-        let home = FileManager.default.homeDirectoryForCurrentUser
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
         let vellumDir = home.appendingPathComponent(".vellum", isDirectory: true)
         let deviceFile = vellumDir.appendingPathComponent("device.json")
 


### PR DESCRIPTION
## Summary
- Replace `FileManager.default.homeDirectoryForCurrentUser` with `URL(fileURLWithPath: NSHomeDirectory())` in `DeviceIdStore.swift`
- `homeDirectoryForCurrentUser` is marked `API_UNAVAILABLE(ios)`, causing the iOS build to fail
- `NSHomeDirectory()` is the cross-platform alternative already used by `resolveVellumDir()` in `DaemonClient.swift`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23120282880/job/67152938513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
