### PR TITLE
fix: update system prompt attachment limit from 20 MB to 50 MB

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -285,7 +285,7 @@ function buildAttachmentSection(): string {
     "",
     'Example: `<vellum-attachment source="sandbox" path="scratch/chart.png" />`',
     "",
-    "Limits: 20 MB per attachment. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
+    "Limits: 50 MB per attachment. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
     "",
     "### Inline Images and GIFs",
     "Embed images/GIFs inline using markdown: `![description](URL)`. Do NOT wrap in code fences.",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** System prompt still says 20 MB per attachment
**What was expected:** Should reflect new 50 MB limit
**What was found:** Stale 20 MB reference in system-prompt.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
