### PR TITLE
fix: prevent unrecoverable secret-blocked retry in HTTP mode

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1766,13 +1766,18 @@ public final class HTTPTransport {
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let errorCategory = json["error"] as? String,
                       errorCategory == "secret_blocked" {
-                // Surface secret-block errors through the .error path so
-                // ChatViewModel's secret_blocked handler can offer "Send Anyway".
+                // HTTP mode cannot handle secret-blocked retries (no bypassSecretCheck
+                // support), so surface as a non-retryable conversation error instead
+                // of routing through .error(category: "secret_blocked") which would
+                // activate ChatViewModel's "Send Anyway" UI and create an unrecoverable loop.
                 let message = (json["message"] as? String) ?? "Message blocked — contains secrets"
                 log.warning("Message blocked by secret-ingress check")
-                onMessage?(.error(ErrorMessage(
-                    message: message,
-                    category: "secret_blocked"
+                onMessage?(.conversationError(ConversationErrorMessage(
+                    conversationId: sessionId,
+                    code: .providerApi,
+                    userMessage: message,
+                    retryable: false,
+                    failedMessageContent: content
                 )))
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"


### PR DESCRIPTION
## Summary
- Changes HTTP mode's handling of 422 `secret_blocked` responses to emit a non-retryable `.conversationError` instead of `.error(category: "secret_blocked")`
- Prevents the "Send Anyway" recovery UI from activating in HTTP mode, where `bypassSecretCheck` is not supported and would create an infinite 422 loop

## Test plan
- [ ] Verify secret-blocked message on desktop via HTTP transport shows a non-retryable error message instead of the "Send Anyway" button
- [ ] Verify SSE transport secret-blocked flow still works as before (unchanged)

Addresses review feedback from PR #16472.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
