### PR TITLE
Add file name and size header bar to workspace file viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -683,17 +683,33 @@ private struct WorkspaceFileViewer: View {
     private func fileContent(_ detail: WorkspaceFileResponse) -> some View {
         let mime = detail.mimeType.lowercased()
 
-        if !detail.isBinary, detail.content != nil {
-            textViewer(detail)
-        } else if mime.hasPrefix("image/") {
-            imageViewer(detail)
-        } else if mime.hasPrefix("video/") {
-            videoViewer(detail)
-        } else if !detail.isBinary, detail.content == nil {
-            fileTooLarge(detail)
-        } else {
-            binaryFallback(detail)
+        VStack(spacing: 0) {
+            FileContentHeaderBar(
+                icon: fileIcon(for: mime),
+                fileName: detail.name,
+                fileSize: formatFileSize(detail.size)
+            )
+            Divider().background(VColor.borderBase)
+
+            if !detail.isBinary, detail.content != nil {
+                textViewer(detail)
+            } else if mime.hasPrefix("image/") {
+                imageViewer(detail)
+            } else if mime.hasPrefix("video/") {
+                videoViewer(detail)
+            } else if !detail.isBinary, detail.content == nil {
+                fileTooLarge(detail)
+            } else {
+                binaryFallback(detail)
+            }
         }
+    }
+
+    private func fileIcon(for mimeType: String) -> VIcon {
+        if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("text/") { return .fileText }
+        if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+        return .file
     }
 
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {


### PR DESCRIPTION
## Summary
- Add FileContentHeaderBar to workspace file viewer using shared component from PR 1
- Header shows file icon, name, and size above all file content types (text, image, video, binary)
- Read-only badge and Save button still appear below the header for text files

Part of plan: unify-file-viewers.md (PR 3 of 3)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
