### PR TITLE
fix: top-align file tree content in file browser sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -523,7 +523,7 @@ struct AgentPanelContent: View {
                 Divider().background(VColor.borderBase)
 
                 // Content (loading, error, or tree)
-                Group {
+                VStack(spacing: 0) {
                     if skillsManager.isLoadingSkillFiles {
                         HStack {
                             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -286,7 +286,7 @@ private struct WorkspaceTreeSidebar: View {
 
             Divider().background(VColor.borderBase)
 
-            Group {
+            VStack(spacing: 0) {
                 if state.isLoadingTree && state.directoryCache.isEmpty {
                     VStack {
                         Spacer()


### PR DESCRIPTION
## Summary
- Replace `Group` with `VStack(spacing: 0)` in both `WorkspacePanel` and `AgentPanel` file tree sections
- `Group` distributes `.frame(maxHeight: .infinity, alignment: .topLeading)` to individual children instead of applying it to the container, which caused the file list to appear centered vertically
- `VStack` applies the frame modifier to the container itself, ensuring content is properly top-aligned

## Original prompt
The files in the file browser should be top aligned not centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
