### PR TITLE
Refactor WorkspaceTreeRow to use shared FileTreeRowLabel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -447,40 +447,42 @@ private struct WorkspaceTreeRow: View {
             Button {
                 Task { await handleTap() }
             } label: {
-                HStack(spacing: VSpacing.xs) {
-                    if entry.isDirectory {
-                        VIconView(isExpanded ? .chevronDown : .chevronRight, size: 9)
-                            .foregroundColor(VColor.contentTertiary)
-                            .frame(width: 12)
-                    } else {
-                        Spacer().frame(width: 12)
-                    }
-
-                    VIconView(entry.isDirectory ? .folder : .fileText, size: 12)
-                        .foregroundColor(entry.isDirectory ? VColor.primaryBase : VColor.contentSecondary)
-
+                Group {
                     if state.renamingPath == entry.path {
-                        TextField("Name", text: $state.renamingText)
-                            .textFieldStyle(.plain)
-                            .font(VFont.body)
-                            .fixedSize(horizontal: true, vertical: false)
-                            .onSubmit {
-                                submitRename()
+                        // Rename mode: inline TextField (cannot use shared label)
+                        HStack(spacing: VSpacing.xs) {
+                            if entry.isDirectory {
+                                VIconView(isExpanded ? .chevronDown : .chevronRight, size: 9)
+                                    .foregroundColor(VColor.contentTertiary)
+                                    .frame(width: 12)
+                            } else {
+                                Spacer().frame(width: 12)
                             }
-                            .onExitCommand {
-                                state.renamingPath = nil
-                            }
+                            VIconView(entry.isDirectory ? .folder : .fileText, size: 12)
+                                .foregroundColor(entry.isDirectory ? VColor.primaryBase : VColor.contentSecondary)
+                            TextField("Name", text: $state.renamingText)
+                                .textFieldStyle(.plain)
+                                .font(VFont.body)
+                                .fixedSize(horizontal: true, vertical: false)
+                                .onSubmit { submitRename() }
+                                .onExitCommand { state.renamingPath = nil }
+                        }
+                        .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
+                        .padding(.trailing, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .frame(minWidth: minRowWidth, alignment: .leading)
                     } else {
-                        Text(entry.name)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentDefault)
-                            .fixedSize(horizontal: true, vertical: false)
+                        // Normal mode: shared label
+                        FileTreeRowLabel(
+                            name: entry.name,
+                            isDirectory: entry.isDirectory,
+                            isExpanded: isExpanded,
+                            depth: depth,
+                            fileIcon: .fileText,
+                            minRowWidth: minRowWidth
+                        )
                     }
                 }
-                .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
-                .padding(.trailing, VSpacing.sm)
-                .padding(.vertical, VSpacing.xs)
-                .frame(minWidth: minRowWidth, alignment: .leading)
                 .contentShape(Rectangle())
                 .background(isSelected ? VColor.surfaceActive : Color.clear)
             }


### PR DESCRIPTION
## Summary
- Replace inline HStack rendering in WorkspaceTreeRow's non-rename code path with shared FileTreeRowLabel component
- Rename mode (inline TextField) preserved as a separate conditional branch
- No visual or behavioral changes — same spacing, icons, colors, indentation, context menus, and interactions

Part of plan: shared-file-tree-components.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
