### PR TITLE
fix: clarify Slack channel group-chat classification

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -376,14 +376,20 @@ export function resolveChannelCapabilities(
 /**
  * Returns true when the chat type indicates a group/multi-party conversation
  * (Telegram group/supergroup, Slack channel/group/mpim, etc.).
+ *
+ * Slack "channel" is intentionally classified as group chat: channels are
+ * inherently multi-party spaces where group etiquette (e.g. only respond when
+ * addressed) applies — even for low-traffic or announcement-style channels.
+ * The etiquette helps the assistant avoid responding to every message in a
+ * channel where it is a passive participant.
  */
 export function isGroupChatType(chatType?: string): boolean {
   if (!chatType) return false;
   switch (chatType) {
-    case "group":
-    case "supergroup":
-    case "channel":
-    case "mpim":
+    case "group": // Telegram group
+    case "supergroup": // Telegram supergroup
+    case "channel": // Slack channel — multi-party by definition
+    case "mpim": // Slack multi-party direct message
       return true;
     default:
       return false;


### PR DESCRIPTION
Addresses review feedback from PR #16483. Clarifies the intent behind treating Slack channels as group chat context — channels are inherently multi-party spaces where group etiquette applies, even for low-traffic or announcement-style channels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
