### PR TITLE
fix: handle post-convergence yieldedForBudget in escalation path

### DIFF
--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -1754,4 +1754,165 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
     // have been triggered (contextTooLargeDetected set to true)
     expect(convergenceReducerCalled).toBe(true);
   });
+
+  // ── Test 9 ────────────────────────────────────────────────────────
+  // When the convergence loop reruns the agent loop and it still yields
+  // at checkpoint (yieldedForBudget), the loop must continue reducing
+  // through additional tiers instead of silently dropping the incomplete
+  // turn.
+  test("post-convergence yieldedForBudget continues reduction", async () => {
+    const events: ServerMessage[] = [];
+
+    // Budget = 200_000 * 0.95 = 190_000
+    // Mid-loop threshold = 190_000 * 0.85 = 161_500
+    let estimateCallCount = 0;
+    mockEstimateTokens = () => {
+      estimateCallCount++;
+      // Preflight: below budget
+      if (estimateCallCount === 1) return 100_000;
+      // Every checkpoint call: above threshold — always triggers yield
+      return 170_000;
+    };
+
+    let agentLoopCallCount = 0;
+    const agentLoopRun: AgentLoopRun = async (
+      messages,
+      onEvent,
+      _signal,
+      _requestId,
+      onCheckpoint,
+    ) => {
+      agentLoopCallCount++;
+
+      const withProgress: Message[] = [
+        ...messages,
+        {
+          role: "assistant" as const,
+          content: [
+            { type: "text", text: `Tool call ${agentLoopCallCount}` },
+            {
+              type: "tool_use",
+              id: `tu-${agentLoopCallCount}`,
+              name: "bash",
+              input: { command: "ls" },
+            },
+          ] as ContentBlock[],
+        },
+        {
+          role: "user" as const,
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: `tu-${agentLoopCallCount}`,
+              content: "output",
+              is_error: false,
+            },
+          ] as ContentBlock[],
+        },
+      ];
+
+      onEvent({
+        type: "message_complete",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: `Tool call ${agentLoopCallCount}` },
+            {
+              type: "tool_use",
+              id: `tu-${agentLoopCallCount}`,
+              name: "bash",
+              input: { command: "ls" },
+            },
+          ],
+        },
+      });
+      onEvent({
+        type: "usage",
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+        providerDurationMs: 100,
+      });
+
+      // Always yield at checkpoint — simulates reduction not helping enough
+      if (onCheckpoint) {
+        const decision = onCheckpoint({
+          turnIndex: 0,
+          toolCount: 1,
+          hasToolUse: true,
+          history: withProgress,
+        });
+        if (decision === "yield") {
+          return withProgress;
+        }
+      }
+
+      return withProgress;
+    };
+
+    // Convergence reducer: first call returns non-exhausted, second returns exhausted
+    let reducerCallCount = 0;
+    mockReducerStepFn = (msgs: Message[]) => {
+      reducerCallCount++;
+      if (reducerCallCount === 1) {
+        return {
+          messages: msgs,
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 80_000,
+        };
+      }
+      // Second call: exhausted
+      return {
+        messages: msgs,
+        tier: "tool_result_truncation",
+        state: {
+          appliedTiers: ["forced_compaction", "tool_result_truncation"],
+          injectionMode: "full",
+          exhausted: true,
+        },
+        estimatedTokens: 60_000,
+      };
+    };
+
+    const ctx = makeCtx({
+      agentLoopRun,
+      contextWindowManager: {
+        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+        maybeCompact: async () => ({
+          compacted: true,
+          messages: [
+            {
+              role: "user" as const,
+              content: [{ type: "text", text: "Hello" }],
+            },
+          ] as Message[],
+          compactedPersistedMessages: 5,
+          summaryText: "Compaction summary",
+          previousEstimatedInputTokens: 170_000,
+          estimatedInputTokens: 165_000,
+          maxInputTokens: 200_000,
+          thresholdTokens: 160_000,
+          compactedMessages: 10,
+          summaryCalls: 1,
+          summaryInputTokens: 500,
+          summaryOutputTokens: 200,
+          summaryModel: "mock-model",
+        }),
+      } as unknown as AgentLoopSessionContext["contextWindowManager"],
+    });
+
+    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+    // Reducer should have been called twice: once for first convergence tier,
+    // once more after yieldedForBudget triggered re-entry
+    expect(reducerCallCount).toBe(2);
+
+    // Agent loop: 1 initial + 3 mid-loop re-entries + 2 convergence re-runs = 7 calls
+    expect(agentLoopCallCount).toBe(7);
+  });
 });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1196,6 +1196,21 @@ export async function runAgentLoopImpl(
           reqId,
           onCheckpoint,
         );
+
+        // If the rerun still yields at checkpoint, the turn is still
+        // incomplete — continue reducing through the remaining tiers
+        // instead of silently dropping the incomplete state.
+        if (yieldedForBudget && !abortController.signal.aborted) {
+          rlog.warn(
+            {
+              phase: "convergence",
+              attempt: convergenceAttempts,
+              appliedTiers: reducerState.appliedTiers,
+            },
+            "Post-convergence rerun still yielded at checkpoint — continuing reduction",
+          );
+          state.contextTooLargeDetected = true;
+        }
       }
 
       // All reducer tiers exhausted but provider still rejects —


### PR DESCRIPTION
## Summary
- After the convergence loop reruns the agent loop, if `onCheckpoint` still yields (`yieldedForBudget` remains true), the loop now sets `contextTooLargeDetected = true` to continue reducing through remaining tiers instead of silently dropping the incomplete state.
- Added test verifying that post-convergence `yieldedForBudget` triggers additional reducer iterations.

Addresses review feedback from PR #16484.

## Test plan
- [x] New test: "post-convergence yieldedForBudget continues reduction"
- [x] Existing test 8 unchanged (reducer exhausted case still exits correctly)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
