### PR TITLE
fix: gate billing UI visibility on connectedOrganizationId

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -268,7 +268,7 @@ struct SettingsPanel: View {
     }
 
     private var billingVisible: Bool {
-        isBillingEnabled && authManager.isAuthenticated
+        isBillingEnabled && authManager.isAuthenticated && UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
     }
 
     private var settingsNav: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -15,7 +15,8 @@ struct DrawerMenuView: View {
 
     private var isBillingVisible: Bool {
         authManager.isAuthenticated &&
-        MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled")
+        MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled") &&
+        UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Gate billing UI visibility on `connectedOrganizationId` being set, not just authentication state
- Prevents billing tab and sidebar balance from appearing before bootstrap resolves the org ID
- Affects both `SettingsPanel.billingVisible` and `DrawerMenuView.isBillingVisible`

## Original prompt
Fix: Billing surfaces are exposed as soon as the user is authenticated, but `BillingService` requires `connectedOrganizationId` which is only set during bootstrap. This causes failures if the user navigates to billing before bootstrap completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
