### PR TITLE
fix: remove 2000-char truncation of identity context in memory extraction

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -144,14 +144,8 @@ function buildExtractionSystemPrompt(
   messageRole: string,
 ): string {
   // Inject identity context so extracted memories use real names instead of
-  // generic "User ..." labels. We truncate to a budget to prevent oversized
-  // prompts when SOUL.md / IDENTITY.md / USER.md are large — exceeding the
-  // provider context window would silently degrade to pattern-based extraction.
-  const MAX_IDENTITY_CONTEXT_CHARS = 2000;
-  const rawIdentityContext = buildCoreIdentityContext();
-  const identityContext = rawIdentityContext
-    ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
-    : null;
+  // generic "User ..." labels.
+  const identityContext = buildCoreIdentityContext();
 
   let prompt = "";
   if (identityContext) {


### PR DESCRIPTION
## Summary
- Remove the 2000-character truncation cap on identity context (USER.md/SOUL.md/IDENTITY.md) in the memory extraction prompt
- The full identity context is now passed through to the memory extraction LLM, matching the pattern we just established in the notification decision engine
- Field-level truncation (memory subjects at 80 chars, statements at 500 chars) is unchanged — those are storage limits, not prompt limits

## Original prompt
yes please that would be great

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
