### PR TITLE
feat: accept sendDiagnostics in PATCH /v1/config/privacy endpoint

### DIFF
--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -68,10 +68,34 @@ export function createPrivacyConfigPatchHandler() {
       );
     }
 
-    const { collectUsageData } = body as { collectUsageData?: unknown };
-    if (typeof collectUsageData !== "boolean") {
+    const { collectUsageData, sendDiagnostics } = body as {
+      collectUsageData?: unknown;
+      sendDiagnostics?: unknown;
+    };
+
+    const hasCollectUsageData = "collectUsageData" in (body as object);
+    const hasSendDiagnostics = "sendDiagnostics" in (body as object);
+
+    if (!hasCollectUsageData && !hasSendDiagnostics) {
+      return Response.json(
+        {
+          error:
+            'At least one of "collectUsageData" or "sendDiagnostics" must be provided',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (hasCollectUsageData && typeof collectUsageData !== "boolean") {
       return Response.json(
         { error: '"collectUsageData" must be a boolean' },
+        { status: 400 },
+      );
+    }
+
+    if (hasSendDiagnostics && typeof sendDiagnostics !== "boolean") {
+      return Response.json(
+        { error: '"sendDiagnostics" must be a boolean' },
         { status: 400 },
       );
     }
@@ -91,11 +115,20 @@ export function createPrivacyConfigPatchHandler() {
           }
 
           const config = result.data;
-          config.collectUsageData = collectUsageData;
+          if (hasCollectUsageData) {
+            config.collectUsageData = collectUsageData;
+          }
+          if (hasSendDiagnostics) {
+            config.sendDiagnostics = sendDiagnostics;
+          }
           writeConfigFileAtomic(config);
 
-          log.info({ collectUsageData }, "Privacy config updated");
-          resolve(Response.json({ collectUsageData }));
+          const responseData = {
+            collectUsageData: config.collectUsageData,
+            sendDiagnostics: config.sendDiagnostics,
+          };
+          log.info(responseData, "Privacy config updated");
+          resolve(Response.json(responseData));
         } catch (err) {
           log.error({ err }, "Failed to update privacy config");
           resolve(


### PR DESCRIPTION
## Summary
- Expand PATCH /v1/config/privacy to accept optional sendDiagnostics boolean
- Both keys are now optional but at least one must be present
- Response returns both current values regardless of which were sent

Part of plan: reorg-privacy-toggles.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
