### PR TITLE
fix: narrow migration exclusion in feature flag guard test

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -244,9 +244,13 @@ describe("assistant feature flag indirect key coverage guard", () => {
       if (colonIdx === -1) continue;
       const filePath = line.slice(0, colonIdx);
 
-      // Skip test files and migration files (migrations reference retired flag keys by design)
+      // Skip test files and persisted-data migration files (they reference retired flag keys by design)
       if (isTestFile(filePath)) continue;
-      if (filePath.includes("/migrations/")) continue;
+      if (
+        filePath.includes("/workspace/migrations/") ||
+        filePath.includes("/memory/migrations/")
+      )
+        continue;
 
       // Extract all key occurrences from this line
       const content = line.slice(colonIdx + 1);


### PR DESCRIPTION
## Summary
- Replace broad `filePath.includes('/migrations/')` with explicit checks for `/workspace/migrations/` and `/memory/migrations/` directories
- Ensures feature flag guard still catches undeclared keys in non-data migration paths

Addresses review feedback on #17454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
