### PR TITLE
feat: redesign onboarding step 0 with Log In + Skip flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -36,6 +36,19 @@ final class OnboardingState {
     var accessibilityGranted: Bool = false
     var screenGranted: Bool = false
     var skipPermissionChecks: Bool = false
+
+    /// Whether the user explicitly skipped login during onboarding.
+    var skippedAuth: Bool = false
+
+    /// The hosting mode selected in onboarding step 1.
+    var selectedHostingMode: HostingMode = .local
+
+    enum HostingMode: String {
+        case vellumCloud = "vellum-cloud"
+        case local = "local"
+        case localDocker = "local-docker"
+        case vps = "vps"
+    }
     var hasHatched: Bool = false
     var interviewCompleted: Bool = false
     var cloudProvider: String = "local"
@@ -175,6 +188,7 @@ final class OnboardingState {
         hatchCompleted = false
         hatchLogLines = []
         hasHatched = false
+        skippedAuth = false
 
         // Clear stored API key so the user starts fresh
         APIKeyManager.deleteKey(for: "anthropic")

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -30,17 +30,6 @@ struct WakeUpStepView: View {
         return NSImage(contentsOf: url)
     }()
 
-    private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed_sign_in_enabled")
-    }
-
-    private var primaryButtonTitle: String {
-        onboardingPrimaryButtonTitle(
-            isAuthenticated: authManager?.isAuthenticated == true,
-            hasAssistant: LockfileAssistant.loadLatest() != nil
-        )
-    }
-
     // MARK: - Body
 
     var body: some View {
@@ -83,26 +72,22 @@ struct WakeUpStepView: View {
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)
-            } else if managedSignInEnabled {
-                let buttonTitle = primaryButtonTitle
-                VStack(spacing: VSpacing.xs) {
-                    OnboardingButton(title: buttonTitle, style: .primary) {
-                        onContinueWithVellum()
-                    }
-                    .accessibilityLabel(buttonTitle)
-                }
-
-                if authManager?.isAuthenticated != true {
-                    OnboardingButton(title: "Skip for now", style: .secondary) {
-                        onStartWithAPIKey()
-                    }
-                    .accessibilityLabel("Skip for now")
-                }
             } else {
-                OnboardingButton(title: "Get Started", style: .primary) {
-                    onStartWithAPIKey()
+                OnboardingButton(title: "Log In", style: .primary) {
+                    onContinueWithVellum()
                 }
-                .accessibilityLabel("Get Started")
+                .accessibilityLabel("Log In")
+
+                Button {
+                    state?.skippedAuth = true
+                    onStartWithAPIKey()
+                } label: {
+                    Text("Skip")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Skip")
             }
 
             // Auth error message


### PR DESCRIPTION
## Summary
- Add skippedAuth and selectedHostingMode properties to OnboardingState
- Redesign WakeUpStepView to always show "Log In" as primary button with "Skip" below
- Remove managedSignInEnabled conditional branching from button layout

Part of plan: platform-sign-in.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)