### PR TITLE
fix(acp): fix user_message_chunk updateType and add terminal error handler

### DIFF
--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -80,7 +80,7 @@ export class VellumAcpClientHandler implements Client {
         this.sendToVellum({
           type: "acp_session_update",
           acpSessionId: this.acpSessionId,
-          updateType: "agent_message_chunk",
+          updateType: "user_message_chunk",
           content: text,
         });
         break;
@@ -208,6 +208,13 @@ export class VellumAcpClientHandler implements Client {
       signal: null,
       exitPromise: Promise.resolve(),
     };
+
+    proc.on("error", (err) => {
+      log.error({ terminalId, error: err.message }, "Terminal process error");
+      state.exited = true;
+      state.exitCode = 1;
+      state.signal = null;
+    });
 
     state.exitPromise = new Promise<void>((resolve) => {
       proc.on("exit", (code, signal) => {

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -12,7 +12,12 @@ export interface AcpSessionSpawned {
 export interface AcpSessionUpdate {
   type: "acp_session_update";
   acpSessionId: string;
-  updateType: "agent_message_chunk" | "tool_call" | "tool_call_update" | "plan";
+  updateType:
+    | "agent_message_chunk"
+    | "user_message_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "plan";
   content?: string;
   toolCallId?: string;
   toolTitle?: string;


### PR DESCRIPTION
## Summary
- Fix user_message_chunk to send correct updateType instead of agent_message_chunk
- Add updateType to AcpSessionUpdate union in message-types/acp.ts
- Add proc.on('error') handler in createTerminal to prevent unhandled crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)