### PR TITLE
fix: align code content to top-left in read-only file viewer pane

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -42,7 +42,7 @@ struct ReadOnlyCodeContent: View {
                 .textSelection(.enabled)
                 .fixedSize(horizontal: true, vertical: false)
                 .padding(VSpacing.md)
-                .frame(alignment: .topLeading)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `ReadOnlyCodeContent` in `SharedFileViewerComponents.swift` to align code to top-left instead of center
- The `.frame(alignment: .topLeading)` modifier had no effect without `maxWidth`/`maxHeight` — added `maxWidth: .infinity, maxHeight: .infinity` so the frame expands and alignment takes effect

## Original prompt
help fix the fact that the code in the right pane is centered. It should be aligned top left of its container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
