### PR TITLE
fix: improve truncation detection and restore live output scroll anchor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -747,7 +747,8 @@ private struct StepDetailRow: View {
                         text: toolCall.partialOutput,
                         attributedText: nil,
                         copyText: toolCall.partialOutput,
-                        copyLabel: "Copy live output"
+                        copyLabel: "Copy live output",
+                        isLive: true
                     )
                 }
                 .padding(.horizontal, VSpacing.lg)
@@ -789,11 +790,12 @@ private struct StepDetailRow: View {
         text: String?,
         attributedText: AttributedString?,
         copyText: String,
-        copyLabel: String
+        copyLabel: String,
+        isLive: Bool = false
     ) -> some View {
         let isOutputExpanded = expandedOutputIds.contains(id)
         let lineCount = copyText.components(separatedBy: "\n").count
-        let needsTruncation = lineCount > 8
+        let needsTruncation = lineCount > 8 || copyText.count > 400
 
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -801,6 +803,9 @@ private struct StepDetailRow: View {
                     // Expanded with ScrollView for extremely long outputs
                     ScrollView {
                         outputTextView(text: text, attributedText: attributedText, lineLimit: nil)
+                    }
+                    .if(isLive) { view in
+                        view.defaultScrollAnchor(.bottom)
                     }
                     .frame(maxHeight: 400)
                 } else if let attrText = attributedText {


### PR DESCRIPTION
## Summary
- Adds character-count fallback (`> 400`) to truncation detection for visually-wrapped long lines
- Adds `isLive` parameter to `outputBlock` with `.defaultScrollAnchor(.bottom)` for streaming output
- Ensures "Show more" button appears whenever content is visually truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
