### PR TITLE
ci: add concurrency group to cancel superseded macOS CI runs

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -17,6 +17,10 @@ on:
       - 'packages/**'
       - '.github/workflows/ci-main-macos.yaml'
 
+concurrency:
+  group: ci-main-macos
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Detect Path Changes


### PR DESCRIPTION
## Summary
- Add `concurrency` group with `cancel-in-progress: true` to `ci-main-macos.yaml`
- On `main`, only the latest commit matters — intermediate runs are pure waste that consume limited macOS runner slots
- This immediately eliminates queue buildup when multiple commits land in quick succession

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
