### PR TITLE
fix: align gateway attachment limits and fix file-backed types

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -134,10 +134,10 @@ export function loadConfig(): GatewayConfig {
     gatewayInternalBaseUrl,
     logFile,
     maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024, // Telegram Bot API limit
+      telegram: 20 * 1024 * 1024, // Telegram Bot API getFile limit
       slack: 100 * 1024 * 1024, // Slack standard plan
       whatsapp: 16 * 1024 * 1024, // WhatsApp Business API limit
-      default: 50 * 1024 * 1024, // Fallback for new channels
+      default: 50 * 1024 * 1024, // Fallback; capped by runtime MAX_UPLOAD_BYTES (50 MB)
     },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -154,8 +154,13 @@ export type RuntimeAttachmentMeta = {
 };
 
 export type RuntimeAttachmentPayload = RuntimeAttachmentMeta & {
-  data: string; // base64-encoded
+  data?: string; // base64-encoded; absent for file-backed attachments until hydrated
   fileBacked?: boolean;
+};
+
+/** Attachment payload after hydration — `data` is guaranteed present. */
+export type HydratedAttachmentPayload = RuntimeAttachmentPayload & {
+  data: string;
 };
 
 export type RuntimeInboundResponse = {
@@ -342,7 +347,7 @@ export async function downloadAttachmentContent(
 export async function downloadAttachment(
   config: GatewayConfig,
   attachmentId: string,
-): Promise<RuntimeAttachmentPayload> {
+): Promise<HydratedAttachmentPayload> {
   cbBeforeRequest();
 
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
@@ -366,17 +371,24 @@ export async function downloadAttachment(
     throw new Error(`Attachment download failed (${response.status}): ${body}`);
   }
 
-  cbOnSuccess();
   const payload = (await response.json()) as RuntimeAttachmentPayload;
 
   // Transparently hydrate file-backed attachments: fetch the binary content
   // from the dedicated /content endpoint and inline it as base64.
+  // Note: we defer cbOnSuccess() until after hydration so that a recurring
+  // pattern of metadata-200 + content-5xx correctly accumulates breaker
+  // failures instead of resetting the counter on every metadata success.
   if (payload.fileBacked && !payload.data) {
     const contentBuffer = await downloadAttachmentContent(config, attachmentId);
     payload.data = contentBuffer.toString("base64");
   }
 
-  return payload;
+  if (!payload.data) {
+    throw new Error(`Attachment ${attachmentId} has no data after hydration`);
+  }
+
+  cbOnSuccess();
+  return payload as HydratedAttachmentPayload;
 }
 
 // ── Twilio webhook forwarding ────────────────────────────────────────


### PR DESCRIPTION
Addresses review feedback from PR #17363.

## Changes

- **Telegram attachment limit**: Lowered from 50 MiB to 20 MiB to match the actual Telegram Bot API `getFile` limit
- **Circuit breaker for file-backed content**: Deferred `cbOnSuccess()` in `downloadAttachment` until after content hydration, so that metadata-200 + content-5xx patterns correctly accumulate breaker failures
- **RuntimeAttachmentPayload.data**: Made `data` optional to reflect that file-backed responses omit it; introduced `HydratedAttachmentPayload` type with required `data` for the post-hydration return type

## Test plan

- [ ] Verify Telegram attachment uploads under 20 MiB succeed
- [ ] Verify file-backed attachment hydration still works end-to-end
- [ ] Verify circuit breaker opens after repeated content fetch failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
