### PR TITLE
feat: raise attachment size limit from 20 MB to 50 MB

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -192,6 +192,33 @@ describe("validateDrafts", () => {
     expect(result.accepted).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
   });
+
+  test("accepts a 25 MB attachment (under 50 MB limit)", () => {
+    const drafts = [
+      makeDraft({
+        filename: "video.mov",
+        sizeBytes: 25 * 1024 * 1024,
+      }),
+    ];
+    const result = validateDrafts(drafts);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("rejects a 51 MB attachment with warning mentioning 50.0 MB limit", () => {
+    const drafts = [
+      makeDraft({
+        filename: "huge.mov",
+        sizeBytes: 51 * 1024 * 1024,
+      }),
+    ];
+    const result = validateDrafts(drafts);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("huge.mov");
+    expect(result.warnings[0]).toContain("50.0 MB");
+    expect(result.warnings[0]).toContain("limit");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -17,8 +17,8 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Maximum size in bytes for a single assistant attachment (20 MB). */
-export const MAX_ASSISTANT_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+/** Maximum size in bytes for a single assistant attachment (50 MB). */
+export const MAX_ASSISTANT_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -46,8 +46,8 @@ function formatBytes(bytes: number): string {
 // Size and encoding limits
 // ---------------------------------------------------------------------------
 
-/** Hard ceiling on a single uploaded attachment (20 MB, matching assistant limits). */
-export const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
+/** Hard ceiling on a single uploaded attachment (50 MB, matching assistant limits). */
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 
 /**
  * Validate that a string contains only characters from the standard base64

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -12,8 +12,8 @@ import {
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
-/** 30 MB — base64-encoded 20 MB attachment ≈ 27 MB plus JSON wrapper overhead. */
-const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
+/** 75 MB — base64-encoded 50 MB attachment ≈ 67 MB plus JSON wrapper overhead. */
+const MAX_UPLOAD_BODY_BYTES = 75 * 1024 * 1024;
 
 export async function handleUploadAttachment(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();


### PR DESCRIPTION
## Summary
- Raise MAX_ASSISTANT_ATTACHMENT_BYTES from 20 MB to 50 MB
- Raise MAX_UPLOAD_BYTES from 20 MB to 50 MB  
- Raise MAX_UPLOAD_BODY_BYTES from 30 MB to 75 MB to accommodate base64 encoding overhead
- Update tests to verify new limits

Part of plan: fix-attachment-delivery.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
