### PR TITLE
Add "Files" header and equal-height panes to skill detail file tree

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -361,10 +361,11 @@ struct AgentPanelContent: View {
             }
 
             // Two-pane content: file list + file content viewer
-            HStack(alignment: .top, spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.md) {
                 // Left: file list (always fixed width)
                 skillFilesSection
                     .frame(width: 280, alignment: .topLeading)
+                    .frame(maxHeight: .infinity)
 
                 // Right: file content viewer (always visible)
                 if let selectedPath = expandedFilePath,
@@ -516,26 +517,46 @@ struct AgentPanelContent: View {
     private var skillFilesSection: some View {
         if skillsManager.isLoadingSkillFiles || skillsManager.skillFilesError != nil ||
             (skillsManager.selectedSkillFiles != nil && !skillsManager.selectedSkillFiles!.files.isEmpty) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                if skillsManager.isLoadingSkillFiles {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .controlSize(.small)
-                        Spacer()
-                    }
-                    .padding(.vertical, VSpacing.md)
-                } else if let error = skillsManager.skillFilesError {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemNegativeStrong)
-                } else if let filesResponse = skillsManager.selectedSkillFiles, !filesResponse.files.isEmpty {
-                    SkillFileTreeView(
-                        files: filesResponse.files,
-                        selectedFilePath: $expandedFilePath
-                    )
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack {
+                    Text("Files")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.contentDefault)
+                    Spacer()
                 }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+
+                Divider().background(VColor.borderBase)
+
+                // Content (loading, error, or tree)
+                Group {
+                    if skillsManager.isLoadingSkillFiles {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .controlSize(.small)
+                            Spacer()
+                        }
+                        .padding(.vertical, VSpacing.md)
+                    } else if let error = skillsManager.skillFilesError {
+                        Text(error)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemNegativeStrong)
+                    } else if let filesResponse = skillsManager.selectedSkillFiles, !filesResponse.files.isEmpty {
+                        ScrollView(.vertical) {
+                            SkillFileTreeView(
+                                files: filesResponse.files,
+                                selectedFilePath: $expandedFilePath
+                            )
+                        }
+                    }
+                }
+                .frame(maxHeight: .infinity, alignment: .topLeading)
             }
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -77,12 +77,6 @@ struct SkillFileTreeView: View {
                 .disabled(!item.node.isDirectory && !isText)
             }
         }
-        .background(VColor.surfaceOverlay)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
     }
 
     private func fileIcon(for mimeType: String) -> VIcon {


### PR DESCRIPTION
## Summary
- Add 'Files' header above the skill detail file tree to match workspace visual pattern
- Make file tree and code viewer panes render at equal height
- Move border/background styling from SkillFileTreeView to parent container

Part of plan: unify-file-viewers.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
