### PR TITLE
fix: add dedupeKeys to watcher notification signals

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -483,6 +483,7 @@ export async function runDaemon(): Promise<void> {
             title: notification.title,
             body: notification.body,
           },
+          dedupeKey: `watcher:notification:${Date.now()}`,
         });
       },
       (params) => {
@@ -500,6 +501,7 @@ export async function runDaemon(): Promise<void> {
             title: params.title,
             body: params.body,
           },
+          dedupeKey: `watcher:escalation:${Date.now()}`,
         });
       },
       (info) => {


### PR DESCRIPTION
Addresses review feedback from PR #16488. Adds unique dedupeKeys to watcher.notification and watcher.escalation signals to prevent incorrect deduplication.

The watcher.notification and watcher.escalation signals in lifecycle.ts were emitted without producer dedupeKeys. Without these, updateEventDedupeKey backfills the LLM-generated stable key, which could cause the same dedup bug fixed for schedules in #16488 to affect watcher events. This adds unique per-event dedupeKeys matching the pattern used by schedule signals.

Part of JARVIS-203
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
