### PR TITLE
fix: ensure continue button is visible on onboarding setup step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -52,6 +52,7 @@ struct OnboardingFlowView: View {
                     )
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
                 // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry (steps 0–2)
+                ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
@@ -117,7 +118,13 @@ struct OnboardingFlowView: View {
                         )
                     )
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
+
+                    // Bottom padding so content isn't flush with window edge
+                    Color.clear.frame(height: VSpacing.xxl)
                 }
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+                }
+                .scrollBounceBehavior(.basedOnSize)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
                     RadialGradient(


### PR DESCRIPTION
## Summary
- Wrapped the onboarding flow content in a `ScrollView` so that the Continue button (and Back button) are always reachable, even at the default window size
- Added bottom padding so content isn't flush with the window edge
- Used `.scrollBounceBehavior(.basedOnSize)` so scrolling only activates when content overflows

## Original prompt
The continue button is hidden by default - please fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
