### PR TITLE
fix: remove dead RegenerateRequest type and union membership

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -104,11 +104,6 @@ export interface UndoRequest {
   conversationId: string;
 }
 
-export interface RegenerateRequest {
-  type: "regenerate";
-  conversationId: string;
-}
-
 export interface UsageRequest {
   type: "usage_request";
   conversationId: string;
@@ -395,7 +390,6 @@ export type _ConversationsClientMessages =
   | ModelSetRequest
   | ImageGenModelSetRequest
   | UndoRequest
-  | RegenerateRequest
   | UsageRequest
   | ConversationListRequest
   | ConversationCreateRequest


### PR DESCRIPTION
Addresses review feedback on #17314. Removes the orphaned RegenerateRequest interface and its entry in _SessionsClientMessages union, as the only consumer (handleRegenerate) was already deleted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
