### PR TITLE
fix: reset stale routing cache and cancel prior refresh tasks in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -256,6 +256,7 @@ public final class SettingsStore: ObservableObject {
     /// response arrives.
     private var pendingIngressEnabled: Bool?
     private var pendingIngressUrl: String?
+    private var routingSourceRefreshTask: Task<Void, Never>?
 
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
@@ -1804,7 +1805,10 @@ public final class SettingsStore: ObservableObject {
     /// Fetches provider routing sources from the daemon debug endpoint and
     /// updates `providerRoutingSources`. Non-fatal — silently ignores errors.
     func loadProviderRoutingSources() {
-        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return }
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else {
+            providerRoutingSources = [:]
+            return
+        }
         Task {
             do {
                 let response = try await GatewayHTTPClient.get(
@@ -1825,8 +1829,10 @@ public final class SettingsStore: ObservableObject {
     /// Schedules a delayed refresh of provider routing sources, giving the
     /// daemon time to re-initialize providers after a key change.
     private func scheduleRoutingSourceRefresh() {
-        Task {
+        routingSourceRefreshTask?.cancel()
+        routingSourceRefreshTask = Task {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
             loadProviderRoutingSources()
         }
     }


### PR DESCRIPTION
## Summary
- Clear providerRoutingSources on early return when connectedAssistantId is missing
- Store scheduled routing refresh task and cancel previous before scheduling new one
- Add cancellation guard after Task.sleep to prevent stale refreshes

Addresses review feedback on #17349.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
