### PR TITLE
refactor: rename session→conversation TS symbols & wire strings (PR 4/5)

### DIFF
--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -319,7 +319,7 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
   test("preserves generation_handoff payload", async () => {
     const msg = {
       type: "generation_handoff" as const,
-      sessionId: "conv-handoff",
+      conversationId: "conv-handoff",
       requestId: "req-xyz-789",
       queuedCount: 2,
     };
@@ -327,7 +327,7 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
 
     expect(event.message.type).toBe("generation_handoff");
     const m = event.message as typeof msg;
-    expect(m.sessionId).toBe("conv-handoff");
+    expect(m.conversationId).toBe("conv-handoff");
     expect(m.requestId).toBe("req-xyz-789");
     expect(m.queuedCount).toBe(2);
   });
@@ -337,13 +337,13 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
   test("preserves generation_cancelled payload", async () => {
     const msg = {
       type: "generation_cancelled" as const,
-      sessionId: "conv-cancelled",
+      conversationId: "conv-cancelled",
     };
     const event = await publishAndReadFrame("parity-generation-cancelled", msg);
 
     expect(event.message.type).toBe("generation_cancelled");
     const m = event.message as typeof msg;
-    expect(m.sessionId).toBe("conv-cancelled");
+    expect(m.conversationId).toBe("conv-cancelled");
   });
 
   // ── Envelope integrity ───────────────────────────────────────────────────

