### PR TITLE
fix: restyle skill detail back button and top-align code viewer content

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -263,23 +263,19 @@ struct AgentPanelContent: View {
     private func installedSkillDetailView(_ skill: SkillInfo) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
 
-            // Back button
-            Button(action: {
-                withAnimation(VAnimation.standard) {
-                    selectedInstalledSkillId = nil
-                }
-            }) {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.chevronLeft, size: 11)
-                    Text("Skills")
-                        .font(VFont.caption)
-                }
-                .foregroundColor(VColor.contentTertiary)
-            }
-            .buttonStyle(.plain)
-
-            // Title row
+            // Title row with back button
             HStack(spacing: VSpacing.sm) {
+                VButton(
+                    label: "Back",
+                    iconOnly: VIcon.chevronLeft.rawValue,
+                    style: .ghost,
+                    tooltip: "Back to Skills"
+                ) {
+                    withAnimation(VAnimation.standard) {
+                        selectedInstalledSkillId = nil
+                    }
+                }
+
                 skillIcon(skill.emoji)
 
                 Text(skill.name)
@@ -365,7 +361,7 @@ struct AgentPanelContent: View {
             }
 
             // Two-pane content: file list + file content viewer
-            HStack(spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
                 // Left: file list (always fixed width)
                 skillFilesSection
                     .frame(width: 280, alignment: .topLeading)
@@ -492,7 +488,7 @@ struct AgentPanelContent: View {
             // File content
             ReadOnlyCodeContent(content: content)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -31,5 +31,6 @@ struct ReadOnlyCodeContent: View {
                 .padding(VSpacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }


### PR DESCRIPTION
## Summary
- Replace standalone '< Skills' back button with a ghost icon-only VButton (matching Settings panel pattern), positioned inline to the left of the skill emoji/name
- Top-align the two-pane HStack so the file list pins to the top instead of centering vertically
- Add `.topLeading` alignment to the skill detail content pane frame and ReadOnlyCodeContent ScrollView so code content starts at the top-left instead of centering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
