### PR TITLE
fix: update test description to reference notification_thread_created

### DIFF
--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -200,7 +200,7 @@ describe("ASK_GUARDIAN canonical notification path", () => {
     expect(payload.requestCode).toBeDefined();
   });
 
-  test("uses notification_conversation_created callback instead of a guardian-specific dispatch path", async () => {
+  test("uses notification_thread_created callback instead of a guardian-specific dispatch path", async () => {
     const convId = "conv-guardian-notif-2";
     ensureConversation(convId);
     mockConversationCreated = {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-notification-thread-created-type-mismatch.md.

**Gap:** Test description still references old type name
**What was expected:** All references should use `notification_thread_created`.
**What was found:** `notification-guardian-path.test.ts` test description still said `notification_conversation_created`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
