### PR TITLE
fix: consolidate formatFileSize into shared implementation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -559,11 +559,4 @@ struct AgentPanelContent: View {
         return .file
     }
 
-    private func formatFileSize(_ bytes: Int) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024.0
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024.0
-        return String(format: "%.1f MB", mb)
-    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import VellumAssistantShared
 
+/// Formats a byte count into a human-readable size string.
+/// Shows raw bytes for sizes < 1 KB (e.g. "500 B"), then "KB" / "MB" with one decimal place.
+func formatFileSize(_ bytes: Int) -> String {
+    if bytes < 1024 { return "\(bytes) B" }
+    let kb = Double(bytes) / 1024.0
+    if kb < 1024 { return String(format: "%.1f KB", kb) }
+    let mb = kb / 1024.0
+    return String(format: "%.1f MB", mb)
+}
+
 /// Empty state shown when no file is selected in a file viewer pane.
 struct FileViewerEmptyState: View {
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -86,11 +86,4 @@ struct SkillFileTreeView: View {
         return .file
     }
 
-    private func formatFileSize(_ bytes: Int) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024.0
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024.0
-        return String(format: "%.1f MB", mb)
-    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -861,12 +861,6 @@ private struct WorkspaceFileViewer: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func formatFileSize(_ bytes: Int) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useKB, .useMB, .useGB]
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: Int64(bytes))
-    }
 }
 
 // MARK: - Hidden Path Helper


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewers.md.

**Gap:** Inconsistent formatFileSize implementations between AgentPanel and WorkspacePanel
**What was expected:** Consistent file size display across both panels
**What was found:** AgentPanel used manual formatting, WorkspacePanel used ByteCountFormatter with different output

- Created a single shared `formatFileSize` function in SharedFileViewerComponents.swift using the manual implementation (which handles the bytes-range gracefully, e.g. "500 B" instead of "0 KB")
- Removed duplicate local implementations from AgentPanel.swift, WorkspacePanel.swift, and SkillFileTreeView.swift
- All three call sites now resolve to the shared package-level function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
