### PR TITLE
refactor: rename followups/sequences threadId columns and symbols to conversationId

### DIFF
--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -79,7 +79,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-123",
+        conversation_id: "thread-123",
       },
       ctx,
     );
@@ -95,7 +95,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "slack",
-        thread_id: "slack-thread-1",
+        conversation_id: "slack-thread-1",
         expected_response_hours: 24,
       },
       ctx,
@@ -109,7 +109,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-456",
+        conversation_id: "thread-456",
         reminder_schedule_id: "sched-abc",
       },
       ctx,
@@ -122,7 +122,7 @@ describe("followup_create tool", () => {
   test("rejects missing channel", async () => {
     const result = await executeFollowupCreate(
       {
-        thread_id: "thread-123",
+        conversation_id: "thread-123",
       },
       ctx,
     );
@@ -135,7 +135,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "   ",
-        thread_id: "thread-123",
+        conversation_id: "thread-123",
       },
       ctx,
     );
@@ -144,7 +144,7 @@ describe("followup_create tool", () => {
     expect(result.content).toContain("channel is required");
   });
 
-  test("rejects missing thread_id", async () => {
+  test("rejects missing conversation_id", async () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
@@ -153,14 +153,14 @@ describe("followup_create tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("thread_id is required");
+    expect(result.content).toContain("conversation_id is required");
   });
 
   test("rejects non-positive expected_response_hours", async () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-123",
+        conversation_id: "thread-123",
         expected_response_hours: -1,
       },
       ctx,
@@ -176,7 +176,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-123",
+        conversation_id: "thread-123",
         contact_id: "nonexistent-contact",
       },
       ctx,
@@ -201,11 +201,11 @@ describe("followup_list tool", () => {
 
   test("lists all follow-ups", async () => {
     await executeFollowupCreate(
-      { channel: "email", thread_id: "thread-1" },
+      { channel: "email", conversation_id: "thread-1" },
       ctx,
     );
     await executeFollowupCreate(
-      { channel: "slack", thread_id: "thread-2" },
+      { channel: "slack", conversation_id: "thread-2" },
       ctx,
     );
 
@@ -219,7 +219,7 @@ describe("followup_list tool", () => {
 
   test("filters by status", async () => {
     await executeFollowupCreate(
-      { channel: "email", thread_id: "thread-1" },
+      { channel: "email", conversation_id: "thread-1" },
       ctx,
     );
 
@@ -231,11 +231,11 @@ describe("followup_list tool", () => {
 
   test("filters by channel", async () => {
     await executeFollowupCreate(
-      { channel: "email", thread_id: "thread-1" },
+      { channel: "email", conversation_id: "thread-1" },
       ctx,
     );
     await executeFollowupCreate(
-      { channel: "slack", thread_id: "thread-2" },
+      { channel: "slack", conversation_id: "thread-2" },
       ctx,
     );
 
@@ -263,7 +263,7 @@ describe("followup_resolve tool", () => {
     const createResult = await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-1",
+        conversation_id: "thread-1",
       },
       ctx,
     );
@@ -276,11 +276,11 @@ describe("followup_resolve tool", () => {
     expect(result.content).toContain("Status: resolved");
   });
 
-  test("resolves by channel and thread_id", async () => {
+  test("resolves by channel and conversation_id", async () => {
     await executeFollowupCreate(
       {
         channel: "email",
-        thread_id: "thread-1",
+        conversation_id: "thread-1",
       },
       ctx,
     );
@@ -288,7 +288,7 @@ describe("followup_resolve tool", () => {
     const result = await executeFollowupResolve(
       {
         channel: "email",
-        thread_id: "thread-1",
+        conversation_id: "thread-1",
       },
       ctx,
     );
@@ -299,18 +299,18 @@ describe("followup_resolve tool", () => {
 
   test("resolves multiple follow-ups by thread", async () => {
     await executeFollowupCreate(
-      { channel: "email", thread_id: "shared-thread" },
+      { channel: "email", conversation_id: "shared-thread" },
       ctx,
     );
     await executeFollowupCreate(
-      { channel: "email", thread_id: "shared-thread" },
+      { channel: "email", conversation_id: "shared-thread" },
       ctx,
     );
 
     const result = await executeFollowupResolve(
       {
         channel: "email",
-        thread_id: "shared-thread",
+        conversation_id: "shared-thread",
       },
       ctx,
     );
@@ -323,7 +323,7 @@ describe("followup_resolve tool", () => {
     const result = await executeFollowupResolve(
       {
         channel: "email",
-        thread_id: "nonexistent",
+        conversation_id: "nonexistent",
       },
       ctx,
     );
@@ -339,12 +339,12 @@ describe("followup_resolve tool", () => {
     expect(result.content).toContain("not found");
   });
 
-  test("rejects when neither id nor channel+thread_id provided", async () => {
+  test("rejects when neither id nor channel+conversation_id provided", async () => {
     const result = await executeFollowupResolve({}, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain(
-      "Either id or both channel and thread_id are required",
+      "Either id or both channel and conversation_id are required",
     );
   });
 });

--- a/assistant/src/__tests__/sequence-store.test.ts
+++ b/assistant/src/__tests__/sequence-store.test.ts
@@ -58,7 +58,7 @@ const testSteps: SequenceStep[] = [
     delaySeconds: 0,
     subjectTemplate: "Intro",
     bodyPrompt: "Write an intro email",
-    replyToThread: false,
+    replyInSameConversation: false,
     requireApproval: false,
   },
   {
@@ -66,7 +66,7 @@ const testSteps: SequenceStep[] = [
     delaySeconds: 86400,
     subjectTemplate: "Follow up",
     bodyPrompt: "Write a follow-up",
-    replyToThread: true,
+    replyInSameConversation: true,
     requireApproval: false,
   },
   {
@@ -74,7 +74,7 @@ const testSteps: SequenceStep[] = [
     delaySeconds: 259200,
     subjectTemplate: "Final check",
     bodyPrompt: "Write a final check-in",
-    replyToThread: true,
+    replyInSameConversation: true,
     requireApproval: true,
   },
 ];
@@ -364,7 +364,7 @@ describe("sequence-store", () => {
           delaySeconds: 86400,
           subjectTemplate: "Future",
           bodyPrompt: "Later",
-          replyToThread: false,
+          replyInSameConversation: false,
           requireApproval: false,
         },
       ];
@@ -444,7 +444,7 @@ describe("sequence-store", () => {
         Date.now() + 86400000,
       );
       expect(advanced!.currentStep).toBe(1);
-      expect(advanced!.threadId).toBe("thread-123");
+      expect(advanced!.conversationId).toBe("thread-123");
     });
 
     test("returns undefined for non-existent id", () => {

--- a/assistant/src/config/bundled-skills/followups/SKILL.md
+++ b/assistant/src/config/bundled-skills/followups/SKILL.md
@@ -27,7 +27,7 @@ When `expected_response_hours` is set, the follow-up automatically becomes overd
 
 Follow-ups can be resolved in two ways:
 1. **By ID** -- resolve a specific follow-up directly
-2. **By thread** -- provide channel + thread_id to auto-resolve all matching pending follow-ups (useful when a response arrives on a thread)
+2. **By conversation** -- provide channel + conversation_id to auto-resolve all matching pending follow-ups (useful when a response arrives on a conversation)
 
 ## Tips
 

--- a/assistant/src/config/bundled-skills/followups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/followups/TOOLS.json
@@ -13,9 +13,9 @@
             "type": "string",
             "description": "Communication channel (e.g. email, slack, whatsapp)"
           },
-          "thread_id": {
+          "conversation_id": {
             "type": "string",
-            "description": "External thread or conversation identifier on that channel"
+            "description": "External conversation identifier on that channel"
           },
           "contact_id": {
             "type": "string",
@@ -34,7 +34,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["channel", "thread_id"]
+        "required": ["channel", "conversation_id"]
       },
       "executor": "tools/followup-create.ts",
       "execution_target": "host"
@@ -76,7 +76,7 @@
     },
     {
       "name": "followup_resolve",
-      "description": "Manually resolve a follow-up by ID, or auto-resolve by channel + thread ID when a response is received.",
+      "description": "Manually resolve a follow-up by ID, or auto-resolve by channel + conversation ID when a response is received.",
       "category": "followups",
       "risk": "low",
       "input_schema": {
@@ -88,11 +88,11 @@
           },
           "channel": {
             "type": "string",
-            "description": "Channel to match (used with thread_id for auto-resolution)"
+            "description": "Channel to match (used with conversation_id for auto-resolution)"
           },
-          "thread_id": {
+          "conversation_id": {
             "type": "string",
-            "description": "Thread ID to match (used with channel for auto-resolution)"
+            "description": "Conversation ID to match (used with channel for auto-resolution)"
           },
           "reason": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -34,9 +34,9 @@
                   "type": "string",
                   "description": "Prompt or body text for this step"
                 },
-                "reply_to_thread": {
+                "reply_in_same_conversation": {
                   "type": "boolean",
-                  "description": "Whether to reply in the existing thread (default true for step 2+)"
+                  "description": "Whether to reply in the same conversation (default true for step 2+)"
                 },
                 "require_approval": {
                   "type": "boolean",
@@ -164,9 +164,9 @@
                   "type": "string",
                   "description": "Prompt or body text for this step"
                 },
-                "reply_to_thread": {
+                "reply_in_same_conversation": {
                   "type": "boolean",
-                  "description": "Whether to reply in the existing thread"
+                  "description": "Whether to reply in the same conversation"
                 },
                 "require_approval": {
                   "type": "boolean",

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
@@ -27,7 +27,8 @@ export async function run(
       delaySeconds: (s.delay_seconds as number) ?? 0,
       subjectTemplate: (s.subject as string) ?? `Step ${i + 1}`,
       bodyPrompt: (s.body_prompt as string) ?? "",
-      replyToThread: (s.reply_to_thread as boolean) ?? i > 0,
+      replyInSameConversation:
+        (s.reply_in_same_conversation as boolean) ?? i > 0,
       requireApproval: (s.require_approval as boolean) ?? false,
     }));
 

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
@@ -101,7 +101,8 @@ export async function run(
         delaySeconds: (s.delay_seconds as number) ?? 0,
         subjectTemplate: (s.subject as string) ?? `Step ${i + 1}`,
         bodyPrompt: (s.body_prompt as string) ?? "",
-        replyToThread: (s.reply_to_thread as boolean) ?? i > 0,
+        replyInSameConversation:
+          (s.reply_in_same_conversation as boolean) ?? i > 0,
         requireApproval: (s.require_approval as boolean) ?? false,
       }),
     );

--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -12,7 +12,7 @@ function parseFollowUp(row: typeof followups.$inferSelect): FollowUp {
   return {
     id: row.id,
     channel: row.channel,
-    threadId: row.threadId,
+    conversationId: row.conversationId,
     contactId: row.contactId,
     sentAt: row.sentAt,
     expectedResponseBy: row.expectedResponseBy,
@@ -34,7 +34,7 @@ export function createFollowUp(input: FollowUpCreateInput): FollowUp {
     .values({
       id,
       channel: input.channel,
-      threadId: input.threadId,
+      conversationId: input.conversationId,
       contactId: input.contactId ?? null,
       sentAt: input.sentAt ?? now,
       expectedResponseBy: input.expectedResponseBy ?? null,
@@ -104,18 +104,21 @@ export function resolveFollowUp(id: string): FollowUp {
   return getFollowUp(id)!;
 }
 
-export function resolveByThread(channel: string, threadId: string): FollowUp[] {
+export function resolveByConversation(
+  channel: string,
+  conversationId: string,
+): FollowUp[] {
   const db = getDb();
   const now = Date.now();
 
-  // Find ALL pending/overdue/nudged follow-ups matching this thread
+  // Find ALL pending/overdue/nudged follow-ups matching this conversation
   const rows = db
     .select()
     .from(followups)
     .where(
       and(
         eq(followups.channel, channel),
-        eq(followups.threadId, threadId),
+        eq(followups.conversationId, conversationId),
         or(
           eq(followups.status, "pending"),
           eq(followups.status, "overdue"),

--- a/assistant/src/followups/types.ts
+++ b/assistant/src/followups/types.ts
@@ -3,7 +3,7 @@ export type FollowUpStatus = "pending" | "resolved" | "overdue" | "nudged";
 export interface FollowUp {
   id: string;
   channel: string;
-  threadId: string;
+  conversationId: string;
   contactId: string | null;
   sentAt: number;
   expectedResponseBy: number | null;
@@ -15,7 +15,7 @@ export interface FollowUp {
 
 export interface FollowUpCreateInput {
   channel: string;
-  threadId: string;
+  conversationId: string;
   contactId?: string | null;
   sentAt?: number;
   expectedResponseBy?: number | null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -82,9 +82,11 @@ import {
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
+  migrateRenameFollowupsThreadIdColumn,
   migrateRenameGuardianVerificationValues,
   migrateRenameInboxThreadStateTable,
   migrateRenameNotificationThreadColumns,
+  migrateRenameSequenceEnrollmentsThreadIdColumn,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
@@ -407,6 +409,12 @@ export function initializeDb(): void {
 
   // 68. Rename notification_deliveries thread columns → conversation columns
   migrateRenameNotificationThreadColumns(database);
+
+  // 69. Rename followups.thread_id → conversation_id
+  migrateRenameFollowupsThreadIdColumn(database);
+
+  // 70. Rename sequence_enrollments.thread_id → conversation_id
+  migrateRenameSequenceEnrollmentsThreadIdColumn(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/166-rename-followups-thread-id.ts
+++ b/assistant/src/memory/migrations/166-rename-followups-thread-id.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Rename followups.thread_id → conversation_id, aligning with the broader
+ * thread → conversation terminology unification.
+ *
+ * Wrapped in try/catch for idempotency (SQLite throws if the source column
+ * does not exist, meaning it was already renamed).
+ */
+export function migrateRenameFollowupsThreadIdColumn(
+  database: DrizzleDb,
+): void {
+  try {
+    database.run(
+      `ALTER TABLE followups RENAME COLUMN thread_id TO conversation_id`,
+    );
+  } catch {
+    /* already renamed */
+  }
+}

--- a/assistant/src/memory/migrations/167-rename-sequence-enrollments-thread-id.ts
+++ b/assistant/src/memory/migrations/167-rename-sequence-enrollments-thread-id.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Rename sequence_enrollments.thread_id → conversation_id, aligning with the
+ * broader thread → conversation terminology unification.
+ *
+ * Wrapped in try/catch for idempotency (SQLite throws if the source column
+ * does not exist, meaning it was already renamed).
+ */
+export function migrateRenameSequenceEnrollmentsThreadIdColumn(
+  database: DrizzleDb,
+): void {
+  try {
+    database.run(
+      `ALTER TABLE sequence_enrollments RENAME COLUMN thread_id TO conversation_id`,
+    );
+  } catch {
+    /* already renamed */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -107,6 +107,8 @@ export { migrateGuardianTimestampsEpochMs } from "./162-guardian-timestamps-epoc
 export { migrateRenameNotificationThreadColumns } from "./163-rename-notification-thread-columns.js";
 export { migrateRenameConversationTypeColumn } from "./164-rename-conversation-type-column.js";
 export { migrateRenameInboxThreadStateTable } from "./165-rename-inbox-thread-state-table.js";
+export { migrateRenameFollowupsThreadIdColumn } from "./166-rename-followups-thread-id.js";
+export { migrateRenameSequenceEnrollmentsThreadIdColumn } from "./167-rename-sequence-enrollments-thread-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/notifications.ts
+++ b/assistant/src/memory/schema/notifications.ts
@@ -70,7 +70,7 @@ export const sequenceEnrollments = sqliteTable(
     contactName: text("contact_name"),
     currentStep: integer("current_step").notNull().default(0),
     status: text("status").notNull().default("active"), // active | paused | completed | replied | cancelled | failed
-    threadId: text("thread_id"),
+    conversationId: text("conversation_id"),
     nextStepAt: integer("next_step_at"), // epoch ms
     context: text("context"), // JSON
     createdAt: integer("created_at").notNull(),

--- a/assistant/src/memory/schema/tasks.ts
+++ b/assistant/src/memory/schema/tasks.ts
@@ -65,7 +65,7 @@ export const workItems = sqliteTable("work_items", {
 export const followups = sqliteTable("followups", {
   id: text("id").primaryKey(),
   channel: text("channel").notNull(), // 'email', 'slack', 'whatsapp', etc.
-  threadId: text("thread_id").notNull(), // external thread/conversation identifier
+  conversationId: text("conversation_id").notNull(), // external conversation identifier
   contactId: text("contact_id").references(() => contacts.id, {
     onDelete: "set null",
   }),

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -19,7 +19,7 @@ import {
   getEnrollment,
   getSequence,
   rescheduleEnrollment,
-  updateEnrollmentThreadId,
+  updateEnrollmentConversationId,
 } from "./store.js";
 import type { Sequence, SequenceEnrollment, SequenceStep } from "./types.js";
 
@@ -166,13 +166,13 @@ async function processEnrollment(
   await processMessage(conversation.id, prompt);
 
   // Try to extract the email thread ID from conversation tool results so
-  // subsequent steps can reply in the same thread.
-  const threadId =
+  // subsequent steps can reply in the same conversation.
+  const extractedConversationId =
     extractThreadIdFromConversation(conversation.id) ?? undefined;
-  if (threadId) {
+  if (extractedConversationId) {
     log.info(
-      { enrollmentId: enrollment.id, threadId },
-      "Captured thread ID from step execution",
+      { enrollmentId: enrollment.id, conversationId: extractedConversationId },
+      "Captured conversation ID from step execution",
     );
   }
 
@@ -181,7 +181,8 @@ async function processEnrollment(
   // null so it won't be re-claimed. The approval/send flow is responsible
   // for advancing the enrollment once the draft is approved.
   if (step.requireApproval) {
-    if (threadId) updateEnrollmentThreadId(enrollment.id, threadId);
+    if (extractedConversationId)
+      updateEnrollmentConversationId(enrollment.id, extractedConversationId);
     log.info(
       {
         enrollmentId: enrollment.id,
@@ -203,7 +204,7 @@ async function processEnrollment(
   const nextStepIndex = enrollment.currentStep + 1;
   if (nextStepIndex >= sequence.steps.length) {
     // This was the final step
-    advanceEnrollment(enrollment.id, threadId, null);
+    advanceEnrollment(enrollment.id, extractedConversationId, null);
     recordEvent(sequence.id, enrollment.id, "complete", step.index);
     exitEnrollment(enrollment.id, "completed");
     log.info(
@@ -213,7 +214,7 @@ async function processEnrollment(
   } else {
     const nextStep = sequence.steps[nextStepIndex];
     const nextStepAt = Date.now() + nextStep.delaySeconds * 1000;
-    advanceEnrollment(enrollment.id, threadId, nextStepAt);
+    advanceEnrollment(enrollment.id, extractedConversationId, nextStepAt);
     log.info(
       {
         enrollmentId: enrollment.id,
@@ -264,9 +265,9 @@ function buildStepPrompt(
     parts.push(`Send an email with subject "${step.subjectTemplate}".`);
   }
 
-  if (step.replyToThread && enrollment.threadId) {
+  if (step.replyInSameConversation && enrollment.conversationId) {
     parts.push(
-      `Reply in the existing thread (thread ID: ${enrollment.threadId}).`,
+      `Reply in the existing conversation (conversation ID: ${enrollment.conversationId}).`,
     );
   }
 

--- a/assistant/src/sequence/reply-matcher.ts
+++ b/assistant/src/sequence/reply-matcher.ts
@@ -4,7 +4,7 @@
  *
  * Called from the watcher engine after new events are stored.
  * Matches by sender email against active enrollment contact_email
- * AND thread_id — both must match for a reply to trigger an exit.
+ * AND conversationId — both must match for a reply to trigger an exit.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -54,7 +54,7 @@ export interface ReplyMatchResult {
   contactEmail: string;
   sequenceId: string;
   sequenceName: string;
-  threadId?: string;
+  conversationId?: string;
 }
 
 /**
@@ -77,15 +77,18 @@ export function checkForSequenceReplies(
       const seq = getSequence(enrollment.sequenceId);
       if (!seq || !seq.exitOnReply) continue;
 
-      // Only match when the enrollment has a thread ID and it matches the
-      // incoming payload. Enrollments that haven't sent their first email
-      // yet (threadId is null) are not eligible for reply-based exit —
-      // otherwise any unrelated inbound email from the contact would
-      // prematurely kill the enrollment.
-      const threadMatch =
-        enrollment.threadId != null && enrollment.threadId === payload.threadId;
+      // Only match when the enrollment has a conversation ID and it matches
+      // the incoming payload's thread ID. Enrollments that haven't sent their
+      // first email yet (conversationId is null) are not eligible for
+      // reply-based exit — otherwise any unrelated inbound email from the
+      // contact would prematurely kill the enrollment.
+      // Note: payload.threadId is the external provider's thread identifier
+      // (e.g. Gmail API thread ID) which maps to enrollment.conversationId.
+      const conversationMatch =
+        enrollment.conversationId != null &&
+        enrollment.conversationId === payload.threadId;
 
-      if (!threadMatch) continue;
+      if (!conversationMatch) continue;
 
       recordEvent(
         enrollment.sequenceId,
@@ -94,7 +97,7 @@ export function checkForSequenceReplies(
         enrollment.currentStep,
         {
           senderEmail,
-          threadId: payload.threadId,
+          conversationId: payload.threadId,
         },
       );
       exitEnrollment(enrollment.id, "replied");
@@ -103,7 +106,7 @@ export function checkForSequenceReplies(
         {
           enrollmentId: enrollment.id,
           senderEmail,
-          threadId: payload.threadId,
+          conversationId: payload.threadId,
         },
         "Sequence enrollment exited on reply",
       );
@@ -113,7 +116,7 @@ export function checkForSequenceReplies(
         contactEmail: enrollment.contactEmail,
         sequenceId: enrollment.sequenceId,
         sequenceName: seq.name,
-        threadId: payload.threadId,
+        conversationId: payload.threadId,
       });
     }
   }

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -58,7 +58,7 @@ const parseEnrollmentRow = createRowMapper<
   contactName: "contactName",
   currentStep: "currentStep",
   status: { from: "status", transform: cast<SequenceEnrollment["status"]>() },
-  threadId: "threadId",
+  conversationId: "conversationId",
   nextStepAt: "nextStepAt",
   context: {
     from: "context",
@@ -168,7 +168,7 @@ export function enrollContact(input: EnrollContactInput): SequenceEnrollment {
     contactName: input.contactName ?? null,
     currentStep: 0,
     status: "active" as const,
-    threadId: null,
+    conversationId: null,
     nextStepAt,
     context: input.context ? JSON.stringify(input.context) : null,
     createdAt: now,
@@ -267,7 +267,7 @@ export function claimDueEnrollments(
 
 export function advanceEnrollment(
   id: string,
-  threadId?: string,
+  conversationId?: string,
   nextStepAt?: number | null,
 ): SequenceEnrollment | undefined {
   const db = getDb();
@@ -286,7 +286,7 @@ export function advanceEnrollment(
   if (!current) return undefined;
 
   updates.currentStep = current.currentStep + 1;
-  if (threadId !== undefined) updates.threadId = threadId;
+  if (conversationId !== undefined) updates.conversationId = conversationId;
   if (nextStepAt !== undefined) updates.nextStepAt = nextStepAt;
 
   db.update(sequenceEnrollments)
@@ -367,11 +367,14 @@ export function rescheduleEnrollment(id: string, nextStepAt: number): void {
     .run();
 }
 
-/** Persist a thread ID on an enrollment without advancing the step counter. */
-export function updateEnrollmentThreadId(id: string, threadId: string): void {
+/** Persist a conversation ID on an enrollment without advancing the step counter. */
+export function updateEnrollmentConversationId(
+  id: string,
+  conversationId: string,
+): void {
   const db = getDb();
   db.update(sequenceEnrollments)
-    .set({ threadId, updatedAt: Date.now() })
+    .set({ conversationId, updatedAt: Date.now() })
     .where(eq(sequenceEnrollments.id, id))
     .run();
 }

--- a/assistant/src/sequence/types.ts
+++ b/assistant/src/sequence/types.ts
@@ -18,7 +18,7 @@ export interface SequenceStep {
   delaySeconds: number; // delay from previous step (0 for first step)
   subjectTemplate: string; // subject line template
   bodyPrompt: string; // prompt for the assistant to generate body
-  replyToThread: boolean; // whether to reply in the same thread as step 1
+  replyInSameConversation: boolean; // whether to reply in the same conversation as step 1
   requireApproval: boolean; // draft-first, require human approval before send
 }
 
@@ -41,7 +41,7 @@ export interface SequenceEnrollment {
   contactName: string | null;
   currentStep: number; // index of the next step to send (0-based)
   status: EnrollmentStatus;
-  threadId: string | null; // messaging thread ID (set after first send)
+  conversationId: string | null; // messaging conversation ID (set after first send)
   nextStepAt: number | null; // epoch ms — when the next step is due
   context: Record<string, unknown> | null; // per-enrollment personalization context
   createdAt: number;

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -7,7 +7,7 @@ function formatFollowUp(f: FollowUp): string {
   const lines = [
     `Follow-up ${f.id}`,
     `  Channel: ${f.channel}`,
-    `  Thread: ${f.threadId}`,
+    `  Conversation: ${f.conversationId}`,
     `  Status: ${f.status}`,
     `  Sent at: ${new Date(f.sentAt).toISOString()}`,
   ];
@@ -34,14 +34,15 @@ export async function executeFollowupCreate(
     };
   }
 
-  const threadId = input.thread_id as string | undefined;
+  const conversationId = input.conversation_id as string | undefined;
   if (
-    !threadId ||
-    typeof threadId !== "string" ||
-    threadId.trim().length === 0
+    !conversationId ||
+    typeof conversationId !== "string" ||
+    conversationId.trim().length === 0
   ) {
     return {
-      content: "Error: thread_id is required and must be a non-empty string",
+      content:
+        "Error: conversation_id is required and must be a non-empty string",
       isError: true,
     };
   }
@@ -81,7 +82,7 @@ export async function executeFollowupCreate(
 
     const followUp = createFollowUp({
       channel: channel.trim(),
-      threadId: threadId.trim(),
+      conversationId: conversationId.trim(),
       contactId: contactId ?? null,
       sentAt: now,
       expectedResponseBy,

--- a/assistant/src/tools/followups/followup_list.ts
+++ b/assistant/src/tools/followups/followup_list.ts
@@ -8,7 +8,9 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
 const VALID_STATUSES = ["pending", "resolved", "overdue", "nudged"] as const;
 
 function formatFollowUpSummary(f: FollowUp): string {
-  const parts = [`- **${f.channel}** thread:${f.threadId} (ID: ${f.id})`];
+  const parts = [
+    `- **${f.channel}** conversation:${f.conversationId} (ID: ${f.id})`,
+  ];
   parts.push(
     `  Status: ${f.status} | Sent: ${new Date(f.sentAt).toISOString()}`,
   );

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -1,5 +1,5 @@
 import {
-  resolveByThread,
+  resolveByConversation,
   resolveFollowUp,
 } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
@@ -9,7 +9,7 @@ function formatFollowUp(f: FollowUp): string {
   const lines = [
     `Follow-up ${f.id}`,
     `  Channel: ${f.channel}`,
-    `  Thread: ${f.threadId}`,
+    `  Conversation: ${f.conversationId}`,
     `  Status: ${f.status}`,
   ];
   if (f.contactId) lines.push(`  Contact ID: ${f.contactId}`);
@@ -22,11 +22,12 @@ export async function executeFollowupResolve(
 ): Promise<ToolExecutionResult> {
   const id = input.id as string | undefined;
   const channel = input.channel as string | undefined;
-  const threadId = input.thread_id as string | undefined;
+  const conversationId = input.conversation_id as string | undefined;
 
-  if (!id && !(channel && threadId)) {
+  if (!id && !(channel && conversationId)) {
     return {
-      content: "Error: Either id or both channel and thread_id are required",
+      content:
+        "Error: Either id or both channel and conversation_id are required",
       isError: true,
     };
   }
@@ -39,10 +40,10 @@ export async function executeFollowupResolve(
         isError: false,
       };
     } else {
-      const resolved = resolveByThread(channel!, threadId!);
+      const resolved = resolveByConversation(channel!, conversationId!);
       if (resolved.length === 0) {
         return {
-          content: `No pending follow-up found for channel="${channel}" thread="${threadId}"`,
+          content: `No pending follow-up found for channel="${channel}" conversation="${conversationId}"`,
           isError: false,
         };
       }


### PR DESCRIPTION
## Summary
- Adds DB migrations to rename thread_id columns to conversation_id in followups and sequence_enrollments tables
- Updates Drizzle schema, followup store, sequence store, and tool definitions
- Renames all TS symbols from threadId/replyToThread to conversationId/replyInSameConversation
- Updates TOOLS.json schemas and SKILL.md documentation

Part of plan: conv-unify-symbols.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
