### PR TITLE
fix: handle billing feature flag change notification in SettingsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -181,6 +181,8 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .developer {
                         selectedTab = .general
                     }
+                } else if key == Self.billingFeatureFlagKey {
+                    isBillingEnabled = enabled
                 } else if key == Self.emailFeatureFlagKey {
                     isEmailEnabled = enabled
                 }


### PR DESCRIPTION
## Summary
- Adds `billingFeatureFlagKey` to the `.assistantFeatureFlagDidChange` handler in `SettingsPanel.swift` so the billing tab appears/disappears in real time when the flag is toggled from the Developer tab
- Consistent with how contacts, developer, and email feature flags are already handled
- The existing `.onChange(of: billingVisible)` handler already covers navigating away from the billing tab when it becomes invisible

Addresses review feedback on #17346.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
