### PR TITLE
fix: fire messageListBodyEvaluated signpost on every body evaluation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -551,6 +551,8 @@ struct MessageListView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.md) {
+                    let _ = os_signpost(.event, log: PerfSignposts.log, name: "messageListBodyEvaluated",
+                                        "count=%d", messages.count)
                     // MARK: - Pagination sentinel
 
                     if isLoadingMoreMessages {
@@ -699,10 +701,6 @@ struct MessageListView: View {
                 .padding(.bottom, VSpacing.md)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
-                .background { Color.clear.onAppear {
-                    os_signpost(.event, log: PerfSignposts.log, name: "messageListBodyEvaluated",
-                                "count=%d", messages.count)
-                }}
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")


### PR DESCRIPTION
## Summary
- Replaces `.background { Color.clear.onAppear { os_signpost(...) } }` with `let _ = os_signpost(...)` directly in the LazyVStack body
- Ensures the signpost fires on every body re-evaluation, not just initial appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
