### PR TITLE
fix: fail bootstrap when platform URL injection fails

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -148,7 +148,12 @@ public final class LocalAssistantBootstrapService {
                 try await injectKeyIntoDaemon(key: existingKey)
                 log.info("Re-synced existing API key to daemon")
                 try? await injectPlatformAssistantIdIntoDaemon(id: platformAssistantId)
-                try? await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
+                do {
+                    try await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
+                } catch {
+                    log.error("Failed to inject platform base URL into daemon on existing-key path: \(error.localizedDescription)")
+                    throw LocalBootstrapError.daemonInjectionFailed
+                }
                 return .registeredWithExistingKey(assistantId: platformAssistantId)
             } catch {
                 log.warning("Failed to inject existing key into daemon, will reprovision: \(error.localizedDescription)")
@@ -182,7 +187,12 @@ public final class LocalAssistantBootstrapService {
         if (try? await injectPlatformAssistantIdIntoDaemon(id: platformAssistantId)) == nil {
             log.warning("Failed to inject platform assistant ID into daemon on provision path; the TS env-var fallback will be used")
         }
-        try? await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
+        do {
+            try await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
+        } catch {
+            log.error("Failed to inject platform base URL into daemon on provision path: \(error.localizedDescription)")
+            throw LocalBootstrapError.daemonInjectionFailed
+        }
 
         return .registeredAndProvisioned(assistantId: platformAssistantId)
     }


### PR DESCRIPTION
## Summary

- Replace `try?` with proper error handling on `injectPlatformBaseUrlIntoDaemon()` calls in both the existing-key path and the provision path of `LocalAssistantBootstrapService.bootstrap()`
- Without the platform URL injected into the daemon, managed proxy routing silently breaks even though bootstrap reports success
- Now logs an error and throws `LocalBootstrapError.daemonInjectionFailed` on failure

## Test plan

- [ ] Verify bootstrap succeeds when platform URL injection succeeds (no behavior change)
- [ ] Verify bootstrap fails with a clear error when platform URL injection fails on the existing-key path
- [ ] Verify bootstrap fails with a clear error when platform URL injection fails on the provision path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
