### PR TITLE
fix: batch file-path lookups in conversation history

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -300,6 +300,27 @@ export function getFilePathForAttachment(attachmentId: string): string | null {
 }
 
 /**
+ * Batch-fetch file_path values for multiple attachment IDs in a single query.
+ * Returns a Set of attachment IDs that are file-backed (have a non-null file_path).
+ * Uses raw SQL since file_path is added via runtime migration and is not in the Drizzle schema.
+ */
+export function getFileBackedAttachmentIds(
+  attachmentIds: string[],
+): Set<string> {
+  if (attachmentIds.length === 0) return new Set();
+  if (!filePathColumnEnsured) {
+    ensureFilePathColumn();
+    filePathColumnEnsured = true;
+  }
+  const placeholders = attachmentIds.map(() => "?").join(", ");
+  const rows = rawAll<{ id: string }>(
+    `SELECT id FROM attachments WHERE id IN (${placeholders}) AND file_path IS NOT NULL`,
+    ...attachmentIds,
+  );
+  return new Set(rows.map((r) => r.id));
+}
+
+/**
  * Return the raw binary content for an attachment, abstracting over inline
  * (base64-in-DB) vs file-backed (on-disk) storage.
  *

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -318,80 +318,44 @@ export function handleListMessages(
   const messages: RuntimeMessagePayload[] = parsed.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.id) {
-      if (m.role === "user") {
-        // Use metadata-only query first to avoid loading large base64
-        // blobs for non-image attachments (documents, audio). Then
-        // selectively fetch full data only for images so the client can
-        // generate thumbnails for inline display on history restore.
-        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
-        if (linked.length > 0) {
-          msgAttachments = linked.map((a) => {
-            const isFileBacked = !!attachmentsStore.getFilePathForAttachment(
-              a.id,
-            );
-            if (a.mimeType.startsWith("image/")) {
-              const full = attachmentsStore.getAttachmentById(a.id);
-              return {
-                id: a.id,
-                filename: a.originalFilename,
-                mimeType: a.mimeType,
-                sizeBytes: a.sizeBytes,
-                kind: a.kind,
-                ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
-                ...(a.thumbnailBase64
-                  ? { thumbnailData: a.thumbnailBase64 }
-                  : {}),
-                ...(isFileBacked ? { fileBacked: true } : {}),
-              };
-            }
+      // Use metadata-only query first to avoid loading large base64
+      // blobs for non-image attachments (documents, audio). Then
+      // selectively fetch full data only for images so the client can
+      // generate thumbnails for inline display on history restore.
+      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
+      if (linked.length > 0) {
+        // Batch-fetch file-backed status for all attachments in one query
+        // instead of issuing a separate query per attachment.
+        const fileBackedIds = attachmentsStore.getFileBackedAttachmentIds(
+          linked.map((a) => a.id),
+        );
+        msgAttachments = linked.map((a) => {
+          const isFileBacked = fileBackedIds.has(a.id);
+          if (a.mimeType.startsWith("image/")) {
+            const full = attachmentsStore.getAttachmentById(a.id);
             return {
               id: a.id,
               filename: a.originalFilename,
               mimeType: a.mimeType,
               sizeBytes: a.sizeBytes,
               kind: a.kind,
+              ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),
               ...(isFileBacked ? { fileBacked: true } : {}),
             };
-          });
-        }
-      } else {
-        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
-        if (linked.length > 0) {
-          msgAttachments = linked.map((a) => {
-            const isFileBacked = !!attachmentsStore.getFilePathForAttachment(
-              a.id,
-            );
-            if (a.mimeType.startsWith("image/")) {
-              const full = attachmentsStore.getAttachmentById(a.id);
-              return {
-                id: a.id,
-                filename: a.originalFilename,
-                mimeType: a.mimeType,
-                sizeBytes: a.sizeBytes,
-                kind: a.kind,
-                ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
-                ...(a.thumbnailBase64
-                  ? { thumbnailData: a.thumbnailBase64 }
-                  : {}),
-                ...(isFileBacked ? { fileBacked: true } : {}),
-              };
-            }
-            return {
-              id: a.id,
-              filename: a.originalFilename,
-              mimeType: a.mimeType,
-              sizeBytes: a.sizeBytes,
-              kind: a.kind,
-              ...(a.thumbnailBase64
-                ? { thumbnailData: a.thumbnailBase64 }
-                : {}),
-              ...(isFileBacked ? { fileBacked: true } : {}),
-            };
-          });
-        }
+          }
+          return {
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            sizeBytes: a.sizeBytes,
+            kind: a.kind,
+            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
+            ...(isFileBacked ? { fileBacked: true } : {}),
+          };
+        });
       }
     }
 


### PR DESCRIPTION
Addresses review feedback from PR #17375. Eliminates N+1 per-attachment file-path queries by batching lookups when building conversation history responses.

## Changes

- Added `getFileBackedAttachmentIds()` batch function to `attachments-store.ts` that fetches file-backed status for multiple attachment IDs in a single SQL query
- Replaced per-attachment `getFilePathForAttachment()` calls in `conversation-routes.ts` with a single `getFileBackedAttachmentIds()` call per message
- Deduplicated identical user/assistant attachment mapping branches into shared code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
