### PR TITLE
Flag Gmail send/modify scopes as optional during OAuth setup

### DIFF
--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -26,7 +26,9 @@ The flow has 9 steps total, takes about 3–5 minutes.
 
 ### Step 0: Prerequisite Check
 
-> Before we start — do you have a Google account you'd like to use for this?
+> Before we start — fair warning: this setup involves Google's developer console, which can feel pretty technical. Don't worry about that — you don't need to understand any of it. I'll open every page for you and tell you exactly what to click. If anything looks confusing or different from what I describe, just tell me and I'll figure it out.
+>
+> Do you have a Google account you'd like to use for this?
 
 If no Google account → guide them to create one or defer.
 

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -138,6 +138,8 @@ host_bash:
 > - **Non-sensitive:** `userinfo.email`, `contacts.readonly`
 > - **Sensitive:** `calendar.readonly`, `calendar.events`, `gmail.send`
 > - **Restricted:** `gmail.modify`, `gmail.readonly`
+>
+> **Quick note:** The `gmail.modify` and `gmail.send` scopes are what allow me to draft and send emails on your behalf. If you'd rather I only have read access to your email for now, you can uncheck those two — everything else will still work fine, and you can always come back and add them later.
 
 **Milestone (5 of 9):** "Over halfway — the fiddliest part is behind us."
 

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -8,7 +8,9 @@ Tell the user:
 
 > **Setting up Gmail & Calendar from chat**
 >
-> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+> Fair warning — this involves Google's developer console, which can feel pretty technical. Don't worry about that — you don't need to understand any of it. I'll give you a direct link for every step and tell you exactly what to do. If anything looks confusing, just let me know and I'll help you through it.
+>
+> Since I can't open pages in your browser from here, you'll need:
 >
 > 1. A Google account with access to Google Cloud Console
 > 2. About 5 minutes

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -85,6 +85,8 @@ Tell the user:
 >   - Click **Update** at the bottom of the panel
 >   - Back on the main page, scroll down and click **Save**
 >
+> **Quick note:** The `gmail.modify` and `gmail.send` scopes are what allow me to draft and send emails on your behalf. If you'd rather I only have read access to your email for now, you can remove those two from the list before pasting — everything else will still work fine, and you can always add them later.
+>
 > Let me know when all parts are done.
 
 ## Path B Step 5: Create Web Application Credentials


### PR DESCRIPTION
## Summary
- During Google OAuth setup, the assistant now tells users that `gmail.modify` and `gmail.send` are what enable drafting and sending emails
- Users can opt out of those scopes if they'd prefer read-only email access
- Applies to both the interactive (Path A) and manual (Path B) setup flows

## Test plan
- [ ] Run through Google OAuth setup (Path A) and verify the note appears at step 5c
- [ ] Verify Path B manual setup instructions include the same note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
