### PR TITLE
fix: add SU_PUBLIC_ED_KEY to x64 build and fix Quick Look arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1305,6 +1305,7 @@ jobs:
         run: |
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}" \
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
+          SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
           SIGN_IDENTITY="Developer ID Application" \
           RELEASE_ARCH_FLAGS="--arch x86_64" \
           ./build.sh release

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -805,6 +805,13 @@ fi
 # Copy document type icon for .vellum UTI
 cp "$SCRIPT_DIR/vellum-assistant/Resources/VellumDocument.icns" "$RESOURCES_DIR/"
 
+# Derive target architecture for Quick Look extensions from RELEASE_ARCH_FLAGS.
+# Falls back to host architecture when RELEASE_ARCH_FLAGS is unset (dev builds).
+if [ -n "${RELEASE_ARCH_FLAGS:-}" ]; then
+    QL_TARGET_ARCH=$(echo "$RELEASE_ARCH_FLAGS" | sed -n 's/.*--arch \([^ ]*\).*/\1/p')
+fi
+QL_TARGET_ARCH="${QL_TARGET_ARCH:-$(uname -m)}"
+
 # Build and embed Quick Look Thumbnail extension (appex)
 QLTHUMB_SRC="$SCRIPT_DIR/VellumQLThumbnail"
 if [ -d "$QLTHUMB_SRC" ]; then
@@ -821,7 +828,7 @@ if [ -d "$QLTHUMB_SRC" ]; then
     xcrun swiftc \
         -module-name VellumQLThumbnail \
         -emit-executable \
-        -target "$(uname -m)-apple-macosx14.0" \
+        -target "${QL_TARGET_ARCH}-apple-macosx14.0" \
         -sdk "$(xcrun --show-sdk-path)" \
         -framework QuickLookThumbnailing \
         -framework AppKit \
@@ -850,7 +857,7 @@ if [ -d "$QLPREV_SRC" ]; then
     xcrun swiftc \
         -module-name VellumQLPreview \
         -emit-executable \
-        -target "$(uname -m)-apple-macosx14.0" \
+        -target "${QL_TARGET_ARCH}-apple-macosx14.0" \
         -sdk "$(xcrun --show-sdk-path)" \
         -framework QuickLookUI \
         -framework UniformTypeIdentifiers \


### PR DESCRIPTION
Addresses review feedback from PR #16457. Adds the missing SU_PUBLIC_ED_KEY secret to the x64 build step and ensures Quick Look extensions are compiled for x86_64 in the x64 build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
