### PR TITLE
fix: display billing top-up validation errors in Add Funds card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -11,6 +11,7 @@ struct SettingsBillingTab: View {
     @State private var error: String?
     @State private var topUpAmount: String = ""
     @State private var isProcessingTopUp: Bool = false
+    @State private var topUpError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -132,6 +133,16 @@ struct SettingsBillingTab: View {
             ) {
                 Task { await handleTopUp() }
             }
+
+            if let topUpError {
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.circleAlert, size: 14)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                    Text(topUpError)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
+            }
         }
     }
 
@@ -150,17 +161,17 @@ struct SettingsBillingTab: View {
 
     private func handleTopUp() async {
         guard let amount = Double(topUpAmount) else {
-            error = "Please enter a valid amount."
+            topUpError = "Please enter a valid amount."
             return
         }
 
         if let summary, let minimum = Double(summary.minimum_top_up_usd), amount < minimum {
-            error = "Minimum top-up amount is $\(summary.minimum_top_up_usd)."
+            topUpError = "Minimum top-up amount is $\(summary.minimum_top_up_usd)."
             return
         }
 
         isProcessingTopUp = true
-        error = nil
+        topUpError = nil
         defer { isProcessingTopUp = false }
 
         do {
@@ -168,7 +179,7 @@ struct SettingsBillingTab: View {
             NSWorkspace.shared.open(checkoutURL)
             topUpAmount = ""
         } catch {
-            self.error = "Failed to create checkout session. Please try again."
+            self.topUpError = "Failed to create checkout session. Please try again."
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for platform-sign-in.md.

**Gap:** Billing top-up validation errors are never displayed
**What was expected:** Users should see error messages for invalid amounts or checkout failures
**What was found:** Error state only rendered when summary is nil, but top-up form requires summary to be non-nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
