### PR TITLE
fix: prefix bare precomputed state references with state.

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -650,7 +650,7 @@ struct MessageListView: View {
                         } else {
                             thinkingIndicatorRow(displayMessages: state.displayMessages)
                         }
-                    } else if isCompacting && !shouldShowThinkingIndicator && !canInlineProcessing {
+                    } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                         compactingIndicatorRow()
                     }
 


### PR DESCRIPTION
## Summary
Fixes compile error where `shouldShowThinkingIndicator` and `canInlineProcessing` were used without `state.` prefix after the PrecomputedMessageListState refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
