### PR TITLE
refactor: rename macOS Thread types and symbols to Conversation

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -130,7 +130,7 @@ Use the Swift convention `TypeName+Purpose.swift` for files that contain extensi
 ### When to Split a File
 - **Target: ~500-600 lines max per file.** If a file exceeds this, split it.
 - **Extension files** (`TypeName+Purpose.swift`) — use when the code logically belongs to the same type but can be grouped by purpose. The extension lives in the same directory as the primary file.
-- **Standalone views** (`SidebarThreadItem.swift`) — use when a view has its own identity, state, and can be reused independently. Place in a subdirectory if there are multiple related views (e.g., `Sidebar/`).
+- **Standalone views** (`SidebarConversationItem.swift`) — use when a view has its own identity, state, and can be reused independently. Place in a subdirectory if there are multiple related views (e.g., `Sidebar/`).
 - **Helper types** (`MainWindowGroupedState.swift`) — use for supporting types (state enums, delegates) that don't belong in the main view file.
 
 ### Access Control Across File Boundaries
@@ -143,7 +143,7 @@ Swift does not allow `private` members to be accessed from a different file, eve
 - Comments and docstrings must describe the code's intent and behavior, not its refactoring history.
 - Do not leave breadcrumb comments like `// moved to X.swift` or `// extracted from Y()`. These become stale and clutter the code.
 - Good: `/// Cancellable task for the delayed hover trigger on the collapsed thread section.`
-- Bad: `// threadItem — moved to Sidebar/SidebarThreadItem.swift (standalone view)`
+- Bad: `// conversationItem — moved to Sidebar/SidebarConversationItem.swift (standalone view)`
 
 ---
 

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -26,10 +26,10 @@ The main window has three dedicated state objects:
 | Object | Pattern | Scope |
 |--------|---------|-------|
 | `MainWindowState` | `ObservableObject` | Cross-view UI state: active panel, dynamic workspace, API key status |
-| `ThreadManager` | `ObservableObject` | Thread CRUD, tab management, conforms to `ThreadRestorerDelegate` |
-| `ThreadSessionRestorer` | Plain class with delegate | Daemon session restoration (session list responses, history hydration) |
+| `ConversationManager` | `ObservableObject` | Conversation CRUD, tab management, conforms to `ConversationRestorerDelegate` |
+| `ConversationRestorer` | Plain class with delegate | Daemon session restoration (session list responses, history hydration) |
 
-`ThreadManager` owns thread lifecycle. `ThreadSessionRestorer` handles the async daemon communication for restoring sessions on reconnect, delegating state mutations back through the `ThreadRestorerDelegate` protocol for testability.
+`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring sessions on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
 
 ### Observation Framework Migration
 

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -252,7 +252,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -302,7 +302,7 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         vm2.conversationId = "sess-b"
 
         // Delta for conversation A
-        let deltaA = AssistantTextDeltaMessage(text: "For A", conversationId: "sess-a")
+        let deltaA = AssistantTextDeltaMessage(text: "For A", sessionId: "sess-a")
         vm1.handleServerMessage(.assistantTextDelta(deltaA))
         vm1.flushStreamingBuffer()
         vm2.handleServerMessage(.assistantTextDelta(deltaA))

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -55,7 +55,7 @@ All UI and feature code lives in `Features/`, organized by domain:
 | `CommandPalette/` | Command palette (search, actions) |
 | `Contacts/` | Contact management |
 | `ChannelVerification/` | Channel verification flow |
-| `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ThreadManager, side panels |
+| `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ConversationManager, side panels |
 | `MainWindow/Panels/` | Side panels including DebugPanel (real-time trace viewer with metrics + timeline) |
 | `Onboarding/` | Multi-step first-launch flow (OnboardingFlowView → OnboardingState) |
 | `QuickInput/` | Quick task input popover and screen selection |
@@ -72,7 +72,7 @@ NavigationToolbar     (row 2 — Chat tab + panel toggle buttons)
 VSplitView            (row 3 — ChatView + optional side panel)
 ```
 
-**Data flow**: `ThreadManager` (`@MainActor ObservableObject`) owns `[ThreadModel]` and a dictionary of `ChatViewModel` instances keyed by thread ID. `MainWindowView` binds to the active `ChatViewModel` via `threadManager.activeViewModel`. ThreadManager subscribes to each nested ChatViewModel's `objectWillChange` and forwards it via Combine so SwiftUI picks up changes.
+**Data flow**: `ConversationManager` (`@MainActor ObservableObject`) owns `[ConversationModel]` and a dictionary of `ChatViewModel` instances keyed by conversation ID. `MainWindowView` binds to the active `ChatViewModel` via `conversationManager.activeViewModel`. ConversationManager subscribes to each nested ChatViewModel's `objectWillChange` and forwards it via Combine so SwiftUI picks up changes.
 
 ---
 
@@ -205,7 +205,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 |---------|-------------|
 | `@State` | Local, view-scoped transient state (hover, drag, focus, form fields) |
 | `@Binding` | Pass mutable state from parent to child view |
-| `@StateObject` | Own an ObservableObject for the view's lifetime (e.g. ThreadManager in MainWindowView) |
+| `@StateObject` | Own an ObservableObject for the view's lifetime (e.g. ConversationManager in MainWindowView) |
 | `@ObservedObject` | Observe an ObservableObject owned elsewhere |
 | `@AppStorage` | Persistent user preferences backed by UserDefaults |
 | `@Observable` | Modern Observation framework (used by OnboardingState) |
@@ -213,7 +213,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 ### Rules
 
 - **`@MainActor` on all ObservableObject classes** — all view models and managers that touch UI must be `@MainActor`.
-- **Nested ObservableObject**: When a view reads properties from a nested ObservableObject (e.g. `threadManager.activeViewModel.messages`), the parent must subscribe to the child's `objectWillChange` and forward it. See `ThreadManager.subscribeToActiveViewModel()`.
+- **Nested ObservableObject**: When a view reads properties from a nested ObservableObject (e.g. `conversationManager.activeViewModel.messages`), the parent must subscribe to the child's `objectWillChange` and forward it. See `ConversationManager.subscribeToActiveViewModel()`.
 - **Dependency injection**: Pass dependencies (DaemonClient, AmbientAgent) through init parameters, not singletons. Session dependencies use protocols for testability.
 - **Previews**: Do not add `#Preview` or `PreviewProvider` blocks. Use the Component Gallery as the single visual review surface.
 - **Gallery**: When adding or modifying a design system primitive/component, update the corresponding Gallery section file (`Gallery/Sections/`) so the visual catalog stays current.
@@ -224,7 +224,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 - Design system types: `V` prefix (VButton, VColor, VTab, etc.)
 - Feature views: Place in `Features/<Module>/`. New feature modules get their own directory.
 - **Extension files**: Use `TypeName+Purpose.swift` naming (e.g., `MainWindowView+Sidebar.swift`). This is the standard Swift convention for splitting a type across files. Place extension files in the same directory as the primary file.
-- **Standalone child views**: Extract into their own file when the view has its own identity and state (e.g., `SidebarThreadItem.swift`). Group related views in a subdirectory (e.g., `Sidebar/`).
+- **Standalone child views**: Extract into their own file when the view has its own identity and state (e.g., `SidebarConversationItem.swift`). Group related views in a subdirectory (e.g., `Sidebar/`).
 - **Helper/state types**: Extract into a separate file named after the type (e.g., `MainWindowGroupedState.swift` for `SharingState`, `SidebarInteractionState`, etc.).
 - New `.swift` files are auto-picked up by SPM — no project file edits needed.
 - Panel views: Place in `Features/MainWindow/Panels/` and add a case to `SidePanelType`.

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -439,7 +439,7 @@ Features/
   CommandPalette/     Command palette (search, actions)
   Contacts/           Contact management
   ChannelVerification/ Channel verification flow
-  MainWindow/         Main window shell, ThreadTabBar, PanelCoordinator, side panels
+  MainWindow/         Main window shell, ThreadTabBar, ConversationManager, PanelCoordinator, side panels
   Onboarding/         First-launch setup flow (permissions, naming, Fn key)
   QuickInput/         Quick task input popover and screen selection
   Session/            Session overlay UI for computer-use task execution

