### PR TITLE
refactor: extract createBackgroundConversation helper to deduplicate creation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -430,103 +430,86 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         log.info("Removed private conversation \(id)")
     }
 
+    /// Shared creation path for conversations spawned by background processes
+    /// (schedules, task runs, notifications). All background conversations start
+    /// with the unread badge set, ensuring the user sees new activity.
+    ///
+    /// - Parameters:
+    ///   - conversationId: Daemon conversation ID to bind.
+    ///   - title: Display title for the sidebar.
+    ///   - source: Optional source tag ("schedule", "notification", etc.).
+    ///   - scheduleJobId: Optional schedule job ID for schedule grouping.
+    ///   - markHistoryLoaded: When true (default), marks history as loaded
+    ///     since these conversations stream live. Set to false for notification
+    ///     conversations that have a pre-existing seed message requiring fetch.
+    /// - Returns: The conversation's local ID if created, nil if a duplicate was skipped.
+    @discardableResult
+    private func createBackgroundConversation(
+        conversationId: String,
+        title: String,
+        source: String? = nil,
+        scheduleJobId: String? = nil,
+        markHistoryLoaded: Bool = true
+    ) -> UUID? {
+        guard !conversations.contains(where: { $0.conversationId == conversationId }) else {
+            return nil
+        }
+
+        var conversation = ConversationModel(title: title, conversationId: conversationId)
+        if let source { conversation.source = source }
+        if let scheduleJobId { conversation.scheduleJobId = scheduleJobId }
+        conversation.hasUnseenLatestAssistantMessage = true
+
+        let viewModel = makeViewModel()
+        viewModel.conversationId = conversationId
+        if markHistoryLoaded {
+            viewModel.isHistoryLoaded = true
+        }
+        viewModel.startMessageLoop()
+
+        conversations.insert(conversation, at: 0)
+        chatViewModels[conversation.id] = viewModel
+        subscribeToBusyState(for: conversation.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: conversation.id, viewModel: viewModel)
+        subscribeToInteractionState(for: conversation.id, viewModel: viewModel)
+        touchVMAccessOrder(conversation.id)
+        evictStaleCachedViewModels()
+
+        return conversation.id
+    }
+
     /// Create a visible thread bound to an existing task run conversation.
     /// Called when the daemon broadcasts `task_run_conversation_created` so the user
     /// can see task execution messages streaming in real-time.
     func createTaskRunConversation(conversationId: String, workItemId: String, title: String) {
-        // Avoid creating a duplicate thread if one already exists for this conversation
-        if conversations.contains(where: { $0.conversationId == conversationId }) {
-            return
-        }
-
-        var thread = ConversationModel(title: title, conversationId: conversationId)
-        thread.hasUnseenLatestAssistantMessage = true
-        let viewModel = makeViewModel()
-        viewModel.conversationId = conversationId
-        // Mark history as loaded since this thread streams live — there is no
-        // prior history to fetch. Without this, handleAssistantMessageArrival
-        // would drop all live updates (unseen indicators, recency bumps) because
-        // the !isHistoryLoaded guard returns early.
-        viewModel.isHistoryLoaded = true
-        // Start the message loop so the view model receives streamed messages
-        viewModel.startMessageLoop()
-
-        conversations.insert(thread, at: 0)
-        chatViewModels[thread.id] = viewModel
-        subscribeToBusyState(for: thread.id, viewModel: viewModel)
-        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
-        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
-        touchVMAccessOrder(thread.id)
-        evictStaleCachedViewModels()
-
-        log.info("Created task run conversation \(thread.id) for conversation \(conversationId) (work item \(workItemId))")
+        guard let localId = createBackgroundConversation(conversationId: conversationId, title: title) else { return }
+        log.info("Created task run conversation \(localId) for conversation \(conversationId) (work item \(workItemId))")
     }
 
     /// Create a visible thread bound to a schedule-created conversation.
     /// Called when the daemon broadcasts `schedule_conversation_created` so the user
     /// sees scheduled conversations in the sidebar without a full refresh.
     func createScheduleConversation(conversationId: String, scheduleJobId: String, title: String) {
-        // Avoid creating a duplicate thread if one already exists for this conversation
-        if conversations.contains(where: { $0.conversationId == conversationId }) {
-            return
-        }
-
-        var thread = ConversationModel(title: title, conversationId: conversationId)
-        thread.scheduleJobId = scheduleJobId
-        thread.source = "schedule"
-        thread.hasUnseenLatestAssistantMessage = true
-        let viewModel = makeViewModel()
-        viewModel.conversationId = conversationId
-        viewModel.isHistoryLoaded = true
-        viewModel.startMessageLoop()
-
-        conversations.insert(thread, at: 0)
-        chatViewModels[thread.id] = viewModel
-        subscribeToBusyState(for: thread.id, viewModel: viewModel)
-        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
-        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
-        touchVMAccessOrder(thread.id)
-        evictStaleCachedViewModels()
-
-        log.info("Created schedule conversation \(thread.id) for conversation \(conversationId) (schedule \(scheduleJobId))")
+        guard let localId = createBackgroundConversation(
+            conversationId: conversationId,
+            title: title,
+            source: "schedule",
+            scheduleJobId: scheduleJobId
+        ) else { return }
+        log.info("Created schedule conversation \(localId) for conversation \(conversationId) (schedule \(scheduleJobId))")
     }
 
     /// Create a visible thread bound to a notification-created conversation.
     /// Called when the daemon broadcasts `notification_thread_created` so the user
     /// can see notification conversations and deep-link into them.
     func createNotificationConversation(conversationId: String, title: String, sourceEventName: String) {
-        // Avoid creating a duplicate thread if one already exists for this conversation
-        if conversations.contains(where: { $0.conversationId == conversationId }) {
-            return
-        }
-
-        var thread = ConversationModel(title: title, conversationId: conversationId)
-        thread.source = "notification"
-        thread.hasUnseenLatestAssistantMessage = true
-        let viewModel = makeViewModel()
-        viewModel.conversationId = conversationId
-        // Do NOT set isHistoryLoaded here — notification conversations have a
-        // pre-existing seed message persisted by conversation-pairing before
-        // the notification_thread_created event is emitted. Leaving
-        // isHistoryLoaded false allows ConversationRestorer.loadHistoryIfNeeded
-        // to fetch that seed message when the thread is first selected.
-        // The handleAssistantMessageArrival guard dropping updates is correct
-        // for notification conversations because their content arrives via history
-        // load, not live streaming. Unread state is already set explicitly
-        // above (hasUnseenLatestAssistantMessage = true).
-
-        // Start the message loop so the view model receives streamed messages
-        viewModel.startMessageLoop()
-
-        conversations.insert(thread, at: 0)
-        chatViewModels[thread.id] = viewModel
-        subscribeToBusyState(for: thread.id, viewModel: viewModel)
-        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
-        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
-        touchVMAccessOrder(thread.id)
-        evictStaleCachedViewModels()
-
-        log.info("Created notification conversation \(thread.id) for conversation \(conversationId) (source: \(sourceEventName))")
+        guard let localId = createBackgroundConversation(
+            conversationId: conversationId,
+            title: title,
+            source: "notification",
+            markHistoryLoaded: false
+        ) else { return }
+        log.info("Created notification conversation \(localId) for conversation \(conversationId) (source: \(sourceEventName))")
     }
 
     func closeConversation(id: UUID) {

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -655,6 +655,75 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(appendedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 9.0)
     }
 
