### PR TITLE
fix: move managed CES error constant to ces-contracts shared package

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -36,15 +36,13 @@ import {
   HandshakeAckSchema,
   HandshakeRequestSchema,
   localStaticHandle,
+  MANAGED_LOCAL_STATIC_REJECTION_ERROR,
   parseHandle,
   platformOAuthHandle,
   UpdateManagedCredentialResponseSchema,
   UpdateManagedCredentialSchema,
 } from "@vellumai/ces-contracts";
 
-// Importing the production error constant directly from credential-executor.
-// This is allowed in __tests__/ files (the CES boundary guard skips them).
-import { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "../../../credential-executor/src/managed-errors.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
   isCesManagedSidecarEnabled,

--- a/credential-executor/src/managed-errors.ts
+++ b/credential-executor/src/managed-errors.ts
@@ -1,18 +1,9 @@
 /**
  * Error message constants for managed-mode CES.
  *
- * Extracted into a side-effect-free module so contract tests can import
- * and assert against the exact production strings without pulling in the
- * managed-main.ts entrypoint (which has process-level side effects).
+ * Re-exported from @vellumai/ces-contracts so both the assistant and
+ * credential-executor can share the constant via the approved shared-code
+ * path without violating the hard process-boundary isolation.
  */
 
-/**
- * Error returned when a local_static credential handle is used in managed
- * mode. The encrypted key store uses PBKDF2 key derivation from user
- * identity (username, homedir), but the assistant container runs as root
- * while CES runs as ces — different derived keys make decryption silently
- * fail. Managed deployments must use platform_oauth handles exclusively.
- */
-export const MANAGED_LOCAL_STATIC_REJECTION_ERROR =
-  "local_static credential handles are not supported in managed mode. " +
-  "Use platform_oauth handles for managed deployments.";
+export { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "@vellumai/ces-contracts";

--- a/packages/ces-contracts/src/error.ts
+++ b/packages/ces-contracts/src/error.ts
@@ -12,3 +12,14 @@ export const RpcErrorSchema = z.object({
   details: z.record(z.string(), z.unknown()).optional(),
 });
 export type RpcError = z.infer<typeof RpcErrorSchema>;
+
+/**
+ * Error returned when a local_static credential handle is used in managed
+ * mode. The encrypted key store uses PBKDF2 key derivation from user
+ * identity (username, homedir), but the assistant container runs as root
+ * while CES runs as ces — different derived keys make decryption silently
+ * fail. Managed deployments must use platform_oauth handles exclusively.
+ */
+export const MANAGED_LOCAL_STATIC_REJECTION_ERROR =
+  "local_static credential handles are not supported in managed mode. " +
+  "Use platform_oauth handles for managed deployments.";

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -72,7 +72,11 @@ export type RpcEnvelope = z.infer<typeof RpcEnvelopeSchema>;
 // RPC error (defined in error.ts to avoid circular deps with rpc.ts)
 // ---------------------------------------------------------------------------
 
-export { RpcErrorSchema, type RpcError } from "./error.js";
+export {
+  RpcErrorSchema,
+  type RpcError,
+  MANAGED_LOCAL_STATIC_REJECTION_ERROR,
+} from "./error.js";
 
 // ---------------------------------------------------------------------------
 // Tool request / response base shapes


### PR DESCRIPTION
## Summary
- Move MANAGED_LOCAL_STATIC_REJECTION_ERROR from credential-executor to packages/ces-contracts
- Re-export from credential-executor for backwards compatibility
- Update test import to use @vellumai/ces-contracts instead of cross-package source import
- Respects the CES hard process-boundary isolation documented in credential-execution-service.md

Addresses review feedback on #17473.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
