### PR TITLE
fix: add video MIME type mapping to SkillFileTreeView fileIcon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -81,6 +81,7 @@ struct SkillFileTreeView: View {
 
     private func fileIcon(for mimeType: String) -> VIcon {
         if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
         return .file


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewers.md.

**Gap:** SkillFileTreeView.fileIcon(for:) missing video/* mapping
**What was expected:** Consistent video icon across all file viewers
**What was found:** SkillFileTreeView showed generic file icon for video files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
