### PR TITLE
fix: add fileBacked field to Swift GeneratedAPITypes

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4825,8 +4825,10 @@ public struct UserMessageAttachment: Codable, Sendable {
     public let thumbnailData: String?
     /// Absolute path to the local file on disk. Present for file-backed attachments (e.g. recordings).
     public let filePath: String?
+    /// True when the attachment is file-backed and clients should hydrate via the /content endpoint.
+    public let fileBacked: Bool?
 
-    public init(id: String? = nil, filename: String, mimeType: String, data: String, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil) {
+    public init(id: String? = nil, filename: String, mimeType: String, data: String, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil, fileBacked: Bool? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
@@ -4835,6 +4837,7 @@ public struct UserMessageAttachment: Codable, Sendable {
         self.sizeBytes = sizeBytes
         self.thumbnailData = thumbnailData
         self.filePath = filePath
+        self.fileBacked = fileBacked
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `fileBacked: Bool?` property to `UserMessageAttachment` in Swift `GeneratedAPITypes.swift`
- Aligns the Swift client types with the TypeScript `UserMessageAttachment` from PR #17379

## Context
Addresses review feedback from PR #17379 (Devin flagged that the `fileBacked` field was missing from Swift generated types).

## Test plan
- [ ] Verify Swift build passes in CI
- [ ] Confirm `fileBacked` field is decoded from SSE attachment payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
