### PR TITLE
fix: rename remaining session symbols in VoiceBridgeDeps, http-types, and AppDelegate

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -366,7 +366,7 @@ describe("relay-server", () => {
     mockConfig.calls.verification.codeLength = 6;
     mockConfig.calls.callerIdentity.userNumber = undefined;
     setVoiceBridgeDeps({
-      getOrCreateSession: async (conversationId) => {
+      getOrCreateConversation: async (conversationId) => {
         const session = {
           callSessionId: undefined as string | undefined,
           currentRequestId: undefined as string | undefined,

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -224,7 +224,7 @@ function setupBridgeDeps(
   let currentSession: ReturnType<typeof createMockSession>["session"] | null =
     null;
   setVoiceBridgeDeps({
-    getOrCreateSession: async () => {
+    getOrCreateConversation: async () => {
       currentSession = sessionFactory();
       return currentSession as any;
     },

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -92,7 +92,7 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
  */
 function injectDeps(sessionFactory: () => Conversation): void {
   setVoiceBridgeDeps({
-    getOrCreateSession: async () => sessionFactory(),
+    getOrCreateConversation: async () => sessionFactory(),
     resolveAttachments: () => [],
     deriveDefaultStrictSideEffects: () => false,
   });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -36,7 +36,7 @@ const log = getLogger("voice-session-bridge");
 // ---------------------------------------------------------------------------
 
 export interface VoiceBridgeDeps {
-  getOrCreateSession: (
+  getOrCreateConversation: (
     conversationId: string,
     transport?: {
       channelId: ChannelId;
@@ -291,7 +291,10 @@ export async function startVoiceTurn(
   const transport = {
     channelId: "phone" as ChannelId,
   };
-  const session = await deps.getOrCreateSession(opts.conversationId, transport);
+  const session = await deps.getOrCreateConversation(
+    opts.conversationId,
+    transport,
+  );
 
   if (session.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait briefly for the

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -2,7 +2,7 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-evictor");
 
-/** Minimal interface a session must satisfy to be evictable. */
+/** Minimal interface a conversation must satisfy to be evictable. */
 export interface EvictableConversation {
   isProcessing(): boolean;
   dispose(): void;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -645,7 +645,7 @@ export async function runDaemon(): Promise<void> {
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.
     // The bridge must be available even when the HTTP server fails to bind.
     setVoiceBridgeDeps({
-      getOrCreateSession: (conversationId, _transport) =>
+      getOrCreateConversation: (conversationId, _transport) =>
         server.getConversationForMessages(conversationId),
       resolveAttachments: (attachmentIds) =>
         attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1133,14 +1133,14 @@ export class DaemonServer {
   }
 
   /**
-   * Look up an active session by ID without creating one.
+   * Look up an active conversation by ID without creating one.
    */
   findConversation(conversationId: string): Conversation | undefined {
     return this.conversations.get(conversationId);
   }
 
   /**
-   * Look up an active session that owns a given surfaceId.
+   * Look up an active conversation that owns a given surfaceId.
    */
   findConversationBySurfaceId(surfaceId: string): Conversation | undefined {
     for (const s of this.conversations.values()) {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -181,8 +181,8 @@ export interface RuntimeHttpServerOptions {
   sendMessageDeps?: SendMessageDeps;
   /** Context provider for skill management HTTP routes. */
   getSkillContext?: () => SkillOperationContext;
-  /** Lookup an active session by ID (for surface actions and content fetches). */
-  findConversation?: (sessionId: string) =>
+  /** Lookup an active conversation by ID (for surface actions and content fetches). */
+  findConversation?: (conversationId: string) =>
     | {
         handleSurfaceAction(
           surfaceId: string,
@@ -203,7 +203,7 @@ export interface RuntimeHttpServerOptions {
         removeQueuedMessage?: (requestId: string) => boolean;
       }
     | undefined;
-  /** Lookup an active session by surfaceId (fallback when sessionId is absent). */
+  /** Lookup an active conversation by surfaceId (fallback when conversationId is absent). */
   findConversationBySurfaceId?: (surfaceId: string) =>
     | {
         handleSurfaceAction(

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -197,7 +197,7 @@ extension AppDelegate {
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+N as a local shortcut to create a new thread.
+    /// Registers Cmd+N as a local shortcut to create a new conversation.
     func registerCmdNMonitor() {
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -207,7 +207,7 @@ extension AppDelegate {
             }
             Task { @MainActor in
                 guard self?.isBootstrapping != true else { return }
-                self?.createNewThread()
+                self?.createNewConversation()
             }
             return nil
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -428,7 +428,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     public func performZoomOut() { zoomManager.zoomOut() }
     public func performZoomReset() { zoomManager.resetZoom() }
 
-    public func createNewThread() {
+    public func createNewConversation() {
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
     }


### PR DESCRIPTION
## Summary
Fixes round 2 gaps from plan review for conv-unify-symbols.md.

- Renames VoiceBridgeDeps.getOrCreateSession to getOrCreateConversation
- Fixes findConversation callback param name sessionId to conversationId
- Renames AppDelegate.createNewThread() to createNewConversation()
- Updates stale comments in http-types, server.ts, conversation-evictor.ts

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
