### PR TITLE
feat: use file-backed storage for large assistant-created attachments

### DIFF
--- a/assistant/src/__tests__/session-attachments.test.ts
+++ b/assistant/src/__tests__/session-attachments.test.ts
@@ -1,0 +1,226 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "session-attach-test-"));
+const workspaceDir = join(testDir, "workspace");
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+// Stub out video thumbnail generation (requires ffmpeg)
+mock.module("../daemon/video-thumbnail.js", () => ({
+  generateVideoThumbnail: () => Promise.resolve(null),
+}));
+
+// Stub out permission checker / trust store
+mock.module("../permissions/checker.js", () => ({
+  check: () => Promise.resolve({ decision: "allow" }),
+  classifyRisk: () => Promise.resolve("low"),
+  generateAllowlistOptions: () => Promise.resolve([]),
+  generateScopeOptions: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+}));
+
+mock.module("../permissions/types.js", () => ({
+  isAllowDecision: () => true,
+}));
+
+import type { AssistantAttachmentDraft } from "../daemon/assistant-attachments.js";
+import {
+  FILE_BACKED_THRESHOLD_BYTES,
+  getFilePathForAttachment,
+} from "../memory/attachments-store.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+/**
+ * Create a base64 string of approximately `bytes` decoded size.
+ */
+function makeBase64(bytes: number): string {
+  const buf = Buffer.alloc(bytes, 0x41); // fill with 'A'
+  return buf.toString("base64");
+}
+
+// ---------------------------------------------------------------------------
+// resolveAssistantAttachments — inline vs file-backed storage
+// ---------------------------------------------------------------------------
+
+describe("resolveAssistantAttachments", () => {
+  beforeEach(resetTables);
+
+  test("attachments under 5 MB are stored inline via uploadAttachment", async () => {
+    const conv = createConversation("test-conv");
+    const msg = await addMessage(conv.id, "assistant", "hello");
+
+    const smallSize = 2 * 1024 * 1024; // 2 MB
+    const dataBase64 = makeBase64(smallSize);
+
+    const draft: AssistantAttachmentDraft = {
+      sourceType: "sandbox_file",
+      filename: "small-image.png",
+      mimeType: "image/png",
+      dataBase64,
+      sizeBytes: smallSize,
+      kind: "image",
+    };
+
+    mock.module("../daemon/assistant-attachments.js", () => ({
+      resolveDirectives: () =>
+        Promise.resolve({ drafts: [draft], warnings: [] }),
+      contentBlocksToDrafts: () => [],
+      deduplicateDrafts: (d: AssistantAttachmentDraft[]) => d,
+      validateDrafts: (d: AssistantAttachmentDraft[]) => ({
+        accepted: d,
+        warnings: [],
+      }),
+    }));
+
+    // Re-import to pick up mocks
+    const { resolveAssistantAttachments: resolve } =
+      await import("../daemon/session-attachments.js");
+
+    const result = await resolve(
+      [
+        {
+          source: "sandbox" as const,
+          path: "/fake",
+          filename: "small-image.png",
+          mimeType: "image/png",
+        },
+      ],
+      [],
+      [],
+      "/tmp",
+      async () => true,
+      msg.id,
+    );
+
+    expect(result.emittedAttachments.length).toBe(1);
+    const emitted = result.emittedAttachments[0];
+    expect(emitted.id).toBeDefined();
+    expect(emitted.data).toBe(dataBase64); // inline — data is present
+    expect(emitted.sizeBytes).toBeUndefined(); // no sizeBytes hint for inline
+
+    // Verify the attachment is in the DB and not file-backed
+    const filePath = getFilePathForAttachment(emitted.id!);
+    expect(filePath).toBeNull();
+  });
+
+  test("attachments over 5 MB are stored via uploadFileBackedAttachment with file on disk", async () => {
+    const conv = createConversation("test-conv-large");
+    const msg = await addMessage(conv.id, "assistant", "hello");
+
+    const largeSize = 10 * 1024 * 1024; // 10 MB
+    const dataBase64 = makeBase64(largeSize);
+
+    const draft: AssistantAttachmentDraft = {
+      sourceType: "sandbox_file",
+      filename: "big-video.mov",
+      mimeType: "video/quicktime",
+      dataBase64,
+      sizeBytes: largeSize,
+      kind: "video",
+    };
+
+    mock.module("../daemon/assistant-attachments.js", () => ({
+      resolveDirectives: () =>
+        Promise.resolve({ drafts: [draft], warnings: [] }),
+      contentBlocksToDrafts: () => [],
+      deduplicateDrafts: (d: AssistantAttachmentDraft[]) => d,
+      validateDrafts: (d: AssistantAttachmentDraft[]) => ({
+        accepted: d,
+        warnings: [],
+      }),
+    }));
+
+    const { resolveAssistantAttachments: resolve } =
+      await import("../daemon/session-attachments.js");
+
+    const result = await resolve(
+      [
+        {
+          source: "sandbox" as const,
+          path: "/fake",
+          filename: "big-video.mov",
+          mimeType: "video/quicktime",
+        },
+      ],
+      [],
+      [],
+      "/tmp",
+      async () => true,
+      msg.id,
+    );
+
+    expect(result.emittedAttachments.length).toBe(1);
+    const emitted = result.emittedAttachments[0];
+    expect(emitted.id).toBeDefined();
+    // File-backed: data should be empty, sizeBytes should be set
+    expect(emitted.data).toBe("");
+    expect(emitted.sizeBytes).toBe(largeSize);
+
+    // Verify the file exists on disk at the expected path
+    const filePath = getFilePathForAttachment(emitted.id!);
+    expect(filePath).not.toBeNull();
+    expect(filePath!).toContain("attachments");
+    expect(filePath!).toContain("big-video.mov");
+    expect(existsSync(filePath!)).toBe(true);
+  });
+});
+
+describe("FILE_BACKED_THRESHOLD_BYTES", () => {
+  test("is 5 MB", () => {
+    expect(FILE_BACKED_THRESHOLD_BYTES).toBe(5 * 1024 * 1024);
+  });
+});

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -1,8 +1,11 @@
 import {
   AttachmentUploadError,
+  FILE_BACKED_THRESHOLD_BYTES,
   linkAttachmentToMessage,
   setAttachmentThumbnail,
   uploadAttachment,
+  uploadFileBackedAttachment,
+  writeAttachmentToDisk,
 } from "../memory/attachments-store.js";
 import {
   check,
@@ -205,13 +208,27 @@ export async function resolveAssistantAttachments(
   if (assistantAttachments.length > 0 && lastAssistantMessageId) {
     for (let i = 0; i < assistantAttachments.length; i++) {
       const draft = assistantAttachments[i];
+      const isFileBacked = draft.sizeBytes > FILE_BACKED_THRESHOLD_BYTES;
       let stored;
       try {
-        stored = uploadAttachment(
-          draft.filename,
-          draft.mimeType,
-          draft.dataBase64,
-        );
+        if (isFileBacked) {
+          const filePath = writeAttachmentToDisk(
+            draft.dataBase64,
+            draft.filename,
+          );
+          stored = uploadFileBackedAttachment(
+            draft.filename,
+            draft.mimeType,
+            filePath,
+            draft.sizeBytes,
+          );
+        } else {
+          stored = uploadAttachment(
+            draft.filename,
+            draft.mimeType,
+            draft.dataBase64,
+          );
+        }
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
           log.warn(
@@ -227,7 +244,9 @@ export async function resolveAssistantAttachments(
       }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       const isVideo = draft.mimeType.startsWith("video/");
-      const omitData = isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
+      const omitData =
+        isFileBacked ||
+        (isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE);
 
       // Generate and persist a thumbnail for video attachments.
       let thumbnailData: string | undefined;

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -5,11 +5,13 @@
  * data. Provides upload, delete, and message-linkage operations.
  */
 
-import { unlinkSync } from "node:fs";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getWorkspaceDir } from "../util/platform.js";
 import { getDb, rawAll, rawGet, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
 
@@ -48,6 +50,26 @@ function formatBytes(bytes: number): string {
 
 /** Hard ceiling on a single uploaded attachment (50 MB, matching assistant limits). */
 export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+/** Attachments larger than this are stored on disk instead of inline in SQLite. */
+export const FILE_BACKED_THRESHOLD_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Write decoded base64 data to disk under the workspace attachments directory.
+ * Returns the absolute file path of the written file.
+ */
+export function writeAttachmentToDisk(
+  dataBase64: string,
+  filename: string,
+): string {
+  const dir = join(getWorkspaceDir(), "data", "attachments");
+  mkdirSync(dir, { recursive: true });
+  const destFilename = `${uuid()}-${filename}`;
+  const destPath = join(dir, destFilename);
+  const buffer = Buffer.from(dataBase64, "base64");
+  writeFileSync(destPath, buffer);
+  return destPath;
+}
 
 /**
  * Validate that a string contains only characters from the standard base64


### PR DESCRIPTION
## Summary
- Add FILE_BACKED_THRESHOLD_BYTES (5 MB) constant and writeAttachmentToDisk() helper
- Route attachments over 5 MB through file-backed storage instead of inline SQLite blobs
- Add tests verifying inline vs file-backed storage paths

Part of JARVIS-212
Part of plan: fix-attachment-delivery.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
