### PR TITLE
refactor: use UserDefaults for "Collect usage data" toggle, sync via privacy config endpoint

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -428,78 +428,22 @@ extension AppDelegate {
 
     // MARK: - Privacy
 
-    /// Queries the gateway feature-flags API for the collect-usage-data flag and,
-    /// if the user has opted out, shuts down Sentry to stop future event capturing.
-    /// Called after the daemon is first connected so the gateway is reachable.
+    /// Applies the user's privacy preference from UserDefaults (source of truth)
+    /// and syncs it to the daemon config for the next restart.
     func checkAndApplyPrivacyFlag() {
         Task {
-            do {
-                let featureFlagKey = "feature_flags.collect-usage-data.enabled"
+            let collectUsageData = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
 
-                // Check if the user explicitly interacted with the privacy
-                // toggle during onboarding. The `collectUsageDataExplicitlySet`
-                // flag is only written when the user actually touches the
-                // toggle, NOT when the onAppear block sets the default value.
-                // This prevents the auto-written default from making the
-                // UserDefaults key always non-nil and blocking daemon sync.
-                if UserDefaults.standard.bool(forKey: "collectUsageDataExplicitlySet"),
-                   let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
-                    // Always apply Sentry state locally first, regardless of
-                    // whether the daemon sync succeeds — the user's explicit
-                    // choice must take effect immediately.
-                    if !onboardingValue {
-                        MetricKitManager.closeSentry()
-                    }
-
-                    // Best-effort sync to daemon. Only clear the explicit-set
-                    // flag when the sync succeeds so that a transient gateway
-                    // failure preserves the flag for retry on next reconnect.
-                    if let flags = try? await daemonClient.getFeatureFlags() {
-                        let daemonValue = flags
-                            .first(where: { $0.key == featureFlagKey })
-                            .map { $0.enabled }
-                            ?? true
-
-                        var syncSucceeded = true
-                        if onboardingValue != daemonValue {
-                            do {
-                                try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
-                            } catch {
-                                syncSucceeded = false
-                                log.debug("Failed to sync onboarding privacy flag to daemon: \(error)")
-                            }
-                        }
-
-                        // Only clear the flag when both read and write
-                        // succeeded so a failed write preserves the flag
-                        // for retry on next reconnect.
-                        if syncSucceeded {
-                            UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
-                        }
-                    }
-                } else {
-                    // No explicit user interaction — use the daemon's value
-                    // as the source of truth.
-                    let flags = try await daemonClient.getFeatureFlags()
-                    let collectUsageData = flags
-                        .first(where: { $0.key == featureFlagKey })
-                        .map { $0.enabled }
-                        ?? true
-                    // Persist so MetricKitManager can check this flag synchronously
-                    // during the startup window on the next launch, regardless of
-                    // whether the user has visited the Privacy settings tab.
-                    UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
-                    if !collectUsageData {
-                        // Route through sentrySerialQueue to prevent races with
-                        // concurrent MetricKit captures or manual report sends.
-                        MetricKitManager.closeSentry()
-                    }
-                }
-            } catch {
-                // Flag check is best-effort; Sentry stays active when the flag
-                // cannot be read (e.g. gateway not yet ready on first boot).
-                log.debug("Could not read privacy flag from gateway: \(error)")
+            // Apply Sentry state based on UserDefaults
+            if !collectUsageData {
+                MetricKitManager.closeSentry()
             }
+
+            // Clear legacy onboarding sync flag
+            UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+
+            // Best-effort sync to daemon config
+            try? await daemonClient.setPrivacyConfig(collectUsageData: collectUsageData)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -8,43 +8,16 @@ struct SettingsPrivacyTab: View {
     var daemonClient: DaemonClient?
     @ObservedObject var store: SettingsStore
 
-    private static let collectUsageDataKey = "feature_flags.collect-usage-data.enabled"
-
-    @State private var collectUsageData: Bool = true
-    @State private var isLoading: Bool = false
-    @State private var isUpdating: Bool = false
-    @State private var loadError: String?
+    @State private var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
 
     var body: some View {
         diagnosticsSection
-            .onAppear {
-                Task { await loadPrivacyFlags() }
-            }
     }
 
     // MARK: - Diagnostics Section
 
     private var diagnosticsSection: some View {
         SettingsCard(title: "Diagnostics") {
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.small)
-                        .progressViewStyle(.circular)
-                }
-            }
-
-            if let error = loadError {
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.triangleAlert, size: 12)
-                        .foregroundColor(VColor.systemNegativeHover)
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemNegativeStrong)
-                }
-            }
-
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Collect usage data")
@@ -58,15 +31,13 @@ struct SettingsPrivacyTab: View {
                 VToggle(isOn: Binding(
                     get: { collectUsageData },
                     set: { newValue in
-                        let previousPerfMetrics = store.sendPerformanceReports
                         collectUsageData = newValue
                         if !newValue {
                             store.sendPerformanceReports = false
                         }
-                        Task { await setCollectUsageData(newValue, previousPerfMetrics: previousPerfMetrics) }
+                        setCollectUsageData(newValue)
                     }
                 ))
-                .disabled(isLoading || isUpdating || daemonClient == nil)
             }
 
             SettingsDivider()
