### PR TITLE
feat: add sendDiagnostics parameter to setPrivacyConfig API calls

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2385,14 +2385,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Update the privacy config via the gateway's PATCH /v1/config/privacy endpoint.
     /// Authenticates with the feature-flag token (same auth scope).
-    public func setPrivacyConfig(collectUsageData: Bool) async throws {
+    public func setPrivacyConfig(collectUsageData: Bool? = nil, sendDiagnostics: Bool? = nil) async throws {
         guard let token = resolveFeatureFlagAuthToken() else {
             throw FeatureFlagError.missingToken
         }
 
         #if os(macOS)
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
-            try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, featureFlagToken: token)
+            try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, sendDiagnostics: sendDiagnostics, featureFlagToken: token)
             return
         }
 
@@ -2402,7 +2402,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let body: [String: Any] = ["collectUsageData": collectUsageData]
+        var body: [String: Any] = [:]
+        if let collectUsageData { body["collectUsageData"] = collectUsageData }
+        if let sendDiagnostics { body["sendDiagnostics"] = sendDiagnostics }
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (_, response) = try await URLSession.shared.data(for: request)
@@ -2411,7 +2413,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         #else
         guard let httpTransport else { return }
-        try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, featureFlagToken: token)
+        try await httpTransport.setPrivacyConfig(collectUsageData: collectUsageData, sendDiagnostics: sendDiagnostics, featureFlagToken: token)
         #endif
     }
 

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -3152,7 +3152,7 @@ public final class HTTPTransport {
     }
 
     /// Update the privacy config via the gateway's PATCH /v1/config/privacy endpoint.
-    func setPrivacyConfig(collectUsageData: Bool, featureFlagToken: String) async throws {
+    func setPrivacyConfig(collectUsageData: Bool?, sendDiagnostics: Bool?, featureFlagToken: String) async throws {
         guard let url = buildURL(for: .privacyConfig) else {
             throw HTTPTransportError.invalidURL
         }
@@ -3163,7 +3163,9 @@ public final class HTTPTransport {
         request.setValue("Bearer \(featureFlagToken)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
-        let body: [String: Any] = ["collectUsageData": collectUsageData]
+        var body: [String: Any] = [:]
+        if let collectUsageData { body["collectUsageData"] = collectUsageData }
+        if let sendDiagnostics { body["sendDiagnostics"] = sendDiagnostics }
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (_, response) = try await URLSession.shared.data(for: request)


### PR DESCRIPTION
## Summary
- Update DaemonClient.setPrivacyConfig to accept optional sendDiagnostics parameter
- Update HTTPDaemonClient.setPrivacyConfig to accept optional sendDiagnostics parameter
- Both clients build JSON body dynamically, only including non-nil keys

Part of plan: reorg-privacy-toggles.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
