### PR TITLE
fix: handle multiline function signatures in brace-depth tracking

### DIFF
--- a/assistant/src/__tests__/session-history-web-search.test.ts
+++ b/assistant/src/__tests__/session-history-web-search.test.ts
@@ -800,6 +800,12 @@ describe("web_search_tool_result structural guard", () => {
     // helper function definition (which canonically defines the check).
     // We use brace depth tracking so nested blocks (if/else, etc.) inside the
     // helper don't prematurely end the allowlisted region.
+    //
+    // Two-phase state: `insideHelperSignature` is true when we've matched the
+    // function name but haven't yet seen the opening `{` (handles multi-line
+    // signatures like `function isToolResultBlock(\n  ...\n): boolean {`).
+    // Once the first `{` is found, we switch to brace-depth tracking.
+    let insideHelperSignature = false;
     let helperBraceDepth = 0;
 
     // Track which lines have already been used to suppress a raw tool_result check.
@@ -813,17 +819,35 @@ describe("web_search_tool_result structural guard", () => {
 
       // Detect entry of known helper functions that define the canonical check
       if (
+        !insideHelperSignature &&
         helperBraceDepth === 0 &&
         /function isToolResult(Block|Content)\b/.test(line)
       ) {
-        // Count opening braces on the declaration line itself (e.g. `function foo() {`)
+        // The opening `{` may be on this line or a subsequent line (multi-line
+        // signatures). Check if there are braces on this line to determine
+        // whether we can start depth tracking immediately.
         const opens = (line.match(/{/g) || []).length;
         const closes = (line.match(/}/g) || []).length;
-        helperBraceDepth = opens - closes;
+        if (opens > 0) {
+          helperBraceDepth = opens - closes;
+        } else {
+          insideHelperSignature = true;
+        }
         continue;
       }
 
-      // Track brace depth while inside a helper function
+      // Still scanning the multi-line function signature for the opening `{`
+      if (insideHelperSignature) {
+        const opens = (line.match(/{/g) || []).length;
+        if (opens > 0) {
+          const closes = (line.match(/}/g) || []).length;
+          helperBraceDepth = opens - closes;
+          insideHelperSignature = false;
+        }
+        continue;
+      }
+
+      // Track brace depth while inside a helper function body
       if (helperBraceDepth > 0) {
         const opens = (line.match(/{/g) || []).length;
         const closes = (line.match(/}/g) || []).length;


### PR DESCRIPTION
Addresses review feedback from PR #16475. Fixes brace-depth tracking to handle multi-line function signatures where the opening brace is not on the same line as the function keyword.

Both Codex and Devin flagged that the brace-depth entry logic assumed the opening `{` is on the same line as `function isToolResultBlock|Content`, but the actual helper is declared over multiple lines. This caused `helperBraceDepth` to remain 0, meaning the scanner never entered helper scope.

The fix introduces a two-phase state machine: `insideHelperSignature` tracks when we've matched the function name but haven't yet seen the opening `{`, and once the brace is found we switch to brace-depth tracking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
