### PR TITLE
fix: complete sessionId → conversationId rename in convenience inits

### DIFF
--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -302,7 +302,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         vm2.conversationId = "sess-b"
 
         // Delta for conversation A
-        let deltaA = AssistantTextDeltaMessage(text: "For A", sessionId: "sess-a")
+        let deltaA = AssistantTextDeltaMessage(text: "For A", conversationId: "sess-a")
         vm1.handleServerMessage(.assistantTextDelta(deltaA))
         vm1.flushStreamingBuffer()
         vm2.handleServerMessage(.assistantTextDelta(deltaA))

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -654,8 +654,8 @@ public typealias UserMessageEchoMessage = UserMessageEcho
 public typealias AssistantTextDeltaMessage = AssistantTextDelta
 
 extension AssistantTextDelta {
-    public init(text: String, sessionId: String? = nil) {
-        self.init(type: "assistant_text_delta", text: text, sessionId: sessionId)
+    public init(text: String, conversationId: String? = nil) {
+        self.init(type: "assistant_text_delta", text: text, sessionId: conversationId)
     }
 }
 
@@ -673,8 +673,8 @@ extension AssistantThinkingDelta {
 public typealias MessageCompleteMessage = MessageComplete
 
 extension MessageComplete {
-    public init(sessionId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
-        self.init(type: "message_complete", sessionId: sessionId, attachments: attachments, messageId: messageId)
+    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
+        self.init(type: "message_complete", sessionId: conversationId, attachments: attachments, messageId: messageId)
     }
 }
 
@@ -830,8 +830,8 @@ public typealias UndoCompleteMessage = UndoComplete
 public struct GenerationCancelledMessage: Decodable, Sendable {
     public let sessionId: String?
 
-    public init(sessionId: String?) {
-        self.sessionId = sessionId
+    public init(conversationId: String?) {
+        self.sessionId = conversationId
     }
 }
 


### PR DESCRIPTION
## Summary
- Update convenience init parameter labels from `sessionId:` to `conversationId:` for `AssistantTextDelta`, `MessageComplete`, and `GenerationCancelledMessage` in `MessageTypes.swift`
- Fix one remaining `sessionId:` call site in `ConversationLifecycleIOSTests.swift`
- These were missed in #17455, causing the iOS build to fail

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23124299207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
