### PR TITLE
feat: add `automated` field to UserMessage wire type

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4794,10 +4794,12 @@ public struct UserMessage: Codable, Sendable {
     public let pttActivationKey: String?
     /// Whether the client has been granted microphone permission by the OS.
     public let microphonePermissionGranted: Bool?
+    /// When true, the message was auto-sent by the client (e.g. wake-up greeting) and should not trigger memory extraction.
+    public let automated: Bool?
     /// Structured command intent — bypasses text parsing when present.
     public let commandIntent: CommandIntent?
 
-    public init(type: String, conversationId: String, content: String? = nil, attachments: [UserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String, pttActivationKey: String? = nil, microphonePermissionGranted: Bool? = nil, commandIntent: CommandIntent? = nil) {
+    public init(type: String, conversationId: String, content: String? = nil, attachments: [UserMessageAttachment]? = nil, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String, pttActivationKey: String? = nil, microphonePermissionGranted: Bool? = nil, automated: Bool? = nil, commandIntent: CommandIntent? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.content = content
@@ -4809,6 +4811,7 @@ public struct UserMessage: Codable, Sendable {
         self.interface = interface
         self.pttActivationKey = pttActivationKey
         self.microphonePermissionGranted = microphonePermissionGranted
+        self.automated = automated
         self.commandIntent = commandIntent
     }
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -253,8 +253,8 @@ extension UserMessage {
         #endif
     }
 
-    public init(conversationId: String, content: String, attachments: [Attachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String? = nil, pttActivationKey: String? = nil, microphonePermissionGranted: Bool? = nil) {
-        self.init(type: "user_message", conversationId: conversationId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck, channel: channel ?? Self.defaultChannel, interface: interface ?? Self.defaultInterface, pttActivationKey: pttActivationKey, microphonePermissionGranted: microphonePermissionGranted)
+    public init(conversationId: String, content: String, attachments: [Attachment]?, activeSurfaceId: String? = nil, currentPage: String? = nil, bypassSecretCheck: Bool? = nil, channel: String? = nil, interface: String? = nil, pttActivationKey: String? = nil, microphonePermissionGranted: Bool? = nil, automated: Bool? = nil) {
+        self.init(type: "user_message", conversationId: conversationId, content: content, attachments: attachments, activeSurfaceId: activeSurfaceId, currentPage: currentPage, bypassSecretCheck: bypassSecretCheck, channel: channel ?? Self.defaultChannel, interface: interface ?? Self.defaultInterface, pttActivationKey: pttActivationKey, microphonePermissionGranted: microphonePermissionGranted, automated: automated)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `automated: Bool?` property to `UserMessage` struct in `GeneratedAPITypes.swift`
- Update both the generated init and the convenience init in `MessageTypes.swift` to accept and forward the field

Part of plan: skip-automated-memory-extraction.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
