### PR TITLE
fix: add generation counter to prevent stale API key propagation

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -36,14 +36,19 @@ function isManagedProxyCredential(service: string, field: string): boolean {
 const CES_READY_POLL_INTERVAL_MS = 500;
 const CES_READY_POLL_TIMEOUT_MS = 30_000;
 
+/** Monotonic counter that increments each time a new assistant API key is handled.
+ *  Queued propagation attempts check this before pushing to avoid overwriting
+ *  a newer key with a stale one. */
+let apiKeyGeneration = 0;
+
 /**
- * Poll the CES client until it becomes ready, then push the API key.
- * Handles the timing window where the secret route is called while the
- * CES handshake is still in flight.
+ * Poll the CES client until it becomes ready, then push the API key —
+ * but only if no newer key has been handled in the meantime.
  */
 async function queueApiKeyPropagation(
   cesClient: CesClient,
   apiKey: string,
+  generation: number,
 ): Promise<void> {
   log.info(
     "CES client not ready — queuing API key propagation until handshake completes",
@@ -51,7 +56,19 @@ async function queueApiKeyPropagation(
   const deadline = Date.now() + CES_READY_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, CES_READY_POLL_INTERVAL_MS));
+    if (generation < apiKeyGeneration) {
+      log.info(
+        "Discarding stale queued API key propagation — a newer key was already handled",
+      );
+      return;
+    }
     if (cesClient.isReady()) {
+      if (generation < apiKeyGeneration) {
+        log.info(
+          "Discarding stale queued API key propagation — a newer key was already handled",
+        );
+        return;
+      }
       try {
         await cesClient.updateAssistantApiKey(apiKey);
         log.info(
@@ -150,6 +167,7 @@ export async function handleAddSecret(
         if (service === "vellum" && field === "assistant_api_key") {
           // Push the API key to CES so managed credential materialization
           // works even though the handshake ran before the key was available.
+          const generation = ++apiKeyGeneration;
           const cesClient = getCesClient?.();
           if (cesClient) {
             if (cesClient.isReady()) {
@@ -167,7 +185,7 @@ export async function handleAddSecret(
             } else {
               // CES handshake is still in flight — queue the key propagation
               // so it fires once CES becomes ready.
-              void queueApiKeyPropagation(cesClient, value);
+              void queueApiKeyPropagation(cesClient, value, generation);
             }
           }
         }


### PR DESCRIPTION
Addresses review feedback on #17303. Adds a monotonic generation counter to `handleAddSecret` so that stale `queueApiKeyPropagation` calls are discarded when a newer key has already been pushed.

## Summary
- Adds module-level `apiKeyGeneration` counter incremented each time `handleAddSecret` processes a `vellum:assistant_api_key` credential
- `queueApiKeyPropagation` receives the generation at call time and checks it before pushing — if a newer key was handled, the stale propagation is logged and discarded
- Prevents the race where a queued poll fires after a newer key was already pushed immediately, overwriting the fresh key with a stale one
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
