### PR TITLE
fix: add ensureMainWindow to document editor handlers

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -243,16 +243,24 @@ extension AppDelegate {
         }
 
         daemonClient.onDocumentEditorShow = { [weak self] msg in
-            self?.mainWindow?.handleDocumentEditorShow(msg)
+            guard let self else { return }
+            self.ensureMainWindowExists()
+            self.mainWindow?.handleDocumentEditorShow(msg)
         }
         daemonClient.onDocumentEditorUpdate = { [weak self] msg in
-            self?.mainWindow?.handleDocumentEditorUpdate(msg)
+            guard let self else { return }
+            self.ensureMainWindowExists()
+            self.mainWindow?.handleDocumentEditorUpdate(msg)
         }
         daemonClient.onDocumentSaveResponse = { [weak self] msg in
-            self?.mainWindow?.handleDocumentSaveResponse(msg)
+            guard let self else { return }
+            self.ensureMainWindowExists()
+            self.mainWindow?.handleDocumentSaveResponse(msg)
         }
         daemonClient.onDocumentLoadResponse = { [weak self] msg in
-            self?.mainWindow?.handleDocumentLoadResponse(msg)
+            guard let self else { return }
+            self.ensureMainWindowExists()
+            self.mainWindow?.handleDocumentLoadResponse(msg)
         }
 
         // Handle diagnostics export response — show a toast in the main window


### PR DESCRIPTION
## Summary

- Adds `ensureMainWindowExists()` calls to the four document editor daemon handlers (`onDocumentEditorShow`, `onDocumentEditorUpdate`, `onDocumentSaveResponse`, `onDocumentLoadResponse`) for consistency with schedule/task thread handlers
- Prevents silent event drops if the daemon pushes document editor events while the main window is nil (e.g., background/menu-bar-only state)

Addresses review feedback from PR #16460.

## Test plan

- [ ] Trigger a document editor event while the app is in menu-bar-only mode (main window closed)
- [ ] Verify the main window is created and the document editor opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
