### PR TITLE
feat: reorganize privacy settings UI with independent toggles and updated copy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -1,41 +1,40 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Privacy settings tab — lets the user opt out of crash reporting and
-/// error diagnostics sent to help improve the app.
+/// Privacy settings tab — lets the user control usage analytics and
+/// crash/error diagnostics independently.
 @MainActor
 struct SettingsPrivacyTab: View {
     var daemonClient: DaemonClient?
     @ObservedObject var store: SettingsStore
 
-    @State private var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
-
     var body: some View {
-        diagnosticsSection
+        privacySection
     }
 
-    // MARK: - Diagnostics Section
+    // MARK: - Privacy Section
 
-    private var diagnosticsSection: some View {
-        SettingsCard(title: "Diagnostics") {
+    private var privacySection: some View {
+        SettingsCard(title: "Privacy") {
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Collect usage data")
+                    Text("Share usage analytics")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentSecondary)
-                    Text("Send crash reports and error diagnostics to help improve the app. No personal data or message content is ever sent.")
+                    Text("Send anonymized usage metrics (e.g. token counts, feature adoption) to help us improve the product. No personal data or message content is included.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
                 Spacer()
                 VToggle(isOn: Binding(
-                    get: { collectUsageData },
+                    get: { store.collectUsageData },
                     set: { newValue in
-                        collectUsageData = newValue
-                        if !newValue {
-                            store.sendPerformanceReports = false
+                        store.collectUsageData = newValue
+                        if let daemonClient {
+                            Task {
+                                try? await daemonClient.setPrivacyConfig(collectUsageData: newValue)
+                            }
                         }
-                        setCollectUsageData(newValue)
                     }
                 ))
             }
@@ -44,42 +43,30 @@ struct SettingsPrivacyTab: View {
 
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Share performance metrics")
+                    Text("Send diagnostics")
                         .font(VFont.body)
-                        .foregroundColor(collectUsageData ? VColor.contentSecondary : VColor.contentTertiary)
-                    Text(collectUsageData
-                         ? "Send anonymised performance metrics (hang rate, scroll speed) to help us improve responsiveness. No personal data or message content is included."
-                         : "Requires \"Collect usage data\" to be enabled.")
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("Share crash reports, error diagnostics, and performance metrics (hang rate, responsiveness) to help us improve stability. No personal data or message content is included.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
                 Spacer()
                 VToggle(isOn: Binding(
-                    get: { store.sendPerformanceReports },
-                    set: { store.sendPerformanceReports = $0 }
+                    get: { store.sendDiagnostics },
+                    set: { newValue in
+                        store.sendDiagnostics = newValue
+                        if newValue {
+                            MetricKitManager.startSentry()
+                        } else {
+                            MetricKitManager.closeSentry()
+                        }
+                        if let daemonClient {
+                            Task {
+                                try? await daemonClient.setPrivacyConfig(sendDiagnostics: newValue)
+                            }
+                        }
+                    }
                 ))
-                .disabled(!collectUsageData)
-            }
-        }
-    }
-
-    // MARK: - Privacy Config
-
-    private func setCollectUsageData(_ enabled: Bool) {
-        // UserDefaults is the source of truth
-        UserDefaults.standard.set(enabled, forKey: "collectUsageDataEnabled")
-
-        // Apply Sentry state immediately
-        if enabled {
-            MetricKitManager.startSentry()
-        } else {
-            MetricKitManager.closeSentry()
-        }
-
-        // Best-effort sync to daemon config for next restart
-        if let daemonClient {
-            Task {
-                try? await daemonClient.setPrivacyConfig(collectUsageData: enabled)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -225,10 +225,17 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Privacy
 
-    /// Whether the user has opted in to sharing anonymised performance metrics (e.g. hang rate,
-    /// scroll speed). Defaults to `true`. Read by the MetricKit integration (M4) to decide
-    /// whether to forward payloads.
-    @Published var sendPerformanceReports: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
+    /// Whether the user has opted in to sending crash reports, error diagnostics, and
+    /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
+    @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+        ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
+        ?? true
+
+    /// Whether the user has opted in to sharing anonymized usage analytics (e.g. token counts,
+    /// feature adoption). Defaults to `true`. Independent from diagnostics.
+    @Published var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+        ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
+        ?? true
 
     // MARK: - Private
 
@@ -391,20 +398,23 @@ public final class SettingsStore: ObservableObject {
             .sink { value in UserDefaults.standard.set(value, forKey: "cmdEnterToSend") }
             .store(in: &cancellables)
 
-        $sendPerformanceReports
+        $sendDiagnostics
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink {
-                UserDefaults.standard.set($0, forKey: "sendPerformanceReports")
-                // Restart Sentry so the updated profilesSampleRate takes effect
-                // (Sentry config is immutable after start). Only restart when the
-                // user has opted into usage data — otherwise we'd re-enable Sentry
-                // after the user explicitly disabled it.
-                let collectUsageData = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
-                guard collectUsageData else { return }
-                MetricKitManager.closeSentry()
-                MetricKitManager.startSentry()
+                UserDefaults.standard.set($0, forKey: "sendDiagnostics")
+                if $0 {
+                    MetricKitManager.startSentry()
+                } else {
+                    MetricKitManager.closeSentry()
+                }
             }
+            .store(in: &cancellables)
+
+        $collectUsageData
+            .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { value in UserDefaults.standard.set(value, forKey: "collectUsageData") }
             .store(in: &cancellables)
 
         // Persist shortcut changes immediately so the hotkey re-registers without delay


### PR DESCRIPTION
## Summary
- Rewrite SettingsPrivacyTab with new copy and independent toggles
- Add sendDiagnostics and collectUsageData published properties to SettingsStore
- Remove cascade logic — both toggles always interactive
- Gate Sentry on sendDiagnostics independently from usage analytics

Part of plan: reorg-privacy-toggles.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
