### PR TITLE
ci: gate macOS app build on path change detection

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       clients: ${{ steps.filter.outputs.clients }}
+      bundled: ${{ steps.filter.outputs.bundled }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,6 +34,13 @@ jobs:
         with:
           filters: |
             clients:
+              - 'clients/**'
+              - '.github/workflows/ci-main-macos.yaml'
+            bundled:
+              - 'assistant/**'
+              - 'cli/**'
+              - 'gateway/**'
+              - 'packages/**'
               - 'clients/**'
               - '.github/workflows/ci-main-macos.yaml'
 
@@ -110,6 +118,8 @@ jobs:
 
   build-app:
     name: Build macOS App
+    needs: [changes]
+    if: needs.changes.outputs.bundled == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     timeout-minutes: 30
     env:
@@ -191,6 +201,7 @@ jobs:
           GITHUB_USER="${{ github.actor }}"
 
           # lint-unused and test are conditionally skipped when only non-client paths change
+          # build-app is conditionally skipped when only non-bundled paths change
           CLIENTS_CHANGED="${{ needs.changes.outputs.clients }}"
 
           if [[ "${{ needs.build-app.result }}" == "failure" ]]; then


### PR DESCRIPTION
## Summary
- Expand the `changes` job to detect `bundled` path changes (assistant, cli, gateway, packages, clients)
- Gate `build-app` on `needs.changes.outputs.bundled == 'true'` so it skips when only non-app paths change
- Saves ~30 minutes of macOS runner time for pushes that don't affect the app bundle

## Test plan
- [x] Verify the workflow YAML is syntactically valid
- [ ] Push a commit touching only `.github/` (non-workflow) paths and confirm `build-app` is skipped
- [ ] Push a commit touching `assistant/` and confirm `build-app` runs
- [ ] Trigger workflow_dispatch and confirm all jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
