### PR TITLE
fix: refresh provider routing sources after Settings sign-in

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -300,6 +300,13 @@ struct SettingsPanel: View {
         case .general:
             SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, onSignIn: {
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
+                // Refresh routing sources after bootstrap has time to inject credentials
+                Task {
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    await MainActor.run {
+                        store.loadProviderRoutingSources()
+                    }
+                }
             })
         case .modelsAndServices:
             integrationsContent


### PR DESCRIPTION
## Summary
- Refresh provider routing sources after Settings sign-in so the "Managed by Vellum" badge updates without requiring a panel reopen
- Adds a delayed `loadProviderRoutingSources()` call in the `onSignIn` callback to give the bootstrap and daemon time to complete

## Original prompt
Fix: The Models & Services "Managed by Vellum" state can stay stale after Settings sign-in because the sign-in path never refreshes provider routing sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
