### PR TITLE
fix: compacting indicator display during concurrent thinking

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -344,7 +344,9 @@ struct AssistantProgressView: View {
     /// from zero regardless of how long the view has been alive.
     private var processingLabel: some View {
         let initialLabel = ChatBubble.friendlyProcessingLabel(processingStatusText)
-        let labels = [
+        // Pin the label when compacting — don't cycle to generic labels.
+        let pinLabel = processingStatusText?.lowercased().contains("compacting") == true
+        let labels: [String] = pinLabel ? [initialLabel] : [
             initialLabel,
             "Putting this together",
             "Finalizing your response",

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -619,6 +619,8 @@ struct MessageListView: View {
                         } else {
                             thinkingIndicatorRow(displayMessages: displayMessages)
                         }
+                    } else if isCompacting && !shouldShowThinkingIndicator && !canInlineProcessing {
+                        compactingIndicatorRow()
                     }
 
                     Color.clear


### PR DESCRIPTION
## Summary
- Restore fallback compacting indicator when `shouldShowThinkingIndicator` is false — fixes the case where `isCompacting` is true but thinking indicator conditions aren't met (e.g., `hasActiveToolCall` is true during compaction)
- Pin the "Compacting context…" label in inline processing mode so it doesn't cycle to generic labels like "Putting this together" after 8 seconds

Addresses review feedback from PR #16482.

## Test plan
- [ ] Trigger context overflow recovery during an active tool call — verify "Compacting context…" indicator appears
- [ ] Trigger context overflow recovery when last message is assistant bubble (inline case) — verify label stays pinned as "Compacting context…"
- [ ] Verify normal thinking indicator and label cycling still work when not compacting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
