### PR TITLE
fix: update stale session-*.ts file references in CODEOWNERS, READMEs, and comments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ assistant/src/config/skill-state.ts @awlevin
 assistant/src/config/bundled-skills/ @awlevin
 assistant/src/daemon/handlers/skills.ts @awlevin
 assistant/src/daemon/message-types/skills.ts @awlevin
-assistant/src/daemon/session-skill-tools.ts @awlevin
+assistant/src/daemon/conversation-skill-tools.ts @awlevin
 
 # Agent-to-agent / agent-to-person interactions (Harrison)
 assistant/src/subagent/ @NgoHarrison
@@ -29,8 +29,8 @@ assistant/src/messaging/ @NgoHarrison
 assistant/src/notifications/ @NgoHarrison
 assistant/src/runtime/routes/ @NgoHarrison
 assistant/src/runtime/ingress-service.ts @NgoHarrison
-assistant/src/daemon/session-messaging.ts @NgoHarrison
-assistant/src/daemon/session-surfaces.ts @NgoHarrison
+assistant/src/daemon/conversation-messaging.ts @NgoHarrison
+assistant/src/daemon/conversation-surfaces.ts @NgoHarrison
 gateway/src/channels/ @NgoHarrison
 gateway/src/handlers/ @NgoHarrison
 gateway/src/routing/ @NgoHarrison
@@ -86,7 +86,7 @@ assistant/src/runtime/confirmation-request-guardian-bridge.ts @noanflaherty
 assistant/src/runtime/actor-trust-resolver.ts @noanflaherty
 assistant/src/runtime/approval-*.ts @noanflaherty
 assistant/src/runtime/verification-rate-limiter.ts @noanflaherty
