### PR TITLE
feat: add gateway endpoint for privacy config writes

### DIFF
--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -1,0 +1,110 @@
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  renameSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getRootDir } from "../../credential-reader.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("privacy-config");
+
+/** Serializes config writes so concurrent PATCH requests don't race. */
+let configWriteChain: Promise<void> = Promise.resolve();
+
+function getConfigPath(): string {
+  return join(getRootDir(), "workspace", "config.json");
+}
+
+function readConfigFile():
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; detail: string } {
+  const cfgPath = getConfigPath();
+  if (!existsSync(cfgPath)) {
+    return { ok: true, data: {} };
+  }
+  try {
+    const raw = readFileSync(cfgPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, detail: "Config file is not a JSON object" };
+    }
+    return { ok: true, data: parsed };
+  } catch (err) {
+    return { ok: false, detail: String(err) };
+  }
+}
+
+function writeConfigFileAtomic(data: Record<string, unknown>): void {
+  const cfgPath = getConfigPath();
+  const dir = dirname(cfgPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = join(dir, `.config.${randomBytes(6).toString("hex")}.tmp`);
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  renameSync(tmpPath, cfgPath);
+}
+
+export function createPrivacyConfigPatchHandler() {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { collectUsageData } = body as { collectUsageData?: unknown };
+    if (typeof collectUsageData !== "boolean") {
+      return Response.json(
+        { error: '"collectUsageData" must be a boolean' },
+        { status: 400 },
+      );
+    }
+
+    const writeResult = new Promise<Response>((resolve) => {
+      configWriteChain = configWriteChain.then(() => {
+        try {
+          const result = readConfigFile();
+          if (!result.ok) {
+            resolve(
+              Response.json(
+                { error: "Config file is malformed, cannot safely write" },
+                { status: 500 },
+              ),
+            );
+            return;
+          }
+
+          const config = result.data;
+          config.collectUsageData = collectUsageData;
+          writeConfigFileAtomic(config);
+
+          log.info({ collectUsageData }, "Privacy config updated");
+          resolve(Response.json({ collectUsageData }));
+        } catch (err) {
+          log.error({ err }, "Failed to update privacy config");
+          resolve(
+            Response.json({ error: "Internal server error" }, { status: 500 }),
+          );
+        }
+      });
+    });
+
+    return writeResult;
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -44,6 +44,7 @@ import {
   createFeatureFlagsGetHandler,
   createFeatureFlagsPatchHandler,
 } from "./http/routes/feature-flags.js";
+import { createPrivacyConfigPatchHandler } from "./http/routes/privacy-config.js";
 import { createChannelVerificationSessionProxyHandler } from "./http/routes/channel-verification-session-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
@@ -259,6 +260,7 @@ async function main() {
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
+  const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
@@ -679,6 +681,15 @@ async function main() {
         }
         return handleFeatureFlagsPatch(req, flagKey);
       },
+    },
+
+    // ── Privacy config (scope-protected) ──
+    {
+      path: "/v1/config/privacy",
+      method: "PATCH",
+      auth: "edge-scoped",
+      scope: "feature_flags.write",
+      handler: (req) => handlePrivacyConfigPatch(req),
     },
   ];
 


### PR DESCRIPTION
## Summary
- Add `PATCH /v1/config/privacy` gateway endpoint for writing privacy config (collectUsageData)
- Follows existing atomic config write pattern with serialized concurrent writes
- Uses `feature_flags.write` auth scope for consistent authorization

Part of plan: collect-usage-data-userdefaults.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
