### PR TITLE
Extract shared FileViewerEmptyState and ReadOnlyCodeContent components

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Empty state shown when no file is selected in a file viewer pane.
+struct FileViewerEmptyState: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            VIconView(.fileText, size: 32)
+                .foregroundColor(VColor.contentTertiary)
+                .padding(.bottom, VSpacing.sm)
+            Text("Select a file to view")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Scrollable read-only monospace text display for file content.
+struct ReadOnlyCodeContent: View {
+    let content: String
+
+    var body: some View {
+        ScrollView([.vertical, .horizontal]) {
+            Text(content)
+                .font(VFont.mono)
+                .foregroundColor(VColor.contentDefault)
+                .textSelection(.enabled)
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create new SharedFileViewerComponents.swift with two reusable views
- FileViewerEmptyState: 'Select a file to view' empty state with icon
- ReadOnlyCodeContent: scrollable monospace text display for read-only file content

Part of plan: workspace-skill-viewer-unify.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
