### PR TITLE
fix: clear keychain credentials for all local assistants on logout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -156,10 +156,16 @@ extension AppDelegate {
                 log.warning("No actor token available during logout — skipping daemon credential cleanup")
             }
 
-            // Clear the locally-cached credential from Keychain
+            // Clear locally-cached credentials from Keychain for all local assistants
+            let keychainStorage = KeychainCredentialStorage()
+            for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
+                let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistant.assistantId)
+                _ = keychainStorage.delete(account: credentialAccount)
+            }
+            // Also clear for the connected assistant in case it's not in the lockfile
             if let assistantId = connectedAssistantId {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistantId)
-                _ = KeychainCredentialStorage().delete(account: credentialAccount)
+                _ = keychainStorage.delete(account: credentialAccount)
             }
 
             // Reset dock icon to default before tearing down UI


### PR DESCRIPTION
## Summary
- On logout, only the currently-connected assistant's keychain credential was cleared. Stale keys for other local assistants persisted and could be reused on subsequent login as a different user/org, routing requests through the wrong account.
- Now iterates all lockfile assistants and clears credentials for every local (non-remote, non-managed) entry, plus the connected assistant as a fallback in case it's not in the lockfile.

## Test plan
- [ ] Log in, bootstrap multiple local assistants, switch between them to populate keychain entries
- [ ] Log out and verify all local assistant keychain credentials are cleared (check Keychain Access)
- [ ] Log back in as a different user/org and verify no stale credentials are reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
