### PR TITLE
fix: update test expectations after session-to-conversation rename

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -127,7 +127,7 @@ describe("executeBrowserFillCredential", () => {
 
   test("fills credential into element by element_id", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -161,7 +161,7 @@ describe("executeBrowserFillCredential", () => {
   test("returns error when credential not found", async () => {
     mockGetCredentialMetadata = mock(() => undefined);
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -177,7 +177,7 @@ describe("executeBrowserFillCredential", () => {
   test("returns error when metadata exists but no stored value", async () => {
     mockGetSecureKey = mock(() => undefined);
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -202,7 +202,7 @@ describe("executeBrowserFillCredential", () => {
 
   test("presses Enter after fill when press_enter is true", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e2", '[data-vellum-eid="e2"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -227,7 +227,7 @@ describe("executeBrowserFillCredential", () => {
 
   test("credential value NEVER appears in result content", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -240,7 +240,7 @@ describe("executeBrowserFillCredential", () => {
 
   test("returns error when service is missing", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -253,7 +253,7 @@ describe("executeBrowserFillCredential", () => {
 
   test("returns error when field is missing", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserFillCredential(
@@ -270,7 +270,7 @@ describe("executeBrowserFillCredential", () => {
   describe("broker integration", () => {
     test("fill succeeds with no domain or tool-policy checks", async () => {
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       const result = await executeBrowserFillCredential(
@@ -284,7 +284,7 @@ describe("executeBrowserFillCredential", () => {
 
     test("credential access goes through broker (metadata + value checked)", async () => {
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       await executeBrowserFillCredential(
@@ -307,7 +307,7 @@ describe("executeBrowserFillCredential", () => {
         allowedTools: ["some_other_tool"],
       }));
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       const result = await executeBrowserFillCredential(
@@ -327,7 +327,7 @@ describe("executeBrowserFillCredential", () => {
         allowedDomains: ["other-site.com"],
       }));
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       const result = await executeBrowserFillCredential(
@@ -346,7 +346,7 @@ describe("executeBrowserFillCredential", () => {
         allowedDomains: ["example.com"],
       }));
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       const result = await executeBrowserFillCredential(
@@ -364,7 +364,7 @@ describe("executeBrowserFillCredential", () => {
         allowedTools: ["other_tool"],
       }));
       snapshotMaps.set(
-        "test-session",
+        "test-conversation",
         new Map([["e1", '[data-vellum-eid="e1"]']]),
       );
       const result = await executeBrowserFillCredential(

--- a/assistant/src/__tests__/credential-execution-api-key-propagation.test.ts
+++ b/assistant/src/__tests__/credential-execution-api-key-propagation.test.ts
@@ -99,7 +99,7 @@ async function completeHandshake(
     JSON.stringify({
       type: "handshake_ack",
       protocolVersion: CES_PROTOCOL_VERSION,
-      conversationId: sent.conversationId,
+      sessionId: sent.sessionId,
       accepted: true,
     }),
   );
@@ -122,7 +122,7 @@ describe("handshake schema includes assistantApiKey", () => {
     const result = HandshakeRequestSchema.safeParse({
       type: "handshake_request",
       protocolVersion: "0.1.0",
-      conversationId: "test-session",
+      sessionId: "test-session",
       assistantApiKey: "vak_test_key_12345",
     });
     expect(result.success).toBe(true);
@@ -132,7 +132,7 @@ describe("handshake schema includes assistantApiKey", () => {
     const result = HandshakeRequestSchema.safeParse({
       type: "handshake_request",
       protocolVersion: "0.1.0",
-      conversationId: "test-session",
+      sessionId: "test-session",
     });
     expect(result.success).toBe(true);
   });
@@ -233,7 +233,7 @@ describe("CesClient.updateAssistantApiKey()", () => {
       JSON.stringify({
         type: "handshake_ack",
         protocolVersion: CES_PROTOCOL_VERSION,
-        conversationId: hsSent.conversationId,
+        sessionId: hsSent.sessionId,
         accepted: true,
       }),
     );

--- a/assistant/src/__tests__/credential-execution-client.test.ts
+++ b/assistant/src/__tests__/credential-execution-client.test.ts
@@ -163,14 +163,14 @@ describe("CES client", () => {
     const sent = JSON.parse(transport.sentMessages[0]);
     expect(sent.type).toBe("handshake_request");
     expect(sent.protocolVersion).toBe(CES_PROTOCOL_VERSION);
-    expect(sent.conversationId).toBeTruthy();
+    expect(sent.sessionId).toBeTruthy();
 
     // Simulate handshake ack
     transport.simulateMessage(
       JSON.stringify({
         type: "handshake_ack",
         protocolVersion: CES_PROTOCOL_VERSION,
-        conversationId: sent.conversationId,
+        sessionId: sent.sessionId,
         accepted: true,
       }),
     );
@@ -213,7 +213,7 @@ describe("CES client", () => {
       JSON.stringify({
         type: "handshake_ack",
         protocolVersion: CES_PROTOCOL_VERSION,
-        conversationId: sent.conversationId,
+        sessionId: sent.sessionId,
         accepted: false,
         reason: "Protocol version mismatch",
       }),
@@ -255,7 +255,7 @@ describe("CES client", () => {
       JSON.stringify({
         type: "handshake_ack",
         protocolVersion: CES_PROTOCOL_VERSION,
-        conversationId: sent.conversationId,
+        sessionId: sent.sessionId,
         accepted: true,
       }),
     );
@@ -288,7 +288,7 @@ describe("CES client", () => {
       JSON.stringify({
         type: "handshake_ack",
         protocolVersion: CES_PROTOCOL_VERSION,
-        conversationId: sent.conversationId,
+        sessionId: sent.sessionId,
         accepted: true,
       }),
     );

--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -8,7 +8,7 @@
  *    stateful_template.yaml K8s spec (read-only mount + private PVC).
  *
  * 2. Bootstrap handshake contract: protocol version is valid semver and
- *    the handshake schema requires both protocolVersion and conversationId.
+ *    the handshake schema requires both protocolVersion and sessionId.
  *
  * 3. local_static handle rejection: managed mode returns clear errors
  *    when local_static credential handles are used (the core managed-mode
@@ -260,13 +260,13 @@ describe("managed CES bootstrap handshake contract", () => {
     expect(CES_PROTOCOL_VERSION).toBe("0.1.0");
   });
 
-  test("handshake request schema requires protocolVersion and conversationId", () => {
+  test("handshake request schema requires protocolVersion and sessionId", () => {
     // Both fields are mandatory for the managed bootstrap handshake.
     // A handshake missing either must be rejected at parse time.
     const validHandshake = {
       type: "handshake_request" as const,
       protocolVersion: CES_PROTOCOL_VERSION,
-      conversationId: "test-session-123",
+      sessionId: "test-session-123",
     };
     const result = HandshakeRequestSchema.safeParse(validHandshake);
     expect(result.success).toBe(true);
@@ -275,12 +275,12 @@ describe("managed CES bootstrap handshake contract", () => {
   test("handshake request schema rejects missing protocolVersion", () => {
     const result = HandshakeRequestSchema.safeParse({
       type: "handshake_request",
-      conversationId: "test-session-123",
+      sessionId: "test-session-123",
     });
     expect(result.success).toBe(false);
   });
 
-  test("handshake request schema rejects missing conversationId", () => {
+  test("handshake request schema rejects missing sessionId", () => {
     const result = HandshakeRequestSchema.safeParse({
       type: "handshake_request",
       protocolVersion: CES_PROTOCOL_VERSION,
@@ -293,7 +293,7 @@ describe("managed CES bootstrap handshake contract", () => {
     const result = HandshakeRequestSchema.safeParse({
       type: "handshake_request",
       protocolVersion: CES_PROTOCOL_VERSION,
-      conversationId: "test-session-123",
+      sessionId: "test-session-123",
       assistantApiKey: "vellum_key_test",
     });
     expect(result.success).toBe(true);
@@ -303,7 +303,7 @@ describe("managed CES bootstrap handshake contract", () => {
     const acceptedAck = {
       type: "handshake_ack" as const,
       protocolVersion: CES_PROTOCOL_VERSION,
-      conversationId: "test-session-123",
+      sessionId: "test-session-123",
       accepted: true,
     };
     const result = HandshakeAckSchema.safeParse(acceptedAck);
@@ -312,7 +312,7 @@ describe("managed CES bootstrap handshake contract", () => {
     const rejectedAck = {
       type: "handshake_ack" as const,
       protocolVersion: CES_PROTOCOL_VERSION,
-      conversationId: "test-session-123",
+      sessionId: "test-session-123",
       accepted: false,
       reason: "Unsupported protocol version",
     };

--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -23,7 +23,7 @@ describe("EventBus", () => {
       startedAtMs: Date.now(),
     });
 
-    expect(seen).toEqual(["first:bash", "second:sess-1"]);
+    expect(seen).toEqual(["first:bash", "second:conv-1"]);
   });
 
   test("supports onAny listeners with event envelopes", async () => {

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -118,7 +118,7 @@ describe("executeBrowserClick", () => {
 
   test("clicks by element_id via snapshot map", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserClick({ element_id: "e1" }, ctx);
@@ -139,7 +139,7 @@ describe("executeBrowserClick", () => {
 
   test("prefers element_id over selector", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserClick(
@@ -194,7 +194,7 @@ describe("executeBrowserType", () => {
 
   test("types with element_id and default clear_first=true", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e3", '[data-vellum-eid="e3"]']]),
     );
     const result = await executeBrowserType(
@@ -332,7 +332,7 @@ describe("executeBrowserSnapshot", () => {
     ];
     mockPage.evaluate = mock(async () => sampleElements);
     await executeBrowserSnapshot({}, ctx);
-    const map = snapshotMaps.get("test-session");
+    const map = snapshotMaps.get("test-conversation");
     expect(map).toBeDefined();
     expect(map!.get("e1")).toBe('[data-vellum-eid="e1"]');
   });
@@ -504,7 +504,7 @@ describe("executeBrowserPressKey", () => {
 
   test("presses key on targeted element via element_id", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e5", '[data-vellum-eid="e5"]']]),
     );
     const result = await executeBrowserPressKey(
@@ -621,7 +621,7 @@ describe("executeBrowserSelectOption", () => {
 
   test("selects by value via element_id", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e4", '[data-vellum-eid="e4"]']]),
     );
     const result = await executeBrowserSelectOption(
@@ -702,7 +702,7 @@ describe("executeBrowserHover", () => {
 
   test("hovers by element_id via snapshot map", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e2", '[data-vellum-eid="e2"]']]),
     );
     const result = await executeBrowserHover({ element_id: "e2" }, ctx);
@@ -761,7 +761,7 @@ describe("browser execution wrapper contract", () => {
 
   test("executeBrowserClick matches wrapper contract (input, context) → result", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserClick({ element_id: "e1" }, ctx);
@@ -774,7 +774,7 @@ describe("browser execution wrapper contract", () => {
 
   test("executeBrowserType matches wrapper contract", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e3", '[data-vellum-eid="e3"]']]),
     );
     const result = await executeBrowserType(
@@ -839,7 +839,7 @@ describe("browser execution wrapper contract", () => {
 
   test("executeBrowserSelectOption matches wrapper contract", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e4", '[data-vellum-eid="e4"]']]),
     );
     const result = await executeBrowserSelectOption(
@@ -853,7 +853,7 @@ describe("browser execution wrapper contract", () => {
 
   test("executeBrowserHover matches wrapper contract", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e2", '[data-vellum-eid="e2"]']]),
     );
     const result = await executeBrowserHover({ element_id: "e2" }, ctx);

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -107,7 +107,7 @@ describe("executeBrowserPressKey", () => {
 
   test("presses key on targeted element via element_id", async () => {
     snapshotMaps.set(
-      "test-session",
+      "test-conversation",
       new Map([["e1", '[data-vellum-eid="e1"]']]),
     );
     const result = await executeBrowserPressKey(

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -133,7 +133,7 @@ describe("executeBrowserSnapshot", () => {
     await executeBrowserSnapshot({}, ctx);
     expect(storeSnapshotMapMock).toHaveBeenCalledTimes(1);
 
-    const stored = storedMaps.get("test-session");
+    const stored = storedMaps.get("test-conversation");
     expect(stored).toBeDefined();
     expect(stored!.get("e1")).toBe('[data-vellum-eid="e1"]');
     expect(stored!.get("e2")).toBe('[data-vellum-eid="e2"]');
@@ -178,7 +178,7 @@ describe("executeBrowserClose", () => {
     const result = await executeBrowserClose({}, ctx);
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Browser page closed for this session.");
-    expect(closeSessionPageMock).toHaveBeenCalledWith("test-session");
+    expect(closeSessionPageMock).toHaveBeenCalledWith("test-conversation");
     expect(closeAllPagesMock).not.toHaveBeenCalled();
   });
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -750,7 +750,7 @@ describe("host_bash — proxy delegation", () => {
     expect(calls[0].input.command).toBe("echo hello");
     expect(calls[0].input.working_dir).toBe("/tmp");
     expect(calls[0].input.timeout_seconds).toBe(30);
-    expect(calls[0].conversationId).toBe("test-session");
+    expect(calls[0].conversationId).toBe("test-conversation");
     // Should NOT have spawned a local process
     expect(spawnCalls.length).toBe(0);
   });

--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  * - Runtime and managed target URL construction (trailing slashes, path format)
- * - Auth header injection (Authorization for runtime, X-Conversation-Token for managed)
+ * - Auth header injection (Authorization for runtime, X-Session-Token for managed)
  * - validate: success, validation failure, HTTP error
  * - export: runtime binary download, managed async job initiation
  * - import-preflight: success with report, validation failure
@@ -161,10 +161,10 @@ describe("Auth headers", () => {
     await validateBundle(runtimeConfig({ fetchFn }), sampleFileData);
     const headers = captured[0].init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer test-jwt");
-    expect(headers["X-Conversation-Token"]).toBeUndefined();
+    expect(headers["X-Session-Token"]).toBeUndefined();
   });
 
-  test("managed uses X-Conversation-Token header by default", async () => {
+  test("managed uses X-Session-Token header by default", async () => {
     const { fetchFn, captured } = capturingFetch(200, {
       is_valid: true,
       errors: [],
@@ -172,7 +172,7 @@ describe("Auth headers", () => {
     });
     await validateBundle(managedConfig({ fetchFn }), sampleFileData);
     const headers = captured[0].init.headers as Record<string, string>;
-    expect(headers["X-Conversation-Token"]).toBe("test-session-token");
+    expect(headers["X-Session-Token"]).toBe("test-session-token");
     expect(headers["Authorization"]).toBeUndefined();
   });
 
@@ -207,7 +207,7 @@ describe("Auth headers", () => {
     const headers = captured[0].init.headers as Record<string, string>;
     expect(headers["Vellum-Organization-Id"]).toBe("org-123");
     // Managed auth header should still be present
-    expect(headers["X-Conversation-Token"]).toBe("test-session-token");
+    expect(headers["X-Session-Token"]).toBe("test-session-token");
   });
 
   test("runtime request is unchanged when no defaultHeaders provided", async () => {
@@ -228,16 +228,16 @@ describe("Auth headers", () => {
       errors: [],
       manifest: {},
     });
-    // defaultHeaders sets X-Conversation-Token, but authHeader should override it
+    // defaultHeaders sets X-Session-Token, but authHeader should override it
     await validateBundle(
       managedConfig({
         fetchFn,
-        defaultHeaders: { "X-Conversation-Token": "should-be-overridden" },
+        defaultHeaders: { "X-Session-Token": "should-be-overridden" },
       }),
       sampleFileData,
     );
     const headers = captured[0].init.headers as Record<string, string>;
-    expect(headers["X-Conversation-Token"]).toBe("test-session-token");
+    expect(headers["X-Session-Token"]).toBe("test-session-token");
   });
 
   test("auth header wins over case-insensitive entry in defaultHeaders", async () => {
@@ -259,7 +259,7 @@ describe("Auth headers", () => {
       string,
       string
     >;
-    expect(managedHeaders["X-Conversation-Token"]).toBe("test-session-token");
+    expect(managedHeaders["X-Session-Token"]).toBe("test-session-token");
     expect(managedHeaders["x-session-token"]).toBeUndefined();
 
     const runtime = capturingFetch(200, {
@@ -296,7 +296,7 @@ describe("Auth headers", () => {
     );
     const headers = captured[0].init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBeUndefined();
-    expect(headers["X-Conversation-Token"]).toBeUndefined();
+    expect(headers["X-Session-Token"]).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -50,7 +50,7 @@ describe("send-notification tool", () => {
       contextPayload: {
         requestedMessage: "Your verification code is 123456",
         requestedByTool: "send_notification",
-        requestedBySessionId: "sess-1",
+        requestedBySessionId: "conv-1",
         requestedTitle: "Verification code",
         requestedByConversationId: "conv-override",
         preferredChannels: ["vellum"],


### PR DESCRIPTION
## Summary
- Update 11 test files to match the recent session/thread → conversation rename in source code
- Fix test expectations for conversationId values, snapshot map keys, header names, and schema field names
- Tests now correctly expect "test-conversation"/"conv-1" instead of "test-session"/"sess-1"

## Original prompt
help me fix CI errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/23126033468/job/67169145352

We recently did a bunch of renames to change session and thread to conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
