### PR TITLE
fix: update Swift test init params to use conversationId

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -252,7 +252,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -302,7 +302,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         vm2.conversationId = "sess-b"
 
         // Delta for conversation A
-        let deltaA = AssistantTextDeltaMessage(text: "For A", sessionId: "sess-a")
+        let deltaA = AssistantTextDeltaMessage(text: "For A", conversationId: "sess-a")
         vm1.handleServerMessage(.assistantTextDelta(deltaA))
         vm1.flushStreamingBuffer()
         vm2.handleServerMessage(.assistantTextDelta(deltaA))

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -244,7 +244,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -256,7 +256,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isThinking = true
 
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -581,7 +581,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[0].isStreaming)
 
         // Daemon acknowledges cancellation
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
         XCTAssertFalse(viewModel.isSending)
     }
 
@@ -601,7 +601,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].text, "Partial")
 
         // Daemon acknowledges cancellation — clears isCancelling
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
         XCTAssertFalse(viewModel.isSending)
 
         // After acknowledgment, new deltas should work normally
@@ -908,7 +908,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // User initiates cancel, then server acknowledges
         viewModel.isCancelling = true
-        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(sessionId: nil)))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: nil)))
 
         let messageBAfterCancel = viewModel.messages.first(where: { $0.text == "Message B" })!
         XCTAssertEqual(messageBAfterCancel.status, .sent, "Message B should be .sent after generationCancelled, not .processing")
@@ -1192,7 +1192,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaFromDifferentSessionIsIgnored() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", sessionId: "other-session")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", conversationId: "other-session")))
         // Should still be thinking — delta was ignored
         XCTAssertTrue(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 0) // No messages
@@ -1201,7 +1201,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaFromSameSessionIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: "my-session")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: "my-session")))
         XCTAssertFalse(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 1)
         XCTAssertEqual(viewModel.messages[0].text, "hello")
@@ -1210,7 +1210,7 @@ final class ChatViewModelTests: XCTestCase {
     func testTextDeltaWithNilSessionIdIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", sessionId: nil)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: nil)))
         XCTAssertFalse(viewModel.isThinking)
         XCTAssertEqual(viewModel.messages.count, 1)
     }
@@ -1219,7 +1219,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "other-session")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "other-session")))
         // Should still be sending/thinking — message was ignored
         XCTAssertTrue(viewModel.isSending)
         XCTAssertTrue(viewModel.isThinking)
@@ -1229,7 +1229,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "my-session")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "my-session")))
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
     }
@@ -1677,7 +1677,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isCancelling = true
 
         viewModel.handleServerMessage(.generationCancelled(
-            GenerationCancelledMessage(sessionId: "sess-1")
+            GenerationCancelledMessage(conversationId: "sess-1")
         ))
 
         XCTAssertFalse(viewModel.isThinking,
@@ -1704,7 +1704,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
+            MessageCompleteMessage(conversationId: nil, attachments: [attachment])
         ))
 
         XCTAssertEqual(viewModel.messages.count, 1, "Should add attachments to existing message, not create new")
@@ -1724,7 +1724,7 @@ final class ChatViewModelTests: XCTestCase {
             data: "JVBER", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(sessionId: nil, attachments: [attachment])
+            MessageCompleteMessage(conversationId: nil, attachments: [attachment])
         ))
 
         XCTAssertEqual(viewModel.messages.count, 1, "Should create new assistant message for attachment-only turn")
@@ -1772,7 +1772,7 @@ final class ChatViewModelTests: XCTestCase {
 
         // Complete with empty attachments array
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(sessionId: nil, attachments: [])
+            MessageCompleteMessage(conversationId: nil, attachments: [])
         ))
 
         // Should have no messages — no extra empty assistant message
@@ -2661,7 +2661,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.pendingSendDirectAttachments = nil
 
         // Simulate generationCancelled arriving
-        let cancelled = GenerationCancelledMessage(sessionId: "sess-1")
+        let cancelled = GenerationCancelledMessage(conversationId: "sess-1")
         viewModel.handleServerMessage(.generationCancelled(cancelled))
 
         // After cancellation, the pending text should have been dispatched

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -86,7 +86,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         initialVm.messages.append(ChatMessage(role: .user, text: "Seed"))
 
         initialVm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: "First chunk", sessionId: "session-initial")
+            AssistantTextDeltaMessage(text: "First chunk", conversationId: "session-initial")
         ))
         waitForPropagation()
         XCTAssertFalse(conversationManager.conversations[initialIndex].hasUnseenLatestAssistantMessage)
@@ -104,10 +104,10 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         conversationManager.selectConversation(id: secondaryThreadId)
 
         initialVm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: " + second chunk", sessionId: "session-initial")
+            AssistantTextDeltaMessage(text: " + second chunk", conversationId: "session-initial")
         ))
         initialVm.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(sessionId: "session-initial")
+            MessageCompleteMessage(conversationId: "session-initial")
         ))
 
         waitForPropagation()
@@ -131,8 +131,8 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         conversationManager.conversations[index].hasUnseenLatestAssistantMessage = false
         vm.conversationId = "session-realtime"
 
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Streaming reply", sessionId: "session-realtime")))
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-realtime")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Streaming reply", conversationId: "session-realtime")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-realtime")))
 
         waitForPropagation()
 
@@ -338,7 +338,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         vm.conversationId = "session-live-unread"
 
         vm.handleServerMessage(.assistantTextDelta(
-            AssistantTextDeltaMessage(text: "Live reply", sessionId: "session-live-unread")
+            AssistantTextDeltaMessage(text: "Live reply", conversationId: "session-live-unread")
         ))
         waitForPropagation()
 
@@ -576,7 +576,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         vm.conversationId = "session-streaming"
 
         // First delta creates a new message — should emit one seen signal
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", conversationId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterFirstDelta = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -584,9 +584,9 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         let countAfterFirst = signalsAfterFirstDelta.count
 
         // Subsequent deltas on the same message should NOT emit additional seen signals
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk2", sessionId: "session-streaming")))
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk3", sessionId: "session-streaming")))
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", sessionId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk2", conversationId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk3", conversationId: "session-streaming")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", conversationId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterMoreDeltas = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -595,7 +595,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                        "Mid-stream text deltas should not emit additional seen signals (was O(n), should be O(1))")
 
         // Stream completion should emit one more seen signal
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-streaming")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-streaming")))
         waitForPropagation()
 
         let signalsAfterComplete = sentMessages.compactMap { $0 as? ConversationSeenSignal }
@@ -616,8 +616,8 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         conversationManager.conversations[index].hasUnseenLatestAssistantMessage = true
         vm.conversationId = "session-active"
 
-        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Visible reply", sessionId: "session-active")))
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-active")))
+        vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Visible reply", conversationId: "session-active")))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(conversationId: "session-active")))
 
         waitForPropagation()
 


### PR DESCRIPTION
## Summary
- Update `ConversationManagerUnseenStateTests.swift` to use `conversationId:` parameter in `AssistantTextDeltaMessage` and `MessageCompleteMessage` convenience inits
- Update `ChatViewModelTests.swift` (macOS) to use `conversationId:` in `GenerationCancelledMessage`, `AssistantTextDeltaMessage`, and `MessageCompleteMessage` inits
- Update `ConversationLifecycleIOSTests.swift` and `ChatViewModelIOSTests.swift` (iOS) with the same parameter name fixes

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23125741678/job/67168350406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