-assistant/src/runtime/session-approval-overrides.ts @noanflaherty
+assistant/src/runtime/conversation-approval-overrides.ts @noanflaherty
 assistant/src/runtime/routes/approval-routes.ts @noanflaherty
 assistant/src/runtime/routes/channel-guardian-routes.ts @noanflaherty
 assistant/src/runtime/routes/guardian-*.ts @noanflaherty

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -721,7 +721,7 @@ describe("web_search_tool_result structural guard", () => {
    * are listed in the allowlist below.
    *
    * If this test fails, either:
-   * 1. Use `isToolResultBlock()` from session-history.ts, or
+   * 1. Use `isToolResultBlock()` from conversation-history.ts, or
    * 2. Include both "tool_result" and "web_search_tool_result" in the check, or
    * 3. Add the file to the allowlist with a comment explaining why only
    *    `tool_result` is correct.
@@ -956,7 +956,7 @@ describe("web_search_tool_result structural guard", () => {
         ...allViolations.map((v) => `  - ${v.file}:${v.line}: ${v.text}`),
         "",
         "Fix options:",
-        "  1. Use isToolResultBlock() from session-history.ts",
+        "  1. Use isToolResultBlock() from conversation-history.ts",
         '  2. Add || block.type === "web_search_tool_result" to your check',
         "  3. If only tool_result is correct, add the file to ALLOWLISTED_FILES",
         "     in this test with a comment explaining why.",

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -2118,7 +2118,7 @@ describe("tamper detection", () => {
     expect(sessionState.get("deploy")).toBe("v1:initial-hash");
 
     // Make computeSkillVersionHash throw to exercise the catch branch
-    // in session-skill-tools.ts that falls back to `unknown-${Date.now()}`
+    // in conversation-skill-tools.ts that falls back to `unknown-${Date.now()}`
     mockVersionHashErrors.add("deploy");
     mockUnregisteredSkillIds = [];
 

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -1,6 +1,6 @@
 /**
  * Regression tests for app surface refresh and eventing side effects in
- * createToolExecutor (session-tool-setup.ts).
+ * createToolExecutor (conversation-tool-setup.ts).
  *
  * After the App Builder tools source swap (PR 8), app tools like app_update,
  * app_file_edit, and app_file_write are provided by the app-builder skill

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -4,7 +4,7 @@ import type { AgentEvent } from "../agent/loop.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
-// Mock dependencies — follows session-profile-injection.test.ts pattern
+// Mock dependencies — follows conversation-profile-injection.test.ts pattern
 // ---------------------------------------------------------------------------
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -479,7 +479,7 @@ describe("guardian-action-late-reply", () => {
       );
       const code = req1.requestCode; // e.g. "A1B2C3"
 
-      // Simulate case-insensitive prefix matching as done in session-process.ts
+      // Simulate case-insensitive prefix matching as done in conversation-process.ts
       const userInput = `${code.toLowerCase()} the answer is 42`;
       const matched = userInput.toUpperCase().startsWith(code);
       expect(matched).toBe(true);

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -2,7 +2,7 @@
  * Tests for confirmation response handling (handleConfirmationResponse).
  *
  * The legacy handleUserMessage tests that previously lived here were removed
- * when session-user-message.ts was deleted. The approval-reply behavior they
+ * when conversation-user-message.ts was deleted. The approval-reply behavior they
  * tested now lives on the HTTP path and is covered by
  * conversation-routes-guardian-reply.test.ts, send-endpoint-busy.test.ts,
  * and http-user-message-parity.test.ts.

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -2846,7 +2846,7 @@ describe("Memory regressions", () => {
     expect(privRecall.recencyHits).toBeGreaterThan(0);
 
     // 5. Standard conversation recall — must NOT find the Zephyr fact (no leak)
-    // Mirror the production call in session-memory.ts: for standard conversations
+    // Mirror the production call in conversation-memory.ts: for standard conversations
     // (scopeId === 'default'), scopePolicyOverride is undefined.
     const stdRecall = await buildMemoryRecall(
       "Zephyr framework microservices",

--- a/assistant/src/approvals/AGENTS.md
+++ b/assistant/src/approvals/AGENTS.md
@@ -16,11 +16,11 @@ Conversational guardian verification control-plane invocation is guardian-only. 
 
 ## Memory Provenance Invariant
 
-All memory retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not receive memory recall results. This invariant is enforced in `indexer.ts` (write gate) and `session-memory.ts` (read gate).
+All memory retrieval decisions must consider actor-role provenance. Untrusted actors (non-guardian, unverified_channel) must not receive memory recall results. This invariant is enforced in `indexer.ts` (write gate) and `conversation-memory.ts` (read gate).
 
 ## Guardian Privilege Isolation Invariant
 
 Untrusted actors (`non-guardian`, `unverified_channel`) must never receive privileged host/tool capabilities or privileged conversation context directly.
 
 - Tool execution gate: untrusted actors cannot execute host-target tools or side-effect tools in-band. These actions require guardian-mediated approval flow. Enforcement lives in `assistant/src/tools/tool-approval-handler.ts`.
-- History view gate: when loading session history for untrusted actors, only untrusted-provenance messages are included and compacted summaries are suppressed. This prevents replay of guardian-era context after trust downgrades. Enforcement lives in `assistant/src/daemon/session-lifecycle.ts` and actor-scoped reload wiring in `assistant/src/daemon/session.ts`.
+- History view gate: when loading session history for untrusted actors, only untrusted-provenance messages are included and compacted summaries are suppressed. This prevents replay of guardian-era context after trust downgrades. Enforcement lives in `assistant/src/daemon/conversation-lifecycle.ts` and actor-scoped reload wiring in `assistant/src/daemon/conversation.ts`.

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -3,7 +3,7 @@
  *
  * Conversation delegates `drainQueue` and `processMessage` to the module-level
  * functions exported here, following the same context-interface pattern
- * used by session-history.ts.
+ * used by conversation-history.ts.
  */
 
 import {

--- a/assistant/src/daemon/doordash-steps.ts
+++ b/assistant/src/daemon/doordash-steps.ts
@@ -1,7 +1,7 @@
 /**
  * DoorDash-specific step-tracking logic for the task_progress surface.
  *
- * Extracted from session-tool-setup.ts so the generic tool executor
+ * Extracted from conversation-tool-setup.ts so the generic tool executor
  * remains clean and extensible.
  */
 

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -377,7 +377,7 @@ Each `guardian_action_request` is assigned a unique 6-character hex code (e.g. `
 
 ### Disambiguation Flow
 
-The disambiguation logic is identical on all channels — mac/vellum (`session-process.ts`) and Telegram (`inbound-message-handler.ts`):
+The disambiguation logic is identical on all channels — mac/vellum (`conversation-process.ts`) and Telegram (`inbound-message-handler.ts`):
 
 1. **Single pending delivery in the conversation**: The guardian's reply is matched to the sole pending request automatically. No request code prefix is needed. This is the **single-match fast path**.
 
@@ -389,7 +389,7 @@ The disambiguation logic is identical on all channels — mac/vellum (`session-p
 
 The disambiguation invariant is enforced identically across:
 
-- **Mac/Vellum** (`session-process.ts`): Intercepts user messages in conversations with pending guardian action deliveries before the agent loop runs.
+- **Mac/Vellum** (`conversation-process.ts`): Intercepts user messages in conversations with pending guardian action deliveries before the agent loop runs.
 - **Telegram** (`inbound-message-handler.ts`): Intercepts inbound messages matched to conversations with pending guardian action deliveries.
 
 All three paths use the same pattern: look up pending deliveries by conversation, apply single-match fast path or request-code prefix matching, and send disambiguation messages via the guardian action message composer when ambiguous.
@@ -530,7 +530,7 @@ ORDER BY d.created_at DESC;
 
 Users express notification preferences in natural language during conversations (e.g., "Use Telegram for urgent alerts", "Mute notifications after 10pm"). The system:
 
-1. **Detects** preferences via `preference-extractor.ts` -- an LLM call that runs on each user message in `session-process.ts`
+1. **Detects** preferences via `preference-extractor.ts` -- an LLM call that runs on each user message in `conversation-process.ts`
 2. **Stores** them in `notification_preferences` with structured conditions (`appliesWhen`: timeRange, channels, urgencyLevels, contexts) and a priority level (0=default, 1=override, 2=critical)
 3. **Summarizes** them at decision time via `preference-summary.ts`, which builds a compact text block injected into the decision engine's system prompt
 

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -3,7 +3,7 @@
  * request is resolved with tool metadata.
  *
  * Used by both the channel inbound path (inbound-message-handler.ts) and
- * the desktop path (session-process.ts) to ensure grants are minted
+ * the desktop path (conversation-process.ts) to ensure grants are minted
  * consistently regardless of which channel the guardian answers on.
  */
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -730,7 +730,7 @@ export async function handleSendMessage(
       onEvent,
       // Desktop path: disable NL classification to avoid consuming non-decision
       // messages while a tool confirmation is pending. Deterministic code-prefix
-      // and callback parsing remain active. Mirrors session-process.ts behavior.
+      // and callback parsing remain active. Mirrors conversation-process.ts behavior.
       approvalConversationGenerator:
         sourceChannel === "vellum"
           ? undefined

--- a/clients/README.md
+++ b/clients/README.md
@@ -227,7 +227,7 @@ Test files in `clients/ios/Tests/`:
 - `AttachmentFlowIOSTests.swift` — attachment limits, send flow, thumbnails
 - `ChatTranscriptFormatterIOSTests.swift` — markdown formatting
 - `ChatViewModelIOSTests.swift` — send/receive flow, streaming, error handling
-- `ThreadLifecycleIOSTests.swift` — session creation, thread isolation
+- `ConversationLifecycleIOSTests.swift` — session creation, thread isolation
 - `UsageDashboardViewTests.swift` — usage dashboard state, data loading, formatting
 
 Tests use mock implementations of protocols for dependency injection:

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -117,7 +117,7 @@ Test files in `clients/ios/Tests/`:
 - `AttachmentFlowIOSTests.swift` — attachment limits, send flow, thumbnails
 - `ChatTranscriptFormatterIOSTests.swift` — markdown formatting, plain text extraction
 - `ChatViewModelIOSTests.swift` — message send/receive flow, streaming, error handling
-- `ThreadLifecycleIOSTests.swift` — session creation, backfill, thread isolation
+- `ConversationLifecycleIOSTests.swift` — session creation, backfill, thread isolation
 - `UsageDashboardViewTests.swift` — usage dashboard state, data loading, formatting
 
 ### Shared Tests


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for conv-unify-symbols.md.

- Updates CODEOWNERS paths from session-*.ts to conversation-*.ts (skill-tools, messaging, surfaces, approval-overrides)
- Updates README references from ThreadLifecycleIOSTests to ConversationLifecycleIOSTests
- Updates stale session-*.ts file path references in code comments across TS files
- Updates stale session-*.ts references in approvals/AGENTS.md and notifications/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
