### PR TITLE
feat: add typed telemetry event definitions for v2 ingest endpoint

### DIFF
--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -1,0 +1,26 @@
+/** Base fields present on every telemetry event. */
+export interface TelemetryEventBase {
+  type: string;
+  daemon_event_id: string;
+  recorded_at: number;
+}
+
+/** LLM usage event — one per provider API call. */
+export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
+  type: "llm_usage";
+  provider: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number | null;
+  cache_read_input_tokens: number | null;
+  actor: string;
+}
+
+/** Turn event — one per user message. */
+export interface TurnTelemetryEvent extends TelemetryEventBase {
+  type: "turn";
+}
+
+/** Discriminated union of all telemetry event types. */
+export type TelemetryEvent = LlmUsageTelemetryEvent | TurnTelemetryEvent;


### PR DESCRIPTION
## Summary
- Add `assistant/src/telemetry/types.ts` with typed telemetry event definitions
- Define discriminated union `TelemetryEvent = LlmUsageTelemetryEvent | TurnTelemetryEvent` for the v2 ingest endpoint
- Types-only change with no runtime behavior impact

Part of plan: ndjson-telemetry.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
