### PR TITLE
feat: forward `automated` flag through HTTP client

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -17,7 +17,7 @@ extension HTTPTransport {
             guard let self else { return false }
 
             if let msg = message as? UserMessageMessage {
-                Task { await self.sendMessage(content: msg.content, conversationId: msg.conversationId, attachments: msg.attachments) }
+                Task { await self.sendMessage(content: msg.content, conversationId: msg.conversationId, attachments: msg.attachments, automated: msg.automated) }
                 return true
             } else if let msg = message as? ConfirmationResponseMessage {
                 Task { await self.sendDecision(requestId: msg.requestId, decision: msg.decision, selectedPattern: msg.selectedPattern, selectedScope: msg.selectedScope) }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1673,7 +1673,7 @@ public final class HTTPTransport {
         }
     }
 
-    func sendMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]? = nil, uploadedAttachmentIds: [String]? = nil, isRetry: Bool = false) async {
+    func sendMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]? = nil, uploadedAttachmentIds: [String]? = nil, automated: Bool? = nil, isRetry: Bool = false) async {
         locallyOwnedConversationIds.insert(conversationId)
 
         // On retry, reuse already-uploaded attachment IDs to avoid duplicates
@@ -1723,6 +1723,9 @@ public final class HTTPTransport {
         if privateConversationIds.contains(conversationId) {
             body["conversationType"] = "private"
         }
+        if automated == true {
+            body["automated"] = true
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -1754,7 +1757,7 @@ public final class HTTPTransport {
                 switch refreshResult {
                 case .success:
                     // Reuse already-uploaded IDs to avoid duplicate uploads
-                    await sendMessage(content: content, conversationId: conversationId, uploadedAttachmentIds: attachmentIds, isRetry: true)
+                    await sendMessage(content: content, conversationId: conversationId, uploadedAttachmentIds: attachmentIds, automated: automated, isRetry: true)
                 case .terminalFailure:
                     // performRefresh() already emitted .authenticationRequired — don't overwrite it
                     break


### PR DESCRIPTION
## Summary
- Add `automated: Bool?` parameter to `HTTPDaemonClient.sendMessage()`
- Include `automated: true` in the HTTP request body when set
- Forward through retry path and route dispatch

Part of plan: skip-automated-memory-extraction.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
