### PR TITLE
fix: replace 3-second timer with event-driven routing source refresh

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -17,6 +17,7 @@ extension Notification.Name {
     static let appPreviewImageCaptured = Notification.Name("MainWindow.appPreviewImageCaptured")
     static let requestAppPreview = Notification.Name("MainWindow.requestAppPreview")
     static let assistantFeatureFlagDidChange = Notification.Name("assistantFeatureFlagDidChange")
+    static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
 }
 
 /// Manages API keys using UserDefaults. The daemon owns the canonical encrypted

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -288,6 +288,7 @@ extension AppDelegate {
                 case .registeredAndProvisioned(let id):
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
+                NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
                 self.mainWindow?.windowState.showToast(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -300,13 +300,6 @@ struct SettingsPanel: View {
         case .general:
             SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, onSignIn: {
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
-                // Refresh routing sources after bootstrap has time to inject credentials
-                Task {
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    await MainActor.run {
-                        store.loadProviderRoutingSources()
-                    }
-                }
             })
         case .modelsAndServices:
             integrationsContent

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -374,6 +374,15 @@ public final class SettingsStore: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // Refresh routing sources when local assistant bootstrap completes
+        // (e.g. after sign-in provisions an API key into the daemon)
+        NotificationCenter.default.publisher(for: .localBootstrapCompleted)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.loadProviderRoutingSources()
+            }
+            .store(in: &cancellables)
+
         // maxStepsPerSession is read at session startup, so it must be persisted synchronously
         // to avoid a race where a new session reads a stale value before the debounced write fires.
         $maxSteps


### PR DESCRIPTION
## Summary
- Replace the fragile 3-second timer for routing source refresh after sign-in with an event-driven NotificationCenter approach
- Post `.localBootstrapCompleted` notification when bootstrap succeeds in `ensureLocalAssistantApiKey()`
- Observe the notification in `SettingsStore` to refresh provider routing sources on completion
- Remove the fixed-delay hack from `SettingsPanel.swift`

## Original prompt
Fix: The "Managed by Vellum" settings badge is refreshed on a fixed 3-second timer instead of on bootstrap completion. The bootstrap can take up to 60 seconds for actor token retrieval, so the timer is a race condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
