### PR TITLE
fix: remove sendPerformanceReports fallback from sendDiagnostics reads

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -439,7 +439,6 @@ extension AppDelegate {
                 ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
                 ?? true
             let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
                 ?? true
 
             // Apply Sentry state based on sendDiagnostics

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -199,7 +199,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // lifecycle.ts (init at top, close after config load if flag disabled).
         // Gated on sendDiagnostics: if disabled, Sentry is never initialized.
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-            ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
             ?? true
         if sendDiagnostics {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -146,7 +146,6 @@ struct SettingsDeveloperTab: View {
 
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
                 ?? true
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -228,7 +228,6 @@ public final class SettingsStore: ObservableObject {
     /// Whether the user has opted in to sending crash reports, error diagnostics, and
     /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
     @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-        ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
         ?? true
 
     /// Whether the user has opted in to sharing anonymized usage analytics (e.g. token counts,

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -194,7 +194,6 @@ import os
     private nonisolated static func restartSentryInline() {
         guard !SentrySDK.isEnabled else { return }
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-            ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
             ?? true
         guard sendDiagnostics else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
@@ -229,7 +228,6 @@ extension MetricKitManager: MXMetricManagerSubscriber {
 
             // Only send to Sentry if sendDiagnostics is enabled.
             let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
                 ?? true
             guard sendDiagnostics else { continue }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for reorg-privacy-toggles.md.

**Gap:** Semantic mismatch in sendPerformanceReports → sendDiagnostics fallback
**What was expected:** Upgrading users who disabled profiling only should retain crash reporting
**What was found:** Using sendPerformanceReports as fallback for sendDiagnostics incorrectly disables all Sentry for users who only opted out of profiling

Changes all `sendDiagnostics` read chains from:
```swift
UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
    ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
    ?? true
```
to:
```swift
UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
    ?? true
```

Files updated:
- `AppDelegate.swift` — Sentry init fallback chain
- `AppDelegate+DaemonSetup.swift` — syncPrivacyConfig sendDiagnostics read
- `MetricKitManager.swift` — restartSentryInline and didReceive fallback chains (2 occurrences)
- `SettingsStore.swift` — sendDiagnostics property initialization
- `SettingsDeveloperTab.swift` — developer tab warning check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
