### PR TITLE
feat: show remaining credits and Add Funds link in Preferences drawer menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -511,6 +511,7 @@ struct MainWindowView: View {
                         let dividerHeight: CGFloat = 1 + SidebarLayoutMetrics.dividerVerticalPadding * 2
                         let drawerY = bottomPad + SidebarLayoutMetrics.rowMinHeight + dividerHeight + VSpacing.xs
                         DrawerMenuView(
+                            authManager: authManager,
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.settings)
@@ -526,6 +527,11 @@ struct MainWindowView: View {
                             onLogOut: {
                                 sidebar.showPreferencesDrawer = false
                                 AppDelegate.shared?.performLogout()
+                            },
+                            onOpenBilling: {
+                                sidebar.showPreferencesDrawer = false
+                                settingsStore.pendingSettingsTab = .billing
+                                windowState.selection = .panel(.settings)
                             }
                         )
                         .frame(width: drawerWidth)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -2,10 +2,17 @@ import SwiftUI
 import VellumAssistantShared
 
 struct DrawerMenuView: View {
+    let authManager: AuthManager
     let onSettings: () -> Void
     let onUsage: () -> Void
     let onDebug: () -> Void
     let onLogOut: () -> Void
+    let onOpenBilling: () -> Void
+
+    @State private var effectiveBalance: String?
+    @State private var isLowBalance = false
+    @State private var isZeroBalance = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             DrawerThemeToggle()
@@ -13,6 +20,27 @@ struct DrawerMenuView: View {
 
             VColor.surfaceBase.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
+
+            if let balance = effectiveBalance {
+                HStack {
+                    Text("$\(balance) remaining")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(
+                            isZeroBalance ? VColor.systemNegativeStrong :
+                            isLowBalance ? VColor.systemMidStrong :
+                            VColor.contentDefault
+                        )
+                    Spacer()
+                    Button("Add funds") { onOpenBilling() }
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.primaryBase)
+                        .buttonStyle(.plain)
+                }
+                .padding(.horizontal, VSpacing.sm)
+
+                VColor.surfaceBase.frame(height: 1)
+                    .padding(.vertical, VSpacing.xs)
+            }
 
             VStack(alignment: .leading, spacing: 0) {
                 SidebarPrimaryRow(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
@@ -38,5 +66,23 @@ struct DrawerMenuView: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+        .task {
+            await loadBalance()
+        }
+    }
+
+    private func loadBalance() async {
+        guard authManager.isAuthenticated else { return }
+        do {
+            let summary = try await BillingService.shared.getBillingSummary()
+            let balanceString = summary.effective_balance_usd
+            effectiveBalance = balanceString
+            if let value = Double(balanceString) {
+                isZeroBalance = value <= 0
+                isLowBalance = value < 1.0
+            }
+        } catch {
+            // Silently ignore errors — don't show error state in the popup
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Show effective balance with color-coded status (red/amber/default) in Preferences popup when signed in
- Add "Add funds" link that navigates to the Billing settings tab
- Fetch balance asynchronously on popup appear via BillingService

Part of plan: platform-sign-in.md (PR 12 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)