### PR TITLE
feat: gateway support for file-backed attachments and per-channel size limits

### DIFF
--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -41,7 +41,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/channel-verification-session-proxy.test.ts
+++ b/gateway/src/__tests__/channel-verification-session-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -9,7 +9,12 @@ describe("config: hardcoded defaults", () => {
     expect(config.runtimeMaxRetries).toBe(2);
     expect(config.runtimeInitialBackoffMs).toBe(500);
     expect(config.maxWebhookPayloadBytes).toBe(1024 * 1024);
-    expect(config.maxAttachmentBytes).toBe(20 * 1024 * 1024);
+    expect(config.maxAttachmentBytes).toEqual({
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    });
     expect(config.maxAttachmentConcurrency).toBe(3);
     expect(config.runtimeProxyEnabled).toBe(false);
     expect(config.runtimeProxyRequireAuth).toBe(true);

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -61,7 +61,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/load-guards.test.ts
+++ b/gateway/src/__tests__/load-guards.test.ts
@@ -30,7 +30,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 256, // very small for testing
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/oauth-callback.test.ts
+++ b/gateway/src/__tests__/oauth-callback.test.ts
@@ -42,7 +42,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -17,7 +17,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/runtime-client.test.ts
+++ b/gateway/src/__tests__/runtime-client.test.ts
@@ -44,7 +44,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,
@@ -209,6 +214,45 @@ describe("downloadAttachment", () => {
 
     const calledUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
     expect(calledUrl).toContain("/attachments/att-1");
+  });
+
+  test("transparently hydrates file-backed attachments from /content endpoint", async () => {
+    const binaryContent = Buffer.from("fake-binary-content");
+    const attachmentMeta = {
+      id: "att-fb-1",
+      filename: "video.mov",
+      mimeType: "video/quicktime",
+      sizeBytes: binaryContent.length,
+      fileBacked: true,
+      // data is absent — file-backed attachment
+    };
+
+    let callCount = 0;
+    fetchMock = mock(async (input) => {
+      const calledUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      callCount++;
+      if (calledUrl.endsWith("/content")) {
+        // Return raw binary for the /content endpoint
+        return new Response(new Uint8Array(binaryContent), { status: 200 });
+      }
+      // Return the JSON metadata (no data field)
+      return new Response(JSON.stringify(attachmentMeta), { status: 200 });
+    });
+
+    const config = makeConfig();
+    const result = await downloadAttachment(config, "att-fb-1");
+
+    expect(result.id).toBe("att-fb-1");
+    expect(result.fileBacked).toBe(true);
+    // data should be hydrated with base64-encoded binary content
+    expect(result.data).toBe(binaryContent.toString("base64"));
+    // Should have made two calls: one for metadata, one for /content
+    expect(callCount).toBe(2);
   });
 
   test("throws on 404 not found", async () => {

--- a/gateway/src/__tests__/runtime-health-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-health-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/runtime-proxy-auth.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-auth.test.ts
@@ -49,7 +49,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/slack-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/slack-control-plane-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/slack-deliver-ratelimit.test.ts
+++ b/gateway/src/__tests__/slack-deliver-ratelimit.test.ts
@@ -29,7 +29,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1048576,
     port: 7830,

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -33,7 +33,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1048576,
     port: 7830,
@@ -979,7 +984,14 @@ describe("slack attachment delivery", () => {
 
   test("skips oversized attachment and sends failure notice", async () => {
     const handler = createSlackDeliverHandler(
-      makeConfig({ maxAttachmentBytes: 50 }),
+      makeConfig({
+        maxAttachmentBytes: {
+          telegram: 50,
+          slack: 50,
+          whatsapp: 50,
+          default: 50,
+        },
+      }),
       undefined,
       makeCaches(),
     );

--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -27,7 +27,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: "default-assistant",
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1048576,
     port: 7830,

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -14,7 +14,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: "default-assistant",
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1048576,
     port: 7830,

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -11,7 +11,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: "default-assistant",
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1048576,
     port: 7830,

--- a/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/telegram-control-plane-proxy.test.ts
@@ -35,7 +35,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -52,7 +52,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -38,7 +38,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,
@@ -176,7 +181,14 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig({ maxAttachmentBytes: 50 });
+    const config = makeConfig({
+      maxAttachmentBytes: {
+        telegram: 50,
+        slack: 50,
+        whatsapp: 50,
+        default: 50,
+      },
+    });
     const meta: RuntimeAttachmentMeta = {
       id: "att-3",
       filename: "huge.zip",
@@ -334,7 +346,14 @@ describe("sendTelegramAttachments", () => {
       return new Response(JSON.stringify(telegramOk));
     });
 
-    const config = makeConfig({ maxAttachmentBytes: 50 });
+    const config = makeConfig({
+      maxAttachmentBytes: {
+        telegram: 50,
+        slack: 50,
+        whatsapp: 50,
+        default: 50,
+      },
+    });
     // No sizeBytes in meta — will be hydrated from download payload (200 > 50 limit)
     const meta: RuntimeAttachmentMeta = { id: "att-big" };
 

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -37,7 +37,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -52,7 +52,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -129,7 +129,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/whatsapp-download.test.ts
+++ b/gateway/src/__tests__/whatsapp-download.test.ts
@@ -34,7 +34,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/__tests__/whatsapp-webhook.test.ts
+++ b/gateway/src/__tests__/whatsapp-webhook.test.ts
@@ -61,7 +61,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     runtimeInitialBackoffMs: 500,
     maxWebhookPayloadBytes: 1048576,
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20971520,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     trustProxy: false,

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -11,7 +11,11 @@ export type GatewayConfig = {
   defaultAssistantId: string | undefined;
   gatewayInternalBaseUrl: string;
   logFile: LogFileConfig;
-  maxAttachmentBytes: number;
+  maxAttachmentBytes: Record<
+    "telegram" | "slack" | "whatsapp" | "default",
+    number
+  > &
+    Record<string, number>;
   maxAttachmentConcurrency: number;
   maxWebhookPayloadBytes: number;
   port: number;
@@ -129,7 +133,12 @@ export function loadConfig(): GatewayConfig {
     defaultAssistantId,
     gatewayInternalBaseUrl,
     logFile,
-    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024, // Telegram Bot API limit
+      slack: 100 * 1024 * 1024, // Slack standard plan
+      whatsapp: 16 * 1024 * 1024, // WhatsApp Business API limit
+      default: 50 * 1024 * 1024, // Fallback for new channels
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,
     port,

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -237,7 +237,8 @@ export async function sendSlackAttachments(
     // Skip oversized attachments before downloading when size is known
     if (
       meta.sizeBytes !== undefined &&
-      meta.sizeBytes > config.maxAttachmentBytes
+      meta.sizeBytes >
+        (config.maxAttachmentBytes.slack ?? config.maxAttachmentBytes.default)
     ) {
       log.warn(
         { attachmentId: meta.id, sizeBytes: meta.sizeBytes },
@@ -258,7 +259,10 @@ export async function sendSlackAttachments(
       const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? buffer.length;
 
       // Check size after hydration for ID-only payloads
-      if (sizeBytes > config.maxAttachmentBytes) {
+      if (
+        sizeBytes >
+        (config.maxAttachmentBytes.slack ?? config.maxAttachmentBytes.default)
+      ) {
         log.warn(
           { attachmentId: meta.id, sizeBytes },
           "Skipping oversized outbound attachment (detected after download)",

--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -32,7 +32,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,
     port: 7830,

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -60,7 +60,12 @@ const baseConfig: GatewayConfig = {
   defaultAssistantId: "ast-default",
   gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentBytes: {
+    telegram: 50 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    default: 50 * 1024 * 1024,
+  },
   maxAttachmentConcurrency: 3,
   maxWebhookPayloadBytes: 1024 * 1024,
   port: 7830,

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -569,13 +569,17 @@ export function createTelegramWebhookHandler(
         const eligible = eventAttachments.filter((att) => {
           if (
             att.fileSize !== undefined &&
-            att.fileSize > config.maxAttachmentBytes
+            att.fileSize >
+              (config.maxAttachmentBytes.telegram ??
+                config.maxAttachmentBytes.default)
           ) {
             tlog.warn(
               {
                 fileId: att.fileId,
                 fileSize: att.fileSize,
-                limit: config.maxAttachmentBytes,
+                limit:
+                  config.maxAttachmentBytes.telegram ??
+                  config.maxAttachmentBytes.default,
               },
               "Skipping oversized attachment",
             );

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -65,7 +65,12 @@ const baseConfig: GatewayConfig = {
   defaultAssistantId: undefined,
   gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentBytes: {
+    telegram: 50 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    default: 50 * 1024 * 1024,
+  },
   maxAttachmentConcurrency: 3,
   maxWebhookPayloadBytes: 1024 * 1024,
   port: 7830,

--- a/gateway/src/http/routes/whatsapp-deliver.test.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.test.ts
@@ -42,7 +42,12 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     defaultAssistantId: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,
     port: 7830,

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -81,7 +81,12 @@ const baseConfig: GatewayConfig = {
   defaultAssistantId: "ast-default",
   gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentBytes: {
+    telegram: 50 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    default: 50 * 1024 * 1024,
+  },
   maxAttachmentConcurrency: 3,
   maxWebhookPayloadBytes: 1024 * 1024,
   port: 7830,

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -296,13 +296,17 @@ export function createWhatsAppWebhookHandler(
           const eligible = eventAttachments.filter((att) => {
             if (
               att.fileSize !== undefined &&
-              att.fileSize > config.maxAttachmentBytes
+              att.fileSize >
+                (config.maxAttachmentBytes.whatsapp ??
+                  config.maxAttachmentBytes.default)
             ) {
               tlog.warn(
                 {
                   fileId: att.fileId,
                   fileSize: att.fileSize,
-                  limit: config.maxAttachmentBytes,
+                  limit:
+                    config.maxAttachmentBytes.whatsapp ??
+                    config.maxAttachmentBytes.default,
                 },
                 "Skipping oversized WhatsApp attachment",
               );

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -155,6 +155,7 @@ export type RuntimeAttachmentMeta = {
 
 export type RuntimeAttachmentPayload = RuntimeAttachmentMeta & {
   data: string; // base64-encoded
+  fileBacked?: boolean;
 };
 
 export type RuntimeInboundResponse = {
@@ -304,6 +305,40 @@ export type UploadAttachmentResponse = {
   id: string;
 };
 
+export async function downloadAttachmentContent(
+  config: GatewayConfig,
+  attachmentId: string,
+): Promise<Buffer> {
+  cbBeforeRequest();
+
+  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}/content`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      headers: runtimeServiceHeaders(config),
+      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+    });
+  } catch (err) {
+    cbOnFailure();
+    throw err;
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status >= 500) cbOnFailure();
+    else cbOnSuccess();
+    throw new Error(
+      `Attachment content download failed (${response.status}): ${body}`,
+    );
+  }
+
+  cbOnSuccess();
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
 export async function downloadAttachment(
   config: GatewayConfig,
   attachmentId: string,
@@ -332,7 +367,16 @@ export async function downloadAttachment(
   }
 
   cbOnSuccess();
-  return (await response.json()) as RuntimeAttachmentPayload;
+  const payload = (await response.json()) as RuntimeAttachmentPayload;
+
+  // Transparently hydrate file-backed attachments: fetch the binary content
+  // from the dedicated /content endpoint and inline it as base64.
+  if (payload.fileBacked && !payload.data) {
+    const contentBuffer = await downloadAttachmentContent(config, attachmentId);
+    payload.data = contentBuffer.toString("base64");
+  }
+
+  return payload;
 }
 
 // ── Twilio webhook forwarding ────────────────────────────────────────

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -27,7 +27,12 @@ const baseConfig: GatewayConfig = {
   defaultAssistantId: undefined,
   gatewayInternalBaseUrl: "http://127.0.0.1:7830",
   logFile: { dir: undefined, retentionDays: 30 },
-  maxAttachmentBytes: 20 * 1024 * 1024,
+  maxAttachmentBytes: {
+    telegram: 50 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    default: 50 * 1024 * 1024,
+  },
   maxAttachmentConcurrency: 3,
   maxWebhookPayloadBytes: 1024 * 1024,
   port: 7830,

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -84,7 +84,9 @@ export async function sendTelegramAttachments(
     // When size is known upfront, skip oversized attachments before downloading.
     if (
       meta.sizeBytes !== undefined &&
-      meta.sizeBytes > config.maxAttachmentBytes
+      meta.sizeBytes >
+        (config.maxAttachmentBytes.telegram ??
+          config.maxAttachmentBytes.default)
     ) {
       log.warn(
         { attachmentId: meta.id, sizeBytes: meta.sizeBytes },
@@ -107,7 +109,11 @@ export async function sendTelegramAttachments(
       const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? buffer.length;
 
       // Check size after hydration for ID-only payloads where size was unknown.
-      if (sizeBytes > config.maxAttachmentBytes) {
+      if (
+        sizeBytes >
+        (config.maxAttachmentBytes.telegram ??
+          config.maxAttachmentBytes.default)
+      ) {
         log.warn(
           { attachmentId: meta.id, sizeBytes },
           "Skipping oversized outbound attachment (detected after download)",

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -57,9 +57,12 @@ export async function downloadWhatsAppFile(
 ): Promise<DownloadedFile> {
   const meta = await getWhatsAppMediaMetadata(mediaId, caches);
 
-  if (meta.file_size > config.maxAttachmentBytes) {
+  if (
+    meta.file_size >
+    (config.maxAttachmentBytes.whatsapp ?? config.maxAttachmentBytes.default)
+  ) {
     throw new WhatsAppNonRetryableError(
-      `WhatsApp media ${mediaId} exceeds size limit (${meta.file_size} > ${config.maxAttachmentBytes} bytes)`,
+      `WhatsApp media ${mediaId} exceeds size limit (${meta.file_size} > ${config.maxAttachmentBytes.whatsapp ?? config.maxAttachmentBytes.default} bytes)`,
     );
   }
 

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -136,7 +136,9 @@ export async function sendWhatsAppAttachments(
   for (const meta of attachments) {
     if (
       meta.sizeBytes !== undefined &&
-      meta.sizeBytes > config.maxAttachmentBytes
+      meta.sizeBytes >
+        (config.maxAttachmentBytes.whatsapp ??
+          config.maxAttachmentBytes.default)
     ) {
       log.warn(
         { attachmentId: meta.id, sizeBytes: meta.sizeBytes },
@@ -155,7 +157,11 @@ export async function sendWhatsAppAttachments(
       const buffer = Buffer.from(payload.data, "base64");
       const sizeBytes = meta.sizeBytes ?? payload.sizeBytes ?? buffer.length;
 
-      if (sizeBytes > config.maxAttachmentBytes) {
+      if (
+        sizeBytes >
+        (config.maxAttachmentBytes.whatsapp ??
+          config.maxAttachmentBytes.default)
+      ) {
         log.warn(
           { attachmentId: meta.id, sizeBytes },
           "Skipping oversized outbound attachment (detected after download)",


### PR DESCRIPTION
## Summary
- Add fileBacked field to RuntimeAttachmentPayload and transparent hydration in downloadAttachment()
- Add downloadAttachmentContent() for fetching binary content of file-backed attachments
- Replace flat maxAttachmentBytes with per-channel limits (Telegram 50MB, Slack 100MB, WhatsApp 16MB)
- Update all channel delivery code to use channel-specific size limits

Part of plan: fix-attachment-delivery.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
