### PR TITLE
fix: extract automated flag in backfill handler

### DIFF
--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -19,16 +19,22 @@ import { messages } from "../schema.js";
 const BACKFILL_CHECKPOINT_KEY = "memory:backfill:last_created_at";
 const BACKFILL_CHECKPOINT_ID_KEY = "memory:backfill:last_message_id";
 
-function parseProvenanceTrustClass(
-  rawMetadata: string | null,
-): TrustClass | undefined {
-  if (!rawMetadata) return undefined;
+function parseMessageMetadata(rawMetadata: string | null): {
+  provenanceTrustClass: TrustClass | undefined;
+  automated: boolean | undefined;
+} {
+  if (!rawMetadata)
+    return { provenanceTrustClass: undefined, automated: undefined };
   try {
     const parsed = messageMetadataSchema.safeParse(JSON.parse(rawMetadata));
-    if (!parsed.success) return undefined;
-    return parsed.data.provenanceTrustClass;
+    if (!parsed.success)
+      return { provenanceTrustClass: undefined, automated: undefined };
+    return {
+      provenanceTrustClass: parsed.data.provenanceTrustClass,
+      automated: parsed.data.automated,
+    };
   } catch {
-    return undefined;
+    return { provenanceTrustClass: undefined, automated: undefined };
   }
 }
 
@@ -73,7 +79,7 @@ export async function backfillJob(
         scopeId = getConversationMemoryScopeId(message.conversationId);
         scopeCache.set(message.conversationId, scopeId);
       }
-      const provenanceTrustClass = parseProvenanceTrustClass(
+      const { provenanceTrustClass, automated } = parseMessageMetadata(
         message.metadata ?? null,
       );
       await indexMessageNow(
@@ -85,6 +91,7 @@ export async function backfillJob(
           createdAt: message.createdAt,
           scopeId,
           provenanceTrustClass,
+          automated,
         },
         config.memory,
       );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skip-automated-memory-extraction.md.

**Gap:** Backfill handler does not extract automated from message metadata
**What was expected:** The backfill handler should pass the automated flag to indexMessageNow
**What was found:** Only provenanceTrustClass was extracted, not automated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
