### PR TITLE
feat: thread `automated` flag from HTTP body to message metadata

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -530,6 +530,7 @@ export async function handleSendMessage(
     sourceChannel?: string;
     interface?: string;
     conversationType?: string;
+    automated?: boolean;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -772,6 +773,7 @@ export async function handleSendMessage(
         assistantMessageChannel: sourceChannel,
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
+        ...(body.automated ? { automated: true } : {}),
       },
       { isInteractive },
     );
@@ -875,6 +877,7 @@ export async function handleSendMessage(
         assistantMessageChannel: sourceChannel,
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
+        ...(body.automated ? { automated: true } : {}),
       };
       const userMsg = createUserMessage(rawContent, attachments);
       const persisted = await addMessage(
@@ -963,6 +966,7 @@ export async function handleSendMessage(
       resolvedContent,
       attachments,
       requestId,
+      body.automated ? { automated: true } : undefined,
     );
   } catch (err) {
     throw err;


### PR DESCRIPTION
## Summary
- Parse `automated` from the `POST /v1/messages` request body
- Thread it into metadata for all three message processing paths (enqueue, slash command, normal)
- The flag flows through to `persistUserMessage()` → `addMessage()` → `indexMessageNow()`

Part of plan: skip-automated-memory-extraction.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
