### PR TITLE
fix: remove duplicate file name/size from fileTooLarge and binaryFallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -786,19 +786,9 @@ private struct WorkspaceFileViewer: View {
             VIconView(.fileText, size: 40)
                 .foregroundColor(VColor.contentTertiary)
 
-            VStack(spacing: VSpacing.sm) {
-                Text(detail.name)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.contentDefault)
-
-                Text("File too large to preview")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
-
-                Text(formatFileSize(detail.size))
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-            }
+            Text("File too large to preview")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
 
             Spacer()
         }
@@ -839,14 +829,6 @@ private struct WorkspaceFileViewer: View {
                 .foregroundColor(VColor.contentTertiary)
 
             VStack(spacing: VSpacing.sm) {
-                Text(detail.name)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.contentDefault)
-
-                Text(formatFileSize(detail.size))
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentSecondary)
-
                 Text(detail.mimeType)
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentSecondary)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewers.md.

**Gap:** Duplicate file name and size in fileTooLarge and binaryFallback views
**What was expected:** Sub-views should not duplicate file name/size now shown by FileContentHeaderBar
**What was found:** Both fileTooLarge() and binaryFallback() still displayed file name and size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
