### PR TITLE
fix: bound identity context size in memory extraction prompt

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -143,11 +143,15 @@ function buildExtractionSystemPrompt(
   }>,
   messageRole: string,
 ): string {
-  // NOTE: If you want to reduce token costs for extraction, you can remove
-  // the full identity context below and replace it with just the user's name,
-  // e.g. via resolveUserReference(). But you should always provide at least
-  // basic context like the user's name to avoid generic "User ..." labels.
-  const identityContext = buildCoreIdentityContext();
+  // Inject identity context so extracted memories use real names instead of
+  // generic "User ..." labels. We truncate to a budget to prevent oversized
+  // prompts when SOUL.md / IDENTITY.md / USER.md are large — exceeding the
+  // provider context window would silently degrade to pattern-based extraction.
+  const MAX_IDENTITY_CONTEXT_CHARS = 2000;
+  const rawIdentityContext = buildCoreIdentityContext();
+  const identityContext = rawIdentityContext
+    ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
+    : null;
 
   let prompt = "";
   if (identityContext) {


### PR DESCRIPTION
## Summary
- Truncate the identity context injected into memory extraction prompts to 2000 characters max
- Prevents oversized prompts when SOUL.md / IDENTITY.md / USER.md are large, which could exceed provider context limits and silently degrade to pattern-based extraction

Addresses review feedback from PR #17335 (Codex P2: "Bound identity context size in extraction prompt").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
