### PR TITLE
fix: rehydrate platform_assistant_id from secure store on daemon startup

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -144,12 +144,18 @@ export function getPlatformBaseUrl(): string {
   return str("PLATFORM_BASE_URL") ?? _platformBaseUrlOverride ?? "";
 }
 
+let _platformAssistantIdOverride: string | undefined;
+
+export function setPlatformAssistantId(value: string | undefined): void {
+  _platformAssistantIdOverride = value;
+}
+
 /**
  * PLATFORM_ASSISTANT_ID — UUID of this assistant on the platform.
  * Required for registering callback routes when containerized.
  */
 export function getPlatformAssistantId(): string {
-  return str("PLATFORM_ASSISTANT_ID") ?? "";
+  return str("PLATFORM_ASSISTANT_ID") ?? _platformAssistantIdOverride ?? "";
 }
 
 /**

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,4 +1,4 @@
-import { setPlatformBaseUrl } from "../config/env.js";
+import { setPlatformAssistantId, setPlatformBaseUrl } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
@@ -39,6 +39,22 @@ export async function initializeProvidersAndTools(
     log.warn(
       { error: err instanceof Error ? err.message : String(err) },
       "Failed to rehydrate platform base URL from credential store (non-fatal)",
+    );
+  }
+
+  // Rehydrate the platform assistant ID from the credential store so
+  // isPlatformManaged() works after assistant restarts.
+  try {
+    const key = credentialKey("vellum", "platform_assistant_id");
+    const persisted = await getSecureKeyAsync(key);
+    if (persisted) {
+      setPlatformAssistantId(persisted);
+      log.info("Rehydrated platform assistant ID from credential store");
+    }
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to rehydrate platform assistant ID from credential store (non-fatal)",
     );
   }
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -1,4 +1,7 @@
-import { setPlatformBaseUrl } from "../../config/env.js";
+import {
+  setPlatformAssistantId,
+  setPlatformBaseUrl,
+} from "../../config/env.js";
 import {
   API_KEY_PROVIDERS,
   getConfig,
@@ -162,6 +165,9 @@ export async function handleAddSecret(
       if (service === "vellum" && field === "platform_base_url") {
         setPlatformBaseUrl(value);
       }
+      if (service === "vellum" && field === "platform_assistant_id") {
+        setPlatformAssistantId(value);
+      }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());
         if (service === "vellum" && field === "assistant_api_key") {
@@ -284,6 +290,9 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       deleteCredentialMetadata(service, field);
       if (service === "vellum" && field === "platform_base_url") {
         setPlatformBaseUrl(undefined);
+      }
+      if (service === "vellum" && field === "platform_assistant_id") {
+        setPlatformAssistantId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());


### PR DESCRIPTION
## Summary
- Add `setPlatformAssistantId()` to `env.ts` with an in-memory override, mirroring the existing `platform_base_url` pattern
- Handle `vellum:platform_assistant_id` in `handleAddSecret` and `handleDeleteSecret` to update the in-memory override at runtime
- Rehydrate `platform_assistant_id` from the secure store on daemon startup so `isPlatformManaged()` returns true for local signed-in assistants
- Enables managed OAuth catalog and platform callback registration for local platform sign-in

## Original prompt
Fix: `vellum:platform_assistant_id` is injected into the daemon's secure store by the client but never rehydrated or read into runtime config. `getPlatformAssistantId()` only reads from the env var, so local signed-in assistants don't get platform-managed features.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Existing `secret-routes-managed-proxy.test.ts` tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
