### PR TITLE
feat: hide Local Docker and VPS options from onboarding setup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -84,21 +84,6 @@ struct APIKeyStepView: View {
                 comingSoon: false
             )
 
-            hostingCard(
-                icon: .package,
-                title: "Local Docker",
-                subtitle: "Run in a Docker container",
-                mode: .localDocker,
-                comingSoon: true
-            )
-
-            hostingCard(
-                icon: .globe,
-                title: "VPS",
-                subtitle: "Run on a virtual private server",
-                mode: .vps,
-                comingSoon: true
-            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -46,8 +46,6 @@ final class OnboardingState {
     enum HostingMode: String {
         case vellumCloud = "vellum-cloud"
         case local = "local"
-        case localDocker = "local-docker"
-        case vps = "vps"
     }
     var hasHatched: Bool = false
     var interviewCompleted: Bool = false


### PR DESCRIPTION
## Summary
- Removed the "Local Docker" and "VPS" hosting cards from the onboarding setup step since they're not yet available
- Cleaned up the unused `localDocker` and `vps` cases from the `HostingMode` enum

## Original prompt
Hide the Local Docker and VPS options for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
