### PR TITLE
fix: update stale Sentry comment in AppDelegate to reflect conditional init

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -193,11 +193,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // can appear as a blank window during activation policy transitions).
         NSWindow.allowsAutomaticWindowTabbing = false
 
-        // Initialize crash reporting eagerly so crashes before the daemon connects
-        // are captured. Privacy opt-out is checked after the daemon is ready and
-        // applied via SentrySDK.close() — matching the daemon-side pattern in
-        // lifecycle.ts (init at top, close after config load if flag disabled).
-        // Gated on sendDiagnostics: if disabled, Sentry is never initialized.
+        // Gated on sendDiagnostics: if the user has previously disabled diagnostics,
+        // Sentry is never initialized. Otherwise, initialize eagerly so crashes
+        // before the daemon connects are captured.
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
             ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
             ?? true


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for reorg-privacy-toggles.md.

**Gap:** Stale comment in AppDelegate.swift contradicts new conditional Sentry init
**What was expected:** Comment should describe the current conditional init behavior
**What was found:** Comment still described the old eager-init-late-close pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
