### PR TITLE
fix: make billing tab visibility reactive to bootstrap completion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -68,6 +68,7 @@ struct SettingsPanel: View {
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
+    @State private var bootstrapGeneration: Int = 0
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
@@ -198,6 +199,9 @@ struct SettingsPanel: View {
                 await refreshPermissionStatus()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
+            bootstrapGeneration += 1
+        }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
@@ -268,7 +272,8 @@ struct SettingsPanel: View {
     }
 
     private var billingVisible: Bool {
-        isBillingEnabled && authManager.isAuthenticated && UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
+        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
+        return isBillingEnabled && authManager.isAuthenticated && UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
     }
 
     private var settingsNav: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -12,9 +12,11 @@ struct DrawerMenuView: View {
     @State private var effectiveBalance: String?
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
+    @State private var bootstrapGeneration: Int = 0
 
     private var isBillingVisible: Bool {
-        authManager.isAuthenticated &&
+        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
+        return authManager.isAuthenticated &&
         MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled") &&
         UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
     }
@@ -74,6 +76,9 @@ struct DrawerMenuView: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+        .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
+            bootstrapGeneration += 1
+        }
         .task {
             await loadBalance()
         }


### PR DESCRIPTION
## Summary
- Observe `.localBootstrapCompleted` notification in `SettingsPanel` and `DrawerMenuView` to trigger view recomputation
- Makes billing tab visibility reactive when `connectedOrganizationId` is written by bootstrap after sign-in
- Billing tab now appears immediately after successful bootstrap without requiring a panel reopen

## Original prompt
Fix: Signing in from Settings does not reliably make the Billing tab appear until the panel is reopened, because SwiftUI doesn't observe raw `UserDefaults` reads used in the `billingVisible` computed property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
