### PR TITLE
fix: update stale 20 MB references in JSDoc and test comments

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -167,7 +167,7 @@ describe("uploadAttachment", () => {
   });
 
   test("accepts payload exactly at MAX_UPLOAD_BYTES", () => {
-    // MAX_UPLOAD_BYTES (20 MB) is divisible by 3, so (MAX/3)*4 base64 chars
+    // MAX_UPLOAD_BYTES (50 MB) is divisible by 3, so (MAX/3)*4 base64 chars
     // decodes to exactly MAX bytes with no padding.
     const exactLength = (MAX_UPLOAD_BYTES / 3) * 4;
     const exactData = "A".repeat(exactLength);

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -237,7 +237,7 @@ let filePathColumnEnsured = false;
 /**
  * Store a file-backed attachment by path reference, without reading the file
  * into memory. This avoids OOM risk for large recordings that exceed the
- * normal 20 MB upload limit.
+ * normal 50 MB upload limit.
  *
  * The file stays on disk; the attachment row stores an empty dataBase64 and
  * records the on-disk path in a `file_path` column (added via runtime


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** Stale JSDoc and test comments still reference 20 MB
**What was expected:** Comments should say 50 MB
**What was found:** uploadFileBackedAttachment JSDoc and test comment still said 20 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
