### PR TITLE
fix: hide identity intro during bootstrap onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -22,6 +22,11 @@ struct IdentityPanel: View {
     private let sidebarMaxWidth: CGFloat = 280
     private let sidebarFraction: CGFloat = 0.3
 
+    /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
+    private var isBootstrapActive: Bool {
+        FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
+    }
+
     private let panelPadding: CGFloat = VSpacing.xl
 
     private var assistantDisplayName: String {
@@ -169,7 +174,9 @@ struct IdentityPanel: View {
                     }
                 }
 
-                generateIntro()
+                if !isBootstrapActive {
+                    generateIntro()
+                }
             }
             .onDisappear { introTask?.cancel() }
         }


### PR DESCRIPTION
## Summary
- Skip generating the daemon intro message in `IdentityPanel` when `BOOTSTRAP.md` is still present
- During first-run onboarding the assistant hasn't established its identity yet, so the intro text (e.g. "I'm Claude, your thinking partner.") is premature and confusing

## Original prompt
Don't show this message if BOOTSTRAP.md is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
