### PR TITLE
fix: use correct return path for Stripe checkout redirect

### DIFF
--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -83,7 +83,7 @@ public final class BillingService {
         }
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
-        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/billing")
+        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/settings?panel=billing")
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(requestBody)
 


### PR DESCRIPTION
## Summary
- The macOS client was sending `return_path: "/billing"` when creating a Stripe checkout session, but there is no `/billing` route in the platform web app. Users landed on a dead page after completing checkout.
- Changed to `"/settings?panel=billing"` to match the platform default and web client behavior.

## Test plan
- [ ] Create a top-up checkout session from the macOS client
- [ ] Complete the Stripe checkout flow
- [ ] Verify redirect lands on `/settings?panel=billing` instead of the dead `/billing` route

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
