### PR TITLE
feat: show Managed by Vellum badge in Models & Services when using platform proxy

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -135,6 +135,7 @@ struct SettingsPanel: View {
         .onAppear {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             store.refreshAPIKeyState()
+            store.loadProviderRoutingSources()
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
@@ -325,6 +326,7 @@ struct SettingsPanel: View {
                 subtitle: "Required for AI responses",
                 isConnected: store.hasKey,
                 keyPlaceholder: "Enter your API key",
+                isManagedProxy: store.providerRoutingSources["anthropic"] == "managed-proxy",
                 keyText: $apiKeyText,
                 onSave: {
                     store.saveAPIKey(apiKeyText)
@@ -361,6 +363,7 @@ struct SettingsPanel: View {
                 subtitle: "Enables real-time web search in responses",
                 isConnected: store.hasPerplexityKey,
                 keyPlaceholder: "Enter your Perplexity API key",
+                isManagedProxy: store.providerRoutingSources["perplexity"] == "managed-proxy",
                 keyText: $perplexityKeyText,
                 onSave: {
                     store.savePerplexityKey(perplexityKeyText)
@@ -378,6 +381,7 @@ struct SettingsPanel: View {
                 subtitle: "Enables private web search in responses",
                 isConnected: store.hasBraveKey,
                 keyPlaceholder: "Enter your Brave Search API key",
+                isManagedProxy: store.providerRoutingSources["brave"] == "managed-proxy",
                 keyText: $braveKeyText,
                 onSave: {
                     store.saveBraveKey(braveKeyText)
@@ -395,6 +399,7 @@ struct SettingsPanel: View {
                 subtitle: "Enables AI image generation via Gemini",
                 isConnected: store.hasImageGenKey,
                 keyPlaceholder: "Enter your Gemini API key",
+                isManagedProxy: store.providerRoutingSources["gemini"] == "managed-proxy",
                 keyText: $imageGenKeyText,
                 onSave: {
                     store.saveImageGenKey(imageGenKeyText)

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
@@ -3,11 +3,13 @@ import VellumAssistantShared
 
 /// A reusable card for Models & Services integrations that need an API key.
 ///
-/// Shows three visual states:
+/// Shows four visual states:
 /// - **Not connected (empty)**: API key field with placeholder, Save disabled
 /// - **Not connected (key entered)**: API key field with masked input, Save enabled
 /// - **Connected**: "Connected" badge inline with title, masked placeholder in key field,
 ///   Save disabled, "Reset (disconnect)" button visible
+/// - **Managed proxy**: "Managed by Vellum" badge inline with title, API key field
+///   collapsed under a disclosure ("Override with your own key")
 ///
 /// Pass optional extra content (e.g. a model picker) via the trailing `@ViewBuilder` closure.
 struct ServiceCredentialCard<ExtraContent: View>: View {
@@ -15,10 +17,13 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
     let subtitle: String
     let isConnected: Bool
     let keyPlaceholder: String
+    let isManagedProxy: Bool
     @Binding var keyText: String
     let onSave: () -> Void
     let onReset: () -> Void
     @ViewBuilder let extraContent: () -> ExtraContent
+
+    @State private var showKeyOverride: Bool = false
 
     private var isSaveEnabled: Bool {
         let hasNewKey = !keyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -29,7 +34,7 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Header: title + connected badge
+            // Header: title + connected/managed badge
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 HStack(spacing: VSpacing.sm) {
                     Text(title)
@@ -46,6 +51,17 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
                         .padding(.vertical, VSpacing.xxs)
                         .background(VColor.systemPositiveStrong.opacity(0.12))
                         .clipShape(Capsule())
+                    } else if isManagedProxy {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.circleCheck, size: 12)
+                            Text("Managed by Vellum")
+                                .font(VFont.captionMedium)
+                        }
+                        .foregroundColor(VColor.primaryBase)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(VColor.primaryBase.opacity(0.12))
+                        .clipShape(Capsule())
                     }
                 }
                 Text(subtitle)
@@ -53,39 +69,65 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
                     .foregroundColor(VColor.contentTertiary)
             }
 
-            // API Key field
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Text("API Key")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.contentSecondary)
-                SecureField(
-                    isConnected && keyText.isEmpty
-                        ? "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
-                        : keyPlaceholder,
-                    text: $keyText
-                )
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.contentDefault)
-            }
+            // API Key field — collapsed under disclosure when managed proxy without user key
+            if isManagedProxy && !isConnected {
+                DisclosureGroup("Override with your own key", isExpanded: $showKeyOverride) {
+                    apiKeyField
+                        .padding(.top, VSpacing.sm)
 
-            extraContent()
-
-            // Action buttons
-            HStack(spacing: VSpacing.sm) {
-                VButton(label: "Save", style: .primary, isDisabled: !isSaveEnabled) {
-                    onSave()
+                    // Action buttons
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Save", style: .primary, isDisabled: !isSaveEnabled) {
+                            onSave()
+                        }
+                    }
+                    .padding(.top, VSpacing.sm)
                 }
-                if isConnected {
-                    VButton(label: "Clear", style: .danger) {
-                        onReset()
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+            } else {
+                apiKeyField
+
+                extraContent()
+
+                // Action buttons
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Save", style: .primary, isDisabled: !isSaveEnabled) {
+                        onSave()
+                    }
+                    if isConnected {
+                        VButton(label: "Clear", style: .danger) {
+                            onReset()
+                        }
                     }
                 }
+            }
+
+            // Extra content shown outside disclosure when managed (e.g. model picker)
+            if isManagedProxy && !isConnected {
+                extraContent()
             }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceOverlay)
+    }
+
+    private var apiKeyField: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("API Key")
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+            SecureField(
+                isConnected && keyText.isEmpty
+                    ? "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
+                    : keyPlaceholder,
+                text: $keyText
+            )
+            .vInputStyle()
+            .font(VFont.body)
+            .foregroundColor(VColor.contentDefault)
+        }
     }
 }
 
