### PR TITLE
feat: flash-highlight message after notification deep-link scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -68,6 +68,8 @@ struct ChatView: View {
     var onRequestGreeting: (() -> Void)? = nil
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
+    /// Message ID to visually highlight after an anchor scroll completes.
+    @Binding var highlightedMessageId: UUID?
 
     // MARK: - BTW Side-Chain
 
@@ -222,6 +224,7 @@ struct ChatView: View {
                             loadPreviousMessagePage: loadPreviousMessagePage,
                             threadId: threadId,
                             anchorMessageId: $anchorMessageId,
+                            highlightedMessageId: $highlightedMessageId,
                             isNearBottom: $isNearBottom,
                             containerWidth: containerWidth
                         )
@@ -790,6 +793,7 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
 private struct ChatViewPreviewWrapper: View {
     @State private var text = ""
     @State private var anchorMessageId: UUID?
+    @State private var highlightedMessageId: UUID?
 
     private let sampleMessages: [ChatMessage] = [
         ChatMessage(role: .assistant, text: "Hello! How can I help you today?"),
@@ -834,7 +838,8 @@ private struct ChatViewPreviewWrapper: View {
                 watchSession: nil,
                 onStopWatch: {},
                 subagentDetailStore: SubagentDetailStore(),
-                anchorMessageId: $anchorMessageId
+                anchorMessageId: $anchorMessageId,
+                highlightedMessageId: $highlightedMessageId
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -98,6 +98,8 @@ struct MessageListView: View {
     /// When set, scroll to this message ID and clear the binding.
     /// Used by notification deep links to anchor the view to a specific message.
     @Binding var anchorMessageId: UUID?
+    /// Message ID to visually highlight after an anchor scroll completes.
+    @Binding var highlightedMessageId: UUID?
     @Binding var isNearBottom: Bool
     /// Measured width of the chat container, used to detect sidebar/split resizes
     /// and stabilize scroll position during layout width changes.
@@ -156,6 +158,8 @@ struct MessageListView: View {
     @State private var lastHandledContainerWidth: CGFloat = 0
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State private var resizeScrollTask: Task<Void, Never>?
+    /// Task that clears the highlight flash after the animation duration.
+    @State private var highlightDismissTask: Task<Void, Never>?
     /// In-flight staged scroll-to-bottom task used after thread switches and
     /// app restarts to reliably anchor the viewport once layout settles.
     @State private var scrollRestoreTask: Task<Void, Never>?
@@ -490,6 +494,25 @@ struct MessageListView: View {
         }
     }
 
+    /// Flash-highlight the given message after an anchor scroll completes.
+    /// The highlight fades out automatically after 1.5 seconds.
+    private func flashHighlight(messageId: UUID) {
+        highlightDismissTask?.cancel()
+        highlightedMessageId = messageId
+        highlightDismissTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 1_500_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            withAnimation(VAnimation.slow) {
+                highlightedMessageId = nil
+            }
+            highlightDismissTask = nil
+        }
+    }
+
     private var shouldAnchorThinkingToConfirmationChip: Bool {
         assistantActivityPhase == "thinking"
             && assistantActivityAnchor == "assistant_turn"
@@ -609,6 +632,7 @@ struct MessageListView: View {
                             assistantStatusText: state.effectiveStatusText,
                             dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                             activeSurfaceId: activeSurfaceId,
+                            isHighlighted: highlightedMessageId == message.id,
                             mediaEmbedSettings: mediaEmbedSettings,
                             resolveHttpPort: resolveHttpPort,
                             onConfirmationAllow: onConfirmationAllow,
@@ -805,6 +829,7 @@ struct MessageListView: View {
                     // Anchor is already set and the target message is loaded —
                     // scroll to it immediately instead of falling through to bottom.
                     proxy.scrollTo(id, anchor: .center)
+                    flashHighlight(messageId: id)
                     anchorMessageId = nil
                     anchorSetTime = nil
                 } else if anchorMessageId != nil {
@@ -857,6 +882,8 @@ struct MessageListView: View {
                 scrollRestoreTask = nil
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
+                highlightDismissTask?.cancel()
+                highlightDismissTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -920,6 +947,7 @@ struct MessageListView: View {
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)
                     }
+                    flashHighlight(messageId: id)
                     anchorMessageId = nil
                     anchorSetTime = nil
                     anchorTimeoutTask?.cancel()
@@ -1011,6 +1039,9 @@ struct MessageListView: View {
                 isPaginationInFlight = false
                 isSuppressingBottomScroll = false
                 isNearBottom = true
+                highlightedMessageId = nil
+                highlightDismissTask?.cancel()
+                highlightDismissTask = nil
                 anchorTracker.isVisible = true
                 anchorTracker.lastMinY = 0
                 hasReceivedScrollEvent = false
@@ -1063,6 +1094,7 @@ struct MessageListView: View {
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)
                     }
+                    flashHighlight(messageId: id)
                     anchorMessageId = nil
                     anchorSetTime = nil
                 } else {
@@ -1156,6 +1188,7 @@ private struct MessageCellView: View, Equatable {
             && lhs.assistantStatusText == rhs.assistantStatusText
             && lhs.dismissedDocumentSurfaceIds == rhs.dismissedDocumentSurfaceIds
             && lhs.activeSurfaceId == rhs.activeSurfaceId
+            && lhs.isHighlighted == rhs.isHighlighted
             && lhs.selectedModel == rhs.selectedModel
     }
 
@@ -1172,6 +1205,8 @@ private struct MessageCellView: View, Equatable {
     let assistantStatusText: String?
     let dismissedDocumentSurfaceIds: Set<String>
     let activeSurfaceId: String?
+    /// When true, the cell renders a brief highlight flash.
+    let isHighlighted: Bool
     let mediaEmbedSettings: MediaEmbedResolverSettings?
     let resolveHttpPort: () -> Int?
     let onConfirmationAllow: (String) -> Void
@@ -1343,6 +1378,13 @@ private struct MessageCellView: View, Equatable {
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
                 activeSurfaceId: activeSurfaceId
             )
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.primaryBase.opacity(isHighlighted ? 0.15 : 0))
+                    .padding(.horizontal, -VSpacing.sm)
+                    .padding(.vertical, -VSpacing.xs)
+            )
+            .animation(VAnimation.slow, value: isHighlighted)
             .id(message.id)
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -383,7 +383,8 @@ extension MainWindowView {
                     toggleVoiceMode()
                 },
                 threadId: threadManager.activeThreadId,
-                anchorMessageId: $threadManager.pendingAnchorMessageId
+                anchorMessageId: $threadManager.pendingAnchorMessageId,
+                highlightedMessageId: $threadManager.highlightedMessageId
             )
             .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
             .overlay(alignment: .top) {
@@ -580,6 +581,7 @@ struct ActiveChatViewWrapper: View {
     var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
     @Binding var anchorMessageId: UUID?
+    @Binding var highlightedMessageId: UUID?
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -693,6 +695,7 @@ struct ActiveChatViewWrapper: View {
             daemonGreeting: viewModel.emptyStateGreeting,
             onRequestGreeting: { [weak viewModel] in viewModel?.generateGreeting() },
             anchorMessageId: $anchorMessageId,
+            highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,
             btwLoading: viewModel.btwLoading,
             onDismissBtw: { viewModel.dismissBtw() },

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -135,6 +135,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var interactionStateCancellables: [UUID: Set<AnyCancellable>] = [:]
     /// Pending anchor message ID for scroll-to behavior on notification deep links.
     @Published var pendingAnchorMessageId: UUID?
+    /// Message ID to visually highlight after an anchor scroll completes.
+    /// Set by MessageListView when it scrolls to the anchor, cleared after the flash animation.
+    @Published var highlightedMessageId: UUID?
     /// Tracks which thread the pending anchor belongs to so stale anchors are
     /// cleared automatically when the user switches to a different thread.
     private var pendingAnchorThreadId: UUID?


### PR DESCRIPTION
## Summary
- When clicking a macOS notification that targets a specific message, the app now flash-highlights that message with a subtle accent-colored glow that fades after 1.5 seconds
- The highlight is triggered at all 3 anchor-scroll completion points (onAppear, messages.count change, anchorMessageId change) and cleaned up on disappear/thread switch
- Added `isHighlighted` to MessageCellView's Equatable conformance so the EquatableView wrapper correctly re-renders on highlight state changes

## Original prompt
Add auto-scroll and highlight for the corresponding message when clicking a notification deep link, or at least auto-scroll to the bottom/latest of the thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
