### PR TITLE
fix: correct is_degraded warning copy to reflect stale pending-compute data

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -71,7 +71,7 @@ struct SettingsBillingTab: View {
                 HStack(spacing: VSpacing.sm) {
                     VIconView(.triangleAlert, size: 14)
                         .foregroundColor(VColor.systemMidStrong)
-                    Text("Your balance is low. Add funds to avoid service interruption.")
+                    Text("Pending charges could not be calculated. The balance shown may be incomplete.")
                         .font(VFont.body)
                         .foregroundColor(VColor.systemMidStrong)
                 }


### PR DESCRIPTION
## Summary
- The `is_degraded` flag on the billing summary means pending-compute data is stale/unavailable (e.g. Valkey down), not that the balance is low.
- Changed the warning copy from "Your balance is low. Add funds to avoid service interruption." to "Pending charges could not be calculated. The balance shown may be incomplete." so it accurately describes what degradation means.

## Test plan
- [ ] Verify in the macOS billing tab that when `is_degraded` is true, the new message is displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
