### PR TITLE
Adopt shared FileViewerEmptyState and ReadOnlyCodeContent in Workspace viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -675,17 +675,7 @@ private struct WorkspaceFileViewer: View {
     }
 
     private var emptyState: some View {
-        VStack {
-            Spacer()
-            VIconView(.fileText, size: 32)
-                .foregroundColor(VColor.contentTertiary)
-                .padding(.bottom, VSpacing.sm)
-            Text("Select a file to view")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentTertiary)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        FileViewerEmptyState()
     }
 
     @ViewBuilder
@@ -739,15 +729,8 @@ private struct WorkspaceFileViewer: View {
             }
 
             if readOnly {
-                ScrollView {
-                    Text(detail.content ?? "")
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.contentDefault)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(VSpacing.md)
-                        .textSelection(.enabled)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ReadOnlyCodeContent(content: detail.content ?? "")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 TextEditor(text: $state.editableContent)
                     .font(VFont.mono)


### PR DESCRIPTION
## Summary
- Replace inline emptyState property body with shared FileViewerEmptyState component
- Replace inline read-only ScrollView with shared ReadOnlyCodeContent component
- Adds horizontal scrolling for long lines in read-only mode (matching skill detail behavior)

Part of plan: workspace-skill-viewer-unify.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
