### PR TITLE
fix: clean up on-disk files when deleting file-backed attachments

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -416,7 +416,19 @@ export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
 
   if (refCount > 0) return "still_referenced";
 
+  // Collect file path BEFORE deleting the DB row (the row contains the path reference)
+  const filePath = getFilePathForAttachment(attachmentId);
+
   db.delete(attachments).where(eq(attachments.id, attachmentId)).run();
+
+  // Clean up on-disk file only after the DB row has been removed
+  if (filePath) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      /* file may already be gone */
+    }
+  }
 
   return "deleted";
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** deleteAttachment leaks on-disk files for file-backed attachments
**What was expected:** On-disk files should be cleaned up on deletion
**What was found:** Only DB row was deleted, disk file persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
