### PR TITLE
fix: sanitize filename in writeAttachmentToDisk to prevent path traversal

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
@@ -64,7 +64,7 @@ export function writeAttachmentToDisk(
 ): string {
   const dir = join(getWorkspaceDir(), "data", "attachments");
   mkdirSync(dir, { recursive: true });
-  const destFilename = `${uuid()}-${filename}`;
+  const destFilename = `${uuid()}-${basename(filename)}`;
   const destPath = join(dir, destFilename);
   const buffer = Buffer.from(dataBase64, "base64");
   writeFileSync(destPath, buffer);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** writeAttachmentToDisk has no filename sanitization
**What was expected:** Filenames should be sanitized to prevent directory traversal
**What was found:** path.join resolves ../ sequences, allowing writes outside attachments dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
