### PR TITLE
fix: add GB support to shared formatFileSize

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -2,13 +2,15 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Formats a byte count into a human-readable size string.
-/// Shows raw bytes for sizes < 1 KB (e.g. "500 B"), then "KB" / "MB" with one decimal place.
+/// Shows raw bytes for sizes < 1 KB (e.g. "500 B"), then "KB" / "MB" / "GB" with one decimal place.
 func formatFileSize(_ bytes: Int) -> String {
     if bytes < 1024 { return "\(bytes) B" }
     let kb = Double(bytes) / 1024.0
     if kb < 1024 { return String(format: "%.1f KB", kb) }
     let mb = kb / 1024.0
-    return String(format: "%.1f MB", mb)
+    if mb < 1024 { return String(format: "%.1f MB", mb) }
+    let gb = mb / 1024.0
+    return String(format: "%.1f GB", gb)
 }
 
 /// Empty state shown when no file is selected in a file viewer pane.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewers.md.

**Gap:** formatFileSize missing GB support
**What was expected:** Handle all file sizes including GB+
**What was found:** Only handled B, KB, MB — GB files would show incorrect MB values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
