### PR TITLE
fix: clean stale workspace data when hatching a new local assistant

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readFileSync,
   readlinkSync,
+  rmSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -622,6 +623,26 @@ async function hatchLocal(
     resources = existingEntry.resources;
   } else {
     resources = await allocateLocalResources(instanceName);
+  }
+
+  // Clean up stale workspace data: if the .vellum directory already exists for
+  // this instance but no lockfile entry owns it, a previous retire failed to
+  // archive it (or a managed-only retire left local data behind). Remove it so
+  // the new assistant starts with a fresh workspace.
+  if (!existingEntry) {
+    const instanceVellumDir = join(resources.instanceDir, ".vellum");
+    if (existsSync(instanceVellumDir)) {
+      const ownedByOther = loadAllAssistants().some((a) => {
+        if (a.cloud !== "local" || !a.resources) return false;
+        return join(a.resources.instanceDir, ".vellum") === instanceVellumDir;
+      });
+      if (!ownedByOther) {
+        console.log(
+          `🧹 Removing stale workspace at ${instanceVellumDir} (not owned by any assistant)...\n`,
+        );
+        rmSync(instanceVellumDir, { recursive: true, force: true });
+      }
+    }
   }
 
   const logsDir = join(


### PR DESCRIPTION
## Summary
- Added stale workspace detection to `hatchLocal()` in the CLI hatch command
- After resource allocation but before starting the daemon, checks if the `.vellum` directory already exists for the instance but isn't owned by any registered assistant in the lockfile
- If stale, removes it so the daemon starts with a fresh workspace (new SOUL.md, IDENTITY.md, empty memory database)

## Original prompt
Fix 3: Clean up ~/.vellum when hatching a new local assistant — The hatch flow should detect stale workspace data that doesn't belong to any registered assistant and clear it before starting the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
