### PR TITLE
fix: forward automated flag in queue-drain slash path

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -326,6 +326,7 @@ export async function drainQueue(
                 queuedInterfaceCtx.assistantMessageInterface,
             }
           : {}),
+        ...(next.metadata?.automated ? { automated: true } : {}),
       };
       const userMsg = createUserMessage(next.content, next.attachments);
       // When displayContent is provided (e.g. original text before recording


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skip-automated-memory-extraction.md.

**Gap:** Queue-drain unknown-slash path does not forward automated from queued metadata
**What was expected:** drainChannelMeta should include automated from next.metadata
**What was found:** Only provenance and channel context were spread, not automated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
