### PR TITLE
fix: capture actor token before logout to ensure daemon credential cleanup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -138,10 +138,13 @@ extension AppDelegate {
             // Capture assistant ID before logout clears it from UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
+            // Capture actor token before logout clears session state
+            let actorToken = ActorTokenManager.getToken()
+
             await authManager.logout()
 
             // Clear managed proxy credentials from the running daemon
-            if let token = ActorTokenManager.getToken(), !token.isEmpty {
+            if let token = actorToken, !token.isEmpty {
                 let assistantId = connectedAssistantId ?? ""
                 let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
                 let daemonBaseURL = "http://localhost:\(port)"
@@ -149,6 +152,8 @@ extension AppDelegate {
                     daemonBaseURL: daemonBaseURL,
                     daemonToken: token
                 )
+            } else {
+                log.warning("No actor token available during logout — skipping daemon credential cleanup")
             }
 
             // Clear the locally-cached credential from Keychain


### PR DESCRIPTION
## Summary
- Captures the actor token **before** `authManager.logout()` so logout side effects can't nil-out the token and silently skip daemon credential cleanup.
- Adds a log warning when no actor token is available during logout, making the skip visible in diagnostics.

## Test plan
- [ ] Log out while authenticated and verify daemon credentials are cleared (check logs for `clearDaemonCredentials` call)
- [ ] Log out with no actor token and verify the warning log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
