### PR TITLE
fix: add migration for replyToThread→replyInSameConversation in sequence steps JSON

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -87,6 +87,7 @@ import {
   migrateRenameInboxThreadStateTable,
   migrateRenameNotificationThreadColumns,
   migrateRenameSequenceEnrollmentsThreadIdColumn,
+  migrateRenameSequenceStepsReplyKey,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
@@ -415,6 +416,9 @@ export function initializeDb(): void {
 
   // 70. Rename sequence_enrollments.thread_id → conversation_id
   migrateRenameSequenceEnrollmentsThreadIdColumn(database);
+
+  // 71. Rename replyToThread → replyInSameConversation in sequence steps JSON blobs
+  migrateRenameSequenceStepsReplyKey(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/168-rename-sequence-steps-reply-key.ts
+++ b/assistant/src/memory/migrations/168-rename-sequence-steps-reply-key.ts
@@ -1,0 +1,17 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Backfill existing sequence steps JSON blobs to rename the
+ * `replyToThread` key to `replyInSameConversation`, aligning with
+ * the broader thread → conversation terminology unification.
+ *
+ * The UPDATE is naturally idempotent — REPLACE is a no-op when
+ * the old key does not appear in the text, so no checkpoint guard
+ * is needed.
+ */
+export function migrateRenameSequenceStepsReplyKey(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(
+    /*sql*/ `UPDATE sequences SET steps = REPLACE(steps, '"replyToThread"', '"replyInSameConversation"') WHERE steps LIKE '%"replyToThread"%'`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -109,6 +109,7 @@ export { migrateRenameConversationTypeColumn } from "./164-rename-conversation-t
 export { migrateRenameInboxThreadStateTable } from "./165-rename-inbox-thread-state-table.js";
 export { migrateRenameFollowupsThreadIdColumn } from "./166-rename-followups-thread-id.js";
 export { migrateRenameSequenceEnrollmentsThreadIdColumn } from "./167-rename-sequence-enrollments-thread-id.js";
+export { migrateRenameSequenceStepsReplyKey } from "./168-rename-sequence-steps-reply-key.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-unify-symbols.md.

**Gap:** Stored sequence steps JSON has stale replyToThread key
**What was expected:** Existing JSON data should use the new replyInSameConversation key
**What was found:** No migration for the JSON blob inside the steps column

Adds migration 168 which uses SQL REPLACE to rename the key in existing sequence steps JSON blobs. The migration is naturally idempotent (REPLACE is a no-op when the old key is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
