### PR TITLE
Add FileTreeRowLabel shared view for file tree row rendering

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Shared row label for file tree views — renders indentation, expand/collapse chevron,
+/// file/folder icon, and name. Used by both SkillFileTreeView and WorkspaceTreeRow.
+struct FileTreeRowLabel: View {
+    let name: String
+    let isDirectory: Bool
+    let isExpanded: Bool
+    let depth: Int
+    let fileIcon: VIcon
+    var minRowWidth: CGFloat = 0
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            // Expand/collapse chevron for directories, spacer for files
+            if isDirectory {
+                VIconView(isExpanded ? .chevronDown : .chevronRight, size: 9)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 12)
+            } else {
+                Spacer().frame(width: 12)
+            }
+
+            // File or folder icon
+            VIconView(isDirectory ? .folder : fileIcon, size: 12)
+                .foregroundColor(isDirectory ? VColor.primaryBase : VColor.contentSecondary)
+
+            // Name label
+            Text(name)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
+        .padding(.trailing, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .frame(minWidth: minRowWidth, alignment: .leading)
+    }
+}


### PR DESCRIPTION
## Summary
- Add FileTreeRowLabel view matching WorkspaceTreeRow's visual pattern: indentation, chevron, file/folder icon, name
- Purely presentational — consumers apply their own Button, selection background, and interaction logic
- Will be used by both SkillFileTreeView and WorkspaceTreeRow

Part of plan: shared-file-tree-components.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
