### PR TITLE
Adopt shared FileViewerEmptyState and ReadOnlyCodeContent in skill detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -379,23 +379,13 @@ struct AgentPanelContent: View {
                     skillFileContentPane(file: file, content: content)
                 } else {
                     // Empty state when no file is selected or loading
-                    VStack {
-                        Spacer()
-                        VIconView(.fileText, size: 32)
-                            .foregroundColor(VColor.contentTertiary)
-                            .padding(.bottom, VSpacing.sm)
-                        Text("Select a file to view")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentTertiary)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(VColor.surfaceOverlay)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.borderBase, lineWidth: 1)
-                    )
+                    FileViewerEmptyState()
+                        .background(VColor.surfaceOverlay)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.borderBase, lineWidth: 1)
+                        )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -500,14 +490,7 @@ struct AgentPanelContent: View {
             Divider().background(VColor.borderBase)
 
             // File content
-            ScrollView([.vertical, .horizontal]) {
-                Text(content)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentDefault)
-                    .textSelection(.enabled)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            ReadOnlyCodeContent(content: content)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .background(VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
- Replace inline empty state VStack with shared FileViewerEmptyState component
- Replace inline ScrollView code viewer with shared ReadOnlyCodeContent component
- Visual appearance unchanged; reduces code duplication with Workspace tab

Part of plan: workspace-skill-viewer-unify.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