@@ -87,60 +58,29 @@ struct SettingsPrivacyTab: View {
                     get: { store.sendPerformanceReports },
                     set: { store.sendPerformanceReports = $0 }
                 ))
-                .disabled(!collectUsageData || isLoading || isUpdating)
+                .disabled(!collectUsageData)
             }
         }
     }
 
-    // MARK: - Data Loading
+    // MARK: - Privacy Config
 
-    private func loadPrivacyFlags() async {
-        guard let daemonClient else { return }
-        isLoading = true
-        loadError = nil
-        do {
-            let flags = try await daemonClient.getFeatureFlags()
-            if let flag = flags.first(where: { $0.key == Self.collectUsageDataKey }) {
-                collectUsageData = flag.enabled
-            }
-            // If the flag is not present in the registry response, default to true
-            // (matches the registry defaultEnabled: true).
-        } catch {
-            loadError = "Could not load privacy settings: \(error.localizedDescription)"
-        }
-        isLoading = false
-    }
+    private func setCollectUsageData(_ enabled: Bool) {
+        // UserDefaults is the source of truth
+        UserDefaults.standard.set(enabled, forKey: "collectUsageDataEnabled")
 
-    private func setCollectUsageData(_ enabled: Bool, previousPerfMetrics: Bool = false) async {
-        guard let daemonClient else { return }
-        isUpdating = true
-        do {
-            try await daemonClient.setFeatureFlag(key: Self.collectUsageDataKey, enabled: enabled)
-            // Clear any previous error so stale failure messages don't persist after a successful save.
-            loadError = nil
-            // Apply Sentry state immediately rather than waiting for the next daemon
-            // reconnect to call checkAndApplyPrivacyFlag(). Both paths are serialised
-            // through sentrySerialQueue so they don't race with concurrent MetricKit
-            // captures or manual report sends.
-            // Persist so MetricKitManager can check this flag synchronously
-            // during the startup window before the daemon connects.
-            UserDefaults.standard.set(enabled, forKey: "collectUsageDataEnabled")
-            if enabled {
-                MetricKitManager.startSentry()
-            } else {
-                MetricKitManager.closeSentry()
-            }
-        } catch {
-            // Revert the optimistic toggle on failure, including the
-            // cascaded performance metrics toggle — restore to its
-            // previous value rather than blindly setting true.
-            collectUsageData = !enabled
-            if !enabled {
-                store.sendPerformanceReports = previousPerfMetrics
-            }
-            loadError = "Could not save privacy setting: \(error.localizedDescription)"
+        // Apply Sentry state immediately
+        if enabled {
+            MetricKitManager.startSentry()
+        } else {
+            MetricKitManager.closeSentry()
         }
-        isUpdating = false
+
+        // Best-effort sync to daemon config for next restart
+        if let daemonClient {
+            Task {
+                try? await daemonClient.setPrivacyConfig(collectUsageData: enabled)
+            }
+        }
     }
 }
-

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2383,6 +2383,38 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #endif
     }
 
