### PR TITLE
fix: handle prefixed credits_exhausted categories in error banner

### DIFF
--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -107,7 +107,8 @@ public struct ConversationError: Equatable {
     }
 
     /// Whether this error indicates that the user's credits are exhausted.
+    /// Matches both plain "credits_exhausted" and prefixed variants like "regenerate:credits_exhausted".
     public var isCreditsExhausted: Bool {
-        errorCategory == "credits_exhausted"
+        errorCategory?.hasSuffix("credits_exhausted") == true
     }
 }


### PR DESCRIPTION
Addresses review feedback on #17356. Fixes isCreditsExhausted to match prefixed categories like 'regenerate:credits_exhausted' so the Add Funds banner appears for all credit exhaustion scenarios.

The daemon emits prefixed error categories (e.g. `regenerate:credits_exhausted`) when a regeneration fails due to credit exhaustion. The previous exact-match check missed these, so the banner never appeared. Changed to `hasSuffix` matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
