### PR TITLE
fix: wait for local bootstrap before sending first-launch wake-up greeting

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -68,6 +68,39 @@ extension AppDelegate {
         return daemonClient.isConnected
     }
 
+    /// Waits for the local bootstrap to complete (`.localBootstrapCompleted` notification)
+    /// or until the timeout expires. This ensures managed-proxy credentials are provisioned
+    /// before the wake-up greeting triggers an LLM call.
+    func awaitLocalBootstrapCompleted(timeout: TimeInterval) async {
+        await withCheckedContinuation { continuation in
+            var resumed = false
+            var observer: (any NSObjectProtocol)?
+            observer = NotificationCenter.default.addObserver(
+                forName: .localBootstrapCompleted,
+                object: nil,
+                queue: .main
+            ) { _ in
+                guard !resumed else { return }
+                resumed = true
+                if let obs = observer {
+                    NotificationCenter.default.removeObserver(obs)
+                }
+                continuation.resume()
+            }
+
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                guard !resumed else { return }
+                resumed = true
+                if let obs = observer {
+                    NotificationCenter.default.removeObserver(obs)
+                }
+                log.warning("Local bootstrap did not complete within \(timeout)s — proceeding with wake-up")
+                continuation.resume()
+            }
+        }
+    }
+
     /// Sends the wake-up greeting. If the daemon is disconnected, waits for
     /// reconnection before proceeding. Since `showMainWindow` always creates
     /// the window (via `ensureMainWindowExists`), there is no need for a

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -364,6 +364,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 let ready = await awaitDaemonReady(timeout: 15)
 
                 if ready {
+                    // If the user is signed in with a local assistant, wait for
+                    // credential provisioning to complete before sending the wake-up
+                    // greeting, so the managed-proxy key is available for the LLM call.
+                    if authManager.isAuthenticated && !isCurrentAssistantManaged {
+                        await awaitLocalBootstrapCompleted(timeout: 30)
+                    }
+
                     // Daemon connected within timeout — proceed directly
                     // to mandatory wake-up send with retries.
                     transitionBootstrap(to: .pendingWakeupSend)


### PR DESCRIPTION
## Summary
- Wait for local credential bootstrap to complete before sending the first-launch wake-up greeting
- Prevents the wake-up LLM call from racing managed-proxy provisioning for signed-in users with no BYO key
- Uses the existing `.localBootstrapCompleted` notification with a 30-second timeout

## Original prompt
Fix: First-launch local sign-in can send the mandatory wake-up turn before Vellum credentials are ready. `ensureLocalAssistantApiKey()` runs in a background Task while the first-launch bootstrap sends the greeting as soon as the daemon connects, with no coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
