### PR TITLE
fix: remove unused dataBase64 select from loadAttachmentById

### DIFF
--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -48,7 +48,7 @@ function formatBytes(bytes: number): string {
 }
 
 /**
- * Load an attachment row (including base64 data) by its primary key.
+ * Load attachment metadata by its primary key.
  *
  * Not scoped by assistantId because attachment access is enforced by
  * conversation visibility checks in execute().
@@ -58,7 +58,6 @@ function loadAttachmentById(attachmentId: string): {
   originalFilename: string;
   mimeType: string;
   sizeBytes: number;
-  dataBase64: string;
 } | null {
   const db = getDb();
   const row = db
@@ -67,7 +66,6 @@ function loadAttachmentById(attachmentId: string): {
       originalFilename: attachments.originalFilename,
       mimeType: attachments.mimeType,
       sizeBytes: attachments.sizeBytes,
-      dataBase64: attachments.dataBase64,
     })
     .from(attachments)
     .where(eq(attachments.id, attachmentId))


### PR DESCRIPTION
Addresses review feedback from PR #17370. Removes the unused dataBase64 column selection from loadAttachmentById now that file-backed attachments read content from disk via getAttachmentContent. This also eliminates a double DB read for inline attachments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
