### PR TITLE
fix: enable managed sign-in onboarding by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -151,7 +151,7 @@
       "key": "managed_sign_in_enabled",
       "label": "Managed Sign In",
       "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
-      "defaultEnabled": false
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `managed_sign_in_enabled` feature flag in `meta/feature-flags/feature-flag-registry.json` defaulted to `false`, which hid the login-first onboarding flow from users.
- Users only saw "Get Started" (API key entry) and never got the "Log In" button.
- Changed `defaultEnabled` from `false` to `true` so the managed sign-in option is visible by default.

## Test plan
- [ ] Verify the onboarding flow shows both "Get Started" and "Log In" buttons
- [ ] Verify existing users with explicit feature flag overrides are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
