### PR TITLE
fix: refresh billing data when app becomes active after Stripe payment

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -82,6 +82,11 @@ struct DrawerMenuView: View {
         .task {
             await loadBalance()
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task {
+                await loadBalance()
+            }
+        }
     }
 
     private func loadBalance() async {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -23,6 +23,11 @@ struct SettingsBillingTab: View {
         .task {
             await loadSummary()
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task {
+                await loadSummary()
+            }
+        }
     }
 
     // MARK: - Balance Card


### PR DESCRIPTION
## Summary
- Refresh billing data when the app becomes active (returns from background/browser)
- Observes `NSApplication.didBecomeActiveNotification` in `SettingsBillingTab` and `DrawerMenuView`
- Ensures balance updates after Stripe top-up payment without requiring manual panel reopen

## Original prompt
Fix: The add-funds recovery loop leaves stale desktop state after a successful payment. The billing tab and drawer only fetch on appear, so users can pay successfully and still see stale zero-balance UI until they manually reopen the surface.

## Test plan
- [ ] Open the billing tab, note the balance
- [ ] Click "Add funds" and complete a Stripe payment in the browser
- [ ] Return to the desktop app — balance should refresh automatically
- [ ] Verify the drawer menu also shows updated balance after returning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
