### PR TITLE
fix: scope CI concurrency group per ref to avoid cross-branch cancellation

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/ci-main-macos.yaml'
 
 concurrency:
-  group: ci-main-macos
+  group: ci-main-macos-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Include github.ref in concurrency group key so workflow_dispatch runs on different branches are not cancelled by pushes to main
- Preserves cancel-in-progress behavior for superseded runs on the same ref

Addresses review feedback on #17481.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
