### PR TITLE
fix: remove gap between welcome characters graphic and window bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -119,8 +119,12 @@ struct OnboardingFlowView: View {
                     )
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
-                    // Bottom padding so content isn't flush with window edge
-                    Color.clear.frame(height: VSpacing.xxl)
+                    // Bottom padding so content isn't flush with window edge.
+                    // Skip for step 0 (WakeUpStepView) where the characters
+                    // graphic is designed to sit flush at the window bottom.
+                    if state.currentStep != 0 || isBootstrappingManaged {
+                        Color.clear.frame(height: VSpacing.xxl)
+                    }
                 }
                 .frame(maxWidth: .infinity, minHeight: geometry.size.height)
                 }


### PR DESCRIPTION
## Summary
- Skip the 32pt bottom padding in OnboardingFlowView for step 0 (WakeUpStepView) so the characters graphic sits flush at the window bottom
- Other onboarding steps (API key entry, etc.) retain the bottom padding

## Original prompt
This graphic should always appear at the bottom of the window. See how there's a space between it and the bottom here? That shouldn't happen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
