### PR TITLE
fix: update Swift client to decode notification_thread_created SSE type

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -93,8 +93,8 @@ extension AppDelegate {
             case .notDetermined:
                 guard !hasRequestedNotificationAuthorizationFromConversationSignal else { return }
                 hasRequestedNotificationAuthorizationFromConversationSignal = true
-                log.info("Requesting notification authorization from notification_conversation_created signal")
-                requestNotificationAuthorization(trigger: "notification_conversation_created", showDeniedToast: true)
+                log.info("Requesting notification authorization from notification_thread_created signal")
+                requestNotificationAuthorization(trigger: "notification_thread_created", showDeniedToast: true)
             case .denied:
                 showNotificationPermissionSettingsToastIfNeeded()
             @unknown default:
@@ -361,7 +361,7 @@ extension AppDelegate {
         )
     }
 
-    /// Schedules a fallback local notification for any notification_conversation_created
+    /// Schedules a fallback local notification for any notification_thread_created
     /// event. If the corresponding notification_intent event arrives within the
     /// delay window, the fallback is cancelled (preventing duplicates). Guardian
     /// questions use a specific body; all other event types use a generic body.

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -62,7 +62,7 @@ extension AppDelegate {
         if let target = msg.targetGuardianPrincipalId {
             let localId = ActorTokenManager.getGuardianPrincipalId()
             if let localId, localId != target {
-                log.info("Skipping notification_conversation_created for guardian \(target) — local guardian is \(localId)")
+                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId)")
                 return
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -487,7 +487,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Create a visible thread bound to a notification-created conversation.
-    /// Called when the daemon broadcasts `notification_conversation_created` so the user
+    /// Called when the daemon broadcasts `notification_thread_created` so the user
     /// can see notification threads and deep-link into them.
     func createNotificationThread(conversationId: String, title: String, sourceEventName: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
@@ -502,7 +502,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.sessionId = conversationId
         // Do NOT set isHistoryLoaded here — notification threads have a
         // pre-existing seed message persisted by conversation-pairing before
-        // the notification_conversation_created event is emitted. Leaving
+        // the notification_thread_created event is emitted. Leaving
         // isHistoryLoaded false allows ThreadSessionRestorer.loadHistoryIfNeeded
         // to fetch that seed message when the thread is first selected.
         // The handleAssistantMessageArrival guard dropping updates is correct

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2365,7 +2365,7 @@ public enum ServerMessage: Decodable, Sendable {
         case "notification_intent":
             let message = try NotificationIntentMessage(from: decoder)
             self = .notificationIntent(message)
-        case "notification_conversation_created":
+        case "notification_thread_created":
             let message = try NotificationConversationCreated(from: decoder)
             self = .notificationConversationCreated(message)
         case "watch_started":


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-notification-thread-created-type-mismatch.md.

**Gap:** Swift client SSE decoder and references not updated
**What was expected:** The Swift client should decode `notification_thread_created` to match the daemon's new wire-protocol type string.
**What was found:** The Swift client still decoded `notification_conversation_created`, causing all notification thread creation events to be silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
