### PR TITLE
fix: surface bootstrap failures to user after Settings sign-in

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -290,6 +290,10 @@ extension AppDelegate {
                 }
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
+                self.mainWindow?.windowState.showToast(
+                    message: "Failed to set up Vellum credentials. You may need to sign out and sign in again.",
+                    style: .error
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Surface bootstrap failures to the user after Settings sign-in instead of silently logging them
- When `ensureLocalAssistantApiKey()` fails, show a visible error toast so the user knows their Vellum credentials weren't provisioned

## Original prompt
Fix: Bootstrap failures are invisible to the user, so the app can look "signed in" without actually being provisioned for local Vellum-backed usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