--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -52,7 +52,7 @@ extension AppDelegate {
         // Bring the main window to front and consume the pending message
         // in the active thread's view model.
         showMainWindow()
-        mainWindow?.threadManager.activeViewModel?.consumeDeepLinkIfNeeded()
+        mainWindow?.conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
     }
 
     // MARK: - Bundle Open Handling

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -40,7 +40,7 @@ extension AppDelegate {
             // The daemon will classify it and invoke CU tools via host_cu_request
             // if computer use is needed.
             self.ensureMainWindowExists()
-            if let viewModel = self.mainWindow?.threadManager.activeViewModel {
+            if let viewModel = self.mainWindow?.conversationManager.activeViewModel {
                 _ = viewModel.sendSilently(effectiveTask)
             } else {
                 log.warning("No active chat view model — cannot send message")
@@ -68,7 +68,7 @@ extension AppDelegate {
         }
 
         ensureMainWindowExists()
-        mainWindow?.threadManager.createNotificationThread(
+        mainWindow?.conversationManager.createNotificationConversation(
             conversationId: msg.conversationId,
             title: msg.title,
             sourceEventName: msg.sourceEventName
@@ -99,7 +99,7 @@ extension AppDelegate {
     }
 
     /// Opens the main window and navigates to the thread for the given conversation ID.
-    /// Retries if the thread isn't populated yet (e.g., ThreadManager hasn't loaded it).
+    /// Retries if the thread isn't populated yet (e.g., ConversationManager hasn't loaded it).
     /// Used by Quick Chat and notification deep links.
     /// - Parameters:
     ///   - conversationId: The conversation to navigate to.
@@ -109,31 +109,31 @@ extension AppDelegate {
         guard let conversationId else { return }
 
         func trySelect() -> Bool {
-            guard let threadManager = mainWindow?.threadManager,
-                  let thread = threadManager.threads.first(where: { $0.conversationId == conversationId }) else {
+            guard let conversationManager = mainWindow?.conversationManager,
+                  let thread = conversationManager.conversations.first(where: { $0.conversationId == conversationId }) else {
                 return false
             }
-            threadManager.activeThreadId = thread.id
+            conversationManager.activeConversationId = thread.id
             // Switch the main content area to the chat thread so the user sees it
             // even if they were last viewing a panel, app, or other non-chat view.
             mainWindow?.windowState.selection = nil
             // Clear unseen state and notify the daemon when deep-linking into a
-            // conversation. selectThread's unseen-clear is guarded by
-            // id != previousActiveId, which is false when activeThreadId was
+            // conversation. selectConversation's unseen-clear is guarded by
+            // id != previousActiveId, which is false when activeConversationId was
             // already set above, so we call markConversationSeen explicitly to
             // keep both the local flag and the daemon's server-side state in sync.
-            threadManager.markConversationSeen(threadId: thread.id)
+            conversationManager.markConversationSeen(threadId: thread.id)
             // Set pending anchor message so the message list scrolls to the
             // relevant notification message when the view appears.
             if let anchorMessageId, let anchorUUID = UUID(uuidString: anchorMessageId) {
-                threadManager.setPendingAnchorMessage(threadId: thread.id, messageId: anchorUUID)
+                conversationManager.setPendingAnchorMessage(threadId: thread.id, messageId: anchorUUID)
             }
             return true
         }
 
         if trySelect() { return }
 
-        // Thread may not be loaded yet — retry up to 5 times with 500ms delay
+        // Conversation may not be loaded yet — retry up to 5 times with 500ms delay
         Task { @MainActor in
             for _ in 0..<5 {
                 try? await Task.sleep(nanoseconds: 500_000_000)

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -212,7 +212,7 @@ extension AppDelegate {
         daemonClient.onTaskRunConversationCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
-            self.mainWindow?.threadManager.createTaskRunThread(
+            self.mainWindow?.conversationManager.createTaskRunConversation(
                 conversationId: msg.conversationId,
                 workItemId: msg.workItemId,
                 title: msg.title
@@ -223,7 +223,7 @@ extension AppDelegate {
         daemonClient.onScheduleConversationCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
-            self.mainWindow?.threadManager.createScheduleThread(
+            self.mainWindow?.conversationManager.createScheduleConversation(
                 conversationId: msg.conversationId,
                 scheduleJobId: msg.scheduleJobId,
                 title: msg.title

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -307,8 +307,8 @@ extension AppDelegate {
         // Static actions
         window.actions = [
             CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
-                self?.mainWindow?.threadManager.createThread()
-                if let id = self?.mainWindow?.threadManager.activeThreadId {
+                self?.mainWindow?.conversationManager.createConversation()
+                if let id = self?.mainWindow?.conversationManager.activeConversationId {
                     self?.mainWindow?.windowState.selection = .thread(id)
                 }
             },
@@ -338,9 +338,9 @@ extension AppDelegate {
             },
         ]
 
-        // Recent conversations from ThreadManager
-        if let threads = mainWindow?.threadManager.threads {
-            window.recentItems = threads
+        // Recent conversations from ConversationManager
+        if let conversations = mainWindow?.conversationManager.conversations {
+            window.recentItems = conversations
                 .filter { !$0.isArchived }
                 .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                 .prefix(5)
@@ -348,13 +348,13 @@ extension AppDelegate {
         }
 
         window.onSelectConversation = { [weak self] threadId in
-            self?.mainWindow?.threadManager.selectThread(id: threadId)
+            self?.mainWindow?.conversationManager.selectConversation(id: threadId)
         }
 
         window.onSelectSearchConversation = { [weak self] sessionId in
             Task { @MainActor in
-                let found = await self?.mainWindow?.threadManager.selectThreadByConversationIdAsync(sessionId) ?? false
-                if found, let threadId = self?.mainWindow?.threadManager.activeThreadId {
+                let found = await self?.mainWindow?.conversationManager.selectThreadByConversationIdAsync(sessionId) ?? false
+                if found, let threadId = self?.mainWindow?.conversationManager.activeConversationId {
                     self?.mainWindow?.windowState.selection = .thread(threadId)
                 }
             }
@@ -401,9 +401,9 @@ extension AppDelegate {
         window.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }
-        // Provide the 3 most recent non-archived threads
-        if let threads = mainWindow?.threadManager.threads {
-            window.recentThreads = threads
+        // Provide the 3 most recent non-archived conversations
+        if let conversations = mainWindow?.conversationManager.conversations {
+            window.recentThreads = conversations
                 .filter { !$0.isArchived }
                 .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                 .prefix(3)
@@ -450,8 +450,8 @@ extension AppDelegate {
             window.onMicrophoneToggle = { [weak self] in
                 self?.voiceInput?.toggleRecording()
             }
-            if let threads = self.mainWindow?.threadManager.threads {
-                window.recentThreads = threads
+            if let conversations = self.mainWindow?.conversationManager.conversations {
+                window.recentThreads = conversations
                     .filter { !$0.isArchived }
                     .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                     .prefix(3)
@@ -470,8 +470,8 @@ extension AppDelegate {
         // Never show it — quick input is fire-and-forget.
         ensureMainWindowExists()
         guard let mainWindow else { return }
-        mainWindow.threadManager.createThread()
-        if let threadId = mainWindow.threadManager.activeThreadId {
+        mainWindow.conversationManager.createConversation()
+        if let threadId = mainWindow.conversationManager.activeConversationId {
             mainWindow.windowState.selection = .thread(threadId)
         }
         guard let viewModel = mainWindow.activeViewModel else { return }
@@ -525,7 +525,7 @@ extension AppDelegate {
     func handleQuickInputSelectThread(_ threadId: UUID) {
         showMainWindow()
         guard let mainWindow else { return }
-        mainWindow.threadManager.activeThreadId = threadId
+        mainWindow.conversationManager.activeConversationId = threadId
     }
 
     /// Tears down and re-registers the global "Open Vellum" hotkey based on

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -63,7 +63,7 @@ extension AppDelegate {
 
         let markAllSeenItem = NSMenuItem(
             title: "Mark All Threads as Seen",
-            action: #selector(markAllThreadsSeen),
+            action: #selector(markAllConversationsSeen),
             keyEquivalent: "k"
         )
         markAllSeenItem.keyEquivalentModifierMask = [.command, .shift]
@@ -100,8 +100,8 @@ extension AppDelegate {
 
     @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         guard let action = menuItem.action else { return true }
-        if action == #selector(markAllThreadsSeen) {
-            return (mainWindow?.threadManager.unseenVisibleConversationCount ?? 0) > 0
+        if action == #selector(markAllConversationsSeen) {
+            return (mainWindow?.conversationManager.unseenVisibleConversationCount ?? 0) > 0
         }
         return true
     }
@@ -190,7 +190,7 @@ extension AppDelegate {
 
     var currentAssistantStatus: AssistantStatus {
         if !daemonClient.isConnected { return .disconnected }
-        guard let viewModel = mainWindow?.threadManager.activeViewModel else { return .idle }
+        guard let viewModel = mainWindow?.conversationManager.activeViewModel else { return .idle }
         if let error = viewModel.errorText { return .error(error) }
         if viewModel.isThinking { return .thinking }
         return .idle
@@ -221,10 +221,10 @@ extension AppDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let currentThreadItem = NSMenuItem(title: "Current Thread", action: #selector(openCurrentThread), keyEquivalent: "")
-        currentThreadItem.target = self
-        currentThreadItem.image = VIcon.messageSquare.nsImage
-        menu.addItem(currentThreadItem)
+        let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
+        currentConversationItem.target = self
+        currentConversationItem.image = VIcon.messageSquare.nsImage
+        menu.addItem(currentConversationItem)
 
         let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")
         newChatItem.target = self
@@ -306,11 +306,11 @@ extension AppDelegate {
         sendLogsItem.image = VIcon.upload.nsImage
         menu.addItem(sendLogsItem)
 
-        let sendThreadLogsItem = NSMenuItem(title: "Send Logs for Current Thread", action: #selector(sendCurrentThreadLogsToSentry), keyEquivalent: "")
-        sendThreadLogsItem.target = self
-        sendThreadLogsItem.image = VIcon.upload.nsImage
-        sendThreadLogsItem.isEnabled = mainWindow?.threadManager.activeThread?.conversationId != nil && !isCurrentAssistantManaged
-        menu.addItem(sendThreadLogsItem)
+        let sendConversationLogsItem = NSMenuItem(title: "Send Logs for Current Conversation", action: #selector(sendCurrentConversationLogsToSentry), keyEquivalent: "")
+        sendConversationLogsItem.target = self
+        sendConversationLogsItem.image = VIcon.upload.nsImage
+        sendConversationLogsItem.isEnabled = mainWindow?.conversationManager.activeConversation?.conversationId != nil && !isCurrentAssistantManaged
+        menu.addItem(sendConversationLogsItem)
 
         if MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items") {
             menu.addItem(NSMenuItem.separator())
@@ -350,23 +350,23 @@ extension AppDelegate {
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 2), in: button)
     }
 
-    @objc func markAllThreadsSeen() {
-        guard let threadManager = mainWindow?.threadManager else { return }
-        let markedIds = threadManager.markAllThreadsSeen()
+    @objc func markAllConversationsSeen() {
+        guard let conversationManager = mainWindow?.conversationManager else { return }
+        let markedIds = conversationManager.markAllConversationsSeen()
         guard !markedIds.isEmpty else { return }
         let count = markedIds.count
         let toastId = mainWindow?.windowState.showToast(
             message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
             style: .success,
             primaryAction: VToastAction(label: "Undo") { [weak self] in
-                self?.mainWindow?.threadManager.restoreUnseen(threadIds: markedIds)
+                self?.mainWindow?.conversationManager.restoreUnseen(threadIds: markedIds)
                 self?.mainWindow?.windowState.dismissToast()
             },
             onDismiss: { [weak self] in
-                self?.mainWindow?.threadManager.commitPendingSeenSignals()
+                self?.mainWindow?.conversationManager.commitPendingSeenSignals()
             }
         )
-        threadManager.schedulePendingSeenSignals { [weak self] in
+        conversationManager.schedulePendingSeenSignals { [weak self] in
             guard let toastId else { return }
             self?.mainWindow?.windowState.dismissToast(id: toastId)
         }
@@ -381,7 +381,7 @@ extension AppDelegate {
 
         let markAllSeenItem = NSMenuItem(
             title: "Mark All Threads as Seen",
-            action: #selector(markAllThreadsSeen),
+            action: #selector(markAllConversationsSeen),
             keyEquivalent: ""
         )
         markAllSeenItem.target = self
@@ -390,7 +390,7 @@ extension AppDelegate {
         return menu
     }
 
-    @objc func openCurrentThread() {
+    @objc func openCurrentConversation() {
         guard !isBootstrapping else { return }
         showMainWindow()
     }
@@ -398,15 +398,15 @@ extension AppDelegate {
     @objc func openNewChat() {
         guard !isBootstrapping else { return }
         showMainWindow()
-        mainWindow?.threadManager.createThread()
-        if let id = mainWindow?.threadManager.activeThreadId {
+        mainWindow?.conversationManager.createConversation()
+        if let id = mainWindow?.conversationManager.activeConversationId {
             mainWindow?.windowState.selection = .thread(id)
         }
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
 
     @objc func activateChatSearch() {
-        NotificationCenter.default.post(name: .activateChatSearch, object: mainWindow?.threadManager.activeThreadId)
+        NotificationCenter.default.post(name: .activateChatSearch, object: mainWindow?.conversationManager.activeConversationId)
     }
 
     @objc func openAppCollection() {
@@ -489,8 +489,8 @@ extension AppDelegate {
         }
     }
 
-    @objc func sendCurrentThreadLogsToSentry() {
-        guard let thread = mainWindow?.threadManager.activeThread,
+    @objc func sendCurrentConversationLogsToSentry() {
+        guard let thread = mainWindow?.conversationManager.activeConversation,
               let conversationId = thread.conversationId else { return }
 
         // Defer window creation until after the status menu finishes dismissing,
@@ -534,7 +534,7 @@ extension AppDelegate {
         case .global:
             window.title = "Send Logs to Vellum"
         case .thread:
-            window.title = "Send Logs for Thread"
+            window.title = "Send Logs for Conversation"
         }
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -515,8 +515,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                         evidenceText: "User clicked View on notification"
                     )
                     // Clear local unseen state so sidebar dot disappears immediately
-                    if let threadIdx = self.mainWindow?.threadManager.threads.firstIndex(where: { $0.conversationId == conversationId }) {
-                        self.mainWindow?.threadManager.threads[threadIdx].hasUnseenLatestAssistantMessage = false
+                    if let threadIdx = self.mainWindow?.conversationManager.conversations.firstIndex(where: { $0.conversationId == conversationId }) {
+                        self.mainWindow?.conversationManager.conversations[threadIdx].hasUnseenLatestAssistantMessage = false
                     }
                 } else {
                     self.showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -83,7 +83,7 @@ extension AppDelegate {
             let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
 
             // Sync recording state: clear on the view model that started recording
-            // to avoid stale isRecording when the user switches threads mid-recording.
+            // to avoid stale isRecording when the user switches conversations mid-recording.
             if isRecording {
                 self?.recordingViewModel = self?.mainWindow?.activeViewModel
             }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -149,7 +149,7 @@ extension AppDelegate {
                             requestId: msg.requestId,
                             decision: "allow"
                         )
-                        self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
+                        self.mainWindow?.conversationManager.updateConfirmationStateAcrossThreads(
                             requestId: msg.requestId,
                             decision: "allow"
                         )
@@ -166,7 +166,7 @@ extension AppDelegate {
                 // the inline bubble won't be visible, so we must still fire the
                 // native notification.
                 if NSApp.isActive, let mainWindow = self.mainWindow, mainWindow.isVisible {
-                    let activeSessionId = mainWindow.threadManager.activeViewModel?.conversationId
+                    let activeSessionId = mainWindow.conversationManager.activeViewModel?.conversationId
                     let confirmationIsForActiveThread = msg.sessionId == nil || msg.sessionId == activeSessionId
                     if confirmationIsForActiveThread {
                         return
@@ -185,7 +185,7 @@ extension AppDelegate {
                         decision: decision
                     )
                     // Only sync the inline message state if the send succeeded.
-                    self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
+                    self.mainWindow?.conversationManager.updateConfirmationStateAcrossThreads(
                         requestId: msg.requestId,
                         decision: decision
                     )
@@ -497,7 +497,7 @@ extension AppDelegate {
         main.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }
-        main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
+        main.conversationManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
             guard let self else { return }
             self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
             UNUserNotificationCenter.current().removeDeliveredNotifications(
@@ -506,7 +506,7 @@ extension AppDelegate {
         }
         mainWindow = main
         observeAssistantStatus()
-        observeConversationBadge(main.threadManager)
+        observeConversationBadge(main.conversationManager)
         return main
     }
 
@@ -558,16 +558,16 @@ extension AppDelegate {
         // updates when isThinking or errorText changes, even though SwiftUI
         // views now use ActiveChatViewWrapper for their own observation.
         //
-        // Use the emitted UUID directly (not activeViewModel) because $activeThreadId
-        // fires during willSet — at that point activeThreadId still holds the old value,
+        // Use the emitted UUID directly (not activeViewModel) because $activeConversationId
+        // fires during willSet — at that point activeConversationId still holds the old value,
         // so activeViewModel would resolve to the previous thread's view model.
-        statusIconCancellable = mainWindow?.threadManager.$activeThreadId
+        statusIconCancellable = mainWindow?.conversationManager.$activeConversationId
             .compactMap { [weak mainWindow] (id: UUID?) -> ChatViewModel? in
                 guard let id else { return nil }
-                return mainWindow?.threadManager.chatViewModel(for: id)
+                return mainWindow?.conversationManager.chatViewModel(for: id)
             }
             .handleEvents(receiveOutput: { [weak self] _ in
-                // Update immediately when switching threads
+                // Update immediately when switching conversations
                 self?.updateMenuBarIcon()
             })
             .map { $0.objectWillChange }
@@ -578,13 +578,13 @@ extension AppDelegate {
             }
     }
 
-    func observeConversationBadge(_ threadManager: ThreadManager) {
+    func observeConversationBadge(_ conversationManager: ConversationManager) {
         conversationBadgeCancellable?.cancel()
 
-        applyDockConversationBadge(count: threadManager.unseenVisibleConversationCount)
+        applyDockConversationBadge(count: conversationManager.unseenVisibleConversationCount)
 
-        conversationBadgeCancellable = threadManager.$threads
-            .map { threads in threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count }
+        conversationBadgeCancellable = conversationManager.$conversations
+            .map { conversations in conversations.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count }
             .removeDuplicates()
             .sink { [weak self] count in
                 self?.applyDockConversationBadge(count: count)
@@ -607,7 +607,7 @@ extension AppDelegate {
     }
 
     func refreshDockConversationBadge() {
-        applyDockConversationBadge(count: mainWindow?.threadManager.unseenVisibleConversationCount ?? 0)
+        applyDockConversationBadge(count: mainWindow?.conversationManager.unseenVisibleConversationCount ?? 0)
     }
 }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -429,7 +429,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     public func createNewThread() {
         showMainWindow()
-        mainWindow?.threadManager.createThread()
+        mainWindow?.conversationManager.createConversation()
     }
 
 }

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -30,7 +30,7 @@ public final class AppServices {
 
     /// Reconfigure the daemon client's transport in place (e.g., for HTTP transport).
     /// This preserves the DaemonClient object identity so long-lived holders
-    /// (ThreadManager, ChatViewModel, RecordingManager, SettingsStore) continue
+    /// (ConversationManager, ChatViewModel, RecordingManager, SettingsStore) continue
     /// to reference the same instance after an assistant switch.
     func reconfigureDaemonClient(config: DaemonConfig) {
         daemonClient.reconfigure(config: config)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -635,7 +635,7 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // Called synchronously so isNearBottom is cleared before any competing
                 // layout pass can trigger an auto-scroll-to-bottom.
                 // Guard: only untether if content is actually scrollable (prevents false
-                // untethers on short threads that can't scroll).
+                // untethers on short conversations that can't scroll).
                 if let scrollView = coordinator.findEnclosingScrollView() {
                     let clipHeight = scrollView.contentView.bounds.height
                     let docHeight = scrollView.documentView?.frame.height ?? 0

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -286,7 +286,7 @@ struct ComposerView: View {
 
             let group = DispatchGroup()
             // Collect URLs on the main queue to avoid concurrent Array mutation
-            // from loadObject callbacks that may fire on different threads.
+            // from loadObject callbacks that may fire on different conversations.
             var urls: [URL] = []
             var imageDataItems: [NSItemProvider] = []
             for provider in providers {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -177,7 +177,7 @@ struct MarkdownSegmentView: View {
     private static let maxCacheBytes = 5_000_000
     @MainActor static var estimatedCacheBytes: Int = 0
 
-    /// Clears the attributed string cache.  Called when switching threads
+    /// Clears the attributed string cache.  Called when switching conversations
     /// or archiving a conversation to reclaim memory.
     static func clearAttributedStringCache() {
         attributedStringCache.removeAll()

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -12,7 +12,7 @@ final class CommandPaletteViewModel {
     /// Static actions (set once at palette creation).
     var actions: [CommandPaletteAction] = []
 
-    /// Recent conversations (set once at palette creation from ThreadManager).
+    /// Recent conversations (set once at palette creation from ConversationManager).
     var recentItems: [CommandPaletteRecentItem] = []
 
     /// Server search results populated from the global search API.

--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct CollapsedThreadSwitcherPresentation {
-    let switchTargets: [ThreadModel]
+struct CollapsedConversationSwitcherPresentation {
+    let switchTargets: [ConversationModel]
     let activeThreadTitle: String?
     let totalRegularThreadCount: Int
 
@@ -14,22 +14,22 @@ struct CollapsedThreadSwitcherPresentation {
 
     var accessibilityLabel: String {
         if let title = activeThreadTitle {
-            return "Switch threads: \(title)"
+            return "Switch conversations: \(title)"
         }
-        return "Switch threads"
+        return "Switch conversations"
     }
 
     var accessibilityValue: String {
-        totalRegularThreadCount == 0 ? "" : "\(totalRegularThreadCount) threads"
+        totalRegularThreadCount == 0 ? "" : "\(totalRegularThreadCount) conversations"
     }
 
-    init(regularThreads: [ThreadModel], activeThreadId: UUID?) {
-        self.totalRegularThreadCount = regularThreads.count
-        if let activeId = activeThreadId {
-            self.switchTargets = regularThreads.filter { $0.id != activeId }
-            self.activeThreadTitle = regularThreads.first(where: { $0.id == activeId })?.title
+    init(regularConversations: [ConversationModel], activeConversationId: UUID?) {
+        self.totalRegularThreadCount = regularConversations.count
+        if let activeId = activeConversationId {
+            self.switchTargets = regularConversations.filter { $0.id != activeId }
+            self.activeThreadTitle = regularConversations.first(where: { $0.id == activeId })?.title
         } else {
-            self.switchTargets = regularThreads
+            self.switchTargets = regularConversations
             self.activeThreadTitle = nil
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 /// Presentation model for the thread title + actions control in the top bar.
 /// Keeps UI logic deterministic and testable.
 @MainActor
-struct ThreadHeaderPresentation {
+struct ConversationHeaderPresentation {
     let displayTitle: String
     let isStarted: Bool
     let showsActionsMenu: Bool
@@ -12,8 +12,8 @@ struct ThreadHeaderPresentation {
     let canCopy: Bool
     let isPinned: Bool
 
-    init(activeThread: ThreadModel?, activeViewModel: ChatViewModel?, isConversationVisible: Bool) {
-        guard isConversationVisible, let thread = activeThread else {
+    init(activeConversation: ConversationModel?, activeViewModel: ChatViewModel?, isConversationVisible: Bool) {
+        guard isConversationVisible, let thread = activeConversation else {
             self.displayTitle = "New thread"
             self.isStarted = false
             self.showsActionsMenu = false
@@ -33,7 +33,7 @@ struct ThreadHeaderPresentation {
         }) ?? false
         self.isStarted = thread.conversationId != nil || hasUserMessage
 
-        // Private threads don't show the full actions menu
+        // Private conversations don't show the full actions menu
         self.showsActionsMenu = isStarted && !isPrivateThread
 
         // Can copy when there's non-empty content

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -5,7 +5,7 @@ import UserNotifications
 import os
 import Combine
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadManager")
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
 private let archivedSessionsKey = "archivedConversationIds"
 
 // MARK: - Conversation Client Protocol
@@ -30,13 +30,13 @@ struct ConversationClient: ConversationClientProtocol {
 }
 
 @MainActor
-final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
-    @AppStorage("restoreRecentThreads") private(set) var restoreRecentThreads = true
-    @AppStorage("lastActiveThreadId") private var lastActiveThreadIdString: String?
+final class ConversationManager: ObservableObject, ConversationRestorerDelegate {
+    @AppStorage("restoreRecentConversations") private(set) var restoreRecentConversations = true
+    @AppStorage("lastActiveConversationId") private var lastActiveConversationIdString: String?
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
-    @Published var threads: [ThreadModel] = []
-    @Published var hasMoreThreads: Bool = false
-    @Published var isLoadingMoreThreads: Bool = false
+    @Published var conversations: [ConversationModel] = []
+    @Published var hasMoreConversations: Bool = false
+    @Published var isLoadingMoreConversations: Bool = false
     private struct AssistantActivitySnapshot: Equatable {
         let messageId: UUID
         let textLength: Int
@@ -48,20 +48,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Tracks the number of rows already fetched from the daemon so pagination
     /// offsets stay correct even when the client filters out some sessions.
     var serverOffset: Int = 0
-    @Published var activeThreadId: UUID? {
+    @Published var activeConversationId: UUID? {
         didSet {
-            if let activeThreadId {
+            if let activeConversationId {
                 // Switching to a real thread discards any draft
                 draftViewModel = nil
 
-                let activeViewModel = getOrCreateViewModel(for: activeThreadId)
+                let activeViewModel = getOrCreateViewModel(for: activeConversationId)
                 activeViewModel?.ensureMessageLoopStarted()
-                conversationRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
+                conversationRestorer.loadHistoryIfNeeded(threadId: activeConversationId)
                 // Only persist the active thread ID if we're not in the middle of restoration.
                 // During init and session restoration, the didSet fires multiple times and would
-                // overwrite the saved value before restoreLastActiveThread() reads it.
-                if !isRestoringThreads {
-                    lastActiveThreadIdString = activeThreadId.uuidString
+                // overwrite the saved value before restoreLastActiveConversation() reads it.
+                if !isRestoringConversations {
+                    lastActiveConversationIdString = activeConversationId.uuidString
                 }
                 // Notify the daemon so it rebinds the socket to this thread's session.
                 // Without this, socketToSession stays stale after thread switches,
@@ -75,18 +75,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 }
             } else {
                 // Only clear the persisted thread ID outside of restoration.
-                // During init, enterDraftMode() sets activeThreadId = nil before
-                // restoreLastActiveThread() reads the saved value.
-                if !isRestoringThreads {
-                    lastActiveThreadIdString = nil
+                // During init, enterDraftMode() sets activeConversationId = nil before
+                // restoreLastActiveConversation() reads the saved value.
+                if !isRestoringConversations {
+                    lastActiveConversationIdString = nil
                 }
             }
             // Clear stale anchor when switching away from the thread that
             // owns it — prevents the anchor from suppressing scroll-to-bottom
             // on unrelated thread switches.
-            if let anchorThread = pendingAnchorThreadId, anchorThread != activeThreadId {
+            if let anchorThread = pendingAnchorConversationId, anchorThread != activeConversationId {
                 pendingAnchorMessageId = nil
-                pendingAnchorThreadId = nil
+                pendingAnchorConversationId = nil
             }
             // Subscribe to the new active view model's changes
             subscribeToActiveViewModel()
@@ -103,34 +103,34 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var vmAccessOrder: [UUID] = []
     private let daemonClient: DaemonClient
     private let conversationClient: ConversationClientProtocol
-    private let conversationRestorer: ThreadConversationRestorer
+    private let conversationRestorer: ConversationRestorer
     private let activityNotificationService: ActivityNotificationService?
-    /// Queued renames for threads that don't yet have a sessionId.
+    /// Queued renames for conversations that don't yet have a sessionId.
     /// Flushed in backfillConversationId when the daemon assigns a session.
     private var pendingRenames: [UUID: String] = [:]
-    /// Flag to suppress lastActiveThreadIdString writes during initialization and session restoration.
-    private var isRestoringThreads = false
+    /// Flag to suppress lastActiveConversationIdString writes during initialization and session restoration.
+    private var isRestoringConversations = false
     /// Subscription to activeViewModel's messages count changes.
     /// Drives activeMessageCount so only message-count-dependent views re-render,
     /// not the entire window tree.
     private var activeViewModelCancellable: AnyCancellable?
     /// Tracks the message count of the active thread's view model.
     /// SwiftUI views that need to react to new messages should observe this
-    /// instead of subscribing to ThreadManager.objectWillChange, which fires
+    /// instead of subscribing to ConversationManager.objectWillChange, which fires
     /// for every property change and causes full-tree re-renders.
     @Published public private(set) var activeMessageCount: Int = 0
     /// Subscriptions to per-thread busy-state changes (isSending, isThinking, pendingQueuedCount).
     private var busyStateCancellables: [UUID: Set<AnyCancellable>] = [:]
     /// Subscription to assistant activity per thread.
-    /// Used to mark inactive threads as unseen when assistant output changes.
+    /// Used to mark inactive conversations as unseen when assistant output changes.
     private var assistantActivityCancellables: [UUID: AnyCancellable] = [:]
     /// Last observed assistant activity snapshot per thread.
     private var latestAssistantActivitySnapshots: [UUID: AssistantActivitySnapshot] = [:]
     /// Cached set of thread IDs whose ChatViewModel indicates active processing.
-    @Published private(set) var busyThreadIds: Set<UUID> = []
+    @Published private(set) var busyConversationIds: Set<UUID> = []
     /// Per-thread interaction state derived from ChatViewModel properties.
     /// Priority: error > waitingForInput > processing > idle.
-    @Published private(set) var threadInteractionStates: [UUID: ThreadInteractionState] = [:]
+    @Published private(set) var conversationInteractionStates: [UUID: ConversationInteractionState] = [:]
     /// Subscriptions to per-thread interaction-state changes.
     private var interactionStateCancellables: [UUID: Set<AnyCancellable>] = [:]
     /// Pending anchor message ID for scroll-to behavior on notification deep links.
@@ -140,7 +140,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     @Published var highlightedMessageId: UUID?
     /// Tracks which thread the pending anchor belongs to so stale anchors are
     /// cleared automatically when the user switches to a different thread.
-    private var pendingAnchorThreadId: UUID?
+    private var pendingAnchorConversationId: UUID?
     /// Session IDs whose seen signals are deferred pending undo expiration.
     private var pendingSeenConversationIds: [String] = []
     /// Task that auto-commits deferred seen signals after the undo window.
@@ -162,29 +162,29 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let override: PendingAttentionOverride?
     }
 
-    /// Snapshots captured by the most recent `markAllThreadsSeen()` call,
+    /// Snapshots captured by the most recent `markAllConversationsSeen()` call,
     /// keyed by thread ID. Consumed by `restoreUnseen(threadIds:)`.
     private var markAllSeenPriorStates: [UUID: MarkAllSeenPriorState] = [:]
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
-    /// Sorted: pinned first (by pinnedOrder ascending), then threads with explicit
-    /// displayOrder ascending, then remaining threads by lastInteractedAt descending.
+    /// Sorted: pinned first (by pinnedOrder ascending), then conversations with explicit
+    /// displayOrder ascending, then remaining conversations by lastInteractedAt descending.
     /// Threads move to the top when messages are sent or received, but NOT when clicked/selected.
-    var visibleThreads: [ThreadModel] {
-        threads.filter { !$0.isArchived && $0.kind != .private }
-            .sorted { visibleThreadSortOrder($0, $1) }
+    var visibleConversations: [ConversationModel] {
+        conversations.filter { !$0.isArchived && $0.kind != .private }
+            .sorted { visibleConversationSortOrder($0, $1) }
     }
 
-    /// Shared sort predicate for visible threads: pinned first (by pinnedOrder),
-    /// then threads with explicit displayOrder, then remaining by recency.
-    private func visibleThreadSortOrder(_ a: ThreadModel, _ b: ThreadModel) -> Bool {
+    /// Shared sort predicate for visible conversations: pinned first (by pinnedOrder),
+    /// then conversations with explicit displayOrder, then remaining by recency.
+    private func visibleConversationSortOrder(_ a: ConversationModel, _ b: ConversationModel) -> Bool {
         if a.isPinned && b.isPinned {
             return (a.pinnedOrder ?? 0) < (b.pinnedOrder ?? 0)
         }
         if a.isPinned { return true }
         if b.isPinned { return false }
         // Threads without explicit displayOrder (nil) sort by recency and
-        // appear ABOVE explicitly-ordered threads so new/active threads are
+        // appear ABOVE explicitly-ordered conversations so new/active conversations are
         // never buried below stale manual ordering.
         if a.displayOrder == nil && b.displayOrder == nil {
             return a.lastInteractedAt > b.lastInteractedAt
@@ -194,60 +194,60 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return a.displayOrder! < b.displayOrder!
     }
 
-    /// Count of visible (non-archived, non-private) threads with unseen assistant messages.
+    /// Count of visible (non-archived, non-private) conversations with unseen assistant messages.
     /// Used by AppDelegate to drive the dock badge.
     var unseenVisibleConversationCount: Int {
-        threads.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count
+        conversations.filter { !$0.isArchived && $0.kind != .private && $0.hasUnseenLatestAssistantMessage }.count
     }
 
-    var archivedThreads: [ThreadModel] {
-        threads.filter { $0.isArchived }
+    var archivedConversations: [ConversationModel] {
+        conversations.filter { $0.isArchived }
     }
 
-    var activeThread: ThreadModel? {
-        guard let id = activeThreadId else { return nil }
-        return threads.first { $0.id == id }
+    var activeConversation: ConversationModel? {
+        guard let id = activeConversationId else { return nil }
+        return conversations.first { $0.id == id }
     }
 
     var activeViewModel: ChatViewModel? {
-        if activeThreadId == nil, let draftViewModel {
+        if activeConversationId == nil, let draftViewModel {
             return draftViewModel
         }
-        guard let activeThreadId else { return nil }
-        return getOrCreateViewModel(for: activeThreadId)
+        guard let activeConversationId else { return nil }
+        return getOrCreateViewModel(for: activeConversationId)
     }
 
     init(daemonClient: DaemonClient, conversationClient: ConversationClientProtocol = ConversationClient(), activityNotificationService: ActivityNotificationService? = nil, isFirstLaunch: Bool = false) {
         self.daemonClient = daemonClient
         self.conversationClient = conversationClient
         self.activityNotificationService = activityNotificationService
-        self.conversationRestorer = ThreadConversationRestorer(daemonClient: daemonClient)
+        self.conversationRestorer = ConversationRestorer(daemonClient: daemonClient)
         // On first launch (post-onboarding), skip session restoration — there are
-        // no meaningful prior sessions. Allow activeThreadId writes immediately so
+        // no meaningful prior sessions. Allow activeConversationId writes immediately so
         // the wake-up thread's UUID is persisted.
         // On normal launches, suppress writes during restoration so the saved
-        // value isn't overwritten before restoreLastActiveThread() reads it.
-        self.isRestoringThreads = !isFirstLaunch
+        // value isn't overwritten before restoreLastActiveConversation() reads it.
+        self.isRestoringConversations = !isFirstLaunch
         // Enter draft mode so the window shows an empty chat without a sidebar entry
         enterDraftMode()
         conversationRestorer.delegate = self
         conversationRestorer.startObserving(skipInitialFetch: isFirstLaunch)
     }
 
-    func createThread() {
+    func createConversation() {
         // If already in draft mode with an empty draft, no-op
-        if draftViewModel != nil, activeThreadId == nil {
+        if draftViewModel != nil, activeConversationId == nil {
             return
         }
 
         // If the active thread is still empty, just keep it instead of creating another.
         // Only reuse when the thread is truly fresh: no messages at all, no persisted
         // session, and not a private thread (which have different persistence semantics).
-        if let activeId = activeThreadId,
+        if let activeId = activeConversationId,
            let vm = chatViewModels[activeId],
            vm.messages.isEmpty {
-            let activeThread = threads.first(where: { $0.id == activeId })
-            if activeThread?.kind != .private && activeThread?.conversationId == nil {
+            let activeConversation = conversations.first(where: { $0.id == activeId })
+            if activeConversation?.kind != .private && activeConversation?.conversationId == nil {
                 return
             }
         }
@@ -261,7 +261,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     ///
     /// - Parameters:
     ///   - message: Text to place in the input field. When nil, the input is left unchanged.
-    ///   - forceNew: When true, always creates a fresh thread via `createThread()`
+    ///   - forceNew: When true, always creates a fresh thread via `createConversation()`
     ///     even if one is already active. Defaults to false (reuse the active thread).
     ///   - autoSend: When true **and** a message is provided, the message is sent
     ///     immediately. When false the message is only placed in the input field.
@@ -270,14 +270,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     ///     is populated/sent (e.g., set skill invocation data or dock state).
     /// - Returns: The active `ChatViewModel`, or nil if thread creation failed.
     @discardableResult
-    func openThread(
+    func openConversation(
         message: String? = nil,
         forceNew: Bool = false,
         autoSend: Bool = true,
         configure: ((ChatViewModel) -> Void)? = nil
     ) -> ChatViewModel? {
         if forceNew || activeViewModel == nil {
-            createThread()
+            createConversation()
         }
         guard let viewModel = activeViewModel else { return nil }
         configure?(viewModel)
@@ -295,19 +295,19 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Selection priority:
     /// 1. If `preferredConversationId` is provided, select a non-archived thread with that session.
     /// 2. Otherwise, select the first visible thread.
-    /// 3. If no threads exist, create a new one.
+    /// 3. If no conversations exist, create a new one.
     ///
     /// Used by `.onAppear` handlers in panel layouts to guarantee a `ChatViewModel`
     /// is available before the chat view renders.
-    func ensureActiveThread(preferredConversationId: String? = nil) {
+    func ensureActiveConversation(preferredConversationId: String? = nil) {
         guard activeViewModel == nil else { return }
         if let conversationId = preferredConversationId,
-           let match = threads.first(where: { $0.conversationId == conversationId && !$0.isArchived }) {
-            selectThread(id: match.id)
-        } else if let first = visibleThreads.first {
-            selectThread(id: first.id)
+           let match = conversations.first(where: { $0.conversationId == conversationId && !$0.isArchived }) {
+            selectConversation(id: match.id)
+        } else if let first = visibleConversations.first {
+            selectConversation(id: first.id)
         } else {
-            createThread()
+            createConversation()
         }
     }
 
@@ -315,7 +315,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// The thread is only created when the user sends their first message.
     func enterDraftMode() {
         // If already in draft mode with an empty draft, no-op (reuse existing draft)
-        if let draftVM = draftViewModel, draftVM.messages.isEmpty, activeThreadId == nil {
+        if let draftVM = draftViewModel, draftVM.messages.isEmpty, activeConversationId == nil {
             return
         }
 
@@ -328,20 +328,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.promoteDraft(fromUserSend: true)
         }
         draftViewModel = viewModel
-        activeThreadId = nil
+        activeConversationId = nil
         subscribeToActiveViewModel()
         log.info("Entered draft mode")
     }
 
     /// Promote the draft view model to a real thread.
     /// - Parameter fromUserSend: true when triggered by a user message send,
-    ///   false when triggered by `createThread()` needing a guaranteed `activeThreadId`.
+    ///   false when triggered by `createConversation()` needing a guaranteed `activeConversationId`.
     private func promoteDraft(fromUserSend: Bool) {
         guard let viewModel = draftViewModel else { return }
 
-        let thread = ThreadModel(title: "Untitled")
+        let thread = ConversationModel(title: "Untitled")
         let threadId = thread.id
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
@@ -350,7 +350,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         evictStaleCachedViewModels()
         draftViewModel = nil
 
-        // Increment only on actual user sends, not programmatic createThread() calls.
+        // Increment only on actual user sends, not programmatic createConversation() calls.
         if fromUserSend {
             completedConversationCount += 1
         }
@@ -358,13 +358,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Wire up callbacks now that we have a real thread.
         // onFirstUserMessage is already consumed for user-send promotions
         // (it fires before onUserMessageSent in sendMessage), so only set it
-        // for createThread()-triggered promotions where no message was sent yet.
+        // for createConversation()-triggered promotions where no message was sent yet.
         if !fromUserSend {
             viewModel.onFirstUserMessage = { [weak self] _ in
                 self?.completedConversationCount += 1
                 // Only set "Untitled" if the user hasn't already renamed this thread.
                 if self?.pendingRenames[threadId] == nil {
-                    self?.updateThreadTitle(id: threadId, title: "Untitled")
+                    self?.updateConversationTitle(id: threadId, title: "Untitled")
                 }
                 self?.updateLastInteracted(threadId: threadId)
             }
@@ -373,13 +373,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.updateLastInteracted(threadId: threadId)
         }
 
-        activeThreadId = thread.id
+        activeConversationId = thread.id
         updateLastInteracted(threadId: thread.id)
-        log.info("Promoted draft to thread \(thread.id)")
+        log.info("Promoted draft to conversation \(thread.id)")
     }
 
-    func createPrivateThread() {
-        let thread = ThreadModel(kind: .private)
+    func createPrivateConversation() {
+        let thread = ConversationModel(kind: .private)
         let viewModel = makeViewModel()
         viewModel.isHistoryLoaded = true  // No session yet — nothing to load
         let threadId = thread.id
@@ -387,38 +387,38 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             self?.completedConversationCount += 1
             // Only set "Untitled" if the user hasn't already renamed this thread.
             if self?.pendingRenames[threadId] == nil {
-                self?.updateThreadTitle(id: threadId, title: "Untitled")
+                self?.updateConversationTitle(id: threadId, title: "Untitled")
             }
             self?.updateLastInteracted(threadId: threadId)
         }
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
         subscribeToInteractionState(for: thread.id, viewModel: viewModel)
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
-        activeThreadId = thread.id
+        activeConversationId = thread.id
 
         // Immediately create a daemon session so the thread is persisted
         // before the user sends any messages.
         viewModel.createConversationIfNeeded(conversationType: "private")
 
-        log.info("Created private thread \(thread.id)")
+        log.info("Created private conversation \(thread.id)")
     }
 
     /// Remove a private (temporary) thread and delete its backend conversation.
     /// Stops any active generation before cleanup.
-    func removePrivateThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id && $0.kind == .private }) else { return }
+    func removePrivateConversation(id: UUID) {
+        guard let index = conversations.firstIndex(where: { $0.id == id && $0.kind == .private }) else { return }
 
-        let conversationId = threads[index].conversationId
+        let conversationId = conversations[index].conversationId
 
         // Stop generation and clean up local state
         chatViewModels[id]?.stopGenerating()
-        threads.remove(at: index)
+        conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
-        unsubscribeAllForThread(id: id)
+        unsubscribeAllForConversation(id: id)
         vmAccessOrder.removeAll { $0 == id }
         Self.clearRenderCaches()
 
@@ -427,19 +427,19 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             daemonClient.deleteConversation(conversationId)
         }
 
-        log.info("Removed private thread \(id)")
+        log.info("Removed private conversation \(id)")
     }
 
     /// Create a visible thread bound to an existing task run conversation.
     /// Called when the daemon broadcasts `task_run_conversation_created` so the user
     /// can see task execution messages streaming in real-time.
-    func createTaskRunThread(conversationId: String, workItemId: String, title: String) {
+    func createTaskRunConversation(conversationId: String, workItemId: String, title: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
-        if threads.contains(where: { $0.conversationId == conversationId }) {
+        if conversations.contains(where: { $0.conversationId == conversationId }) {
             return
         }
 
-        let thread = ThreadModel(title: title, conversationId: conversationId)
+        let thread = ConversationModel(title: title, conversationId: conversationId)
         let viewModel = makeViewModel()
         viewModel.conversationId = conversationId
         // Mark history as loaded since this thread streams live — there is no
@@ -450,7 +450,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Start the message loop so the view model receives streamed messages
         viewModel.startMessageLoop()
 
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
@@ -458,19 +458,19 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
-        log.info("Created task run thread \(thread.id) for conversation \(conversationId) (work item \(workItemId))")
+        log.info("Created task run conversation \(thread.id) for conversation \(conversationId) (work item \(workItemId))")
     }
 
     /// Create a visible thread bound to a schedule-created conversation.
     /// Called when the daemon broadcasts `schedule_conversation_created` so the user
-    /// sees scheduled threads in the sidebar without a full refresh.
-    func createScheduleThread(conversationId: String, scheduleJobId: String, title: String) {
+    /// sees scheduled conversations in the sidebar without a full refresh.
+    func createScheduleConversation(conversationId: String, scheduleJobId: String, title: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
-        if threads.contains(where: { $0.conversationId == conversationId }) {
+        if conversations.contains(where: { $0.conversationId == conversationId }) {
             return
         }
 
-        var thread = ThreadModel(title: title, conversationId: conversationId)
+        var thread = ConversationModel(title: title, conversationId: conversationId)
         thread.scheduleJobId = scheduleJobId
         thread.source = "schedule"
         let viewModel = makeViewModel()
@@ -478,7 +478,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.isHistoryLoaded = true
         viewModel.startMessageLoop()
 
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
@@ -486,37 +486,37 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
-        log.info("Created schedule thread \(thread.id) for conversation \(conversationId) (schedule \(scheduleJobId))")
+        log.info("Created schedule conversation \(thread.id) for conversation \(conversationId) (schedule \(scheduleJobId))")
     }
 
     /// Create a visible thread bound to a notification-created conversation.
     /// Called when the daemon broadcasts `notification_thread_created` so the user
-    /// can see notification threads and deep-link into them.
-    func createNotificationThread(conversationId: String, title: String, sourceEventName: String) {
+    /// can see notification conversations and deep-link into them.
+    func createNotificationConversation(conversationId: String, title: String, sourceEventName: String) {
         // Avoid creating a duplicate thread if one already exists for this conversation
-        if threads.contains(where: { $0.conversationId == conversationId }) {
+        if conversations.contains(where: { $0.conversationId == conversationId }) {
             return
         }
 
-        var thread = ThreadModel(title: title, conversationId: conversationId)
+        var thread = ConversationModel(title: title, conversationId: conversationId)
         thread.source = "notification"
         thread.hasUnseenLatestAssistantMessage = true
         let viewModel = makeViewModel()
         viewModel.conversationId = conversationId
-        // Do NOT set isHistoryLoaded here — notification threads have a
+        // Do NOT set isHistoryLoaded here — notification conversations have a
         // pre-existing seed message persisted by conversation-pairing before
         // the notification_thread_created event is emitted. Leaving
-        // isHistoryLoaded false allows ThreadConversationRestorer.loadHistoryIfNeeded
+        // isHistoryLoaded false allows ConversationRestorer.loadHistoryIfNeeded
         // to fetch that seed message when the thread is first selected.
         // The handleAssistantMessageArrival guard dropping updates is correct
-        // for notification threads because their content arrives via history
+        // for notification conversations because their content arrives via history
         // load, not live streaming. Unread state is already set explicitly
         // above (hasUnseenLatestAssistantMessage = true).
 
         // Start the message loop so the view model receives streamed messages
         viewModel.startMessageLoop()
 
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
@@ -524,22 +524,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
-        log.info("Created notification thread \(thread.id) for conversation \(conversationId) (source: \(sourceEventName))")
+        log.info("Created notification conversation \(thread.id) for conversation \(conversationId) (source: \(sourceEventName))")
     }
 
-    func closeThread(id: UUID) {
+    func closeConversation(id: UUID) {
         // No-op if only 1 thread remains
-        guard threads.count > 1 else { return }
+        guard conversations.count > 1 else { return }
 
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
 
         // Cancel any active generation so the daemon doesn't keep processing
         // an orphaned request after the view model is removed.
         chatViewModels[id]?.stopGenerating()
 
-        threads.remove(at: index)
+        conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
-        unsubscribeAllForThread(id: id)
+        unsubscribeAllForConversation(id: id)
         vmAccessOrder.removeAll { $0 == id }
 
         // Reclaim memory held by static caches that may reference
@@ -547,37 +547,37 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         Self.clearRenderCaches()
 
         // If the closed thread was active, select an adjacent thread
-        if activeThreadId == id {
+        if activeConversationId == id {
             // Prefer the thread at the same index (next), otherwise fall back to last
-            if index < threads.count {
-                activeThreadId = threads[index].id
+            if index < conversations.count {
+                activeConversationId = conversations[index].id
             } else {
-                activeThreadId = threads.last?.id
+                activeConversationId = conversations.last?.id
             }
         }
 
         log.info("Closed thread \(id)")
     }
 
-    func archiveThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+    func archiveConversation(id: UUID) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
 
         // Clear ordering state before archiving so stale is_pinned/display_order
         // values don't affect DB pagination (which sorts by is_pinned DESC).
         // Send the update BEFORE setting isArchived, because sendReorderConversations()
-        // only serializes visibleThreads (non-archived).
-        let wasPinned = threads[index].isPinned
-        let hadOrder = threads[index].displayOrder != nil
+        // only serializes visibleConversations (non-archived).
+        let wasPinned = conversations[index].isPinned
+        let hadOrder = conversations[index].displayOrder != nil
 
         // Batch mutations into a single array write to avoid multiple
         // @Published objectWillChange emissions that can cause SwiftUI
         // ForEach re-entrancy crashes.
-        var thread = threads[index]
+        var thread = conversations[index]
         thread.isPinned = false
         thread.pinnedOrder = nil
         thread.displayOrder = nil
         thread.isArchived = true
-        threads[index] = thread
+        conversations[index] = thread
 
         if wasPinned {
             recompactPinnedOrders()
@@ -586,14 +586,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             sendReorderConversations()
         }
 
-        if let conversationId = threads[index].conversationId {
+        if let conversationId = conversations[index].conversationId {
             chatViewModels[id]?.stopGenerating()
             var archived = archivedConversationIds
             archived.insert(conversationId)
             archivedConversationIds = archived
             // Session ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
-            unsubscribeAllForThread(id: id)
+            unsubscribeAllForConversation(id: id)
             vmAccessOrder.removeAll { $0 == id }
         } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
                     && chatViewModels[id]?.isBootstrapping != true {
@@ -602,7 +602,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             // a session will never be created, so there is nothing to backfill.
             // Clean up immediately.
             chatViewModels.removeValue(forKey: id)
-            unsubscribeAllForThread(id: id)
+            unsubscribeAllForConversation(id: id)
             vmAccessOrder.removeAll { $0 == id }
         } else {
             // Session ID is nil but a session is expected (user messages exist
@@ -619,22 +619,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         // If the archived thread was active, select an adjacent visible thread
         // or create a new one if none remain.
-        if activeThreadId == id {
-            // Find the position of the archived thread among visible threads
+        if activeConversationId == id {
+            // Find the position of the archived thread among visible conversations
             // (before archiving filtered it out) and pick the neighbor.
-            let visible = visibleThreads
+            let visible = visibleConversations
             if !visible.isEmpty {
-                // The archived thread was at `index` in the full `threads` array.
+                // The archived thread was at `index` in the full `conversations` array.
                 // Find the closest visible thread by scanning neighbors.
-                let visibleAfter = threads[index...].dropFirst().first(where: { !$0.isArchived })
-                let visibleBefore = threads[..<index].last(where: { !$0.isArchived })
+                let visibleAfter = conversations[index...].dropFirst().first(where: { !$0.isArchived })
+                let visibleBefore = conversations[..<index].last(where: { !$0.isArchived })
                 if let next = visibleAfter ?? visibleBefore {
-                    activeThreadId = next.id
+                    activeConversationId = next.id
                 } else {
-                    activeThreadId = visible.first?.id
+                    activeConversationId = visible.first?.id
                 }
             } else {
-                createThread()
+                createConversation()
             }
         }
 
@@ -645,15 +645,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Archived thread \(id)")
     }
 
-    func unarchiveThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+    func unarchiveConversation(id: UUID) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
 
-        threads[index].isArchived = false
+        conversations[index].isArchived = false
 
         // Ensure a ChatViewModel exists (lazily created if it was evicted on archive).
         getOrCreateViewModel(for: id)
 
-        if let conversationId = threads[index].conversationId {
+        if let conversationId = conversations[index].conversationId {
             var archived = archivedConversationIds
             archived.remove(conversationId)
             archivedConversationIds = archived
@@ -666,20 +666,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         archivedConversationIds.contains(conversationId)
     }
 
-    /// Load more threads from the daemon (pagination).
+    /// Load more conversations from the daemon (pagination).
     func loadMoreThreads() {
-        guard !isLoadingMoreThreads else { return }
-        isLoadingMoreThreads = true
+        guard !isLoadingMoreConversations else { return }
+        isLoadingMoreConversations = true
         do {
             try daemonClient.sendConversationList(offset: serverOffset, limit: 50)
         } catch {
-            log.error("Failed to request more threads: \(error.localizedDescription)")
-            isLoadingMoreThreads = false
+            log.error("Failed to request more conversations: \(error.localizedDescription)")
+            isLoadingMoreConversations = false
         }
     }
 
-    /// Handle appended threads from a "load more" response.
-    func appendThreads(from response: ConversationListResponseMessage) {
+    /// Handle appended conversations from a "load more" response.
+    func appendConversations(from response: ConversationListResponseMessage) {
         // Increment offset by the unfiltered count so pagination stays aligned
         // with the daemon's row numbering regardless of client-side filtering.
         serverOffset += response.conversations.count
@@ -688,10 +688,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
-        // Compute the next pinnedOrder based on existing pinned threads AND
-        // persisted displayOrder values in the incoming batch, so legacy threads
+        // Compute the next pinnedOrder based on existing pinned conversations AND
+        // persisted displayOrder values in the incoming batch, so legacy conversations
         // (nil displayOrder) don't collide with explicit or already-loaded ones.
-        let existingMax = threads.compactMap(\.pinnedOrder).max() ?? -1
+        let existingMax = conversations.compactMap(\.pinnedOrder).max() ?? -1
         let batchMax = recentSessions
             .filter { $0.isPinned ?? false }
             .compactMap { $0.displayOrder.map { Int($0) } }
@@ -700,13 +700,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         for session in recentSessions {
             // If a local thread already exists, merge server pin/order metadata.
-            if let existingIdx = threads.firstIndex(where: { $0.conversationId == session.id }) {
+            if let existingIdx = conversations.firstIndex(where: { $0.conversationId == session.id }) {
                 let isPinned = session.isPinned ?? false
-                var thread = threads[existingIdx]
+                var thread = conversations[existingIdx]
                 thread.isPinned = isPinned
                 thread.pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil
                 thread.displayOrder = session.displayOrder.map { Int($0) }
-                threads[existingIdx] = thread
+                conversations[existingIdx] = thread
                 mergeAssistantAttention(from: session, intoThreadAt: existingIdx)
                 if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
                 continue
@@ -714,7 +714,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
             let isPinned = session.isPinned ?? false
             let effectiveCreatedAt = session.createdAt ?? session.updatedAt
-            let thread = ThreadModel(
+            let thread = ConversationModel(
                 title: session.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 conversationId: session.id,
@@ -737,28 +737,28 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
             // VM creation is lazy — getOrCreateViewModel() will instantiate
             // when the thread is first accessed (e.g. selected by the user).
-            threads.append(thread)
+            conversations.append(thread)
         }
 
         if let hasMore = response.hasMore {
-            hasMoreThreads = hasMore
+            hasMoreConversations = hasMore
         }
         evictStaleCachedViewModels()
-        isLoadingMoreThreads = false
+        isLoadingMoreConversations = false
     }
 
     /// Clear the `activeSurfaceId` on a specific thread's ChatViewModel.
-    /// Used when switching threads to prevent stale surface context injection.
+    /// Used when switching conversations to prevent stale surface context injection.
     func clearActiveSurface(threadId: UUID) {
         chatViewModels[threadId]?.activeSurfaceId = nil
     }
 
-    func selectThread(id: UUID) {
-        guard let thread = threads.first(where: { $0.id == id }) else { return }
+    func selectConversation(id: UUID) {
+        guard let thread = conversations.first(where: { $0.id == id }) else { return }
 
         removeAbandonedEmptyThread(switching: id)
 
-        let previousActiveId = activeThreadId
+        let previousActiveId = activeConversationId
         trimPreviousThreadIfNeeded(nextThreadId: id)
 
         // Re-create the ViewModel if it was LRU-evicted.
@@ -773,15 +773,15 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         touchVMAccessOrder(id)
-        activeThreadId = id
-        // Switching threads is a natural point to shed cached render
+        activeConversationId = id
+        // Switching conversations is a natural point to shed cached render
         // artefacts from the previous conversation.
         Self.clearRenderCaches()
 
         // Emit explicit seen signal for user-initiated thread selection.
         // Skip if this thread was already active to avoid duplicate signals
-        // (e.g. when openConversationThread sets activeThreadId directly and
-        // SwiftUI's onChange cycle calls selectThread with the same id).
+        // (e.g. when openConversationThread sets activeConversationId directly and
+        // SwiftUI's onChange cycle calls selectConversation with the same id).
         if id != previousActiveId {
             markConversationSeen(threadId: id)
         }
@@ -791,8 +791,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Returns `true` if a matching thread was found and selected, `false` otherwise.
     @discardableResult
     func selectThreadByConversationId(_ conversationId: String) -> Bool {
-        guard let thread = threads.first(where: { $0.conversationId == conversationId }) else { return false }
-        selectThread(id: thread.id)
+        guard let thread = conversations.first(where: { $0.conversationId == conversationId }) else { return false }
+        selectConversation(id: thread.id)
         return true
     }
 
@@ -815,13 +815,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             return true
         }
 
-        // Don't insert external-channel or private threads into the main sidebar
+        // Don't insert external-channel or private conversations into the main sidebar
         if session.conversationType == "private" || session.channelBinding?.sourceChannel != nil {
             return false
         }
 
         let effectiveCreatedAt = session.createdAt ?? session.updatedAt
-        let thread = ThreadModel(
+        let thread = ConversationModel(
             title: session.title,
             createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
             conversationId: session.id,
@@ -846,7 +846,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // Leave isHistoryLoaded false so history is fetched when the thread activates
         viewModel.startMessageLoop()
 
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         chatViewModels[thread.id] = viewModel
         subscribeToBusyState(for: thread.id, viewModel: viewModel)
         subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
@@ -854,7 +854,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(thread.id)
         evictStaleCachedViewModels()
 
-        selectThread(id: thread.id)
+        selectConversation(id: thread.id)
         return true
     }
 
@@ -881,7 +881,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Update confirmation state across all *existing* chat view models, not just
     /// the active one. Only iterates VMs that are already instantiated — does not
-    /// trigger lazy creation for threads that have never been accessed.
+    /// trigger lazy creation for conversations that have never been accessed.
     func updateConfirmationStateAcrossThreads(requestId: String, decision: String) {
         for viewModel in chatViewModels.values {
             viewModel.updateConfirmationState(requestId: requestId, decision: decision)
@@ -889,7 +889,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Returns true if the given ChatViewModel is the one that most recently
-    /// received a `toolUseStart` event across all threads. Used to route
+    /// received a `toolUseStart` event across all conversations. Used to route
     /// `confirmationRequest` messages (which lack a conversationId) to exactly
     /// one ChatViewModel, preventing duplicates and ensuring confirmations
     /// are accepted even in flows that don't go through `sendMessage()`.
@@ -906,51 +906,51 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     // MARK: - Pinning & Ordering
 
     func pinThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
-        let nextOrder = (threads.compactMap(\.pinnedOrder).max() ?? -1) + 1
-        var thread = threads[index]
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        let nextOrder = (conversations.compactMap(\.pinnedOrder).max() ?? -1) + 1
+        var thread = conversations[index]
         thread.isPinned = true
         thread.pinnedOrder = nextOrder
-        threads[index] = thread
+        conversations[index] = thread
         sendReorderConversations()
     }
 
     func unpinThread(id: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
-        var thread = threads[index]
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        var thread = conversations[index]
         thread.isPinned = false
         thread.pinnedOrder = nil
         thread.displayOrder = nil
-        threads[index] = thread
+        conversations[index] = thread
         recompactPinnedOrders()
         sendReorderConversations()
     }
 
     func reorderPinnedThreads(from source: IndexSet, to destination: Int) {
-        var pinned = visibleThreads.filter(\.isPinned)
+        var pinned = visibleConversations.filter(\.isPinned)
         pinned.move(fromOffsets: source, toOffset: destination)
-        var draft = threads
+        var draft = conversations
         for (order, item) in pinned.enumerated() {
             if let idx = draft.firstIndex(where: { $0.id == item.id }) {
                 draft[idx].pinnedOrder = order
             }
         }
-        threads = draft
+        conversations = draft
         sendReorderConversations()
     }
 
     func updateLastInteracted(threadId: UUID) {
-        guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
-        var thread = threads[index]
+        guard let index = conversations.firstIndex(where: { $0.id == threadId }) else { return }
+        var thread = conversations[index]
         thread.lastInteractedAt = Date()
         // Clear explicit displayOrder so the thread reverts to recency-based sorting.
-        // This ensures actively-used threads float to the top naturally and new threads
-        // aren't permanently stuck below explicitly-ordered threads.
+        // This ensures actively-used conversations float to the top naturally and new conversations
+        // aren't permanently stuck below explicitly-ordered conversations.
         let hadOrder = thread.displayOrder != nil
         if hadOrder {
             thread.displayOrder = nil
         }
-        threads[index] = thread
+        conversations[index] = thread
         if hadOrder {
             sendReorderConversations()
         }
@@ -960,21 +960,21 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Works for any thread: pinned-to-pinned reorders among pinned items,
     /// unpinned-to-pinned pins the source, and unpinned-to-unpinned reorders
     /// using displayOrder. When the target is a schedule thread, the source is
-    /// inserted at the end of the unpinned regular threads list (the boundary
-    /// between regular and scheduled threads).
+    /// inserted at the end of the unpinned regular conversations list (the boundary
+    /// between regular and scheduled conversations).
     ///
-    /// Only assigns displayOrder to the dragged thread and threads that already
+    /// Only assigns displayOrder to the dragged thread and conversations that already
     /// had an explicit displayOrder. Threads without explicit ordering (sorted
-    /// by recency) keep nil displayOrder so new threads continue to appear at top.
+    /// by recency) keep nil displayOrder so new conversations continue to appear at top.
     @discardableResult
     func moveThread(sourceId: UUID, targetId: UUID) -> Bool {
-        guard let sourceIdx = threads.firstIndex(where: { $0.id == sourceId }),
-              let targetIdx = threads.firstIndex(where: { $0.id == targetId }) else { return false }
-        let targetThread = threads[targetIdx]
+        guard let sourceIdx = conversations.firstIndex(where: { $0.id == sourceId }),
+              let targetIdx = conversations.firstIndex(where: { $0.id == targetId }) else { return false }
+        let targetThread = conversations[targetIdx]
 
         // Work on a local copy to batch all mutations into a single
         // @Published write, preventing SwiftUI ForEach re-entrancy crashes.
-        var draft = threads
+        var draft = conversations
 
         if targetThread.isPinned {
             // Dropping onto a pinned thread — pin the source if needed and reorder
@@ -1008,28 +1008,28 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 recompactPinnedOrders(in: &draft)
             }
 
-            // Build the unpinned list in sidebar display order: regular threads first,
-            // then schedule threads. This matches the UI sections and prevents dropping
-            // onto a schedule thread from inserting the source among regular threads
+            // Build the unpinned list in sidebar display order: regular conversations first,
+            // then schedule conversations. This matches the UI sections and prevents dropping
+            // onto a schedule thread from inserting the source among regular conversations
             // at the wrong position.
             let visible = draft.filter { !$0.isArchived && $0.kind != .private }
-                .sorted { visibleThreadSortOrder($0, $1) }
+                .sorted { visibleConversationSortOrder($0, $1) }
             let allUnpinned = visible.filter { !$0.isPinned }
-            let regularUnpinned = allUnpinned.filter { !$0.isScheduleThread }
-            let scheduleUnpinned = allUnpinned.filter { $0.isScheduleThread }
+            let regularUnpinned = allUnpinned.filter { !$0.isScheduleConversation }
+            let scheduleUnpinned = allUnpinned.filter { $0.isScheduleConversation }
             let unpinned = regularUnpinned + scheduleUnpinned
 
             var reordered = unpinned.filter { $0.id != sourceId }
 
             let insertPos: Int
             let sourceThread = draft[sourceIdx]
-            if targetThread.isScheduleThread && !sourceThread.isScheduleThread {
+            if targetThread.isScheduleConversation && !sourceThread.isScheduleConversation {
                 // Cross-section drag: insert at section boundary
-                insertPos = reordered.firstIndex(where: { $0.isScheduleThread }) ?? reordered.endIndex
+                insertPos = reordered.firstIndex(where: { $0.isScheduleConversation }) ?? reordered.endIndex
             } else {
                 // Direction-aware: if source was visually above target (dragging down),
                 // insert AFTER target; if below (dragging up), insert BEFORE target.
-                // Pinned threads are always visually above unpinned ones, so a
+                // Pinned conversations are always visually above unpinned ones, so a
                 // pinned→unpinned drag is always "dragging down".
                 let draggingDown: Bool
                 if sourceWasPinned {
@@ -1052,12 +1052,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 reordered.insert(movedThread, at: insertPos)
             }
 
-            // Assign displayOrder to ALL threads in the reordered list. When a
+            // Assign displayOrder to ALL conversations in the reordered list. When a
             // user drags a thread they are explicitly defining an ordering, so every
             // thread in the affected section needs a concrete displayOrder. Without
-            // this, dragging between recency-sorted threads (nil displayOrder) would
+            // this, dragging between recency-sorted conversations (nil displayOrder) would
             // only assign an order to the source, causing it to jump to the top of
-            // the list since visibleThreads sorts non-nil displayOrder above nil.
+            // the list since visibleConversations sorts non-nil displayOrder above nil.
             for (order, item) in reordered.enumerated() {
                 if let idx = draft.firstIndex(where: { $0.id == item.id }) {
                     draft[idx].displayOrder = order
@@ -1066,13 +1066,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
 
         // Single write — triggers objectWillChange exactly once.
-        threads = draft
+        conversations = draft
         sendReorderConversations()
         return true
     }
 
     /// Recompact pinned orders in the given draft array (no @Published writes).
-    private func recompactPinnedOrders(in draft: inout [ThreadModel]) {
+    private func recompactPinnedOrders(in draft: inout [ConversationModel]) {
         let pinned = draft.enumerated()
             .filter { $0.element.isPinned }
             .sorted { ($0.element.pinnedOrder ?? 0) < ($1.element.pinnedOrder ?? 0) }
@@ -1082,24 +1082,24 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     private func recompactPinnedOrders() {
-        var draft = threads
+        var draft = conversations
         recompactPinnedOrders(in: &draft)
-        threads = draft
+        conversations = draft
     }
 
     /// Send the current thread ordering to the daemon so it persists across restarts.
-    /// For pinned threads, derives a deterministic displayOrder from pinnedOrder so
-    /// the pinned ordering survives restarts. For unpinned threads that have been
+    /// For pinned conversations, derives a deterministic displayOrder from pinnedOrder so
+    /// the pinned ordering survives restarts. For unpinned conversations that have been
     /// explicitly reordered (non-nil displayOrder), sends their displayOrder. For
-    /// unpinned threads without explicit ordering, sends nil so they sort by recency.
+    /// unpinned conversations without explicit ordering, sends nil so they sort by recency.
     private func sendReorderConversations() {
-        let visible = visibleThreads
+        let visible = visibleConversations
         var updates: [ReorderConversationsRequestUpdate] = []
         for thread in visible {
             guard let conversationId = thread.conversationId else { continue }
             let order: Double?
             if thread.isPinned {
-                // Pinned threads always need a persisted displayOrder derived from
+                // Pinned conversations always need a persisted displayOrder derived from
                 // their pinnedOrder so their user-defined order survives restarts.
                 order = Double(thread.pinnedOrder ?? 0)
             } else {
@@ -1122,7 +1122,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
-    // MARK: - ThreadRestorerDelegate
+    // MARK: - ConversationRestorerDelegate
 
     func chatViewModel(for threadId: UUID) -> ChatViewModel? {
         return getOrCreateViewModel(for: threadId)
@@ -1150,14 +1150,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         touchVMAccessOrder(threadId)
         evictStaleCachedViewModels()
         // Re-subscribe if this is the active view model
-        if threadId == activeThreadId {
+        if threadId == activeConversationId {
             subscribeToActiveViewModel()
         }
     }
 
     func removeChatViewModel(for threadId: UUID) {
         chatViewModels.removeValue(forKey: threadId)
-        unsubscribeAllForThread(id: threadId)
+        unsubscribeAllForConversation(id: threadId)
         vmAccessOrder.removeAll { $0 == threadId }
     }
 
@@ -1170,20 +1170,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// can create and manage WatchSession objects.
     weak var ambientAgent: AmbientAgent?
 
-    func updateThreadTitle(id: UUID, title: String) {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
-        threads[index].title = title
+    func updateConversationTitle(id: UUID, title: String) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        conversations[index].title = title
     }
 
     /// Rename a thread and send the rename to the daemon.
     /// If the thread doesn't have a sessionId yet, the rename is queued
     /// and flushed when backfillConversationId is called.
-    func renameThread(id: UUID, title: String) {
+    func renameConversation(id: UUID, title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
-        threads[index].title = trimmed
-        if let conversationId = threads[index].conversationId {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        conversations[index].title = trimmed
+        if let conversationId = conversations[index].conversationId {
             try? daemonClient.send(ConversationRenameRequest(
                 type: "conversation_rename",
                 conversationId: conversationId,
@@ -1277,14 +1277,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return viewModel
     }
 
-    func activateThread(_ id: UUID) {
-        let previousActiveId = activeThreadId
+    func activateConversation(_ id: UUID) {
+        let previousActiveId = activeConversationId
         trimPreviousThreadIfNeeded(nextThreadId: id)
-        activeThreadId = id
+        activeConversationId = id
 
         // Emit explicit seen signal for user-initiated thread activation.
         // Skip during session restoration to avoid false "seen" signals on bootstrap.
-        if !isRestoringThreads, id != previousActiveId {
+        if !isRestoringConversations, id != previousActiveId {
             markConversationSeen(threadId: id)
         }
     }
@@ -1295,47 +1295,47 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// marked seen without requiring a thread switch.
     func markActiveThreadSeenIfNeeded() {
         guard NSApp.isActive,
-              !isRestoringThreads,
-              let activeId = activeThreadId,
-              let idx = threads.firstIndex(where: { $0.id == activeId }),
-              threads[idx].hasUnseenLatestAssistantMessage else { return }
+              !isRestoringConversations,
+              let activeId = activeConversationId,
+              let idx = conversations.firstIndex(where: { $0.id == activeId }),
+              conversations[idx].hasUnseenLatestAssistantMessage else { return }
         markConversationSeen(threadId: activeId)
     }
 
     /// Clear the local unseen flag and notify the daemon that the conversation
-    /// has been seen. Use this from call-sites that bypass `selectThread` (e.g.
+    /// has been seen. Use this from call-sites that bypass `selectConversation` (e.g.
     /// deep-link navigation in `openConversationThread`) where the `id != previousActiveId`
     /// guard would skip the signal.
     internal func markConversationSeen(threadId: UUID) {
-        guard let idx = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        guard let idx = conversations.firstIndex(where: { $0.id == threadId }) else { return }
         // If the thread has a pending .unread override, opening the thread clears it
         // so the normal seen flow proceeds rather than leaving the thread stuck as unread.
-        if let conversationId = threads[idx].conversationId,
+        if let conversationId = conversations[idx].conversationId,
            case .unread = pendingAttentionOverrides[conversationId] {
             pendingAttentionOverrides.removeValue(forKey: conversationId)
         }
-        var thread = threads[idx]
+        var thread = conversations[idx]
         thread.hasUnseenLatestAssistantMessage = false
         if let conversationId = thread.conversationId {
             pendingAttentionOverrides[conversationId] = .seen(
                 latestAssistantMessageAt: thread.latestAssistantMessageAt
             )
             thread.lastSeenAssistantMessageAt = thread.latestAssistantMessageAt
-            threads[idx] = thread
+            conversations[idx] = thread
             emitConversationSeenSignal(conversationId: conversationId)
         } else {
-            threads[idx] = thread
+            conversations[idx] = thread
         }
     }
 
     internal func markConversationUnread(threadId: UUID) {
-        guard let idx = threads.firstIndex(where: { $0.id == threadId }),
-              let conversationId = threads[idx].conversationId,
+        guard let idx = conversations.firstIndex(where: { $0.id == threadId }),
+              let conversationId = conversations[idx].conversationId,
               canMarkConversationUnread(threadId: threadId, at: idx) else { return }
 
-        let latestAssistantMessageAt = threads[idx].latestAssistantMessageAt
+        let latestAssistantMessageAt = conversations[idx].latestAssistantMessageAt
 
-        let previousLastSeenAssistantMessageAt = threads[idx].lastSeenAssistantMessageAt
+        let previousLastSeenAssistantMessageAt = conversations[idx].lastSeenAssistantMessageAt
         let previousOverride = pendingAttentionOverrides[conversationId]
         let wasPendingSeen = pendingSeenConversationIds.contains(conversationId)
 
@@ -1343,10 +1343,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         pendingAttentionOverrides[conversationId] = .unread(
             latestAssistantMessageAt: latestAssistantMessageAt
         )
-        var thread = threads[idx]
+        var thread = conversations[idx]
         thread.hasUnseenLatestAssistantMessage = true
         thread.lastSeenAssistantMessageAt = nil
-        threads[idx] = thread
+        conversations[idx] = thread
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -1368,43 +1368,43 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Set a pending anchor message for scroll-to behavior on notification deep links.
     /// Only takes effect when the specified thread is currently active.
     func setPendingAnchorMessage(threadId: UUID, messageId: UUID) {
-        guard activeThreadId == threadId else { return }
+        guard activeConversationId == threadId else { return }
         pendingAnchorMessageId = messageId
-        pendingAnchorThreadId = threadId
+        pendingAnchorConversationId = threadId
     }
 
-    /// Mark all visible (non-archived, non-private) threads as seen locally.
+    /// Mark all visible (non-archived, non-private) conversations as seen locally.
     /// Seen signals are NOT sent immediately — call `commitPendingSeenSignals()`
     /// after the undo window expires, or `cancelPendingSeenSignals()` if the
-    /// user clicks Undo. Returns the IDs of threads that were actually marked.
+    /// user clicks Undo. Returns the IDs of conversations that were actually marked.
     @discardableResult
-    internal func markAllThreadsSeen() -> [UUID] {
+    internal func markAllConversationsSeen() -> [UUID] {
         // Commit (not cancel) any already-pending signals so a second
         // mark-all invocation doesn't silently drop the first batch.
         commitPendingSeenSignals()
         var markedIds: [UUID] = []
         var sessionIds: [String] = []
         var priorStates: [UUID: MarkAllSeenPriorState] = [:]
-        for idx in threads.indices {
-            guard !threads[idx].isArchived,
-                  threads[idx].kind != .private,
-                  threads[idx].hasUnseenLatestAssistantMessage else { continue }
-            let threadId = threads[idx].id
-            let conversationId = threads[idx].conversationId
+        for idx in conversations.indices {
+            guard !conversations[idx].isArchived,
+                  conversations[idx].kind != .private,
+                  conversations[idx].hasUnseenLatestAssistantMessage else { continue }
+            let threadId = conversations[idx].id
+            let conversationId = conversations[idx].conversationId
             // Capture prior state before overwriting
             priorStates[threadId] = MarkAllSeenPriorState(
-                lastSeenAssistantMessageAt: threads[idx].lastSeenAssistantMessageAt,
+                lastSeenAssistantMessageAt: conversations[idx].lastSeenAssistantMessageAt,
                 conversationId: conversationId,
                 override: conversationId.flatMap { pendingAttentionOverrides[$0] }
             )
-            threads[idx].hasUnseenLatestAssistantMessage = false
+            conversations[idx].hasUnseenLatestAssistantMessage = false
             markedIds.append(threadId)
             if let conversationId {
                 sessionIds.append(conversationId)
                 pendingAttentionOverrides[conversationId] = .seen(
-                    latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+                    latestAssistantMessageAt: conversations[idx].latestAssistantMessageAt
                 )
-                threads[idx].lastSeenAssistantMessageAt = threads[idx].latestAssistantMessageAt
+                conversations[idx].lastSeenAssistantMessageAt = conversations[idx].latestAssistantMessageAt
             }
         }
         markAllSeenPriorStates = priorStates
@@ -1415,7 +1415,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Send the deferred seen signals that were collected by
-    /// `markAllThreadsSeen()`. Called when the undo window expires
+    /// `markAllConversationsSeen()`. Called when the undo window expires
     /// (toast dismissed or auto-dismiss timer fires).
     internal func commitPendingSeenSignals() {
         let sessionIds = pendingSeenConversationIds
@@ -1453,20 +1453,20 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// Restore the unseen flag for the given thread IDs and cancel any
     /// pending seen signals (used by undo). Restores prior
     /// `lastSeenAssistantMessageAt` and `pendingAttentionOverrides`
-    /// values captured by `markAllThreadsSeen()` instead of blindly
+    /// values captured by `markAllConversationsSeen()` instead of blindly
     /// clearing them.
     internal func restoreUnseen(threadIds: [UUID]) {
         cancelPendingSeenSignals()
         let priorStates = markAllSeenPriorStates
         markAllSeenPriorStates = [:]
         for id in threadIds {
-            if let idx = threads.firstIndex(where: { $0.id == id }) {
-                threads[idx].hasUnseenLatestAssistantMessage = true
+            if let idx = conversations.firstIndex(where: { $0.id == id }) {
+                conversations[idx].hasUnseenLatestAssistantMessage = true
                 if let prior = priorStates[id] {
-                    threads[idx].lastSeenAssistantMessageAt = prior.lastSeenAssistantMessageAt
+                    conversations[idx].lastSeenAssistantMessageAt = prior.lastSeenAssistantMessageAt
                     if let conversationId = prior.conversationId {
                         // Only restore the override if the current override is
-                        // still the .seen that markAllThreadsSeen() installed.
+                        // still the .seen that markAllConversationsSeen() installed.
                         // If the user changed it (e.g. marked unread during
                         // the undo window), keep the newer override.
                         if let currentOverride = pendingAttentionOverrides[conversationId],
@@ -1481,8 +1481,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 } else {
                     // Fallback: no prior state captured (shouldn't happen in
                     // normal flow), clear conservatively.
-                    threads[idx].lastSeenAssistantMessageAt = nil
-                    if let conversationId = threads[idx].conversationId {
+                    conversations[idx].lastSeenAssistantMessageAt = nil
+                    if let conversationId = conversations[idx].conversationId {
                         pendingAttentionOverrides.removeValue(forKey: conversationId)
                     }
                 }
@@ -1529,8 +1529,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         previousOverride: PendingAttentionOverride?,
         wasPendingSeen: Bool = false
     ) {
-        guard let idx = threads.firstIndex(where: { $0.id == threadId }),
-              threads[idx].conversationId == conversationId,
+        guard let idx = conversations.firstIndex(where: { $0.id == threadId }),
+              conversations[idx].conversationId == conversationId,
               case .unread(let pendingLatestAssistantMessageAt) = pendingAttentionOverrides[conversationId],
               pendingLatestAssistantMessageAt == latestAssistantMessageAt else { return }
 
@@ -1539,8 +1539,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         } else {
             pendingAttentionOverrides.removeValue(forKey: conversationId)
         }
-        threads[idx].hasUnseenLatestAssistantMessage = false
-        threads[idx].lastSeenAssistantMessageAt = previousLastSeenAssistantMessageAt
+        conversations[idx].hasUnseenLatestAssistantMessage = false
+        conversations[idx].lastSeenAssistantMessageAt = previousLastSeenAssistantMessageAt
 
         if wasPendingSeen && !pendingSeenConversationIds.contains(conversationId) {
             pendingSeenConversationIds.append(conversationId)
@@ -1551,21 +1551,21 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Remove the currently active thread if it was never used (no messages,
-    /// no persisted session, not private). Prevents abandoned empty threads
+    /// no persisted session, not private). Prevents abandoned empty conversations
     /// from accumulating in the sidebar.
     /// - Parameter switching: The thread ID being switched to. Pass `nil`
-    ///   when called from `createThread()` (the active thread is checked
+    ///   when called from `createConversation()` (the active thread is checked
     ///   separately by the reuse guard above).
     private func removeAbandonedEmptyThread(switching nextId: UUID? = nil) {
-        guard let previousId = activeThreadId,
+        guard let previousId = activeConversationId,
               previousId != nextId,
               let vm = chatViewModels[previousId],
               vm.messages.isEmpty else { return }
-        let thread = threads.first(where: { $0.id == previousId })
+        let thread = conversations.first(where: { $0.id == previousId })
         guard thread?.kind != .private, thread?.conversationId == nil else { return }
-        threads.removeAll { $0.id == previousId }
+        conversations.removeAll { $0.id == previousId }
         chatViewModels.removeValue(forKey: previousId)
-        unsubscribeAllForThread(id: previousId)
+        unsubscribeAllForConversation(id: previousId)
         vmAccessOrder.removeAll { $0 == previousId }
         log.info("Removed abandoned empty thread \(previousId)")
     }
@@ -1574,34 +1574,34 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// switching to a different thread. Skipped when the VM hasn't loaded
     /// history yet or when it has an active generation in progress.
     private func trimPreviousThreadIfNeeded(nextThreadId: UUID) {
-        guard let previousId = activeThreadId, previousId != nextThreadId,
+        guard let previousId = activeConversationId, previousId != nextThreadId,
               let vm = chatViewModels[previousId],
               vm.isHistoryLoaded,
               !vm.isSending, !vm.isThinking, !vm.isLoadingMoreMessages else { return }
         vm.trimForBackground()
     }
 
-    /// Backfill ThreadModel.conversationId when the daemon assigns a session to a new thread.
+    /// Backfill ConversationModel.conversationId when the daemon assigns a session to a new thread.
     private func backfillConversationId(_ conversationId: String, for viewModel: ChatViewModel) {
         guard let threadId = chatViewModels.first(where: { $0.value === viewModel })?.key,
-              let index = threads.firstIndex(where: { $0.id == threadId }),
-              threads[index].conversationId == nil else { return }
-        threads[index].conversationId = conversationId
+              let index = conversations.firstIndex(where: { $0.id == threadId }),
+              conversations[index].conversationId == nil else { return }
+        conversations[index].conversationId = conversationId
         // If the thread was archived before the conversation ID arrived,
         // persist the archive state now that we have a session ID and
         // release the view model that was kept alive for this callback.
-        if threads[index].isArchived {
+        if conversations[index].isArchived {
             var archived = archivedConversationIds
             archived.insert(conversationId)
             archivedConversationIds = archived
             chatViewModels.removeValue(forKey: threadId)
-            unsubscribeAllForThread(id: threadId)
+            unsubscribeAllForConversation(id: threadId)
             vmAccessOrder.removeAll { $0 == threadId }
         }
         // Re-send ordering now that this thread has a session ID.
         // Any drag/pin actions performed before the daemon assigned
         // a session would have been skipped by sendReorderConversations()
-        // because it filters out threads without a sessionId.
+        // because it filters out conversations without a sessionId.
         sendReorderConversations()
         // Flush any rename that was queued before the session ID was assigned.
         if let pendingTitle = pendingRenames.removeValue(forKey: threadId) {
@@ -1617,23 +1617,23 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         from item: ConversationListResponseItem,
         intoThreadAt index: Int
     ) {
-        threads[index].hasUnseenLatestAssistantMessage =
+        conversations[index].hasUnseenLatestAssistantMessage =
             item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
-        threads[index].latestAssistantMessageAt =
+        conversations[index].latestAssistantMessageAt =
             item.assistantAttention?.latestAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
-        threads[index].lastSeenAssistantMessageAt =
+        conversations[index].lastSeenAssistantMessageAt =
             item.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
 
-        guard let conversationId = threads[index].conversationId,
+        guard let conversationId = conversations[index].conversationId,
               let override = pendingAttentionOverrides[conversationId] else { return }
 
         switch override {
         case .seen(let targetLatestAssistantMessageAt):
-            if !threads[index].hasUnseenLatestAssistantMessage {
+            if !conversations[index].hasUnseenLatestAssistantMessage {
                 pendingAttentionOverrides.removeValue(forKey: conversationId)
                 return
             }
@@ -1644,45 +1644,45 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 return
             }
             if let targetLatestAssistantMessageAt,
-               let serverLatestAssistantMessageAt = threads[index].latestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = conversations[index].latestAssistantMessageAt,
                serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
                 pendingAttentionOverrides.removeValue(forKey: conversationId)
                 return
             }
 
             if let targetLatestAssistantMessageAt,
-               threads[index].latestAssistantMessageAt == nil {
-                threads[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
+               conversations[index].latestAssistantMessageAt == nil {
+                conversations[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
             }
-            threads[index].hasUnseenLatestAssistantMessage = false
-            threads[index].lastSeenAssistantMessageAt =
-                threads[index].latestAssistantMessageAt
+            conversations[index].hasUnseenLatestAssistantMessage = false
+            conversations[index].lastSeenAssistantMessageAt =
+                conversations[index].latestAssistantMessageAt
 
         case .unread(let targetLatestAssistantMessageAt):
-            if threads[index].hasUnseenLatestAssistantMessage {
+            if conversations[index].hasUnseenLatestAssistantMessage {
                 pendingAttentionOverrides.removeValue(forKey: conversationId)
                 return
             }
             if let targetLatestAssistantMessageAt,
-               let serverLatestAssistantMessageAt = threads[index].latestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = conversations[index].latestAssistantMessageAt,
                serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
                 pendingAttentionOverrides.removeValue(forKey: conversationId)
                 return
             }
 
             if let targetLatestAssistantMessageAt,
-               threads[index].latestAssistantMessageAt == nil {
-                threads[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
+               conversations[index].latestAssistantMessageAt == nil {
+                conversations[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
             }
-            threads[index].hasUnseenLatestAssistantMessage = true
-            threads[index].lastSeenAssistantMessageAt = nil
+            conversations[index].hasUnseenLatestAssistantMessage = true
+            conversations[index].lastSeenAssistantMessageAt = nil
         }
     }
 
     // MARK: - Lazy VM Creation
 
     /// Returns an existing ChatViewModel or lazily creates one for the given thread.
-    /// This is the single entry point for VM access — `appendThreads` and session
+    /// This is the single entry point for VM access — `appendConversations` and session
     /// restoration no longer eagerly create VMs for every loaded session.
     @discardableResult
     private func getOrCreateViewModel(for threadId: UUID) -> ChatViewModel? {
@@ -1691,7 +1691,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             return vm
         }
         // Only create if the thread exists
-        guard let thread = threads.first(where: { $0.id == threadId }) else { return nil }
+        guard let thread = conversations.first(where: { $0.id == threadId }) else { return nil }
         let viewModel = makeViewModel()
         viewModel.conversationId = thread.conversationId
         if thread.conversationId == nil {
@@ -1719,9 +1719,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private func evictStaleCachedViewModels() {
         while chatViewModels.count > maxCachedViewModels {
             // Find the oldest non-active, non-busy VM so we never cancel an in-flight response
-            // just because the user switched threads.
+            // just because the user switched conversations.
             guard let victim = vmAccessOrder.first(where: {
-                guard $0 != activeThreadId, let vm = chatViewModels[$0] else { return false }
+                guard $0 != activeConversationId, let vm = chatViewModels[$0] else { return false }
                 return !vm.isSending && !vm.isThinking && vm.pendingQueuedCount == 0
             }) else {
                 break
@@ -1744,47 +1744,47 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
 
     /// Restore the last active thread from UserDefaults after session restoration completes
-    func restoreLastActiveThread() {
+    func restoreLastActiveConversation() {
         // After restoration finishes, re-run the active-thread seen check.
-        // The didBecomeActive notification may have fired while isRestoringThreads
+        // The didBecomeActive notification may have fired while isRestoringConversations
         // was true, causing markActiveThreadSeenIfNeeded() to no-op. Deferring
         // ensures the check runs once restoration is complete.
         defer { markActiveThreadSeenIfNeeded() }
 
-        guard restoreRecentThreads else {
+        guard restoreRecentConversations else {
             // Clear the flag even if restoration is disabled
-            isRestoringThreads = false
+            isRestoringConversations = false
             return
         }
-        guard let savedUUIDString = lastActiveThreadIdString,
+        guard let savedUUIDString = lastActiveConversationIdString,
               let savedUUID = UUID(uuidString: savedUUIDString) else {
-            // Clear the flag and allow future activeThreadId changes to persist
-            isRestoringThreads = false
+            // Clear the flag and allow future activeConversationId changes to persist
+            isRestoringConversations = false
             return
         }
 
         // Only restore if thread exists and is visible (not archived)
-        if threads.contains(where: { $0.id == savedUUID && !$0.isArchived }) {
-            activeThreadId = savedUUID
-            log.info("Restored last active thread: \(savedUUID)")
+        if conversations.contains(where: { $0.id == savedUUID && !$0.isArchived }) {
+            activeConversationId = savedUUID
+            log.info("Restored last active conversation: \(savedUUID)")
         } else {
-            // Thread no longer exists, clear saved state
-            lastActiveThreadIdString = nil
-            log.info("Saved thread not found, falling back to default")
+            // Conversation no longer exists, clear saved state
+            lastActiveConversationIdString = nil
+            log.info("Saved conversation not found, falling back to default")
         }
 
-        // Clear the flag so future activeThreadId changes persist normally
-        isRestoringThreads = false
+        // Clear the flag so future activeConversationId changes persist normally
+        isRestoringConversations = false
     }
 
     // MARK: - Busy State
 
     /// Whether the given thread's ChatViewModel indicates active processing.
-    func isThreadBusy(_ threadId: UUID) -> Bool {
-        busyThreadIds.contains(threadId)
+    func isConversationBusy(_ threadId: UUID) -> Bool {
+        busyConversationIds.contains(threadId)
     }
 
-    /// Subscribe to busy-state publishers on a ChatViewModel so `busyThreadIds` stays current.
+    /// Subscribe to busy-state publishers on a ChatViewModel so `busyConversationIds` stays current.
     func subscribeToBusyState(for threadId: UUID, viewModel: ChatViewModel) {
         // Tear down any previous subscriptions for this thread.
         busyStateCancellables.removeValue(forKey: threadId)
@@ -1804,9 +1804,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         .sink { [weak self] isBusy in
             guard let self else { return }
             if isBusy {
-                self.busyThreadIds.insert(threadId)
+                self.busyConversationIds.insert(threadId)
             } else {
-                self.busyThreadIds.remove(threadId)
+                self.busyConversationIds.remove(threadId)
             }
         }
         .store(in: &subs)
@@ -1816,7 +1816,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Subscribe to assistant activity for a thread.
     /// Any change to the latest assistant message's rendered content marks
-    /// inactive threads unseen, including mid-stream continuation updates.
+    /// inactive conversations unseen, including mid-stream continuation updates.
     private func subscribeToAssistantActivity(for threadId: UUID, viewModel: ChatViewModel) {
         assistantActivityCancellables[threadId]?.cancel()
         if let snapshot = latestAssistantActivitySnapshot(in: viewModel.messages) {
@@ -1858,42 +1858,42 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Remove busy-state and interaction-state subscriptions for a thread.
     ///
-    /// Does NOT clear `threadInteractionStates` — the last known interaction
-    /// state is preserved so that evicted (but still visible) threads continue
+    /// Does NOT clear `conversationInteractionStates` — the last known interaction
+    /// state is preserved so that evicted (but still visible) conversations continue
     /// showing the correct sidebar cue.  Callers that permanently remove a
-    /// thread (close / archive) should use `unsubscribeAllForThread(id:)` instead.
+    /// thread (close / archive) should use `unsubscribeAllForConversation(id:)` instead.
     private func unsubscribeFromBusyState(for threadId: UUID) {
         busyStateCancellables.removeValue(forKey: threadId)
         assistantActivityCancellables[threadId]?.cancel()
         assistantActivityCancellables.removeValue(forKey: threadId)
         latestAssistantActivitySnapshots.removeValue(forKey: threadId)
-        busyThreadIds.remove(threadId)
+        busyConversationIds.remove(threadId)
         interactionStateCancellables.removeValue(forKey: threadId)
     }
 
     /// Atomically cancel all per-thread subscriptions and remove cached state
     /// for a thread that is being permanently removed (closed, archived, or
     /// session-backfilled-then-discarded). Unlike `unsubscribeFromBusyState`,
-    /// this also clears `threadInteractionStates` so stale sidebar cues don't linger.
-    private func unsubscribeAllForThread(id: UUID) {
+    /// this also clears `conversationInteractionStates` so stale sidebar cues don't linger.
+    private func unsubscribeAllForConversation(id: UUID) {
         busyStateCancellables[id] = nil
         assistantActivityCancellables[id]?.cancel()
         assistantActivityCancellables[id] = nil
         latestAssistantActivitySnapshots.removeValue(forKey: id)
-        busyThreadIds.remove(id)
+        busyConversationIds.remove(id)
         interactionStateCancellables[id] = nil
-        threadInteractionStates.removeValue(forKey: id)
+        conversationInteractionStates.removeValue(forKey: id)
     }
 
     // MARK: - Interaction State
 
     /// Returns the derived interaction state for a thread, defaulting to `.idle`.
-    func interactionState(for threadId: UUID) -> ThreadInteractionState {
-        threadInteractionStates[threadId] ?? .idle
+    func interactionState(for threadId: UUID) -> ConversationInteractionState {
+        conversationInteractionStates[threadId] ?? .idle
     }
 
     /// Subscribe to interaction-state–relevant publishers on a ChatViewModel so
-    /// `threadInteractionStates` stays current.
+    /// `conversationInteractionStates` stays current.
     ///
     /// Derives state with priority: error > waitingForInput > processing > idle.
     func subscribeToInteractionState(for threadId: UUID, viewModel: ChatViewModel) {
@@ -1924,22 +1924,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             let isBusy = isSending || isThinking || pendingQueuedCount > 0
 
             if hasError {
-                return ThreadInteractionState.error
+                return ConversationInteractionState.error
             } else if hasPendingConfirmation {
-                return ThreadInteractionState.waitingForInput
+                return ConversationInteractionState.waitingForInput
             } else if isBusy {
-                return ThreadInteractionState.processing
+                return ConversationInteractionState.processing
             } else {
-                return ThreadInteractionState.idle
+                return ConversationInteractionState.idle
             }
         }
         .removeDuplicates()
         .sink { [weak self] state in
             guard let self else { return }
             if state == .idle {
-                self.threadInteractionStates.removeValue(forKey: threadId)
+                self.conversationInteractionStates.removeValue(forKey: threadId)
             } else {
-                self.threadInteractionStates[threadId] = state
+                self.conversationInteractionStates[threadId] = state
             }
         }
         .store(in: &subs)
@@ -1981,42 +1981,42 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // loadHistoryIfNeeded populates messages which triggers the Combine
         // publisher, but those are historical messages, not fresh assistant
         // replies. Without this guard the handler would clear real unread
-        // state on app launch, or bump threads to the top when clicking on
+        // state on app launch, or bump conversations to the top when clicking on
         // them causes an evicted ViewModel to reload its history.
-        guard !isRestoringThreads else { return }
+        guard !isRestoringConversations else { return }
         if let vm = chatViewModels[threadId], vm.isLoadingHistory || !vm.isHistoryLoaded {
             return
         }
-        guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        guard let index = conversations.firstIndex(where: { $0.id == threadId }) else { return }
         updateLastInteracted(threadId: threadId)
         let isNewMessage = previousSnapshot?.messageId != currentSnapshot.messageId
         // Keep the local attention timestamp current for live assistant replies
         // so unread eligibility survives until the next session-list refresh.
-        if threads[index].latestAssistantMessageAt == nil || isNewMessage {
-            threads[index].latestAssistantMessageAt = Date()
+        if conversations[index].latestAssistantMessageAt == nil || isNewMessage {
+            conversations[index].latestAssistantMessageAt = Date()
         }
-        if threadId == activeThreadId {
-            threads[index].hasUnseenLatestAssistantMessage = false
+        if threadId == activeConversationId {
+            conversations[index].hasUnseenLatestAssistantMessage = false
             // Only emit the seen signal on meaningful transitions:
             // 1. A new assistant message appeared (different messageId)
             // 2. Streaming just completed (isStreaming went true -> false)
             let streamingJustCompleted = previousSnapshot?.isStreaming == true && !currentSnapshot.isStreaming
             if isNewMessage || streamingJustCompleted {
-                if let conversationId = threads[index].conversationId {
+                if let conversationId = conversations[index].conversationId {
                     emitConversationSeenSignal(conversationId: conversationId)
                 }
             }
         } else {
-            threads[index].hasUnseenLatestAssistantMessage = true
+            conversations[index].hasUnseenLatestAssistantMessage = true
         }
     }
 
     private func canMarkConversationUnread(threadId: UUID, at threadIndex: Int) -> Bool {
-        guard threads[threadIndex].conversationId != nil,
-              !threads[threadIndex].hasUnseenLatestAssistantMessage else { return false }
+        guard conversations[threadIndex].conversationId != nil,
+              !conversations[threadIndex].hasUnseenLatestAssistantMessage else { return false }
         // Live assistant replies update the in-memory activity snapshot before
         // session-list hydration backfills latestAssistantMessageAt.
-        return threads[threadIndex].latestAssistantMessageAt != nil
+        return conversations[threadIndex].latestAssistantMessageAt != nil
             || latestAssistantActivitySnapshots[threadId] != nil
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-enum ThreadKind: String, Hashable, Sendable {
+enum ConversationKind: String, Hashable, Sendable {
     case standard
     case `private`
 }
 
-struct ThreadModel: Identifiable, Hashable {
+struct ConversationModel: Identifiable, Hashable {
     let id: UUID
     var title: String
     let createdAt: Date
-    /// Daemon conversation ID for restored threads. Nil for new, unsaved threads.
+    /// Daemon conversation ID for restored conversations. Nil for new, unsaved conversations.
     /// Mutable so it can be backfilled when the daemon assigns a conversation to a new thread.
     var conversationId: String?
     var isArchived: Bool
@@ -19,7 +19,7 @@ struct ThreadModel: Identifiable, Hashable {
     /// nil means no explicit order — thread is sorted by recency.
     var displayOrder: Int?
     var lastInteractedAt: Date
-    var kind: ThreadKind
+    var kind: ConversationKind
     var source: String?
     /// The schedule job ID that created this thread, if any.
     /// Threads sharing the same scheduleJobId belong to the same schedule group.
@@ -28,7 +28,7 @@ struct ThreadModel: Identifiable, Hashable {
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -47,9 +47,9 @@ struct ThreadModel: Identifiable, Hashable {
     }
 
     /// Whether this thread was created by a schedule trigger (including one-shot/reminders).
-    /// Checks for legacy "reminder" source for threads created before unification.
+    /// Checks for legacy "reminder" source for conversations created before unification.
     /// Falls back to title prefix when source is nil (HTTP mode).
-    var isScheduleThread: Bool {
+    var isScheduleConversation: Bool {
         if let source = source {
             return source == "schedule" || source == "reminder"
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -3,16 +3,16 @@ import Foundation
 import VellumAssistantShared
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadConversationRestorer")
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationRestorer")
 
 /// Delegate protocol so the restorer can read and mutate thread state
-/// owned by `ThreadManager`.
+/// owned by `ConversationManager`.
 @MainActor
-protocol ThreadRestorerDelegate: AnyObject {
-    var threads: [ThreadModel] { get set }
-    var restoreRecentThreads: Bool { get }
-    var isLoadingMoreThreads: Bool { get set }
-    var hasMoreThreads: Bool { get set }
+protocol ConversationRestorerDelegate: AnyObject {
+    var conversations: [ConversationModel] { get set }
+    var restoreRecentConversations: Bool { get }
+    var isLoadingMoreConversations: Bool { get set }
+    var hasMoreConversations: Bool { get set }
     var serverOffset: Int { get set }
     /// Returns or lazily creates a ChatViewModel for the given thread.
     func chatViewModel(for threadId: UUID) -> ChatViewModel?
@@ -21,11 +21,11 @@ protocol ThreadRestorerDelegate: AnyObject {
     func setChatViewModel(_ vm: ChatViewModel, for threadId: UUID)
     func removeChatViewModel(for threadId: UUID)
     func makeViewModel() -> ChatViewModel
-    func activateThread(_ id: UUID)
-    func createThread()
+    func activateConversation(_ id: UUID)
+    func createConversation()
     func isConversationArchived(_ conversationId: String) -> Bool
-    func restoreLastActiveThread()
-    func appendThreads(from response: ConversationListResponseMessage)
+    func restoreLastActiveConversation()
+    func appendConversations(from response: ConversationListResponseMessage)
     /// Returns an existing ChatViewModel matching the given conversation ID, if any.
     func existingChatViewModel(forConversationId conversationId: String) -> ChatViewModel?
     /// Merge daemon attention metadata into an existing thread, allowing the
@@ -38,9 +38,9 @@ protocol ThreadRestorerDelegate: AnyObject {
 }
 
 /// Handles daemon conversation restoration: fetching the conversation list on connect,
-/// creating threads for recent conversations, and loading per-thread history on demand.
+/// creating conversations for recent conversations, and loading per-thread history on demand.
 @MainActor
-final class ThreadConversationRestorer {
+final class ConversationRestorer {
     /// Maps conversation IDs to thread IDs for in-flight `history_request` messages,
     /// so rapid tab switches don't cause history from one thread to land in another.
     /// Exposed as internal for `@testable` test access.
@@ -50,7 +50,7 @@ final class ThreadConversationRestorer {
     private var connectionCancellable: AnyCancellable?
     private var disconnectCancellable: AnyCancellable?
 
-    weak var delegate: ThreadRestorerDelegate?
+    weak var delegate: ConversationRestorerDelegate?
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -84,7 +84,7 @@ final class ThreadConversationRestorer {
             .removeDuplicates()
             .filter { !$0 }
             .sink { [weak self] _ in
-                self?.delegate?.isLoadingMoreThreads = false
+                self?.delegate?.isLoadingMoreConversations = false
             }
 
         connectionCancellable = daemonClient.$isConnected
@@ -98,7 +98,7 @@ final class ThreadConversationRestorer {
 
     func loadHistoryIfNeeded(threadId: UUID) {
         guard let delegate else { return }
-        guard let thread = delegate.threads.first(where: { $0.id == threadId }) else { return }
+        guard let thread = delegate.conversations.first(where: { $0.id == threadId }) else { return }
         guard let conversationId = thread.conversationId else { return }
         guard let viewModel = delegate.chatViewModel(for: threadId) else { return }
         guard !viewModel.isHistoryLoaded else { return }
@@ -124,7 +124,7 @@ final class ThreadConversationRestorer {
     func requestReconnectHistory(conversationId: String) {
         guard let delegate else { return }
         // Find the thread that owns this conversationId.
-        guard let thread = delegate.threads.first(where: { $0.conversationId == conversationId }) else { return }
+        guard let thread = delegate.conversations.first(where: { $0.conversationId == conversationId }) else { return }
         pendingHistoryByConversationId[conversationId] = thread.id
         do {
             try daemonClient.sendHistoryRequest(conversationId: conversationId, limit: 50, mode: "light", maxToolResultChars: 1000)
@@ -138,8 +138,8 @@ final class ThreadConversationRestorer {
     /// trigger in the message list when all locally loaded messages are visible.
     func requestPaginatedHistory(conversationId: String, beforeTimestamp: Double) {
         guard let delegate else { return }
-        guard let thread = delegate.threads.first(where: { $0.conversationId == conversationId }) else {
-            // Thread removed from the list during a concurrent reconnect/refresh.
+        guard let thread = delegate.conversations.first(where: { $0.conversationId == conversationId }) else {
+            // Conversation removed from the list during a concurrent reconnect/refresh.
             // Reset loading state so the user isn't stuck with a permanent spinner.
             delegate.existingChatViewModel(forConversationId: conversationId)?.isLoadingMoreMessages = false
             return
@@ -162,35 +162,35 @@ final class ThreadConversationRestorer {
     func handleConversationListResponse(_ response: ConversationListResponseMessage) {
         guard let delegate else { return }
 
-        // If ThreadManager is waiting for a "load more" response, route there.
-        if delegate.isLoadingMoreThreads {
-            delegate.appendThreads(from: response)
+        // If ConversationManager is waiting for a "load more" response, route there.
+        if delegate.isLoadingMoreConversations {
+            delegate.appendConversations(from: response)
             return
         }
 
-        guard delegate.restoreRecentThreads else {
-            delegate.restoreLastActiveThread()
+        guard delegate.restoreRecentConversations else {
+            delegate.restoreLastActiveConversation()
             return
         }
         guard !response.conversations.isEmpty else {
-            delegate.restoreLastActiveThread()
+            delegate.restoreLastActiveConversation()
             return
         }
 
-        // Filter out private threads and conversations bound to external channels
+        // Filter out private conversations and conversations bound to external channels
         // (e.g. Telegram). External channel-bound conversations belong to their own
         // lane and should not appear in the desktop conversation list.
         let recentSessions = response.conversations.filter {
             $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
-        let defaultThreadIsEmpty = delegate.threads.count == 1
-            && delegate.chatViewModel(for: delegate.threads[0].id)?.messages.isEmpty ?? true
-            && delegate.chatViewModel(for: delegate.threads[0].id)?.conversationId == nil
+        let defaultThreadIsEmpty = delegate.conversations.count == 1
+            && delegate.chatViewModel(for: delegate.conversations[0].id)?.messages.isEmpty ?? true
+            && delegate.chatViewModel(for: delegate.conversations[0].id)?.conversationId == nil
 
-        var restoredThreads: [ThreadModel] = []
+        var restoredThreads: [ConversationModel] = []
         // Seed the fallback counter past the highest persisted pinned order
-        // so legacy threads (nil displayOrder) don't collide with explicit ones.
+        // so legacy conversations (nil displayOrder) don't collide with explicit ones.
         let maxPersistedPinnedOrder = recentSessions
             .filter { $0.isPinned ?? false }
             .compactMap { $0.displayOrder.map { Int($0) } }
@@ -198,31 +198,31 @@ final class ThreadConversationRestorer {
         var pinnedCount = maxPersistedPinnedOrder + 1
         for session in recentSessions {
             // If a local thread already exists (e.g. created by
-            // createNotificationThread before the session list response arrived),
+            // createNotificationConversation before the session list response arrived),
             // merge server pin/order metadata into it instead of creating a duplicate.
-            if let existingIdx = delegate.threads.firstIndex(where: { $0.conversationId == session.id }) {
+            if let existingIdx = delegate.conversations.firstIndex(where: { $0.conversationId == session.id }) {
                 let isPinned = session.isPinned ?? false
-                delegate.threads[existingIdx].isPinned = isPinned
-                delegate.threads[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
-                delegate.threads[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
+                delegate.conversations[existingIdx].isPinned = isPinned
+                delegate.conversations[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
+                delegate.conversations[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
                 delegate.mergeAssistantAttention(from: session, intoThreadAt: existingIdx)
                 if isPinned && session.displayOrder == nil { pinnedCount += 1 }
                 continue
             }
 
-            let kind: ThreadKind = session.conversationType == "private" ? .private : .standard
+            let kind: ConversationKind = session.conversationType == "private" ? .private : .standard
 
             // Preserve user-set titles: if a thread with this session already
             // exists locally and has a non-default title, keep it instead of
             // overwriting with the daemon's auto-generated title.
-            let existingTitle = delegate.threads
+            let existingTitle = delegate.conversations
                 .first(where: { $0.conversationId == session.id && $0.title != "New Conversation" })?
                 .title
             let title = existingTitle ?? session.title
 
             let isPinned = session.isPinned ?? false
             let effectiveCreatedAt = session.createdAt ?? session.updatedAt
-            let thread = ThreadModel(
+            let thread = ConversationModel(
                 title: title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
                 conversationId: session.id,
@@ -249,28 +249,28 @@ final class ThreadConversationRestorer {
         }
 
         if defaultThreadIsEmpty {
-            if let defaultThread = delegate.threads.first {
+            if let defaultThread = delegate.conversations.first {
                 delegate.removeChatViewModel(for: defaultThread.id)
             }
-            delegate.threads = restoredThreads
+            delegate.conversations = restoredThreads
         } else {
-            delegate.threads = restoredThreads + delegate.threads
+            delegate.conversations = restoredThreads + delegate.conversations
         }
 
         if let firstVisible = restoredThreads.first(where: { !$0.isArchived }) {
-            delegate.activateThread(firstVisible.id)
+            delegate.activateConversation(firstVisible.id)
         } else if defaultThreadIsEmpty {
-            // All restored threads are archived and the default thread was removed,
+            // All restored conversations are archived and the default thread was removed,
             // so create a new empty thread to avoid a blank window.
-            delegate.createThread()
+            delegate.createConversation()
         }
 
         if let hasMore = response.hasMore {
-            delegate.hasMoreThreads = hasMore
+            delegate.hasMoreConversations = hasMore
         }
         delegate.serverOffset = response.conversations.count
-        log.info("Restored \(restoredThreads.count) threads from daemon (hasMore: \(response.hasMore ?? false))")
-        delegate.restoreLastActiveThread()
+        log.info("Restored \(restoredThreads.count) conversations from daemon (hasMore: \(response.hasMore ?? false))")
+        delegate.restoreLastActiveConversation()
     }
 
     func handleHistoryResponse(_ response: HistoryResponse) {
@@ -290,27 +290,27 @@ final class ThreadConversationRestorer {
         )
 
         // Wire up the onLoadMoreHistory callback if not already set (e.g. for
-        // reconnect-restored threads that didn't go through loadHistoryIfNeeded).
+        // reconnect-restored conversations that didn't go through loadHistoryIfNeeded).
         if viewModel.onLoadMoreHistory == nil {
             viewModel.onLoadMoreHistory = { [weak self] conversationId, beforeTimestamp in
                 self?.requestPaginatedHistory(conversationId: conversationId, beforeTimestamp: beforeTimestamp)
             }
         }
 
-        log.info("Loaded \(response.messages.count) history messages for thread \(threadId) (hasMore: \(response.hasMore), isPagination: \(isPaginationLoad))")
+        log.info("Loaded \(response.messages.count) history messages for conversation \(threadId) (hasMore: \(response.hasMore), isPagination: \(isPaginationLoad))")
     }
 
     func handleConversationTitleUpdated(_ response: ConversationTitleUpdatedMessage) {
         guard let delegate else { return }
-        guard let index = delegate.threads.firstIndex(where: { $0.conversationId == response.conversationId }) else { return }
-        delegate.threads[index].title = response.title
+        guard let index = delegate.conversations.firstIndex(where: { $0.conversationId == response.conversationId }) else { return }
+        delegate.conversations[index].title = response.title
     }
 
     func handleMessageContentResponse(_ response: MessageContentResponse) {
         guard let delegate else { return }
         // Route the full content back to the ChatViewModel that owns this message.
-        // We check all threads with existing VMs for a matching daemonMessageId.
-        for thread in delegate.threads {
+        // We check all conversations with existing VMs for a matching daemonMessageId.
+        for thread in delegate.conversations {
             guard let viewModel = delegate.existingChatViewModel(for: thread.id) else { continue }
             if viewModel.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
                 viewModel.handleMessageContentResponse(response)
@@ -321,10 +321,10 @@ final class ThreadConversationRestorer {
 
     func handleSubagentDetailResponse(_ response: SubagentDetailResponse) {
         guard let delegate else { return }
-        // Only check threads that already have a VM — subagent events are only
+        // Only check conversations that already have a VM — subagent events are only
         // relevant to active conversations, so we must not trigger lazy VM
         // creation for every thread in the list.
-        for thread in delegate.threads {
+        for thread in delegate.conversations {
             guard let viewModel = delegate.existingChatViewModel(for: thread.id) else { continue }
             if viewModel.activeSubagents.contains(where: { $0.id == response.subagentId }) {
                 viewModel.subagentDetailStore.populateFromDetailResponse(response)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -3,8 +3,8 @@ import VellumAssistantShared
 
 /// Top-left thread header above the chat: shows thread title + chevron.
 /// Tapping opens a drawer-style popover with thread actions.
-struct ThreadTitleActionsControl: View {
-    let presentation: ThreadHeaderPresentation
+struct ConversationTitleActionsControl: View {
+    let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
@@ -28,8 +28,8 @@ struct ThreadTitleActionsControl: View {
 }
 
 /// Drawer-style popover for thread actions, matching the preferences drawer pattern.
-struct ThreadActionsDrawer: View {
-    let presentation: ThreadHeaderPresentation
+struct ConversationActionsDrawer: View {
+    let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -15,7 +15,7 @@ struct DaemonLoadingChatSkeleton: View {
     }
 }
 
-/// Skeleton thread rows shown in the sidebar while threads are loading.
+/// Skeleton thread rows shown in the sidebar while conversations are loading.
 /// Mimics 5 thread rows matching the height of nav items like "Things".
 struct DaemonLoadingThreadsSkeleton: View {
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -215,7 +215,7 @@ private class NonDraggableContainerView: NSView {
 public final class MainWindow {
     private let services: AppServices
     private var window: NSWindow?
-    let threadManager: ThreadManager
+    let conversationManager: ConversationManager
     let appListManager = AppListManager()
     let traceStore = TraceStore()
     let usageDashboardStore: UsageDashboardStore
@@ -254,18 +254,18 @@ public final class MainWindow {
 
     /// The active ChatViewModel from the current thread, if any.
     var activeViewModel: ChatViewModel? {
-        threadManager.activeViewModel
+        conversationManager.activeViewModel
     }
 
     init(services: AppServices, isFirstLaunch: Bool = false) {
         self.services = services
-        self.threadManager = ThreadManager(
+        self.conversationManager = ConversationManager(
             daemonClient: services.daemonClient,
             activityNotificationService: services.activityNotificationService,
             isFirstLaunch: isFirstLaunch
         )
         self.usageDashboardStore = UsageDashboardStore()
-        self.threadManager.ambientAgent = services.ambientAgent
+        self.conversationManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient
         services.daemonClient.onTraceEvent = { [weak self] msg in
             Task { @MainActor in
@@ -357,7 +357,7 @@ public final class MainWindow {
         let wakeUpMessage = pendingWakeUpMessage
         let wakeUpCallback: (() -> Void)? = wakeUpMessage != nil ? { [weak self] in
             guard let self, let message = wakeUpMessage,
-                  let viewModel = self.threadManager.activeViewModel else { return }
+                  let viewModel = self.conversationManager.activeViewModel else { return }
             viewModel.inputText = message
             viewModel.sendMessage(hidden: true)
             self.pendingWakeUpMessage = nil
@@ -373,7 +373,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -67,9 +67,9 @@ final class SidebarInteractionState {
         }
     }
 
-    /// Thread ID that is currently the drop target during a drag-and-drop reorder.
+    /// Conversation ID that is currently the drop target during a drag-and-drop reorder.
     var dropTargetThreadId: UUID?
-    /// Thread ID currently being dragged (set on drag start, cleared on drop).
+    /// Conversation ID currently being dragged (set on drag start, cleared on drop).
     var draggingThreadId: UUID?
     /// Whether the drop indicator should appear at the bottom of the target (true)
     /// or the top (false). Set based on drag direction.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -35,7 +35,7 @@ extension MainWindowView {
                         enterAppEditing(appId: currentAppId)
                     }
                     // Inject message into active session to trigger assistant-driven setup
-                    if let viewModel = threadManager.activeViewModel {
+                    if let viewModel = conversationManager.activeViewModel {
                         viewModel.inputText = "I need to set up a Vercel API token to publish my app. Please load the vercel-token-setup skill and follow its instructions."
                         viewModel.sendMessage()
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -6,19 +6,19 @@ import VellumAssistantShared
 
 extension MainWindowView {
 
-    func selectThread(_ thread: ThreadModel) {
+    func selectConversation(_ thread: ConversationModel) {
         if case .appEditing(let appId, _) = windowState.selection {
             windowState.selection = .appEditing(appId: appId, threadId: thread.id)
-            threadManager.selectThread(id: thread.id)
+            conversationManager.selectConversation(id: thread.id)
         } else {
             windowState.selection = .thread(thread.id)
-            threadManager.selectThread(id: thread.id)
+            conversationManager.selectConversation(id: thread.id)
         }
     }
 
-    func startNewThread() {
-        threadManager.createThread()
-        if let id = threadManager.activeThreadId {
+    func startNewConversation() {
+        conversationManager.createConversation()
+        if let id = conversationManager.activeConversationId {
             windowState.selection = .thread(id)
         } else {
             // Draft mode — clear selection so no sidebar thread is highlighted
@@ -28,8 +28,8 @@ extension MainWindowView {
     }
 
     /// Maps a thread's interaction state to a dot color for VThreadIcon.
-    func interactionDotColor(for thread: ThreadModel) -> Color? {
-        switch threadManager.interactionState(for: thread.id) {
+    func interactionDotColor(for thread: ConversationModel) -> Color? {
+        switch conversationManager.interactionState(for: thread.id) {
         case .processing: return VColor.primaryBase
         case .waitingForInput: return VColor.systemNegativeHover
         case .error: return VColor.systemNegativeStrong
@@ -37,30 +37,30 @@ extension MainWindowView {
         }
     }
 
-    var regularThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { !$0.isScheduleThread }
+    var regularConversations: [ConversationModel] {
+        conversationManager.visibleConversations.filter { !$0.isScheduleConversation }
     }
 
-    var scheduleThreads: [ThreadModel] {
-        threadManager.visibleThreads.filter { $0.isScheduleThread }
+    var scheduleConversations: [ConversationModel] {
+        conversationManager.visibleConversations.filter { $0.isScheduleConversation }
     }
 
-    var displayedThreads: [ThreadModel] {
-        let all = regularThreads
+    var displayedThreads: [ConversationModel] {
+        let all = regularConversations
         return sidebar.showAllThreads ? all : Array(all.prefix(5))
     }
 
-    var displayedScheduleThreads: [ThreadModel] {
-        let all = scheduleThreads
+    var displayedScheduleThreads: [ConversationModel] {
+        let all = scheduleConversations
         return sidebar.showAllScheduleThreads ? all : Array(all.prefix(3))
     }
 
-    /// Groups schedule threads by their scheduleJobId.
+    /// Groups schedule conversations by their scheduleJobId.
     /// Threads without a scheduleJobId are placed in individual groups keyed by their session ID.
-    var scheduleThreadGroups: [(key: String, label: String, threads: [ThreadModel])] {
-        var grouped: [String: [ThreadModel]] = [:]
+    var scheduleThreadGroups: [(key: String, label: String, conversations: [ConversationModel])] {
+        var grouped: [String: [ConversationModel]] = [:]
         var order: [String] = []
-        for thread in scheduleThreads {
+        for thread in scheduleConversations {
             let key = thread.scheduleJobId ?? thread.conversationId ?? thread.id.uuidString
             if grouped[key] == nil {
                 order.append(key)
@@ -68,11 +68,11 @@ extension MainWindowView {
             grouped[key, default: []].append(thread)
         }
         return order.compactMap { key in
-            guard let threads = grouped[key], let first = threads.first else { return nil }
+            guard let conversations = grouped[key], let first = conversations.first else { return nil }
             // Use the schedule title prefix (before the colon) as the group label,
             // or fall back to the full title when there's no colon.
             let label: String
-            if threads.count > 1 {
+            if conversations.count > 1 {
                 let base = first.title
                 if let colonRange = base.range(of: ":") {
                     label = String(base[base.startIndex..<colonRange.lowerBound])
@@ -82,18 +82,18 @@ extension MainWindowView {
             } else {
                 label = first.title
             }
-            return (key: key, label: label, threads: threads)
+            return (key: key, label: label, conversations: conversations)
         }
     }
 
-    var displayedScheduleGroups: [(key: String, label: String, threads: [ThreadModel])] {
+    var displayedScheduleGroups: [(key: String, label: String, conversations: [ConversationModel])] {
         let all = scheduleThreadGroups
         if sidebar.showAllScheduleThreads { return all }
-        // Auto-expand if any hidden group has unread threads.
+        // Auto-expand if any hidden group has unread conversations.
         let visible = Array(all.prefix(3))
         let hidden = all.dropFirst(3)
         if hidden.contains(where: { group in
-            group.threads.contains(where: { $0.hasUnseenLatestAssistantMessage })
+            group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
         }) {
             return all
         }
@@ -123,7 +123,7 @@ extension MainWindowView {
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .clipped()
-        .alert("Rename Thread", isPresented: Binding(
+        .alert("Rename Conversation", isPresented: Binding(
             get: { sidebar.renamingThreadId != nil },
             set: { if !$0 { sidebar.renamingThreadId = nil } }
         )) {
@@ -134,7 +134,7 @@ extension MainWindowView {
             Button("Cancel", role: .cancel) { sidebar.renamingThreadId = nil }
             Button("Save") {
                 if let id = sidebar.renamingThreadId {
-                    threadManager.renameThread(id: id, title: sidebar.renameText)
+                    conversationManager.renameConversation(id: id, title: sidebar.renameText)
                 }
                 sidebar.renamingThreadId = nil
             }
@@ -198,33 +198,33 @@ extension MainWindowView {
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
                 windowState.showPanel(.apps)
             }
-            // Divider between nav items and threads
+            // Divider between nav items and conversations
             sidebarSectionDivider(isExpanded: true)
 
             // MARK: Threads (scrollable)
             SidebarThreadsHeader(
-                hasUnseenThreads: threadManager.unseenVisibleConversationCount > 0,
+                hasUnseenThreads: conversationManager.unseenVisibleConversationCount > 0,
                 isLoading: showDaemonLoading,
                 onMarkAllSeen: {
-                    let markedIds = threadManager.markAllThreadsSeen()
+                    let markedIds = conversationManager.markAllConversationsSeen()
                     guard !markedIds.isEmpty else { return }
                     let count = markedIds.count
                     let toastId = windowState.showToast(
                         message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
                         style: .success,
                         primaryAction: VToastAction(label: "Undo") {
-                            threadManager.restoreUnseen(threadIds: markedIds)
+                            conversationManager.restoreUnseen(threadIds: markedIds)
                             windowState.dismissToast()
                         },
                         onDismiss: {
-                            threadManager.commitPendingSeenSignals()
+                            conversationManager.commitPendingSeenSignals()
                         }
                     )
-                    threadManager.schedulePendingSeenSignals {
+                    conversationManager.schedulePendingSeenSignals {
                         windowState.dismissToast(id: toastId)
                     }
                 },
-                onNewThread: { startNewThread() }
+                onNewThread: { startNewConversation() }
             )
 
             ScrollView {
@@ -236,10 +236,10 @@ extension MainWindowView {
                     ForEach(displayedThreads) { thread in
                         SidebarThreadItem(
                             thread: thread,
-                            threadManager: threadManager,
+                            conversationManager: conversationManager,
                             windowState: windowState,
                             sidebar: sidebar,
-                            selectThread: { selectThread(thread) }
+                            selectConversation: { selectConversation(thread) }
                         )
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
@@ -256,12 +256,12 @@ extension MainWindowView {
                                 guard let droppedId = items.first,
                                       let sourceUUID = UUID(uuidString: droppedId),
                                       sourceUUID != thread.id else { return false }
-                                return threadManager.moveThread(sourceId: sourceUUID, targetId: thread.id)
+                                return conversationManager.moveThread(sourceId: sourceUUID, targetId: thread.id)
                             } isTargeted: { isTargeted in
                                 if isTargeted && thread.id != sidebar.draggingThreadId {
                                     sidebar.dropTargetThreadId = thread.id
                                     if let dragId = sidebar.draggingThreadId {
-                                        let visible = threadManager.visibleThreads
+                                        let visible = conversationManager.visibleConversations
                                         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
                                         let tIdx = visible.firstIndex(where: { $0.id == thread.id }) ?? 0
                                         sidebar.dropIndicatorAtBottom = sIdx < tIdx
@@ -272,7 +272,7 @@ extension MainWindowView {
                             }
                     }
 
-                    if regularThreads.count > 5 {
+                    if regularConversations.count > 5 {
                         Button {
                             withAnimation(VAnimation.standard) { sidebar.showAllThreads.toggle() }
                         } label: {
@@ -288,8 +288,8 @@ extension MainWindowView {
                         .pointerCursor()
                     }
 
-                    if !scheduleThreads.isEmpty {
-                        // Scheduled threads section
+                    if !scheduleConversations.isEmpty {
+                        // Scheduled conversations section
                         HStack {
                             Text("Scheduled")
                                 .font(VFont.caption)
@@ -302,14 +302,14 @@ extension MainWindowView {
                         .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
 
                         ForEach(displayedScheduleGroups, id: \.key) { group in
-                            if group.threads.count == 1, let thread = group.threads.first {
+                            if group.conversations.count == 1, let thread = group.conversations.first {
                                 // Single-thread group: render inline without a disclosure wrapper
                                 SidebarThreadItem(
                                     thread: thread,
-                                    threadManager: threadManager,
+                                    conversationManager: conversationManager,
                                     windowState: windowState,
                                     sidebar: sidebar,
-                                    selectThread: { selectThread(thread) }
+                                    selectConversation: { selectConversation(thread) }
                                 )
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
@@ -323,13 +323,13 @@ extension MainWindowView {
                                     .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
                                         targetThread: thread,
                                         sidebar: sidebar,
-                                        threadManager: threadManager
+                                        conversationManager: conversationManager
                                     ))
                             } else {
                                 // Multi-thread group: custom disclosure styled like a nav row
                                 let isGroupExpanded = sidebar.expandedScheduleGroups.contains(group.key)
                                 let hasUnread = !isGroupExpanded &&
-                                    group.threads.contains(where: { $0.hasUnseenLatestAssistantMessage })
+                                    group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
 
                                 // Header row — chevron in icon slot, label + count badge
                                 Button {
@@ -360,7 +360,7 @@ extension MainWindowView {
                                             .foregroundColor(VColor.contentDefault)
                                             .lineLimit(1)
                                             .truncationMode(.tail)
-                                        Text("\(group.threads.count)")
+                                        Text("\(group.conversations.count)")
                                             .font(.system(size: 10, weight: .medium))
                                             .foregroundColor(VColor.contentTertiary)
                                             .padding(.horizontal, 6)
@@ -383,13 +383,13 @@ extension MainWindowView {
 
                                 // Expanded child rows
                                 if isGroupExpanded {
-                                    ForEach(group.threads) { thread in
+                                    ForEach(group.conversations) { thread in
                                         SidebarThreadItem(
                                             thread: thread,
-                                            threadManager: threadManager,
+                                            conversationManager: conversationManager,
                                             windowState: windowState,
                                             sidebar: sidebar,
-                                            selectThread: { selectThread(thread) }
+                                            selectConversation: { selectConversation(thread) }
                                         )
                                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
@@ -403,20 +403,20 @@ extension MainWindowView {
                                             .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
                                                 targetThread: thread,
                                                 sidebar: sidebar,
-                                                threadManager: threadManager
+                                                conversationManager: conversationManager
                                             ))
                                     }
                                 }
 
                                 // Drop target on the group header so collapsed groups accept drops
-                                // (only from threads within the same schedule group).
+                                // (only from conversations within the same schedule group).
                                 if !isGroupExpanded {
                                     Color.clear
                                         .frame(height: 0)
                                         .onDrop(of: [.plainText], delegate: ScheduleGroupHeaderDropDelegate(
                                             group: group,
                                             sidebar: sidebar,
-                                            threadManager: threadManager
+                                            conversationManager: conversationManager
                                         ))
                                 }
                             }
@@ -483,13 +483,13 @@ extension MainWindowView {
             sidebarSectionDivider(isExpanded: false)
 
             SidebarNavRow(icon: VIcon.squarePen.rawValue, label: "New Chat", isActive: false, isExpanded: false) {
-                startNewThread()
+                startNewConversation()
             }
 
-            // MARK: Thread Section (collapsed)
-            let switcher = CollapsedThreadSwitcherPresentation(
-                regularThreads: regularThreads,
-                activeThreadId: threadManager.activeThreadId
+            // MARK: Conversation Section (collapsed)
+            let switcher = CollapsedConversationSwitcherPresentation(
+                regularConversations: regularConversations,
+                activeConversationId: conversationManager.activeConversationId
             )
             if switcher.showsSwitcher {
                 Button {
@@ -504,7 +504,7 @@ extension MainWindowView {
                             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.md)
-                                    .fill(windowState.isShowingChat && threadManager.activeThread != nil
+                                    .fill(windowState.isShowingChat && conversationManager.activeConversation != nil
                                         ? VColor.surfaceActive
                                         : VColor.surfaceBase)
                             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 import UniformTypeIdentifiers
 
 struct MainWindowView: View {
-    @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var appListManager: AppListManager
     var zoomManager: ZoomManager
     var conversationZoomManager: ConversationZoomManager
@@ -19,12 +19,12 @@ struct MainWindowView: View {
     @State var sidebar = SidebarInteractionState()
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
     @State private var jitPermissionManager = JITPermissionManager()
-    @State var showThreadActionsDrawer = false
+    @State var showConversationActionsDrawer = false
     /// Frame of the thread title button in the coordinate space of coreLayoutView,
     /// used to position the actions drawer directly below it.
     @State private var threadTitleFrame: CGRect = .zero
     /// Stores the thread ID the user was on before entering temporary chat,
-    /// so we can restore it when they exit instead of jumping to visibleThreads.first
+    /// so we can restore it when they exit instead of jumping to visibleConversations.first
     /// (which may be a pinned thread unrelated to what they were doing).
     @State private var preTemporaryChatThreadId: UUID?
 
@@ -56,8 +56,8 @@ struct MainWindowView: View {
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
-        self.threadManager = threadManager
+    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
+        self.conversationManager = conversationManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
         self.conversationZoomManager = conversationZoomManager
@@ -97,11 +97,11 @@ struct MainWindowView: View {
             voiceModeManager.deactivate()
         } else {
             // Ensure a thread exists
-            if threadManager.activeViewModel == nil {
-                threadManager.enterDraftMode()
+            if conversationManager.activeViewModel == nil {
+                conversationManager.enterDraftMode()
             }
             // Activate directly — voice bar appears automatically via ComposerSection
-            if let viewModel = threadManager.activeViewModel {
+            if let viewModel = conversationManager.activeViewModel {
                 voiceModeManager.activate(chatViewModel: viewModel, settingsStore: settingsStore)
                 voiceModeManager.startListening()
             }
@@ -110,46 +110,46 @@ struct MainWindowView: View {
 
     private func toggleTemporaryChat() {
         withAnimation(VAnimation.standard) {
-            if let privateThread = threadManager.activeThread, privateThread.kind == .private {
+            if let privateThread = conversationManager.activeConversation, privateThread.kind == .private {
                 let privateId = privateThread.id
 
                 // Restore the thread the user was on before entering temporary chat.
-                // Fall back to visibleThreads.first only if the stored thread no longer exists.
+                // Fall back to visibleConversations.first only if the stored thread no longer exists.
                 if let savedId = preTemporaryChatThreadId,
-                   threadManager.visibleThreads.contains(where: { $0.id == savedId }) {
-                    threadManager.selectThread(id: savedId)
-                } else if let recent = threadManager.visibleThreads.first {
-                    threadManager.selectThread(id: recent.id)
+                   conversationManager.visibleConversations.contains(where: { $0.id == savedId }) {
+                    conversationManager.selectConversation(id: savedId)
+                } else if let recent = conversationManager.visibleConversations.first {
+                    conversationManager.selectConversation(id: recent.id)
                 } else {
-                    threadManager.enterDraftMode()
+                    conversationManager.enterDraftMode()
                 }
                 preTemporaryChatThreadId = nil
 
                 // Delete the private thread and its backend conversation.
-                threadManager.removePrivateThread(id: privateId)
+                conversationManager.removePrivateConversation(id: privateId)
             } else {
-                preTemporaryChatThreadId = threadManager.activeThreadId
-                threadManager.createPrivateThread()
+                preTemporaryChatThreadId = conversationManager.activeConversationId
+                conversationManager.createPrivateConversation()
             }
         }
     }
 
     /// Resolve a thread ID for the chat bubble toggle using strict priority:
-    /// 1. activeThreadId (currently selected thread)
+    /// 1. activeConversationId (currently selected thread)
     /// 2. persistentThreadId (app's last-used thread)
-    /// 3. visibleThreads.first (first available thread)
+    /// 3. visibleConversations.first (first available thread)
     /// 4. create a new thread
     private func resolveThreadId() -> UUID {
-        if let id = threadManager.activeThreadId { return id }
+        if let id = conversationManager.activeConversationId { return id }
         if let id = windowState.persistentThreadId { return id }
-        if let id = threadManager.visibleThreads.first?.id { return id }
-        threadManager.createThread()
-        return threadManager.activeThreadId!
+        if let id = conversationManager.visibleConversations.first?.id { return id }
+        conversationManager.createConversation()
+        return conversationManager.activeConversationId!
     }
 
     func enterAppEditing(appId: String) {
         let threadId = resolveThreadId()
-        threadManager.selectThread(id: threadId)
+        conversationManager.selectConversation(id: threadId)
         windowState.setAppEditing(appId: appId, threadId: threadId)
     }
 
@@ -183,8 +183,8 @@ struct MainWindowView: View {
     }
 
     func copyActiveThreadToClipboard() {
-        let messages = threadManager.activeViewModel?.messages ?? []
-        let title = threadManager.activeThread?.title
+        let messages = conversationManager.activeViewModel?.messages ?? []
+        let title = conversationManager.activeConversation?.title
         let names = resolveParticipantNames()
         let markdown = ChatTranscriptFormatter.threadMarkdown(
             messages: messages,
@@ -194,26 +194,26 @@ struct MainWindowView: View {
         guard !markdown.isEmpty else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(markdown, forType: .string)
-        windowState.showToast(message: "Thread copied to clipboard", style: .success)
+        windowState.showToast(message: "Conversation copied to clipboard", style: .success)
     }
 
-    private var threadHeaderPresentation: ThreadHeaderPresentation {
-        ThreadHeaderPresentation(
-            activeThread: threadManager.activeThread,
-            activeViewModel: threadManager.activeViewModel,
+    private var threadHeaderPresentation: ConversationHeaderPresentation {
+        ConversationHeaderPresentation(
+            activeConversation: conversationManager.activeConversation,
+            activeViewModel: conversationManager.activeViewModel,
             isConversationVisible: windowState.isConversationVisible
         )
     }
 
     func dismissThreadDrawer() {
         withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-            showThreadActionsDrawer = false
+            showConversationActionsDrawer = false
         }
     }
 
     func startRenameActiveThread() {
-        guard let id = threadManager.activeThreadId,
-              let thread = threadManager.activeThread else { return }
+        guard let id = conversationManager.activeConversationId,
+              let thread = conversationManager.activeConversation else { return }
         sidebar.renamingThreadId = id
         sidebar.renameText = thread.title
     }
@@ -235,28 +235,28 @@ struct MainWindowView: View {
                     .transition(.opacity)
                 }
             }
-            .onChange(of: threadManager.activeThreadId) { oldId, newId in
+            .onChange(of: conversationManager.activeConversationId) { oldId, newId in
                 // Deactivate voice mode on a real thread switch (UUID → different UUID),
                 // but not on draft promotion (nil → UUID) which happens on first send.
                 if let oldId, oldId != newId, voiceModeManager.state != .off {
                     voiceModeManager.deactivate()
                 }
                 // Dismiss thread actions drawer on thread switch
-                if showThreadActionsDrawer {
-                    showThreadActionsDrawer = false
+                if showConversationActionsDrawer {
+                    showConversationActionsDrawer = false
                 }
             }
             .onChange(of: windowState.selection) { oldSelection, newSelection in
-                // When selection transitions to .thread, ensure ThreadManager is synced
+                // When selection transitions to .thread, ensure ConversationManager is synced
                 // so chat content targets the correct thread (e.g. after dismissOverlay).
-                // Guard against archived threads: if the thread was archived while an
+                // Guard against archived conversations: if the thread was archived while an
                 // overlay was open, persistentThreadId may still point to the stale ID.
                 if case .thread(let id) = newSelection {
-                    if threadManager.threads.contains(where: { $0.id == id && !$0.isArchived }) {
-                        threadManager.selectThread(id: id)
+                    if conversationManager.conversations.contains(where: { $0.id == id && !$0.isArchived }) {
+                        conversationManager.selectConversation(id: id)
                     } else {
-                        // Thread was archived/deleted — fall back to the first visible thread
-                        if let fallback = threadManager.visibleThreads.first {
+                        // Conversation was archived/deleted — fall back to the first visible conversation
+                        if let fallback = conversationManager.visibleConversations.first {
                             windowState.applySelectionCorrection(.thread(fallback.id))
                         } else {
                             windowState.applySelectionCorrection(nil)
@@ -267,8 +267,8 @@ struct MainWindowView: View {
                 // Sync surface and chat dock state when selection changes
                 let expanded = windowState.isDynamicExpanded
                 let docked = windowState.isChatDockOpen
-                threadManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
-                threadManager.activeViewModel?.isChatDockedToSide = expanded && docked
+                conversationManager.activeViewModel?.activeSurfaceId = expanded ? windowState.activeDynamicSurface?.surfaceId : nil
+                conversationManager.activeViewModel?.isChatDockedToSide = expanded && docked
 
                 // Reset expanded state and active surface when navigating away from app/generated
                 let oldIsApp: Bool = {
@@ -329,7 +329,7 @@ struct MainWindowView: View {
             }
             .onChange(of: windowState.activeDynamicSurface?.surfaceId) { _, surfaceId in
                 if windowState.isDynamicExpanded {
-                    threadManager.activeViewModel?.activeSurfaceId = surfaceId
+                    conversationManager.activeViewModel?.activeSurfaceId = surfaceId
                 }
             }
             .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
@@ -379,26 +379,26 @@ struct MainWindowView: View {
             }
             Spacer()
             if windowState.isConversationVisible {
-                ThreadTitleActionsControl(
+                ConversationTitleActionsControl(
                     presentation: threadHeaderPresentation,
                     onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
                     onPin: {
-                        guard let id = threadManager.activeThreadId else { return }
-                        threadManager.pinThread(id: id)
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.pinThread(id: id)
                         dismissThreadDrawer()
                     },
                     onUnpin: {
-                        guard let id = threadManager.activeThreadId else { return }
-                        threadManager.unpinThread(id: id)
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.unpinThread(id: id)
                         dismissThreadDrawer()
                     },
                     onArchive: {
-                        guard let id = threadManager.activeThreadId else { return }
-                        threadManager.archiveThread(id: id)
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.archiveConversation(id: id)
                         dismissThreadDrawer()
                     },
                     onRename: { startRenameActiveThread(); dismissThreadDrawer() },
-                    showDrawer: $showThreadActionsDrawer
+                    showDrawer: $showConversationActionsDrawer
                 )
                 .background(GeometryReader { proxy in
                     Color.clear.onAppear {
@@ -415,14 +415,14 @@ struct MainWindowView: View {
                 windowState.selection = .panel(.settings)
             }
             if windowState.isConversationVisible {
-                // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
-                // only visible on normal threads when no messages exist yet
-                if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {
+                // Temporary chat toggle — always visible on private conversations (so users can exit temp chat),
+                // only visible on normal conversations when no messages exist yet
+                if conversationManager.activeConversation?.kind == .private || conversationManager.activeViewModel?.messages.contains(where: {
                     !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 }) != true {
                     TemporaryChatToggle(
-                        isActive: threadManager.activeThread?.kind == .private,
-                        tooltip: threadManager.activeThread?.kind == .private ? "Exit temporary chat" : "Temporary chat",
+                        isActive: conversationManager.activeConversation?.kind == .private,
+                        tooltip: conversationManager.activeConversation?.kind == .private ? "Exit temporary chat" : "Temporary chat",
                         onToggle: { toggleTemporaryChat() }
                     )
                 }
@@ -475,31 +475,31 @@ struct MainWindowView: View {
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for thread actions drawer
-                    if showThreadActionsDrawer {
+                    if showConversationActionsDrawer {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture { dismissThreadDrawer() }
                     }
                 }
                 .overlay(alignment: .topLeading) {
-                    if showThreadActionsDrawer {
+                    if showConversationActionsDrawer {
                         let presentation = threadHeaderPresentation
-                        ThreadActionsDrawer(
+                        ConversationActionsDrawer(
                             presentation: presentation,
                             onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
                             onPin: {
-                                guard let id = threadManager.activeThreadId else { return }
-                                threadManager.pinThread(id: id)
+                                guard let id = conversationManager.activeConversationId else { return }
+                                conversationManager.pinThread(id: id)
                                 dismissThreadDrawer()
                             },
                             onUnpin: {
-                                guard let id = threadManager.activeThreadId else { return }
-                                threadManager.unpinThread(id: id)
+                                guard let id = conversationManager.activeConversationId else { return }
+                                conversationManager.unpinThread(id: id)
                                 dismissThreadDrawer()
                             },
                             onArchive: {
-                                guard let id = threadManager.activeThreadId else { return }
-                                threadManager.archiveThread(id: id)
+                                guard let id = conversationManager.activeConversationId else { return }
+                                conversationManager.archiveConversation(id: id)
                                 dismissThreadDrawer()
                             },
                             onRename: { startRenameActiveThread(); dismissThreadDrawer() }
@@ -558,12 +558,12 @@ struct MainWindowView: View {
                 .overlay(alignment: .topLeading) {
                     if showThreadSwitcher {
                         ThreadSwitcherDrawer(
-                            regularThreads: regularThreads,
-                            activeThreadId: threadManager.activeThreadId,
-                            threadManager: threadManager,
+                            regularConversations: regularConversations,
+                            activeConversationId: conversationManager.activeConversationId,
+                            conversationManager: conversationManager,
                             windowState: windowState,
                             sidebar: sidebar,
-                            selectThread: { selectThread($0) },
+                            selectConversation: { selectConversation($0) },
                             onDismiss: { showThreadSwitcher = false }
                         )
                         .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
@@ -573,7 +573,7 @@ struct MainWindowView: View {
                         )
                         .zIndex(10)
                         .transition(.opacity)
-                        .onChange(of: threadManager.activeThreadId) { _, _ in
+                        .onChange(of: conversationManager.activeConversationId) { _, _ in
                             showThreadSwitcher = false
                         }
                         .onChange(of: sidebarExpanded) { _, expanded in
@@ -602,7 +602,7 @@ struct MainWindowView: View {
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
         .overlay(alignment: .top) {
             Group {
-                if let viewModel = threadManager.activeViewModel {
+                if let viewModel = conversationManager.activeViewModel {
                     ErrorToastOverlay(
                         errorManager: viewModel.errorManager,
                         hasAPIKey: windowState.hasAPIKey,
@@ -655,9 +655,9 @@ struct MainWindowView: View {
             // disable it, leaving panels stuck in split mode.
             isAppChatOpen = false
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
-            selectedThreadId = threadManager.activeThreadId
+            selectedThreadId = conversationManager.activeConversationId
             // Initialize persistent thread tracking on launch
-            if let activeId = threadManager.activeThreadId {
+            if let activeId = conversationManager.activeConversationId {
                 windowState.persistentThreadId = activeId
             }
             daemonClient.startSSE()
@@ -680,7 +680,7 @@ struct MainWindowView: View {
         .onReceive(daemonClient.$isConnected) { connected in
             windowState.refreshAPIKeyStatus(isConnected: connected)
 
-            // Fallback for fresh users with 0 threads: dismiss skeleton after a
+            // Fallback for fresh users with 0 conversations: dismiss skeleton after a
             // short delay once the daemon is connected. Only applies during initial load.
             guard connected, showDaemonLoading else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
@@ -690,8 +690,8 @@ struct MainWindowView: View {
                 }
             }
         }
-        .onChange(of: threadManager.threads.isEmpty) { _, isEmpty in
-            // Dismiss skeleton when threads arrive from daemon
+        .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
+            // Dismiss skeleton when conversations arrive from daemon
             if !isEmpty && showDaemonLoading {
                 withAnimation(VAnimation.standard) {
                     showDaemonLoading = false
@@ -699,15 +699,15 @@ struct MainWindowView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            threadManager.markActiveThreadSeenIfNeeded()
+            conversationManager.markActiveThreadSeenIfNeeded()
         }
         .onChange(of: selectedThreadId) { _, newId in
             if let newId = newId {
-                threadManager.selectThread(id: newId)
+                conversationManager.selectConversation(id: newId)
             }
         }
-        .onChange(of: threadManager.activeThreadId) { oldId, newId in
-            // Sync activeThreadId changes back to selectedThreadId to keep sidebar selection in sync
+        .onChange(of: conversationManager.activeConversationId) { oldId, newId in
+            // Sync activeConversationId changes back to selectedThreadId to keep sidebar selection in sync
             selectedThreadId = newId
             // Always sync persistentThreadId so the sidebar highlights the
             // correct thread — even when an overlay (.panel, .app) is active.
@@ -723,16 +723,16 @@ struct MainWindowView: View {
             windowState.selectedSubagentId = nil
             // Clear stale activeSurfaceId on the old thread and sync the new one
             if let oldId {
-                threadManager.clearActiveSurface(threadId: oldId)
+                conversationManager.clearActiveSurface(threadId: oldId)
             }
-            threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
-            threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
+            conversationManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
+            conversationManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
             // Consume any buffered deep-link message now that a thread is active.
             // Mirrors the iOS pattern (ChatTabView.onAppear, ThreadListView.onAppear)
             // where consumeDeepLinkIfNeeded() is called when the view model becomes
             // visible. Without this, deep links arriving before the window/thread is
             // fully initialized are silently dropped on macOS.
-            threadManager.activeViewModel?.consumeDeepLinkIfNeeded()
+            conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
@@ -867,10 +867,10 @@ struct MainWindowView: View {
 
 /// Wrapper view that directly observes a `ChatViewModel` via `@ObservedObject`,
 /// ensuring error state changes (conversationError, errorText) trigger UI updates
-/// even though MainWindowView only observes ThreadManager.
+/// even though MainWindowView only observes ConversationManager.
 ///
 /// By capturing the viewModel reference at render-time, closures always act on
-/// the correct thread's ViewModel — even if the user switches threads while a
+/// the correct thread's ViewModel — even if the user switches conversations while a
 /// toast is visible.
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -23,12 +23,12 @@ extension MainWindowView {
         case .chat:
             chatView
         case .settings:
-            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
                 daemonClient: daemonClient,
-                activeSessionId: threadManager.activeViewModel?.conversationId,
+                activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.selection = nil }
             )
         case .generated:
@@ -73,7 +73,7 @@ extension MainWindowView {
                     }
                 },
                 onNewThread: {
-                    threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
+                    conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                     windowState.selection = nil
                 }
             )
@@ -81,7 +81,7 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
                 onInvokeSkill: { skill in
-                    let vm = threadManager.openThread(message: "Use the \(skill.name) skill") { vm in
+                    let vm = conversationManager.openConversation(message: "Use the \(skill.name) skill") { vm in
                         vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,
@@ -123,7 +123,7 @@ extension MainWindowView {
                        !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         // Ensure a thread exists so the prompt doesn't silently fail
                         // on fresh app launch before any chat thread is created.
-                        threadManager.openThread(
+                        conversationManager.openConversation(
                             message: prompt.trimmingCharacters(in: .whitespacesAndNewlines)
                         ) { vm in
                             // Sync dock state before sending so the message is
@@ -220,7 +220,7 @@ extension MainWindowView {
     func chatContentView(geometry: GeometryProxy) -> some View {
         switch windowState.selection {
         case .thread:
-            // Show chat for this thread (threadManager.activeViewModel is synced)
+            // Show chat for this thread (conversationManager.activeViewModel is synced)
             defaultChatLayout
         case .app(let appId), .appEditing(let appId, _):
             if let surface = windowState.activeDynamicParsedSurface,
@@ -272,7 +272,7 @@ extension MainWindowView {
                         }
                     },
                     onNewThread: {
-                        threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
+                        conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                         windowState.selection = nil
                     }
                 )
@@ -293,7 +293,7 @@ extension MainWindowView {
                     }
                 )
                 .onAppear {
-                    threadManager.ensureActiveThread(preferredConversationId: documentManager.sessionId)
+                    conversationManager.ensureActiveConversation(preferredConversationId: documentManager.sessionId)
                 }
             } else if isAppChatOpen {
                 // Split view: chat (left) + panel (right)
@@ -311,7 +311,7 @@ extension MainWindowView {
                     }
                 )
                 .onAppear {
-                    threadManager.ensureActiveThread()
+                    conversationManager.ensureActiveConversation()
                 }
             } else {
                 // Full-window panels: settings, debug, identity
@@ -328,7 +328,7 @@ extension MainWindowView {
     var defaultChatLayout: some View {
         let config = windowState.layoutConfig
         let showConfigPanel = config.right.visible && config.right.content != .empty
-        let showSubagentPanel = windowState.selectedSubagentId != nil && threadManager.activeViewModel != nil
+        let showSubagentPanel = windowState.selectedSubagentId != nil && conversationManager.activeViewModel != nil
 
         VSplitView(
             panelWidth: $sidePanelWidth,
@@ -338,7 +338,7 @@ extension MainWindowView {
             main: { slotView(for: config.center.content) },
             panel: {
                 if let subagentId = windowState.selectedSubagentId,
-                   let viewModel = threadManager.activeViewModel {
+                   let viewModel = conversationManager.activeViewModel {
                     SubagentDetailPanel(
                         subagentId: subagentId,
                         viewModel: viewModel,
@@ -361,8 +361,8 @@ extension MainWindowView {
 
     @ViewBuilder
     var chatView: some View {
-        if let viewModel = threadManager.activeViewModel {
-            let activeThread = threadManager.activeThread
+        if let viewModel = conversationManager.activeViewModel {
+            let activeConversation = conversationManager.activeConversation
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
@@ -370,7 +370,7 @@ extension MainWindowView {
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
                 onMicrophoneToggle: onMicrophoneToggle,
-                isTemporaryChat: activeThread?.kind == .private,
+                isTemporaryChat: activeConversation?.kind == .private,
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceModeManager.openAIVoiceService,
                 onEndVoiceMode: {
@@ -382,9 +382,9 @@ extension MainWindowView {
                 onVoiceModeToggle: {
                     toggleVoiceMode()
                 },
-                threadId: threadManager.activeThreadId,
-                anchorMessageId: $threadManager.pendingAnchorMessageId,
-                highlightedMessageId: $threadManager.highlightedMessageId
+                threadId: conversationManager.activeConversationId,
+                anchorMessageId: $conversationManager.pendingAnchorMessageId,
+                highlightedMessageId: $conversationManager.highlightedMessageId
             )
             .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
             .overlay(alignment: .top) {
@@ -402,12 +402,12 @@ extension MainWindowView {
     func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, threadManager: threadManager, authManager: authManager)
+            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager)
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
                 daemonClient: daemonClient,
-                activeSessionId: threadManager.activeViewModel?.conversationId,
+                activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.dismissOverlay() }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
@@ -444,7 +444,7 @@ extension MainWindowView {
                     }
                 },
                 onNewThread: {
-                    threadManager.openThread(message: "What kind of apps can you build?", forceNew: true)
+                    conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                     windowState.dismissOverlay()
                 }
             )
@@ -454,7 +454,7 @@ extension MainWindowView {
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
                 onInvokeSkill: { skill in
-                    let vm = threadManager.openThread(message: "Use the \(skill.name) skill") { vm in
+                    let vm = conversationManager.openConversation(message: "Use the \(skill.name) skill") { vm in
                         vm.pendingSkillInvocation = SkillInvocationData(
                             name: skill.name,
                             emoji: skill.emoji,
@@ -499,7 +499,7 @@ extension MainWindowView {
 
     @ViewBuilder
     func dynamicWorkspaceView(surface: Surface, data: DynamicPageSurfaceData) -> some View {
-        if let viewModel = threadManager.activeViewModel {
+        if let viewModel = conversationManager.activeViewModel {
             DynamicWorkspaceWrapper(
                 viewModel: viewModel,
                 surface: surface,
@@ -563,7 +563,7 @@ func openFilePicker(viewModel: ChatViewModel) {
 // MARK: - Wrapper Views
 // These observe the ChatViewModel directly so that only the views that
 // actually need ChatViewModel state are invalidated on change, instead
-// of propagating every change up through ThreadManager.
+// of propagating every change up through ConversationManager.
 
 /// Observes the active ChatViewModel and renders the chat interface.
 struct ActiveChatViewWrapper: View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -140,7 +140,7 @@ struct AppsGridView: View {
             title: "Your library is empty",
             subtitle: "Ask your assistant to build something",
             icon: VIcon.layoutGrid.rawValue,
-            actionLabel: "New Thread",
+            actionLabel: "New Conversation",
             actionIcon: VIcon.plus.rawValue,
             action: { onNewThread?() }
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -8,7 +8,7 @@ enum SettingsTab: String {
     case permissionsAndPrivacy = "Permissions & Privacy"
     case contacts = "Contacts"
     case billing = "Billing"
-    case archivedThreads = "Archived Threads"
+    case archivedConversations = "Archived Threads"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
@@ -24,7 +24,7 @@ enum SettingsTab: String {
         if billingEnabled {
             tabs.append(.billing)
         }
-        tabs.append(.archivedThreads)
+        tabs.append(.archivedConversations)
         return tabs
     }
 
@@ -44,7 +44,7 @@ struct SettingsPanel: View {
     var onClose: () -> Void
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
-    @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var conversationManager: ConversationManager
     var authManager: AuthManager
 
     @State private var apiKeyText: String = ""
@@ -261,7 +261,7 @@ struct SettingsPanel: View {
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
-        // .archivedThreads is already included via primaryTabs()
+        // .archivedConversations is already included via primaryTabs()
         return tabs
     }
 
@@ -309,8 +309,8 @@ struct SettingsPanel: View {
             ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled)
         case .billing:
             SettingsBillingTab(authManager: authManager)
-        case .archivedThreads:
-            SettingsArchivedThreadsTab(threadManager: threadManager)
+        case .archivedConversations:
+            SettingsArchivedThreadsTab(conversationManager: conversationManager)
         case .developer:
             SettingsDeveloperTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -2,17 +2,17 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ThreadSwitcherDrawer: View {
-    let regularThreads: [ThreadModel]
-    let activeThreadId: UUID?
-    @ObservedObject var threadManager: ThreadManager
+    let regularConversations: [ConversationModel]
+    let activeConversationId: UUID?
+    @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var windowState: MainWindowState
     var sidebar: SidebarInteractionState
-    let selectThread: (ThreadModel) -> Void
+    let selectConversation: (ConversationModel) -> Void
     let onDismiss: () -> Void
 
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
-            Text("\(regularThreads.count) threads")
+            Text("\(regularConversations.count) conversations")
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -23,13 +23,13 @@ struct ThreadSwitcherDrawer: View {
             VColor.surfaceBase.frame(height: 1)
                 .padding(.horizontal, VSpacing.xs)
 
-            ForEach(regularThreads) { thread in
+            ForEach(regularConversations) { thread in
                 SidebarThreadItem(
                     thread: thread,
-                    threadManager: threadManager,
+                    conversationManager: conversationManager,
                     windowState: windowState,
                     sidebar: sidebar,
-                    selectThread: { selectThread(thread) },
+                    selectConversation: { selectConversation(thread) },
                     onSelect: onDismiss
                 )
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
@@ -1,18 +1,18 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Drop delegate for reordering scheduled threads within the same schedule group.
+/// Drop delegate for reordering scheduled conversations within the same schedule group.
 /// Returns `.move` operation to show a reorder cursor instead of the copy/plus icon.
 struct ScheduleReorderDropDelegate: DropDelegate {
-    let targetThread: ThreadModel
+    let targetThread: ConversationModel
     let sidebar: SidebarInteractionState
-    let threadManager: ThreadManager
+    let conversationManager: ConversationManager
 
     func validateDrop(info: DropInfo) -> Bool {
         guard let dragId = sidebar.draggingThreadId,
               dragId != targetThread.id,
-              let sourceThread = threadManager.visibleThreads.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleThread,
+              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == targetThread.scheduleJobId
         else { return false }
         return true
@@ -25,13 +25,13 @@ struct ScheduleReorderDropDelegate: DropDelegate {
     func dropEntered(info: DropInfo) {
         guard let dragId = sidebar.draggingThreadId,
               dragId != targetThread.id,
-              let sourceThread = threadManager.visibleThreads.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleThread,
+              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == targetThread.scheduleJobId
         else { return }
 
         sidebar.dropTargetThreadId = targetThread.id
-        let visible = threadManager.visibleThreads
+        let visible = conversationManager.visibleConversations
         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
         let tIdx = visible.firstIndex(where: { $0.id == targetThread.id }) ?? 0
         sidebar.dropIndicatorAtBottom = sIdx < tIdx
@@ -48,25 +48,25 @@ struct ScheduleReorderDropDelegate: DropDelegate {
         sidebar.dropTargetThreadId = nil
         sidebar.draggingThreadId = nil
         guard let sourceId = sourceId, sourceId != targetThread.id else { return false }
-        return threadManager.moveThread(sourceId: sourceId, targetId: targetThread.id)
+        return conversationManager.moveThread(sourceId: sourceId, targetId: targetThread.id)
     }
 }
 
 /// Drop delegate for the collapsed schedule group header.
 /// Targets the first thread in the group; only accepts drops from the same schedule group.
 struct ScheduleGroupHeaderDropDelegate: DropDelegate {
-    let group: (key: String, label: String, threads: [ThreadModel])
+    let group: (key: String, label: String, conversations: [ConversationModel])
     let sidebar: SidebarInteractionState
-    let threadManager: ThreadManager
+    let conversationManager: ConversationManager
 
-    private var firstThread: ThreadModel? { group.threads.first }
+    private var firstThread: ConversationModel? { group.conversations.first }
 
     func validateDrop(info: DropInfo) -> Bool {
         guard let firstThread = firstThread,
               let dragId = sidebar.draggingThreadId,
               dragId != firstThread.id,
-              let sourceThread = threadManager.visibleThreads.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleThread,
+              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == firstThread.scheduleJobId
         else { return false }
         return true
@@ -80,8 +80,8 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
         guard let firstThread = firstThread,
               let dragId = sidebar.draggingThreadId,
               dragId != firstThread.id,
-              let sourceThread = threadManager.visibleThreads.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleThread,
+              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == firstThread.scheduleJobId
         else { return }
 
@@ -103,6 +103,6 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
               let sourceId = sourceId,
               sourceId != firstThread.id
         else { return false }
-        return threadManager.moveThread(sourceId: sourceId, targetId: firstThread.id)
+        return conversationManager.moveThread(sourceId: sourceId, targetId: firstThread.id)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -4,12 +4,12 @@ import VellumAssistantShared
 /// A single thread row in the sidebar, handling hover, pin, archive, rename,
 /// and drag interactions.
 struct SidebarThreadItem: View {
-    let thread: ThreadModel
-    @ObservedObject var threadManager: ThreadManager
+    let thread: ConversationModel
+    @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var windowState: MainWindowState
     var sidebar: SidebarInteractionState
     /// Called when the user taps the thread row (handles selection logic).
-    var selectThread: () -> Void
+    var selectConversation: () -> Void
     /// Optional additional callback after selection (e.g. dismiss a popover).
     var onSelect: (() -> Void)? = nil
 
@@ -28,7 +28,7 @@ struct SidebarThreadItem: View {
     }
 
     private var isHovered: Bool { sidebar.isHoveredThread == thread.id }
-    private var interactionState: ThreadInteractionState { threadManager.interactionState(for: thread.id) }
+    private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: thread.id) }
     // Reserve trailing space when hovered for archive button overlay.
     private var hasTrailingIcon: Bool { isHovered || sidebar.threadPendingDeletion == thread.id }
     private var isPendingDeletion: Bool { sidebar.threadPendingDeletion == thread.id }
@@ -50,9 +50,9 @@ struct SidebarThreadItem: View {
                     Button {
                         withAnimation(VAnimation.standard) {
                             if thread.isPinned {
-                                threadManager.unpinThread(id: thread.id)
+                                conversationManager.unpinThread(id: thread.id)
                             } else {
-                                threadManager.pinThread(id: thread.id)
+                                conversationManager.pinThread(id: thread.id)
                             }
                         }
                     } label: {
@@ -130,18 +130,18 @@ struct SidebarThreadItem: View {
             .animation(VAnimation.fast, value: isHovered)
         }
         .onTapGesture {
-            selectThread()
+            selectConversation()
             onSelect?()
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel("Thread: \(thread.title)")
+        .accessibilityLabel("Conversation: \(thread.title)")
         .accessibilityAction(.default) {
-            selectThread()
+            selectConversation()
         }
         .overlay(alignment: .trailing) {
             if sidebar.threadPendingDeletion == thread.id {
                 VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    threadManager.archiveThread(id: thread.id)
+                    conversationManager.archiveConversation(id: thread.id)
                     sidebar.threadPendingDeletion = nil
                 }
                 .fixedSize()
@@ -166,9 +166,9 @@ struct SidebarThreadItem: View {
             Button {
                 withAnimation(VAnimation.standard) {
                     if thread.isPinned {
-                        threadManager.unpinThread(id: thread.id)
+                        conversationManager.unpinThread(id: thread.id)
                     } else {
-                        threadManager.pinThread(id: thread.id)
+                        conversationManager.pinThread(id: thread.id)
                     }
                 }
             } label: {
@@ -181,12 +181,12 @@ struct SidebarThreadItem: View {
                 Label { Text("Rename thread") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
-                threadManager.archiveThread(id: thread.id)
+                conversationManager.archiveConversation(id: thread.id)
             } label: {
                 Label { Text("Archive thread") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
-                threadManager.markConversationUnread(threadId: thread.id)
+                conversationManager.markConversationUnread(threadId: thread.id)
             } label: {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
@@ -198,7 +198,7 @@ struct SidebarThreadItem: View {
                 guard let conversationId = thread.conversationId else { return }
                 AppDelegate.shared?.showLogReportWindow(scope: .thread(conversationId: conversationId, threadTitle: thread.title))
             } label: {
-                Label { Text("Send Logs for Thread") } icon: { VIconView(.upload, size: 14) }
+                Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
             }
             .disabled(thread.conversationId == nil || LogExporter.isManagedAssistant)
         }

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Lightweight model for recent threads shown in the quick input dropdown.
+/// Lightweight model for recent conversations shown in the quick input dropdown.
 struct QuickInputThread: Identifiable {
     let id: UUID
     let title: String

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -49,7 +49,7 @@ final class QuickInputWindow {
     var onNotificationToggle: (() -> Void)?
     /// Callback invoked when the user selects an existing thread (navigates to it).
     var onSelectThread: ((UUID) -> Void)?
-    /// Recent threads to show in the dropdown.
+    /// Recent conversations to show in the dropdown.
     var recentThreads: [QuickInputThread] = []
     /// When true, show a screen recording permission prompt below the bar.
     var showScreenPermissionPrompt = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -2,24 +2,24 @@ import SwiftUI
 import VellumAssistantShared
 
 struct SettingsArchivedThreadsTab: View {
-    @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var conversationManager: ConversationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            if threadManager.archivedThreads.isEmpty {
+            if conversationManager.archivedConversations.isEmpty {
                 VEmptyState(
-                    title: "No archived threads",
+                    title: "No archived conversations",
                     subtitle: "Threads you archive will appear here.",
                     icon: VIcon.archive.rawValue
                 )
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(threadManager.archivedThreads.enumerated()), id: \.element.id) { index, thread in
+                    ForEach(Array(conversationManager.archivedConversations.enumerated()), id: \.element.id) { index, thread in
                         if index > 0 {
                             SettingsDivider()
                         }
                         ArchivedThreadRow(thread: thread) {
-                            threadManager.unarchiveThread(id: thread.id)
+                            conversationManager.unarchiveConversation(id: thread.id)
                         }
                     }
                 }
@@ -32,10 +32,10 @@ struct SettingsArchivedThreadsTab: View {
     }
 }
 
-// MARK: - Archived Thread Row
+// MARK: - Archived Conversation Row
 
 private struct ArchivedThreadRow: View {
-    let thread: ThreadModel
+    let thread: ConversationModel
     let onUnarchive: () -> Void
 
     private static let dateFormatter: DateFormatter = {

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -58,7 +58,7 @@ final class DebugStateWriter {
 
     private func captureSnapshot(from appDelegate: AppDelegate) -> DebugSnapshot {
         let daemonClient = appDelegate.services.daemonClient
-        let threadManager = appDelegate.mainWindow?.threadManager
+        let conversationManager = appDelegate.mainWindow?.conversationManager
 
         let transport: String
         switch daemonClient.config.transport {
@@ -73,9 +73,9 @@ final class DebugStateWriter {
             transport: transport
         )
 
-        let threadSnapshots: [DebugSnapshot.ThreadInfo] = (threadManager?.threads ?? []).map { thread in
-            let vm = threadManager?.chatViewModel(for: thread.id)
-            return DebugSnapshot.ThreadInfo(
+        let conversationSnapshots: [DebugSnapshot.ConversationInfo] = (conversationManager?.conversations ?? []).map { thread in
+            let vm = conversationManager?.chatViewModel(for: thread.id)
+            return DebugSnapshot.ConversationInfo(
                 id: thread.id.uuidString,
                 title: thread.title,
                 conversationId: thread.conversationId,
@@ -86,14 +86,14 @@ final class DebugStateWriter {
             )
         }
 
-        let threadsState = DebugSnapshot.ThreadsState(
-            activeThreadId: threadManager?.activeThreadId?.uuidString,
-            count: threadManager?.threads.count ?? 0,
-            threads: threadSnapshots
+        let conversationsState = DebugSnapshot.ConversationsState(
+            activeConversationId: conversationManager?.activeConversationId?.uuidString,
+            count: conversationManager?.conversations.count ?? 0,
+            conversations: conversationSnapshots
         )
 
         var activeChatState: DebugSnapshot.ActiveChatState?
-        if let vm = threadManager?.activeViewModel {
+        if let vm = conversationManager?.activeViewModel {
             activeChatState = DebugSnapshot.ActiveChatState(
                 conversationId: vm.conversationId,
                 isThinking: vm.isThinking,
@@ -122,7 +122,7 @@ final class DebugStateWriter {
             timestamp: Date(),
             appVersion: version ?? "unknown",
             daemon: daemonState,
-            threads: threadsState,
+            conversations: conversationsState,
             activeChat: activeChatState,
             computerUse: cuState
         )
@@ -135,7 +135,7 @@ struct DebugSnapshot: Codable {
     let timestamp: Date
     let appVersion: String
     let daemon: DaemonState
-    let threads: ThreadsState
+    let conversations: ConversationsState
     let activeChat: ActiveChatState?
     let computerUse: ComputerUseState
 
@@ -146,13 +146,13 @@ struct DebugSnapshot: Codable {
         let transport: String
     }
 
-    struct ThreadsState: Codable {
-        let activeThreadId: String?
+    struct ConversationsState: Codable {
+        let activeConversationId: String?
         let count: Int
-        let threads: [ThreadInfo]
+        let conversations: [ConversationInfo]
     }
 
-    struct ThreadInfo: Codable {
+    struct ConversationInfo: Codable {
         let id: String
         let title: String
         let conversationId: String?

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -91,10 +91,10 @@ enum LogExporter {
             // Surface active session state as tags so the Sentry event itself
             // is useful for triage without downloading the log archive.
             var extra: [String: Any] = [:]
-            let threadManager = AppDelegate.shared?.mainWindow?.threadManager
-            if let activeThread = threadManager?.activeThread {
-                extra["thread_title"] = activeThread.title
-                if let sessionId = activeThread.conversationId {
+            let conversationManager = AppDelegate.shared?.mainWindow?.conversationManager
+            if let activeConversation = conversationManager?.activeConversation {
+                extra["thread_title"] = activeConversation.title
+                if let sessionId = activeConversation.conversationId {
                     tags["session_id"] = sessionId
                     // conversation_id mirrors session_id — the daemon tags its
                     // Sentry events with both names for the same value. Setting
@@ -110,7 +110,7 @@ enum LogExporter {
                 }
             }
             var errorCategoryString: String?
-            if let vm = threadManager?.activeViewModel {
+            if let vm = conversationManager?.activeViewModel {
                 extra["message_count"] = vm.messages.count
                 if let conversationError = vm.conversationError {
                     let category = "\(conversationError.category)"

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -38,7 +38,7 @@ enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
 
 /// Determines what data the log export should include.
 enum LogExportScope: Sendable {
-    /// Full global export — all threads, all data.
+    /// Full global export — all conversations, all data.
     case global
     /// Scoped to a single thread/conversation.
     case thread(conversationId: String, threadTitle: String,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -244,7 +244,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -256,7 +256,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isThinking = true
 
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -581,7 +581,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[0].isStreaming)
 
         // Daemon acknowledges cancellation
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
         XCTAssertFalse(viewModel.isSending)
     }
 
@@ -601,7 +601,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].text, "Partial")
 
         // Daemon acknowledges cancellation — clears isCancelling
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
         XCTAssertFalse(viewModel.isSending)
 
         // After acknowledgment, new deltas should work normally
@@ -677,7 +677,7 @@ final class ChatViewModelTests: XCTestCase {
     func testMessageQueuedIncrementsPendingCount() {
         XCTAssertEqual(viewModel.pendingQueuedCount, 0)
 
-        let queued = MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 1)
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
         viewModel.handleServerMessage(.messageQueued(queued))
 
         XCTAssertEqual(viewModel.pendingQueuedCount, 1)
@@ -685,13 +685,13 @@ final class ChatViewModelTests: XCTestCase {
 
     func testMessageDequeuedDecrementsPendingCount() {
         // Start with some queued
-        let queued1 = MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 1)
-        let queued2 = MessageQueuedMessage(conversationId: "sess-1", requestId: "req-2", position: 2)
+        let queued1 = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
+        let queued2 = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-2", position: 2)
         viewModel.handleServerMessage(.messageQueued(queued1))
         viewModel.handleServerMessage(.messageQueued(queued2))
         XCTAssertEqual(viewModel.pendingQueuedCount, 2)
 
-        let dequeued = MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-1")
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
         viewModel.handleServerMessage(.messageDequeued(dequeued))
 
         XCTAssertEqual(viewModel.pendingQueuedCount, 1)
@@ -700,7 +700,7 @@ final class ChatViewModelTests: XCTestCase {
     func testMessageDequeuedDoesNotGoBelowZero() {
         XCTAssertEqual(viewModel.pendingQueuedCount, 0)
 
-        let dequeued = MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-1")
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
         viewModel.handleServerMessage(.messageDequeued(dequeued))
 
         XCTAssertEqual(viewModel.pendingQueuedCount, 0)
@@ -714,7 +714,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.sendMessage()
 
         // Daemon confirms it's queued at position 2
-        let queued = MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 2)
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 2)
         viewModel.handleServerMessage(.messageQueued(queued))
 
         // The user message should have its position updated
@@ -733,10 +733,10 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.sendMessage()
 
         // Daemon confirms queued then dequeued
-        let queued = MessageQueuedMessage(conversationId: "sess-1", requestId: "req-1", position: 1)
+        let queued = MessageQueuedMessage(sessionId: "sess-1", requestId: "req-1", position: 1)
         viewModel.handleServerMessage(.messageQueued(queued))
 
-        let dequeued = MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-1")
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-1")
         viewModel.handleServerMessage(.messageDequeued(dequeued))
 
         XCTAssertEqual(viewModel.messages[0].status, .processing)
@@ -750,12 +750,12 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.inputText = "Message B"
         viewModel.sendMessage()
 
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         let indexBeforeDequeue = viewModel.messages.firstIndex(where: { $0.text == "Message B" })
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let indexAfterDequeue = viewModel.messages.firstIndex(where: { $0.text == "Message B" })
 
         XCTAssertEqual(indexBeforeDequeue, indexAfterDequeue, "Dequeued message should stay in place in the transcript")
@@ -778,7 +778,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
 
         // Message B is dequeued and starts processing
-        let dequeued = MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-2")
+        let dequeued = MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-2")
         viewModel.handleServerMessage(.messageDequeued(dequeued))
 
         // isSending and isThinking must be restored so the UI shows
@@ -804,14 +804,14 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 2)
 
         // Daemon confirms B is queued
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
 
         // Assistant responds to A, then handoff
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         // Daemon dequeues B — status becomes .processing
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterDequeue.status, .processing, "Message B should be processing after dequeue")
 
@@ -833,10 +833,10 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.inputText = "Message B"
         viewModel.sendMessage()
 
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
 
         let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterDequeue.status, .processing)
@@ -846,7 +846,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(
             .messageRequestComplete(
                 MessageRequestCompleteMessage(
-                    conversationId: "sess-1",
+                    sessionId: "sess-1",
                     requestId: "req-B",
                     runStillActive: false
                 )
@@ -868,15 +868,15 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.inputText = "Message B"
         viewModel.sendMessage()
 
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
 
         viewModel.handleServerMessage(
             .messageRequestComplete(
                 MessageRequestCompleteMessage(
-                    conversationId: "sess-1",
+                    sessionId: "sess-1",
                     requestId: "req-B",
                     runStillActive: true
                 )
@@ -899,16 +899,16 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.sendMessage()
 
         // Daemon confirms B is queued, then dequeued
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterDequeue.status, .processing)
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
 
         let messageBAfterCancel = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterCancel.status, .sent, "Message B should be .sent after generationCancelled, not .processing")
@@ -927,19 +927,19 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.sendMessage()
 
         // Queue B and C
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-C", position: 2)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-C", position: 2)))
 
         // A completes via handoff, B is dequeued and becomes processing
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 2)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 2)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBAfterDequeue = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterDequeue.status, .processing)
 
         // B completes via handoff (C is still queued)
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         // B should be reset to .sent after generationHandoff
         let messageBAfterHandoff = viewModel.messages.first(where: { $0.text == "Message B" })!
@@ -957,7 +957,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial response")))
 
         // Handoff: generation cut short, queued messages waiting
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         XCTAssertTrue(viewModel.isSending, "isSending must stay true during handoff")
         XCTAssertFalse(viewModel.isThinking)
@@ -969,7 +969,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isThinking = true
 
         // Handoff without any prior text deltas
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         XCTAssertTrue(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -985,7 +985,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1) // first assistant only
 
         // Handoff clears currentAssistantMessageId
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         // Second text delta should create a NEW assistant message
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Second response")))
@@ -1044,8 +1044,8 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 3)
 
         // 4. Daemon sends messageQueued for B (position 1) and C (position 2)
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-C", position: 2)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-C", position: 2)))
         XCTAssertEqual(viewModel.pendingQueuedCount, 2)
         if case .queued(let pos) = viewModel.messages[1].status {
             XCTAssertEqual(pos, 1)
@@ -1055,7 +1055,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // 5. Assistant responds to A, then generation_handoff
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 2)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 2)))
 
         XCTAssertTrue(viewModel.isSending, "isSending stays true after handoff")
         XCTAssertFalse(viewModel.isThinking, "isThinking cleared after handoff")
@@ -1063,7 +1063,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[3].isStreaming, "First assistant message should be finalized")
 
         // 6. Daemon dequeues B (status transitions to .processing)
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBStatus = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBStatus.status, .processing, "Message B should be processing")
         XCTAssertTrue(viewModel.isThinking, "isThinking restored after dequeue")
@@ -1072,14 +1072,14 @@ final class ChatViewModelTests: XCTestCase {
 
         // 7. Text delta for B, then generation_handoff
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
 
         // Second assistant message finalized
         XCTAssertFalse(viewModel.messages[4].isStreaming, "Second assistant message should be finalized")
         XCTAssertTrue(viewModel.isSending, "isSending stays true — C is still queued")
 
         // 8. Daemon dequeues C (status transitions to .processing)
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-C")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-C")))
         let messageCStatus = viewModel.messages.first(where: { $0.text == "Message C" })!
         XCTAssertEqual(messageCStatus.status, .processing, "Message C should be processing")
         XCTAssertEqual(viewModel.pendingQueuedCount, 0)
@@ -1128,8 +1128,8 @@ final class ChatViewModelTests: XCTestCase {
         }
 
         // Simulate daemon confirming B and C are queued
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-B", position: 1)))
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-C", position: 2)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-B", position: 1)))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-C", position: 2)))
         XCTAssertEqual(viewModel.pendingQueuedCount, 2)
 
         // Verify positions were updated
@@ -1149,7 +1149,7 @@ final class ChatViewModelTests: XCTestCase {
         // A(0), B(1), C(2), assistantA(3)
         XCTAssertEqual(viewModel.messages.count, 4)
 
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 2)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 2)))
 
         // After handoff: isSending stays true, isThinking cleared, streaming finalized
         XCTAssertTrue(viewModel.isSending, "isSending must stay true during handoff")
@@ -1160,7 +1160,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.pendingQueuedCount, 2)
 
         // Simulate messageDequeued for B — first queued goes to .processing
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-B")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-B")))
         let messageBStatus = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBStatus.status, .processing, "Message B should now be processing")
         XCTAssertTrue(viewModel.isSending)
@@ -1169,11 +1169,11 @@ final class ChatViewModelTests: XCTestCase {
 
         // Assistant responds to B, then another handoff
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to B")))
-        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1)))
+        viewModel.handleServerMessage(.generationHandoff(GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1)))
         XCTAssertTrue(viewModel.isSending, "isSending stays true — C is still queued")
 
         // Simulate messageDequeued for C
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-C")))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-C")))
         let messageCStatus = viewModel.messages.first(where: { $0.text == "Message C" })!
         XCTAssertEqual(messageCStatus.status, .processing, "Message C should now be processing")
         XCTAssertEqual(viewModel.pendingQueuedCount, 0)
@@ -1192,7 +1192,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaFromDifferentSessionIsIgnored() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", conversationId: "other-session")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", sessionId: "other-session")))
         // Should still be thinking — delta was ignored
         XCTAssertTrue(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 0) // No messages
@@ -1201,7 +1201,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaFromSameSessionIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: "my-session")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: "my-session")))
         XCTAssertFalse(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 1)
         XCTAssertEqual(viewModel.messages[0].text, "hello")
@@ -1210,7 +1210,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaWithNilSessionIdIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: nil)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 1)
     }
@@ -1219,7 +1219,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "other-session")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "other-session")))
         // Should still be sending/thinking — message was ignored
         XCTAssertTrue(viewModel.isSending)
         XCTAssertTrue(viewModel.isThinking)
@@ -1229,7 +1229,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "my-session")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "my-session")))
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
     }
@@ -1677,7 +1677,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isCancelling = true
 
         viewModel.handleServerMessage(.generationCancelled(
-            GenerationCancelledMessage(conversationId: "sess-1")
+            GenerationCancelledMessage(sessionId: "sess-1")
         ))
 
         XCTAssertFalse(viewModel.isThinking,
@@ -1704,7 +1704,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(conversationId: nil, attachments: [attachment])
+            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
         ))
 
         XCTAssertEqual(viewModel.messages.count, 1, "Should add attachments to existing message, not create new")
@@ -1724,7 +1724,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "JVBER", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(conversationId: nil, attachments: [attachment])
+            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
         ))
 
         XCTAssertEqual(viewModel.messages.count, 1, "Should create new assistant message for attachment-only turn")
@@ -1747,7 +1747,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "Y29sQQ==", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.generationHandoff(
-            GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1, attachments: [attachment])
+            GenerationHandoffMessage(sessionId: "sess-1", requestId: nil, queuedCount: 1, attachments: [attachment])
         ))
 
         XCTAssertEqual(viewModel.messages[0].attachments.count, 1)
@@ -1772,7 +1772,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // Complete with empty attachments array
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(conversationId: nil, attachments: [])
+            MessageCompleteMessage(sessionId: nil, attachments: [])
         ))
 
         // Should have no messages — no extra empty assistant message
@@ -1834,7 +1834,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextToolTextCreatesInterleavedSegments() {
         // Text delta → tool call → more text delta
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "What are you working on?")))
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "memory_manage", input: ["key": AnyCodable("task")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "memory_manage", input: ["key": AnyCodable("task")], sessionId: nil)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Saved that to memory.")))
 
         XCTAssertEqual(viewModel.messages.count, 1)
@@ -1859,7 +1859,7 @@ final class ChatViewModelTests: XCTestCase {
     func testSuppressedToolsDoNotCreateSegmentBoundary() {
         // ui_show is suppressed and should not create a segment boundary
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Before")))
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], sessionId: nil)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " after")))
 
         XCTAssertEqual(viewModel.messages.count, 1)
@@ -1870,7 +1870,7 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testToolOnlyMessageHasToolCallInContentOrder() {
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -1951,8 +1951,8 @@ final class ChatViewModelTests: XCTestCase {
         // Text delta → tool call start (flushes automatically) + result → more text delta
         // should produce separate text segments with interleaved content order.
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Let me check.")))
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], conversationId: nil)))
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Here are the files.")))
         // Flush the second text delta so it lands in messages.
         viewModel.flushStreamingBuffer()
@@ -2194,7 +2194,7 @@ final class ChatViewModelTests: XCTestCase {
                     type: "tool_use_start",
                     toolName: "computer_use_click",
                     input: ["x": AnyCodable(100), "y": AnyCodable(200)],
-                    conversationId: nil
+                    sessionId: nil
                 )
             )
         )
@@ -2222,7 +2222,7 @@ final class ChatViewModelTests: XCTestCase {
                     isError: true,
                     diff: nil,
                     status: nil,
-                    conversationId: nil,
+                    sessionId: nil,
                     imageData: nil
                 )
             )
@@ -2244,7 +2244,7 @@ final class ChatViewModelTests: XCTestCase {
                     type: "tool_use_start",
                     toolName: "computer_use_click",
                     input: ["x": AnyCodable(100), "y": AnyCodable(200)],
-                    conversationId: nil
+                    sessionId: nil
                 )
             )
         )
@@ -2272,7 +2272,7 @@ final class ChatViewModelTests: XCTestCase {
                     isError: true,
                     diff: nil,
                     status: nil,
-                    conversationId: nil,
+                    sessionId: nil,
                     imageData: nil
                 )
             )
@@ -2295,11 +2295,11 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking, "Text delta should clear thinking")
 
         // Tool starts
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking, "Tool chip is visible, thinking should be false")
 
         // Tool completes — agent is processing the result but isn't "thinking" yet
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should not restore after tool result — tool chip indicates activity")
     }
 
@@ -2307,7 +2307,7 @@ final class ChatViewModelTests: XCTestCase {
         // If isSending is false (shouldn't happen normally), don't set thinking
         viewModel.isSending = false
         viewModel.isThinking = false
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should not restore when not sending")
     }
 
@@ -2315,14 +2315,14 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isSending = true
         viewModel.isCancelling = true
         viewModel.isThinking = false
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "ok", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should not restore during cancellation")
     }
 
     func testToolUseStartClearsThinkingState() {
         viewModel.isThinking = true
         viewModel.isSending = true
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking, "Tool use start should clear thinking since tool chip shows activity")
     }
 
@@ -2330,7 +2330,7 @@ final class ChatViewModelTests: XCTestCase {
         // ui_show is suppressed (no chip rendered), so thinking should NOT be cleared
         viewModel.isThinking = true
         viewModel.isSending = true
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "ui_show", input: [:], sessionId: nil)))
         XCTAssertTrue(viewModel.isThinking, "Suppressed tools should not clear thinking state")
     }
 
@@ -2345,19 +2345,19 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
 
         // First tool starts
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking)
 
         // First tool completes — no "Thinking" flash between tools
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "files", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "files", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should not show between tools")
 
         // Second tool starts
-        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "file_read", input: ["path": AnyCodable("foo.txt")], conversationId: nil)))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "file_read", input: ["path": AnyCodable("foo.txt")], sessionId: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should stay false when new tool starts")
 
         // Second tool completes
-        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "file_read", result: "contents", isError: nil, diff: nil, status: nil, conversationId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "file_read", result: "contents", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
         XCTAssertFalse(viewModel.isThinking, "Thinking should not show after second tool")
 
         // Message completes
@@ -2510,8 +2510,8 @@ final class ChatViewModelTests: XCTestCase {
         // Inline approval: queued → dequeued → text delta → request complete
         viewModel.inputText = "approve"
         viewModel.sendMessage()
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-approve", position: 0)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-approve")))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-approve", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-approve")))
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Decision applied.")))
 
         // Flush the buffer so the text lands on the message (simulates timer fire)
@@ -2523,7 +2523,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(
             .messageRequestComplete(
                 MessageRequestCompleteMessage(
-                    conversationId: "sess-1",
+                    sessionId: "sess-1",
                     requestId: "req-approve",
                     runStillActive: false
                 )
@@ -2553,12 +2553,12 @@ final class ChatViewModelTests: XCTestCase {
         // Inline approval arrives mid-stream: queued → dequeued → request complete (no delta)
         viewModel.inputText = "yes"
         viewModel.sendMessage()
-        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(conversationId: "sess-1", requestId: "req-yes", position: 0)))
-        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(conversationId: "sess-1", requestId: "req-yes")))
+        viewModel.handleServerMessage(.messageQueued(MessageQueuedMessage(sessionId: "sess-1", requestId: "req-yes", position: 0)))
+        viewModel.handleServerMessage(.messageDequeued(MessageDequeuedMessage(sessionId: "sess-1", requestId: "req-yes")))
         viewModel.handleServerMessage(
             .messageRequestComplete(
                 MessageRequestCompleteMessage(
-                    conversationId: "sess-1",
+                    sessionId: "sess-1",
                     requestId: "req-yes",
                     runStillActive: true
                 )
@@ -2578,7 +2578,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "sess-1"
         let activity = AssistantActivityStateMessage(
             type: "assistant_activity_state",
-            conversationId: "sess-1",
+            sessionId: "sess-1",
             activityVersion: 1,
             phase: "thinking",
             anchor: "assistant_turn",
@@ -2599,7 +2599,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "sess-1"
         let newer = AssistantActivityStateMessage(
             type: "assistant_activity_state",
-            conversationId: "sess-1",
+            sessionId: "sess-1",
             activityVersion: 2,
             phase: "thinking",
             anchor: "assistant_turn",
@@ -2608,7 +2608,7 @@ final class ChatViewModelTests: XCTestCase {
         )
         let stale = AssistantActivityStateMessage(
             type: "assistant_activity_state",
-            conversationId: "sess-1",
+            sessionId: "sess-1",
             activityVersion: 1,
             phase: "idle",
             anchor: "global",
@@ -2661,7 +2661,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.pendingSendDirectAttachments = nil
 
         // Simulate generationCancelled arriving
-        let cancelled = GenerationCancelledMessage(conversationId: "sess-1")
+        let cancelled = GenerationCancelledMessage(sessionId: "sess-1")
         viewModel.handleServerMessage(.generationCancelled(cancelled))
 
         // After cancellation, the pending text should have been dispatched

--- a/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
@@ -1,35 +1,35 @@
 import XCTest
 @testable import VellumAssistantLib
 
-final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
+final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
 
-    private func makeThread(id: UUID = UUID(), title: String = "Thread") -> ThreadModel {
-        ThreadModel(id: id, title: title)
+    private func makeThread(id: UUID = UUID(), title: String = "Conversation") -> ConversationModel {
+        ConversationModel(id: id, title: title)
     }
 
-    // MARK: - Draft mode (no active thread)
+    // MARK: - Draft mode (no active conversation)
 
     func testDraftMode_withExistingThreads_showsSwitcher() {
-        let threads = [makeThread(), makeThread()]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = [makeThread(), makeThread()]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertTrue(sut.showsSwitcher)
         XCTAssertEqual(sut.switchTargets.count, 2)
     }
 
     func testDraftMode_withNoThreads_hidesSwitcher() {
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [], activeThreadId: nil)
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [], activeConversationId: nil)
 
         XCTAssertFalse(sut.showsSwitcher)
         XCTAssertTrue(sut.switchTargets.isEmpty)
     }
 
-    // MARK: - Active thread
+    // MARK: - Active conversation
 
     func testActiveThread_onlyThatThread_showsSwitcherWithBadge() {
         let id = UUID()
-        let threads = [makeThread(id: id)]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: id)
+        let conversations = [makeThread(id: id)]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: id)
 
         XCTAssertTrue(sut.showsSwitcher)
         XCTAssertEqual(sut.totalRegularThreadCount, 1)
@@ -39,8 +39,8 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
     func testActiveThread_withOtherThreads_showsSwitcherAndExcludesActive() {
         let activeId = UUID()
         let otherId = UUID()
-        let threads = [makeThread(id: activeId, title: "Active"), makeThread(id: otherId, title: "Other")]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: activeId)
+        let conversations = [makeThread(id: activeId, title: "Active"), makeThread(id: otherId, title: "Other")]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: activeId)
 
         XCTAssertTrue(sut.showsSwitcher)
         XCTAssertEqual(sut.switchTargets.count, 1)
@@ -50,35 +50,35 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
     // MARK: - Total count and badge
 
     func testTotalRegularThreadCount() {
-        let threads = [makeThread(), makeThread(), makeThread()]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = [makeThread(), makeThread(), makeThread()]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.totalRegularThreadCount, 3)
     }
 
     func testBadgeText_normalCount() {
-        let threads = [makeThread(), makeThread()]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = [makeThread(), makeThread()]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "2")
     }
 
     func testBadgeText_singleThread() {
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [makeThread()], activeThreadId: nil)
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeThread()], activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "1")
     }
 
     func testBadgeText_capsAt99Plus() {
-        let threads = (0..<100).map { _ in makeThread() }
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = (0..<100).map { _ in makeThread() }
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "99+")
     }
 
     func testBadgeText_99IsNotCapped() {
-        let threads = (0..<99).map { _ in makeThread() }
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = (0..<99).map { _ in makeThread() }
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "99")
     }
@@ -87,27 +87,27 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
 
     func testAccessibilityLabel_withActiveThread() {
         let id = UUID()
-        let threads = [makeThread(id: id, title: "My Chat"), makeThread()]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: id)
+        let conversations = [makeThread(id: id, title: "My Chat"), makeThread()]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: id)
 
-        XCTAssertEqual(sut.accessibilityLabel, "Switch threads: My Chat")
+        XCTAssertEqual(sut.accessibilityLabel, "Switch conversations: My Chat")
     }
 
     func testAccessibilityLabel_draftMode() {
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [makeThread()], activeThreadId: nil)
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeThread()], activeConversationId: nil)
 
-        XCTAssertEqual(sut.accessibilityLabel, "Switch threads")
+        XCTAssertEqual(sut.accessibilityLabel, "Switch conversations")
     }
 
     func testAccessibilityValue_reflectsTotalCount() {
-        let threads = [makeThread(), makeThread(), makeThread()]
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+        let conversations = [makeThread(), makeThread(), makeThread()]
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
-        XCTAssertEqual(sut.accessibilityValue, "3 threads")
+        XCTAssertEqual(sut.accessibilityValue, "3 conversations")
     }
 
     func testAccessibilityValue_emptyWhenNoThreads() {
-        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [], activeThreadId: nil)
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [], activeConversationId: nil)
 
         XCTAssertEqual(sut.accessibilityValue, "")
     }

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -3,13 +3,13 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadHeaderPresentationTests: XCTestCase {
+final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - No active thread / draft
 
     func testDraftShowsNewThreadTitle() {
-        let p = ThreadHeaderPresentation(
-            activeThread: nil,
+        let p = ConversationHeaderPresentation(
+            activeConversation: nil,
             activeViewModel: nil,
             isConversationVisible: true
         )
@@ -20,9 +20,9 @@ final class ThreadHeaderPresentationTests: XCTestCase {
     }
 
     func testConversationNotVisibleShowsNewThread() {
-        let thread = ThreadModel(title: "My Thread", sessionId: "session-1")
-        let p = ThreadHeaderPresentation(
-            activeThread: thread,
+        let thread = ConversationModel(title: "My Conversation", conversationId: "session-1")
+        let p = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: nil,
             isConversationVisible: false
         )
@@ -33,14 +33,14 @@ final class ThreadHeaderPresentationTests: XCTestCase {
     // MARK: - Started standard thread
 
     func testStartedStandardThreadShowsActionsMenu() {
-        let thread = ThreadModel(title: "Test Thread", sessionId: "session-1")
+        let thread = ConversationModel(title: "Test Conversation", conversationId: "session-1")
         let vm = ChatViewModel(daemonClient: DaemonClient())
-        let p = ThreadHeaderPresentation(
-            activeThread: thread,
+        let p = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: vm,
             isConversationVisible: true
         )
-        XCTAssertEqual(p.displayTitle, "Test Thread")
+        XCTAssertEqual(p.displayTitle, "Test Conversation")
         XCTAssertTrue(p.isStarted)
         XCTAssertTrue(p.showsActionsMenu)
     }
@@ -48,9 +48,9 @@ final class ThreadHeaderPresentationTests: XCTestCase {
     // MARK: - Private thread
 
     func testPrivateThreadHidesActionsMenu() {
-        let thread = ThreadModel(title: "Private Chat", sessionId: "session-2", kind: .private)
-        let p = ThreadHeaderPresentation(
-            activeThread: thread,
+        let thread = ConversationModel(title: "Private Chat", conversationId: "session-2", kind: .private)
+        let p = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: nil,
             isConversationVisible: true
         )
@@ -62,10 +62,10 @@ final class ThreadHeaderPresentationTests: XCTestCase {
     // MARK: - Not started (no sessionId, no messages)
 
     func testUnstartedThreadDoesNotShowActions() {
-        let thread = ThreadModel(title: "New Conversation")
+        let thread = ConversationModel(title: "New Conversation")
         let vm = ChatViewModel(daemonClient: DaemonClient())
-        let p = ThreadHeaderPresentation(
-            activeThread: thread,
+        let p = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: vm,
             isConversationVisible: true
         )
@@ -77,9 +77,9 @@ final class ThreadHeaderPresentationTests: XCTestCase {
     // MARK: - Pin state
 
     func testPinnedThreadShowsPinnedState() {
-        let thread = ThreadModel(title: "Pinned", sessionId: "s", isPinned: true)
-        let p = ThreadHeaderPresentation(
-            activeThread: thread,
+        let thread = ConversationModel(title: "Pinned", conversationId: "s", isPinned: true)
+        let p = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: nil,
             isConversationVisible: true
         )

--- a/clients/macos/vellum-assistantTests/ConversationManagerBusyStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerBusyStateTests.swift
@@ -3,22 +3,22 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadManagerBusyStateTests: XCTestCase {
+final class ConversationManagerBusyStateTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
-    private var threadManager: ThreadManager!
+    private var conversationManager: ConversationManager!
 
     override func setUp() {
         super.setUp()
         daemonClient = DaemonClient()
         daemonClient.isConnected = true
         daemonClient.sendOverride = { _ in }
-        threadManager = ThreadManager(daemonClient: daemonClient)
+        conversationManager = ConversationManager(daemonClient: daemonClient)
     }
 
     override func tearDown() {
         daemonClient?.sendOverride = nil
-        threadManager = nil
+        conversationManager = nil
         daemonClient = nil
         super.tearDown()
     }
@@ -26,15 +26,15 @@ final class ThreadManagerBusyStateTests: XCTestCase {
     // MARK: - Busy state derivation
 
     func testBusyFalseByDefault() {
-        // init creates a default thread
-        let threadId = threadManager.activeThreadId!
-        XCTAssertFalse(threadManager.isThreadBusy(threadId), "Thread should not be busy by default")
-        XCTAssertTrue(threadManager.busyThreadIds.isEmpty)
+        // init creates a default conversation
+        let threadId = conversationManager.activeConversationId!
+        XCTAssertFalse(conversationManager.isConversationBusy(threadId), "Conversation should not be busy by default")
+        XCTAssertTrue(conversationManager.busyConversationIds.isEmpty)
     }
 
     func testBusyTrueWhenIsSending() {
-        let threadId = threadManager.activeThreadId!
-        let vm = threadManager.activeViewModel!
+        let threadId = conversationManager.activeConversationId!
+        let vm = conversationManager.activeViewModel!
         vm.isSending = true
 
         // Allow Combine pipeline to deliver
@@ -42,36 +42,36 @@ final class ThreadManagerBusyStateTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
         wait(for: [exp], timeout: 1.0)
 
-        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when isSending is true")
+        XCTAssertTrue(conversationManager.isConversationBusy(threadId), "Conversation should be busy when isSending is true")
     }
 
     func testBusyTrueWhenIsThinking() {
-        let threadId = threadManager.activeThreadId!
-        let vm = threadManager.activeViewModel!
+        let threadId = conversationManager.activeConversationId!
+        let vm = conversationManager.activeViewModel!
         vm.isThinking = true
 
         let exp = expectation(description: "busy state propagates")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
         wait(for: [exp], timeout: 1.0)
 
-        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when isThinking is true")
+        XCTAssertTrue(conversationManager.isConversationBusy(threadId), "Conversation should be busy when isThinking is true")
     }
 
     func testBusyTrueWhenPendingQueuedCountPositive() {
-        let threadId = threadManager.activeThreadId!
-        let vm = threadManager.activeViewModel!
+        let threadId = conversationManager.activeConversationId!
+        let vm = conversationManager.activeViewModel!
         vm.pendingQueuedCount = 3
 
         let exp = expectation(description: "busy state propagates")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { exp.fulfill() }
         wait(for: [exp], timeout: 1.0)
 
-        XCTAssertTrue(threadManager.isThreadBusy(threadId), "Thread should be busy when pendingQueuedCount > 0")
+        XCTAssertTrue(conversationManager.isConversationBusy(threadId), "Conversation should be busy when pendingQueuedCount > 0")
     }
 
     func testBusyFalseAfterAllReturnToIdle() {
-        let threadId = threadManager.activeThreadId!
-        let vm = threadManager.activeViewModel!
+        let threadId = conversationManager.activeConversationId!
+        let vm = conversationManager.activeViewModel!
 
         // Set busy
         vm.isSending = true
@@ -81,7 +81,7 @@ final class ThreadManagerBusyStateTests: XCTestCase {
         let expBusy = expectation(description: "busy state set")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expBusy.fulfill() }
         wait(for: [expBusy], timeout: 1.0)
-        XCTAssertTrue(threadManager.isThreadBusy(threadId))
+        XCTAssertTrue(conversationManager.isConversationBusy(threadId))
 
         // Return to idle
         vm.isSending = false
@@ -92,41 +92,41 @@ final class ThreadManagerBusyStateTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expIdle.fulfill() }
         wait(for: [expIdle], timeout: 1.0)
 
-        XCTAssertFalse(threadManager.isThreadBusy(threadId), "Thread should not be busy after all states return to idle")
-        XCTAssertTrue(threadManager.busyThreadIds.isEmpty)
+        XCTAssertFalse(conversationManager.isConversationBusy(threadId), "Conversation should not be busy after all states return to idle")
+        XCTAssertTrue(conversationManager.busyConversationIds.isEmpty)
     }
 
     func testLRUEvictionSkipsBusyBackgroundThread() {
-        guard let originalThreadId = threadManager.activeThreadId else {
-            XCTFail("Expected initial active thread")
+        guard let originalThreadId = conversationManager.activeConversationId else {
+            XCTFail("Expected initial active conversation")
             return
         }
 
         for _ in 0..<9 {
-            threadManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
-            threadManager.createThread()
+            conversationManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
+            conversationManager.createConversation()
         }
 
-        guard let busyVm = threadManager.existingChatViewModel(for: originalThreadId) else {
-            XCTFail("Expected original thread view model")
+        guard let busyVm = conversationManager.existingChatViewModel(for: originalThreadId) else {
+            XCTFail("Expected original conversation view model")
             return
         }
         busyVm.isSending = true
 
-        let expBusy = expectation(description: "busy thread marked")
+        let expBusy = expectation(description: "busy conversation marked")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expBusy.fulfill() }
         wait(for: [expBusy], timeout: 1.0)
-        XCTAssertTrue(threadManager.isThreadBusy(originalThreadId))
+        XCTAssertTrue(conversationManager.isConversationBusy(originalThreadId))
 
         // Trigger one more creation to force an LRU eviction pass.
-        threadManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
-        threadManager.createThread()
+        conversationManager.activeViewModel?.messages.append(ChatMessage(role: .user, text: "seed"))
+        conversationManager.createConversation()
 
         let expEvict = expectation(description: "eviction pass complete")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expEvict.fulfill() }
         wait(for: [expEvict], timeout: 1.0)
 
-        XCTAssertNotNil(threadManager.existingChatViewModel(for: originalThreadId), "Busy thread should not be evicted")
-        XCTAssertTrue(threadManager.isThreadBusy(originalThreadId), "Busy state should be preserved after eviction pass")
+        XCTAssertNotNil(conversationManager.existingChatViewModel(for: originalThreadId), "Busy conversation should not be evicted")
+        XCTAssertTrue(conversationManager.isConversationBusy(originalThreadId), "Busy state should be preserved after eviction pass")
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
@@ -3,54 +3,54 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadManagerSessionLoopTests: XCTestCase {
+final class ConversationManagerSessionLoopTests: XCTestCase {
     private var daemonClient: DaemonClient!
-    private var threadManager: ThreadManager!
+    private var conversationManager: ConversationManager!
 
     override func setUp() {
         super.setUp()
         daemonClient = DaemonClient()
         daemonClient.isConnected = true
         daemonClient.sendOverride = { _ in }
-        threadManager = ThreadManager(daemonClient: daemonClient)
+        conversationManager = ConversationManager(daemonClient: daemonClient)
     }
 
     override func tearDown() {
         daemonClient?.sendOverride = nil
-        threadManager = nil
+        conversationManager = nil
         daemonClient = nil
         super.tearDown()
     }
 
     func testSelectingSessionBackedThreadStartsMessageLoop() {
-        guard let threadId = threadManager.activeThreadId,
-              let vm = threadManager.chatViewModel(for: threadId),
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let vm = conversationManager.chatViewModel(for: threadId),
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-active"
+        conversationManager.conversations[index].conversationId = "session-active"
         vm.conversationId = "session-active"
 
         XCTAssertEqual(daemonClient.subscribers.count, 0)
-        threadManager.selectThread(id: threadId)
+        conversationManager.selectConversation(id: threadId)
         XCTAssertEqual(daemonClient.subscribers.count, 1)
     }
 
     func testSelectingSameSessionBackedThreadDoesNotDuplicateMessageLoop() {
-        guard let threadId = threadManager.activeThreadId,
-              let vm = threadManager.chatViewModel(for: threadId),
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let vm = conversationManager.chatViewModel(for: threadId),
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-active"
+        conversationManager.conversations[index].conversationId = "session-active"
         vm.conversationId = "session-active"
 
-        threadManager.selectThread(id: threadId)
-        threadManager.selectThread(id: threadId)
+        conversationManager.selectConversation(id: threadId)
+        conversationManager.selectConversation(id: threadId)
 
         XCTAssertEqual(daemonClient.subscribers.count, 1)
     }

--- a/clients/macos/vellum-assistantTests/ConversationManagerPrivateConversationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerPrivateConversationTests.swift
@@ -3,10 +3,10 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadManagerPrivateThreadTests: XCTestCase {
+final class ConversationManagerPrivateThreadTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
-    private var threadManager: ThreadManager!
+    private var conversationManager: ConversationManager!
     private var capturedMessages: [Any] = []
 
     override func setUp() {
@@ -18,46 +18,47 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
             guard let self else { return }
             capturedMessages.append(msg)
         }
-        threadManager = ThreadManager(daemonClient: daemonClient)
+        conversationManager = ConversationManager(daemonClient: daemonClient)
     }
 
     override func tearDown() {
         daemonClient?.sendOverride = nil
-        threadManager = nil
+        conversationManager = nil
         capturedMessages = []
         daemonClient = nil
         super.tearDown()
     }
 
-    // MARK: - createPrivateThread
+    // MARK: - createPrivateConversation
 
     func testCreatePrivateThreadAddsThreadWithPrivateKind() {
-        threadManager.createPrivateThread()
+        conversationManager.createPrivateConversation()
 
-        // init creates a default standard thread, so we expect 2 threads total
-        XCTAssertEqual(threadManager.threads.count, 2)
-        let privateThread = threadManager.threads.first!
+        // init enters draft mode (conversations empty), createPrivateConversation adds one
+        XCTAssertEqual(conversationManager.conversations.count, 1)
+        let privateThread = conversationManager.conversations.first!
         XCTAssertEqual(privateThread.kind, .private, "New thread should have kind .private")
     }
 
     func testCreatePrivateThreadSetsActiveThread() {
-        threadManager.createPrivateThread()
+        conversationManager.createPrivateConversation()
 
-        let privateThread = threadManager.threads.first!
-        XCTAssertEqual(threadManager.activeThreadId, privateThread.id)
+        let privateThread = conversationManager.conversations.first!
+        XCTAssertEqual(conversationManager.activeConversationId, privateThread.id)
     }
 
     func testCreatePrivateThreadCallsCreateSessionIfNeeded() {
-        threadManager.createPrivateThread()
+        conversationManager.createPrivateConversation()
 
-        let vm = threadManager.activeViewModel!
-        XCTAssertTrue(vm.isSending, "Should be in sending state from createConversationIfNeeded bootstrap")
+        let vm = conversationManager.activeViewModel!
+        // Message-less session creates (private thread pre-allocation) don't set isSending.
+        XCTAssertFalse(vm.isSending, "Message-less bootstrap should not set isSending")
         XCTAssertTrue(vm.isBootstrapping, "Should be bootstrapping a session")
         XCTAssertEqual(vm.conversationType, "private", "conversationType should be set to private")
     }
 
     func testCreatePrivateThreadSendsSessionCreate() {
-        threadManager.createPrivateThread()
+        conversationManager.createPrivateConversation()
 
         // Allow the async Task in bootstrapConversation to execute
         let expectation = XCTestExpectation(description: "session_create sent")
@@ -73,22 +74,22 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
     }
 
     func testCreatePrivateThreadDoesNotReuseEmptyStandardThread() {
-        // init already creates an empty standard thread — createPrivateThread
-        // should NOT reuse it (unlike createThread which skips if active is empty).
-        let standardThreadId = threadManager.activeThreadId
-        threadManager.createPrivateThread()
+        // init enters draft mode (activeConversationId is nil) — createPrivateConversation
+        // should create a new private thread, not reuse the draft.
+        let draftId = conversationManager.activeConversationId
+        conversationManager.createPrivateConversation()
 
-        XCTAssertNotEqual(threadManager.activeThreadId, standardThreadId,
-                          "Should create a new thread, not reuse the empty standard one")
-        XCTAssertEqual(threadManager.threads.count, 2)
+        XCTAssertNotEqual(conversationManager.activeConversationId, draftId,
+                          "Should create a new thread, not reuse the draft")
+        XCTAssertEqual(conversationManager.conversations.count, 1)
     }
 
     // MARK: - Session backfill
 
     func testPrivateThreadSessionBackfill() {
-        threadManager.createPrivateThread()
-        let privateThread = threadManager.threads.first!
-        let vm = threadManager.activeViewModel!
+        conversationManager.createPrivateConversation()
+        let privateThread = conversationManager.conversations.first!
+        let vm = conversationManager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
 
         // Simulate daemon responding with session_info
@@ -96,17 +97,17 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
         vm.handleServerMessage(.conversationInfo(info))
 
         // The thread's sessionId should be backfilled via onConversationCreated
-        let updatedThread = threadManager.threads.first(where: { $0.id == privateThread.id })!
-        XCTAssertEqual(updatedThread.conversationId, "private-session-42", "Session ID should be backfilled into the ThreadModel")
+        let updatedThread = conversationManager.conversations.first(where: { $0.id == privateThread.id })!
+        XCTAssertEqual(updatedThread.conversationId, "private-session-42", "Session ID should be backfilled into the ConversationModel")
         XCTAssertEqual(vm.conversationId, "private-session-42")
         XCTAssertFalse(vm.isSending, "Should reset isSending after session_info for message-less create")
         XCTAssertFalse(vm.isBootstrapping, "Should no longer be bootstrapping after session_info")
     }
 
     func testPrivateThreadTitleCallbackStillWorks() {
-        threadManager.createPrivateThread()
-        let privateThread = threadManager.threads.first!
-        let vm = threadManager.activeViewModel!
+        conversationManager.createPrivateConversation()
+        let privateThread = conversationManager.conversations.first!
+        let vm = conversationManager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
 
         // Complete the session bootstrap
@@ -118,13 +119,13 @@ final class ThreadManagerPrivateThreadTests: XCTestCase {
         vm.inputText = "Hello private thread"
         vm.sendMessage()
 
-        let updatedThread = threadManager.threads.first(where: { $0.id == privateThread.id })!
+        let updatedThread = conversationManager.conversations.first(where: { $0.id == privateThread.id })!
         XCTAssertEqual(updatedThread.title, "Untitled", "First user message should trigger title update")
     }
 
     func testCreatePrivateThreadSetsOnSessionCreatedCallback() {
-        threadManager.createPrivateThread()
-        let vm = threadManager.activeViewModel!
+        conversationManager.createPrivateConversation()
+        let vm = conversationManager.activeViewModel!
         XCTAssertNotNil(vm.onConversationCreated, "onConversationCreated should be set for session ID backfill")
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationManagerRenameTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerRenameTests.swift
@@ -3,10 +3,10 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadManagerRenameTests: XCTestCase {
+final class ConversationManagerRenameTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
-    private var threadManager: ThreadManager!
+    private var conversationManager: ConversationManager!
     private var capturedMessages: [Any] = []
 
     override func setUp() {
@@ -18,13 +18,13 @@ final class ThreadManagerRenameTests: XCTestCase {
             guard let self else { return }
             capturedMessages.append(msg)
         }
-        threadManager = ThreadManager(daemonClient: daemonClient)
-        threadManager.createThread()
+        conversationManager = ConversationManager(daemonClient: daemonClient)
+        conversationManager.createConversation()
     }
 
     override func tearDown() {
         daemonClient?.sendOverride = nil
-        threadManager = nil
+        conversationManager = nil
         capturedMessages = []
         daemonClient = nil
         super.tearDown()
@@ -33,17 +33,17 @@ final class ThreadManagerRenameTests: XCTestCase {
     // MARK: - Rename with sessionId
 
     func testRenameWithSessionIdSendsMessage() {
-        guard let thread = threadManager.threads.first else {
+        guard let thread = conversationManager.conversations.first else {
             XCTFail("Expected at least one thread")
             return
         }
 
-        threadManager.threads[0].conversationId = "session-abc"
+        conversationManager.conversations[0].conversationId = "session-abc"
         capturedMessages = [] // clear setup noise
 
-        threadManager.renameThread(id: thread.id, title: "Renamed Thread")
+        conversationManager.renameConversation(id: thread.id, title: "Renamed Thread")
 
-        XCTAssertEqual(threadManager.threads[0].title, "Renamed Thread")
+        XCTAssertEqual(conversationManager.conversations[0].title, "Renamed Thread")
 
         let renameMessages = capturedMessages.compactMap { $0 as? ConversationRenameRequest }
         XCTAssertEqual(renameMessages.count, 1)
@@ -54,31 +54,31 @@ final class ThreadManagerRenameTests: XCTestCase {
     // MARK: - Empty/whitespace rename rejected
 
     func testEmptyRenameIsRejected() {
-        guard let thread = threadManager.threads.first else {
+        guard let thread = conversationManager.conversations.first else {
             XCTFail("Expected at least one thread")
             return
         }
         let originalTitle = thread.title
-        threadManager.threads[0].conversationId = "session-abc"
+        conversationManager.conversations[0].conversationId = "session-abc"
 
-        threadManager.renameThread(id: thread.id, title: "")
+        conversationManager.renameConversation(id: thread.id, title: "")
 
-        XCTAssertEqual(threadManager.threads[0].title, originalTitle)
+        XCTAssertEqual(conversationManager.conversations[0].title, originalTitle)
         let renameMessages = capturedMessages.compactMap { $0 as? ConversationRenameRequest }
         XCTAssertTrue(renameMessages.isEmpty)
     }
 
     func testWhitespaceOnlyRenameIsRejected() {
-        guard let thread = threadManager.threads.first else {
+        guard let thread = conversationManager.conversations.first else {
             XCTFail("Expected at least one thread")
             return
         }
         let originalTitle = thread.title
-        threadManager.threads[0].conversationId = "session-abc"
+        conversationManager.conversations[0].conversationId = "session-abc"
 
-        threadManager.renameThread(id: thread.id, title: "   \n  ")
+        conversationManager.renameConversation(id: thread.id, title: "   \n  ")
 
-        XCTAssertEqual(threadManager.threads[0].title, originalTitle)
+        XCTAssertEqual(conversationManager.conversations[0].title, originalTitle)
         let renameMessages = capturedMessages.compactMap { $0 as? ConversationRenameRequest }
         XCTAssertTrue(renameMessages.isEmpty)
     }
@@ -86,15 +86,15 @@ final class ThreadManagerRenameTests: XCTestCase {
     // MARK: - Rename trims whitespace
 
     func testRenameTrimsWhitespace() {
-        guard let thread = threadManager.threads.first else {
+        guard let thread = conversationManager.conversations.first else {
             XCTFail("Expected at least one thread")
             return
         }
-        threadManager.threads[0].conversationId = "session-abc"
+        conversationManager.conversations[0].conversationId = "session-abc"
         capturedMessages = []
 
-        threadManager.renameThread(id: thread.id, title: "  Trimmed Title  ")
+        conversationManager.renameConversation(id: thread.id, title: "  Trimmed Title  ")
 
-        XCTAssertEqual(threadManager.threads[0].title, "Trimmed Title")
+        XCTAssertEqual(conversationManager.conversations[0].title, "Trimmed Title")
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -3,10 +3,10 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ThreadManagerUnseenStateTests: XCTestCase {
+final class ConversationManagerUnseenStateTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
-    private var threadManager: ThreadManager!
+    private var conversationManager: ConversationManager!
     private var sentMessages: [Any] = []
 
     private func makeConversationListResponse(
@@ -31,31 +31,31 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         daemonClient.sendOverride = { [weak self] message in
             self?.sentMessages.append(message)
         }
-        threadManager = ThreadManager(daemonClient: daemonClient)
-        threadManager.createThread()
+        conversationManager = ConversationManager(daemonClient: daemonClient)
+        conversationManager.createConversation()
     }
 
     override func tearDown() {
         daemonClient?.sendOverride = nil
-        threadManager = nil
+        conversationManager = nil
         daemonClient = nil
         sentMessages = []
         super.tearDown()
     }
 
     func testInactiveStandardThreadMarkedUnseenWhenAssistantReplies() {
-        guard let initialThreadId = threadManager.activeThreadId else {
-            XCTFail("Expected an initial active thread")
+        guard let initialThreadId = conversationManager.activeConversationId else {
+            XCTFail("Expected an initial active conversation")
             return
         }
-        threadManager.chatViewModel(for: initialThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        conversationManager.chatViewModel(for: initialThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        threadManager.createThread()
-        let activeThreadId = threadManager.activeThreadId
-        XCTAssertNotEqual(initialThreadId, activeThreadId)
+        conversationManager.createConversation()
+        let activeConversationId = conversationManager.activeConversationId
+        XCTAssertNotEqual(initialThreadId, activeConversationId)
 
-        guard let vm = threadManager.chatViewModel(for: initialThreadId) else {
-            XCTFail("Expected ChatViewModel for inactive thread")
+        guard let vm = conversationManager.chatViewModel(for: initialThreadId) else {
+            XCTFail("Expected ChatViewModel for inactive conversation")
             return
         }
 
@@ -64,79 +64,79 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         waitForPropagation()
 
-        guard let updated = threadManager.threads.first(where: { $0.id == initialThreadId }) else {
-            XCTFail("Expected thread to exist")
+        guard let updated = conversationManager.conversations.first(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected conversation to exist")
             return
         }
 
-        XCTAssertNil(updated.source, "Regression guard: should work for normal (non-notification) threads")
+        XCTAssertNil(updated.source, "Regression guard: should work for normal (non-notification) conversations")
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
     func testInactiveThreadMarkedUnseenWhenAssistantContinuesSameMessageAfterSwitch() {
-        guard let initialThreadId = threadManager.activeThreadId,
-              let initialVm = threadManager.chatViewModel(for: initialThreadId),
-              let initialIndex = threadManager.threads.firstIndex(where: { $0.id == initialThreadId }) else {
-            XCTFail("Expected an initial active thread and VM")
+        guard let initialThreadId = conversationManager.activeConversationId,
+              let initialVm = conversationManager.chatViewModel(for: initialThreadId),
+              let initialIndex = conversationManager.conversations.firstIndex(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected an initial active conversation and VM")
             return
         }
 
-        threadManager.threads[initialIndex].conversationId = "session-initial"
+        conversationManager.conversations[initialIndex].conversationId = "session-initial"
         initialVm.conversationId = "session-initial"
         initialVm.messages.append(ChatMessage(role: .user, text: "Seed"))
 
         initialVm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: "First chunk", conversationId: "session-initial")
+            AssistantTextDeltaMessage(text: "First chunk", sessionId: "session-initial")
         ))
         waitForPropagation()
-        XCTAssertFalse(threadManager.threads[initialIndex].hasUnseenLatestAssistantMessage)
+        XCTAssertFalse(conversationManager.conversations[initialIndex].hasUnseenLatestAssistantMessage)
 
-        threadManager.createThread()
-        guard let secondaryThreadId = threadManager.activeThreadId,
-              let secondaryIndex = threadManager.threads.firstIndex(where: { $0.id == secondaryThreadId }),
-              let secondaryVm = threadManager.chatViewModel(for: secondaryThreadId) else {
-            XCTFail("Expected a secondary active thread and VM")
+        conversationManager.createConversation()
+        guard let secondaryThreadId = conversationManager.activeConversationId,
+              let secondaryIndex = conversationManager.conversations.firstIndex(where: { $0.id == secondaryThreadId }),
+              let secondaryVm = conversationManager.chatViewModel(for: secondaryThreadId) else {
+            XCTFail("Expected a secondary active conversation and VM")
             return
         }
 
-        threadManager.threads[secondaryIndex].conversationId = "session-secondary"
+        conversationManager.conversations[secondaryIndex].conversationId = "session-secondary"
         secondaryVm.conversationId = "session-secondary"
-        threadManager.selectThread(id: secondaryThreadId)
+        conversationManager.selectConversation(id: secondaryThreadId)
 
         initialVm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: " + second chunk", conversationId: "session-initial")
+            AssistantTextDeltaMessage(text: " + second chunk", sessionId: "session-initial")
         ))
         initialVm.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(conversationId: "session-initial")
+            MessageCompleteMessage(sessionId: "session-initial")
         ))
 
         waitForPropagation()
 
-        guard let updated = threadManager.threads.first(where: { $0.id == initialThreadId }) else {
-            XCTFail("Expected thread to exist")
+        guard let updated = conversationManager.conversations.first(where: { $0.id == initialThreadId }) else {
+            XCTFail("Expected conversation to exist")
             return
         }
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
     func testActiveThreadEmitsSeenSignalOnNewMessageAndStreamCompletion() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
-              let vm = threadManager.chatViewModel(for: threadId) else {
-            XCTFail("Expected active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }),
+              let vm = conversationManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-realtime"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].conversationId = "session-realtime"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
         vm.conversationId = "session-realtime"
 
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Streaming reply", conversationId: "session-realtime")))
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-realtime")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Streaming reply", sessionId: "session-realtime")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-realtime")))
 
         waitForPropagation()
 
-        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
 
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertFalse(seenSignals.isEmpty, "Seen signal should be emitted on new message arrival and stream completion")
@@ -144,136 +144,136 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     }
 
     func testUnseenVisibleConversationCountExcludesArchivedThreads() {
-        // Start with the initial thread created by setUp
-        guard let threadId = threadManager.activeThreadId,
-              threadManager.threads.firstIndex(where: { $0.id == threadId }) != nil else {
-            XCTFail("Expected an initial active thread")
+        // Start with the initial conversation created by setUp
+        guard let threadId = conversationManager.activeConversationId,
+              conversationManager.conversations.firstIndex(where: { $0.id == threadId }) != nil else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        // Seed a user message so createThread doesn't skip
-        threadManager.chatViewModel(for: threadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        // Seed a user message so createConversation doesn't skip
+        conversationManager.chatViewModel(for: threadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        // Switch away so the initial thread becomes inactive
-        threadManager.createThread()
-        XCTAssertNotEqual(threadManager.activeThreadId, threadId)
+        // Switch away so the initial conversation becomes inactive
+        conversationManager.createConversation()
+        XCTAssertNotEqual(conversationManager.activeConversationId, threadId)
 
-        // Mark the initial thread as unseen
-        if let idx = threadManager.threads.firstIndex(where: { $0.id == threadId }) {
-            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        // Mark the initial conversation as unseen
+        if let idx = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) {
+            conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
         }
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 1)
 
         // Archive it — count should drop to 0
-        threadManager.archiveThread(id: threadId)
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+        conversationManager.archiveConversation(id: threadId)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 0)
     }
 
     func testUnseenVisibleConversationCountExcludesPrivateThreads() {
-        // Create a private thread (this switches activeThreadId to the private thread)
-        threadManager.createPrivateThread()
-        guard let privateId = threadManager.activeThreadId,
-              let idx = threadManager.threads.firstIndex(where: { $0.id == privateId }) else {
-            XCTFail("Expected a private thread")
+        // Create a private conversation (this switches activeConversationId to the private thread)
+        conversationManager.createPrivateConversation()
+        guard let privateId = conversationManager.activeConversationId,
+              let idx = conversationManager.conversations.firstIndex(where: { $0.id == privateId }) else {
+            XCTFail("Expected a private conversation")
             return
         }
 
-        // Mark the private thread as unseen
-        threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        // Mark the private conversation as unseen
+        conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
 
-        // Private threads are excluded from the visible count
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+        // Private conversations are excluded from the visible count
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 0)
     }
 
     func testUnseenVisibleConversationCountIncludesMultipleUnseen() {
-        // Start with the initial thread
-        guard let firstId = threadManager.activeThreadId else {
-            XCTFail("Expected an initial active thread")
+        // Start with the initial conversation
+        guard let firstId = conversationManager.activeConversationId else {
+            XCTFail("Expected an initial active conversation")
             return
         }
-        // Seed a user message so createThread actually creates a new one
-        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        // Seed a user message so createConversation actually creates a new one
+        conversationManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        // Create a second thread
-        threadManager.createThread()
-        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
-            XCTFail("Expected a different second thread")
+        // Create a second conversation
+        conversationManager.createConversation()
+        guard let secondId = conversationManager.activeConversationId, secondId != firstId else {
+            XCTFail("Expected a different second conversation")
             return
         }
-        // Seed the second thread too
-        threadManager.chatViewModel(for: secondId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        // Seed the second conversation too
+        conversationManager.chatViewModel(for: secondId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        // Create a third thread (becomes active)
-        threadManager.createThread()
-        guard let thirdId = threadManager.activeThreadId, thirdId != secondId else {
-            XCTFail("Expected a different third thread")
+        // Create a third conversation (becomes active)
+        conversationManager.createConversation()
+        guard let thirdId = conversationManager.activeConversationId, thirdId != secondId else {
+            XCTFail("Expected a different third conversation")
             return
         }
 
         // Mark first and second as unseen
-        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
-            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        if let idx = conversationManager.conversations.firstIndex(where: { $0.id == firstId }) {
+            conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
         }
-        if let idx = threadManager.threads.firstIndex(where: { $0.id == secondId }) {
-            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
+        if let idx = conversationManager.conversations.firstIndex(where: { $0.id == secondId }) {
+            conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
         }
 
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 2)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 2)
     }
 
     func testSelectingThreadDecrementsUnseenCount() {
-        // Start with the initial thread
-        guard let firstId = threadManager.activeThreadId else {
-            XCTFail("Expected an initial active thread")
+        // Start with the initial conversation
+        guard let firstId = conversationManager.activeConversationId else {
+            XCTFail("Expected an initial active conversation")
             return
         }
-        // Seed so createThread proceeds
-        threadManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        // Seed so createConversation proceeds
+        conversationManager.chatViewModel(for: firstId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        // Create a second thread (becomes active)
-        threadManager.createThread()
-        guard let secondId = threadManager.activeThreadId, secondId != firstId else {
-            XCTFail("Expected a different second thread")
+        // Create a second conversation (becomes active)
+        conversationManager.createConversation()
+        guard let secondId = conversationManager.activeConversationId, secondId != firstId else {
+            XCTFail("Expected a different second conversation")
             return
         }
 
-        // Mark the first (inactive) thread as unseen and give it a sessionId
-        // (selectThread only clears unseen when sessionId is present)
-        if let idx = threadManager.threads.firstIndex(where: { $0.id == firstId }) {
-            threadManager.threads[idx].hasUnseenLatestAssistantMessage = true
-            threadManager.threads[idx].conversationId = "session-first"
+        // Mark the first (inactive) conversation as unseen and give it a sessionId
+        // (selectConversation only clears unseen when sessionId is present)
+        if let idx = conversationManager.conversations.firstIndex(where: { $0.id == firstId }) {
+            conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
+            conversationManager.conversations[idx].conversationId = "session-first"
         }
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 1)
 
         sentMessages.removeAll()
 
-        // Select the unseen thread — should clear its unseen flag and emit seen signal
-        threadManager.selectThread(id: firstId)
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+        // Select the unseen conversation — should clear its unseen flag and emit seen signal
+        conversationManager.selectConversation(id: firstId)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 0)
 
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
-        XCTAssertFalse(seenSignals.isEmpty, "selectThread should emit a seen signal to the daemon")
+        XCTAssertFalse(seenSignals.isEmpty, "selectConversation should emit a seen signal to the daemon")
         XCTAssertEqual(seenSignals.last?.conversationId, "session-first")
     }
 
     func testMarkConversationSeenEmitsSignalAndClearsFlag() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-mark-seen"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 1)
+        conversationManager.conversations[index].conversationId = "session-mark-seen"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 1)
 
         sentMessages.removeAll()
 
-        threadManager.markConversationSeen(threadId: threadId)
+        conversationManager.markConversationSeen(threadId: threadId)
 
-        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+        XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage,
                        "markConversationSeen should clear the unseen flag")
-        XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
+        XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 0)
 
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertFalse(seenSignals.isEmpty, "markConversationSeen should emit a seen signal to the daemon")
@@ -281,22 +281,22 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     }
 
     func testMarkConversationUnreadEmitsSignalAndSetsFlag() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-mark-unread"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].conversationId = "session-mark-unread"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
 
         sentMessages.removeAll()
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
         waitForPropagation()
 
-        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+        XCTAssertTrue(conversationManager.conversations[index].hasUnseenLatestAssistantMessage,
                       "markConversationUnread should set the unseen flag")
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
@@ -305,50 +305,50 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     }
 
     func testMarkConversationUnreadDoesNotEmitDuplicateSignalForUnreadThread() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-already-unread"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].conversationId = "session-already-unread"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
 
         sentMessages.removeAll()
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
-        XCTAssertTrue(unreadSignals.isEmpty, "Already-unread threads should not emit duplicate unread signals")
-        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertTrue(unreadSignals.isEmpty, "Already-unread conversations should not emit duplicate unread signals")
+        XCTAssertTrue(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
     }
 
     func testMarkConversationUnreadAllowsLiveAssistantReplyWithoutHydratedTimestamp() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
-              let vm = threadManager.chatViewModel(for: threadId) else {
-            XCTFail("Expected an initial active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }),
+              let vm = conversationManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected an initial active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-live-unread"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
-        threadManager.threads[index].latestAssistantMessageAt = nil
+        conversationManager.conversations[index].conversationId = "session-live-unread"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].latestAssistantMessageAt = nil
         vm.conversationId = "session-live-unread"
 
         vm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: "Live reply", conversationId: "session-live-unread")
+            AssistantTextDeltaMessage(text: "Live reply", sessionId: "session-live-unread")
         ))
         waitForPropagation()
 
-        threadManager.threads[index].latestAssistantMessageAt = nil
+        conversationManager.conversations[index].latestAssistantMessageAt = nil
         sentMessages.removeAll()
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
         waitForPropagation()
 
-        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+        XCTAssertTrue(conversationManager.conversations[index].hasUnseenLatestAssistantMessage,
                       "Live assistant replies should allow unread even before hydration backfills timestamps")
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
@@ -357,52 +357,52 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     }
 
     func testMarkConversationUnreadRollsBackWhenSendFails() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
         daemonClient.sendOverride = { _ in
-            throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
+            throw NSError(domain: "ConversationManagerUnseenStateTests", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "offline"
             ])
         }
 
-        threadManager.threads[index].conversationId = "session-unread-failure"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
-        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].conversationId = "session-unread-failure"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
         waitForPropagation()
 
-        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
         XCTAssertEqual(
-            threadManager.threads[index].lastSeenAssistantMessageAt,
+            conversationManager.conversations[index].lastSeenAssistantMessageAt,
             Date(timeIntervalSince1970: 9)
         )
     }
 
     func testUnreadRollbackRequeuesDeferredSeenSignal() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-requeue"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 5)
+        conversationManager.conversations[index].conversationId = "session-requeue"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 5)
 
         // mark-all-seen defers the seen signal
-        threadManager.markAllThreadsSeen()
+        conversationManager.markAllConversationsSeen()
 
         // Fail only unread signals so markConversationUnread triggers rollback,
         // while allowing seen signals from commitPendingSeenSignals to succeed.
         daemonClient.sendOverride = { [weak self] message in
             if message is ConversationUnreadSignal {
-                throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
+                throw NSError(domain: "ConversationManagerUnseenStateTests", code: 1, userInfo: [
                     NSLocalizedDescriptionKey: "offline"
                 ])
             }
@@ -411,55 +411,55 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         sentMessages.removeAll()
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
         waitForPropagation()
 
         // After rollback the deferred seen signal should be re-queued,
         // so committing should emit a seen signal for the session.
-        threadManager.commitPendingSeenSignals()
+        conversationManager.commitPendingSeenSignals()
 
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.map(\.conversationId), ["session-requeue"])
     }
 
     func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-no-assistant-reply"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
-        threadManager.threads[index].latestAssistantMessageAt = nil
+        conversationManager.conversations[index].conversationId = "session-no-assistant-reply"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].latestAssistantMessageAt = nil
 
         sentMessages.removeAll()
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertTrue(unreadSignals.isEmpty, "Threads without assistant replies should not emit unread signals")
-        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
     }
 
     func testAttentionMergePreservesLocalSeenUntilDaemonAcknowledgesIt() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-refresh-seen"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
-        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 8)
+        conversationManager.conversations[index].conversationId = "session-refresh-seen"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 8)
 
-        threadManager.markConversationSeen(threadId: threadId)
+        conversationManager.markConversationSeen(threadId: threadId)
 
         let staleResponse = makeConversationListResponse(
             conversations: [[
                 "id": "session-refresh-seen",
-                "title": "Restored thread",
+                "title": "Restored conversation",
                 "createdAt": 5_000,
                 "updatedAt": 6_000,
                 "assistantAttention": [
@@ -469,36 +469,36 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
                 ],
             ]]
         )
-        guard let session = staleResponse.sessions.first else {
+        guard let session = staleResponse.conversations.first else {
             XCTFail("Expected response session")
             return
         }
 
-        threadManager.mergeAssistantAttention(from: session, intoThreadAt: index)
+        conversationManager.mergeAssistantAttention(from: session, intoThreadAt: index)
 
         XCTAssertFalse(
-            threadManager.threads.first(where: { $0.conversationId == "session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true
+            conversationManager.conversations.first(where: { $0.conversationId == "session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true
         )
     }
 
     func testAppendThreadsPreservesLocalUnreadUntilDaemonAcknowledgesIt() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-refresh-unread"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
-        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
-        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].conversationId = "session-refresh-unread"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        conversationManager.conversations[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
 
-        threadManager.markConversationUnread(threadId: threadId)
+        conversationManager.markConversationUnread(threadId: threadId)
 
         let staleResponse = makeConversationListResponse(
             conversations: [[
                 "id": "session-refresh-unread",
-                "title": "Paginated thread",
+                "title": "Paginated conversation",
                 "createdAt": 5_000,
                 "updatedAt": 6_000,
                 "assistantAttention": [
@@ -509,44 +509,44 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
             ]]
         )
 
-        threadManager.appendThreads(from: staleResponse)
+        conversationManager.appendConversations(from: staleResponse)
 
         XCTAssertTrue(
-            threadManager.threads.first(where: { $0.conversationId == "session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
+            conversationManager.conversations.first(where: { $0.conversationId == "session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
         )
     }
 
     func testMarkConversationUnreadRemovesPendingSeenSignalForSameSession() {
-        guard let firstThreadId = threadManager.activeThreadId,
-              let firstIndex = threadManager.threads.firstIndex(where: { $0.id == firstThreadId }) else {
-            XCTFail("Expected an initial active thread")
+        guard let firstThreadId = conversationManager.activeConversationId,
+              let firstIndex = conversationManager.conversations.firstIndex(where: { $0.id == firstThreadId }) else {
+            XCTFail("Expected an initial active conversation")
             return
         }
 
-        threadManager.threads[firstIndex].conversationId = "session-first"
-        threadManager.threads[firstIndex].hasUnseenLatestAssistantMessage = true
-        threadManager.threads[firstIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 1)
-        threadManager.chatViewModel(for: firstThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+        conversationManager.conversations[firstIndex].conversationId = "session-first"
+        conversationManager.conversations[firstIndex].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[firstIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 1)
+        conversationManager.chatViewModel(for: firstThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
 
-        threadManager.createThread()
+        conversationManager.createConversation()
 
-        guard let secondThreadId = threadManager.activeThreadId,
-              let secondIndex = threadManager.threads.firstIndex(where: { $0.id == secondThreadId }) else {
-            XCTFail("Expected a second active thread")
+        guard let secondThreadId = conversationManager.activeConversationId,
+              let secondIndex = conversationManager.conversations.firstIndex(where: { $0.id == secondThreadId }) else {
+            XCTFail("Expected a second active conversation")
             return
         }
 
-        threadManager.threads[secondIndex].conversationId = "session-second"
-        threadManager.threads[secondIndex].hasUnseenLatestAssistantMessage = true
-        threadManager.threads[secondIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 2)
+        conversationManager.conversations[secondIndex].conversationId = "session-second"
+        conversationManager.conversations[secondIndex].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[secondIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 2)
 
         sentMessages.removeAll()
 
-        let markedIds = Set(threadManager.markAllThreadsSeen())
+        let markedIds = Set(conversationManager.markAllConversationsSeen())
         XCTAssertEqual(markedIds, Set([firstThreadId, secondThreadId]))
 
-        threadManager.markConversationUnread(threadId: firstThreadId)
-        threadManager.commitPendingSeenSignals()
+        conversationManager.markConversationUnread(threadId: firstThreadId)
+        conversationManager.commitPendingSeenSignals()
         waitForPropagation()
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
@@ -555,28 +555,28 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.map(\.conversationId), ["session-second"])
 
-        XCTAssertTrue(threadManager.threads.contains(where: {
+        XCTAssertTrue(conversationManager.conversations.contains(where: {
             $0.id == firstThreadId && $0.hasUnseenLatestAssistantMessage
         }))
-        XCTAssertTrue(threadManager.threads.contains(where: {
+        XCTAssertTrue(conversationManager.conversations.contains(where: {
             $0.id == secondThreadId && !$0.hasUnseenLatestAssistantMessage
         }))
     }
 
     func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
-              let vm = threadManager.chatViewModel(for: threadId) else {
-            XCTFail("Expected active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }),
+              let vm = conversationManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-streaming"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[index].conversationId = "session-streaming"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
         vm.conversationId = "session-streaming"
 
         // First delta creates a new message — should emit one seen signal
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", conversationId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", sessionId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterFirstDelta = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -584,9 +584,9 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         let countAfterFirst = signalsAfterFirstDelta.count
 
         // Subsequent deltas on the same message should NOT emit additional seen signals
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk2", conversationId: "session-streaming")))
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk3", conversationId: "session-streaming")))
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", conversationId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk2", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk3", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", sessionId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterMoreDeltas = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -595,7 +595,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
                        "Mid-stream text deltas should not emit additional seen signals (was O(n), should be O(1))")
 
         // Stream completion should emit one more seen signal
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-streaming")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterComplete = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -605,23 +605,23 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     }
 
     func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
-        guard let threadId = threadManager.activeThreadId,
-              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
-              let vm = threadManager.chatViewModel(for: threadId) else {
-            XCTFail("Expected active thread and view model")
+        guard let threadId = conversationManager.activeConversationId,
+              let index = conversationManager.conversations.firstIndex(where: { $0.id == threadId }),
+              let vm = conversationManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected active conversation and view model")
             return
         }
 
-        threadManager.threads[index].conversationId = "session-active"
-        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[index].conversationId = "session-active"
+        conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
         vm.conversationId = "session-active"
 
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Visible reply", conversationId: "session-active")))
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-active")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Visible reply", sessionId: "session-active")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-active")))
 
         waitForPropagation()
 
-        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
 
         let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.last?.conversationId, "session-active")
@@ -631,7 +631,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         let response = makeConversationListResponse(
             conversations: [[
                 "id": "session-paginated",
-                "title": "Paginated thread",
+                "title": "Paginated conversation",
                 "createdAt": 5_000,
                 "updatedAt": 6_000,
                 "assistantAttention": [
@@ -643,9 +643,9 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
             hasMore: false
         )
 
-        threadManager.appendThreads(from: response)
+        conversationManager.appendConversations(from: response)
 
-        guard let appendedThread = threadManager.threads.first(where: { $0.conversationId == "session-paginated" }) else {
+        guard let appendedThread = conversationManager.conversations.first(where: { $0.conversationId == "session-paginated" }) else {
             XCTFail("Expected appended thread")
             return
         }

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -6,11 +6,11 @@ import VellumAssistantShared
 // MARK: - Mock Delegate
 
 @MainActor
-final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
-    var threads: [ThreadModel] = []
-    var restoreRecentThreads: Bool = true
-    var isLoadingMoreThreads: Bool = false
-    var hasMoreThreads: Bool = false
+final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
+    var conversations: [ConversationModel] = []
+    var restoreRecentConversations: Bool = true
+    var isLoadingMoreConversations: Bool = false
+    var hasMoreConversations: Bool = false
     var serverOffset: Int = 0
     var viewModels: [UUID: ChatViewModel] = [:]
     var activatedThreadId: UUID?
@@ -31,7 +31,7 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
     }
 
     func existingChatViewModel(forConversationId conversationId: String) -> ChatViewModel? {
-        for (_, vm) in viewModels where vm.conversationId == sessionId {
+        for (_, vm) in viewModels where vm.conversationId == conversationId {
             return vm
         }
         return nil
@@ -49,15 +49,15 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         ChatViewModel(daemonClient: daemonClient)
     }
 
-    func activateThread(_ id: UUID) {
+    func activateConversation(_ id: UUID) {
         activatedThreadId = id
     }
 
-    func createThread() {
+    func createConversation() {
         createThreadCallCount += 1
-        let thread = ThreadModel()
+        let thread = ConversationModel()
         let vm = makeViewModel()
-        threads.insert(thread, at: 0)
+        conversations.insert(thread, at: 0)
         viewModels[thread.id] = vm
         activatedThreadId = thread.id
     }
@@ -66,11 +66,11 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         archivedConversationIds.contains(conversationId)
     }
 
-    func restoreLastActiveThread() {
+    func restoreLastActiveConversation() {
         // no-op for tests
     }
 
-    func appendThreads(from response: ConversationListResponseMessage) {
+    func appendConversations(from response: ConversationListResponseMessage) {
         // no-op for tests
     }
 
@@ -78,14 +78,14 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
         from item: ConversationListResponseItem,
         intoThreadAt index: Int
     ) {
-        threads[index].hasUnseenLatestAssistantMessage =
-            session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
-        threads[index].latestAssistantMessageAt =
-            session.assistantAttention?.latestAssistantMessageAt.map {
+        conversations[index].hasUnseenLatestAssistantMessage =
+            item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+        conversations[index].latestAssistantMessageAt =
+            item.assistantAttention?.latestAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
-        threads[index].lastSeenAssistantMessageAt =
-            session.assistantAttention?.lastSeenAssistantMessageAt.map {
+        conversations[index].lastSeenAssistantMessageAt =
+            item.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
     }
@@ -148,28 +148,28 @@ private func makeHistoryResponse(conversationId: String, messages: [(role: Strin
 
 /// Build a ConversationTitleUpdatedMessage via JSON round-trip.
 private func makeConversationTitleUpdated(conversationId: String, title: String) -> ConversationTitleUpdatedMessage {
-    let dict: [String: Any] = ["type": "conversation_title_updated", "sessionId": conversationId, "title": title]
+    let dict: [String: Any] = ["type": "conversation_title_updated", "conversationId": conversationId, "title": title]
     let data = try! JSONSerialization.data(withJSONObject: dict)
     return try! JSONDecoder().decode(ConversationTitleUpdatedMessage.self, from: data)
 }
 
 // MARK: - Tests
 
-@Suite("ThreadConversationRestorer")
-struct ThreadConversationRestorerTests {
+@Suite("ConversationRestorer")
+struct ConversationRestorerTests {
 
     // MARK: - History Response Routing
 
     @Test @MainActor
     func historyResponseRoutesToCorrectThread() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
 
-        // Set up two threads with session IDs
-        let threadA = ThreadModel(title: "Thread A", conversationId: "session-A")
-        let threadB = ThreadModel(title: "Thread B", conversationId: "session-B")
-        delegate.threads = [threadA, threadB]
+        // Set up two conversations with session IDs
+        let threadA = ConversationModel(title: "Conversation A", conversationId: "session-A")
+        let threadB = ConversationModel(title: "Conversation B", conversationId: "session-B")
+        delegate.conversations = [threadA, threadB]
 
         let vmA = delegate.makeViewModel()
         let vmB = delegate.makeViewModel()
@@ -205,12 +205,12 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func staleHistoryResponseIsDropped() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ThreadModel(title: "Thread", conversationId: "session-X")
-        delegate.threads = [thread]
+        let thread = ConversationModel(title: "Thread", conversationId: "session-X")
+        delegate.conversations = [thread]
         let vm = delegate.makeViewModel()
         delegate.viewModels[thread.id] = vm
 
@@ -228,13 +228,13 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func rapidTabSwitchDoesNotCrossContaminate() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let threadA = ThreadModel(title: "A", conversationId: "sa")
-        let threadB = ThreadModel(title: "B", conversationId: "sb")
-        delegate.threads = [threadA, threadB]
+        let threadA = ConversationModel(title: "A", conversationId: "sa")
+        let threadB = ConversationModel(title: "B", conversationId: "sb")
+        delegate.conversations = [threadA, threadB]
 
         let vmA = delegate.makeViewModel()
         let vmB = delegate.makeViewModel()
@@ -267,33 +267,33 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func sessionTitleUpdatedUpdatesMatchingThread() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ThreadModel(title: "Untitled", conversationId: "session-1")
-        delegate.threads = [thread]
+        let thread = ConversationModel(title: "Untitled", conversationId: "session-1")
+        delegate.conversations = [thread]
         delegate.viewModels[thread.id] = delegate.makeViewModel()
 
         restorer.handleConversationTitleUpdated(makeConversationTitleUpdated(conversationId: "session-1", title: "Plan sprint rollout"))
 
-        #expect(delegate.threads[0].title == "Plan sprint rollout")
+        #expect(delegate.conversations[0].title == "Plan sprint rollout")
     }
 
     @Test @MainActor
     func sessionTitleUpdatedIgnoresUnknownSessionId() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ThreadModel(title: "Untitled", conversationId: "session-1")
-        delegate.threads = [thread]
+        let thread = ConversationModel(title: "Untitled", conversationId: "session-1")
+        delegate.conversations = [thread]
         delegate.viewModels[thread.id] = delegate.makeViewModel()
 
         restorer.handleConversationTitleUpdated(makeConversationTitleUpdated(conversationId: "other-session", title: "Should not apply"))
 
-        #expect(delegate.threads[0].title == "Untitled")
+        #expect(delegate.conversations[0].title == "Untitled")
     }
 
     // MARK: - Session List Restoration
@@ -301,14 +301,14 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func sessionListCreatesRestoredThreads() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
         // Start with one empty default thread
-        let defaultThread = ThreadModel()
+        let defaultThread = ConversationModel()
         let defaultVm = delegate.makeViewModel()
-        delegate.threads = [defaultThread]
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = defaultVm
 
         let response = makeConversationListResponse(conversations: [
@@ -318,31 +318,31 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Default empty thread should be replaced
-        #expect(delegate.threads.count == 2)
+        #expect(delegate.conversations.count == 2)
         #expect(delegate.viewModels[defaultThread.id] == nil)
 
-        // Restored threads have correct session IDs
-        #expect(delegate.threads[0].conversationId == "s1")
-        #expect(delegate.threads[1].conversationId == "s2")
-        #expect(delegate.threads[0].title == "Chat 1")
+        // Restored conversations have correct session IDs
+        #expect(delegate.conversations[0].conversationId == "s1")
+        #expect(delegate.conversations[1].conversationId == "s2")
+        #expect(delegate.conversations[0].title == "Chat 1")
 
         // VMs are lazily created — not eagerly allocated during restore
-        #expect(delegate.viewModels[delegate.threads[0].id] == nil)
-        #expect(delegate.viewModels[delegate.threads[1].id] == nil)
+        #expect(delegate.viewModels[delegate.conversations[0].id] == nil)
+        #expect(delegate.viewModels[delegate.conversations[1].id] == nil)
 
         // Most recent thread should be activated
-        #expect(delegate.activatedThreadId == delegate.threads[0].id)
+        #expect(delegate.activatedThreadId == delegate.conversations[0].id)
     }
 
     @Test @MainActor
     func sessionListPreservesAssistantAttentionTimestamps() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversationDicts: [[
@@ -359,7 +359,7 @@ struct ThreadConversationRestorerTests {
 
         restorer.handleConversationListResponse(response)
 
-        guard let restoredThread = delegate.threads.first(where: { $0.conversationId == "s-attention" }) else {
+        guard let restoredThread = delegate.conversations.first(where: { $0.conversationId == "s-attention" }) else {
             Issue.record("Expected restored attention thread")
             return
         }
@@ -372,38 +372,38 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func sessionListSkipsWhenRestoreDisabled() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
-        delegate.restoreRecentThreads = false
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
+        delegate.restoreRecentConversations = false
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Chat 1", updatedAt: 1000),
         ])
         restorer.handleConversationListResponse(response)
 
-        // Should not modify threads
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].id == defaultThread.id)
+        // Should not modify conversations
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].id == defaultThread.id)
         #expect(delegate.activatedThreadId == nil)
     }
 
     @Test @MainActor
     func sessionListPreservesNonEmptyDefaultThread() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
         // Default thread that has an active session (not empty)
-        let activeThread = ThreadModel(title: "Active")
+        let activeConversation = ConversationModel(title: "Active")
         let activeVm = delegate.makeViewModel()
         activeVm.conversationId = "active-session"
-        delegate.threads = [activeThread]
-        delegate.viewModels[activeThread.id] = activeVm
+        delegate.conversations = [activeConversation]
+        delegate.viewModels[activeConversation.id] = activeVm
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Restored", updatedAt: 1000),
@@ -411,20 +411,20 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Active thread is preserved, restored thread prepended
-        #expect(delegate.threads.count == 2)
-        #expect(delegate.threads[1].id == activeThread.id)
-        #expect(delegate.threads[0].conversationId == "s1")
+        #expect(delegate.conversations.count == 2)
+        #expect(delegate.conversations[1].id == activeConversation.id)
+        #expect(delegate.conversations[0].conversationId == "s1")
     }
 
     @Test @MainActor
     func sessionListRestoresAllAndSetsOffset() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let sessions = (0..<10).map { i in
@@ -433,7 +433,7 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(makeConversationListResponse(conversations: sessions))
 
         // Client restores all sessions from the response; pagination is server-side
-        #expect(delegate.threads.count == 10)
+        #expect(delegate.conversations.count == 10)
         #expect(delegate.serverOffset == 10)
     }
 
@@ -442,16 +442,16 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func allArchivedSessionsCreatesNewThread() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
         // Mark all sessions as archived
         delegate.archivedConversationIds = ["s1", "s2"]
 
         // Start with one empty default thread
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -460,30 +460,30 @@ struct ThreadConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Default thread replaced, restored threads are archived, new thread created
+        // Default thread replaced, restored conversations are archived, new thread created
         #expect(delegate.createThreadCallCount == 1)
-        // 2 archived threads + 1 new thread
-        #expect(delegate.threads.count == 3)
+        // 2 archived conversations + 1 new thread
+        #expect(delegate.conversations.count == 3)
         // The new thread should be active
         #expect(delegate.activatedThreadId != nil)
-        #expect(delegate.threads.first(where: { $0.id == delegate.activatedThreadId })?.isArchived == false)
+        #expect(delegate.conversations.first(where: { $0.id == delegate.activatedThreadId })?.isArchived == false)
     }
 
     @Test @MainActor
     func allArchivedWithNonEmptyDefaultDoesNotCreateThread() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
         delegate.archivedConversationIds = ["s1"]
 
         // Default thread has an active session (not empty)
-        let activeThread = ThreadModel(title: "Active")
+        let activeConversation = ConversationModel(title: "Active")
         let activeVm = delegate.makeViewModel()
         activeVm.conversationId = "active-session"
-        delegate.threads = [activeThread]
-        delegate.viewModels[activeThread.id] = activeVm
+        delegate.conversations = [activeConversation]
+        delegate.viewModels[activeConversation.id] = activeVm
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Archived Chat", updatedAt: 1000),
@@ -492,21 +492,21 @@ struct ThreadConversationRestorerTests {
 
         // Default thread preserved, no new thread created
         #expect(delegate.createThreadCallCount == 0)
-        #expect(delegate.threads.count == 2)
-        #expect(delegate.threads.contains(where: { $0.id == activeThread.id }))
+        #expect(delegate.conversations.count == 2)
+        #expect(delegate.conversations.contains(where: { $0.id == activeConversation.id }))
     }
 
-    // MARK: - Thread Type Mapping
+    // MARK: - Conversation Type Mapping
 
     @Test @MainActor
     func privateThreadTypeIsExcludedFromRestore() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -515,20 +515,20 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Private sessions are filtered out; empty default is removed and a new thread created
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
         #expect(delegate.createThreadCallCount == 1)
     }
 
     @Test @MainActor
     func nilConversationTypeRestoresAsStandardKind() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -536,19 +536,19 @@ struct ThreadConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
     }
 
     @Test @MainActor
     func standardConversationTypeRestoresAsStandardKind() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -556,8 +556,8 @@ struct ThreadConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
     }
 
     // MARK: - Channel Binding Filtering
@@ -565,12 +565,12 @@ struct ThreadConversationRestorerTests {
     @Test @MainActor
     func telegramBoundSessionIsExcludedFromRestore() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -580,21 +580,21 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Telegram-bound session filtered out; empty default removed; new thread created
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].conversationId == nil)
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].conversationId == nil)
         #expect(delegate.createThreadCallCount == 1)
     }
 
     @Test @MainActor
     func voiceBoundSessionIsExcludedFromRestore() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -604,21 +604,21 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Voice-bound session filtered out; empty default removed; new thread created
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].conversationId == nil)
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].conversationId == nil)
         #expect(delegate.createThreadCallCount == 1)
     }
 
     @Test @MainActor
     func mixedDesktopVoiceAndTelegramRestoresOnlyDesktop() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -632,23 +632,23 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Only the two desktop sessions should be restored
-        #expect(delegate.threads.count == 2)
-        #expect(delegate.threads[0].conversationId == "s1")
-        #expect(delegate.threads[0].title == "Desktop Chat")
-        #expect(delegate.threads[1].conversationId == "s4")
-        #expect(delegate.threads[1].title == "Another Desktop Chat")
+        #expect(delegate.conversations.count == 2)
+        #expect(delegate.conversations[0].conversationId == "s1")
+        #expect(delegate.conversations[0].title == "Desktop Chat")
+        #expect(delegate.conversations[1].conversationId == "s4")
+        #expect(delegate.conversations[1].title == "Another Desktop Chat")
         #expect(delegate.createThreadCallCount == 0)
     }
 
     @Test @MainActor
     func mixedDesktopAndTelegramRestoresOnlyDesktop() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
@@ -660,11 +660,11 @@ struct ThreadConversationRestorerTests {
         restorer.handleConversationListResponse(response)
 
         // Only the two desktop sessions should be restored
-        #expect(delegate.threads.count == 2)
-        #expect(delegate.threads[0].conversationId == "s1")
-        #expect(delegate.threads[0].title == "Desktop Chat")
-        #expect(delegate.threads[1].conversationId == "s3")
-        #expect(delegate.threads[1].title == "Another Desktop Chat")
+        #expect(delegate.conversations.count == 2)
+        #expect(delegate.conversations[0].conversationId == "s1")
+        #expect(delegate.conversations[0].title == "Desktop Chat")
+        #expect(delegate.conversations[1].conversationId == "s3")
+        #expect(delegate.conversations[1].title == "Another Desktop Chat")
         #expect(delegate.createThreadCallCount == 0)
     }
 }

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -52,26 +52,26 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
         XCTAssertFalse(state.isConversationVisible)
     }
 
-    // MARK: - ThreadHeaderPresentation for document editor
+    // MARK: - ConversationHeaderPresentation for document editor
 
     func testDocumentEditorShowsThreadTitleWhenActiveThreadExists() {
-        let thread = ThreadModel(title: "Doc Session Thread", sessionId: "doc-session-1")
+        let thread = ConversationModel(title: "Doc Session Conversation", conversationId: "doc-session-1")
         let vm = ChatViewModel(daemonClient: DaemonClient())
-        let presentation = ThreadHeaderPresentation(
-            activeThread: thread,
+        let presentation = ConversationHeaderPresentation(
+            activeConversation: thread,
             activeViewModel: vm,
             isConversationVisible: true  // document editor always reports conversation as visible
         )
 
-        XCTAssertEqual(presentation.displayTitle, "Doc Session Thread",
+        XCTAssertEqual(presentation.displayTitle, "Doc Session Conversation",
                         "Document editor should show actual thread title, not 'New thread'")
         XCTAssertTrue(presentation.isStarted)
         XCTAssertTrue(presentation.showsActionsMenu)
     }
 
     func testDocumentEditorShowsNewThreadWhenNoActiveThread() {
-        let presentation = ThreadHeaderPresentation(
-            activeThread: nil,
+        let presentation = ConversationHeaderPresentation(
+            activeConversation: nil,
             activeViewModel: nil,
             isConversationVisible: true
         )

--- a/clients/macos/vellum-assistantTests/PrivateConversationPersistenceTests.swift
+++ b/clients/macos/vellum-assistantTests/PrivateConversationPersistenceTests.swift
@@ -3,14 +3,14 @@ import Testing
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-/// End-to-end behavior tests verifying that private threads persist correctly
+/// End-to-end behavior tests verifying that private conversations persist correctly
 /// and reappear with the right kind after a session restore cycle.
 @Suite("PrivateThreadPersistence")
 struct PrivateThreadPersistenceTests {
 
     // MARK: - End-to-end Flow
 
-    /// Verifies the full lifecycle: create a private thread via ThreadManager,
+    /// Verifies the full lifecycle: create a private thread via ConversationManager,
     /// simulate the daemon assigning a session ID, then confirm the session
     /// restorer reconstructs it as a private thread.
     @Test @MainActor
@@ -19,52 +19,52 @@ struct PrivateThreadPersistenceTests {
         dc.isConnected = true
         dc.sendOverride = { _ in }
 
-        let manager = ThreadManager(daemonClient: dc)
+        let manager = ConversationManager(daemonClient: dc)
 
-        // ThreadManager.init creates one default standard thread
-        #expect(manager.threads.count == 1)
-        #expect(manager.threads[0].kind == .standard)
+        // ConversationManager.init enters draft mode — conversations array is empty,
+        // the initial chat lives as a draftViewModel.
+        #expect(manager.conversations.count == 0)
 
-        // Create a private thread — should appear immediately with .private kind
-        manager.createPrivateThread()
-        #expect(manager.threads.count == 2)
+        // Create a private conversation — promotes the draft and adds a private conversation
+        manager.createPrivateConversation()
+        #expect(manager.conversations.count == 1)
 
-        let privateThread = manager.threads.first!
+        let privateThread = manager.conversations.first!
         #expect(privateThread.kind == .private)
-        #expect(manager.activeThreadId == privateThread.id)
+        #expect(manager.activeConversationId == privateThread.id)
 
         // Simulate daemon assigning a session ID via session_info callback
         let vm = manager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
         let info = ConversationInfoMessage(
             conversationId: "private-session-e2e",
-            title: "Private Thread",
+            title: "Private Conversation",
             correlationId: correlationId
         )
         vm.handleServerMessage(.conversationInfo(info))
 
-        // Session ID should be backfilled into the ThreadModel
-        let updatedThread = manager.threads.first(where: { $0.id == privateThread.id })!
+        // Session ID should be backfilled into the ConversationModel
+        let updatedThread = manager.conversations.first(where: { $0.id == privateThread.id })!
         #expect(updatedThread.conversationId == "private-session-e2e")
         #expect(updatedThread.kind == .private)
 
         // Now simulate a fresh restore: build a session list response
         // that includes this session with conversationType "private", and verify
         // the restorer creates it with .private kind.
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let sessionListJSON: [String: Any] = [
             "type": "conversation_list_response",
-            "sessions": [
+            "conversations": [
                 [
                     "id": "private-session-e2e",
-                    "title": "Private Thread",
+                    "title": "Private Conversation",
                     "createdAt": 4000,
                     "updatedAt": 5000,
                     "conversationType": "private"
@@ -75,11 +75,11 @@ struct PrivateThreadPersistenceTests {
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private threads are excluded from restoration — the default thread
+        // Private conversations are excluded from restoration — the default thread
         // is removed (it was empty) and no private sessions are restored,
-        // so a new empty thread is created via createThread().
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
+        // so a new empty thread is created via createConversation().
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
     }
 
     /// Verifies that a standard thread round-trips correctly through
@@ -90,24 +90,25 @@ struct PrivateThreadPersistenceTests {
         dc.isConnected = true
         dc.sendOverride = { _ in }
 
-        let manager = ThreadManager(daemonClient: dc)
-        #expect(manager.threads[0].kind == .standard)
+        let manager = ConversationManager(daemonClient: dc)
+        // ConversationManager.init enters draft mode — no conversations in the array yet
+        #expect(manager.conversations.isEmpty)
 
         // Restore a session list with a standard thread
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let sessionListJSON: [String: Any] = [
             "type": "conversation_list_response",
-            "sessions": [
+            "conversations": [
                 [
                     "id": "standard-session-e2e",
-                    "title": "Standard Thread",
+                    "title": "Standard Conversation",
                     "createdAt": 2000,
                     "updatedAt": 3000,
                     "conversationType": "standard"
@@ -118,29 +119,29 @@ struct PrivateThreadPersistenceTests {
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].conversationId == "standard-session-e2e")
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].conversationId == "standard-session-e2e")
     }
 
-    // MARK: - Mixed Thread Restore
+    // MARK: - Mixed Conversation Restore
 
-    /// Verifies that a session list containing both private and standard threads
+    /// Verifies that a session list containing both private and standard conversations
     /// restores each with the correct kind.
     @Test @MainActor
     func mixedThreadTypesRestoreCorrectly() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         let sessionListJSON: [String: Any] = [
             "type": "conversation_list_response",
-            "sessions": [
+            "conversations": [
                 ["id": "s-private-1", "title": "Private A", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
                 ["id": "s-standard-1", "title": "Standard B", "createdAt": 3000, "updatedAt": 4000, "conversationType": "standard"],
                 ["id": "s-private-2", "title": "Private C", "createdAt": 2000, "updatedAt": 3000, "conversationType": "private"],
@@ -150,10 +151,10 @@ struct PrivateThreadPersistenceTests {
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private threads are filtered out before restore — only standard threads appear
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].conversationId == "s-standard-1")
+        // Private conversations are filtered out before restore — only standard conversations appear
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].conversationId == "s-standard-1")
     }
 
     // MARK: - Legacy Daemon Payload Fallback
@@ -163,18 +164,18 @@ struct PrivateThreadPersistenceTests {
     @Test @MainActor
     func legacyPayloadWithoutConversationTypeDefaultsToStandard() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         // JSON with no conversationType key at all — simulates an older daemon
         let legacyJSON: [String: Any] = [
             "type": "conversation_list_response",
-            "sessions": [
+            "conversations": [
                 ["id": "legacy-1", "title": "Old Chat", "createdAt": 1000, "updatedAt": 2000],
             ]
         ]
@@ -182,9 +183,9 @@ struct PrivateThreadPersistenceTests {
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].conversationId == "legacy-1")
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].conversationId == "legacy-1")
     }
 
     /// Verifies that a session list mixing legacy (no conversationType) and modern
@@ -192,12 +193,12 @@ struct PrivateThreadPersistenceTests {
     @Test @MainActor
     func mixedLegacyAndModernPayloadsRestoreCorrectly() {
         let dc = DaemonClient()
-        let restorer = ThreadConversationRestorer(daemonClient: dc)
-        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ThreadModel()
-        delegate.threads = [defaultThread]
+        let defaultThread = ConversationModel()
+        delegate.conversations = [defaultThread]
         delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
 
         // Build sessions array manually: first has conversationType, second doesn't
@@ -205,20 +206,20 @@ struct PrivateThreadPersistenceTests {
             ["id": "modern-1", "title": "Modern Private", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
             ["id": "legacy-1", "title": "Legacy Chat", "createdAt": 3000, "updatedAt": 4000],
         ]
-        let dict: [String: Any] = ["type": "conversation_list_response", "sessions": sessions]
+        let dict: [String: Any] = ["type": "conversation_list_response", "conversations": conversations]
         let data = try! JSONSerialization.data(withJSONObject: dict)
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private threads are filtered out — only the legacy standard thread is restored
-        #expect(delegate.threads.count == 1)
-        #expect(delegate.threads[0].kind == .standard)
-        #expect(delegate.threads[0].title == "Legacy Chat")
+        // Private conversations are filtered out — only the legacy standard thread is restored
+        #expect(delegate.conversations.count == 1)
+        #expect(delegate.conversations[0].kind == .standard)
+        #expect(delegate.conversations[0].title == "Legacy Chat")
     }
 
-    // MARK: - ThreadManager.createPrivateThread Immediate Persistence
+    // MARK: - ConversationManager.createPrivateConversation Immediate Persistence
 
-    /// Verifies that createPrivateThread() immediately sends a session_create
+    /// Verifies that createPrivateConversation() immediately sends a session_create
     /// with conversationType "private" — the thread is persisted on the daemon side
     /// before the user sends any messages.
     @Test @MainActor
@@ -230,8 +231,8 @@ struct PrivateThreadPersistenceTests {
             captured.append(msg)
         }
 
-        let manager = ThreadManager(daemonClient: dc)
-        manager.createPrivateThread()
+        let manager = ConversationManager(daemonClient: dc)
+        manager.createPrivateConversation()
 
         let vm = manager.activeViewModel!
         #expect(vm.isBootstrapping)
@@ -246,15 +247,15 @@ struct PrivateThreadPersistenceTests {
     /// Verifies that a private thread's kind survives the session backfill
     /// callback — the kind should remain .private after the daemon responds.
     @Test @MainActor
-    func privateThreadKindSurvivesSessionBackfill() {
+    func privateConversationKindSurvivesSessionBackfill() {
         let dc = DaemonClient()
         dc.isConnected = true
         dc.sendOverride = { _ in }
 
-        let manager = ThreadManager(daemonClient: dc)
-        manager.createPrivateThread()
+        let manager = ConversationManager(daemonClient: dc)
+        manager.createPrivateConversation()
 
-        let privateThread = manager.threads.first!
+        let privateThread = manager.conversations.first!
         #expect(privateThread.kind == .private)
 
         let vm = manager.activeViewModel!
@@ -269,7 +270,7 @@ struct PrivateThreadPersistenceTests {
         vm.handleServerMessage(.conversationInfo(info))
 
         // Kind must still be .private after backfill
-        let updated = manager.threads.first(where: { $0.id == privateThread.id })!
+        let updated = manager.conversations.first(where: { $0.id == privateThread.id })!
         #expect(updated.kind == .private)
         #expect(updated.conversationId == "persist-check")
     }

--- a/clients/macos/vellum-assistantTests/SidebarLayoutMetricsTests.swift
+++ b/clients/macos/vellum-assistantTests/SidebarLayoutMetricsTests.swift
@@ -40,7 +40,7 @@ final class SidebarLayoutMetricsTests: XCTestCase {
     // MARK: - List Row Spacing
 
     func testListRowGapMatchesCompactRhythm() {
-        // Thread row gap uses compact spacing (VSpacing.xs = 4pt).
+        // Conversation row gap uses compact spacing (VSpacing.xs = 4pt).
         XCTAssertEqual(SidebarLayoutMetrics.listRowGap, 4)
     }
 

--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -10,7 +10,7 @@ public struct VThreadIcon: View {
     let size: Size
     var isActive: Bool = false
     /// Optional dot color for interaction-state overlay (bottom-right corner).
-    /// Callers map ThreadInteractionState → Color externally to keep the
+    /// Callers map ConversationInteractionState → Color externally to keep the
     /// design system decoupled from feature types.
     var dotColor: Color?
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -273,7 +273,7 @@ public final class ChatViewModel: ObservableObject {
         set { errorManager.conversationError = newValue }
     }
     /// Whether this view model has an active error (either a session error or error text).
-    /// Used by ThreadManager to derive `ThreadInteractionState.error`.
+    /// Used by ConversationManager to derive `ConversationInteractionState.error`.
     public var hasActiveError: Bool {
         conversationError != nil || errorText != nil
     }

--- a/clients/shared/Features/Chat/ThreadInteractionState.swift
+++ b/clients/shared/Features/Chat/ThreadInteractionState.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-/// Describes the current interaction state of a thread, derived from its
+/// Describes the current interaction state of a conversation, derived from its
 /// ChatViewModel's error, confirmation, and busy properties.
 ///
 /// Priority order (highest to lowest): error > waitingForInput > processing > idle.
-/// M2/M3 will use this to drive visual cues in the thread list and chat view.
-public enum ThreadInteractionState: Equatable, Sendable {
-    /// Nothing happening — the thread is at rest.
+/// M2/M3 will use this to drive visual cues in the conversation list and chat view.
+public enum ConversationInteractionState: Equatable, Sendable {
+    /// Nothing happening — the conversation is at rest.
     case idle
     /// The assistant is thinking, sending, or has queued messages.
     case processing
-    /// The thread has a pending tool confirmation waiting for user approval.
+    /// The conversation has a pending tool confirmation waiting for user approval.
     case waitingForInput
-    /// The thread has an active error (session error or error text).
+    /// The conversation has an active error (session error or error text).
     case error
 }

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -345,7 +345,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
             )!
             let body = """
             {
-              "sessions": [
+              "conversations": [
                 {
                   "id": "session-123",
                   "title": "Pinned thread",
@@ -377,7 +377,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
 
         await fulfillment(of: [responseExpectation], timeout: 1.0)
 
-        let session = try XCTUnwrap(capturedResponse?.sessions.first)
+        let session = try XCTUnwrap(capturedResponse?.conversations.first)
         XCTAssertEqual(session.displayOrder, 7)
         XCTAssertEqual(session.isPinned, true)
     }

--- a/clients/shared/Tests/MockDaemonClientTests.swift
+++ b/clients/shared/Tests/MockDaemonClientTests.swift
@@ -67,7 +67,7 @@ final class MockDaemonClientTests: XCTestCase {
 
     func testSendRecordsCancelMessage() throws {
         let client = MockDaemonClient()
-        let msg = CancelMessage(conversationId: "sess-abc")
+        let msg = CancelMessage(sessionId: "sess-abc")
         try client.send(msg)
         XCTAssertEqual(client.sentMessages.count, 1)
     }


### PR DESCRIPTION
Renames ThreadModel to ConversationModel, ThreadManager to ConversationManager, ThreadKind to ConversationKind. Updates all variable names, consumer files, test files, and documentation. Part of plan: conv-unify-symbols.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
