### PR TITLE
fix: re-enable cached-key re-sync path on 409 from ensure-registration

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -135,8 +135,23 @@ public final class LocalAssistantBootstrapService {
             }
         } catch let error as PlatformAPIError {
             if case .serverError(let statusCode, _) = error, statusCode == 409 {
-                log.info("Registration returned 409 — will resolve platform assistant ID from reprovision")
-                // platformAssistantId stays nil — will be resolved from the reprovision response
+                // Try to resolve platform assistant ID from cache for key re-sync
+                if let storage = credentialStorage,
+                   let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+                   let uid = try? await resolveUserId(),
+                   let cachedId = PlatformAssistantIdResolver.resolve(
+                       lockfileAssistantId: runtimeAssistantId,
+                       isManaged: false,
+                       organizationId: orgId,
+                       userId: uid,
+                       credentialStorage: storage
+                   ) {
+                    platformAssistantId = cachedId
+                    log.info("Registration returned 409 — resolved platform assistant ID from cache: \(cachedId, privacy: .public)")
+                } else {
+                    log.info("Registration returned 409 — no cached platform ID, will resolve from reprovision")
+                    // platformAssistantId stays nil — reprovision will provide it
+                }
             } else {
                 throw mapPlatformError(error, context: .registration)
             }


### PR DESCRIPTION
## Summary
- Re-enable cached-key re-sync path when `ensure-registration` returns 409
- Try to resolve platform assistant ID from `PlatformAssistantIdResolver` cache on 409; if found, Step 2 (cached key injection) runs and avoids unnecessary key rotation
- Fall through gracefully to reprovision (Step 3) when cache misses — no hard failure

## Original prompt
Fix: The cached-key re-sync path is effectively dead after PR #17531 made 409 always skip to reprovision. Every sign-in after the first one rotates the key unnecessarily even when a valid cached key exists in Keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
