### PR TITLE
fix: use unique script content in egress and materialization tests to avoid digest collisions

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -604,7 +604,11 @@ describe("executeAuthenticatedCommand — credential materialization", () => {
         },
       },
     });
-    const { digest } = publishTestBundle(manifest);
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "credential materialization test"\n',
+    );
 
     const deps = buildDeps({
       materializeCredential: failMaterializer("Credential store is locked"),
@@ -815,7 +819,11 @@ describe("executeAuthenticatedCommand — egress enforcement", () => {
     const manifest = buildManifest({
       egressMode: EgressMode.ProxyRequired,
     });
-    const { digest } = publishTestBundle(manifest);
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "egress enforcement test"\n',
+    );
 
     const deps = buildDeps({
       egressHooks: undefined, // No hooks provided


### PR DESCRIPTION
## Summary
- Give the credential materialization and egress enforcement tests unique script content to prevent tar archive digest collisions with other tests that use default script content
- Root cause: when two `publishTestBundle` calls produce identical tar archives (same file content + mtime within second granularity), the deduplication logic serves a stale manifest with the wrong `egressMode`, causing the egress enforcement test to miss its rejection path

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23125759134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
