### PR TITLE
fix: restore one-click progress for flag-off onboarding path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -79,8 +79,9 @@ struct OnboardingFlowView: View {
                             case 0:
                                 WakeUpStepView(
                                     state: state,
-                                    authManager: authManager,
+                                    authManager: managedSignInEnabled ? authManager : nil,
                                     isAdvancing: isAdvancingFromWakeUp,
+                                    managedSignInEnabled: managedSignInEnabled,
                                     onStartWithAPIKey: {
                                         guard !isAdvancingFromWakeUp else { return }
                                         isAdvancingFromWakeUp = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -14,6 +14,10 @@ struct WakeUpStepView: View {
     /// When true, disables all buttons (e.g. during 0.3s advance delay).
     var isAdvancing: Bool = false
 
+    /// When true, the primary action triggers managed sign-in ("Log In").
+    /// When false, the primary action is "Get Started" and advances directly.
+    var managedSignInEnabled: Bool = false
+
     // Callbacks
     var onStartWithAPIKey: () -> Void = {}
     var onContinueWithVellum: () -> Void = {}
@@ -72,7 +76,7 @@ struct WakeUpStepView: View {
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)
-            } else {
+            } else if managedSignInEnabled {
                 OnboardingButton(title: "Log In", style: .primary) {
                     onContinueWithVellum()
                 }
@@ -88,6 +92,11 @@ struct WakeUpStepView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Skip")
+            } else {
+                OnboardingButton(title: "Get Started", style: .primary) {
+                    onStartWithAPIKey()
+                }
+                .accessibilityLabel("Get Started")
             }
 
             // Auth error message


### PR DESCRIPTION
Addresses review feedback on #17339. Ensures the default (managed_sign_in_enabled=false) onboarding path doesn't stall after sign-in on step 0.

When managed_sign_in_enabled is false, WakeUpStepView now shows 'Get Started' as the primary action which advances directly, instead of 'Log In' which would trigger a WorkOS sign-in flow that stalls because the auth-change handler doesn't auto-advance without the flag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
