### PR TITLE
fix: tighten isPlatformManaged check to require assistant API key

### DIFF
--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -24,18 +24,26 @@ import {
   getPlatformInternalApiKey,
 } from "../config/env.js";
 import { getIsContainerized } from "../config/env-registry.js";
+import { isManagedProxyEnabledSync } from "../providers/managed-proxy/context.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("platform-callback-registration");
 
 /**
- * Whether this is a platform-managed deployment.
- * True when PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID are both set,
- * regardless of containerization. Use this to gate behaviour that depends
- * on platform-managed credentials and OAuth flows.
+ * Whether this is a platform-managed deployment with usable managed credentials.
+ *
+ * True when PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID are both set **and**
+ * the managed proxy prerequisites (including the assistant API key) were
+ * satisfied the last time `resolveManagedProxyContext()` ran. This prevents
+ * the system prompt from claiming managed credentials are available during
+ * partial/failed platform bootstrap where the API key is missing.
  */
 export function isPlatformManaged(): boolean {
-  return !!getPlatformBaseUrl() && !!getPlatformAssistantId();
+  return (
+    !!getPlatformBaseUrl() &&
+    !!getPlatformAssistantId() &&
+    isManagedProxyEnabledSync()
+  );
 }
 
 /**

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -30,6 +30,14 @@ export interface ManagedProxyContext {
 }
 
 /**
+ * Cached result of the last `resolveManagedProxyContext()` call.
+ * Updated every time the context is resolved (startup, credential changes).
+ * Defaults to `false` so that callers see a safe value before the first
+ * async resolution completes.
+ */
+let _managedProxyEnabled = false;
+
+/**
  * Resolve managed proxy context from environment and secure storage.
  *
  * Returns an enabled context only when both the platform base URL and
@@ -41,6 +49,7 @@ export async function resolveManagedProxyContext(): Promise<ManagedProxyContext>
     (await getSecureKeyAsync(ASSISTANT_API_KEY_STORAGE_KEY)) ?? "";
 
   const enabled = !!platformBaseUrl && !!assistantApiKey;
+  _managedProxyEnabled = enabled;
 
   return { enabled, platformBaseUrl, assistantApiKey };
 }
@@ -83,4 +92,21 @@ export async function managedFallbackEnabledFor(
   const meta = MANAGED_PROVIDER_META[provider];
   if (!meta?.managed) return false;
   return await hasManagedProxyPrereqs();
+}
+
+/**
+ * Synchronous check for whether managed proxy prerequisites were satisfied
+ * the last time `resolveManagedProxyContext()` ran.
+ *
+ * Returns `false` before the first async resolution or when the API key is
+ * missing. Safe for use in synchronous code paths (e.g. system prompt
+ * building) that cannot await the credential store.
+ */
+export function isManagedProxyEnabledSync(): boolean {
+  return _managedProxyEnabled;
+}
+
+/** @internal Test-only: reset the cached managed-proxy-enabled flag. */
+export function _resetManagedProxyEnabledCache(): void {
+  _managedProxyEnabled = false;
 }


### PR DESCRIPTION
## Summary
- Add `isManagedProxyEnabledSync()` to `context.ts` — a synchronous cache of whether managed proxy prerequisites (platform URL + API key) are satisfied
- Cache is updated every time `resolveManagedProxyContext()` runs (startup, credential add/delete)
- `isPlatformManaged()` now requires all three: `PLATFORM_BASE_URL` + `PLATFORM_ASSISTANT_ID` + managed proxy enabled (API key present)
- Fixes edge case where partial platform bootstrap (base URL + assistant ID but no API key) showed platform-only credential instructions even though local credentials were still usable

Addresses review feedback on #17475.