### PR TITLE
fix: add missing getAttachmentContent mock in media-generate-image test

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -73,6 +73,11 @@ let mockAttachments: Array<{
 mock.module("../memory/attachments-store.js", () => ({
   getAttachmentsByIds: (_assistantId: string, _ids: string[]) =>
     mockAttachments,
+  getAttachmentContent: (id: string) => {
+    const att = mockAttachments.find((a) => a.id === id);
+    if (!att) return null;
+    return Buffer.from(att.dataBase64, "base64");
+  },
 }));
 
 mock.module("../memory/db.js", () => ({


### PR DESCRIPTION
## Summary
- The `media-generate-image.test.ts` test mocked `attachments-store.js` but only provided `getAttachmentsByIds`, not `getAttachmentContent`. The real `getAttachmentContent` was called, hitting the uninitialized SQLite database via `getSqlite()` and causing a TypeError.
- Added `getAttachmentContent` to the mock, returning a Buffer from the matching mock attachment's base64 data.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23121589564/job/67156529278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
