### PR TITLE
fix: normalize top-up amount to two decimal places

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -170,12 +170,14 @@ struct SettingsBillingTab: View {
             return
         }
 
+        let normalizedAmount = String(format: "%.2f", amount)
+
         isProcessingTopUp = true
         topUpError = nil
         defer { isProcessingTopUp = false }
 
         do {
-            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amountUsd: topUpAmount)
+            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amountUsd: normalizedAmount)
             NSWorkspace.shared.open(checkoutURL)
             topUpAmount = ""
         } catch {


### PR DESCRIPTION
## Summary
- The macOS billing top-up flow accepted amounts like "10" or "25.5" that the platform API rejects because it requires exactly two decimal places (e.g. "25.00").
- Added `String(format: "%.2f", amount)` normalization in `handleTopUp()` before passing the amount to `BillingService.shared.createTopUpCheckout()`, matching the web client's `normalizeUsdAmount()` behavior.

## Test plan
- [ ] Enter "10" as top-up amount, verify it sends "10.00" to the API
- [ ] Enter "25.5" as top-up amount, verify it sends "25.50" to the API
- [ ] Enter "19.99" as top-up amount, verify it sends "19.99" unchanged
- [ ] Verify invalid inputs (letters, empty) still show validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
