### PR TITLE
fix: use on-disk file for video thumbnail generation of file-backed attachments

### DIFF
--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -28,7 +28,10 @@ import {
   validateDrafts,
 } from "./assistant-attachments.js";
 import type { UserMessageAttachment } from "./message-protocol.js";
-import { generateVideoThumbnail } from "./video-thumbnail.js";
+import {
+  generateVideoThumbnail,
+  generateVideoThumbnailFromPath,
+} from "./video-thumbnail.js";
 
 const log = getLogger("session-attachments");
 
@@ -210,16 +213,17 @@ export async function resolveAssistantAttachments(
       const draft = assistantAttachments[i];
       const isFileBacked = draft.sizeBytes > FILE_BACKED_THRESHOLD_BYTES;
       let stored;
+      let diskFilePath: string | undefined;
       try {
         if (isFileBacked) {
-          const filePath = writeAttachmentToDisk(
+          diskFilePath = writeAttachmentToDisk(
             draft.dataBase64,
             draft.filename,
           );
           stored = uploadFileBackedAttachment(
             draft.filename,
             draft.mimeType,
-            filePath,
+            diskFilePath,
             draft.sizeBytes,
           );
         } else {
@@ -255,7 +259,9 @@ export async function resolveAssistantAttachments(
         if (existing) {
           thumbnailData = existing;
         } else {
-          const generated = await generateVideoThumbnail(draft.dataBase64);
+          const generated = diskFilePath
+            ? await generateVideoThumbnailFromPath(diskFilePath)
+            : await generateVideoThumbnail(draft.dataBase64);
           if (generated) {
             setAttachmentThumbnail(stored.id, generated);
             thumbnailData = generated;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** Thumbnail generation decodes base64 into memory when file is already on disk
**What was expected:** Use the disk file path for ffmpeg thumbnail generation
**What was found:** Full video decoded twice into memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
