### PR TITLE
refactor: rename ClassifiedSessionError, classifySessionError, buildSessionErrorMessage to conversation terminology

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -283,7 +283,7 @@ mock.module("../workspace/git-service.js", () => ({
 }));
 
 mock.module("../daemon/conversation-error.js", () => ({
-  classifySessionError: (_err: unknown, _ctx: unknown) => ({
+  classifyConversationError: (_err: unknown, _ctx: unknown) => ({
     code: "CONVERSATION_PROCESSING_FAILED",
     userMessage: "Something went wrong processing your message.",
     retryable: false,
@@ -295,7 +295,7 @@ mock.module("../daemon/conversation-error.js", () => ({
     if (err instanceof Error && err.name === "AbortError") return true;
     return false;
   },
-  buildSessionErrorMessage: (
+  buildConversationErrorMessage: (
     conversationId: string,
     classified: Record<string, unknown>,
   ) => ({
@@ -698,8 +698,8 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // After PR 2 fix, the reducer SHOULD be called to attempt compaction.
       expect(reducerCalled).toBe(true);
 
-      // BUG: Currently a session_error IS emitted instead of retrying.
-      // After PR 2 fix, there should be no session_error.
+      // BUG: Currently a conversation_error IS emitted instead of retrying.
+      // After PR 2 fix, there should be no conversation_error.
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },
@@ -806,7 +806,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
       // The reducer should be called in the convergence loop
       expect(reducerCalled).toBe(true);
-      // Should recover without session_error
+      // Should recover without conversation_error
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       expect(callCount).toBe(2);
@@ -940,7 +940,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       );
       expect(capturedTargetTokens!).toBe(expectedCorrectedTarget);
 
-      // Should recover without session_error
+      // Should recover without conversation_error
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       expect(callCount).toBe(2);
@@ -1229,7 +1229,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // After PR 2 fix, emergency compaction should be attempted.
       expect(emergencyCompactCalled).toBe(true);
 
-      // BUG: Currently a session_error IS emitted.
+      // BUG: Currently a conversation_error IS emitted.
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },
@@ -1405,7 +1405,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // Agent loop should have been called twice: once before yield, once after compaction
       expect(agentLoopCallCount).toBe(2);
 
-      // No session_error should be emitted
+      // No conversation_error should be emitted
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
 
@@ -1592,7 +1592,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // Agent loop called twice: once (yielded at tool 3), once after compaction
       expect(agentLoopCallCount).toBe(2);
 
-      // No session_error
+      // No conversation_error
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     },

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -266,7 +266,7 @@ mock.module("../workspace/git-service.js", () => ({
 }));
 
 mock.module("../daemon/conversation-error.js", () => ({
-  classifySessionError: (_err: unknown, _ctx: unknown) => ({
+  classifyConversationError: (_err: unknown, _ctx: unknown) => ({
     code: "CONVERSATION_PROCESSING_FAILED",
     userMessage: "Something went wrong processing your message.",
     retryable: false,
@@ -278,7 +278,7 @@ mock.module("../daemon/conversation-error.js", () => ({
     if (err instanceof Error && err.name === "AbortError") return true;
     return false;
   },
-  buildSessionErrorMessage: (
+  buildConversationErrorMessage: (
     conversationId: string,
     classified: Record<string, unknown>,
   ) => ({
@@ -549,7 +549,7 @@ describe("session-agent-loop", () => {
       expect(sessionError).toBeDefined();
     });
 
-    test("non-error agent loop completion does not emit session_error", async () => {
+    test("non-error agent loop completion does not emit conversation_error", async () => {
       const events: ServerMessage[] = [];
 
       const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
@@ -773,7 +773,7 @@ describe("session-agent-loop", () => {
       expect(compactEvent).toBeDefined();
     });
 
-    test("emits session_error when context stays too large after all recovery attempts", async () => {
+    test("emits conversation_error when context stays too large after all recovery attempts", async () => {
       const events: ServerMessage[] = [];
 
       const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
@@ -902,7 +902,7 @@ describe("session-agent-loop", () => {
       expect(complete).toBeDefined();
     });
 
-    test("interactive deny produces graceful assistant response instead of session_error", async () => {
+    test("interactive deny produces graceful assistant response instead of conversation_error", async () => {
       const events: ServerMessage[] = [];
 
       // Reducer exhausts all tiers but context is still too large
@@ -950,7 +950,7 @@ describe("session-agent-loop", () => {
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      // Should NOT emit session_error
+      // Should NOT emit conversation_error
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
 
@@ -1056,7 +1056,7 @@ describe("session-agent-loop", () => {
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      // Should not produce session_error since auto-compress recovered
+      // Should not produce conversation_error since auto-compress recovered
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
@@ -1506,7 +1506,7 @@ describe("session-agent-loop", () => {
 
       const cancelled = events.find((e) => e.type === "generation_cancelled");
       expect(cancelled).toBeDefined();
-      // Should NOT emit a session_error for user cancellation
+      // Should NOT emit a conversation_error for user cancellation
       const sessionError = events.find((e) => e.type === "conversation_error");
       expect(sessionError).toBeUndefined();
     });

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import type { ErrorContext } from "../daemon/conversation-error.js";
 import {
-  buildSessionErrorMessage,
-  classifySessionError,
+  buildConversationErrorMessage,
+  classifyConversationError,
   isUserCancellation,
 } from "../daemon/conversation-error.js";
 import { ProviderError } from "../util/errors.js";
@@ -56,7 +56,7 @@ describe("isUserCancellation", () => {
   });
 });
 
-describe("classifySessionError", () => {
+describe("classifyConversationError", () => {
   const baseCtx: ErrorContext = { phase: "agent_loop" };
 
   describe("network errors", () => {
@@ -74,7 +74,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_NETWORK`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_NETWORK");
         expect(result.retryable).toBe(true);
         expect(result.errorCategory).toBe("provider_network");
@@ -93,7 +93,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_RATE_LIMIT`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_RATE_LIMIT");
         expect(result.retryable).toBe(true);
         expect(result.userMessage).toContain("busy");
@@ -114,7 +114,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_API`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_API");
         expect(result.retryable).toBe(true);
       });
@@ -126,7 +126,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_API with timeout message`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_API");
         expect(result.userMessage).toContain("timed out");
         expect(result.retryable).toBe(true);
@@ -135,7 +135,7 @@ describe("classifySessionError", () => {
     }
 
     it('does not steal "connection timeout" from PROVIDER_NETWORK', () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("connection timeout"),
         baseCtx,
       );
@@ -143,7 +143,7 @@ describe("classifySessionError", () => {
     });
 
     it('does not steal "Gateway timeout" from PROVIDER_API', () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("Gateway timeout"),
         baseCtx,
       );
@@ -167,7 +167,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as CONTEXT_TOO_LARGE`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("CONTEXT_TOO_LARGE");
         expect(result.retryable).toBe(false);
         expect(result.userMessage).toContain("too long");
@@ -183,7 +183,7 @@ describe("classifySessionError", () => {
         "anthropic",
         400,
       );
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("CONTEXT_TOO_LARGE");
       expect(result.retryable).toBe(false);
     });
@@ -194,7 +194,7 @@ describe("classifySessionError", () => {
         "anthropic",
         413,
       );
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("CONTEXT_TOO_LARGE");
       expect(result.retryable).toBe(false);
     });
@@ -205,7 +205,7 @@ describe("classifySessionError", () => {
         "anthropic",
         400,
       );
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
@@ -222,7 +222,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_ORDERING`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_ORDERING");
         expect(result.retryable).toBe(true);
         expect(result.userMessage).toBe(
@@ -238,7 +238,7 @@ describe("classifySessionError", () => {
         "anthropic",
         400,
       );
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_ORDERING");
       expect(result.retryable).toBe(true);
       expect(result.errorCategory).toBe("tool_ordering");
@@ -253,7 +253,7 @@ describe("classifySessionError", () => {
 
     for (const msg of cases) {
       it(`classifies "${msg}" as PROVIDER_WEB_SEARCH`, () => {
-        const result = classifySessionError(new Error(msg), baseCtx);
+        const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_WEB_SEARCH");
         expect(result.retryable).toBe(true);
         expect(result.userMessage).toBe(
@@ -269,7 +269,7 @@ describe("classifySessionError", () => {
         "anthropic",
         400,
       );
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_WEB_SEARCH");
       expect(result.retryable).toBe(true);
       expect(result.errorCategory).toBe("web_search_ordering");
@@ -278,7 +278,7 @@ describe("classifySessionError", () => {
 
   describe("abort/cancel errors (non-user-initiated)", () => {
     it('classifies "aborted" as CONVERSATION_ABORTED', () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("Request aborted"),
         baseCtx,
       );
@@ -287,7 +287,7 @@ describe("classifySessionError", () => {
     });
 
     it('classifies "cancelled" as CONVERSATION_ABORTED', () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("Operation cancelled"),
         baseCtx,
       );
@@ -299,7 +299,7 @@ describe("classifySessionError", () => {
   describe("regenerate phase", () => {
     it("returns REGENERATE_FAILED with nested classification info", () => {
       const ctx: ErrorContext = { phase: "regenerate" };
-      const result = classifySessionError(new Error("ECONNREFUSED"), ctx);
+      const result = classifyConversationError(new Error("ECONNREFUSED"), ctx);
       expect(result.code).toBe("REGENERATE_FAILED");
       expect(result.retryable).toBe(true);
       expect(result.userMessage).toContain("regenerate");
@@ -308,7 +308,7 @@ describe("classifySessionError", () => {
 
     it("returns REGENERATE_FAILED for generic errors", () => {
       const ctx: ErrorContext = { phase: "regenerate" };
-      const result = classifySessionError(new Error("unknown issue"), ctx);
+      const result = classifyConversationError(new Error("unknown issue"), ctx);
       expect(result.code).toBe("REGENERATE_FAILED");
       expect(result.retryable).toBe(true);
     });
@@ -316,7 +316,7 @@ describe("classifySessionError", () => {
 
   describe("generic errors", () => {
     it("classifies unknown errors as CONVERSATION_PROCESSING_FAILED with error summary", () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("something completely unexpected"),
         baseCtx,
       );
@@ -328,20 +328,20 @@ describe("classifySessionError", () => {
 
     it("includes debugDetails with stack trace", () => {
       const err = new Error("test error");
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.debugDetails).toBeDefined();
       expect(result.debugDetails).toContain("test error");
     });
 
     it("handles non-Error values", () => {
-      const result = classifySessionError("plain string error", baseCtx);
+      const result = classifyConversationError("plain string error", baseCtx);
       expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.userMessage).toContain("plain string error");
       expect(result.debugDetails).toBe("plain string error");
     });
 
     it("falls back to generic message for empty error", () => {
-      const result = classifySessionError(new Error(""), baseCtx);
+      const result = classifyConversationError(new Error(""), baseCtx);
       expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
       expect(result.userMessage).toBe(
         "Something went wrong processing your message. Please try again.",
@@ -349,7 +349,7 @@ describe("classifySessionError", () => {
     });
 
     it("skips leading newlines to find first non-empty line", () => {
-      const result = classifySessionError(
+      const result = classifyConversationError(
         new Error("\n\nactual error on line 3"),
         baseCtx,
       );
@@ -361,7 +361,7 @@ describe("classifySessionError", () => {
   describe("ProviderError with statusCode (deterministic classification)", () => {
     it("classifies ProviderError with 429 as PROVIDER_RATE_LIMIT", () => {
       const err = new ProviderError("Rate limit exceeded", "anthropic", 429);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_RATE_LIMIT");
       expect(result.retryable).toBe(true);
       expect(result.errorCategory).toBe("rate_limit");
@@ -369,35 +369,35 @@ describe("classifySessionError", () => {
 
     it("classifies ProviderError with 500 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Internal server error", "anthropic", 500);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
 
     it("classifies ProviderError with 502 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Bad gateway", "openai", 502);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
 
     it("classifies ProviderError with 503 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Service unavailable", "gemini", 503);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
 
     it("classifies ProviderError with 401 as PROVIDER_BILLING (non-retryable)", () => {
       const err = new ProviderError("Unauthorized", "anthropic", 401);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_BILLING");
       expect(result.retryable).toBe(false);
     });
 
     it("classifies ProviderError with 402 as credits_exhausted (non-retryable)", () => {
       const err = new ProviderError("Payment Required", "anthropic", 402);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_BILLING");
       expect(result.errorCategory).toBe("credits_exhausted");
       expect(result.retryable).toBe(false);
@@ -405,14 +405,14 @@ describe("classifySessionError", () => {
 
     it("classifies ProviderError with 400 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Bad request", "anthropic", 400);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
 
     it("ProviderError without statusCode falls back to regex", () => {
       const err = new ProviderError("ECONNREFUSED", "anthropic");
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_NETWORK");
       expect(result.retryable).toBe(true);
     });
@@ -420,7 +420,7 @@ describe("classifySessionError", () => {
     it("statusCode takes priority over conflicting message regex", () => {
       // Message says "rate limit" but statusCode is 500 → should use statusCode
       const err = new ProviderError("rate limit error", "anthropic", 500);
-      const result = classifySessionError(err, baseCtx);
+      const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
       expect(result.retryable).toBe(true);
     });
@@ -439,7 +439,7 @@ describe("classifySessionError", () => {
         },
       ];
       for (const { error, ctx } of cases) {
-        const result = classifySessionError(error, ctx);
+        const result = classifyConversationError(error, ctx);
         expect(result.errorCategory).toBeDefined();
         expect(result.errorCategory.length).toBeGreaterThan(0);
       }
@@ -449,14 +449,14 @@ describe("classifySessionError", () => {
   describe("debug detail truncation", () => {
     it("truncates debugDetails longer than 4000 chars", () => {
       const longMsg = "x".repeat(5000);
-      const result = classifySessionError(new Error(longMsg), baseCtx);
+      const result = classifyConversationError(new Error(longMsg), baseCtx);
       expect(result.debugDetails!.length).toBeLessThanOrEqual(4020); // 4000 + truncation marker
       expect(result.debugDetails!).toContain("(truncated)");
     });
 
     it("preserves debugDetails under 4000 chars", () => {
       const shortMsg = "short error message";
-      const result = classifySessionError(new Error(shortMsg), baseCtx);
+      const result = classifyConversationError(new Error(shortMsg), baseCtx);
       expect(result.debugDetails).toBeDefined();
       expect(result.debugDetails!).not.toContain("(truncated)");
     });
@@ -486,9 +486,9 @@ describe("classifySessionError", () => {
   });
 });
 
-describe("buildSessionErrorMessage", () => {
+describe("buildConversationErrorMessage", () => {
   it("builds a valid ConversationErrorMessage", () => {
-    const msg = buildSessionErrorMessage("session-123", {
+    const msg = buildConversationErrorMessage("session-123", {
       code: "PROVIDER_NETWORK",
       userMessage: "Network error",
       retryable: true,
@@ -506,7 +506,7 @@ describe("buildSessionErrorMessage", () => {
   });
 
   it("omits debugDetails when not provided", () => {
-    const msg = buildSessionErrorMessage("session-456", {
+    const msg = buildConversationErrorMessage("session-456", {
       code: "UNKNOWN",
       userMessage: "Something went wrong",
       retryable: false,
@@ -519,7 +519,7 @@ describe("buildSessionErrorMessage", () => {
   });
 
   it("includes errorCategory for ordering errors", () => {
-    const msg = buildSessionErrorMessage("session-789", {
+    const msg = buildConversationErrorMessage("session-789", {
       code: "PROVIDER_ORDERING",
       userMessage: "An internal error occurred. Please try again.",
       retryable: true,
@@ -531,7 +531,7 @@ describe("buildSessionErrorMessage", () => {
   });
 
   it("includes errorCategory for web search errors", () => {
-    const msg = buildSessionErrorMessage("session-abc", {
+    const msg = buildConversationErrorMessage("session-abc", {
       code: "PROVIDER_WEB_SEARCH",
       userMessage:
         "An internal error occurred with web search. Please try again.",

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -556,7 +556,7 @@ describe("provider ordering error retry", () => {
     expect(events.some((e) => e.type === "conversation_error")).toBe(false);
   });
 
-  test("ProviderError with statusCode 413 triggers forced-compaction retry via classifySessionError", async () => {
+  test("ProviderError with statusCode 413 triggers forced-compaction retry via classifyConversationError", async () => {
     firstRunErrorMode = "context_too_large_413";
     forceCompactionEnabled = true;
 
@@ -571,7 +571,7 @@ describe("provider ordering error retry", () => {
     );
 
     // The 413 ProviderError message "request entity too large" doesn't match
-    // the regex patterns, but classifySessionError recognizes statusCode 413
+    // the regex patterns, but classifyConversationError recognizes statusCode 413
     // as CONTEXT_TOO_LARGE and sets contextTooLargeDetected = true.
     expect(agentLoopRunCount).toBe(2);
     expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
@@ -598,7 +598,7 @@ describe("provider ordering error retry", () => {
     // since compaction didn't help (forceCompactionEnabled=false).
     expect(agentLoopRunCount).toBe(2);
 
-    // The error must be surfaced to clients via session_error, not silently swallowed.
+    // The error must be surfaced to clients via conversation_error, not silently swallowed.
     const sessionError = events.find((e) => e.type === "conversation_error") as
       | { code?: string }
       | undefined;

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -28,8 +28,8 @@ import {
 } from "./assistant-attachments.js";
 import type { AgentLoopConversationContext } from "./conversation-agent-loop.js";
 import {
-  buildSessionErrorMessage,
-  classifySessionError,
+  buildConversationErrorMessage,
+  classifyConversationError,
   isContextTooLarge,
 } from "./conversation-error.js";
 import { isProviderOrderingError } from "./conversation-slash.js";
@@ -600,7 +600,7 @@ export function handleError(
     state.contextTooLargeDetected = true;
     state.contextTooLargeErrorMessage = event.error.message;
   } else {
-    const classified = classifySessionError(event.error, {
+    const classified = classifyConversationError(event.error, {
       phase: "agent_loop",
     });
     if (classified.code === "CONTEXT_TOO_LARGE") {
@@ -610,13 +610,13 @@ export function handleError(
       classified.code === "PROVIDER_ORDERING" ||
       classified.code === "PROVIDER_WEB_SEARCH"
     ) {
-      // Ordering errors detected via classifySessionError (e.g. from ProviderError
+      // Ordering errors detected via classifyConversationError (e.g. from ProviderError
       // with statusCode 400 and ordering message) — trigger the retry path.
       state.orderingErrorDetected = true;
       state.deferredOrderingError = event.error.message;
     } else {
       deps.onEvent(
-        buildSessionErrorMessage(deps.ctx.conversationId, classified),
+        buildConversationErrorMessage(deps.ctx.conversationId, classified),
       );
       state.providerErrorUserMessage = classified.userMessage;
     }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -82,8 +82,8 @@ import {
   resolveAssistantAttachments,
 } from "./conversation-attachments.js";
 import {
-  buildSessionErrorMessage,
-  classifySessionError,
+  buildConversationErrorMessage,
+  classifyConversationError,
   isUserCancellation,
 } from "./conversation-error.js";
 import { consolidateAssistantMessages } from "./conversation-history.js";
@@ -1295,7 +1295,7 @@ export async function runAgentLoopImpl(
             );
           } else {
             // User denied compression — emit a graceful assistant explanation
-            // instead of a session_error, and end the turn cleanly.
+            // instead of a conversation_error, and end the turn cleanly.
             state.contextTooLargeDetected = false;
             const denyText =
               "The conversation has grown too long for the model to process, " +
@@ -1403,20 +1403,20 @@ export async function runAgentLoopImpl(
 
       // Final fallback: all recovery paths exhausted
       if (state.contextTooLargeDetected) {
-        const classified = classifySessionError(
+        const classified = classifyConversationError(
           new Error("context_length_exceeded"),
           { phase: "agent_loop" },
         );
-        onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+        onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
       }
     }
 
     if (state.deferredOrderingError) {
-      const classified = classifySessionError(
+      const classified = classifyConversationError(
         new Error(state.deferredOrderingError),
         { phase: "agent_loop" },
       );
-      onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
     }
 
     // Reconcile synthesized cancellation tool_results
@@ -1697,7 +1697,7 @@ export async function runAgentLoopImpl(
       const message = err instanceof Error ? err.message : String(err);
       const errorClass = err instanceof Error ? err.constructor.name : "Error";
       rlog.error({ err }, "Conversation processing error");
-      const classified = classifySessionError(err, errorCtx);
+      const classified = classifyConversationError(err, errorCtx);
       ctx.traceEmitter.emit("request_error", truncate(message, 200, ""), {
         requestId: reqId,
         status: "error",
@@ -1709,7 +1709,7 @@ export async function runAgentLoopImpl(
         },
       });
       onEvent({ type: "error", message: classified.userMessage });
-      onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
+      onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
       void getHookManager().trigger("on-error", {
         error: err instanceof Error ? err.name : "Error",
         message,

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -5,9 +5,9 @@ import type {
 } from "./message-protocol.js";
 
 /**
- * Classified session error ready for client emission.
+ * Classified conversation error ready for client emission.
  */
-export interface ClassifiedSessionError {
+export interface ClassifiedConversationError {
   code: ConversationErrorCode;
   userMessage: string;
   retryable: boolean;
@@ -85,7 +85,7 @@ const WEB_SEARCH_ORDERING_PATTERNS = [
   /web_search.*tool_result/i,
 ];
 
-// User-initiated cancellation patterns — these should NOT produce session_error
+// User-initiated cancellation patterns — these should NOT produce conversation_error
 const CANCEL_PATTERNS = [/abort/i, /cancel/i];
 
 /**
@@ -101,7 +101,7 @@ export interface ErrorContext {
 /**
  * Returns true if the error looks like a user-initiated cancellation
  * (AbortError or explicit cancel). These should use `generation_cancelled`
- * instead of `session_error`.
+ * instead of `conversation_error`.
  */
 export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   if (!ctx.aborted) return false;
@@ -122,7 +122,7 @@ function truncateDebugDetails(details: string): string {
 }
 
 /**
- * Classify an unknown error into a structured session error.
+ * Classify an unknown error into a structured conversation error.
  * Does NOT handle user-initiated cancellation — callers should check
  * `isUserCancellation` first and emit `generation_cancelled` instead.
  *
@@ -131,10 +131,10 @@ function truncateDebugDetails(details: string): string {
  * 2. ProviderError.statusCode (deterministic for provider failures)
  * 3. Regex fallback for network/cancel/unknown errors
  */
-export function classifySessionError(
+export function classifyConversationError(
   error: unknown,
   ctx: ErrorContext,
-): ClassifiedSessionError {
+): ClassifiedConversationError {
   const message = error instanceof Error ? error.message : String(error);
   const rawDetails =
     (error instanceof Error ? error.stack : undefined) ?? message;
@@ -167,7 +167,7 @@ export function classifySessionError(
 function classifyCore(
   error: unknown,
   message: string,
-): Omit<ClassifiedSessionError, "debugDetails"> {
+): Omit<ClassifiedConversationError, "debugDetails"> {
   // ProviderError with statusCode — deterministic classification
   if (error instanceof ProviderError && error.statusCode !== undefined) {
     if (error.statusCode === 413) {
@@ -290,7 +290,7 @@ export function isOrderingError(message: string): boolean {
 
 function classifyByMessage(
   message: string,
-): Omit<ClassifiedSessionError, "debugDetails"> {
+): Omit<ClassifiedConversationError, "debugDetails"> {
   // Check context-too-large before other patterns
   if (isContextTooLarge(message)) {
     return {
@@ -405,11 +405,11 @@ function classifyByMessage(
 }
 
 /**
- * Build a `session_error` server message from a classified error.
+ * Build a `conversation_error` server message from a classified error.
  */
-export function buildSessionErrorMessage(
+export function buildConversationErrorMessage(
   conversationId: string,
-  classified: ClassifiedSessionError,
+  classified: ClassifiedConversationError,
 ): ConversationErrorMessage {
   return {
     type: "conversation_error",

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -4,7 +4,7 @@ import { getApp, getAppPreview, updateApp } from "../memory/app-store.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
-import { buildSessionErrorMessage } from "./conversation-error.js";
+import { buildConversationErrorMessage } from "./conversation-error.js";
 import type {
   CardSurfaceData,
   DynamicPageSurfaceData,
@@ -609,7 +609,7 @@ export function handleSurfaceAction(
           "Failed to process history-restored relay prompt",
         );
         onEvent(
-          buildSessionErrorMessage(ctx.conversationId, {
+          buildConversationErrorMessage(ctx.conversationId, {
             code: "CONVERSATION_PROCESSING_FAILED",
             userMessage: `Something went wrong: ${message}`,
             retryable: false,


### PR DESCRIPTION
## Summary
- Rename `ClassifiedSessionError` → `ClassifiedConversationError`, `classifySessionError` → `classifyConversationError`, `buildSessionErrorMessage` → `buildConversationErrorMessage`
- Update all callers, imports, mocks, and test references across 8 files
- Update all comments referencing `session_error` → `conversation_error`

Part of plan: conv-remaining-symbols.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
