### PR TITLE
fix: Intelligence page UI improvements

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -480,6 +480,7 @@ struct AgentPanelContent: View {
 
             // File content
             ReadOnlyCodeContent(content: content)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -189,6 +189,12 @@ struct WorkspacePanel: View {
         state.isLoadingTree = true
         if let response = await daemonClient.fetchWorkspaceTree(path: "", showHidden: state.showHiddenFiles) {
             state.directoryCache[""] = response.entries
+
+            // Auto-select IDENTITY.md if it exists and no file is already selected
+            if state.selectedFilePath == nil,
+               let identityEntry = response.entries.first(where: { $0.name == "IDENTITY.md" && !$0.isDirectory }) {
+                await state.loadFile(path: identityEntry.path, using: daemonClient)
+            }
         }
         state.isLoadingTree = false
     }
@@ -667,7 +673,7 @@ private struct WorkspaceFileViewer: View {
                         RoundedRectangle(cornerRadius: VRadius.md)
                             .strokeBorder(VColor.borderBase, lineWidth: 1)
                     )
-                    .padding(VSpacing.md)
+                    .padding(.horizontal, VSpacing.md)
             } else {
                 emptyState
             }


### PR DESCRIPTION
## Summary
- Fix Workspace tab right pane to extend full height (match file explorer sidebar)
- Auto-select IDENTITY.md when Workspace tab loads (if it exists)
- Fix skill detail page file content alignment to top-left instead of centered

Part of plan: intel-page-improvements.md (all PRs combined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
