### PR TITLE
fix: enable billing settings tab by default so Add Funds CTA is reachable

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -143,7 +143,7 @@
       "key": "settings_billing_enabled",
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "managed-sign-in",


### PR DESCRIPTION
## Summary
- Changes the `settings-billing` feature flag default from `false` to `true` in the feature flag registry.
- The platform already enforces 402s on depleted balances and surfaces an "Add Funds" CTA that navigates to Settings. With the billing tab disabled by default, users hit a dead end. Enabling it by default makes the billing tab reachable.

## Test plan
- [ ] Verify the billing tab appears in Settings for signed-in users without any feature flag override.
- [ ] Verify the "Add Funds" CTA from a 402 error leads to the billing tab in Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
