### PR TITLE
fix: image studio tool reads file-backed attachment content from disk

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -8,7 +8,10 @@ import {
   type ImageGenCredentials,
   mapGeminiError,
 } from "../../../../media/gemini-image-service.js";
-import { getAttachmentsByIds } from "../../../../memory/attachments-store.js";
+import {
+  getAttachmentContent,
+  getAttachmentsByIds,
+} from "../../../../memory/attachments-store.js";
 import { getConversationType } from "../../../../memory/conversation-crud.js";
 import {
   buildManagedBaseUrl,
@@ -110,10 +113,16 @@ export async function run(
       };
     }
 
-    sourceImages = visibleAttachments.map((att) => ({
-      mimeType: att.mimeType,
-      dataBase64: att.dataBase64,
-    }));
+    sourceImages = visibleAttachments
+      .map((att) => {
+        const buffer = getAttachmentContent(att.id);
+        if (!buffer) return undefined;
+        return {
+          mimeType: att.mimeType,
+          dataBase64: buffer.toString("base64"),
+        };
+      })
+      .filter((img): img is NonNullable<typeof img> => img !== undefined);
   }
 
   try {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** media-generate-image.ts reads empty dataBase64 for file-backed attachments
**What was expected:** Should read actual content from disk
**What was found:** Passes empty string to Gemini API for file-backed attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
