### PR TITLE
fix(acp): return 404 instead of 500 for unknown ACP session IDs

### DIFF
--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -75,7 +75,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           return httpError("BAD_REQUEST", "instruction is required", 400);
         }
         const manager = getAcpSessionManager();
-        await manager.steer(params.id, body.instruction);
+        try {
+          await manager.steer(params.id, body.instruction);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, steered: true });
       },
     },
@@ -87,7 +91,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
       policyKey: "acp/cancel",
       handler: async ({ params }) => {
         const manager = getAcpSessionManager();
-        await manager.cancel(params.id);
+        try {
+          await manager.cancel(params.id);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, cancelled: true });
       },
     },
@@ -99,7 +107,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
       policyKey: "acp/close",
       handler: async ({ params }) => {
         const manager = getAcpSessionManager();
-        manager.close(params.id);
+        try {
+          manager.close(params.id);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, closed: true });
       },
     },


### PR DESCRIPTION
## Summary
- Wrap steer/cancel/close handlers in try/catch to return 404 for unknown sessions
- Follows subagents-routes.ts error handling pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)