### PR TITLE
fix: remaining TS session→conversation symbol renames

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1317,9 +1317,9 @@ function createMockCtx(): {
       captured = msg as ChannelVerificationSessionResponse;
     },
     broadcast: () => {},
-    clearAllSessions: () => 0,
-    getOrCreateSession: () => Promise.resolve({} as never),
-    touchSession: () => {},
+    clearAllConversations: () => 0,
+    getOrCreateConversation: () => Promise.resolve({} as never),
+    touchConversation: () => {},
   } as unknown as HandlerContext;
   return { ctx, lastResponse: () => captured };
 }

--- a/assistant/src/__tests__/conversation-evictor.test.ts
+++ b/assistant/src/__tests__/conversation-evictor.test.ts
@@ -29,7 +29,7 @@ describe("ConversationEvictor", () => {
       sessions as Map<string, EvictableConversation>,
       {
         ttlMs: 1000,
-        maxSessions: 3,
+        maxConversations: 3,
         memoryThresholdBytes: Number.MAX_SAFE_INTEGER, // disable memory pressure for most tests
         sweepIntervalMs: 60_000,
       },
@@ -87,8 +87,8 @@ describe("ConversationEvictor", () => {
   });
 
   describe("LRU eviction", () => {
-    test("evicts least-recently-used sessions when over maxSessions", () => {
-      // maxSessions = 3, add 5 sessions
+    test("evicts least-recently-used conversations when over maxConversations", () => {
+      // maxConversations = 3, add 5 sessions
       const allSessions: Array<EvictableConversation & { disposed: boolean }> =
         [];
       for (let i = 0; i < 5; i++) {
@@ -119,7 +119,7 @@ describe("ConversationEvictor", () => {
     });
 
     test("skips processing sessions during LRU eviction", () => {
-      // maxSessions = 3, add 4 sessions, one processing
+      // maxConversations = 3, add 4 sessions, one processing
       const s0 = createMockSession(true); // processing — should not be evicted
       const s1 = createMockSession();
       const s2 = createMockSession();

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -346,17 +346,17 @@ export async function startVoiceTurn(
   // Serialized publish chain so hub subscribers observe events in order.
   let hubChain: Promise<void> = Promise.resolve();
   const publishToHub = (msg: ServerMessage): void => {
-    // ServerMessage is a large union; sessionId exists on most but not all variants.
-    const msgSessionId =
-      "sessionId" in msg &&
-      typeof (msg as { sessionId?: unknown }).sessionId === "string"
-        ? (msg as { sessionId: string }).sessionId
+    // ServerMessage is a large union; conversationId exists on most but not all variants.
+    const msgConversationId =
+      "conversationId" in msg &&
+      typeof (msg as { conversationId?: unknown }).conversationId === "string"
+        ? (msg as { conversationId: string }).conversationId
         : undefined;
-    const resolvedSessionId = msgSessionId ?? opts.conversationId;
+    const resolvedConversationId = msgConversationId ?? opts.conversationId;
     const event = buildAssistantEvent(
       DAEMON_INTERNAL_ASSISTANT_ID,
       msg,
-      resolvedSessionId,
+      resolvedConversationId,
     );
     hubChain = (async () => {
       await hubChain;

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "../util/logger.js";
 
-const log = getLogger("session-evictor");
+const log = getLogger("conversation-evictor");
 
 /** Minimal interface a session must satisfy to be evictable. */
 export interface EvictableConversation {
@@ -9,71 +9,72 @@ export interface EvictableConversation {
 }
 
 export interface EvictorOptions {
-  /** Max idle time before a session is eligible for eviction (ms). Default: 30 min. */
+  /** Max idle time before a conversation is eligible for eviction (ms). Default: 30 min. */
   ttlMs?: number;
-  /** Max number of in-memory sessions before LRU eviction kicks in. Default: 100. */
-  maxSessions?: number;
-  /** RSS threshold (bytes) above which idle sessions are aggressively evicted. Default: 3 GB. */
+  /** Max number of in-memory conversations before LRU eviction kicks in. Default: 100. */
+  maxConversations?: number;
+  /** RSS threshold (bytes) above which idle conversations are aggressively evicted. Default: 3 GB. */
   memoryThresholdBytes?: number;
   /** Interval between periodic sweeps (ms). Default: 60 s. */
   sweepIntervalMs?: number;
 }
 
 export interface EvictionResult {
-  /** Sessions evicted because they exceeded TTL. */
+  /** Conversations evicted because they exceeded TTL. */
   ttlEvicted: number;
-  /** Sessions evicted because pool exceeded maxSessions (LRU order). */
+  /** Conversations evicted because pool exceeded maxConversations (LRU order). */
   lruEvicted: number;
-  /** Sessions evicted due to memory pressure. */
+  /** Conversations evicted due to memory pressure. */
   memoryEvicted: number;
-  /** Sessions skipped because they were actively processing. */
+  /** Conversations skipped because they were actively processing. */
   skipped: number;
 }
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
-const DEFAULT_MAX_SESSIONS = 100;
+const DEFAULT_MAX_CONVERSATIONS = 100;
 const DEFAULT_MEMORY_THRESHOLD_BYTES = 3072 * 1024 * 1024; // 3 GB
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000; // 60 seconds
 
 export class ConversationEvictor {
   private readonly ttlMs: number;
-  private readonly maxSessions: number;
+  private readonly maxConversations: number;
   private readonly memoryThresholdBytes: number;
   private readonly sweepIntervalMs: number;
 
-  /** Tracks last access time per session ID. */
+  /** Tracks last access time per conversation ID. */
   private lastAccess = new Map<string, number>();
 
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
-  private sessions: Map<string, EvictableConversation>;
+  private conversations: Map<string, EvictableConversation>;
 
-  /** Optional hook called for each evicted session (for cleanup in DaemonServer). */
-  onEvict?: (sessionId: string) => void;
+  /** Optional hook called for each evicted conversation (for cleanup in DaemonServer). */
+  onEvict?: (conversationId: string) => void;
 
-  /** Optional guard: if this returns true, the session is protected from eviction. */
-  shouldProtect?: (sessionId: string) => boolean;
+  /** Optional guard: if this returns true, the conversation is protected from eviction. */
+  shouldProtect?: (conversationId: string) => boolean;
 
   constructor(
-    sessions: Map<string, EvictableConversation>,
+    conversations: Map<string, EvictableConversation>,
     options?: EvictorOptions,
   ) {
-    this.sessions = sessions;
+    this.conversations = conversations;
     this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
-    this.maxSessions = options?.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.maxConversations =
+      options?.maxConversations ?? DEFAULT_MAX_CONVERSATIONS;
     this.memoryThresholdBytes =
       options?.memoryThresholdBytes ?? DEFAULT_MEMORY_THRESHOLD_BYTES;
     this.sweepIntervalMs =
       options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
   }
 
-  /** Record an access for the given session (resets its idle clock). */
-  touch(sessionId: string): void {
-    this.lastAccess.set(sessionId, Date.now());
+  /** Record an access for the given conversation (resets its idle clock). */
+  touch(conversationId: string): void {
+    this.lastAccess.set(conversationId, Date.now());
   }
 
-  /** Remove tracking state for a session that was externally removed. */
-  remove(sessionId: string): void {
-    this.lastAccess.delete(sessionId);
+  /** Remove tracking state for a conversation that was externally removed. */
+  remove(conversationId: string): void {
+    this.lastAccess.delete(conversationId);
   }
 
   /** Start the periodic sweep timer. */
@@ -115,8 +116,8 @@ export class ConversationEvictor {
       skipped: 0,
     };
 
-    // Phase 1: TTL eviction — remove sessions idle longer than ttlMs.
-    for (const [id, session] of this.sessions) {
+    // Phase 1: TTL eviction — remove conversations idle longer than ttlMs.
+    for (const [id, session] of this.conversations) {
       const lastAccessTime = this.lastAccess.get(id) ?? 0;
       if (now - lastAccessTime < this.ttlMs) continue;
       if (session.isProcessing() || this.shouldProtect?.(id)) {
@@ -128,29 +129,29 @@ export class ConversationEvictor {
     }
 
     // Phase 2: LRU eviction — if still over capacity, evict least-recently-used.
-    if (this.sessions.size > this.maxSessions) {
-      const sorted = this.idleSessionsByLru();
+    if (this.conversations.size > this.maxConversations) {
+      const sorted = this.idleConversationsByLru();
       for (const [id, session] of sorted) {
-        if (this.sessions.size <= this.maxSessions) break;
+        if (this.conversations.size <= this.maxConversations) break;
         this.evict(id, session);
         result.lruEvicted++;
       }
     }
 
-    // Phase 3: Memory pressure — if RSS exceeds threshold, evict idle sessions
+    // Phase 3: Memory pressure — if RSS exceeds threshold, evict idle conversations
     // starting from least-recently-used until we're under the threshold or
-    // no more idle sessions remain.
+    // no more idle conversations remain.
     const rss = process.memoryUsage.rss();
     if (rss > this.memoryThresholdBytes) {
-      const sorted = this.idleSessionsByLru();
+      const sorted = this.idleConversationsByLru();
       if (sorted.length > 0) {
         log.warn(
           {
             rssBytes: rss,
             thresholdBytes: this.memoryThresholdBytes,
-            sessionCount: this.sessions.size,
+            conversationCount: this.conversations.size,
           },
-          "Memory pressure detected, evicting idle sessions",
+          "Memory pressure detected, evicting idle conversations",
         );
         for (const [id, session] of sorted) {
           if (process.memoryUsage.rss() <= this.memoryThresholdBytes) break;
@@ -160,10 +161,10 @@ export class ConversationEvictor {
       }
     }
 
-    // Clean up stale lastAccess entries for sessions that no longer exist
-    // (e.g. removed by clearAllConversations or evictSessionsForReload).
+    // Clean up stale lastAccess entries for conversations that no longer exist
+    // (e.g. removed by clearAllConversations or evictConversationsForReload).
     for (const id of this.lastAccess.keys()) {
-      if (!this.sessions.has(id)) {
+      if (!this.conversations.has(id)) {
         this.lastAccess.delete(id);
       }
     }
@@ -171,7 +172,7 @@ export class ConversationEvictor {
     return result;
   }
 
-  /** Current number of tracked sessions (for diagnostics). */
+  /** Current number of tracked conversations (for diagnostics). */
   get trackedCount(): number {
     return this.lastAccess.size;
   }
@@ -180,19 +181,19 @@ export class ConversationEvictor {
 
   private evict(id: string, session: EvictableConversation): void {
     session.dispose();
-    this.sessions.delete(id);
+    this.conversations.delete(id);
     this.lastAccess.delete(id);
     this.onEvict?.(id);
-    log.debug({ sessionId: id }, "Evicted idle session");
+    log.debug({ conversationId: id }, "Evicted idle conversation");
   }
 
   /**
-   * Return idle (non-processing) sessions sorted by last access time
+   * Return idle (non-processing) conversations sorted by last access time
    * ascending (least recently used first).
    */
-  private idleSessionsByLru(): Array<[string, EvictableConversation]> {
+  private idleConversationsByLru(): Array<[string, EvictableConversation]> {
     const idle: Array<[string, EvictableConversation, number]> = [];
-    for (const [id, session] of this.sessions) {
+    for (const [id, session] of this.conversations) {
       if (session.isProcessing()) continue;
       if (this.shouldProtect?.(id)) continue;
       idle.push([id, session, this.lastAccess.get(id) ?? 0]);

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -35,7 +35,7 @@ import type {
   UserMessageAttachment,
 } from "./message-protocol.js";
 
-const log = getLogger("session-messaging");
+const log = getLogger("conversation-messaging");
 
 interface IngressSecretTarget {
   service: string;
@@ -166,7 +166,7 @@ function resolveIngressSecretTarget(
 
 // ── Context Interface ────────────────────────────────────────────────
 
-export interface MessagingSessionContext {
+export interface MessagingConversationContext {
   readonly conversationId: string;
   messages: Message[];
   processing: boolean;
@@ -205,7 +205,7 @@ function extractTurnInterfaceContext(
 // ── enqueueMessage ───────────────────────────────────────────────────
 
 export function enqueueMessage(
-  ctx: MessagingSessionContext,
+  ctx: MessagingConversationContext,
   content: string,
   attachments: UserMessageAttachment[],
   onEvent: (msg: ServerMessage) => void,
@@ -256,7 +256,7 @@ export function enqueueMessage(
 // ── persistUserMessage ───────────────────────────────────────────────
 
 export async function persistUserMessage(
-  ctx: MessagingSessionContext,
+  ctx: MessagingConversationContext,
   content: string,
   attachments: UserMessageAttachment[],
   requestId?: string,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -154,8 +154,8 @@ export interface HandlerContext {
     conversationId: string,
     options?: ConversationCreateOptions,
   ): Promise<Conversation>;
-  /** Refresh the eviction timestamp for a session that was accessed directly. */
-  touchConversation(sessionId: string): void;
+  /** Refresh the eviction timestamp for a conversation that was accessed directly. */
+  touchConversation(conversationId: string): void;
   /** Optional heartbeat service reference for "Run Now" support. */
   heartbeatService?: HeartbeatService;
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -577,15 +577,17 @@ export async function runDaemon(): Promise<void> {
           renameConversation(conversationId, name),
         clearAllConversations: () =>
           clearAllConversations(server.getHandlerContext()),
-        cancelGeneration: (sessionId) =>
-          cancelGeneration(sessionId, server.getHandlerContext()),
-        destroyConversation: (sessionId) => server.destroySession(sessionId),
-        undoLastMessage: (sessionId) =>
-          undoLastMessage(sessionId, server.getHandlerContext()),
-        regenerateResponse: (sessionId) => {
+        cancelGeneration: (conversationId) =>
+          cancelGeneration(conversationId, server.getHandlerContext()),
+        destroyConversation: (conversationId) =>
+          server.destroyConversation(conversationId),
+        undoLastMessage: (conversationId) =>
+          undoLastMessage(conversationId, server.getHandlerContext()),
+        regenerateResponse: (conversationId) => {
           // Resolve conversation key up front so SSE events are tagged with
           // the internal conversation ID, not the raw client key.
-          const resolvedId = resolveConversationId(sessionId) ?? sessionId;
+          const resolvedId =
+            resolveConversationId(conversationId) ?? conversationId;
           let hubChain: Promise<void> = Promise.resolve();
           const sendEvent = (event: ServerMessage) => {
             const ae = buildAssistantEvent(
@@ -606,7 +608,7 @@ export async function runDaemon(): Promise<void> {
             })();
           };
           return regenerateResponse(
-            sessionId,
+            conversationId,
             server.getHandlerContext(),
             sendEvent,
           );

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -484,7 +484,7 @@ export class DaemonServer {
     });
 
     this.configWatcher.start(
-      () => this.evictSessionsForReload(),
+      () => this.evictConversationsForReload(),
       () => this.broadcastIdentityChanged(),
     );
 
@@ -636,10 +636,10 @@ export class DaemonServer {
   }
 
   /**
-   * Abort and dispose a single in-memory session, removing it from the session
-   * map. No-op if no session exists for the given ID.
+   * Abort and dispose a single in-memory conversation, removing it from the
+   * conversation map. No-op if no conversation exists for the given ID.
    */
-  destroySession(conversationId: string): void {
+  destroyConversation(conversationId: string): void {
     const session = this.conversations.get(conversationId);
     if (!session) return;
     this.evictor.remove(conversationId);
@@ -649,7 +649,7 @@ export class DaemonServer {
     this.sessionOptions.delete(conversationId);
   }
 
-  private evictSessionsForReload(): void {
+  private evictConversationsForReload(): void {
     const subagentManager = getSubagentManager();
     for (const [id, session] of this.conversations) {
       if (!session.isProcessing()) {
@@ -673,7 +673,7 @@ export class DaemonServer {
 
   async refreshConfigFromSources(): Promise<boolean> {
     const changed = await this.configWatcher.refreshConfigFromSources();
-    if (changed) this.evictSessionsForReload();
+    if (changed) this.evictConversationsForReload();
     return changed;
   }
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -93,18 +93,17 @@ export async function closeSentry(): Promise<void> {
   await Sentry.close();
 }
 
-// ── Dynamic session-scoped Sentry tags ──────────────────────────────
+// ── Dynamic conversation-scoped Sentry tags ─────────────────────────
 //
 // These tags change per conversation turn and are set on the current
 // Sentry scope before the agent loop runs. Any `Sentry.captureException`
 // call within that async execution chain (e.g. inside agent/loop.ts)
-// will inherit these tags, enabling filtering by conversation, session,
-// user, or assistant in the Sentry dashboard.
+// will inherit these tags, enabling filtering by conversation, user, or
+// assistant in the Sentry dashboard.
 
 /** Tag keys set by {@link setSentryConversationContext}. */
 const CONVERSATION_TAG_KEYS = [
   "assistant_id",
-  "conversation_id",
   "conversation_id",
   "message_count",
   "user_identifier",
@@ -113,7 +112,7 @@ const CONVERSATION_TAG_KEYS = [
 export interface SentryConversationContext {
   /** Internal assistant ID (daemon uses 'self'). */
   assistantId: string;
-  /** Conversation/session identifier. */
+  /** Conversation identifier. */
   conversationId: string;
   /** Number of messages in the conversation at time of the turn. */
   messageCount: number;
@@ -122,18 +121,15 @@ export interface SentryConversationContext {
 }
 
 /**
- * Set session-scoped tags on the current Sentry scope.
+ * Set conversation-scoped tags on the current Sentry scope.
  *
  * Call at the start of each agent loop turn so that any exceptions
- * captured within the turn include conversation/session context.
+ * captured within the turn include conversation context.
  */
 export function setSentryConversationContext(
   ctx: SentryConversationContext,
 ): void {
   Sentry.setTag("assistant_id", ctx.assistantId);
-  Sentry.setTag("conversation_id", ctx.conversationId);
-  // session_id mirrors conversation_id — in this codebase they are the
-  // same value, but downstream Sentry users may search by either name.
   Sentry.setTag("conversation_id", ctx.conversationId);
   Sentry.setTag("message_count", String(ctx.messageCount));
   if (ctx.userIdentifier) {
@@ -142,7 +138,7 @@ export function setSentryConversationContext(
 }
 
 /**
- * Clear session-scoped tags from the current Sentry scope.
+ * Clear conversation-scoped tags from the current Sentry scope.
  *
  * Call in the finally block after the agent loop completes so tags
  * from one conversation do not leak into unrelated error captures.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for conv-unify-symbols.md.

- Removes duplicate Sentry conversation_id tag and stale session_id comment
- Renames MessagingSessionContext → MessagingConversationContext
- Renames conversation-evictor.ts internal session terminology
- Renames server.ts destroySession/evictSessionsForReload methods
- Fixes HandlerContext.touchConversation param name
- Fixes lifecycle.ts lambda param names
- Fixes voice-session-bridge stale sessionId check
- Fixes channel-guardian.test.ts mock property names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
