### PR TITLE
fix: complete MessageCellView Equatable with confirmation, subagent, and tool call state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1145,18 +1145,24 @@ private struct MessageCellView: View, Equatable {
         lhs.message.id == rhs.message.id
             && lhs.message.text.count == rhs.message.text.count
             && lhs.message.isStreaming == rhs.message.isStreaming
-            && lhs.message.toolCalls.count == rhs.message.toolCalls.count
+            && lhs.message.toolCalls == rhs.message.toolCalls
             && lhs.message.status == rhs.message.status
+            && lhs.message.confirmation == rhs.message.confirmation
+            && lhs.message.guardianDecision == rhs.message.guardianDecision
+            && lhs.message.inlineSurfaces.count == rhs.message.inlineSurfaces.count
             && lhs.index == rhs.index
             && lhs.showTimestamp == rhs.showTimestamp
             && lhs.activePendingRequestId == rhs.activePendingRequestId
             && lhs.latestAssistantId == rhs.latestAssistantId
+            && lhs.anchoredThinkingIndex == rhs.anchoredThinkingIndex
+            && lhs.subagentsByParent[lhs.message.id]?.count == rhs.subagentsByParent[rhs.message.id]?.count
             && lhs.canInlineProcessing == rhs.canInlineProcessing
             && lhs.shouldShowThinkingIndicator == rhs.shouldShowThinkingIndicator
             && lhs.assistantStatusText == rhs.assistantStatusText
             && lhs.dismissedDocumentSurfaceIds == rhs.dismissedDocumentSurfaceIds
             && lhs.activeSurfaceId == rhs.activeSurfaceId
             && lhs.selectedModel == rhs.selectedModel
+            && lhs.configuredProviders == rhs.configuredProviders
     }
 
     let message: ChatMessage


### PR DESCRIPTION
## Summary
- Upgrades `toolCalls` comparison from count-only to full equality so tool call status/output changes trigger re-renders
- Adds `message.confirmation` comparison so tool confirmation approve/deny updates the UI
- Adds `message.guardianDecision` comparison so guardian decision state and isSubmitting changes re-render
- Adds `message.inlineSurfaces.count` comparison so new inline surfaces appear
- Adds `anchoredThinkingIndex` comparison so the thinking indicator tracks the correct message
- Adds `subagentsByParent[message.id]?.count` comparison so subagent rows appear/update
- Adds `configuredProviders` comparison so model list rendering stays current

## Test plan
- [ ] Verify tool confirmation approve/deny buttons update immediately when clicked
- [ ] Verify guardian decision UI updates without needing to scroll away and back
- [ ] Verify subagent rows appear as they are spawned during a conversation
- [ ] Verify thinking indicator moves correctly between messages
- [ ] Verify tool call status changes (running -> complete) render promptly
- [ ] Verify inline surfaces appear when emitted by the assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
