### PR TITLE
fix: update remaining sessionId labels to conversationId

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -186,7 +186,7 @@ extension AppDelegate {
         proxy.onCancel = { [weak self] in
             guard let self else { return }
             do {
-                try self.daemonClient.send(CancelMessage(sessionId: conversationId))
+                try self.daemonClient.send(CancelMessage(conversationId: conversationId))
             } catch {
                 log.error("Failed to send cancel for host CU session \(conversationId): \(error)")
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1693,7 +1693,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         do {
-            try daemonClient.send(CancelMessage(sessionId: conversationId!))
+            try daemonClient.send(CancelMessage(conversationId: conversationId!))
         } catch {
             log.error("Failed to send cancel: \(error.localizedDescription)")
             // Cancel failed to send, so no generationCancelled or

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -263,8 +263,8 @@ extension UserMessage {
 public typealias CancelMessage = CancelRequest
 
 extension CancelRequest {
-    public init(sessionId: String) {
-        self.init(type: "cancel", sessionId: sessionId)
+    public init(conversationId: String) {
+        self.init(type: "cancel", sessionId: conversationId)
     }
 }
 

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -345,7 +345,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
             )!
             let body = """
             {
-              "sessions": [
+              "conversations": [
                 {
                   "id": "session-123",
                   "title": "Pinned thread",
@@ -377,7 +377,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
 
         await fulfillment(of: [responseExpectation], timeout: 1.0)
 
-        let session = try XCTUnwrap(capturedResponse?.sessions.first)
+        let session = try XCTUnwrap(capturedResponse?.conversations.first)
         XCTAssertEqual(session.displayOrder, 7)
         XCTAssertEqual(session.isPinned, true)
     }


### PR DESCRIPTION
## Summary
- Update `CancelRequest` convenience init parameter label from `sessionId:` to `conversationId:` (following the pattern set by #17464)
- Update two production call sites in `ChatViewModel` and `AppDelegate+Conversations` to match
- Fix `HTTPDaemonClientUnreadTests` mock JSON key from `"sessions"` to `"conversations"` and property access from `.sessions` to `.conversations`

## Original prompt
fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/23124299210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