--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -284,7 +284,7 @@ mock.module("../workspace/git-service.js", () => ({
 
 mock.module("../daemon/session-error.js", () => ({
   classifySessionError: (_err: unknown, _ctx: unknown) => ({
-    code: "SESSION_PROCESSING_FAILED",
+    code: "CONVERSATION_PROCESSING_FAILED",
     userMessage: "Something went wrong processing your message.",
     retryable: false,
     errorCategory: "processing_failed",
@@ -296,11 +296,11 @@ mock.module("../daemon/session-error.js", () => ({
     return false;
   },
   buildSessionErrorMessage: (
-    sessionId: string,
+    conversationId: string,
     classified: Record<string, unknown>,
   ) => ({
-    type: "session_error",
-    sessionId,
+    type: "conversation_error",
+    conversationId,
     ...classified,
   }),
   isContextTooLarge: (msg: string) =>
@@ -700,7 +700,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
       // BUG: Currently a session_error IS emitted instead of retrying.
       // After PR 2 fix, there should be no session_error.
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },
   );
@@ -807,7 +807,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // The reducer should be called in the convergence loop
       expect(reducerCalled).toBe(true);
       // Should recover without session_error
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       expect(callCount).toBe(2);
     },
@@ -941,7 +941,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(capturedTargetTokens!).toBe(expectedCorrectedTarget);
 
       // Should recover without session_error
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       expect(callCount).toBe(2);
     },
@@ -1037,7 +1037,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(reducerCalled).toBe(true);
       // Should succeed
       expect(callCount).toBe(1);
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
@@ -1230,7 +1230,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(emergencyCompactCalled).toBe(true);
 
       // BUG: Currently a session_error IS emitted.
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },
   );
@@ -1406,7 +1406,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(agentLoopCallCount).toBe(2);
 
       // No session_error should be emitted
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
 
       // A context_compacted event should have been emitted
@@ -1575,9 +1575,9 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
         events.push(msg);
         // Track if context_too_large was ever emitted
         if (
-          msg.type === "session_error" &&
+          msg.type === "conversation_error" &&
           "code" in msg &&
-          msg.code === "SESSION_PROCESSING_FAILED"
+          msg.code === "CONVERSATION_PROCESSING_FAILED"
         ) {
           contextTooLargeEmitted = true;
         }
@@ -1593,7 +1593,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(agentLoopCallCount).toBe(2);
 
       // No session_error
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },
   );

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -267,7 +267,7 @@ mock.module("../workspace/git-service.js", () => ({
 
 mock.module("../daemon/session-error.js", () => ({
   classifySessionError: (_err: unknown, _ctx: unknown) => ({
-    code: "SESSION_PROCESSING_FAILED",
+    code: "CONVERSATION_PROCESSING_FAILED",
     userMessage: "Something went wrong processing your message.",
     retryable: false,
     errorCategory: "processing_failed",
@@ -279,11 +279,11 @@ mock.module("../daemon/session-error.js", () => ({
     return false;
   },
   buildSessionErrorMessage: (
-    sessionId: string,
+    conversationId: string,
     classified: Record<string, unknown>,
   ) => ({
-    type: "session_error",
-    sessionId,
+    type: "conversation_error",
+    conversationId,
     ...classified,
   }),
   isContextTooLarge: (msg: string) => /context.?length.?exceeded/i.test(msg),
@@ -545,7 +545,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "run ls", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeDefined();
     });
 
@@ -579,7 +579,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
@@ -818,7 +818,7 @@ describe("session-agent-loop", () => {
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeDefined();
     });
 
@@ -896,7 +896,7 @@ describe("session-agent-loop", () => {
 
       expect(reducerCalls).toBeGreaterThanOrEqual(1);
       expect(callCount).toBe(2);
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
@@ -951,7 +951,7 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
       // Should NOT emit session_error
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
 
       // Should emit a graceful assistant text delta instead
@@ -1057,7 +1057,7 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
       // Should not produce session_error since auto-compress recovered
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
@@ -1250,7 +1250,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeDefined();
     });
   });
@@ -1507,7 +1507,7 @@ describe("session-agent-loop", () => {
       const cancelled = events.find((e) => e.type === "generation_cancelled");
       expect(cancelled).toBeDefined();
       // Should NOT emit a session_error for user cancellation
-      const sessionError = events.find((e) => e.type === "session_error");
+      const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     });
 

--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -277,21 +277,21 @@ describe("classifySessionError", () => {
   });
 
   describe("abort/cancel errors (non-user-initiated)", () => {
-    it('classifies "aborted" as SESSION_ABORTED', () => {
+    it('classifies "aborted" as CONVERSATION_ABORTED', () => {
       const result = classifySessionError(
         new Error("Request aborted"),
         baseCtx,
       );
-      expect(result.code).toBe("SESSION_ABORTED");
+      expect(result.code).toBe("CONVERSATION_ABORTED");
       expect(result.retryable).toBe(true);
     });
 
-    it('classifies "cancelled" as SESSION_ABORTED', () => {
+    it('classifies "cancelled" as CONVERSATION_ABORTED', () => {
       const result = classifySessionError(
         new Error("Operation cancelled"),
         baseCtx,
       );
-      expect(result.code).toBe("SESSION_ABORTED");
+      expect(result.code).toBe("CONVERSATION_ABORTED");
       expect(result.retryable).toBe(true);
     });
   });
@@ -315,12 +315,12 @@ describe("classifySessionError", () => {
   });
 
   describe("generic errors", () => {
-    it("classifies unknown errors as SESSION_PROCESSING_FAILED with error summary", () => {
+    it("classifies unknown errors as CONVERSATION_PROCESSING_FAILED with error summary", () => {
       const result = classifySessionError(
         new Error("something completely unexpected"),
         baseCtx,
       );
-      expect(result.code).toBe("SESSION_PROCESSING_FAILED");
+      expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.retryable).toBe(false);
       expect(result.userMessage).toContain("something completely unexpected");
       expect(result.errorCategory).toBe("processing_failed");
@@ -335,14 +335,14 @@ describe("classifySessionError", () => {
 
     it("handles non-Error values", () => {
       const result = classifySessionError("plain string error", baseCtx);
-      expect(result.code).toBe("SESSION_PROCESSING_FAILED");
+      expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.userMessage).toContain("plain string error");
       expect(result.debugDetails).toBe("plain string error");
     });
 
     it("falls back to generic message for empty error", () => {
       const result = classifySessionError(new Error(""), baseCtx);
-      expect(result.code).toBe("SESSION_PROCESSING_FAILED");
+      expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.userMessage).toBe(
         "Something went wrong processing your message. Please try again.",
       );
@@ -353,7 +353,7 @@ describe("classifySessionError", () => {
         new Error("\n\nactual error on line 3"),
         baseCtx,
       );
-      expect(result.code).toBe("SESSION_PROCESSING_FAILED");
+      expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.userMessage).toContain("actual error on line 3");
     });
   });
@@ -479,7 +479,7 @@ describe("classifySessionError", () => {
 });
 
 describe("buildSessionErrorMessage", () => {
-  it("builds a valid SessionErrorMessage", () => {
+  it("builds a valid ConversationErrorMessage", () => {
     const msg = buildSessionErrorMessage("session-123", {
       code: "PROVIDER_NETWORK",
       userMessage: "Network error",
@@ -488,8 +488,8 @@ describe("buildSessionErrorMessage", () => {
       errorCategory: "provider_network",
     });
 
-    expect(msg.type).toBe("session_error");
-    expect(msg.sessionId).toBe("session-123");
+    expect(msg.type).toBe("conversation_error");
+    expect(msg.conversationId).toBe("session-123");
     expect(msg.code).toBe("PROVIDER_NETWORK");
     expect(msg.userMessage).toBe("Network error");
     expect(msg.retryable).toBe(true);
@@ -505,7 +505,7 @@ describe("buildSessionErrorMessage", () => {
       errorCategory: "processing_failed",
     });
 
-    expect(msg.type).toBe("session_error");
+    expect(msg.type).toBe("conversation_error");
     expect(msg.debugDetails).toBeUndefined();
     expect(msg.errorCategory).toBe("processing_failed");
   });

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -488,7 +488,7 @@ describe("provider ordering error retry", () => {
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
     expect(events.some((e) => e.type === "message_complete")).toBe(true);
-    expect(events.some((e) => e.type === "session_error")).toBe(false);
+    expect(events.some((e) => e.type === "conversation_error")).toBe(false);
   });
 
   test("context-too-large exhausts reducer tiers without compaction — error surfaces after emergency attempt", async () => {
@@ -515,7 +515,7 @@ describe("provider ordering error retry", () => {
     // reducer's compactFn (force:true).
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
 
-    expect(events.some((e) => e.type === "session_error")).toBe(true);
+    expect(events.some((e) => e.type === "conversation_error")).toBe(true);
   });
 
   test("context-too-large still surfaces when no media payloads are available to trim", async () => {
@@ -533,7 +533,7 @@ describe("provider ordering error retry", () => {
     // Same as above — convergence loop re-runs agent loop, which also fails.
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
-    expect(events.some((e) => e.type === "session_error")).toBe(true);
+    expect(events.some((e) => e.type === "conversation_error")).toBe(true);
   });
 
   test("context-too-large phrase also triggers one forced-compaction retry", async () => {
@@ -553,7 +553,7 @@ describe("provider ordering error retry", () => {
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
     expect(events.some((e) => e.type === "message_complete")).toBe(true);
-    expect(events.some((e) => e.type === "session_error")).toBe(false);
+    expect(events.some((e) => e.type === "conversation_error")).toBe(false);
   });
 
   test("ProviderError with statusCode 413 triggers forced-compaction retry via classifySessionError", async () => {
@@ -576,7 +576,7 @@ describe("provider ordering error retry", () => {
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
     expect(events.some((e) => e.type === "message_complete")).toBe(true);
-    expect(events.some((e) => e.type === "session_error")).toBe(false);
+    expect(events.some((e) => e.type === "conversation_error")).toBe(false);
   });
 
   test("context-too-large after progress surfaces error instead of silent failure", async () => {
@@ -599,7 +599,7 @@ describe("provider ordering error retry", () => {
     expect(agentLoopRunCount).toBe(2);
 
     // The error must be surfaced to clients via session_error, not silently swallowed.
-    const sessionError = events.find((e) => e.type === "session_error") as
+    const sessionError = events.find((e) => e.type === "conversation_error") as
       | { code?: string }
       | undefined;
     expect(sessionError).toBeDefined();

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -567,13 +567,13 @@ describe("Session message queue", () => {
     const cancel2 = events2.find((e) => e.type === "generation_cancelled");
     expect(cancel2).toEqual({
       type: "generation_cancelled",
-      sessionId: "conv-1",
+      conversationId: "conv-1",
     });
 
     const cancel3 = events3.find((e) => e.type === "generation_cancelled");
     expect(cancel3).toEqual({
       type: "generation_cancelled",
-      sessionId: "conv-1",
+      conversationId: "conv-1",
     });
 
     // abort() must NOT emit session_error or generic error for queued discards.
@@ -582,10 +582,10 @@ describe("Session message queue", () => {
     const err3 = events3.find((e) => e.type === "error");
     expect(err3).toBeUndefined();
 
-    const sessionErr2 = events2.find((e) => e.type === "session_error");
+    const sessionErr2 = events2.find((e) => e.type === "conversation_error");
     expect(sessionErr2).toBeUndefined();
 
-    const sessionErr3 = events3.find((e) => e.type === "session_error");
+    const sessionErr3 = events3.find((e) => e.type === "conversation_error");
     expect(sessionErr3).toBeUndefined();
   });
 
@@ -610,7 +610,7 @@ describe("Session message queue", () => {
     await p1;
 
     // Should emit session_error (typed, structured)
-    const sessionErr = events.find((e) => e.type === "session_error");
+    const sessionErr = events.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeDefined();
 
     // Should also emit generic error (callers rely on error events to detect failures)
@@ -861,7 +861,7 @@ describe("Session checkpoint handoff", () => {
     expect(handoff).toBeDefined();
     expect(handoff).toMatchObject({
       type: "generation_handoff",
-      sessionId: "conv-1",
+      conversationId: "conv-1",
       requestId: "req-1",
       queuedCount: 1,
     });
@@ -999,13 +999,13 @@ describe("Session checkpoint handoff", () => {
     expect(handoff).toBeDefined();
     expect(handoff).toMatchObject({
       type: "generation_handoff",
-      sessionId: "conv-1",
+      conversationId: "conv-1",
       requestId: "req-1",
       queuedCount: 1,
     });
     // message_complete should NOT be in events1 (handoff replaces it)
     const messageComplete = events1.find(
-      (e) => e.type === "message_complete" && "sessionId" in e,
+      (e) => e.type === "message_complete" && "conversationId" in e,
     );
     expect(messageComplete).toBeUndefined();
 
@@ -1589,7 +1589,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     expect(cancelEvent).toBeDefined();
 
     // session_error must never appear on cancel
-    const sessionErr = msgEvents.find((e) => e.type === "session_error");
+    const sessionErr = msgEvents.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeUndefined();
   });
 
@@ -1662,7 +1662,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     await p1;
 
     // Should get session_error (structured)
-    const sessionErr = allEvents.find((e) => e.type === "session_error");
+    const sessionErr = allEvents.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeDefined();
 
     // Should also get generic error
@@ -1701,7 +1701,7 @@ describe("Regression: cancel semantics and error channel split", () => {
 
     // No queued message should have received session_error
     for (const events of eventsPerMsg) {
-      const sessionErr = events.find((e) => e.type === "session_error");
+      const sessionErr = events.find((e) => e.type === "conversation_error");
       expect(sessionErr).toBeUndefined();
     }
   });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -498,7 +498,7 @@ export async function startVoiceTurn(
         (msg: ServerMessage) => {
           if (msg.type === "error") {
             lastError = msg.message;
-          } else if (msg.type === "session_error") {
+          } else if (msg.type === "conversation_error") {
             lastError = msg.userMessage;
           }
           publishToHub(msg);
@@ -514,7 +514,7 @@ export async function startVoiceTurn(
             eventSink.onMessageComplete();
           } else if (msg.type === "error") {
             eventSink.onError(msg.message);
-          } else if (msg.type === "session_error") {
+          } else if (msg.type === "conversation_error") {
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input);

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -665,9 +665,9 @@ export async function startCli(): Promise<void> {
 
   function handleMessage(msg: ServerMessage): void {
     switch (msg.type) {
-      case "session_info":
+      case "conversation_info":
         pendingSessionPick = false;
-        sessionId = msg.sessionId;
+        sessionId = msg.conversationId;
         process.stdout.write(
           `\n  Session: ${msg.title}\n  Type your message. Ctrl+D to detach.\n\n`,
         );
@@ -876,11 +876,11 @@ export async function startCli(): Promise<void> {
         break;
       }
 
-      case "session_list_response":
+      case "conversation_list_response":
         if (pendingSessionPick) {
-          renderSessionPicker(msg.sessions);
+          renderSessionPicker(msg.conversations);
         } else {
-          for (const session of msg.sessions) {
+          for (const session of msg.conversations) {
             process.stdout.write(`  ${session.id}  ${session.title}\n`);
           }
           prompt();

--- a/assistant/src/daemon/handlers/conversation-history.ts
+++ b/assistant/src/daemon/handlers/conversation-history.ts
@@ -34,7 +34,7 @@ export function performConversationSearch(params: ConversationSearchParams) {
 }
 
 export interface MessageContentResult {
-  sessionId?: string;
+  conversationId?: string;
   messageId: string;
   text?: string;
   toolCalls?: Array<{
@@ -50,9 +50,9 @@ export interface MessageContentResult {
  */
 export function getMessageContent(
   messageId: string,
-  sessionId?: string,
+  conversationId?: string,
 ): MessageContentResult | null {
-  const dbMessage = getMessageById(messageId, sessionId);
+  const dbMessage = getMessageById(messageId, conversationId);
   if (!dbMessage) return null;
 
   let text: string | undefined;
@@ -79,7 +79,7 @@ export function getMessageContent(
   }
 
   return {
-    sessionId,
+    conversationId,
     messageId,
     ...(text !== undefined ? { text } : {}),
     ...(toolCalls ? { toolCalls } : {}),

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -32,13 +32,13 @@ import { HostCuProxy } from "../host-cu-proxy.js";
 import { HostFileProxy } from "../host-file-proxy.js";
 import type {
   ConfirmationResponse,
+  ConversationCreateRequest,
+  ConversationRenameRequest,
+  ConversationSwitchRequest,
   DeleteQueuedMessage,
   ReorderConversationsRequest,
   SecretResponse,
   ServerMessage,
-  SessionCreateRequest,
-  SessionRenameRequest,
-  SessionSwitchRequest,
   UndoRequest,
   UsageRequest,
 } from "../message-protocol.js";
@@ -213,9 +213,9 @@ export function handleSecretResponse(
 }
 
 /**
- * Clear all sessions and DB conversations. Returns the number of sessions cleared.
+ * Clear all conversations and DB conversations. Returns the number of sessions cleared.
  */
-export function clearAllSessions(ctx: HandlerContext): number {
+export function clearAllConversations(ctx: HandlerContext): number {
   const cleared = ctx.clearAllSessions();
   // Also clear DB conversations. When a new local connection triggers
   // sendInitialSession, it auto-creates a conversation if none exist.
@@ -225,8 +225,8 @@ export function clearAllSessions(ctx: HandlerContext): number {
   return cleared;
 }
 
-export async function handleSessionCreate(
-  msg: SessionCreateRequest,
+export async function handleConversationCreate(
+  msg: ConversationCreateRequest,
   ctx: HandlerContext,
 ): Promise<void> {
   const conversationType = normalizeConversationType(msg.conversationType);
@@ -242,15 +242,15 @@ export async function handleSessionCreate(
     transport: msg.transport,
   });
 
-  // Pre-activate skills before sending session_info so they're available
+  // Pre-activate skills before sending conversation_info so they're available
   // for the initial message processing.
   if (msg.preactivatedSkillIds?.length) {
     session.setPreactivatedSkillIds(msg.preactivatedSkillIds);
   }
 
   ctx.send({
-    type: "session_info",
-    sessionId: conversation.id,
+    type: "conversation_info",
+    conversationId: conversation.id,
     title: conversation.title ?? "New Conversation",
     ...(msg.correlationId ? { correlationId: msg.correlationId } : {}),
     conversationType: normalizeConversationType(conversation.conversationType),
@@ -270,8 +270,8 @@ export async function handleSessionCreate(
         userMessage: msg.initialMessage,
         onTitleUpdated: (newTitle) => {
           ctx.send({
-            type: "session_title_updated",
-            sessionId: conversation.id,
+            type: "conversation_title_updated",
+            conversationId: conversation.id,
             title: newTitle,
           });
         },
@@ -321,7 +321,7 @@ export async function handleSessionCreate(
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         log.error(
-          { err, sessionId: conversation.id },
+          { err, conversationId: conversation.id },
           "Error processing initial message",
         );
         ctx.send({
@@ -337,8 +337,8 @@ export async function handleSessionCreate(
             const fallback = UNTITLED_FALLBACK;
             updateConversationTitle(conversation.id, fallback);
             ctx.send({
-              type: "session_title_updated",
-              sessionId: conversation.id,
+              type: "conversation_title_updated",
+              conversationId: conversation.id,
               title: fallback,
             });
           }
@@ -350,89 +350,92 @@ export async function handleSessionCreate(
 }
 
 /**
- * Switch to an existing session/conversation. Returns session info on success,
+ * Switch to an existing conversation. Returns conversation info on success,
  * or throws/returns an error result when the conversation is not found.
  */
-export async function switchSession(
-  sessionId: string,
+export async function switchConversation(
+  conversationId: string,
   ctx: HandlerContext,
 ): Promise<{
-  sessionId: string;
+  conversationId: string;
   title: string;
   conversationType: ReturnType<typeof normalizeConversationType>;
 } | null> {
-  const conversation = getConversation(sessionId);
+  const conversation = getConversation(conversationId);
   if (!conversation) {
     return null;
   }
 
   // If the target session is headless-locked (actively executing a task run),
   // skip rebinding so tool confirmations stay suppressed.
-  const existingSession = ctx.sessions.get(sessionId);
+  const existingSession = ctx.sessions.get(conversationId);
   const isHeadlessLocked = existingSession?.headlessLock;
 
   if (isHeadlessLocked) {
     // Load the session without rebinding the client — the session stays headless
-    await ctx.getOrCreateSession(sessionId);
+    await ctx.getOrCreateSession(conversationId);
   } else {
-    await ctx.getOrCreateSession(sessionId);
+    await ctx.getOrCreateSession(conversationId);
   }
 
   return {
-    sessionId: conversation.id,
+    conversationId: conversation.id,
     title: conversation.title ?? "Untitled",
     conversationType: normalizeConversationType(conversation.conversationType),
   };
 }
 
-export async function handleSessionSwitch(
-  msg: SessionSwitchRequest,
+export async function handleConversationSwitch(
+  msg: ConversationSwitchRequest,
   ctx: HandlerContext,
 ): Promise<void> {
-  const result = await switchSession(msg.sessionId, ctx);
+  const result = await switchConversation(msg.conversationId, ctx);
   if (!result) {
     ctx.send({
       type: "error",
-      message: `Session ${msg.sessionId} not found`,
+      message: `Conversation ${msg.conversationId} not found`,
     });
     return;
   }
 
   ctx.send({
-    type: "session_info",
-    sessionId: result.sessionId,
+    type: "conversation_info",
+    conversationId: result.conversationId,
     title: result.title,
     conversationType: result.conversationType,
   });
 }
 
 /**
- * Rename a session/conversation. Returns true on success, false if not found.
+ * Rename a conversation. Returns true on success, false if not found.
  */
-export function renameSession(sessionId: string, name: string): boolean {
-  const conversation = getConversation(sessionId);
+export function renameConversation(
+  conversationId: string,
+  name: string,
+): boolean {
+  const conversation = getConversation(conversationId);
   if (!conversation) {
     return false;
   }
-  updateConversationTitle(sessionId, name, 0);
+  updateConversationTitle(conversationId, name, 0);
   return true;
 }
 
-export function handleSessionRename(
-  msg: SessionRenameRequest,
+export function handleConversationRename(
+  msg: ConversationRenameRequest,
   ctx: HandlerContext,
 ): void {
-  const success = renameSession(msg.sessionId, msg.title);
+  const success = renameConversation(msg.conversationId, msg.title);
   if (!success) {
     ctx.send({
       type: "error",
-      message: `Session ${msg.sessionId} not found`,
+      message: `Conversation ${msg.conversationId} not found`,
     });
     return;
   }
   ctx.send({
-    type: "session_title_updated",
-    sessionId: msg.sessionId,
+    type: "conversation_title_updated",
+    conversationId: msg.conversationId,
     title: msg.title,
   });
 }
@@ -481,7 +484,7 @@ export async function handleUndo(
   msg: UndoRequest,
   ctx: HandlerContext,
 ): Promise<void> {
-  const result = await undoLastMessage(msg.sessionId, ctx);
+  const result = await undoLastMessage(msg.conversationId, ctx);
   if (!result) {
     ctx.send({ type: "error", message: "No active session" });
     return;
@@ -489,7 +492,7 @@ export async function handleUndo(
   ctx.send({
     type: "undo_complete",
     removedCount: result.removedCount,
-    sessionId: msg.sessionId,
+    conversationId: msg.conversationId,
   });
 }
 
@@ -543,7 +546,7 @@ export function handleUsageRequest(
   msg: UsageRequest,
   ctx: HandlerContext,
 ): void {
-  const conversation = getConversation(msg.sessionId);
+  const conversation = getConversation(msg.conversationId);
   if (!conversation) {
     ctx.send({ type: "error", message: "No active session" });
     return;
@@ -599,13 +602,13 @@ export function handleDeleteQueuedMessage(
   msg: DeleteQueuedMessage,
   ctx: HandlerContext,
 ): void {
-  const result = deleteQueuedMessage(msg.sessionId, msg.requestId, (id) =>
+  const result = deleteQueuedMessage(msg.conversationId, msg.requestId, (id) =>
     ctx.sessions.get(id),
   );
   if (result.removed) {
     ctx.send({
       type: "message_queued_deleted",
-      sessionId: msg.sessionId,
+      sessionId: msg.conversationId,
       requestId: msg.requestId,
     });
   }
@@ -620,7 +623,7 @@ export function handleReorderConversations(
   }
   batchSetDisplayOrders(
     msg.updates.map((u) => ({
-      id: u.sessionId,
+      id: u.conversationId,
       displayOrder: u.displayOrder ?? null,
       isPinned: u.isPinned ?? false,
     })),

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -8,8 +8,8 @@ import type { DebouncerMap } from "../../util/debounce.js";
 import { getLogger } from "../../util/logger.js";
 import { estimateBase64Bytes } from "../assistant-attachments.js";
 import type {
+  ConversationTransportMetadata,
   ServerMessage,
-  SessionTransportMetadata,
 } from "../message-protocol.js";
 import { Session } from "../session.js";
 import type { TrustContext } from "../session-runtime-assembly.js";
@@ -115,12 +115,12 @@ export interface ParsedHistoryMessage {
 }
 
 /**
- * Optional overrides for session creation (e.g. interview mode).
+ * Optional overrides for conversation creation (e.g. interview mode).
  */
-export interface SessionCreateOptions {
+export interface ConversationCreateOptions {
   systemPromptOverride?: string;
   maxResponseTokens?: number;
-  transport?: SessionTransportMetadata;
+  transport?: ConversationTransportMetadata;
   assistantId?: string;
   trustContext?: TrustContext;
   /** Normalized auth context for the session. */
@@ -152,7 +152,7 @@ export interface HandlerContext {
   clearAllSessions(): number;
   getOrCreateSession(
     conversationId: string,
-    options?: SessionCreateOptions,
+    options?: ConversationCreateOptions,
   ): Promise<Session>;
   /** Refresh the eviction timestamp for a session that was accessed directly. */
   touchSession(sessionId: string): void;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -95,10 +95,10 @@ import {
 } from "./guardian-action-generators.js";
 import {
   cancelGeneration,
-  clearAllSessions,
+  clearAllConversations,
   regenerateResponse,
-  renameSession,
-  switchSession,
+  renameConversation,
+  switchConversation,
   undoLastMessage,
 } from "./handlers/conversations.js";
 import type { ServerMessage } from "./message-protocol.js";
@@ -562,19 +562,21 @@ export async function runDaemon(): Promise<void> {
             data: a.dataBase64,
           })),
       },
-      findSession: (sessionId) => server.findSession(sessionId),
-      findSessionBySurfaceId: (surfaceId) =>
+      findConversation: (sessionId) => server.findSession(sessionId),
+      findConversationBySurfaceId: (surfaceId) =>
         server.findSessionBySurfaceId(surfaceId),
       getSkillContext: () => server.getSkillContext(),
       getModelSetContext: () => server.getHandlerContext(),
-      sessionManagementDeps: {
-        switchSession: (sessionId) =>
-          switchSession(sessionId, server.getHandlerContext()),
-        renameSession: (sessionId, name) => renameSession(sessionId, name),
-        clearAllSessions: () => clearAllSessions(server.getHandlerContext()),
+      conversationManagementDeps: {
+        switchConversation: (conversationId) =>
+          switchConversation(conversationId, server.getHandlerContext()),
+        renameConversation: (conversationId, name) =>
+          renameConversation(conversationId, name),
+        clearAllConversations: () =>
+          clearAllConversations(server.getHandlerContext()),
         cancelGeneration: (sessionId) =>
           cancelGeneration(sessionId, server.getHandlerContext()),
-        destroySession: (sessionId) => server.destroySession(sessionId),
+        destroyConversation: (sessionId) => server.destroySession(sessionId),
         undoLastMessage: (sessionId) =>
           undoLastMessage(sessionId, server.getHandlerContext()),
         regenerateResponse: (sessionId) => {
@@ -733,7 +735,7 @@ export async function runDaemon(): Promise<void> {
               }
               if (
                 "type" in msg &&
-                (msg.type === "error" || msg.type === "session_error")
+                (msg.type === "error" || msg.type === "conversation_error")
               ) {
                 agentLoopError =
                   "message" in msg

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -58,8 +58,8 @@ import type {
   _ContactsServerMessages,
 } from "./message-types/contacts.js";
 import type {
-  _SessionsClientMessages,
-  _SessionsServerMessages,
+  _ConversationsClientMessages,
+  _ConversationsServerMessages,
 } from "./message-types/conversations.js";
 import type {
   _DiagnosticsClientMessages,
@@ -142,7 +142,7 @@ export interface SubagentEvent {
 // === Client -> Server aggregate union ===
 
 export type ClientMessage =
-  | _SessionsClientMessages
+  | _ConversationsClientMessages
   | _MessagesClientMessages
   | _SurfacesClientMessages
   | _SkillsClientMessages
@@ -167,7 +167,7 @@ export type ClientMessage =
 // === Server -> Client aggregate union ===
 
 export type ServerMessage =
-  | _SessionsServerMessages
+  | _ConversationsServerMessages
   | _MessagesServerMessages
   | _SurfacesServerMessages
   | _SkillsServerMessages

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -1,4 +1,4 @@
-// Session lifecycle, auth, model config, and history types.
+// Conversation lifecycle, auth, model config, and history types.
 
 import type { ChannelId, InterfaceId } from "../../channels/types.js";
 import type { ConversationType } from "./shared.js";
@@ -6,16 +6,16 @@ import type { UserMessageAttachment } from "./shared.js";
 
 // === Client → Server ===
 
-export interface SessionListRequest {
-  type: "session_list";
-  /** Number of sessions to skip (for pagination). Defaults to 0. */
+export interface ConversationListRequest {
+  type: "conversation_list";
+  /** Number of conversations to skip (for pagination). Defaults to 0. */
   offset?: number;
-  /** Maximum number of sessions to return. Defaults to 50. */
+  /** Maximum number of conversations to return. Defaults to 50. */
   limit?: number;
 }
 
-/** Lightweight session transport metadata for channel identity and natural-language guidance. */
-export interface SessionTransportMetadata {
+/** Lightweight conversation transport metadata for channel identity and natural-language guidance. */
+export interface ConversationTransportMetadata {
   /** Logical channel identifier (e.g. "desktop", "telegram", "mobile"). */
   channelId: ChannelId;
   /** Interface identifier for this transport (e.g. "macos", "ios", "cli"). */
@@ -28,28 +28,28 @@ export interface SessionTransportMetadata {
   chatType?: string;
 }
 
-export interface SessionCreateRequest {
-  type: "session_create";
+export interface ConversationCreateRequest {
+  type: "conversation_create";
   title?: string;
   systemPromptOverride?: string;
   maxResponseTokens?: number;
   correlationId?: string;
-  transport?: SessionTransportMetadata;
+  transport?: ConversationTransportMetadata;
   conversationType?: ConversationType;
-  /** Skill IDs to pre-activate in the new session (loaded before the first message). */
+  /** Skill IDs to pre-activate in the new conversation (loaded before the first message). */
   preactivatedSkillIds?: string[];
-  /** If provided, automatically sent as the first user message after session creation. */
+  /** If provided, automatically sent as the first user message after conversation creation. */
   initialMessage?: string;
 }
 
-export interface SessionSwitchRequest {
-  type: "session_switch";
-  sessionId: string;
+export interface ConversationSwitchRequest {
+  type: "conversation_switch";
+  conversationId: string;
 }
 
-export interface SessionRenameRequest {
-  type: "session_rename";
-  sessionId: string;
+export interface ConversationRenameRequest {
+  type: "conversation_rename";
+  conversationId: string;
   title: string;
 }
 
@@ -64,12 +64,12 @@ export interface PingMessage {
 
 export interface CancelRequest {
   type: "cancel";
-  sessionId?: string;
+  conversationId?: string;
 }
 
 export interface DeleteQueuedMessage {
   type: "delete_queued_message";
-  sessionId: string;
+  conversationId: string;
   requestId: string;
 }
 
@@ -89,7 +89,7 @@ export interface ImageGenModelSetRequest {
 
 export interface MessageContentResponse {
   type: "message_content_response";
-  sessionId: string;
+  conversationId: string;
   messageId: string;
   text?: string;
   toolCalls?: Array<{
@@ -101,27 +101,27 @@ export interface MessageContentResponse {
 
 export interface UndoRequest {
   type: "undo";
-  sessionId: string;
+  conversationId: string;
 }
 
 export interface RegenerateRequest {
   type: "regenerate";
-  sessionId: string;
+  conversationId: string;
 }
 
 export interface UsageRequest {
   type: "usage_request";
-  sessionId: string;
+  conversationId: string;
 }
 
-export interface SessionsClearRequest {
-  type: "sessions_clear";
+export interface ConversationsClearRequest {
+  type: "conversations_clear";
 }
 
 export interface ReorderConversationsRequest {
   type: "reorder_conversations";
   updates: Array<{
-    sessionId: string;
+    conversationId: string;
     displayOrder: number | null;
     isPinned: boolean;
   }>;
@@ -150,17 +150,17 @@ export interface ConversationSearchResponse {
   results: ConversationSearchResultItem[];
 }
 
-export interface SessionInfo {
-  type: "session_info";
-  sessionId: string;
+export interface ConversationInfo {
+  type: "conversation_info";
+  conversationId: string;
   title: string;
   correlationId?: string;
   conversationType?: ConversationType;
 }
 
-export interface SessionTitleUpdated {
-  type: "session_title_updated";
-  sessionId: string;
+export interface ConversationTitleUpdated {
+  type: "conversation_title_updated";
+  conversationId: string;
   title: string;
 }
 
@@ -182,9 +182,9 @@ export interface AssistantAttention {
   lastSeenSignalType?: string;
 }
 
-export interface SessionListResponse {
-  type: "session_list_response";
-  sessions: Array<{
+export interface ConversationListResponse {
+  type: "conversation_list_response";
+  conversations: Array<{
     id: string;
     title: string;
     createdAt?: number;
@@ -199,12 +199,12 @@ export interface SessionListResponse {
     displayOrder?: number;
     isPinned?: boolean;
   }>;
-  /** Whether more sessions exist beyond the returned page. */
+  /** Whether more conversations exist beyond the returned page. */
   hasMore?: boolean;
 }
 
-export interface SessionsClearResponse {
-  type: "sessions_clear_response";
+export interface ConversationsClearResponse {
+  type: "conversations_clear_response";
   cleared: number;
 }
 
@@ -227,12 +227,12 @@ export interface DaemonStatusMessage {
 
 export interface GenerationCancelled {
   type: "generation_cancelled";
-  sessionId?: string;
+  conversationId?: string;
 }
 
 export interface GenerationHandoff {
   type: "generation_handoff";
-  sessionId: string;
+  conversationId: string;
   requestId?: string;
   queuedCount: number;
   attachments?: UserMessageAttachment[];
@@ -280,7 +280,7 @@ export interface HistoryResponseSurface {
 
 export interface HistoryResponse {
   type: "history_response";
-  sessionId: string;
+  conversationId: string;
   messages: Array<{
     id?: string; // Database message ID (for matching surfaces)
     role: string;
@@ -318,7 +318,7 @@ export interface HistoryResponse {
 export interface UndoComplete {
   type: "undo_complete";
   removedCount: number;
-  sessionId?: string;
+  conversationId?: string;
 }
 
 export interface UsageUpdate {
@@ -352,7 +352,7 @@ export interface ContextCompacted {
   summaryModel: string;
 }
 
-export type SessionErrorCode =
+export type ConversationErrorCode =
   | "PROVIDER_NETWORK"
   | "PROVIDER_RATE_LIMIT"
   | "PROVIDER_API"
@@ -360,15 +360,15 @@ export type SessionErrorCode =
   | "PROVIDER_ORDERING"
   | "PROVIDER_WEB_SEARCH"
   | "CONTEXT_TOO_LARGE"
-  | "SESSION_ABORTED"
-  | "SESSION_PROCESSING_FAILED"
+  | "CONVERSATION_ABORTED"
+  | "CONVERSATION_PROCESSING_FAILED"
   | "REGENERATE_FAILED"
   | "UNKNOWN";
 
-export interface SessionErrorMessage {
-  type: "session_error";
-  sessionId: string;
-  code: SessionErrorCode;
+export interface ConversationErrorMessage {
+  type: "conversation_error";
+  conversationId: string;
+  code: ConversationErrorCode;
   userMessage: string;
   retryable: boolean;
   debugDetails?: string;
@@ -386,7 +386,7 @@ export interface ScheduleConversationCreated {
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _SessionsClientMessages =
+export type _ConversationsClientMessages =
   | AuthMessage
   | PingMessage
   | CancelRequest
@@ -397,14 +397,14 @@ export type _SessionsClientMessages =
   | UndoRequest
   | RegenerateRequest
   | UsageRequest
-  | SessionListRequest
-  | SessionCreateRequest
-  | SessionSwitchRequest
-  | SessionRenameRequest
-  | SessionsClearRequest
+  | ConversationListRequest
+  | ConversationCreateRequest
+  | ConversationSwitchRequest
+  | ConversationRenameRequest
+  | ConversationsClearRequest
   | ReorderConversationsRequest;
 
-export type _SessionsServerMessages =
+export type _ConversationsServerMessages =
   | AuthResult
   | PongMessage
   | DaemonStatusMessage
@@ -416,11 +416,11 @@ export type _SessionsServerMessages =
   | UsageUpdate
   | UsageResponse
   | ContextCompacted
-  | SessionErrorMessage
-  | SessionInfo
-  | SessionTitleUpdated
-  | SessionListResponse
-  | SessionsClearResponse
+  | ConversationErrorMessage
+  | ConversationInfo
+  | ConversationTitleUpdated
+  | ConversationListResponse
+  | ConversationsClearResponse
   | ConversationSearchResponse
   | MessageContentResponse
   | ScheduleConversationCreated;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -66,8 +66,8 @@ import { ConfigWatcher } from "./config-watcher.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type {
+  ConversationCreateOptions,
   HandlerContext,
-  SessionCreateOptions,
 } from "./handlers/shared.js";
 import type { SkillOperationContext } from "./handlers/skills.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
@@ -241,7 +241,7 @@ function makePendingInteractionRegistrar(
 
 export class DaemonServer {
   private sessions = new Map<string, Session>();
-  private sessionOptions = new Map<string, SessionCreateOptions>();
+  private sessionOptions = new Map<string, ConversationCreateOptions>();
   private sessionCreating = new Map<string, Promise<Session>>();
   private sharedRequestTimestamps: number[] = [];
   private httpPort: number | undefined;
@@ -294,7 +294,7 @@ export class DaemonServer {
 
   private applyTransportMetadata(
     _session: Session,
-    options: SessionCreateOptions | undefined,
+    options: ConversationCreateOptions | undefined,
   ): void {
     const transport = options?.transport;
     if (!transport) return;
@@ -676,7 +676,7 @@ export class DaemonServer {
 
   private async getOrCreateSession(
     conversationId: string,
-    options?: SessionCreateOptions,
+    options?: ConversationCreateOptions,
   ): Promise<Session> {
     let session = this.sessions.get(conversationId);
     const sendToClient = () => {};
@@ -822,7 +822,7 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds: string[] | undefined,
-    options: SessionCreateOptions | undefined,
+    options: ConversationCreateOptions | undefined,
     sourceChannel: string | undefined,
     sourceInterface: string | undefined,
   ): Promise<{
@@ -927,7 +927,7 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds?: string[],
-    options?: SessionCreateOptions,
+    options?: ConversationCreateOptions,
     sourceChannel?: string,
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {
@@ -991,7 +991,7 @@ export class DaemonServer {
     conversationId: string,
     content: string,
     attachmentIds?: string[],
-    options?: SessionCreateOptions,
+    options?: ConversationCreateOptions,
     sourceChannel?: string,
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -436,8 +436,8 @@ export async function runAgentLoopImpl(
       ) {
         updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK);
         onEvent({
-          type: "session_title_updated",
-          sessionId: ctx.conversationId,
+          type: "conversation_title_updated",
+          conversationId: ctx.conversationId,
           title: UNTITLED_FALLBACK,
         });
       }
@@ -466,8 +466,8 @@ export async function runAgentLoopImpl(
           userMessage: options?.titleText ?? content,
           onTitleUpdated: (title) => {
             onEvent({
-              type: "session_title_updated",
-              sessionId: ctx.conversationId,
+              type: "conversation_title_updated",
+              conversationId: ctx.conversationId,
               title,
             });
           },
@@ -1541,7 +1541,10 @@ export async function runAgentLoopImpl(
           status: "warning",
         },
       );
-      onEvent({ type: "generation_cancelled", sessionId: ctx.conversationId });
+      onEvent({
+        type: "generation_cancelled",
+        conversationId: ctx.conversationId,
+      });
     } else {
       // Resolve attachments (only when not cancelled — this is expensive async I/O)
       const attachmentResult = await resolveAssistantAttachments(
@@ -1589,7 +1592,7 @@ export async function runAgentLoopImpl(
         );
         onEvent({
           type: "generation_cancelled",
-          sessionId: ctx.conversationId,
+          conversationId: ctx.conversationId,
         });
       } else if (yieldedForHandoff) {
         ctx.traceEmitter.emit(
@@ -1603,7 +1606,7 @@ export async function runAgentLoopImpl(
         );
         onEvent({
           type: "generation_handoff",
-          sessionId: ctx.conversationId,
+          conversationId: ctx.conversationId,
           requestId: reqId,
           queuedCount: ctx.getQueueDepth(),
           ...(emittedAttachments.length > 0
@@ -1646,8 +1649,8 @@ export async function runAgentLoopImpl(
         provider: ctx.provider,
         onTitleUpdated: (title) => {
           onEvent({
-            type: "session_title_updated",
-            sessionId: ctx.conversationId,
+            type: "conversation_title_updated",
+            conversationId: ctx.conversationId,
             title,
           });
         },
@@ -1670,7 +1673,10 @@ export async function runAgentLoopImpl(
           status: "warning",
         },
       );
-      onEvent({ type: "generation_cancelled", sessionId: ctx.conversationId });
+      onEvent({
+        type: "generation_cancelled",
+        conversationId: ctx.conversationId,
+      });
     } else {
       ctx.emitActivityState("idle", "error_terminal", "global", reqId);
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -1,14 +1,14 @@
 import { ProviderError } from "../util/errors.js";
 import type {
-  SessionErrorCode,
-  SessionErrorMessage,
+  ConversationErrorCode,
+  ConversationErrorMessage,
 } from "./message-protocol.js";
 
 /**
  * Classified session error ready for client emission.
  */
 export interface ClassifiedSessionError {
-  code: SessionErrorCode;
+  code: ConversationErrorCode;
   userMessage: string;
   retryable: boolean;
   debugDetails?: string;
@@ -376,7 +376,7 @@ function classifyByMessage(
   for (const pattern of CANCEL_PATTERNS) {
     if (pattern.test(message)) {
       return {
-        code: "SESSION_ABORTED",
+        code: "CONVERSATION_ABORTED",
         userMessage: "The request was interrupted.",
         retryable: true,
         errorCategory: "session_aborted",
@@ -397,7 +397,7 @@ function classifyByMessage(
     ? `Processing failed: ${summary}`
     : "Something went wrong processing your message. Please try again.";
   return {
-    code: "SESSION_PROCESSING_FAILED",
+    code: "CONVERSATION_PROCESSING_FAILED",
     userMessage,
     retryable: false,
     errorCategory: "processing_failed",
@@ -408,12 +408,12 @@ function classifyByMessage(
  * Build a `session_error` server message from a classified error.
  */
 export function buildSessionErrorMessage(
-  sessionId: string,
+  conversationId: string,
   classified: ClassifiedSessionError,
-): SessionErrorMessage {
+): ConversationErrorMessage {
   return {
-    type: "session_error",
-    sessionId,
+    type: "conversation_error",
+    conversationId,
     code: classified.code,
     userMessage: classified.userMessage,
     retryable: classified.retryable,

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -549,7 +549,7 @@ export async function regenerate(
   onEvent({
     type: "undo_complete",
     removedCount: messagesToDelete.length,
-    sessionId: session.conversationId,
+    conversationId: session.conversationId,
   });
 
   // Set up processing state manually and call runAgentLoop directly,

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -220,7 +220,7 @@ export function abortSession(ctx: AbortContext): void {
     for (const queued of ctx.queue) {
       queued.onEvent({
         type: "generation_cancelled",
-        sessionId: ctx.conversationId,
+        conversationId: ctx.conversationId,
       });
     }
     ctx.queue.clear();

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -610,7 +610,7 @@ export function handleSurfaceAction(
         );
         onEvent(
           buildSessionErrorMessage(ctx.conversationId, {
-            code: "SESSION_PROCESSING_FAILED",
+            code: "CONVERSATION_PROCESSING_FAILED",
             userMessage: `Something went wrong: ${message}`,
             retryable: false,
             debugDetails: `History-restored relay prompt processing failed: ${message}`,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -121,8 +121,8 @@ import {
   contactRouteDefinitions,
 } from "./routes/contact-routes.js";
 import { conversationAttentionRouteDefinitions } from "./routes/conversation-attention-routes.js";
-import { sessionManagementRouteDefinitions } from "./routes/conversation-management-routes.js";
-import { sessionQueryRouteDefinitions } from "./routes/conversation-query-routes.js";
+import { conversationManagementRouteDefinitions } from "./routes/conversation-management-routes.js";
+import { conversationQueryRouteDefinitions } from "./routes/conversation-query-routes.js";
 import { conversationRouteDefinitions } from "./routes/conversation-routes.js";
 import { debugRouteDefinitions } from "./routes/debug-routes.js";
 import { diagnosticsRouteDefinitions } from "./routes/diagnostics-routes.js";
@@ -177,7 +177,7 @@ export type {
   MessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeHttpServerOptions,
-  RuntimeMessageSessionOptions,
+  RuntimeMessageConversationOptions,
   SendMessageDeps,
 } from "./http-types.js";
 
@@ -218,10 +218,10 @@ export class RuntimeHttpServer {
   private pairingStore = new PairingStore();
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
-  private findSession?: RuntimeHttpServerOptions["findSession"];
-  private findSessionBySurfaceId?: RuntimeHttpServerOptions["findSessionBySurfaceId"];
+  private findConversation?: RuntimeHttpServerOptions["findConversation"];
+  private findConversationBySurfaceId?: RuntimeHttpServerOptions["findConversationBySurfaceId"];
   private getSkillContext?: RuntimeHttpServerOptions["getSkillContext"];
-  private sessionManagementDeps?: RuntimeHttpServerOptions["sessionManagementDeps"];
+  private conversationManagementDeps?: RuntimeHttpServerOptions["conversationManagementDeps"];
   private getModelSetContext?: RuntimeHttpServerOptions["getModelSetContext"];
   private getWatchDeps?: RuntimeHttpServerOptions["getWatchDeps"];
   private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
@@ -240,10 +240,10 @@ export class RuntimeHttpServer {
       options.guardianFollowUpConversationGenerator;
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
-    this.findSession = options.findSession;
-    this.findSessionBySurfaceId = options.findSessionBySurfaceId;
+    this.findConversation = options.findConversation;
+    this.findConversationBySurfaceId = options.findConversationBySurfaceId;
     this.getSkillContext = options.getSkillContext;
-    this.sessionManagementDeps = options.sessionManagementDeps;
+    this.conversationManagementDeps = options.conversationManagementDeps;
     this.getModelSetContext = options.getModelSetContext;
     this.getWatchDeps = options.getWatchDeps;
     this.getRecordingDeps = options.getRecordingDeps;
@@ -752,9 +752,9 @@ export class RuntimeHttpServer {
           ? {
               getOrCreateSession: (conversationId) =>
                 this.sendMessageDeps!.getOrCreateSession(conversationId),
-              findSession: this.findSession
+              findSession: this.findConversation
                 ? (conversationId) => {
-                    const s = this.findSession!(conversationId);
+                    const s = this.findConversation!(conversationId);
                     if (!s || !("abort" in s)) return undefined;
                     return s as import("../daemon/session.js").Session;
                   }
@@ -763,11 +763,11 @@ export class RuntimeHttpServer {
           : undefined,
       ),
       ...subagentRouteDefinitions(),
-      ...sessionQueryRouteDefinitions({
+      ...conversationQueryRouteDefinitions({
         getModelSetContext: this.getModelSetContext,
-        findSessionForQueue: this.findSession
+        findConversationForQueue: this.findConversation
           ? (id) => {
-              const s = this.findSession!(id);
+              const s = this.findConversation!(id);
               if (!s?.removeQueuedMessage) return undefined;
               return { removeQueuedMessage: s.removeQueuedMessage.bind(s) };
             }
@@ -817,7 +817,7 @@ export class RuntimeHttpServer {
           const attentionStates =
             getAttentionStateByConversationIds(conversationIds);
           return Response.json({
-            sessions: conversations.map((c) => {
+            conversations: conversations.map((c) => {
               const binding = bindings.get(c.id);
               const originChannel = parseChannelId(c.originChannel);
               const attn = attentionStates.get(c.id);
@@ -890,8 +890,10 @@ export class RuntimeHttpServer {
       },
       ...conversationAttentionRouteDefinitions(),
 
-      ...(this.sessionManagementDeps
-        ? sessionManagementRouteDefinitions(this.sessionManagementDeps)
+      ...(this.conversationManagementDeps
+        ? conversationManagementRouteDefinitions(
+            this.conversationManagementDeps,
+          )
         : []),
 
       {
@@ -1026,7 +1028,7 @@ export class RuntimeHttpServer {
               }
             : undefined;
           return Response.json({
-            session: {
+            conversation: {
               id: conversation.id,
               title: conversation.title ?? "Untitled",
               createdAt: conversation.createdAt,
@@ -1082,10 +1084,10 @@ export class RuntimeHttpServer {
         : []),
       ...trustRulesRouteDefinitions(),
       ...surfaceActionRouteDefinitions({
-        findSession: this.findSession,
-        findSessionBySurfaceId: this.findSessionBySurfaceId,
+        findSession: this.findConversation,
+        findSessionBySurfaceId: this.findConversationBySurfaceId,
       }),
-      ...surfaceContentRouteDefinitions({ findSession: this.findSession }),
+      ...surfaceContentRouteDefinitions({ findSession: this.findConversation }),
       ...guardianActionRouteDefinitions(),
 
       ...contactRouteDefinitions(),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -20,7 +20,7 @@ import type {
   ComposeGuardianActionMessageOptions,
   GuardianActionMessageContext,
 } from "./guardian-action-message-composer.js";
-import type { SessionManagementDeps } from "./routes/conversation-management-routes.js";
+import type { ConversationManagementDeps } from "./routes/conversation-management-routes.js";
 /**
  * Daemon-injected function that generates approval copy using a provider.
  * Returns generated text or `null` on failure (caller falls back to deterministic text).
@@ -112,7 +112,7 @@ export type GuardianFollowUpConversationGenerator = (
   context: GuardianFollowUpConversationContext,
 ) => Promise<GuardianFollowUpTurnResult>;
 
-export interface RuntimeMessageSessionOptions {
+export interface RuntimeMessageConversationOptions {
   transport?: {
     channelId: ChannelId;
     hints?: string[];
@@ -137,7 +137,7 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   attachmentIds?: string[],
-  options?: RuntimeMessageSessionOptions,
+  options?: RuntimeMessageConversationOptions,
   sourceChannel?: ChannelId,
   sourceInterface?: InterfaceId,
 ) => Promise<{ messageId: string }>;
@@ -182,7 +182,7 @@ export interface RuntimeHttpServerOptions {
   /** Context provider for skill management HTTP routes. */
   getSkillContext?: () => SkillOperationContext;
   /** Lookup an active session by ID (for surface actions and content fetches). */
-  findSession?: (sessionId: string) =>
+  findConversation?: (sessionId: string) =>
     | {
         handleSurfaceAction(
           surfaceId: string,
@@ -204,7 +204,7 @@ export interface RuntimeHttpServerOptions {
       }
     | undefined;
   /** Lookup an active session by surfaceId (fallback when sessionId is absent). */
-  findSessionBySurfaceId?: (surfaceId: string) =>
+  findConversationBySurfaceId?: (surfaceId: string) =>
     | {
         handleSurfaceAction(
           surfaceId: string,
@@ -217,8 +217,8 @@ export interface RuntimeHttpServerOptions {
         >;
       }
     | undefined;
-  /** Dependencies for session management HTTP routes (switch, rename, clear, cancel, undo, regenerate). */
-  sessionManagementDeps?: SessionManagementDeps;
+  /** Dependencies for conversation management HTTP routes (switch, rename, clear, cancel, undo, regenerate). */
+  conversationManagementDeps?: ConversationManagementDeps;
   /** Lazy factory for model config set context (session eviction, config reload suppression). */
   getModelSetContext?: () => import("../daemon/handlers/config-model.js").ModelSetContext;
   /** Provider for watch observation dependencies (watch routes). */

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -8,7 +8,7 @@
  * POST   /v1/conversations/:id/cancel     — cancel generation
  * POST   /v1/conversations/:id/undo       — undo last message
  * POST   /v1/conversations/:id/regenerate — regenerate last assistant response
- * POST   /v1/sessions/reorder             — reorder / pin sessions
+ * POST   /v1/conversations/reorder        — reorder / pin conversations
  */
 
 import {
@@ -24,23 +24,23 @@ import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
-const log = getLogger("session-management-routes");
+const log = getLogger("conversation-management-routes");
 
 // ---------------------------------------------------------------------------
 // Dependency types — injected by the daemon at wiring time
 // ---------------------------------------------------------------------------
 
-export interface SessionManagementDeps {
-  switchSession: (sessionId: string) => Promise<{
-    sessionId: string;
+export interface ConversationManagementDeps {
+  switchConversation: (conversationId: string) => Promise<{
+    conversationId: string;
     title: string;
     conversationType: string;
   } | null>;
-  renameSession: (sessionId: string, name: string) => boolean;
-  clearAllSessions: () => number;
+  renameConversation: (conversationId: string, name: string) => boolean;
+  clearAllConversations: () => number;
   cancelGeneration: (sessionId: string) => boolean;
   /** Abort and dispose an active in-memory session (if any) before deletion. */
-  destroySession: (sessionId: string) => void;
+  destroyConversation: (sessionId: string) => void;
   undoLastMessage: (
     sessionId: string,
   ) => Promise<{ removedCount: number } | null>;
@@ -53,8 +53,8 @@ export interface SessionManagementDeps {
 // Route definitions
 // ---------------------------------------------------------------------------
 
-export function sessionManagementRouteDefinitions(
-  deps: SessionManagementDeps,
+export function conversationManagementRouteDefinitions(
+  deps: ConversationManagementDeps,
 ): RouteDefinition[] {
   return [
     {
@@ -70,7 +70,7 @@ export function sessionManagementRouteDefinitions(
         if (!conversationId || typeof conversationId !== "string") {
           return httpError("BAD_REQUEST", "Missing conversationId", 400);
         }
-        const result = await deps.switchSession(conversationId);
+        const result = await deps.switchConversation(conversationId);
         if (!result) {
           return httpError(
             "NOT_FOUND",
@@ -84,7 +84,7 @@ export function sessionManagementRouteDefinitions(
           setConversationKeyIfAbsent(body.conversationKey, conversationId);
         }
         return Response.json({
-          sessionId: result.sessionId,
+          conversationId: result.conversationId,
           title: result.title,
           conversationType:
             result.conversationType === "private" ? "private" : "standard",
@@ -101,7 +101,7 @@ export function sessionManagementRouteDefinitions(
         if (!name || typeof name !== "string") {
           return httpError("BAD_REQUEST", "Missing name", 400);
         }
-        const success = deps.renameSession(params.id, name);
+        const success = deps.renameConversation(params.id, name);
         if (!success) {
           return httpError(
             "NOT_FOUND",
@@ -117,7 +117,7 @@ export function sessionManagementRouteDefinitions(
       method: "DELETE",
       policyKey: "conversations",
       handler: () => {
-        deps.clearAllSessions();
+        deps.clearAllConversations();
         return new Response(null, { status: 204 });
       },
     },
@@ -137,7 +137,7 @@ export function sessionManagementRouteDefinitions(
         // Tear down the in-memory session (abort + dispose) before removing
         // persistence so that a running agent loop doesn't write to a deleted
         // conversation row, tripping FK constraints.
-        deps.destroySession(resolvedId);
+        deps.destroyConversation(resolvedId);
         const deleted = deleteConversation(resolvedId);
         // Enqueue Qdrant vector cleanup jobs rather than calling directly.
         // Qdrant may not be initialized yet when the HTTP server starts
@@ -182,7 +182,7 @@ export function sessionManagementRouteDefinitions(
         }
         return Response.json({
           removedCount: result.removedCount,
-          sessionId: params.id,
+          conversationId: params.id,
         });
       },
     },
@@ -216,13 +216,13 @@ export function sessionManagementRouteDefinitions(
       },
     },
     {
-      endpoint: "sessions/reorder",
+      endpoint: "conversations/reorder",
       method: "POST",
-      policyKey: "sessions/reorder",
+      policyKey: "conversations/reorder",
       handler: async ({ req }) => {
         const body = (await req.json()) as {
           updates?: Array<{
-            sessionId: string;
+            conversationId: string;
             displayOrder?: number;
             isPinned?: boolean;
           }>;
@@ -232,7 +232,7 @@ export function sessionManagementRouteDefinitions(
         }
         batchSetDisplayOrders(
           body.updates.map((u) => ({
-            id: u.sessionId,
+            id: u.conversationId,
             displayOrder: u.displayOrder ?? null,
             isPinned: u.isPinned ?? false,
           })),

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -30,11 +30,11 @@ import type { RouteDefinition } from "../http-router.js";
 // Dependency interfaces
 // ---------------------------------------------------------------------------
 
-export interface SessionQueryRouteDeps {
+export interface ConversationQueryRouteDeps {
   /** Lazy factory for model set context (config reload suppression, session eviction). */
   getModelSetContext?: () => ModelSetContext;
   /** Lookup an active session by ID for queued message deletion. */
-  findSessionForQueue?: (
+  findConversationForQueue?: (
     id: string,
   ) => { removeQueuedMessage(requestId: string): boolean } | undefined;
 }
@@ -43,8 +43,8 @@ export interface SessionQueryRouteDeps {
 // Route definitions
 // ---------------------------------------------------------------------------
 
-export function sessionQueryRouteDefinitions(
-  deps: SessionQueryRouteDeps = {},
+export function conversationQueryRouteDefinitions(
+  deps: ConversationQueryRouteDeps = {},
 ): RouteDefinition[] {
   return [
     // ── Model config ──────────────────────────────────────────────────
@@ -155,8 +155,11 @@ export function sessionQueryRouteDefinitions(
       method: "GET",
       policyKey: "messages/content",
       handler: ({ url, params }) => {
-        const sessionId = url.searchParams.get("sessionId");
-        const result = getMessageContent(params.id, sessionId ?? undefined);
+        const conversationId = url.searchParams.get("conversationId");
+        const result = getMessageContent(
+          params.id,
+          conversationId ?? undefined,
+        );
         if (!result) {
           return httpError("NOT_FOUND", `Message ${params.id} not found`, 404);
         }
@@ -170,35 +173,35 @@ export function sessionQueryRouteDefinitions(
       method: "DELETE",
       policyKey: "messages/queued",
       handler: ({ url, params }) => {
-        if (!deps.findSessionForQueue) {
+        if (!deps.findConversationForQueue) {
           return httpError(
             "INTERNAL_ERROR",
             "Queued message deletion not available",
             500,
           );
         }
-        const sessionId = url.searchParams.get("sessionId");
-        if (!sessionId) {
+        const conversationId = url.searchParams.get("conversationId");
+        if (!conversationId) {
           return httpError(
             "BAD_REQUEST",
-            "Missing required query parameter: sessionId",
+            "Missing required query parameter: conversationId",
             400,
           );
         }
         const result = deleteQueuedMessage(
-          sessionId,
+          conversationId,
           params.id,
-          deps.findSessionForQueue,
+          deps.findConversationForQueue,
         );
         if (result.removed) {
           return Response.json({
             ok: true,
-            sessionId,
+            conversationId,
             requestId: params.id,
           });
         }
         if (result.reason === "session_not_found") {
-          return httpError("NOT_FOUND", "Session not found", 404);
+          return httpError("NOT_FOUND", "Conversation not found", 404);
         }
         return httpError("NOT_FOUND", "Queued message not found", 404);
       },


### PR DESCRIPTION
## Summary
- Rename API-layer TypeScript type aliases and interfaces from Session* to Conversation* in `conversations.ts` (e.g., `SessionError` → `ConversationError`, `GenerationCancelled.sessionId` → `.conversationId`)
- Update wire protocol string literals: `session_error` → `conversation_error`, `SESSION_ABORTED` → `CONVERSATION_ABORTED`, `SESSION_PROCESSING_FAILED` → `CONVERSATION_PROCESSING_FAILED`
- Rename handler functions, HTTP route handlers, and CLI entry points that use Session naming to use Conversation naming
- Update all test assertions to match the new wire strings and field names

Part of plan: session-to-conv-api.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
