### PR TITLE
fix: stop daemon on logout when actor token is unavailable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -153,7 +153,9 @@ extension AppDelegate {
                     daemonToken: token
                 )
             } else {
-                log.warning("No actor token available during logout — skipping daemon credential cleanup")
+                log.warning("No actor token available during logout — stopping daemon to ensure stale credentials are not retained")
+                daemonClient.disconnect()
+                assistantCli.stop()
             }
 
             // Clear locally-cached credentials from Keychain for all local assistants


### PR DESCRIPTION
## Summary
- When `performLogout()` can't find the actor token needed to authenticate daemon credential cleanup, it now stops the daemon process entirely via `daemonClient.disconnect()` + `assistantCli.stop()`
- This ensures stale managed proxy credentials (`vellum:assistant_api_key`, `vellum:platform_base_url`, `vellum:platform_assistant_id`) are never retained across logout/login cycles
- The daemon will restart fresh on next login, guaranteeing a clean credential state

## Original prompt
In `AppDelegate+AuthLifecycle.swift`, the `performLogout()` method skips daemon credential cleanup entirely when the actor token is missing (line 147). Even though this is a narrow edge case, we should handle it for defense in depth. When the token is missing, stop the daemon so it starts fresh on next login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)