@@ -97,6 +139,7 @@ extension ServiceCredentialCard where ExtraContent == EmptyView {
         subtitle: String,
         isConnected: Bool,
         keyPlaceholder: String,
+        isManagedProxy: Bool = false,
         keyText: Binding<String>,
         onSave: @escaping () -> Void,
         onReset: @escaping () -> Void
@@ -105,6 +148,7 @@ extension ServiceCredentialCard where ExtraContent == EmptyView {
         self.subtitle = subtitle
         self.isConnected = isConnected
         self.keyPlaceholder = keyPlaceholder
+        self.isManagedProxy = isManagedProxy
         self._keyText = keyText
         self.onSave = onSave
         self.onReset = onReset
@@ -113,4 +157,3 @@ extension ServiceCredentialCard where ExtraContent == EmptyView {
 }
 
 // MARK: - Preview
-

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -178,6 +178,12 @@ public final class SettingsStore: ObservableObject {
     /// Values: "not_configured", "incomplete", "ready".
     @Published var channelSetupStatus: [String: String] = [:]
 
+    // MARK: - Provider Routing Sources
+
+    /// Per-provider routing source from the daemon debug endpoint.
+    /// Values: `"user-key"`, `"managed-proxy"`, or absent.
+    @Published var providerRoutingSources: [String: String] = [:]
+
     // MARK: - Platform Config State
 
     @Published var platformBaseUrl: String = ""
@@ -355,7 +361,10 @@ public final class SettingsStore: ObservableObject {
         // Re-sync all API keys to daemon when it reconnects
         NotificationCenter.default.publisher(for: .daemonDidReconnect)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.syncAllKeysToDaemon() }
+            .sink { [weak self] _ in
+                self?.syncAllKeysToDaemon()
+                self?.loadProviderRoutingSources()
+            }
             .store(in: &cancellables)
 
         // maxStepsPerSession is read at session startup, so it must be persisted synchronously
@@ -649,6 +658,9 @@ public final class SettingsStore: ObservableObject {
         // Ingress config is refreshed by onAppear in SettingsPanel,
         // not here, to avoid duplicate get requests whose
         // stale responses could overwrite an optimistic toggle.
+
+        // Fetch provider routing sources (managed vs BYO) on init
+        loadProviderRoutingSources()
     }
 
     // MARK: - API Key Actions
@@ -661,6 +673,7 @@ public final class SettingsStore: ObservableObject {
         syncKeyToDaemon(provider: "anthropic", value: trimmed)
         hasKey = true
         maskedKey = Self.maskKey(trimmed)
+        scheduleRoutingSourceRefresh()
     }
 
     func clearAPIKey() {
@@ -669,6 +682,7 @@ public final class SettingsStore: ObservableObject {
         deleteKeyFromDaemon(provider: "anthropic")
         hasKey = false
         maskedKey = ""
+        scheduleRoutingSourceRefresh()
     }
 
     func saveBraveKey(_ raw: String) {
@@ -679,6 +693,7 @@ public final class SettingsStore: ObservableObject {
         syncKeyToDaemon(provider: "brave", value: trimmed)
         hasBraveKey = true
         maskedBraveKey = Self.maskKey(trimmed)
+        scheduleRoutingSourceRefresh()
     }
 
     func clearBraveKey() {
@@ -687,6 +702,7 @@ public final class SettingsStore: ObservableObject {
         deleteKeyFromDaemon(provider: "brave")
         hasBraveKey = false
         maskedBraveKey = ""
+        scheduleRoutingSourceRefresh()
     }
 
     func savePerplexityKey(_ raw: String) {
@@ -697,6 +713,7 @@ public final class SettingsStore: ObservableObject {
         syncKeyToDaemon(provider: "perplexity", value: trimmed)
         hasPerplexityKey = true
         maskedPerplexityKey = Self.maskKey(trimmed)
+        scheduleRoutingSourceRefresh()
     }
 
     func clearPerplexityKey() {
@@ -705,6 +722,7 @@ public final class SettingsStore: ObservableObject {
         deleteKeyFromDaemon(provider: "perplexity")
         hasPerplexityKey = false
         maskedPerplexityKey = ""
+        scheduleRoutingSourceRefresh()
     }
 
     func saveImageGenKey(_ raw: String) {
@@ -715,6 +733,7 @@ public final class SettingsStore: ObservableObject {
         syncKeyToDaemon(provider: "gemini", value: trimmed)
         hasImageGenKey = true
         maskedImageGenKey = Self.maskKey(trimmed)
+        scheduleRoutingSourceRefresh()
     }
 
     func clearImageGenKey() {
@@ -723,6 +742,7 @@ public final class SettingsStore: ObservableObject {
         deleteKeyFromDaemon(provider: "gemini")
         hasImageGenKey = false
         maskedImageGenKey = ""
+        scheduleRoutingSourceRefresh()
     }
 
     func saveElevenLabsKey(_ raw: String) {
@@ -1766,6 +1786,38 @@ public final class SettingsStore: ObservableObject {
             platformBaseUrl = previous
             AuthService.shared.configuredBaseURL = previous
             log.error("Failed to send platform config set: \(error)")
+        }
+    }
+
+    // MARK: - Provider Routing Sources
+
+    /// Fetches provider routing sources from the daemon debug endpoint and
+    /// updates `providerRoutingSources`. Non-fatal — silently ignores errors.
+    func loadProviderRoutingSources() {
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return }
+        Task {
+            do {
+                let response = try await GatewayHTTPClient.get(
+                    path: "assistants/\(assistantId)/debug",
+                    timeout: 10
+                )
+                guard response.isSuccess else { return }
+                guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                      let provider = json["provider"] as? [String: Any],
+                      let sources = provider["routingSources"] as? [String: String] else { return }
+                self.providerRoutingSources = sources
+            } catch {
+                log.error("Failed to load provider routing sources: \(error)")
+            }
+        }
+    }
+
+    /// Schedules a delayed refresh of provider routing sources, giving the
+    /// daemon time to re-initialize providers after a key change.
+    private func scheduleRoutingSourceRefresh() {
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            loadProviderRoutingSources()
         }
     }
 


### PR DESCRIPTION
## Summary
- Add providerRoutingSources tracking to SettingsStore via GET /v1/debug endpoint
- Add isManagedProxy parameter to ServiceCredentialCard with "Managed by Vellum" badge
- Wire routing source data to each provider card in SettingsPanel integrationsContent
- Show API key field in disclosure when managed, allowing users to override with their own key
- Refresh routing sources on key save/clear with delay for daemon re-initialization

Part of plan: platform-sign-in.md (PR 13 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
