### PR TITLE
fix: reset app dock icon on logout, retire, and switch assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -157,6 +157,9 @@ extension AppDelegate {
                 _ = KeychainCredentialStorage().delete(account: credentialAccount)
             }
 
+            // Reset dock icon to default before tearing down UI
+            AvatarAppearanceManager.shared.resetForDisconnect()
+
             let detachedWindow = mainWindow?.detachWindow()
             mainWindow = nil
             conversationBadgeCancellable?.cancel()
@@ -297,6 +300,8 @@ extension AppDelegate {
         // 2. Disconnect transport — leave the old daemon running so it stays
         //    awake and can be switched back to without a cold start.
         daemonClient.disconnect()
+        // Reset dock icon to default before loading the new assistant's avatar
+        AvatarAppearanceManager.shared.resetForDisconnect()
         // Close and recreate the main window to reset thread/session state
         mainWindow?.close()
         mainWindow = nil
@@ -326,6 +331,10 @@ extension AppDelegate {
         //    when the app was launched via Finder/open). Push keys from
         //    UserDefaults so the daemon can initialize its LLM providers.
         syncApiKeysToAssistant(assistant)
+
+        // Reload avatar for the new assistant (customAvatarURL now resolves
+        // to the new assistant's path after connectedAssistantId was updated).
+        AvatarAppearanceManager.shared.reloadAvatar()
 
         showMainWindow()
     }
@@ -456,6 +465,7 @@ extension AppDelegate {
         }
 
         // No assistants left — tear down fully and show onboarding
+        AvatarAppearanceManager.shared.resetForDisconnect()
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")
         UserDefaults.standard.removeObject(forKey: "connectedAssistantId")

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -244,6 +244,22 @@ final class AvatarAppearanceManager {
         loadAvatarComponents()
     }
 
+    /// Clears all cached avatar state and resets the dock icon to the default
+    /// bundle icon without deleting any files on disk.
+    /// Called during logout, retire, and switch-assistant flows.
+    func resetForDisconnect() {
+        customAvatarImage = nil
+        characterBodyShape = nil
+        characterEyeStyle = nil
+        characterColor = nil
+        cachedChatAvatar = nil
+        cachedFallbackAvatar = nil
+        cachedFallbackName = nil
+        cachedFullFallbackAvatar = nil
+        cachedFullFallbackName = nil
+        updateDockIcon()
+    }
+
     func clearCustomAvatar() {
         try? FileManager.default.removeItem(at: customAvatarURL)
         try? FileManager.default.removeItem(at: Self.legacyAppSupportCustomAvatarURL())


### PR DESCRIPTION
## Summary
- Added `AvatarAppearanceManager.resetForDisconnect()` — clears all cached avatar state and resets the dock icon to the default bundle icon without touching files on disk
- Called during logout, retire (last assistant), and switch assistant flows so the dock icon doesn't get stuck showing the previous assistant's avatar
- On switch assistant, also calls `reloadAvatar()` after reconnecting to load the new assistant's avatar

## Original prompt
The macos app icon should reset whenever logging out, retiring your current assistant, or switching to a different assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
