### PR TITLE
fix: make firstMatch public and remove stale ensureFilePathColumn refs

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -288,10 +288,6 @@ export function getFileBackedAttachmentIds(
   attachmentIds: string[],
 ): Set<string> {
   if (attachmentIds.length === 0) return new Set();
-  if (!filePathColumnEnsured) {
-    ensureFilePathColumn();
-    filePathColumnEnsured = true;
-  }
   const placeholders = attachmentIds.map(() => "?").join(", ");
   const rows = rawAll<{ id: string }>(
     `SELECT id FROM attachments WHERE id IN (${placeholders}) AND file_path IS NOT NULL`,

--- a/clients/shared/Network/ServerMessageStream+Timeout.swift
+++ b/clients/shared/Network/ServerMessageStream+Timeout.swift
@@ -10,7 +10,7 @@ extension AsyncStream where Element == ServerMessage {
     ///
     /// Returns `nil` when the timeout fires first or the stream ends
     /// without a match.
-    func firstMatch<T: Sendable>(
+    public func firstMatch<T: Sendable>(
         timeout: UInt64 = 15_000_000_000,
         extract: @Sendable @escaping (ServerMessage) -> T?
     ) async -> T? {


### PR DESCRIPTION
## Summary
- Added `public` access modifier to `firstMatch(timeout:extract:)` in `ServerMessageStream+Timeout.swift` — it was `internal` but called cross-module from `GeneratedPanel.swift` in the macOS target, breaking the build.
- Removed stale `filePathColumnEnsured`/`ensureFilePathColumn()` references in `attachments-store.ts` that were left behind after the DB migration refactor in #17404, causing TypeScript compilation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
