### PR TITLE
fix: render credits-exhausted banner inline in chat instead of as overlay toast

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -80,6 +80,15 @@ struct ChatView: View {
     /// Called to dismiss the btw overlay.
     var onDismissBtw: (() -> Void)?
 
+    // MARK: - Credits Exhausted (inline banner)
+
+    /// Non-nil when the conversation ended due to credits exhaustion.
+    var creditsExhaustedError: ConversationError? = nil
+    /// Opens the billing / add-funds flow.
+    var onAddFunds: (() -> Void)? = nil
+    /// Dismisses the credits-exhausted banner.
+    var onDismissCreditsExhausted: (() -> Void)? = nil
+
     // MARK: - Pagination
 
     var displayedMessageCount: Int = .max
@@ -218,6 +227,9 @@ struct ChatView: View {
                             onSurfaceRefetch: onSurfaceRefetch,
                             onRetryFailedMessage: onRetryFailedMessage,
                             subagentDetailStore: subagentDetailStore,
+                            creditsExhaustedError: creditsExhaustedError,
+                            onAddFunds: onAddFunds,
+                            onDismissCreditsExhausted: onDismissCreditsExhausted,
                             displayedMessageCount: displayedMessageCount,
                             hasMoreMessages: hasMoreMessages,
                             isLoadingMoreMessages: isLoadingMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -83,6 +83,15 @@ struct MessageListView: View {
     var onRetryFailedMessage: ((UUID) -> Void)?
     var subagentDetailStore: SubagentDetailStore
 
+    // MARK: - Credits Exhausted (inline banner)
+
+    /// Non-nil when the conversation ended due to credits exhaustion.
+    var creditsExhaustedError: ConversationError? = nil
+    /// Opens the billing / add-funds flow.
+    var onAddFunds: (() -> Void)? = nil
+    /// Dismisses the credits-exhausted banner.
+    var onDismissCreditsExhausted: (() -> Void)? = nil
+
     // MARK: - Pagination
 
     /// Number of messages the view currently displays (suffix window size).
@@ -678,6 +687,16 @@ struct MessageListView: View {
                         }
                     } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                         compactingIndicatorRow()
+                    }
+
+                    // Inline credits-exhausted recovery banner
+                    if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
+                        CreditsExhaustedBanner(
+                            onAddFunds: { onAddFunds?() },
+                            onDismiss: { onDismissCreditsExhausted?() }
+                        )
+                        .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
 
                     Color.clear

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -343,12 +343,6 @@ struct MainWindowView: View {
         return false
     }
 
-    /// Navigates to the Billing settings tab.
-    private func openBillingSettings() {
-        settingsStore.pendingSettingsTab = .billing
-        windowState.selection = .panel(.settings)
-    }
-
     /// Top bar extracted to break up type-checker complexity.
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
@@ -610,7 +604,6 @@ struct MainWindowView: View {
                         onRetryConversationError: { viewModel.retryAfterConversationError() },
                         onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
                         onDismissConversationError: { viewModel.dismissConversationError() },
-                        onAddFunds: { openBillingSettings() },
                         onSendAnyway: { viewModel.sendAnyway() },
                         onRetryLastMessage: { viewModel.retryLastMessage() },
                         onDismissError: { viewModel.dismissError() }
@@ -879,7 +872,6 @@ private struct ErrorToastOverlay: View {
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
     let onDismissConversationError: () -> Void
-    let onAddFunds: () -> Void
     let onSendAnyway: () -> Void
     let onRetryLastMessage: () -> Void
     let onDismissError: () -> Void
@@ -898,23 +890,15 @@ private struct ErrorToastOverlay: View {
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
-            if let conversationError = errorManager.conversationError {
-                if conversationError.isCreditsExhausted {
-                    CreditsExhaustedBanner(
-                        onAddFunds: onAddFunds,
-                        onDismiss: onDismissConversationError
-                    )
-                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-                } else {
-                    ChatConversationErrorToast(
-                        error: conversationError,
-                        onRetry: onRetryConversationError,
-                        onCopyDebugInfo: onCopyDebugInfo,
-                        onDismiss: onDismissConversationError
-                    )
-                    .fixedSize(horizontal: true, vertical: false)
-                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-                }
+            if let conversationError = errorManager.conversationError, !conversationError.isCreditsExhausted {
+                ChatConversationErrorToast(
+                    error: conversationError,
+                    onRetry: onRetryConversationError,
+                    onCopyDebugInfo: onCopyDebugInfo,
+                    onDismiss: onDismissConversationError
+                )
+                .fixedSize(horizontal: true, vertical: false)
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
             if let errorText = errorManager.errorText, errorManager.conversationError == nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -699,6 +699,12 @@ struct ActiveChatViewWrapper: View {
             btwResponse: viewModel.btwResponse,
             btwLoading: viewModel.btwLoading,
             onDismissBtw: { viewModel.dismissBtw() },
+            creditsExhaustedError: viewModel.errorManager.conversationError?.isCreditsExhausted == true ? viewModel.errorManager.conversationError : nil,
+            onAddFunds: {
+                settingsStore.pendingSettingsTab = .billing
+                windowState.selection = .panel(.settings)
+            },
+            onDismissCreditsExhausted: { viewModel.dismissConversationError() },
             displayedMessageCount: viewModel.displayedMessageCount,
             hasMoreMessages: viewModel.hasMoreMessages,
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,


### PR DESCRIPTION
## Summary
- Moves the `CreditsExhaustedBanner` from the `ErrorToastOverlay` (floating overlay at the top of the chat area in `MainWindowView`) to an inline element at the bottom of the chat message list in `MessageListView`
- The banner now appears within the scrollable conversation stream, after the last message and before the scroll anchor, matching the plan for an inline recovery banner
- Removes the now-unused `openBillingSettings()` helper and `onAddFunds` parameter from `ErrorToastOverlay`

## Test plan
- [ ] Trigger a credits-exhausted error and verify the banner appears inline at the bottom of the chat conversation
- [ ] Verify the "Add Funds" button opens the billing settings panel
- [ ] Verify the dismiss button removes the banner
- [ ] Verify non-credits-exhausted conversation errors still appear as overlay toasts at the top
- [ ] Verify the banner scrolls with the chat content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
