### PR TITLE
fix: gate Add Funds button in drawer menu behind billing feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -13,6 +13,11 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
 
+    private var isBillingVisible: Bool {
+        authManager.isAuthenticated &&
+        MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             DrawerThemeToggle()
@@ -31,10 +36,12 @@ struct DrawerMenuView: View {
                             VColor.contentDefault
                         )
                     Spacer()
-                    Button("Add funds") { onOpenBilling() }
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.primaryBase)
-                        .buttonStyle(.plain)
+                    if isBillingVisible {
+                        Button("Add funds") { onOpenBilling() }
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.primaryBase)
+                            .buttonStyle(.plain)
+                    }
                 }
                 .padding(.horizontal, VSpacing.sm)
 


### PR DESCRIPTION
Addresses review feedback on #17348. Hides the Add Funds button in the drawer menu when the billing feature is disabled, preventing a dead-end CTA that routes to Settings without opening the Billing tab.

The button now checks `isBillingVisible` (same condition as SettingsPanel: `authManager.isAuthenticated && settings_billing_enabled` flag) before rendering.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
