### PR TITLE
fix: wrap text in read-only code viewer instead of horizontal scrolling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -23,15 +23,13 @@ struct ReadOnlyCodeContent: View {
     let content: String
 
     var body: some View {
-        GeometryReader { geo in
-            ScrollView([.vertical, .horizontal]) {
-                Text(content)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentDefault)
-                    .textSelection(.enabled)
-                    .padding(VSpacing.md)
-                    .frame(minWidth: geo.size.width, minHeight: geo.size.height, alignment: .topLeading)
-            }
+        ScrollView(.vertical) {
+            Text(content)
+                .font(VFont.mono)
+                .foregroundColor(VColor.contentDefault)
+                .textSelection(.enabled)
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change ReadOnlyCodeContent from dual-axis ScrollView to vertical-only so text wraps within the container width instead of scrolling horizontally
- Removes GeometryReader (no longer needed without horizontal scroll) and uses maxWidth: .infinity for full-width text layout
- Makes read-only code viewer consistent with the editable TextEditor which already wraps text

## Original prompt
Make ReadOnlyCodeContent wrap text instead of scrolling horizontally. Change ScrollView([.vertical, .horizontal]) to ScrollView(.vertical) and remove the horizontal fixedSize/minWidth constraint so text wraps within the container width. The file is clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
