### PR TITLE
Left-align skill file code viewer, matching Workspace tab text display

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -365,7 +365,7 @@ struct AgentPanelContent: View {
             }
 
             // Two-pane content: file list + file content viewer
-            HStack(alignment: .top, spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.md) {
                 // Left: file list (always fixed width)
                 skillFilesSection
                     .frame(width: 280, alignment: .topLeading)
@@ -503,13 +503,13 @@ struct AgentPanelContent: View {
             ScrollView([.vertical, .horizontal]) {
                 Text(content)
                     .font(VFont.mono)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundColor(VColor.contentDefault)
                     .textSelection(.enabled)
                     .padding(VSpacing.md)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(


### PR DESCRIPTION
## Summary
- Add leading alignment to the skill file content pane container
- Change text color from contentSecondary to contentDefault to match Workspace tab
- Remove .top alignment from two-pane HStack so both panes fill available height

Part of plan: skill-detail-ui-fixes.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
