### PR TITLE
feat: wire Settings sign-in to trigger local bootstrap and sign-out to clear daemon credentials

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -137,6 +137,23 @@ extension AppDelegate {
         Task {
             await authManager.logout()
 
+            // Clear managed proxy credentials from the running daemon
+            if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+                let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
+                let daemonBaseURL = "http://localhost:\(port)"
+                await LocalAssistantBootstrapService.clearDaemonCredentials(
+                    daemonBaseURL: daemonBaseURL,
+                    daemonToken: token
+                )
+            }
+
+            // Clear the locally-cached credential from Keychain
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+                let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistantId)
+                _ = KeychainCredentialStorage().delete(account: credentialAccount)
+            }
+
             let detachedWindow = mainWindow?.detachWindow()
             mainWindow = nil
             conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -277,7 +277,9 @@ struct SettingsPanel: View {
     private var selectedTabContent: some View {
         switch selectedTab {
         case .general:
-            SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
+            SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, onSignIn: {
+                AppDelegate.shared?.ensureLocalAssistantApiKey()
+            })
         case .modelsAndServices:
             integrationsContent
         case .voice:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -8,6 +8,7 @@ struct SettingsGeneralTab: View {
     var daemonClient: DaemonClient?
     var authManager: AuthManager
     var onClose: () -> Void
+    var onSignIn: (() -> Void)?
 
     @State private var showingPairingQR: Bool = false
 
@@ -95,7 +96,12 @@ struct SettingsGeneralTab: View {
                     style: .primary,
                     isDisabled: authManager.isSubmitting
                 ) {
-                    Task { await authManager.startWorkOSLogin() }
+                    Task {
+                        await authManager.startWorkOSLogin()
+                        if authManager.isAuthenticated {
+                            onSignIn?()
+                        }
+                    }
                 }
             }
 

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -224,6 +224,35 @@ public final class LocalAssistantBootstrapService {
         }
     }
 
+    /// Clears all managed proxy credentials from the daemon's secret store
+    /// by issuing `DELETE /v1/secrets` for each vellum-namespaced credential.
+    ///
+    /// Uses a direct HTTP call to the daemon (not GatewayHTTPClient) because
+    /// this is called during logout teardown when gateway routing may no
+    /// longer be available.
+    public static func clearDaemonCredentials(
+        daemonBaseURL: String,
+        daemonToken: String
+    ) async {
+        let credentialNames = [
+            "vellum:assistant_api_key",
+            "vellum:platform_base_url",
+            "vellum:platform_assistant_id",
+        ]
+        for name in credentialNames {
+            guard let url = URL(string: "\(daemonBaseURL)/v1/secrets") else { continue }
+            var request = URLRequest(url: url)
+            request.httpMethod = "DELETE"
+            request.timeoutInterval = 5
+            request.setValue("Bearer \(daemonToken)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body: [String: String] = ["type": "credential", "name": name]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            _ = try? await URLSession.shared.data(for: request)
+        }
+        log.info("Cleared managed proxy credentials from daemon")
+    }
+
     /// Resolves the current user ID from the auth session.
     private func resolveUserId() async throws -> String? {
         let session = try await authService.getSession()


### PR DESCRIPTION
## Summary
- Add onSignIn callback to SettingsGeneralTab that triggers ensureLocalAssistantApiKey() after WorkOS login
- In performLogout(), clear managed proxy credentials from daemon and Keychain before teardown
- Add clearDaemonCredentials static method to LocalAssistantBootstrapService for direct daemon credential cleanup

Part of plan: platform-sign-in.md (PR 10 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
