### PR TITLE
feat: show inline error banner in chat when credits are exhausted with Add Funds CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -197,3 +197,44 @@ struct ChatSessionErrorToast: View {
         }
     }
 }
+
+// MARK: - Credits Exhausted Banner
+
+/// Styled inline error banner shown when the user's credits are exhausted.
+/// Displays a clear message and an "Add Funds" CTA button.
+struct CreditsExhaustedBanner: View {
+    let onAddFunds: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.creditCard, size: 16)
+                    .foregroundColor(VColor.systemNegativeStrong)
+                Text("You've run out of credits")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.contentEmphasized)
+                Spacer()
+                Button {
+                    onDismiss()
+                } label: {
+                    VIconView(.x, size: 14)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
+            }
+            Text("Add funds to continue using the assistant.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            VButton(label: "Add Funds", style: .primary) {
+                onAddFunds()
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.systemNegativeWeak.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -343,6 +343,12 @@ struct MainWindowView: View {
         return false
     }
 
+    /// Navigates to the Billing settings tab.
+    private func openBillingSettings() {
+        settingsStore.pendingSettingsTab = .billing
+        windowState.selection = .panel(.settings)
+    }
+
     /// Top bar extracted to break up type-checker complexity.
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
@@ -604,6 +610,7 @@ struct MainWindowView: View {
                         onRetrySessionError: { viewModel.retryAfterSessionError() },
                         onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
                         onDismissSessionError: { viewModel.dismissSessionError() },
+                        onAddFunds: { openBillingSettings() },
                         onSendAnyway: { viewModel.sendAnyway() },
                         onRetryLastMessage: { viewModel.retryLastMessage() },
                         onDismissError: { viewModel.dismissError() }
@@ -872,6 +879,7 @@ private struct ErrorToastOverlay: View {
     let onRetrySessionError: () -> Void
     let onCopyDebugInfo: () -> Void
     let onDismissSessionError: () -> Void
+    let onAddFunds: () -> Void
     let onSendAnyway: () -> Void
     let onRetryLastMessage: () -> Void
     let onDismissError: () -> Void
@@ -891,14 +899,22 @@ private struct ErrorToastOverlay: View {
             }
 
             if let sessionError = errorManager.sessionError {
-                ChatSessionErrorToast(
-                    error: sessionError,
-                    onRetry: onRetrySessionError,
-                    onCopyDebugInfo: onCopyDebugInfo,
-                    onDismiss: onDismissSessionError
-                )
-                .fixedSize(horizontal: true, vertical: false)
-                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                if sessionError.isCreditsExhausted {
+                    CreditsExhaustedBanner(
+                        onAddFunds: onAddFunds,
+                        onDismiss: onDismissSessionError
+                    )
+                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                } else {
+                    ChatSessionErrorToast(
+                        error: sessionError,
+                        onRetry: onRetrySessionError,
+                        onCopyDebugInfo: onCopyDebugInfo,
+                        onDismiss: onDismissSessionError
+                    )
+                    .fixedSize(horizontal: true, vertical: false)
+                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                }
             }
 
             if let errorText = errorManager.errorText, errorManager.sessionError == nil {

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -105,4 +105,9 @@ public struct SessionError: Equatable {
         self.debugDetails = debugDetails
         self.errorCategory = errorCategory
     }
+
+    /// Whether this error indicates that the user's credits are exhausted.
+    public var isCreditsExhausted: Bool {
+        errorCategory == "credits_exhausted"
+    }
 }


### PR DESCRIPTION
## Summary
- Add `isCreditsExhausted` computed property on `SessionError` to detect `credits_exhausted` errorCategory
- Add `CreditsExhaustedBanner` view with styled inline error banner showing "You've run out of credits" message and "Add Funds" CTA button
- Wire `ErrorToastOverlay` to show the credits exhausted banner when `sessionError.isCreditsExhausted` is true, falling through to the existing `ChatSessionErrorToast` for all other session errors
- "Add Funds" button navigates to the Billing settings tab

Part of plan: platform-sign-in.md (PR 14 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
