### PR TITLE
Remove redundant "Files" header from skill detail file list

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -538,10 +538,6 @@ struct AgentPanelContent: View {
         if skillsManager.isLoadingSkillFiles || skillsManager.skillFilesError != nil ||
             (skillsManager.selectedSkillFiles != nil && !skillsManager.selectedSkillFiles!.files.isEmpty) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("Files")
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.contentDefault)
-
                 if skillsManager.isLoadingSkillFiles {
                     HStack {
                         Spacer()


### PR DESCRIPTION
## Summary
- Remove the "Files" text header from the skill detail file list section in the Intelligence panel
- The file list, loading state, and error state remain unchanged

Part of plan: skill-detail-ui-fixes.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
