### PR TITLE
fix: restore horizontal scrolling in ReadOnlyCodeContent

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -23,13 +23,14 @@ struct ReadOnlyCodeContent: View {
     let content: String
 
     var body: some View {
-        ScrollView(.vertical) {
+        ScrollView([.vertical, .horizontal]) {
             Text(content)
                 .font(VFont.mono)
                 .foregroundColor(VColor.contentDefault)
                 .textSelection(.enabled)
+                .fixedSize(horizontal: true, vertical: false)
                 .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(alignment: .topLeading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Restores horizontal scrolling axis on code content ScrollView that was removed in #17416
- Adds `fixedSize(horizontal: true, vertical: false)` on the Text so long code lines extend beyond the container width
- Long code lines are horizontally scrollable again

## Test plan
- [ ] Open a file with long lines in the code viewer
- [ ] Verify horizontal scrolling works for lines that exceed the container width
- [ ] Verify vertical scrolling still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
