### PR TITLE
feat: thread USER.md/SOUL.md/IDENTITY.md into notification decision engine

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -20,6 +20,7 @@ import {
   userMessage,
 } from "../providers/provider-send-message.js";
 import type { ModelIntent } from "../providers/types.js";
+import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import { getLogger } from "../util/logger.js";
 import {
   buildConversationCandidates,
@@ -60,6 +61,7 @@ function buildSystemPrompt(
   availableChannels: NotificationChannel[],
   preferenceContext?: string,
   candidateContext?: string,
+  identityContext?: string,
 ): string {
   const sections: string[] = [
     `You are a notification routing engine. Given a signal describing an event, decide whether the user should be notified, on which channel(s), and compose the notification copy.`,
@@ -73,6 +75,16 @@ function buildSystemPrompt(
       `<user-preferences>`,
       preferenceContext,
       `</user-preferences>`,
+    );
+  }
+
+  if (identityContext) {
+    sections.push(
+      ``,
+      `<assistant-identity>`,
+      `The following describes the assistant's identity, personality, and the user's profile. Use this context to match the assistant's tone and style when composing notification copy. Do not include information from this context that is not relevant to the notification.`,
+      identityContext,
+      `</assistant-identity>`,
     );
   }
 
@@ -777,10 +789,12 @@ async function classifyWithLLM(
   const candidateContext = candidateSet
     ? (serializeCandidatesForPrompt(candidateSet) ?? undefined)
     : undefined;
+  const identityContext = buildCoreIdentityContext() ?? undefined;
   const systemPrompt = buildSystemPrompt(
     availableChannels,
     preferenceContext,
     candidateContext,
+    identityContext,
   );
   const prompt = buildUserPrompt(signal);
   const tool = buildDecisionTool(availableChannels);


### PR DESCRIPTION
## Summary
- Thread `buildCoreIdentityContext()` (SOUL.md, IDENTITY.md, USER.md) into the notification decision engine's system prompt
- Identity context is injected in an `<assistant-identity>` block after user preferences so notification copy reflects the assistant's personality and user profile
- No truncation applied; deterministic fallback path is unaffected

Part of plan: notification-identity-context.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
