### PR TITLE
fix: capture connectedAssistantId before logout to prevent cleanup race

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -135,11 +135,14 @@ extension AppDelegate {
 
     @objc public func performLogout() {
         Task {
+            // Capture assistant ID before logout clears it from UserDefaults
+            let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+
             await authManager.logout()
 
             // Clear managed proxy credentials from the running daemon
             if let token = ActorTokenManager.getToken(), !token.isEmpty {
-                let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+                let assistantId = connectedAssistantId ?? ""
                 let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
                 let daemonBaseURL = "http://localhost:\(port)"
                 await LocalAssistantBootstrapService.clearDaemonCredentials(
@@ -149,7 +152,7 @@ extension AppDelegate {
             }
 
             // Clear the locally-cached credential from Keychain
-            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+            if let assistantId = connectedAssistantId {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistantId)
                 _ = KeychainCredentialStorage().delete(account: credentialAccount)
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for platform-sign-in.md.

**Gap:** Logout cleanup reads UserDefaults keys after they've been cleared
**What was expected:** Daemon credential cleanup and Keychain cleanup should use the connectedAssistantId that was active before logout
**What was found:** authManager.logout() clears connectedAssistantId from UserDefaults before subsequent cleanup code reads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
