### PR TITLE
feat(cli): add --foreground to wake, stop hatch from killing healthy daemons

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -45,6 +45,7 @@ import {
   stopLocalProcesses,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
+import { httpHealthCheck } from "../lib/http-client";
 import { detectOrphanedProcesses } from "../lib/orphan-detection";
 import { isProcessAlive, stopProcess } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
@@ -581,7 +582,9 @@ async function hatchLocal(
     `${species}-${generateRandomSuffix()}`;
 
   // Clean up stale local state: if daemon/gateway processes are running but
-  // the lock file has no entries, stop them before starting fresh.
+  // the lock file has no entries AND the daemon is not healthy, stop them
+  // before starting fresh. A healthy daemon should be reused, not killed —
+  // it may have been started intentionally via `vellum wake`.
   const vellumDir = join(homedir(), ".vellum");
   const existingAssistants = loadAllAssistants();
   const localAssistants = existingAssistants.filter((a) => a.cloud === "local");
@@ -589,10 +592,16 @@ async function hatchLocal(
     const daemonPid = isProcessAlive(join(vellumDir, "vellum.pid"));
     const gatewayPid = isProcessAlive(join(vellumDir, "gateway.pid"));
     if (daemonPid.alive || gatewayPid.alive) {
-      console.log(
-        "🧹 Cleaning up stale local processes (no lock file entry)...\n",
-      );
-      await stopLocalProcesses();
+      // Check if the daemon is actually healthy before killing it.
+      // Default port 7821 is used when there's no lockfile entry.
+      const defaultPort = parseInt(process.env.RUNTIME_HTTP_PORT || "7821", 10);
+      const healthy = await httpHealthCheck(defaultPort);
+      if (!healthy) {
+        console.log(
+          "🧹 Cleaning up stale local processes (no lock file entry)...\n",
+        );
+        await stopLocalProcesses();
+      }
     }
   }
 
@@ -600,17 +609,32 @@ async function hatchLocal(
   // are not tracked by any PID file or lock file entry and kill them before
   // starting new ones. This prevents resource leaks when the desktop app
   // crashes or is force-quit without a clean shutdown.
+  //
+  // Skip orphan cleanup if the daemon is already healthy on the expected port
+  // — those processes are intentional (e.g. started via `vellum wake`) and
+  // startLocalDaemon() will reuse them.
   if (IS_DESKTOP) {
-    const orphans = await detectOrphanedProcesses();
-    if (orphans.length > 0) {
-      desktopLog(
-        `🧹 Found ${orphans.length} orphaned process${orphans.length === 1 ? "" : "es"} — cleaning up...`,
-      );
-      for (const orphan of orphans) {
-        await stopProcess(
-          parseInt(orphan.pid, 10),
-          `${orphan.name} (PID ${orphan.pid})`,
+    const existingResources = findAssistantByName(instanceName);
+    const expectedPort =
+      existingResources?.cloud === "local" && existingResources.resources
+        ? existingResources.resources.daemonPort
+        : undefined;
+    const daemonAlreadyHealthy = expectedPort
+      ? await httpHealthCheck(expectedPort)
+      : false;
+
+    if (!daemonAlreadyHealthy) {
+      const orphans = await detectOrphanedProcesses();
+      if (orphans.length > 0) {
+        desktopLog(
+          `🧹 Found ${orphans.length} orphaned process${orphans.length === 1 ? "" : "es"} — cleaning up...`,
         );
+        for (const orphan of orphans) {
+          await stopProcess(
+            parseInt(orphan.pid, 10),
+            `${orphan.name} (PID ${orphan.pid})`,
+          );
+        }
       }
     }
   }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -24,12 +24,16 @@ export async function wake(): Promise<void> {
     console.log("");
     console.log("Options:");
     console.log(
-      "  --watch    Run assistant and gateway in watch mode (hot reload on source changes)",
+      "  --watch        Run assistant and gateway in watch mode (hot reload on source changes)",
+    );
+    console.log(
+      "  --foreground   Run assistant in foreground with logs printed to terminal",
     );
     process.exit(0);
   }
 
   const watch = args.includes("--watch");
+  const foreground = args.includes("--foreground");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
@@ -85,7 +89,7 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    await startLocalDaemon(watch, resources);
+    await startLocalDaemon(watch, resources, { foreground });
   }
 
   // Start gateway
@@ -131,4 +135,18 @@ export async function wake(): Promise<void> {
   }
 
   console.log("Wake complete.");
+
+  if (foreground) {
+    console.log("Running in foreground (Ctrl+C to stop)...\n");
+    // Block forever — the daemon is running with inherited stdio so its
+    // output streams to this terminal. When the user hits Ctrl+C, SIGINT
+    // propagates to the daemon child and both exit.
+    await new Promise<void>((resolve) => {
+      process.on("SIGINT", () => {
+        console.log("\nShutting down...");
+        resolve();
+      });
+      process.on("SIGTERM", () => resolve());
+    });
+  }
 }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -195,7 +195,9 @@ function resolveDaemonMainPath(assistantIndex: string): string {
 async function startDaemonFromSource(
   assistantIndex: string,
   resources: LocalInstanceResources,
+  options?: { foreground?: boolean },
 ): Promise<void> {
+  const foreground = options?.foreground ?? false;
   const daemonMainPath = resolveDaemonMainPath(assistantIndex);
 
   // Ensure the directory containing PID/socket files exists. For named
@@ -271,14 +273,22 @@ async function startDaemonFromSource(
   // detect the in-progress spawn and wait instead of racing.
   writeFileSync(pidFile, "starting", "utf-8");
 
-  const daemonLogFd = openLogFile("hatch.log");
-  const child = spawn("bun", ["run", daemonMainPath], {
-    detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
-    env,
-  });
-  pipeToLogFile(child, daemonLogFd, "daemon");
-  child.unref();
+  const child = foreground
+    ? spawn("bun", ["run", daemonMainPath], {
+        stdio: "inherit",
+        env,
+      })
+    : (() => {
+        const daemonLogFd = openLogFile("hatch.log");
+        const c = spawn("bun", ["run", daemonMainPath], {
+          detached: true,
+          stdio: ["ignore", "pipe", "pipe"],
+          env,
+        });
+        pipeToLogFile(c, daemonLogFd, "daemon");
+        c.unref();
+        return c;
+      })();
 
   if (child.pid) {
     writeFileSync(pidFile, String(child.pid), "utf-8");
@@ -789,7 +799,9 @@ export function isWatchModeAvailable(): boolean {
 export async function startLocalDaemon(
   watch: boolean = false,
   resources: LocalInstanceResources,
+  options?: { foreground?: boolean },
 ): Promise<void> {
+  const foreground = options?.foreground ?? false;
   // Check for a compiled daemon binary adjacent to the CLI executable.
   // This covers both the desktop app (VELLUM_DESKTOP_APP) and the case where
   // the user runs the compiled CLI directly from the terminal (e.g. via a
@@ -919,15 +931,24 @@ export async function startLocalDaemon(
       // instead of racing to spawn a duplicate daemon.
       writeFileSync(pidFile, "starting", "utf-8");
 
-      const daemonLogFd = openLogFile("hatch.log");
-      const child = spawn(daemonBinary, [], {
-        cwd: dirname(daemonBinary),
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: daemonEnv,
-      });
-      pipeToLogFile(child, daemonLogFd, "daemon");
-      child.unref();
+      const child = foreground
+        ? spawn(daemonBinary, [], {
+            cwd: dirname(daemonBinary),
+            stdio: "inherit",
+            env: daemonEnv,
+          })
+        : (() => {
+            const daemonLogFd = openLogFile("hatch.log");
+            const c = spawn(daemonBinary, [], {
+              cwd: dirname(daemonBinary),
+              detached: true,
+              stdio: ["ignore", "pipe", "pipe"],
+              env: daemonEnv,
+            });
+            pipeToLogFile(c, daemonLogFd, "daemon");
+            c.unref();
+            return c;
+          })();
       const daemonPid = child.pid;
 
       // Overwrite sentinel with real PID, or clean up on spawn failure.
@@ -999,7 +1020,7 @@ export async function startLocalDaemon(
         );
       }
     } else {
-      await startDaemonFromSource(assistantIndex, resources);
+      await startDaemonFromSource(assistantIndex, resources, { foreground });
 
       const daemonReady = await waitForDaemonReady(resources.daemonPort, 60000);
       if (daemonReady) {


### PR DESCRIPTION
## Summary
- Adds `vellum wake --foreground` flag that runs the daemon with inherited stdio so logs print directly to the terminal, blocking until Ctrl+C
- Fixes `hatch` killing healthy daemons during orphan/stale process cleanup — now checks `/healthz` first and skips cleanup if responsive
- Allows `vellum wake` and macOS app to coexist without the app killing a manually-started daemon

## Test plan
- [ ] Run `vellum wake --foreground` — daemon logs should stream to terminal
- [ ] In another terminal, launch macOS app via `./build.sh run` — daemon should stay alive and app should connect
- [ ] Ctrl+C in the foreground terminal should shut down the daemon
- [ ] Normal `vellum wake` (without `--foreground`) should still work as before (background daemon)
- [ ] `vellum hatch` with no running daemon should still clean up orphaned processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
