### PR TITLE
fix: strengthen managed CES contract tests with actual runtime assertions

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -42,6 +42,9 @@ import {
   UpdateManagedCredentialSchema,
 } from "@vellumai/ces-contracts";
 
+// Importing the production error constant directly from credential-executor.
+// This is allowed in __tests__/ files (the CES boundary guard skips them).
+import { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "../../../credential-executor/src/managed-errors.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
   isCesManagedSidecarEnabled,
@@ -168,11 +171,21 @@ describe("local_static handle rejection in managed mode", () => {
     expect(types).toHaveLength(3);
   });
 
-  // NOTE: The managed-mode local_static rejection error message is validated
-  // in credential-executor/src/__tests__/managed-rejection.test.ts, which can
-  // import the actual error constant from managed-errors.ts. We cannot import
-  // from credential-executor here due to the hard process-boundary isolation
-  // (see CES boundary guard in credential-execution-client.test.ts).
+  test("production rejection error mentions platform_oauth as the alternative", () => {
+    // Assert against the actual production constant from managed-errors.ts,
+    // not a test-local copy.
+    expect(MANAGED_LOCAL_STATIC_REJECTION_ERROR).toContain("platform_oauth");
+  });
+
+  test("production rejection error references managed mode", () => {
+    expect(MANAGED_LOCAL_STATIC_REJECTION_ERROR).toContain("managed");
+  });
+
+  test("production rejection error states local_static is not supported", () => {
+    expect(MANAGED_LOCAL_STATIC_REJECTION_ERROR).toContain(
+      "local_static credential handles are not supported",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Import the production `MANAGED_LOCAL_STATIC_REJECTION_ERROR` constant from `credential-executor/src/managed-errors.ts` directly in the test file (boundary guard skips `__tests__/` files)
- Replace the misleading NOTE comment (claiming tests couldn't import from credential-executor) with actual assertions against the production error constant
- Remove tautological pattern where tests only validated test-local strings

Addresses review feedback on #17292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
