### PR TITLE
fix: include fileBacked flag in conversation history attachment responses

### DIFF
--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -237,6 +237,7 @@ export interface RuntimeAttachmentMetadata {
   kind: string;
   data?: string;
   thumbnailData?: string;
+  fileBacked?: boolean;
 }
 
 export interface RuntimeMessagePayload {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -326,6 +326,9 @@ export function handleListMessages(
         const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
         if (linked.length > 0) {
           msgAttachments = linked.map((a) => {
+            const isFileBacked = !!attachmentsStore.getFilePathForAttachment(
+              a.id,
+            );
             if (a.mimeType.startsWith("image/")) {
               const full = attachmentsStore.getAttachmentById(a.id);
               return {
@@ -338,6 +341,7 @@ export function handleListMessages(
                 ...(a.thumbnailBase64
                   ? { thumbnailData: a.thumbnailBase64 }
                   : {}),
+                ...(isFileBacked ? { fileBacked: true } : {}),
               };
             }
             return {
@@ -349,6 +353,7 @@ export function handleListMessages(
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),
+              ...(isFileBacked ? { fileBacked: true } : {}),
             };
           });
         }
@@ -356,6 +361,9 @@ export function handleListMessages(
         const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
         if (linked.length > 0) {
           msgAttachments = linked.map((a) => {
+            const isFileBacked = !!attachmentsStore.getFilePathForAttachment(
+              a.id,
+            );
             if (a.mimeType.startsWith("image/")) {
               const full = attachmentsStore.getAttachmentById(a.id);
               return {
@@ -368,6 +376,7 @@ export function handleListMessages(
                 ...(a.thumbnailBase64
                   ? { thumbnailData: a.thumbnailBase64 }
                   : {}),
+                ...(isFileBacked ? { fileBacked: true } : {}),
               };
             }
             return {
@@ -379,6 +388,7 @@ export function handleListMessages(
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),
+              ...(isFileBacked ? { fileBacked: true } : {}),
             };
           });
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** History response omits fileBacked flag for file-backed attachments
**What was expected:** Clients need fileBacked flag to know to use /content endpoint
**What was found:** No signal in history response for file-backed attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
