### PR TITLE
fix: transcribe-media tool reads file-backed attachment content from disk

### DIFF
--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -10,7 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
 
-import { getAttachmentsByIds } from "../../../../memory/attachments-store.js";
+import {
+  getAttachmentsByIds,
+  getFilePathForAttachment,
+} from "../../../../memory/attachments-store.js";
 import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
@@ -161,6 +164,26 @@ async function resolveSource(
         isError: true,
       };
     }
+    // Check if this is a file-backed attachment (large files stored on disk)
+    const onDiskPath = getFilePathForAttachment(attachment.id);
+    if (onDiskPath) {
+      // File-backed attachment — use the on-disk file directly
+      try {
+        await access(onDiskPath);
+      } catch {
+        return {
+          content: `Attachment file not found on disk: ${onDiskPath}`,
+          isError: true,
+        };
+      }
+      return {
+        inputPath: onDiskPath,
+        isVideo: mime.startsWith("video/"),
+        tempFile: null,
+      };
+    }
+
+    // Inline attachment — decode base64 to a temp file
     const ext = mime.startsWith("video/") ? ".mp4" : ".m4a";
     const tempPath = join(
       tmpdir(),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** transcribe-media tool produces empty temp files for file-backed attachments
**What was expected:** Should write actual media content for transcription
**What was found:** Reads empty dataBase64 instead of on-disk file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
