### PR TITLE
feat: switch telemetry reporter to v2 ingest endpoint with typed events

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -33,6 +33,14 @@ mock.module("../memory/llm-usage-store.js", () => ({
   queryUnreportedUsageEvents: mockQueryUnreportedUsageEvents,
 }));
 
+const mockQueryUnreportedTurnEvents = mock(
+  () => [] as { id: string; createdAt: number }[],
+);
+
+mock.module("../memory/turn-events-store.js", () => ({
+  queryUnreportedTurnEvents: mockQueryUnreportedTurnEvents,
+}));
+
 const mockResolveManagedProxyContext = mock(async () => ({
   enabled: false,
   platformBaseUrl: "",
@@ -59,6 +67,12 @@ const mockGetDeviceId = mock(() => "test-device-id");
 
 mock.module("../util/device-id.js", () => ({
   getDeviceId: mockGetDeviceId,
+}));
+
+const mockGetExternalAssistantId = mock(() => "test-assistant-id");
+
+mock.module("../runtime/auth/external-assistant-id.js", () => ({
+  getExternalAssistantId: mockGetExternalAssistantId,
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -114,11 +128,15 @@ beforeEach(() => {
   mockGetMemoryCheckpoint.mockReset();
   mockSetMemoryCheckpoint.mockReset();
   mockQueryUnreportedUsageEvents.mockReset();
+  mockQueryUnreportedTurnEvents.mockReset();
+  mockQueryUnreportedTurnEvents.mockReturnValue([]);
   mockResolveManagedProxyContext.mockReset();
   mockGetTelemetryPlatformUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
   mockGetDeviceId.mockReset();
   mockGetDeviceId.mockReturnValue("test-device-id");
+  mockGetExternalAssistantId.mockReset();
+  mockGetExternalAssistantId.mockReturnValue("test-assistant-id");
 
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
@@ -165,7 +183,7 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(
-      "https://test.vellum.ai/v1/assistants/self-hosted-local/telemetry/usage/",
+      "https://test.vellum.ai/v1/assistants/self-hosted-local/telemetry/ingest/",
     );
     expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
       "Api-Key test-key",
@@ -193,6 +211,7 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toStartWith("https://platform.test.ai");
+    expect(url).toEndWith("/telemetry/ingest/");
     expect((opts.headers as Record<string, string>)["X-Telemetry-Token"]).toBe(
       "anon-token",
     );
@@ -342,12 +361,14 @@ describe("UsageTelemetryReporter", () => {
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
 
-    // Top-level: installation_id and events array
+    // Top-level: installation_id and events array (no turn_events key)
     expect(body.installation_id).toBe("test-device-id");
     expect(Array.isArray(body.events)).toBe(true);
     expect(body.events.length).toBe(1);
+    expect(body.turn_events).toBeUndefined();
 
     const e = body.events[0];
+    expect(e.type).toBe("llm_usage");
     expect(e.daemon_event_id).toBe("evt-shape-test");
     expect(e.provider).toBe("anthropic");
     expect(e.model).toBe("claude-sonnet-4-20250514");
@@ -357,5 +378,42 @@ describe("UsageTelemetryReporter", () => {
     expect(e.cache_read_input_tokens).toBe(15);
     expect(e.actor).toBe("context_compactor");
     expect(e.recorded_at).toBe(1700000099000);
+  });
+
+  test("turn events are included in the events array with type discriminator", async () => {
+    const usageEvent = makeUsageEvent({ id: "evt-mixed-usage" });
+    mockQueryUnreportedUsageEvents.mockReturnValue([usageEvent]);
+    mockQueryUnreportedTurnEvents.mockReturnValue([
+      { id: "evt-mixed-turn", createdAt: 1700000050000 },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+
+    // Single events array containing both types
+    expect(body.events.length).toBe(2);
+    expect(body.turn_events).toBeUndefined();
+
+    const llmEvent = body.events.find(
+      (e: { type: string }) => e.type === "llm_usage",
+    );
+    const turnEvent = body.events.find(
+      (e: { type: string }) => e.type === "turn",
+    );
+
+    expect(llmEvent).toBeDefined();
+    expect(llmEvent.daemon_event_id).toBe("evt-mixed-usage");
+
+    expect(turnEvent).toBeDefined();
+    expect(turnEvent.daemon_event_id).toBe("evt-mixed-turn");
+    expect(turnEvent.recorded_at).toBe(1700000050000);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -23,6 +23,7 @@ import { resolveManagedProxyContext } from "../providers/managed-proxy/context.j
 import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
+import type { TelemetryEvent } from "./types.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -37,7 +38,7 @@ const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
-const TELEMETRY_PATH = "/v1/assistants/self-hosted-local/telemetry/usage/";
+const TELEMETRY_PATH = "/v1/assistants/self-hosted-local/telemetry/ingest/";
 
 // ---------------------------------------------------------------------------
 // Reporter
@@ -129,24 +130,34 @@ export class UsageTelemetryReporter {
       }
 
       // Build payload
+      const typedEvents: TelemetryEvent[] = [
+        ...events.map(
+          (e): TelemetryEvent => ({
+            type: "llm_usage",
+            daemon_event_id: e.id,
+            provider: e.provider,
+            model: e.model,
+            input_tokens: e.inputTokens,
+            output_tokens: e.outputTokens,
+            cache_creation_input_tokens: e.cacheCreationInputTokens ?? null,
+            cache_read_input_tokens: e.cacheReadInputTokens ?? null,
+            actor: e.actor,
+            recorded_at: e.createdAt,
+          }),
+        ),
+        ...turnEvents.map(
+          (e): TelemetryEvent => ({
+            type: "turn",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+          }),
+        ),
+      ];
+
       const payload = {
         installation_id: getDeviceId(),
         assistant_id: getExternalAssistantId(),
-        events: events.map((e) => ({
-          daemon_event_id: e.id,
-          provider: e.provider,
-          model: e.model,
-          input_tokens: e.inputTokens,
-          output_tokens: e.outputTokens,
-          cache_creation_input_tokens: e.cacheCreationInputTokens ?? null,
-          cache_read_input_tokens: e.cacheReadInputTokens ?? null,
-          actor: e.actor,
-          recorded_at: e.createdAt,
-        })),
-        turn_events: turnEvents.map((e) => ({
-          daemon_event_id: e.id,
-          recorded_at: e.createdAt,
-        })),
+        events: typedEvents,
       };
 
       // Send


### PR DESCRIPTION
## Summary
- Switch telemetry reporter from v1 `/telemetry/usage/` to v2 `/telemetry/ingest/` endpoint
- Unify `events` and `turn_events` into a single typed `events` array with `type` discriminator (`llm_usage` / `turn`)
- Add turn event mocking to tests and new test for mixed event types

Part of plan: ndjson-telemetry.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
