### PR TITLE
perf: throttle high-frequency preference key updates in MessageListView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -28,6 +28,10 @@ extension EnvironmentValues {
     var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
     @Published var isVisible: Bool = true
 
+    /// Updates the tracked minY and recalculates visibility.
+    /// Only publishes `isVisible` when the boundary is actually crossed
+    /// (visible ↔ invisible), not on every scroll tick — this prevents
+    /// SwiftUI re-renders during continuous scrolling.
     func update(minY: CGFloat, viewportHeight: CGFloat) {
         lastMinY = minY
         let newVisible = minY >= -20 && minY <= viewportHeight + 20
@@ -165,6 +169,9 @@ struct MessageListView: View {
     @State private var avatarSmoothingTask: Task<Void, Never>?
     @State private var avatarLastAppliedAt: Date?
     @State private var hasPlayedTailEntryAnimation = false
+    /// Last reported ConversationTailAnchorYKey value. Used to apply a 2pt
+    /// dead-zone so that sub-pixel layout jitter doesn't trigger avatar updates.
+    @State private var lastTailAnchorY: CGFloat = .infinity
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -746,6 +753,9 @@ struct MessageListView: View {
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(AnchorMinYKey.self) { minY in
+                // 2pt dead-zone: skip update when value hasn't meaningfully changed,
+                // reducing layout invalidation cascades during rapid scroll.
+                guard abs(minY - anchorTracker.lastMinY) > 2 else { return }
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
                 anchorTracker.update(minY: minY, viewportHeight: scrollViewportHeight)
                 if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
@@ -753,6 +763,10 @@ struct MessageListView: View {
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in
+                // 2pt dead-zone: skip update when value hasn't meaningfully changed,
+                // reducing layout invalidation cascades during rapid scroll.
+                guard abs(anchorY - lastTailAnchorY) > 2 else { return }
+                lastTailAnchorY = anchorY
                 updateAvatarFollower(anchorY: anchorY)
             }
             .transaction { $0.disablesAnimations = true }


### PR DESCRIPTION
## Summary
- Adds 2pt dead-zone guard to `AnchorMinYKey` preference handler — skips update when new minY is within 2pt of last value
- Adds same dead-zone guard to `ConversationTailAnchorYKey` for avatar follower tracking
- Documents the existing `isVisible` boundary-crossing optimization in `AnchorVisibilityTracker`

Part of plan: chat-layout-hang-fix.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
