### PR TITLE
fix: raise merged macOS CI job timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.clients == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Increase timeout-minutes from 20 to 30 for the merged test job in ci-main-macos.yaml
- Accommodates both lint-unused and test suites running serially after merge in #17483
- Prevents CI flakes from premature timeout on cache-miss or fresh tool install runs

Addresses review feedback on #17483.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
