### PR TITLE
fix: stop Qdrant process during local assistant retire

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -9,7 +9,11 @@ import {
   removeAssistantEntry,
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
-import { fetchOrganizationId, getPlatformUrl, readPlatformToken } from "../lib/platform-client";
+import {
+  fetchOrganizationId,
+  getPlatformUrl,
+  readPlatformToken,
+} from "../lib/platform-client";
 import { retireInstance as retireAwsInstance } from "../lib/aws";
 import { retireDocker } from "../lib/docker";
 import { retireInstance as retireGcpInstance } from "../lib/gcp";
@@ -83,6 +87,21 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   // drain window (5s) before it exits.
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
+
+  // Stop Qdrant — the daemon's graceful shutdown tries to stop it via
+  // qdrantManager.stop(), but if the daemon was SIGKILL'd (after 2s timeout)
+  // Qdrant may still be running as an orphan. Check both the current PID file
+  // location and the legacy location.
+  const qdrantPidFile = join(
+    vellumDir,
+    "workspace",
+    "data",
+    "qdrant",
+    "qdrant.pid",
+  );
+  const qdrantLegacyPidFile = join(vellumDir, "qdrant.pid");
+  await stopProcessByPidFile(qdrantPidFile, "qdrant", undefined, 5000);
+  await stopProcessByPidFile(qdrantLegacyPidFile, "qdrant", undefined, 5000);
 
   // If the PID file didn't track a running daemon, scan for orphaned
   // daemon processes that may have been started without writing a PID.


### PR DESCRIPTION
## Summary
- Added Qdrant PID file handling to `retireLocal()` in the CLI retire command
- Stops Qdrant after daemon/gateway but before the directory rename, checking both the current PID location (`~/.vellum/workspace/data/qdrant/qdrant.pid`) and the legacy location (`~/.vellum/qdrant.pid`)
- Prevents orphaned Qdrant processes from blocking the workspace archive rename, which could cause a newly hatched assistant to inherit old SOUL.md, IDENTITY.md, and memory data

## Original prompt
Fix 1: Stop Qdrant during retire. In cli/src/commands/retire.ts, add Qdrant PID file handling in retireLocal() alongside the daemon and gateway stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
