### PR TITLE
fix: preserve file-path attachments on retry in retryFailedMessage

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2177,17 +2177,19 @@ public final class ChatViewModel: ObservableObject {
         retryMessage.isHidden = message.isHidden
         messages.append(retryMessage)
 
-        // Convert ChatAttachments back to UserMessageAttachments for the send call
+        // Convert ChatAttachments back to UserMessageAttachments for the send call.
+        // Keep file-path-based attachments even when data is empty,
+        // since the daemon can read the file from disk.
         let userAttachments: [UserMessageAttachment]? = message.attachments.isEmpty ? nil : message.attachments.compactMap { att in
-            guard !att.data.isEmpty else { return nil }
+            guard !att.data.isEmpty || att.filePath != nil else { return nil }
             return UserMessageAttachment(
                 id: att.id,
                 filename: att.filename,
                 mimeType: att.mimeType,
                 data: att.data,
                 extractedText: nil,
-                sizeBytes: nil,
-                thumbnailData: nil,
+                sizeBytes: att.sizeBytes,
+                thumbnailData: att.thumbnailData?.base64EncodedString(),
                 filePath: att.filePath
             )
         }


### PR DESCRIPTION
## Summary
- Updates the `retryFailedMessage(id:)` path with the same attachment preservation fix applied to the main retry path in PR #16439
- Guard now keeps file-path-based attachments even when data is empty (`att.filePath != nil`)
- Passes through `sizeBytes` and `thumbnailData` metadata instead of hardcoding nil

## Test plan
- [ ] Retry a failed message that has file-path-based attachments and verify they are preserved
- [ ] Retry a failed message with inline data attachments and verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
