### PR TITLE
fix: check HTTP status in clearDaemonCredentials and stop daemon on failure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -148,10 +148,15 @@ extension AppDelegate {
                 let assistantId = connectedAssistantId ?? ""
                 let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
                 let daemonBaseURL = "http://localhost:\(port)"
-                await LocalAssistantBootstrapService.clearDaemonCredentials(
+                let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials(
                     daemonBaseURL: daemonBaseURL,
                     daemonToken: token
                 )
+                if !cleared {
+                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed proxy state")
+                    daemonClient.disconnect()
+                    assistantCli.stop()
+                }
             } else {
                 log.warning("No actor token available during logout — stopping daemon to ensure stale credentials are not retained")
                 daemonClient.disconnect()

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -284,17 +284,24 @@ public final class LocalAssistantBootstrapService {
     /// Uses a direct HTTP call to the daemon (not GatewayHTTPClient) because
     /// this is called during logout teardown when gateway routing may no
     /// longer be available.
+    ///
+    /// Returns `true` if all credentials were successfully cleared (or didn't exist).
+    @discardableResult
     public static func clearDaemonCredentials(
         daemonBaseURL: String,
         daemonToken: String
-    ) async {
+    ) async -> Bool {
         let credentialNames = [
             "vellum:assistant_api_key",
             "vellum:platform_base_url",
             "vellum:platform_assistant_id",
         ]
+        var allCleared = true
         for name in credentialNames {
-            guard let url = URL(string: "\(daemonBaseURL)/v1/secrets") else { continue }
+            guard let url = URL(string: "\(daemonBaseURL)/v1/secrets") else {
+                allCleared = false
+                continue
+            }
             var request = URLRequest(url: url)
             request.httpMethod = "DELETE"
             request.timeoutInterval = 5
@@ -302,9 +309,26 @@ public final class LocalAssistantBootstrapService {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             let body: [String: String] = ["type": "credential", "name": name]
             request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-            _ = try? await URLSession.shared.data(for: request)
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                if statusCode == 200 || statusCode == 404 {
+                    log.info("Cleared daemon credential: \(name, privacy: .public) (status \(statusCode))")
+                } else {
+                    log.warning("Failed to clear daemon credential: \(name, privacy: .public) (status \(statusCode))")
+                    allCleared = false
+                }
+            } catch {
+                log.warning("Failed to clear daemon credential: \(name, privacy: .public) — \(error.localizedDescription)")
+                allCleared = false
+            }
         }
-        log.info("Cleared managed proxy credentials from daemon")
+        if allCleared {
+            log.info("All managed proxy credentials cleared from daemon")
+        } else {
+            log.warning("Some managed proxy credentials could not be cleared from daemon")
+        }
+        return allCleared
     }
 
     /// Resolves the current user ID from the auth session.


### PR DESCRIPTION
## Summary
- Make `clearDaemonCredentials()` check HTTP response status codes instead of silently discarding results
- Return success/failure boolean so callers can react to cleanup failures
- In `performLogout()`, stop the daemon as a fallback if any credential DELETE fails, preventing stale managed-proxy state from persisting

## Original prompt
Fix: Logout can silently leave managed-proxy credentials active. `clearDaemonCredentials()` ignores every response and logs success unconditionally. If any DELETE fails, stale credentials persist in the daemon's secure store and get rehydrated on next launch.

## Test plan
- [ ] Verify logout with a responsive daemon clears credentials and does not stop daemon
- [ ] Verify logout with an unresponsive daemon (e.g. killed daemon process) triggers the fallback stop path
- [ ] Verify 404 responses (credential doesn't exist) are treated as success
- [ ] Verify non-200/404 responses mark cleanup as incomplete and trigger daemon stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
