### PR TITLE
fix: bootstrap billing account for fresh organizations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -81,7 +81,13 @@ struct DrawerMenuView: View {
     private func loadBalance() async {
         guard authManager.isAuthenticated else { return }
         do {
-            let summary = try await BillingService.shared.getBillingSummary()
+            var summary = try await BillingService.shared.getBillingSummary()
+            // Bootstrap billing for pre-billing orgs with all-zero balances
+            if summary.effective_balance_usd == "0.00" && summary.settled_balance_usd == "0.00" && summary.pending_compute_usd == "0.00" {
+                if let bootstrapped = try? await BillingService.shared.bootstrapBillingSummary() {
+                    summary = bootstrapped
+                }
+            }
             let balanceString = summary.effective_balance_usd
             effectiveBalance = balanceString
             if let value = Double(balanceString) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -152,7 +152,14 @@ struct SettingsBillingTab: View {
         isLoading = true
         error = nil
         do {
-            summary = try await BillingService.shared.getBillingSummary()
+            var result = try await BillingService.shared.getBillingSummary()
+            // Bootstrap billing for pre-billing orgs with all-zero balances
+            if result.effective_balance_usd == "0.00" && result.settled_balance_usd == "0.00" && result.pending_compute_usd == "0.00" {
+                if let bootstrapped = try? await BillingService.shared.bootstrapBillingSummary() {
+                    result = bootstrapped
+                }
+            }
+            summary = result
         } catch {
             self.error = "Unable to load billing information. Please try again."
         }

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -60,6 +60,59 @@ public final class BillingService {
         }
     }
 
+    /// Bootstrap billing for organizations that don't have a BillingAccount yet.
+    /// Calling POST on the summary endpoint creates the account with initial credit.
+    public func bootstrapBillingSummary() async throws -> BillingSummaryResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/summary/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST organizations/billing/summary/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(BillingSummaryResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     /// Create a top-up checkout session and return the Stripe checkout URL.
     public func createTopUpCheckout(amountUsd: String) async throws -> URL {
         let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/top-ups/checkout-session/"


### PR DESCRIPTION
## Summary
- Adds `bootstrapBillingSummary()` POST method to `BillingService` that creates the BillingAccount with initial credit for fresh organizations
- Updates `SettingsBillingTab.loadSummary()` and `DrawerMenuView.loadBalance()` to detect all-zero balances and bootstrap billing automatically
- Fixes fresh signed-in users seeing $0.00 instead of their initial credit

## Test plan
- [ ] Sign in with a fresh organization that has never had billing bootstrapped
- [ ] Verify the billing tab and drawer menu show the initial credit instead of $0.00
- [ ] Verify existing organizations with non-zero balances are unaffected (bootstrap is skipped)
- [ ] Verify bootstrap failure is silently handled (falls back to showing the original GET result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
