### PR TITLE
fix: gate managed credential guidance on platform mode

### DIFF
--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -29,14 +29,22 @@ import { getLogger } from "../util/logger.js";
 const log = getLogger("platform-callback-registration");
 
 /**
+ * Whether this is a platform-managed deployment.
+ * True when PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID are both set,
+ * regardless of containerization. Use this to gate behaviour that depends
+ * on platform-managed credentials and OAuth flows.
+ */
+export function isPlatformManaged(): boolean {
+  return !!getPlatformBaseUrl() && !!getPlatformAssistantId();
+}
+
+/**
  * Whether the daemon should register callback routes with the platform.
  * True when IS_CONTAINERIZED, PLATFORM_BASE_URL, and PLATFORM_ASSISTANT_ID
  * are all set.
  */
 export function shouldUsePlatformCallbacks(): boolean {
-  return (
-    getIsContainerized() && !!getPlatformBaseUrl() && !!getPlatformAssistantId()
-  );
+  return getIsContainerized() && isPlatformManaged();
 }
 
 interface RegisterCallbackRouteResponse {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -7,7 +7,7 @@ import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
-import { shouldUsePlatformCallbacks } from "../inbound/platform-callback-registration.js";
+import { isPlatformManaged } from "../inbound/platform-callback-registration.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
@@ -346,7 +346,7 @@ function buildInChatConfigurationSection(): string {
     "When the user needs to configure a value (API keys, OAuth credentials, webhook URLs, or any setting that can be changed from the Settings page), **always collect it conversationally in the chat first** rather than directing them to the Settings page.",
     "",
     "**How to collect credentials and secrets:**",
-    ...(shouldUsePlatformCallbacks()
+    ...(isPlatformManaged()
       ? [
           "- Secrets and API keys are managed through the platform's credential system. Users connect credentials via OAuth or platform-managed secrets — the `credential_store` prompt flow for API keys is not available in managed deployments.",
           "- For OAuth flows, guide the user to connect through the platform. After connecting, run `assistant oauth connections list` to find the connection ID, and use the `platform_oauth:<connectionId>` handle with CES tools (`make_authenticated_request`, `run_authenticated_command`) for authenticated work.",
@@ -860,7 +860,7 @@ export function buildCliReferenceSection(): string {
     "   - `assistant credentials list` — lists local credentials with their service:field identifiers",
     "   - `assistant oauth connections list` — lists OAuth connections with provider keys",
     "   - `assistant credentials list --search <query>` — filter by service, field, or description",
-    ...(shouldUsePlatformCallbacks()
+    ...(isPlatformManaged()
       ? [
           "   In managed deployments, credential handles use the `platform_oauth:<connectionId>` format (shown in the `handle` field of `assistant oauth connections list`). Local credential handles (`local_static`, `local_oauth`) are not available in managed mode.",
         ]


### PR DESCRIPTION
## Summary
- Add `isPlatformManaged()` to `platform-callback-registration.ts` — checks only `PLATFORM_BASE_URL` + `PLATFORM_ASSISTANT_ID` without the `IS_CONTAINERIZED` gate
- Refactor `shouldUsePlatformCallbacks()` to delegate to `isPlatformManaged()` (preserving its existing behavior for callback routing)
- Replace `shouldUsePlatformCallbacks()` with `isPlatformManaged()` in both system prompt credential guidance sections
- Self-hosted Docker containers now correctly show `credential_store` API-key prompts instead of platform-only credential guidance

Addresses review feedback on #17289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
