### PR TITLE
fix: register managed_sign_in_enabled in feature flag registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -144,6 +144,14 @@
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
       "defaultEnabled": false
+    },
+    {
+      "id": "managed-sign-in",
+      "scope": "macos",
+      "key": "managed_sign_in_enabled",
+      "label": "Managed Sign In",
+      "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `managed_sign_in_enabled` to `feature-flag-registry.json` so it appears in developer settings UI
- Flag was already in use in `OnboardingState.swift` and `OnboardingFlowView.swift` but unregistered, making it impossible to toggle without env vars

Addresses review feedback on #17471.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
