### PR TITLE
fix: getAttachmentContent returns null instead of throwing on missing file

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -311,7 +311,14 @@ export function getFilePathForAttachment(attachmentId: string): string | null {
 export function getAttachmentContent(attachmentId: string): Buffer | null {
   const filePath = getFilePathForAttachment(attachmentId);
   if (filePath) {
-    return readFileSync(filePath);
+    try {
+      return readFileSync(filePath);
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
   }
 
   // Fall back to inline base64 stored in the DB


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** getAttachmentContent throws on missing disk file instead of returning null
**What was expected:** Return null for missing file-backed content
**What was found:** readFileSync throws unhandled ENOENT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
