### PR TITLE
fix: enforce workspace export cap using SQL dump size

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -482,10 +482,7 @@ function collectWorkspaceFiles(): Record<string, string> {
         }
         if (!stat.isFile()) continue;
 
-        // Enforce cumulative size cap
-        if (totalBytes + stat.size > MAX_WORKSPACE_PAYLOAD_BYTES) continue;
-
-        // SQLite DB handling: dump as SQL text
+        // SQLite DB handling: dump as SQL text, then enforce size cap
         if (entry.endsWith(".db")) {
           try {
             const proc = spawnSync("sqlite3", [fullPath, ".dump"], {
@@ -496,14 +493,20 @@ function collectWorkspaceFiles(): Record<string, string> {
                 proc.stdout instanceof Buffer
                   ? proc.stdout.toString("utf-8")
                   : String(proc.stdout);
+              const outputBytes = Buffer.byteLength(output, "utf-8");
+              if (totalBytes + outputBytes > MAX_WORKSPACE_PAYLOAD_BYTES)
+                continue;
               result[relPath + ".sql"] = output;
-              totalBytes += Buffer.byteLength(output, "utf-8");
+              totalBytes += outputBytes;
             }
           } catch {
             // Skip if dump fails
           }
           continue;
         }
+
+        // Enforce cumulative size cap for non-DB files
+        if (totalBytes + stat.size > MAX_WORKSPACE_PAYLOAD_BYTES) continue;
 
         // Read as UTF-8 and skip binary files (null-byte heuristic)
         const content = readFileSync(fullPath, "utf-8");


### PR DESCRIPTION
Addresses review feedback from PR #16465. Uses the actual SQL dump output size rather than the binary .db file size when enforcing the workspace export size cap.

For .db files, the code now performs the sqlite3 dump first, measures the dump output size, and only then checks against the cumulative budget. Previously, stat.size of the binary .db file was used for the pre-check, but the SQL dump text can be much larger than the binary file, allowing the cap to be exceeded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
