### PR TITLE
fix: fail retire when workspace archive rename fails

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -135,12 +135,12 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   try {
     renameSync(dirToArchive, stagingDir);
   } catch (err) {
-    console.warn(
-      `⚠️  Failed to move ${dirToArchive}: ${err instanceof Error ? err.message : err}`,
+    // Re-throw so the caller (and the desktop app) knows the archive failed.
+    // If the rename fails, old workspace data stays in place and a subsequent
+    // hatch would inherit stale SOUL.md, IDENTITY.md, and memories.
+    throw new Error(
+      `Failed to archive ${dirToArchive}: ${err instanceof Error ? err.message : err}`,
     );
-    console.warn("Skipping archive.");
-    console.log("\u2705 Local instance retired.");
-    return;
   }
 
   writeFileSync(metadataPath, JSON.stringify(entry, null, 2) + "\n");


### PR DESCRIPTION
## Summary
- Changed `retireLocal()` to re-throw rename errors instead of silently swallowing them
- Previously, if `renameSync(~/.vellum, stagingDir)` failed, the CLI exited 0 and the desktop app thought retire succeeded, leading to stale workspace data being reused by the next hatch
- Now the error propagates, causing a non-zero exit so the desktop app can show the "Force Remove" option

## Original prompt
Fix 2: Fail retire on rename error — Instead of returning success when renameSync fails, re-throw the error so the CLI exits non-zero and the desktop app knows retire didn't fully complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
