### PR TITLE
fix: sync gateway tests with telegram limit and privacy route

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -10,7 +10,7 @@ describe("config: hardcoded defaults", () => {
     expect(config.runtimeInitialBackoffMs).toBe(500);
     expect(config.maxWebhookPayloadBytes).toBe(1024 * 1024);
     expect(config.maxAttachmentBytes).toEqual({
-      telegram: 50 * 1024 * 1024,
+      telegram: 20 * 1024 * 1024,
       slack: 100 * 1024 * 1024,
       whatsapp: 16 * 1024 * 1024,
       default: 50 * 1024 * 1024,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1705,6 +1705,51 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/config/privacy": {
+        patch: {
+          summary: "Update privacy config",
+          description:
+            "Scope-protected gateway endpoint that updates privacy configuration (collectUsageData, sendDiagnostics). Requires a bearer token with `feature_flags.write` scope.",
+          operationId: "privacyConfigPatch",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    collectUsageData: { type: "boolean" },
+                    sendDiagnostics: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Privacy config updated",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      collectUsageData: { type: "boolean" },
+                      sendDiagnostics: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+            "400": { description: "Invalid request body" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Insufficient scope" },
+            "500": { description: "Internal server error" },
+          },
+        },
+      },
       "/integrations/status": {
         get: {
           summary: "Integration status",


### PR DESCRIPTION
## Summary
- Update `config.test.ts` to expect 20MB telegram attachment limit, matching the actual config value
- Add `/v1/config/privacy` PATCH endpoint to the OpenAPI schema so `route-schema-guard.test.ts` passes

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23125737208

🤖 Generated with [Claude Code](https://claude.com/claude-code)