### PR TITLE
fix: reduce onboarding top inset so back button is visible without scrolling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: geometry.size.height * 0.2)
+                    Color.clear.frame(height: geometry.size.height * 0.08)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)


### PR DESCRIPTION
## Summary
- Reduce the fixed top inset in OnboardingFlowView from 20% to 8% of window height
- This ensures the Back button below Continue is visible without scrolling on the Setup step

## Original prompt
This space should be smaller so that the back button also shows under continue without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
