### PR TITLE
fix: catch attachment read errors in image studio

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -115,7 +115,13 @@ export async function run(
 
     sourceImages = visibleAttachments
       .map((att) => {
-        const buffer = getAttachmentContent(att.id);
+        let buffer: Buffer | null | undefined;
+        try {
+          buffer = getAttachmentContent(att.id);
+        } catch {
+          // File-backed attachment may point to a missing or unreadable file
+          return undefined;
+        }
         if (!buffer) return undefined;
         return {
           mimeType: att.mimeType,


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #17374. Adds error handling around `getAttachmentContent` calls in image source preparation to gracefully handle missing or unreadable file-backed attachments.

When a file-backed attachment points to a missing/unreadable file, `getAttachmentContent(att.id)` throws (from `readFileSync`), and this previously happened before the `try`/`catch` that wraps `generateImage`. Now the error is caught gracefully and the attachment is simply skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
