### PR TITLE
fix: scope logout daemon cleanup to local assistants only

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -143,24 +143,26 @@ extension AppDelegate {
 
             await authManager.logout()
 
-            // Clear managed proxy credentials from the running daemon
-            if let token = actorToken, !token.isEmpty {
-                let assistantId = connectedAssistantId ?? ""
-                let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
-                let daemonBaseURL = "http://localhost:\(port)"
-                let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials(
-                    daemonBaseURL: daemonBaseURL,
-                    daemonToken: token
-                )
-                if !cleared {
-                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed proxy state")
+            // Clear managed proxy credentials from the running daemon (local assistants only)
+            if !isCurrentAssistantManaged && !isCurrentAssistantRemote {
+                if let token = actorToken, !token.isEmpty {
+                    let assistantId = connectedAssistantId ?? ""
+                    let port = LockfileAssistant.loadByName(assistantId)?.daemonPort ?? 7821
+                    let daemonBaseURL = "http://localhost:\(port)"
+                    let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials(
+                        daemonBaseURL: daemonBaseURL,
+                        daemonToken: token
+                    )
+                    if !cleared {
+                        log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed proxy state")
+                        daemonClient.disconnect()
+                        assistantCli.stop()
+                    }
+                } else {
+                    log.warning("No actor token available during logout — stopping daemon to ensure stale credentials are not retained")
                     daemonClient.disconnect()
                     assistantCli.stop()
                 }
-            } else {
-                log.warning("No actor token available during logout — stopping daemon to ensure stale credentials are not retained")
-                daemonClient.disconnect()
-                assistantCli.stop()
             }
 
             // Clear locally-cached credentials from Keychain for all local assistants


### PR DESCRIPTION
## Summary
- Guard daemon credential cleanup in `performLogout()` to only run for local assistants
- Prevents managed/remote assistant logout from accidentally clearing credentials on or stopping an unrelated local daemon
- Keychain cleanup remains unaffected as it's already scoped to local assistants

## Original prompt
Fix: Logout cleanup is not scoped to local assistants, so logging out of a managed or remote assistant can clear or stop an unrelated local daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
