### PR TITLE
fix: use correct error types in HTTPDaemonClient.setPrivacyConfig

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -3168,15 +3168,15 @@ public final class HTTPTransport {
 
         let (_, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else {
-            throw HTTPTransportError.healthCheckFailed
+            throw HTTPTransportError.requestFailed(statusCode: 0, message: nil)
         }
 
         if http.statusCode == 401 {
-            throw HTTPTransportError.healthCheckFailed
+            throw HTTPTransportError.authenticationFailed(message: "Privacy config PATCH failed: authentication error (401)")
         }
 
         guard (200..<300).contains(http.statusCode) else {
-            throw HTTPTransportError.healthCheckFailed
+            throw HTTPTransportError.requestFailed(statusCode: http.statusCode, message: nil)
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for collect-usage-data-userdefaults.md.

**Gap:** HTTPDaemonClient.setPrivacyConfig uses wrong error type
**What was expected:** requestFailed(statusCode) and authenticationFailed per the plan spec
**What was found:** healthCheckFailed used for all error cases, losing the HTTP status code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
