### PR TITLE
fix: align code content to top-left in read-only file viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -35,14 +35,20 @@ struct ReadOnlyCodeContent: View {
     let content: String
 
     var body: some View {
-        ScrollView([.vertical, .horizontal]) {
-            Text(content)
-                .font(VFont.mono)
-                .foregroundColor(VColor.contentDefault)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: true, vertical: false)
-                .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        GeometryReader { geometry in
+            ScrollView([.vertical, .horizontal]) {
+                Text(content)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .padding(VSpacing.md)
+                    .frame(
+                        minWidth: geometry.size.width,
+                        minHeight: geometry.size.height,
+                        alignment: .topLeading
+                    )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `ReadOnlyCodeContent` to align code to top-left instead of center in the Skills/Workspace file viewer pane
- Wrap the ScrollView in a `GeometryReader` and set `minWidth`/`minHeight` on the content to the viewport size with `.topLeading` alignment — this ensures small files pin to the top-left instead of being centered by the ScrollView

## Original prompt
help fix the fact that the code in the right pane is centered. It should be aligned top left of its container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
