### PR TITLE
fix: redirect Stripe top-up return to unauthenticated success page

### DIFF
--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -136,7 +136,7 @@ public final class BillingService {
         }
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
-        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/settings?panel=billing")
+        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/billing/top-up/success")
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(requestBody)
 


### PR DESCRIPTION
## Summary
- Update Stripe top-up `return_path` from `/settings?panel=billing` to `/billing/top-up/success`
- The old path required authentication, showing "Sign in required" to desktop users after payment since the desktop app's auth session is not shared with the browser
- Companion platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/2415

## Original prompt
Fix: Stripe top-up success path returns desktop users to a signed-out web settings page instead of a useful confirmation screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
