### PR TITLE
feat: skip memory extraction for automated messages

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -63,6 +63,7 @@ export const messageMetadataSchema = z
     provenanceSourceChannel: channelIdSchema.optional(),
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
+    automated: z.boolean().optional(),
   })
   .passthrough();
 
@@ -491,6 +492,7 @@ export async function addMessage(
       const provenanceTrustClass = parsed?.success
         ? parsed.data.provenanceTrustClass
         : undefined;
+      const automated = parsed?.success ? parsed.data.automated : undefined;
       await indexMessageNow(
         {
           messageId: message.id,
@@ -500,6 +502,7 @@ export async function addMessage(
           createdAt: message.createdAt,
           scopeId,
           provenanceTrustClass,
+          automated,
         },
         config.memory,
       );

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -31,6 +31,8 @@ export interface IndexMessageInput {
    * profile mutations are triggered.
    */
   provenanceTrustClass?: TrustClass;
+  /** When true, the message was auto-sent by the client (e.g. wake-up greeting) and should not trigger memory extraction. */
+  automated?: boolean;
 }
 
 export interface IndexMessageResult {
@@ -135,7 +137,7 @@ export async function indexMessageNow(
       );
     }
 
-    if (shouldExtract && isTrustedActor) {
+    if (shouldExtract && isTrustedActor && !input.automated) {
       enqueueMemoryJob(
         "extract_items",
         { messageId: input.messageId, scopeId: input.scopeId ?? "default" },
@@ -163,7 +165,11 @@ export async function indexMessageNow(
     );
   }
 
-  const extractionGated = !isTrustedActor;
+  if (input.automated && shouldExtract) {
+    log.info("Skipping extraction jobs for automated message");
+  }
+
+  const extractionGated = !isTrustedActor || !!input.automated;
   const enqueuedJobs =
     segments.length -
     skippedEmbedJobs +


### PR DESCRIPTION
## Summary
- Add `automated?: boolean` field to `IndexMessageInput` and `messageMetadataSchema`
- Skip memory extraction job enqueue when `input.automated === true`
- Thread `automated` from message metadata to indexer

Part of plan: skip-automated-memory-extraction.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
