### PR TITLE
fix: route Settings Log Out through performLogout for credential cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -88,7 +88,7 @@ struct SettingsGeneralTab: View {
                 }
             } else if authManager.currentUser != nil {
                 VButton(label: "Log Out", style: .danger) {
-                    Task { await authManager.logout() }
+                    AppDelegate.shared?.performLogout()
                 }
             } else {
                 VButton(


### PR DESCRIPTION
Addresses review feedback on #17343. The Settings 'Log Out' button was calling authManager.logout() directly, bypassing the daemon credential clearing and Keychain cleanup in performLogout(). Now routes through performLogout() for consistent cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
