### PR TITLE
feat: add Billing tab to Settings with balance display and top-up

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -7,27 +7,33 @@ enum SettingsTab: String {
     case voice = "Voice"
     case permissionsAndPrivacy = "Permissions & Privacy"
     case contacts = "Contacts"
+    case billing = "Billing"
     case archivedThreads = "Archived Threads"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(contactsEnabled: Bool = false) -> [SettingsTab] {
+    static func primaryTabs(contactsEnabled: Bool = false, billingEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general]
         if contactsEnabled {
             tabs.append(.contacts)
         }
         tabs.append(contentsOf: [
             .voice, .modelsAndServices,
-            .permissionsAndPrivacy, .archivedThreads
+            .permissionsAndPrivacy,
         ])
+        if billingEnabled {
+            tabs.append(.billing)
+        }
+        tabs.append(.archivedThreads)
         return tabs
     }
 
     /// Resolves a tab name string to a SettingsTab. Only accepts current canonical names.
-    static func fromRawValue(_ value: String, contactsEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
+    static func fromRawValue(_ value: String, contactsEnabled: Bool = false, billingEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
         guard let tab = SettingsTab(rawValue: value) else { return nil }
         // Block feature-flagged tabs when disabled
         if tab == .contacts && !contactsEnabled { return nil }
+        if tab == .billing && !billingEnabled { return nil }
         if tab == .developer && !developerEnabled { return nil }
         return tab
     }
@@ -56,12 +62,14 @@ struct SettingsPanel: View {
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var selectedTab: SettingsTab = .general
     @State private var isContactsEnabled: Bool = false
+    @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
+    private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
 
@@ -125,6 +133,7 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
+            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             store.refreshAPIKeyState()
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
@@ -151,6 +160,11 @@ struct SettingsPanel: View {
             if let tab = notification.object as? SettingsTab {
                 guard allVisibleTabs.contains(tab) else { return }
                 selectedTab = tab
+            }
+        }
+        .onChange(of: billingVisible) { _, visible in
+            if !visible && selectedTab == .billing {
+                selectedTab = .general
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
@@ -242,7 +256,7 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (primary + gated bottom tabs).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled)
+        var tabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: billingVisible)
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
@@ -250,9 +264,13 @@ struct SettingsPanel: View {
         return tabs
     }
 
+    private var billingVisible: Bool {
+        isBillingEnabled && authManager.isAuthenticated
+    }
+
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: billingVisible), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -286,6 +304,8 @@ struct SettingsPanel: View {
             permissionsAndPrivacyContent
         case .contacts:
             ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled)
+        case .billing:
+            SettingsBillingTab(authManager: authManager)
         case .archivedThreads:
             SettingsArchivedThreadsTab(threadManager: threadManager)
         case .developer:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Billing tab — shows current balance, degradation warning, and Stripe top-up.
+@MainActor
+struct SettingsBillingTab: View {
+    var authManager: AuthManager
+
+    @State private var summary: BillingSummaryResponse?
+    @State private var isLoading: Bool = true
+    @State private var error: String?
+    @State private var topUpAmount: String = ""
+    @State private var isProcessingTopUp: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            balanceCard
+            if summary != nil {
+                addFundsCard
+            }
+        }
+        .task {
+            await loadSummary()
+        }
+    }
+
+    // MARK: - Balance Card
+
+    private var balanceCard: some View {
+        SettingsCard(title: "Balance") {
+            if isLoading {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading billing info...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+            } else if let summary {
+                balanceContent(summary)
+            } else if let error {
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.circleAlert, size: 14)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                    Text(error)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
+            }
+        }
+    }
+
+    // MARK: - Balance Content
+
+    @ViewBuilder
+    private func balanceContent(_ summary: BillingSummaryResponse) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Effective balance — large display
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Effective Balance")
+                    .font(VFont.inputLabel)
+                    .foregroundColor(VColor.contentSecondary)
+                Text("$\(summary.effective_balance_usd)")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.contentEmphasized)
+            }
+
+            // Degradation warning
+            if summary.is_degraded {
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.triangleAlert, size: 14)
+                        .foregroundColor(VColor.systemMidStrong)
+                    Text("Your balance is low. Add funds to avoid service interruption.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.systemMidStrong)
+                }
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(VColor.systemMidWeak)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+
+            // Two-column breakdown
+            SettingsDivider()
+
+            HStack(spacing: VSpacing.xl) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Settled Balance")
+                        .font(VFont.inputLabel)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("$\(summary.settled_balance_usd)")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentDefault)
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Pending Charges")
+                        .font(VFont.inputLabel)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("$\(summary.pending_compute_usd)")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentDefault)
+                }
+            }
+        }
+    }
+
+    // MARK: - Add Funds Card
+
+    private var addFundsCard: some View {
+        SettingsCard(title: "Add Funds") {
+            topUpContent
+        }
+    }
+
+    @ViewBuilder
+    private var topUpContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Amount (USD)")
+                    .font(VFont.inputLabel)
+                    .foregroundColor(VColor.contentSecondary)
+                VTextField(
+                    placeholder: "Enter amount",
+                    text: $topUpAmount
+                )
+            }
+
+            VButton(
+                label: isProcessingTopUp ? "Processing..." : "Add funds",
+                style: .primary,
+                isDisabled: isProcessingTopUp || topUpAmount.isEmpty
+            ) {
+                Task { await handleTopUp() }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadSummary() async {
+        isLoading = true
+        error = nil
+        do {
+            summary = try await BillingService.shared.getBillingSummary()
+        } catch {
+            self.error = "Unable to load billing information. Please try again."
+        }
+        isLoading = false
+    }
+
+    private func handleTopUp() async {
+        guard let amount = Double(topUpAmount) else {
+            error = "Please enter a valid amount."
+            return
+        }
+
+        if let summary, let minimum = Double(summary.minimum_top_up_usd), amount < minimum {
+            error = "Minimum top-up amount is $\(summary.minimum_top_up_usd)."
+            return
+        }
+
+        isProcessingTopUp = true
+        error = nil
+        defer { isProcessingTopUp = false }
+
+        do {
+            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amountUsd: topUpAmount)
+            NSWorkspace.shared.open(checkoutURL)
+            topUpAmount = ""
+        } catch {
+            self.error = "Failed to create checkout session. Please try again."
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create SettingsBillingTab with balance display, degradation warning, settled/pending breakdown, and Stripe top-up
- Add billing case to SettingsTab enum and wire into SettingsPanel
- Gate on settings_billing_enabled feature flag and authentication state

Part of plan: platform-sign-in.md (PR 9 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
