### PR TITLE
fix(acp): handle SIGTERM exit correctly and clean up state on process exit

### DIFF
--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -183,7 +183,7 @@ export class AcpAgentProcess {
    * Handles process exit by logging the event.
    */
   private handleProcessExit(code: number | null): void {
-    if (code !== 0) {
+    if (code != undefined && code !== 0) {
       log.error(
         { agentId: this.agentId, exitCode: code },
         "ACP agent process exited with error",
@@ -194,5 +194,8 @@ export class AcpAgentProcess {
         "ACP agent process exited",
       );
     }
+
+    this.proc = null;
+    this.connection = null;
   }
 }


### PR DESCRIPTION
## Summary
- Fix handleProcessExit to not log SIGTERM (code=null) as error
- Null out proc/connection on process exit so subsequent calls fail cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
