### PR TITLE
fix: add missing generateVideoThumbnailFromPath mock in session-attachments test

### DIFF
--- a/assistant/src/__tests__/session-attachments.test.ts
+++ b/assistant/src/__tests__/session-attachments.test.ts
@@ -39,6 +39,7 @@ mock.module("../config/loader.js", () => ({
 // Stub out video thumbnail generation (requires ffmpeg)
 mock.module("../daemon/video-thumbnail.js", () => ({
   generateVideoThumbnail: () => Promise.resolve(null),
+  generateVideoThumbnailFromPath: () => Promise.resolve(null),
 }));
 
 // Stub out permission checker / trust store


### PR DESCRIPTION
## Summary
- Add `generateVideoThumbnailFromPath` to the `video-thumbnail.js` mock in `session-attachments.test.ts` — the mock was missing this export, causing a `SyntaxError` at module resolution time

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23121774306/job/67157023857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
