### PR TITLE
Fix Workspace tree sidebar vertical alignment — top-align file tree

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -323,7 +323,7 @@ private struct WorkspaceTreeSidebar: View {
                     }
                 }
             }
-            .frame(maxHeight: .infinity)
+            .frame(maxHeight: .infinity, alignment: .topLeading)
 
             if state.uploadingCount > 0 {
                 HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Change `.frame(maxHeight: .infinity)` to `.frame(maxHeight: .infinity, alignment: .topLeading)` on the workspace tree sidebar Group so file entries pin to the top instead of centering vertically

Part of plan: workspace-skill-viewer-unify.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
