### PR TITLE
fix: consistent icon positioning across onboarding steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -101,10 +101,9 @@ struct APIKeyStepView: View {
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.xxl)
 
-        Spacer()
-
-        ScrollView {
+        VStack(spacing: VSpacing.md) {
             VStack(spacing: VSpacing.md) {
                 if showHostingSelector {
                     hostingModeSelector
@@ -122,9 +121,8 @@ struct APIKeyStepView: View {
 
                 footerLinks
             }
-            .padding(.horizontal, VSpacing.xxl)
-            .padding(.bottom, VSpacing.lg)
         }
+        .padding(.horizontal, VSpacing.xxl)
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {
@@ -164,6 +162,8 @@ struct APIKeyStepView: View {
                 }
             }
         }
+
+        Spacer()
 
         if !managedSignInEnabled {
             OnboardingFooter(currentStep: state.currentStep, totalSteps: 3)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,9 @@ struct OnboardingFlowView: View {
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
                 // Onboarding flow: WakeUp → APIKey → ImproveExperience (steps 0–2)
                 VStack(spacing: 0) {
-                    Spacer()
+                    // Fixed top inset — positions the icon consistently
+                    // across all steps regardless of bottom content weight.
+                    Color.clear.frame(height: geometry.size.height * 0.2)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)


### PR DESCRIPTION
## Summary
- Replace flexible `Spacer()` with proportional fixed top inset (`geometry.size.height * 0.2`) in OnboardingFlowView so the app icon is at the same vertical position on all onboarding steps
- Fix APIKeyStepView layout: replace greedy `ScrollView` with plain `VStack` so the bottom `Spacer()` can flex properly, and add proper spacing between subtitle and input field

## Original prompt
Fix the spacing of the API key step in setup flow so the logo is in the same position as the other setup stages and there's proper space between the subtitle and the API key input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