+    func testScheduleConversationCreatedWithUnseenFlag() {
+        conversationManager.createScheduleConversation(
+            conversationId: "schedule-conv-1",
+            scheduleJobId: "sched-1",
+            title: "Daily Standup"
+        )
+
+        guard let conversation = conversationManager.conversations.first(where: { $0.conversationId == "schedule-conv-1" }) else {
+            XCTFail("Expected schedule conversation to be created")
+            return
+        }
+
+        XCTAssertTrue(conversation.hasUnseenLatestAssistantMessage,
+                      "Schedule conversations should start with unread badge")
+        XCTAssertEqual(conversation.source, "schedule")
+        XCTAssertEqual(conversation.scheduleJobId, "sched-1")
+    }
+
+    func testTaskRunConversationCreatedWithUnseenFlag() {
+        conversationManager.createTaskRunConversation(
+            conversationId: "task-conv-1",
+            workItemId: "work-1",
+            title: "Run Tests"
+        )
+
+        guard let conversation = conversationManager.conversations.first(where: { $0.conversationId == "task-conv-1" }) else {
+            XCTFail("Expected task run conversation to be created")
+            return
+        }
+
+        XCTAssertTrue(conversation.hasUnseenLatestAssistantMessage,
+                      "Task run conversations should start with unread badge")
+    }
+
+    func testNotificationConversationCreatedWithUnseenFlag() {
+        conversationManager.createNotificationConversation(
+            conversationId: "notif-conv-1",
+            title: "New Alert",
+            sourceEventName: "watcher.notification"
+        )
+
+        guard let conversation = conversationManager.conversations.first(where: { $0.conversationId == "notif-conv-1" }) else {
+            XCTFail("Expected notification conversation to be created")
+            return
+        }
+
+        XCTAssertTrue(conversation.hasUnseenLatestAssistantMessage,
+                      "Notification conversations should start with unread badge")
+        XCTAssertEqual(conversation.source, "notification")
+    }
+
+    func testBackgroundConversationCreationSkipsDuplicateConversationId() {
+        conversationManager.createScheduleConversation(
+            conversationId: "dup-conv",
+            scheduleJobId: "sched-dup",
+            title: "First"
+        )
+        let countAfterFirst = conversationManager.conversations.count
+
+        conversationManager.createScheduleConversation(
+            conversationId: "dup-conv",
+            scheduleJobId: "sched-dup",
+            title: "Duplicate"
+        )
+
+        XCTAssertEqual(conversationManager.conversations.count, countAfterFirst,
+                       "Duplicate conversationId should not create a second conversation")
+    }
+
     private func waitForPropagation() {
         let exp = expectation(description: "combine propagation")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {


### PR DESCRIPTION
## Summary
- Extract private `createBackgroundConversation` helper that consolidates conversation model creation, viewModel setup, subscriptions, and unseen badge flag
- Rewrite `createTaskRunConversation`, `createScheduleConversation`, and `createNotificationConversation` to delegate to the shared helper
- Add four new tests: badge state for schedule/task-run/notification creation + duplicate prevention

Part of plan: attention-badge-cleanup.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
