### PR TITLE
test: add regression test for 402 credits_exhausted classification

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -395,6 +395,14 @@ describe("classifySessionError", () => {
       expect(result.retryable).toBe(false);
     });
 
+    it("classifies ProviderError with 402 as credits_exhausted (non-retryable)", () => {
+      const err = new ProviderError("Payment Required", "anthropic", 402);
+      const result = classifySessionError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("credits_exhausted");
+      expect(result.retryable).toBe(false);
+    });
+
     it("classifies ProviderError with 400 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Bad request", "anthropic", 400);
       const result = classifySessionError(err, baseCtx);


### PR DESCRIPTION
## Summary
- Adds a regression test verifying that `ProviderError` with HTTP 402 is classified as `PROVIDER_BILLING` with `errorCategory: "credits_exhausted"` and is non-retryable.

## Test plan
- [x] `bun test src/__tests__/conversation-error.test.ts` passes (81 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
