### PR TITLE
fix: add Coming Soon Local Docker and VPS hosting modes to onboarding selector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -84,6 +84,21 @@ struct APIKeyStepView: View {
                 comingSoon: false
             )
 
+            hostingCard(
+                icon: .package,
+                title: "Local Docker",
+                subtitle: "Run in a Docker container",
+                mode: .localDocker,
+                comingSoon: true
+            )
+
+            hostingCard(
+                icon: .globe,
+                title: "VPS",
+                subtitle: "Run on a remote server",
+                mode: .vps,
+                comingSoon: true
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -46,6 +46,8 @@ final class OnboardingState {
     enum HostingMode: String {
         case vellumCloud = "vellum-cloud"
         case local = "local"
+        case localDocker = "local-docker"
+        case vps = "vps"
     }
     var hasHatched: Bool = false
     var interviewCompleted: Bool = false


### PR DESCRIPTION
## Summary
- Adds `localDocker` and `vps` cases to the `HostingMode` enum in `OnboardingState.swift`
- Adds two new disabled hosting cards ("Local Docker" and "VPS") with "Coming Soon" badges to the onboarding hosting selector in `APIKeyStepView.swift`
- Uses `.package` icon for Local Docker and `.globe` icon for VPS (closest available Lucide icons)

## Test plan
- [ ] Verify the onboarding hosting selector displays all four cards: Vellum Cloud, Local, Local Docker, and VPS
- [ ] Verify Local Docker and VPS cards show "Coming Soon" badges and are not selectable
- [ ] Verify the Local card remains selectable and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
