### PR TITLE
fix: stop all local daemons on logout to clear stale managed-proxy credentials

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -175,6 +175,26 @@ extension AppDelegate {
                 _ = keychainStorage.delete(account: credentialAccount)
             }
 
+            // Stop all non-current local daemons to clear in-memory managed proxy
+            // credentials. Assistant switches intentionally leave old daemons running
+            // for fast switching, but on full logout there's no reason to keep them
+            // alive with potentially stale state.
+            for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
+                if assistant.assistantId != connectedAssistantId {
+                    if let instanceDir = assistant.instanceDir {
+                        let env = ["BASE_DATA_DIR": instanceDir]
+                        let pidPath = VellumAssistantShared.resolvePidPath(environment: env)
+                        if let data = try? Data(contentsOf: URL(fileURLWithPath: pidPath)),
+                           let pidString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                           let pid = pid_t(pidString),
+                           kill(pid, 0) == 0 {
+                            kill(pid, SIGTERM)
+                            log.info("Stopped daemon for assistant \(assistant.assistantId, privacy: .public) (pid \(pid))")
+                        }
+                    }
+                }
+            }
+
             // Reset dock icon to default before tearing down UI
             AvatarAppearanceManager.shared.resetForDisconnect()
 


### PR DESCRIPTION
## Summary
- Stop all local daemons on logout, not just the currently connected one
- Ensures no stale managed-proxy credentials remain in-memory on daemons left running by assistant switches
- Uses PID-based termination for non-current daemons via `resolvePidPath()` lookup from each assistant's `instanceDir`

## Original prompt
Fix: Logout only revokes the currently selected daemon, but assistant switches leave older local daemons running with potentially stale in-memory managed-proxy credentials.

## Test plan
- [ ] With multiple local assistants hatched, switch between them (so old daemons stay running)
- [ ] Perform logout and verify all local daemon processes are terminated (check `ps aux | grep vellum`)
- [ ] Verify the current daemon is still cleaned up via the existing credential-clearing path
- [ ] Verify re-login and hatch work correctly after the full logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
