### PR TITLE
fix: use conversationId label in CancelMessage test

### DIFF
--- a/clients/shared/Tests/MockDaemonClientTests.swift
+++ b/clients/shared/Tests/MockDaemonClientTests.swift
@@ -67,7 +67,7 @@ final class MockDaemonClientTests: XCTestCase {
 
     func testSendRecordsCancelMessage() throws {
         let client = MockDaemonClient()
-        let msg = CancelMessage(sessionId: "sess-abc")
+        let msg = CancelMessage(conversationId: "sess-abc")
         try client.send(msg)
         XCTAssertEqual(client.sentMessages.count, 1)
     }


### PR DESCRIPTION
## Summary
- Fix compilation error in `MockDaemonClientTests.swift` where `CancelMessage(sessionId:)` was used but the convenience init was renamed to `CancelMessage(conversationId:)` in #17467
- This was missed because #17466 reverted the test to `sessionId:` while #17467 renamed the init parameter

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23124815653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