+    /// Update the privacy config via the gateway's PATCH /v1/config/privacy endpoint.
+    /// Authenticates with the feature-flag token (same auth scope).
+    public func setPrivacyConfig(collectUsageData: Bool) async throws {
+        guard let token = resolveFeatureFlagAuthToken() else {
+            throw FeatureFlagError.missingToken
+        }
+
+        #if os(macOS)
+        if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, featureFlagToken: token)
+            return
+        }
+
+        // Local mode: call the gateway directly.
+        guard var request = buildLocalRequest(target: .gateway, path: "v1/config/privacy", method: "PATCH", tokenOverride: token) else {
+            throw FeatureFlagError.invalidURL
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = ["collectUsageData": collectUsageData]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return // Best-effort — failure is non-fatal
+        }
+        #else
+        guard let httpTransport else { return }
+        try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, featureFlagToken: token)
+        #endif
+    }
+
     /// Returns true if the given base URL points to localhost / 127.0.0.1.
     private static func isLocalBaseURL(_ urlString: String) -> Bool {
         guard let comps = URLComponents(string: urlString), let host = comps.host?.lowercased() else {

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -271,6 +271,7 @@ public final class HTTPTransport {
         case identity
         case featureFlags
         case featureFlagUpdate(key: String)
+        case privacyConfig
         case surfaceAction
         case trustRulesManage
         case trustRuleManageById(id: String)
@@ -513,6 +514,8 @@ public final class HTTPTransport {
         case .featureFlagUpdate(let key):
             let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? key
             return ("/v1/feature-flags/\(encoded)", nil)
+        case .privacyConfig:
+            return ("/v1/config/privacy", nil)
         case .surfaceAction:
             return ("/v1/surface-actions", nil)
         case .trustRulesManage:
@@ -930,6 +933,8 @@ public final class HTTPTransport {
         case .featureFlagUpdate(let key):
             let encoded = key.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? key
             return ("\(prefix)/feature-flags/\(encoded)/", nil)
+        case .privacyConfig:
+            return ("\(prefix)/config/privacy/", nil)
         case .surfaceAction:
             return ("\(prefix)/surface-actions/", nil)
         case .trustRulesManage:
@@ -3144,6 +3149,35 @@ public final class HTTPTransport {
         }
 
         log.info("Feature flag '\(key)' set to \(enabled)")
+    }
+
+    /// Update the privacy config via the gateway's PATCH /v1/config/privacy endpoint.
+    func setPrivacyConfig(collectUsageData: Bool, featureFlagToken: String) async throws {
+        guard let url = buildURL(for: .privacyConfig) else {
+            throw HTTPTransportError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(featureFlagToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let body: [String: Any] = ["collectUsageData": collectUsageData]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        if http.statusCode == 401 {
+            throw HTTPTransportError.healthCheckFailed
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            throw HTTPTransportError.healthCheckFailed
+        }
     }
 
     /// Fetch all assistant feature flags from the gateway's `GET /v1/feature-flags` endpoint.


### PR DESCRIPTION
## Summary
- Switch "Collect usage data" toggle to use UserDefaults as source of truth instead of daemon feature flags
- Add `setPrivacyConfig` to DaemonClient/HTTPDaemonClient for syncing to the gateway's `PATCH /v1/config/privacy` endpoint
- Simplify SettingsPrivacyTab (remove loading/error states, daemon dependency for toggle state)
- Simplify `checkAndApplyPrivacyFlag` to always use UserDefaults and sync to daemon

Part of plan: collect-usage-data-userdefaults.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
