### PR TITLE
fix: include fileBacked flag in SSE emitted attachments

### DIFF
--- a/assistant/src/daemon/message-types/shared.ts
+++ b/assistant/src/daemon/message-types/shared.ts
@@ -41,4 +41,6 @@ export interface UserMessageAttachment {
   thumbnailData?: string;
   /** Absolute path to the local file on disk. Present for file-backed attachments (e.g. recordings). */
   filePath?: string;
+  /** True when the attachment is file-backed and clients should hydrate via the /content endpoint. */
+  fileBacked?: boolean;
 }

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -269,6 +269,7 @@ export async function resolveAssistantAttachments(
         mimeType: draft.mimeType,
         data: omitData ? "" : draft.dataBase64,
         ...(omitData ? { sizeBytes: draft.sizeBytes } : {}),
+        ...(isFileBacked ? { fileBacked: true } : {}),
         ...(thumbnailData ? { thumbnailData } : {}),
       });
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-attachment-delivery.md.

**Gap:** SSE emitted attachments missing fileBacked flag
**What was expected:** Clients need fileBacked flag in SSE events to hydrate via /content
**What was found:** Only history responses included the flag, not SSE events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
