### PR TITLE
fix: prevent 'Scroll to latest' button from flashing on short conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -40,6 +40,11 @@ extension EnvironmentValues {
 
     func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) {
         storedViewportHeight = height
+        // Don't recompute visibility before the anchor position has been
+        // measured — lastMinY starts at .infinity, and .infinity <= height + 20
+        // evaluates to false, incorrectly flipping isVisible to false and
+        // flashing the "Scroll to latest" button on short conversations.
+        guard lastMinY.isFinite else { return }
         let newVisible = lastMinY >= -20 && lastMinY <= height + 20
         if isVisible != newVisible { isVisible = newVisible }
     }


### PR DESCRIPTION
## Summary
- Fix race condition in `AnchorVisibilityTracker.updateViewport()` where the viewport height preference fires before the anchor position preference
- When `lastMinY` is still `.infinity` (unmeasured), `.infinity <= height + 20` evaluates to `false`, incorrectly flipping `isVisible` and showing the "Scroll to latest" button on short conversations
- Add `guard lastMinY.isFinite` to skip visibility recomputation until the anchor has been measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
