### PR TITLE
fix: update OnboardingState to write canonical privacy UserDefaults keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -156,11 +156,11 @@ final class OnboardingState {
         // Opt in to usage data and performance reports by default for new users.
         // Previously handled by ImproveExperienceStepView.onAppear; that view was
         // removed so we set the defaults here to keep the same behavior.
-        if UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
-            UserDefaults.standard.set(true, forKey: "collectUsageDataEnabled")
+        if UserDefaults.standard.object(forKey: "collectUsageData") == nil {
+            UserDefaults.standard.set(true, forKey: "collectUsageData")
         }
-        if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
-            UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil {
+            UserDefaults.standard.set(true, forKey: "sendDiagnostics")
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for reorg-privacy-toggles.md.

**Gap:** OnboardingState.swift still writes legacy UserDefaults keys for new users
**What was expected:** All code paths should write canonical keys (collectUsageData, sendDiagnostics)
**What was found:** OnboardingState.swift wrote legacy keys (collectUsageDataEnabled, sendPerformanceReports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
