### PR TITLE
Ensure main sidebar container extends to full available height

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -118,6 +118,7 @@ extension MainWindowView {
         }
         .padding(.vertical, VSpacing.md)
         .padding(.horizontal, sidebarExpanded ? VSpacing.md : VSpacing.sm)
+        .frame(maxHeight: .infinity)
         .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth, alignment: .leading)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))


### PR DESCRIPTION
## Summary
- Add maxHeight: .infinity to the sidebar container frame to ensure it fills the full available height
- The dark rounded-rectangle background now extends to the bottom of the main content area

Part of plan: skill-detail-ui-fixes.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
