### PR TITLE
Redesign tool confirmation bubble button layout

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public struct VButton: View {
     public enum Style: Hashable { case primary, danger, dangerOutline, outlined, ghost, contrast }
-    public enum Size: Hashable { case regular, pill }
+    public enum Size: Hashable { case regular, compact, pill }
 
     public let label: String
     public var leftIcon: String? = nil
@@ -51,7 +51,7 @@ public struct VButton: View {
                         VIconView(.resolve(leftIcon), size: textIconSize)
                     }
                     Text(label)
-                        .font(size == .pill ? VFont.captionMedium : VFont.bodyMedium)
+                        .font(size == .regular ? VFont.bodyMedium : VFont.captionMedium)
                     if isFullWidth && (leftIcon != nil || rightIcon != nil) {
                         Spacer(minLength: 0)
                     }
@@ -127,7 +127,7 @@ public struct VButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(configuration: Configuration) -> some View {
-        let cornerRadius = size == .pill ? VRadius.pill : VRadius.md
+        let cornerRadius: CGFloat = size == .pill ? VRadius.pill : VRadius.md
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         configuration.label
@@ -251,7 +251,7 @@ private struct ButtonLayoutModifier: ViewModifier {
         if isIconOnly {
             content
                 .frame(width: iconSize ?? 32, height: iconSize ?? 32)
-        } else if size == .pill {
+        } else if size == .pill || size == .compact {
             content
                 .padding(.horizontal, VSpacing.sm)
                 .frame(height: 24)

--- a/clients/shared/Features/Chat/ApprovalActionRow.swift
+++ b/clients/shared/Features/Chat/ApprovalActionRow.swift
@@ -6,6 +6,7 @@ public struct ApprovalActionButton: View {
     public let label: String
     public let isPrimary: Bool
     public let isDanger: Bool
+    public let isDangerOutline: Bool
     public var isKeyboardSelected: Bool = false
     public let action: () -> Void
 
@@ -13,34 +14,57 @@ public struct ApprovalActionButton: View {
         label: String,
         isPrimary: Bool = false,
         isDanger: Bool = false,
+        isDangerOutline: Bool = false,
         isKeyboardSelected: Bool = false,
         action: @escaping () -> Void
     ) {
         self.label = label
         self.isPrimary = isPrimary
         self.isDanger = isDanger
+        self.isDangerOutline = isDangerOutline
         self.isKeyboardSelected = isKeyboardSelected
         self.action = action
+    }
+
+    private var foregroundColor: Color {
+        if isDangerOutline { return VColor.systemNegativeStrong }
+        if isPrimary || isDanger { return VColor.auxWhite }
+        return VColor.contentSecondary
+    }
+
+    private var backgroundColor: Color {
+        if isDangerOutline { return Color.clear }
+        if isDanger { return VColor.systemNegativeStrong }
+        if isPrimary { return VColor.primaryBase }
+        return Color.clear
+    }
+
+    private var borderColor: Color {
+        if isKeyboardSelected { return VColor.primaryBase }
+        if isDangerOutline { return VColor.systemNegativeStrong }
+        if isPrimary || isDanger { return Color.clear }
+        return VColor.borderBase
     }
 
     public var body: some View {
         Button(action: action) {
             Text(label)
                 .font(VFont.caption)
-                .foregroundColor(isPrimary || isDanger ? VColor.auxWhite : VColor.contentSecondary)
+                .foregroundColor(foregroundColor)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs + 1)
-                .background(isDanger ? VColor.systemNegativeStrong : isPrimary ? VColor.primaryBase : Color.clear)
+                .background(backgroundColor)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.sm)
                         .stroke(
-                            isKeyboardSelected ? VColor.primaryBase : (isPrimary || isDanger ? Color.clear : VColor.borderBase),
+                            borderColor,
                             lineWidth: isKeyboardSelected ? 2 : 1
                         )
                 )
         }
         .buttonStyle(.plain)
+        .pointerCursor()
         .accessibilityLabel(label)
     }
 }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -371,21 +371,20 @@ public struct ToolConfirmationBubble: View {
     private var buttonRow: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Top group: recommended actions
-            if hasTemporaryOptions {
+            // Top group: recommended actions — only shown when allow10m is available
+            // (pairs "Allow for 10 minutes" with "Don't Allow" under "Recommended")
+            if hasAllow10m {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Recommended")
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.contentDefault)
                     HStack(spacing: VSpacing.xs) {
-                        if hasAllow10m {
-                            confirmationButton(
-                                "Allow for 10 minutes",
-                                isPrimary: true,
-                                isDanger: false,
-                                isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
-                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
-                        }
+                        confirmationButton(
+                            "Allow for 10 minutes",
+                            isPrimary: true,
+                            isDanger: false,
+                            isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
+                        ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
                         confirmationButton(
                             "Don\u{2019}t Allow",
                             isPrimary: false,
@@ -397,7 +396,7 @@ public struct ToolConfirmationBubble: View {
             }
             // Bottom group: more options
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if hasTemporaryOptions {
+                if hasAllow10m {
                     Text("More Options")
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.contentDefault)
@@ -405,7 +404,7 @@ public struct ToolConfirmationBubble: View {
                 HStack(spacing: VSpacing.xs) {
                     confirmationButton(
                         "Allow Once",
-                        isPrimary: !hasTemporaryOptions,
+                        isPrimary: !hasAllow10m,
                         isDanger: false,
                         isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
                     ) { markCommandExplanationSeen(); onAllow() }
@@ -418,7 +417,7 @@ public struct ToolConfirmationBubble: View {
                             isKeyboardSelected: keyboardModel?.selectedAction == .allowConversation
                         ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_conversation") }
                     }
-                    if !hasTemporaryOptions {
+                    if !hasAllow10m {
                         confirmationButton(
                             "Don\u{2019}t Allow",
                             isPrimary: false,

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -230,11 +230,11 @@ public struct ToolConfirmationBubble: View {
                 } label: {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.chevronRight, size: 9)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundColor(VColor.contentDefault)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
                         Text(showTechnicalDetails ? "Hide" : "More details")
                             .font(VFont.captionMedium)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundColor(VColor.contentDefault)
                     }
                 }
                 .buttonStyle(.plain)
@@ -346,12 +346,12 @@ public struct ToolConfirmationBubble: View {
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
         if hasAllow10m { actions.append(.allow10m) }
-        if hasAllowConversation { actions.append(.allowConversation) }
+        actions.append(.dontAllow)
         actions.append(.allowOnce)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
-        actions.append(.dontAllow)
+        if hasAllowConversation { actions.append(.allowConversation) }
         return actions
     }
 
@@ -363,12 +363,12 @@ public struct ToolConfirmationBubble: View {
     private var buttonRow: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Top group: temporary approval options (approve all future actions)
+            // Top group: recommended actions
             if hasTemporaryOptions {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Approve all actions")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                    Text("Recommended")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.contentDefault)
                     HStack(spacing: VSpacing.xs) {
                         if hasAllow10m {
                             confirmationButton(
@@ -378,23 +378,21 @@ public struct ToolConfirmationBubble: View {
                                 isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
                             ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
                         }
-                        if hasAllowConversation {
-                            confirmationButton(
-                                "Allow for this conversation",
-                                isPrimary: true,
-                                isDanger: false,
-                                isKeyboardSelected: keyboardModel?.selectedAction == .allowConversation
-                            ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_conversation") }
-                        }
+                        confirmationButton(
+                            "Don\u{2019}t Allow",
+                            isPrimary: false,
+                            isDanger: true,
+                            isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
+                        ) { markCommandExplanationSeen(); onDeny() }
                     }
                 }
             }
-            // Bottom group: per-action options
+            // Bottom group: more options
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 if hasTemporaryOptions {
-                    Text("This action only")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                    Text("More Options")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.contentDefault)
                 }
                 HStack(spacing: VSpacing.xs) {
                     confirmationButton(
@@ -404,12 +402,22 @@ public struct ToolConfirmationBubble: View {
                         isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
                     ) { markCommandExplanationSeen(); onAllow() }
                     if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
-                    confirmationButton(
-                        "Don\u{2019}t Allow",
-                        isPrimary: false,
-                        isDanger: false,
-                        isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
-                    ) { markCommandExplanationSeen(); onDeny() }
+                    if hasAllowConversation {
+                        confirmationButton(
+                            "Allow for this conversation",
+                            isPrimary: false,
+                            isDanger: false,
+                            isKeyboardSelected: keyboardModel?.selectedAction == .allowConversation
+                        ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_conversation") }
+                    }
+                    if !hasTemporaryOptions {
+                        confirmationButton(
+                            "Don\u{2019}t Allow",
+                            isPrimary: false,
+                            isDanger: true,
+                            isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
+                        ) { markCommandExplanationSeen(); onDeny() }
+                    }
                     Spacer()
                 }
             }
@@ -677,17 +685,11 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-    /// Convenience wrapper around the shared `ApprovalActionButton` to preserve
-    /// call-site compatibility within the existing button row logic.
+    /// Convenience wrapper that maps the legacy isPrimary/isDanger flags to a `VButton.Style`.
     @ViewBuilder
-    private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, isKeyboardSelected: Bool = false, action: @escaping () -> Void) -> some View {
-        ApprovalActionButton(
-            label: label,
-            isPrimary: isPrimary,
-            isDanger: isDanger,
-            isKeyboardSelected: isKeyboardSelected,
-            action: action
-        )
+    private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, isDangerOutline: Bool = false, isKeyboardSelected: Bool = false, action: @escaping () -> Void) -> some View {
+        let style: VButton.Style = isDanger ? .danger : isDangerOutline ? .dangerOutline : isPrimary ? .primary : .outlined
+        VButton(label: label, style: style, size: .compact, action: action)
     }
 
     // MARK: - Always Allow Button

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -346,17 +346,20 @@ public struct ToolConfirmationBubble: View {
     /// navigation follows the same sequence the user sees on screen.
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
-        // Top row (Recommended): allow10m, dontAllow — only when temporary options exist
-        if hasAllow10m { actions.append(.allow10m) }
-        if hasTemporaryOptions { actions.append(.dontAllow) }
-        // Bottom row (More Options): allowOnce, alwaysAllow?, allowConversation?
+        // When allow10m is present, it and dontAllow share the top "Recommended" row
+        if hasAllow10m {
+            actions.append(.allow10m)
+            actions.append(.dontAllow)
+        }
+        // Bottom row (or only row): allowOnce, alwaysAllow?, allowConversation?
         actions.append(.allowOnce)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
         if hasAllowConversation { actions.append(.allowConversation) }
-        // When no temporary options, dontAllow is at the end of the single row
-        if !hasTemporaryOptions { actions.append(.dontAllow) }
+        // When allow10m is absent, dontAllow goes at the end (matching its rightmost
+        // visual position) so an allow action is always the default at index 0
+        if !hasAllow10m { actions.append(.dontAllow) }
         return actions
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -342,16 +342,21 @@ public struct ToolConfirmationBubble: View {
     // MARK: - Button Row
 
     /// Build the ordered list of top-level actions based on current confirmation state.
-    /// Temporary options come first (matching visual top-to-bottom, left-to-right order).
+    /// Order matches visual layout (top-to-bottom, left-to-right) so keyboard Tab
+    /// navigation follows the same sequence the user sees on screen.
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
+        // Top row (Recommended): allow10m, dontAllow — only when temporary options exist
         if hasAllow10m { actions.append(.allow10m) }
+        if hasTemporaryOptions { actions.append(.dontAllow) }
+        // Bottom row (More Options): allowOnce, alwaysAllow?, allowConversation?
         actions.append(.allowOnce)
-        actions.append(.dontAllow)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
         if hasAllowConversation { actions.append(.allowConversation) }
+        // When no temporary options, dontAllow is at the end of the single row
+        if !hasTemporaryOptions { actions.append(.dontAllow) }
         return actions
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -699,6 +699,7 @@ public struct ToolConfirmationBubble: View {
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .stroke(VColor.primaryBase, lineWidth: isKeyboardSelected ? 2 : 0)
             )
+            .accessibilityLabel(label)
     }
 
     // MARK: - Always Allow Button

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -346,8 +346,8 @@ public struct ToolConfirmationBubble: View {
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
         if hasAllow10m { actions.append(.allow10m) }
-        actions.append(.dontAllow)
         actions.append(.allowOnce)
+        actions.append(.dontAllow)
         if hasRuleOptions && confirmation.persistentDecisionsAllowed {
             actions.append(.alwaysAllow)
         }
@@ -690,6 +690,10 @@ public struct ToolConfirmationBubble: View {
     private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, isDangerOutline: Bool = false, isKeyboardSelected: Bool = false, action: @escaping () -> Void) -> some View {
         let style: VButton.Style = isDanger ? .danger : isDangerOutline ? .dangerOutline : isPrimary ? .primary : .outlined
         VButton(label: label, style: style, size: .compact, action: action)
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.primaryBase, lineWidth: isKeyboardSelected ? 2 : 0)
+            )
     }
 
     // MARK: - Always Allow Button


### PR DESCRIPTION
## Summary
- Swap "Don't Allow" to recommended row and "Allow for this conversation" to more options row
- Rename section labels: "Approve all actions" → "Recommended", "This action only" → "More Options"
- Replace custom `ApprovalActionButton` with `VButton` (new compact size) for design system consistency
- Style "Don't Allow" as danger button, update section label/accordion colors to `contentDefault`

## Test plan
- [ ] Trigger a tool confirmation with temporary options (allow 10m / allow conversation) and verify layout: "Recommended" row has "Allow for 10 minutes" + "Don't Allow" (danger), "More Options" row has "Allow Once" + "Always Allow" + "Allow for this conversation"
- [ ] Trigger a tool confirmation without temporary options and verify "Don't Allow" appears in the single row
- [ ] Verify pointer cursor on hover for all buttons
- [ ] Verify accordion chevron and labels use `contentDefault` color

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
