### PR TITLE
fix: center hatching screen content in visible window area

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -145,7 +145,6 @@ struct OnboardingFlowView: View {
             }
         }
         }
-        .ignoresSafeArea()
         .task {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()


### PR DESCRIPTION
## Summary
- Removed `.ignoresSafeArea()` from the outer `GeometryReader` in `OnboardingFlowView` so the hatching screen content centers within the visible safe area rather than the full window frame (which includes the title bar)
- Background elements retain their own `.ignoresSafeArea()` so colors and gradients still extend behind the title bar

## Original prompt
This doesn't look right. It should be centered in the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
