### PR TITLE
fix: rename notification_conversation_created to notification_thread_created

### DIFF
--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -6,8 +6,8 @@
  * - Handles missing adapters gracefully
  * - Falls back to copy-composer when decision copy is missing
  * - Reports delivery results per channel
- * - Emits notification_conversation_created only when a new conversation is created
- * - Does NOT emit notification_conversation_created when reusing an existing conversation
+ * - Emits notification_thread_created only when a new conversation is created
+ * - Does NOT emit notification_thread_created when reusing an existing conversation
  * - Passes destination binding context into conversation pairing for external channels
  */
 

--- a/assistant/src/daemon/message-types/notifications.ts
+++ b/assistant/src/daemon/message-types/notifications.ts
@@ -18,7 +18,7 @@ export interface NotificationIntent {
 
 /** Server push — broadcast when a notification creates a new vellum conversation. */
 export interface NotificationConversationCreated {
-  type: "notification_conversation_created";
+  type: "notification_thread_created";
   conversationId: string;
   title: string;
   sourceEventName: string;

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -79,7 +79,7 @@ export class NotificationBroadcaster {
   ): Promise<NotificationDeliveryResult[]> {
     const destinations = resolveDestinations(decision.selectedChannels);
 
-    // Ensure vellum is processed first so the notification_conversation_created
+    // Ensure vellum is processed first so the notification_thread_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s
     // timeout) can delay it past the macOS deep-link retry window.
     const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
@@ -242,7 +242,7 @@ export class NotificationBroadcaster {
           }
         }
 
-        // Emit notification_conversation_created event only when a NEW
+        // Emit notification_thread_created event only when a NEW
         // conversation was actually created. Reusing an existing conversation
         // should not fire the event — the client already knows about the
         // conversation.

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -74,7 +74,7 @@ function getBroadcaster(): NotificationBroadcaster {
       const broadcastFn = registeredBroadcastFn;
       broadcasterInstance.setOnConversationCreated((info) => {
         broadcastFn({
-          type: "notification_conversation_created",
+          type: "notification_thread_created",
           conversationId: info.conversationId,
           title: info.title,
           sourceEventName: info.sourceEventName,
@@ -85,7 +85,7 @@ function getBroadcaster(): NotificationBroadcaster {
             conversationId: info.conversationId,
             guardianScoped: info.targetGuardianPrincipalId != null,
           },
-          "Emitted notification_conversation_created push event",
+          "Emitted notification_thread_created push event",
         );
       });
     }
@@ -168,7 +168,7 @@ export interface EmitSignalParams<TEventName extends string = string> {
   dedupeKey?: string;
   /**
    * Optional callback invoked immediately when the broadcaster pairs a vellum
-   * conversation and emits `notification_conversation_created`.
+   * conversation and emits `notification_thread_created`.
    */
   onConversationCreated?: (info: ConversationCreatedInfo) => void;
   /**
@@ -320,7 +320,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 4: Dispatch through the broadcaster
-    // Note: notification_conversation_created events are emitted eagerly inside
+    // Note: notification_thread_created events are emitted eagerly inside
     // the broadcaster as soon as vellum conversation pairing succeeds, rather
     // than after all channel deliveries complete. This avoids a race where
     // slow Telegram delivery delays the push past the macOS deep-link retry.


### PR DESCRIPTION
## Summary
- Rename the wire-protocol type literal from `notification_conversation_created` to `notification_thread_created` in the notification type definition, emit-signal, and broadcaster
- Update all related comments and log messages to reference the new type name
- Aligns daemon SSE events with what the macOS/iOS client expects

Part of plan: fix-notification-thread-created-type-mismatch.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
