### PR TITLE
fix: register file_path column as DB migration and address export safety

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -223,25 +223,14 @@ function computeContentHash(dataBase64: string): string {
 // File-backed attachment storage (avoids reading large files into memory)
 // ---------------------------------------------------------------------------
 
-function ensureFilePathColumn(): void {
-  try {
-    // SQLite allows ALTER TABLE ADD COLUMN for nullable columns
-    rawRun("ALTER TABLE attachments ADD COLUMN file_path TEXT");
-  } catch {
-    // Column already exists — ignore the error
-  }
-}
-
-let filePathColumnEnsured = false;
-
 /**
  * Store a file-backed attachment by path reference, without reading the file
  * into memory. This avoids OOM risk for large recordings that exceed the
  * normal 50 MB upload limit.
  *
  * The file stays on disk; the attachment row stores an empty dataBase64 and
- * records the on-disk path in a `file_path` column (added via runtime
- * migration since the Drizzle schema doesn't know about it).
+ * records the on-disk path in a `file_path` column (added via DB migration
+ * in 102-alter-table-columns.ts since the Drizzle schema doesn't know about it).
  */
 export function uploadFileBackedAttachment(
   filename: string,
@@ -249,11 +238,6 @@ export function uploadFileBackedAttachment(
   filePath: string,
   sizeBytes: number,
 ): StoredAttachment & { filePath: string } {
-  if (!filePathColumnEnsured) {
-    ensureFilePathColumn();
-    filePathColumnEnsured = true;
-  }
-
   const now = Date.now();
   const kind = classifyKind(mimeType);
   const id = uuid();
@@ -285,13 +269,9 @@ export function uploadFileBackedAttachment(
 
 /**
  * Returns the file_path for a file-backed attachment, or null if not file-backed.
- * Uses raw SQL since file_path is added via runtime migration and is not in the Drizzle schema.
+ * Uses raw SQL since file_path is added via DB migration and is not in the Drizzle schema.
  */
 export function getFilePathForAttachment(attachmentId: string): string | null {
-  if (!filePathColumnEnsured) {
-    ensureFilePathColumn();
-    filePathColumnEnsured = true;
-  }
   const row = rawGet<{ file_path: string | null }>(
     "SELECT file_path FROM attachments WHERE id = ?",
     attachmentId,

--- a/assistant/src/memory/migrations/102-alter-table-columns.ts
+++ b/assistant/src/memory/migrations/102-alter-table-columns.ts
@@ -256,6 +256,11 @@ export function addCoreColumns(database: DrizzleDb): void {
   } catch {
     /* already exists */
   }
+  try {
+    database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN file_path TEXT`);
+  } catch {
+    /* already exists */
+  }
 
   // cron_jobs
   try {

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -415,7 +415,11 @@ function formatBytes(bytes: number): string {
 }
 
 /** Directory prefixes to skip when collecting workspace files. */
-const WORKSPACE_SKIP_DIRS = new Set(["embedding-models", "data/qdrant"]);
+const WORKSPACE_SKIP_DIRS = new Set([
+  "embedding-models",
+  "data/qdrant",
+  "data/attachments",
+]);
 
 /** Files at the workspace root to skip (already covered by sanitized fields). */
 const WORKSPACE_SKIP_ROOT_FILES = new Set(["config.json"]);


### PR DESCRIPTION
## Summary
- Moved `file_path` ALTER TABLE from runtime `ensureFilePathColumn()` in `attachments-store.ts` to a proper DB migration in `102-alter-table-columns.ts`, following the project's migration conventions
- Added `data/attachments` to the `WORKSPACE_SKIP_DIRS` set in `log-export-routes.ts` so file-backed attachments (which can be 5-50 MB of user-sensitive content) are excluded from diagnostic log exports
- Removed dead code: `ensureFilePathColumn()`, `filePathColumnEnsured` flag, and all lazy-init guard blocks

Addresses review feedback from PR #17364.

## Test plan
- [ ] Verify `data/attachments` directory is excluded from export archives (existing test in `log-export-workspace.test.ts` covers skip-dir mechanism)
- [ ] Verify file-backed attachments still work correctly (the `file_path` column is now added at DB init time via `addCoreColumns`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
