### PR TITLE
Extract shared FileContentHeaderBar component to SharedFileViewerComponents

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -469,19 +469,11 @@ struct AgentPanelContent: View {
     private func skillFileContentPane(file: SkillFileEntry, content: String) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             // File header
-            HStack(spacing: VSpacing.sm) {
-                VIconView(fileIcon(for: file.mimeType), size: 12)
-                    .foregroundColor(VColor.primaryBase)
-                Text(file.path)
-                    .font(VFont.captionMedium)
-                    .foregroundColor(VColor.contentDefault)
-                Spacer()
-                Text(formatFileSize(file.size))
-                    .font(VFont.small)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
+            FileContentHeaderBar(
+                icon: fileIcon(for: file.mimeType),
+                fileName: file.path,
+                fileSize: formatFileSize(file.size)
+            )
 
             Divider().background(VColor.borderBase)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -34,3 +34,26 @@ struct ReadOnlyCodeContent: View {
         }
     }
 }
+
+/// Header bar showing file icon, name, and size for file content viewers.
+struct FileContentHeaderBar: View {
+    let icon: VIcon
+    let fileName: String
+    let fileSize: String
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(icon, size: 12)
+                .foregroundColor(VColor.primaryBase)
+            Text(fileName)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.contentDefault)
+            Spacer()
+            Text(fileSize)
+                .font(VFont.small)
+                .foregroundColor(VColor.contentTertiary)
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+    }
+}


### PR DESCRIPTION
## Summary
- Add FileContentHeaderBar view to SharedFileViewerComponents.swift for reuse across panels
- Refactor AgentPanel's skillFileContentPane to use the new shared component
- No visual changes — identical rendering to before

Part of plan: unify-file-viewers.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
