### PR TITLE
feat: gate daemon Sentry on sendDiagnostics instead of collectUsageData

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -321,12 +321,13 @@ export async function runDaemon(): Promise<void> {
       });
     }
 
-    // If the user has opted out of usage data collection or we are in dev mode,
-    // stop Sentry and skip telemetry. Early-startup crashes before this point
-    // are still captured.
+    // Privacy gating: Sentry crash/error reporting is gated by sendDiagnostics,
+    // while the usage telemetry reporter is gated by collectUsageData. Both are
+    // disabled in dev mode. Early-startup crashes before this point are still captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
+    const sendDiagnostics = !isDevMode && config.sendDiagnostics;
     const collectUsageData = !isDevMode && config.collectUsageData;
-    if (!collectUsageData) {
+    if (!sendDiagnostics) {
       await closeSentry();
     }
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -37,7 +37,7 @@ function redactObject(obj: unknown): unknown {
 /**
  * Call after dotenv has loaded so SENTRY_DSN is available.
  * Always initializes Sentry to capture early startup crashes. If the user
- * later opts out via the collectUsageData config key (or VELLUM_DEV=1),
+ * later opts out via the sendDiagnostics config key (or VELLUM_DEV=1),
  * call closeSentry() after config is loaded to stop future event capturing.
  */
 export function initSentry(): void {
@@ -86,7 +86,7 @@ export function initSentry(): void {
 
 /**
  * Stop capturing future Sentry events. Called after config loads when the
- * user has opted out of crash reporting so that early-startup crashes are
+ * user has disabled sendDiagnostics so that early-startup crashes are
  * still captured but subsequent events are suppressed.
  */
 export async function closeSentry(): Promise<void> {


### PR DESCRIPTION
## Summary
- Split daemon privacy gating: Sentry gated by sendDiagnostics, telemetry by collectUsageData
- Update comments in lifecycle.ts and instrument.ts to reflect the new split

Part of plan: reorg-privacy-toggles.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
