### PR TITLE
Add SkillFileTreeView with nested folder tree for skill detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -530,60 +530,13 @@ struct AgentPanelContent: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemNegativeStrong)
                 } else if let filesResponse = skillsManager.selectedSkillFiles, !filesResponse.files.isEmpty {
-                    VStack(spacing: 0) {
-                        ForEach(filesResponse.files, id: \.path) { file in
-                            skillFileRow(file)
-                            if file.path != filesResponse.files.last?.path {
-                                Divider()
-                            }
-                        }
-                    }
-                    .background(VColor.surfaceOverlay)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.borderBase, lineWidth: 1)
+                    SkillFileTreeView(
+                        files: filesResponse.files,
+                        selectedFilePath: $expandedFilePath
                     )
                 }
             }
         }
-    }
-
-    @ViewBuilder
-    private func skillFileRow(_ file: SkillFileEntry) -> some View {
-        let isText = !file.isBinary && file.content != nil
-        let isSelected = expandedFilePath == file.path
-
-        Button {
-            if isText && !isSelected {
-                withAnimation(VAnimation.fast) {
-                    expandedFilePath = file.path
-                }
-            }
-        } label: {
-            HStack(spacing: VSpacing.sm) {
-                VIconView(fileIcon(for: file.mimeType), size: 12)
-                    .foregroundColor(VColor.primaryBase)
-                    .frame(width: 20)
-
-                Text(file.path)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentDefault)
-                    .lineLimit(1)
-
-                Spacer()
-
-                Text(formatFileSize(file.size))
-                    .font(VFont.small)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .contentShape(Rectangle())
-            .background(isSelected ? VColor.surfaceActive : Color.clear)
-        }
-        .buttonStyle(.plain)
-        .disabled(!isText)
     }
 
     private func fileIcon(for mimeType: String) -> VIcon {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Tree view for skill files — builds a folder hierarchy from flat SkillFileEntry paths
+/// and renders it with FileTreeRowLabel. All folders expanded by default.
+struct SkillFileTreeView: View {
+    let files: [SkillFileEntry]
+    @Binding var selectedFilePath: String?
+
+    @State private var collapsedPaths: Set<String> = []
+    // Using collapsedPaths (starts empty = all expanded) instead of expandedPaths
+    // so that all directories are expanded by default without needing initialization.
+
+    private struct FlatItem: Identifiable {
+        let id: String
+        let node: FileTreeNode
+        let depth: Int
+    }
+
+    private var flattenedVisibleNodes: [FlatItem] {
+        var result: [FlatItem] = []
+        func walk(_ nodes: [FileTreeNode], depth: Int) {
+            for node in nodes {
+                result.append(FlatItem(id: node.path, node: node, depth: depth))
+                if node.isDirectory && !collapsedPaths.contains(node.path) {
+                    walk(node.children, depth: depth + 1)
+                }
+            }
+        }
+        walk(FileTreeNode.buildTree(from: files), depth: 0)
+        return result
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(flattenedVisibleNodes) { item in
+                let isSelected = selectedFilePath == item.node.path
+                let isText = !item.node.isBinary && item.node.content != nil
+
+                Button {
+                    if item.node.isDirectory {
+                        withAnimation(VAnimation.fast) {
+                            if collapsedPaths.contains(item.node.path) {
+                                collapsedPaths.remove(item.node.path)
+                            } else {
+                                collapsedPaths.insert(item.node.path)
+                            }
+                        }
+                    } else {
+                        withAnimation(VAnimation.fast) {
+                            selectedFilePath = item.node.path
+                        }
+                    }
+                } label: {
+                    HStack(spacing: VSpacing.sm) {
+                        FileTreeRowLabel(
+                            name: item.node.name,
+                            isDirectory: item.node.isDirectory,
+                            isExpanded: item.node.isDirectory && !collapsedPaths.contains(item.node.path),
+                            depth: item.depth,
+                            fileIcon: fileIcon(for: item.node.mimeType ?? "application/octet-stream")
+                        )
+
+                        Spacer()
+
+                        if !item.node.isDirectory {
+                            Text(formatFileSize(item.node.size ?? 0))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.contentTertiary)
+                                .padding(.trailing, VSpacing.sm)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .background(isSelected ? VColor.surfaceActive : Color.clear)
+                }
+                .buttonStyle(.plain)
+                .disabled(!item.node.isDirectory && !isText)
+            }
+        }
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+    }
+
+    private func fileIcon(for mimeType: String) -> VIcon {
+        if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("text/") { return .fileText }
+        if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+        return .file
+    }
+
+    private func formatFileSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024.0
+        if kb < 1024 { return String(format: "%.1f KB", kb) }
+        let mb = kb / 1024.0
+        return String(format: "%.1f MB", mb)
+    }
+}


### PR DESCRIPTION
## Summary
- Add SkillFileTreeView that builds a nested folder hierarchy from flat SkillFileEntry paths using FileTreeNode and renders with shared FileTreeRowLabel
- All folders expanded by default using inverted collapsedPaths set; clicking folders toggles expand/collapse with animation
- Replace flat file list in AgentPanel's skillFilesSection with SkillFileTreeView; delete now-unused skillFileRow method

Part of plan: shared-file-tree-components.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
