### PR TITLE
feat: add sendDiagnostics config key with workspace migration from sendPerformanceReports

### DIFF
--- a/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
+++ b/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const existsSyncFn = mock((_path: string): boolean => false);
+const readFileSyncFn = mock((_path: string, _encoding: string): string => "");
+const writeFileSyncFn = mock((_path: string, _data: string): void => undefined);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs", () => ({
+  existsSync: existsSyncFn,
+  readFileSync: readFileSyncFn,
+  writeFileSync: writeFileSyncFn,
+}));
+
+// Import after mocking
+import { addSendDiagnosticsMigration } from "../workspace/migrations/005-add-send-diagnostics.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = "/tmp/test-workspace";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("005-add-send-diagnostics migration", () => {
+  beforeEach(() => {
+    existsSyncFn.mockClear();
+    readFileSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+  });
+
+  test("runs without error when config.json is absent", () => {
+    existsSyncFn.mockImplementation(() => false);
+
+    addSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("runs without error on existing config (no-op)", () => {
+    existsSyncFn.mockImplementation(() => true);
+    readFileSyncFn.mockImplementation(() =>
+      JSON.stringify({ collectUsageData: true }),
+    );
+
+    addSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -307,6 +307,7 @@ export const AssistantConfigSchema = z
       )
       .optional(),
     collectUsageData: z.boolean().default(true),
+    sendDiagnostics: z.boolean().default(true),
   })
   .superRefine((config, ctx) => {
     if (

--- a/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
+++ b/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
@@ -1,0 +1,12 @@
+import type { WorkspaceMigration } from "./types.js";
+
+export const addSendDiagnosticsMigration: WorkspaceMigration = {
+  id: "005-add-send-diagnostics",
+  description:
+    "Add sendDiagnostics config key (defaults to true, no data to migrate from UserDefaults)",
+  run(_workspaceDir: string): void {
+    // No-op — the schema default handles new installs, and the macOS client
+    // will sync the UserDefaults value on first startup. This migration exists
+    // as a checkpoint marker for future reference.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,6 +1,7 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
+import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -11,4 +12,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
   seedDeviceIdMigration,
   extractCollectUsageDataMigration,
+  addSendDiagnosticsMigration,
 ];


### PR DESCRIPTION
## Summary
- Add sendDiagnostics boolean to daemon config schema (defaults to true)
- Create workspace migration 005 as checkpoint marker
- Add migration test following existing patterns

Part of plan: reorg-privacy-toggles.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
