### PR TITLE
fix: top-align code viewer and workspace file tree scroll views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -23,14 +23,15 @@ struct ReadOnlyCodeContent: View {
     let content: String
 
     var body: some View {
-        ScrollView([.vertical, .horizontal]) {
-            Text(content)
-                .font(VFont.mono)
-                .foregroundColor(VColor.contentDefault)
-                .textSelection(.enabled)
-                .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        GeometryReader { geo in
+            ScrollView([.vertical, .horizontal]) {
+                Text(content)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .textSelection(.enabled)
+                    .padding(VSpacing.md)
+                    .frame(minWidth: geo.size.width, minHeight: geo.size.height, alignment: .topLeading)
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -295,7 +295,7 @@ private struct WorkspaceTreeSidebar: View {
                         Spacer()
                     }
                 } else {
-                    ScrollView([.vertical, .horizontal]) {
+                    ScrollView(.vertical) {
                         LazyVStack(alignment: .leading, spacing: 0) {
                             if let rootEntries = state.directoryCache[""] {
                                 ForEach(rootEntries) { entry in
@@ -311,7 +311,6 @@ private struct WorkspaceTreeSidebar: View {
                         }
                         .padding(.vertical, VSpacing.xs)
                     }
-                    .defaultScrollAnchor(.topLeading)
                     .background {
                         GeometryReader { geo in
                             Color.clear


### PR DESCRIPTION
## Summary
- Fix ReadOnlyCodeContent centering by wrapping ScrollView in GeometryReader with minWidth/minHeight constraints and .topLeading alignment, so code content aligns to the top-left like an IDE
- Fix workspace file tree centering by switching from dual-axis ScrollView to vertical-only and removing .defaultScrollAnchor(.topLeading) which wasn't working

## Original prompt
fix: top-align code viewer and workspace file tree scroll views

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
