### PR TITLE
feat: migrate collect-usage-data from feature flag to dedicated config key

### DIFF
--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -169,19 +169,4 @@ describe("CES flags do not affect unrelated flags", () => {
       ),
     ).toBe(false);
   });
-
-  test("enabling all CES flags does not change collect-usage-data flag (defaultEnabled: true)", () => {
-    const overrides: Record<string, boolean> = {};
-    for (const key of ALL_CES_FLAG_KEYS) {
-      overrides[key] = true;
-    }
-    const config = makeConfig(overrides);
-
-    expect(
-      isAssistantFeatureFlagEnabled(
-        "feature_flags.collect-usage-data.enabled",
-        config,
-      ),
-    ).toBe(true);
-  });
 });

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -306,6 +306,7 @@ export const AssistantConfigSchema = z
         }),
       )
       .optional(),
+    collectUsageData: z.boolean().default(true),
   })
   .superRefine((config, ctx) => {
     if (

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -321,12 +321,11 @@ export async function runDaemon(): Promise<void> {
       });
     }
 
-    // If the user has opted out of crash reporting, stop Sentry from capturing
-    // future events. Early-startup crashes before this point are still captured.
-    const collectUsageData = isAssistantFeatureFlagEnabled(
-      "feature_flags.collect-usage-data.enabled",
-      config,
-    );
+    // If the user has opted out of usage data collection or we are in dev mode,
+    // stop Sentry and skip telemetry. Early-startup crashes before this point
+    // are still captured.
+    const isDevMode = process.env.VELLUM_DEV === "1";
+    const collectUsageData = !isDevMode && config.collectUsageData;
     if (!collectUsageData) {
       await closeSentry();
     }

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -37,8 +37,8 @@ function redactObject(obj: unknown): unknown {
 /**
  * Call after dotenv has loaded so SENTRY_DSN is available.
  * Always initializes Sentry to capture early startup crashes. If the user
- * later opts out via the "collect-usage-data" feature flag, call closeSentry()
- * after config is loaded to stop future event capturing.
+ * later opts out via the collectUsageData config key (or VELLUM_DEV=1),
+ * call closeSentry() after config is loaded to stop future event capturing.
  */
 export function initSentry(): void {
   Sentry.init({

--- a/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const extractCollectUsageDataMigration: WorkspaceMigration = {
+  id: "004-extract-collect-usage-data",
+  description:
+    "Move collect-usage-data opt-out from assistantFeatureFlagValues to top-level collectUsageData config key",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    const flagValues = config.assistantFeatureFlagValues as
+      | Record<string, unknown>
+      | undefined;
+    if (!flagValues || typeof flagValues !== "object") return;
+
+    const FLAG_KEY = "feature_flags.collect-usage-data.enabled";
+    if (!(FLAG_KEY in flagValues)) return;
+
+    const value = flagValues[FLAG_KEY];
+    if (typeof value !== "boolean") return;
+
+    // Only write collectUsageData if the user had explicitly opted out.
+    // The schema default is true, so we only need to persist false.
+    if (!value) {
+      config.collectUsageData = false;
+    }
+
+    // Remove from feature flag values
+    delete flagValues[FLAG_KEY];
+
+    // Clean up empty assistantFeatureFlagValues object
+    if (Object.keys(flagValues).length === 0) {
+      delete config.assistantFeatureFlagValues;
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,5 +1,6 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
+import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -9,4 +10,5 @@ import type { WorkspaceMigration } from "./types.js";
 export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
   seedDeviceIdMigration,
+  extractCollectUsageDataMigration,
 ];

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "collect-usage-data",
-      "scope": "assistant",
-      "key": "feature_flags.collect-usage-data.enabled",
-      "label": "Collect usage data",
-      "description": "Send crash reports, error diagnostics, and anonymized usage telemetry to help improve the app",
-      "defaultEnabled": true
-    },
-    {
       "id": "user-hosted-enabled",
       "scope": "macos",
       "key": "user_hosted_enabled",


### PR DESCRIPTION
## Summary
- Add `collectUsageData` top-level config key and workspace migration 004 to move existing opt-out from feature flag values
- Add VELLUM_DEV=1 guard to skip telemetry and Sentry in dev mode
- Remove `collect-usage-data` entry from the feature flag registry

Part of plan: collect-usage-data-userdefaults.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
