### PR TITLE
fix: materialize tool reads file-backed attachment content from disk

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -5,7 +5,7 @@
  * data. Provides upload, delete, and message-linkage operations.
  */
 
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { eq } from "drizzle-orm";
@@ -297,6 +297,33 @@ export function getFilePathForAttachment(attachmentId: string): string | null {
     attachmentId,
   );
   return row?.file_path ?? null;
+}
+
+/**
+ * Return the raw binary content for an attachment, abstracting over inline
+ * (base64-in-DB) vs file-backed (on-disk) storage.
+ *
+ * For file-backed attachments the bytes are read from the on-disk path;
+ * for inline attachments the base64 payload is decoded from the DB row.
+ *
+ * Returns null if the attachment does not exist.
+ */
+export function getAttachmentContent(attachmentId: string): Buffer | null {
+  const filePath = getFilePathForAttachment(attachmentId);
+  if (filePath) {
+    return readFileSync(filePath);
+  }
+
+  // Fall back to inline base64 stored in the DB
+  const db = getDb();
+  const row = db
+    .select({ dataBase64: attachments.dataBase64 })
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+
+  if (!row) return null;
+  return Buffer.from(row.dataBase64, "base64");
 }
 
 export function uploadAttachment(

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -7,7 +7,7 @@
  * regular file.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import { eq } from "drizzle-orm";
@@ -16,6 +16,10 @@ import {
   type AttachmentContext,
   isAttachmentVisible,
 } from "../../daemon/media-visibility-policy.js";
+import {
+  getAttachmentContent,
+  getFilePathForAttachment,
+} from "../../memory/attachments-store.js";
 import { getConversationType } from "../../memory/conversation-crud.js";
 import { getDb } from "../../memory/db.js";
 import { attachments } from "../../memory/schema.js";
@@ -205,15 +209,28 @@ class AssetMaterializeTool implements Tool {
       };
     }
 
-    // --- Decode and write ---------------------------------------------------
+    // --- Write to disk -------------------------------------------------------
 
     try {
-      const buffer = Buffer.from(attachment.dataBase64, "base64");
-
       // Ensure parent directories exist
       mkdirSync(dirname(resolvedPath), { recursive: true });
 
-      writeFileSync(resolvedPath, buffer);
+      // For file-backed attachments, copy directly from the on-disk path
+      // to avoid reading potentially large files into memory. For inline
+      // attachments, decode the base64 content from the database.
+      const filePath = getFilePathForAttachment(attachmentId);
+      if (filePath) {
+        copyFileSync(filePath, resolvedPath);
+      } else {
+        const buffer = getAttachmentContent(attachmentId);
+        if (!buffer) {
+          return {
+            content: `Error: Could not read content for attachment "${attachmentId}".`,
+            isError: true,
+          };
+        }
+        writeFileSync(resolvedPath, buffer);
+      }
 
       return {
         content:


### PR DESCRIPTION
## Summary

Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** `asset_materialize` tool writes zero-byte files for file-backed attachments
**What was expected:** Should write actual file content to disk
**What was found:** Reads empty `dataBase64` instead of on-disk file for file-backed attachments (>5 MB)

**Changes:**
- Added `getAttachmentContent(id)` helper in `attachments-store.ts` that abstracts over inline vs file-backed storage
- Updated `materialize.ts` to use `copyFileSync` for file-backed attachments (avoids reading large files into memory) and `getAttachmentContent` for inline attachments

Part of JARVIS-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
