### PR TITLE
perf: add os_signpost markers for chat layout measurement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 import VellumAssistantShared
 
@@ -405,6 +406,8 @@ struct AssistantProgressView: View {
 
     @ViewBuilder
     private var expandedContent: some View {
+        let _ = os_signpost(.event, log: PerfSignposts.log, name: "assistantProgressExpandedContent",
+                            "toolCallCount=%d", toolCalls.count)
         VStack(alignment: .leading, spacing: 0) {
             ForEach(toolCalls) { toolCall in
                 if !toolCall.isComplete && toolCall.toolName == "claude_code"

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 import VellumAssistantShared
 
@@ -161,6 +162,8 @@ struct ChatBubble: View {
     }
 
     var body: some View {
+        let _ = os_signpost(.event, log: PerfSignposts.log, name: "chatBubbleBody",
+                            "id=%{public}s streaming=%d", message.id.uuidString, message.isStreaming ? 1 : 0)
         // Outer HStack: Spacer pushes the content group to the correct side.
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -665,6 +665,10 @@ struct MessageListView: View {
                 .padding(.bottom, VSpacing.md)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
+                .background { Color.clear.onAppear {
+                    os_signpost(.event, log: PerfSignposts.log, name: "messageListBodyEvaluated",
+                                "count=%d", messages.count)
+                }}
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")


### PR DESCRIPTION
## Summary
- Adds `os_signpost` event markers to `MessageListView.body`, `ChatBubble.body`, and `AssistantProgressView` tool output
- Uses existing `PerfSignposts.log` for consistent signpost categorization
- Enables Instruments profiling of chat layout in DMG builds where Vellum frames aren't symbolicated

Part of plan: chat-layout-hang-fix.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
