### PR TITLE
fix: check gateway source availability for watch-mode restart

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -4,7 +4,8 @@ import { join } from "path";
 import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import {
-  isWatchModeAvailable,
+  isAssistantWatchModeAvailable,
+  isGatewayWatchModeAvailable,
   startLocalDaemon,
   startGateway,
 } from "../lib/local";
@@ -64,7 +65,7 @@ export async function wake(): Promise<void> {
           // Watch mode requires bun --watch with .ts sources; packaged desktop
           // builds only have a compiled binary. Stopping the daemon without a
           // viable watch-mode path would leave the user with no running assistant.
-          if (!isWatchModeAvailable()) {
+          if (!isAssistantWatchModeAvailable()) {
             console.log(
               `Assistant running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
             );
@@ -95,8 +96,8 @@ export async function wake(): Promise<void> {
     const { alive, pid } = isProcessAlive(gatewayPidFile);
     if (alive) {
       if (watch) {
-        // Same guard as the daemon: only restart if watch mode is viable.
-        if (!isWatchModeAvailable()) {
+        // Guard gateway restart separately: check gateway source availability.
+        if (!isGatewayWatchModeAvailable()) {
           console.log(
             `Gateway running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
           );

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -769,17 +769,37 @@ export function getLocalLanIPv4(): string | undefined {
 }
 
 /**
- * Check whether watch-mode startup is possible. Watch mode requires source
- * files (bun --watch only works with .ts sources, not compiled binaries).
- * Returns true when assistant source can be resolved, false otherwise.
+ * Check whether watch-mode startup is possible for the assistant daemon.
+ * Watch mode requires source files (bun --watch only works with .ts sources,
+ * not compiled binaries). Returns true when assistant source can be resolved,
+ * false otherwise.
  *
  * Use this before stopping a running assistant for a watch-mode restart — if
  * watch mode isn't available (e.g. packaged desktop app without source), the
  * caller should keep the existing process alive rather than killing it and
  * failing.
  */
-export function isWatchModeAvailable(): boolean {
+export function isAssistantWatchModeAvailable(): boolean {
   return resolveAssistantIndexPath() !== undefined;
+}
+
+/**
+ * Check whether watch-mode startup is possible for the gateway. Watch mode
+ * requires gateway source files (bun --watch only works with .ts sources).
+ * Returns true when the gateway source directory can be resolved, false
+ * otherwise.
+ *
+ * Use this before stopping a running gateway for a watch-mode restart — if
+ * watch mode isn't available, the caller should keep the existing process
+ * alive rather than killing it and failing.
+ */
+export function isGatewayWatchModeAvailable(): boolean {
+  try {
+    resolveGatewayDir();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // NOTE: startLocalDaemon() is the CLI-side daemon lifecycle manager.


### PR DESCRIPTION
## Summary
- Split `isWatchModeAvailable()` into `isAssistantWatchModeAvailable()` and `isGatewayWatchModeAvailable()` in `cli/src/lib/local.ts`
- Gateway watch-mode guard now checks gateway source via `resolveGatewayDir()` instead of assistant source via `resolveAssistantIndexPath()`
- Prevents scenario where assistant source is available but gateway source is not, which would kill the gateway and fail to restart

Addresses review feedback from #16466.

## Test plan
- [ ] Run `vellum wake --watch` from source tree — both assistant and gateway restart in watch mode
- [ ] Run `vellum wake --watch` from packaged build — both log warning and keep existing processes
- [ ] Run `vellum wake` (no --watch) — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
