### PR TITLE
fix: hide Local Docker and VPS options from onboarding setup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -84,21 +84,6 @@ struct APIKeyStepView: View {
                 comingSoon: false
             )
 
-            hostingCard(
-                icon: .package,
-                title: "Local Docker",
-                subtitle: "Run in a Docker container",
-                mode: .localDocker,
-                comingSoon: true
-            )
-
-            hostingCard(
-                icon: .globe,
-                title: "VPS",
-                subtitle: "Run on a remote server",
-                mode: .vps,
-                comingSoon: true
-            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the "Local Docker" and "VPS" hosting cards from the onboarding setup screen since these features aren't available yet

## Original prompt
Let's hide the Local Docker and VPS options for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
