### PR TITLE
fix: set unread badge on schedule and task-run conversation creation

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -292,7 +292,8 @@ class IOSConversationStore: ObservableObject {
             let conversation = IOSConversation(
                 title: msg.title,
                 conversationId: msg.conversationId,
-                scheduleJobId: msg.scheduleJobId
+                scheduleJobId: msg.scheduleJobId,
+                hasUnseenLatestAssistantMessage: true
             )
             // Remove the empty placeholder conversation if it's still present (race:
             // schedule_conversation_created can arrive before the first conversation_list_response).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -439,7 +439,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return
         }
 
-        let thread = ConversationModel(title: title, conversationId: conversationId)
+        var thread = ConversationModel(title: title, conversationId: conversationId)
+        thread.hasUnseenLatestAssistantMessage = true
         let viewModel = makeViewModel()
         viewModel.conversationId = conversationId
         // Mark history as loaded since this thread streams live — there is no
@@ -473,6 +474,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         var thread = ConversationModel(title: title, conversationId: conversationId)
         thread.scheduleJobId = scheduleJobId
         thread.source = "schedule"
+        thread.hasUnseenLatestAssistantMessage = true
         let viewModel = makeViewModel()
         viewModel.conversationId = conversationId
         viewModel.isHistoryLoaded = true


### PR DESCRIPTION
## Summary
- Set `hasUnseenLatestAssistantMessage = true` in `createScheduleConversation` and `createTaskRunConversation` in macOS ConversationManager
- Pass `hasUnseenLatestAssistantMessage: true` to `IOSConversation` initializer in iOS schedule conversation handler
- Fixes missing red unread dot on schedule and task-run conversations

Part of plan: attention-badge-cleanup.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
