### PR TITLE
fix: update guard tests for providers-setup and migration exclusion

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -244,8 +244,9 @@ describe("assistant feature flag indirect key coverage guard", () => {
       if (colonIdx === -1) continue;
       const filePath = line.slice(0, colonIdx);
 
-      // Skip test files
+      // Skip test files and migration files (migrations reference retired flag keys by design)
       if (isTestFile(filePath)) continue;
+      if (filePath.includes("/migrations/")) continue;
 
       // Extract all key occurrences from this line
       const content = line.slice(colonIdx + 1);

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -254,6 +254,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/conversation-slash.ts", // session slash command API key lookup
       "daemon/conversation-process.ts", // session process API key lookup
       "daemon/lifecycle.ts", // CLI edge token persistence at startup
+      "daemon/providers-setup.ts", // provider initialization API key lookup
       "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
     ]);
 


### PR DESCRIPTION
## Summary
- Add `daemon/providers-setup.ts` to the `secure-keys` ALLOWED_IMPORTERS allowlist in credential-security-invariants guard test — the new file imports `getSecureKeyAsync` for provider initialization API key lookup
- Exclude workspace migration files from the feature flag indirect key coverage guard — migrations legitimately reference retired flag keys (e.g. `feature_flags.collect-usage-data.enabled`) when migrating data away from them

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23124152066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
