### PR TITLE
fix: add video MIME type mapping to fileIcon helpers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -554,6 +554,7 @@ struct AgentPanelContent: View {
 
     private func fileIcon(for mimeType: String) -> VIcon {
         if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
         return .file

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -707,6 +707,7 @@ private struct WorkspaceFileViewer: View {
 
     private func fileIcon(for mimeType: String) -> VIcon {
         if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
         return .file


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewers.md.

**Gap:** fileIcon(for:) missing video/* branch
**What was expected:** Video files should show video icon in FileContentHeaderBar
**What was found:** Video files showed generic file icon

Adds `if mimeType.hasPrefix("video/") { return .video }` to:
- `WorkspacePanel.swift` — `fileIcon(for:)`
- `AgentPanel.swift` — `fileIcon(for:)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
