### PR TITLE
refactor: rename parentSessionId→parentConversationId in subagent wire protocol (TS + Swift)

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -66,7 +66,7 @@ function injectFakeSubagent(
     parentSendToClient: parentSendToClient ?? (() => {}),
   });
 
-  const parentId = state.config.parentSessionId;
+  const parentId = state.config.parentConversationId;
   if (!parentToChildren.has(parentId)) {
     parentToChildren.set(parentId, new Set());
   }
@@ -80,7 +80,7 @@ function makeState(
   return {
     config: {
       id: subagentId,
-      parentSessionId: "parent-sess-1",
+      parentConversationId: "parent-sess-1",
       label: "Test subagent",
       objective: "Do something",
     },
@@ -99,9 +99,10 @@ describe("SubagentManager abort notification", () => {
     const state = makeState(subagentId);
     injectFakeSubagent(manager, subagentId, state);
 
-    const notifications: { parentSessionId: string; message: string }[] = [];
-    manager.onSubagentFinished = (parentSessionId, message) => {
-      notifications.push({ parentSessionId, message });
+    const notifications: { parentConversationId: string; message: string }[] =
+      [];
+    manager.onSubagentFinished = (parentConversationId, message) => {
+      notifications.push({ parentConversationId, message });
     };
 
     const clientMessages: ServerMessage[] = [];
@@ -209,10 +210,10 @@ describe("SubagentManager abort notification", () => {
     expect(notified).toBe(false);
   });
 
-  test("abort rejects when callerSessionId does not match parent", () => {
+  test("abort rejects when callerConversationId does not match parent", () => {
     const manager = new SubagentManager();
     const subagentId = "sub-1";
-    const state = makeState(subagentId); // parentSessionId = 'parent-sess-1'
+    const state = makeState(subagentId); // parentConversationId = 'parent-sess-1'
     injectFakeSubagent(manager, subagentId, state);
 
     const result = manager.abort(subagentId, () => {}, "different-session");
@@ -221,7 +222,7 @@ describe("SubagentManager abort notification", () => {
     expect(state.status).toBe("running"); // unchanged
   });
 
-  test("abort succeeds when callerSessionId matches parent", () => {
+  test("abort succeeds when callerConversationId matches parent", () => {
     const manager = new SubagentManager();
     const subagentId = "sub-1";
     const state = makeState(subagentId);
@@ -233,13 +234,13 @@ describe("SubagentManager abort notification", () => {
     expect(state.status).toBe("aborted");
   });
 
-  test("abort succeeds without callerSessionId (no ownership check)", () => {
+  test("abort succeeds without callerConversationId (no ownership check)", () => {
     const manager = new SubagentManager();
     const subagentId = "sub-1";
     const state = makeState(subagentId);
     injectFakeSubagent(manager, subagentId, state);
 
-    // No callerSessionId — internal calls (eviction, abortAllForParent) skip ownership check
+    // No callerConversationId — internal calls (eviction, abortAllForParent) skip ownership check
     const result = manager.abort(subagentId, () => {});
 
     expect(result).toBe(true);
@@ -277,9 +278,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     managed.session.persistUserMessage = () => "msg-1";
     managed.session.runAgentLoop = async () => {};
 
-    const notifications: { parentSessionId: string; message: string }[] = [];
-    manager.onSubagentFinished = (parentSessionId, message) => {
-      notifications.push({ parentSessionId, message });
+    const notifications: { parentConversationId: string; message: string }[] =
+      [];
+    manager.onSubagentFinished = (parentConversationId, message) => {
+      notifications.push({ parentConversationId, message });
     };
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -291,7 +293,7 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
       estimatedCost: 0.005,
     });
     expect(notifications).toHaveLength(1);
-    expect(notifications[0].parentSessionId).toBe("parent-sess-1");
+    expect(notifications[0].parentConversationId).toBe("parent-sess-1");
     expect(notifications[0].message).toContain(
       '[Subagent "Test subagent" completed]',
     );
@@ -312,9 +314,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
       throw new Error("API rate limit exceeded");
     };
 
-    const notifications: { parentSessionId: string; message: string }[] = [];
-    manager.onSubagentFinished = (parentSessionId, message) => {
-      notifications.push({ parentSessionId, message });
+    const notifications: { parentConversationId: string; message: string }[] =
+      [];
+    manager.onSubagentFinished = (parentConversationId, message) => {
+      notifications.push({ parentConversationId, message });
     };
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -345,9 +348,10 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
       throw new Error("Conversation aborted");
     };
 
-    const notifications: { parentSessionId: string; message: string }[] = [];
-    manager.onSubagentFinished = (parentSessionId, message) => {
-      notifications.push({ parentSessionId, message });
+    const notifications: { parentConversationId: string; message: string }[] =
+      [];
+    manager.onSubagentFinished = (parentConversationId, message) => {
+      notifications.push({ parentConversationId, message });
     };
 
     await asInternals(manager).runSubagent(subagentId, "Do something");
@@ -424,9 +428,10 @@ describe("SubagentManager abort race guard", () => {
       { role: "assistant", content: [{ type: "text", text: "Done!" }] },
     ];
 
-    const notifications: { parentSessionId: string; message: string }[] = [];
-    manager.onSubagentFinished = (parentSessionId, message) => {
-      notifications.push({ parentSessionId, message });
+    const notifications: { parentConversationId: string; message: string }[] =
+      [];
+    manager.onSubagentFinished = (parentConversationId, message) => {
+      notifications.push({ parentConversationId, message });
     };
 
     await asInternals(manager).runSubagent(subagentId, "Do something");

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -61,7 +61,7 @@ const findTool = (name: string) =>
 function injectSubagent(
   manager: SubagentManager,
   subagentId: string,
-  parentSessionId: string,
+  parentConversationId: string,
   status: SubagentState["status"] = "running",
   overrides: Partial<SubagentState> = {},
 ): SubagentState {
@@ -75,7 +75,7 @@ function injectSubagent(
   const state: SubagentState = {
     config: {
       id: subagentId,
-      parentSessionId,
+      parentConversationId,
       label: "Test",
       objective: "test",
     },
@@ -100,10 +100,10 @@ function injectSubagent(
     state,
     parentSendToClient: () => {},
   });
-  if (!internals.parentToChildren.has(parentSessionId)) {
-    internals.parentToChildren.set(parentSessionId, new Set());
+  if (!internals.parentToChildren.has(parentConversationId)) {
+    internals.parentToChildren.set(parentConversationId, new Set());
   }
-  internals.parentToChildren.get(parentSessionId)!.add(subagentId);
+  internals.parentToChildren.get(parentConversationId)!.add(subagentId);
   return state;
 }
 
@@ -398,7 +398,7 @@ describe("Subagent spawn success and failure", () => {
       expect(capturedConfig!.label).toBe("Context test");
       expect(capturedConfig!.objective).toBe("Do it");
       expect(capturedConfig!.context).toBe("Extra info here");
-      expect(capturedConfig!.parentSessionId).toBe("sess-spawn-3");
+      expect(capturedConfig!.parentConversationId).toBe("sess-spawn-3");
     } finally {
       manager.spawn = originalSpawn;
     }
@@ -471,7 +471,7 @@ describe("Subagent status detail responses", () => {
     injectSubagent(manager, subagentId, ownerSession, "running", {
       config: {
         id: subagentId,
-        parentSessionId: ownerSession,
+        parentConversationId: ownerSession,
         label: "Detail test",
         objective: "test obj",
       },

--- a/assistant/src/__tests__/subagent-types.test.ts
+++ b/assistant/src/__tests__/subagent-types.test.ts
@@ -32,7 +32,7 @@ describe("SubagentConfig type shape", () => {
   test("can create a valid config object", () => {
     const config: SubagentConfig = {
       id: "test-id",
-      parentSessionId: "parent-id",
+      parentConversationId: "parent-id",
       label: "Test subagent",
       objective: "Do something",
     };
@@ -44,7 +44,7 @@ describe("SubagentConfig type shape", () => {
   test("supports optional fields", () => {
     const config: SubagentConfig = {
       id: "test-id",
-      parentSessionId: "parent-id",
+      parentConversationId: "parent-id",
       label: "Test subagent",
       objective: "Do something",
       context: "Extra context",
@@ -62,7 +62,7 @@ describe("SubagentState type shape", () => {
     const state: SubagentState = {
       config: {
         id: "test-id",
-        parentSessionId: "parent-id",
+        parentConversationId: "parent-id",
         label: "Test",
         objective: "Do something",
       },

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -7,7 +7,7 @@ import type { UsageStats } from "./shared.js";
 export interface SubagentSpawned {
   type: "subagent_spawned";
   subagentId: string;
-  parentSessionId: string;
+  parentConversationId: string;
   label: string;
   objective: string;
 }
@@ -41,7 +41,7 @@ export interface SubagentAbortRequest {
 
 export interface SubagentStatusRequest {
   type: "subagent_status";
-  /** If omitted, returns all subagents for the session. */
+  /** If omitted, returns all subagents for the conversation. */
   subagentId?: string;
 }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -318,15 +318,15 @@ export class DaemonServer {
       );
     };
     getSubagentManager().onSubagentFinished = async (
-      parentSessionId,
+      parentConversationId,
       message,
       sendToClient,
       notification,
     ) => {
-      const parentSession = this.conversations.get(parentSessionId);
+      const parentSession = this.conversations.get(parentConversationId);
       if (!parentSession) {
         log.warn(
-          { parentSessionId },
+          { parentConversationId },
           "Subagent finished but parent session not found",
         );
         return;
@@ -353,7 +353,7 @@ export class DaemonServer {
           .runAgentLoop(message, messageId, sendToClient)
           .catch((err) => {
             log.error(
-              { parentSessionId, err },
+              { parentConversationId, err },
               "Failed to process subagent notification in parent",
             );
           });

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -209,7 +209,7 @@ export function subagentRouteDefinitions(): RouteDefinition[] {
 
         // Ownership check
         const state = manager.getState(params.id);
-        if (!state || state.config.parentSessionId !== conversationId) {
+        if (!state || state.config.parentConversationId !== conversationId) {
           return httpError(
             "NOT_FOUND",
             `Subagent "${params.id}" not found or in terminal state.`,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -65,7 +65,7 @@ export interface SubagentNotificationInfo {
 }
 
 export type ParentNotifyCallback = (
-  parentSessionId: string,
+  parentConversationId: string,
   message: string,
   sendToClient: (msg: ServerMessage) => void,
   notification: SubagentNotificationInfo,
@@ -74,7 +74,7 @@ export type ParentNotifyCallback = (
 export class SubagentManager {
   /** subagentId → ManagedSubagent */
   private subagents = new Map<string, ManagedSubagent>();
-  /** parentSessionId → Set<subagentId> */
+  /** parentConversationId → Set<subagentId> */
   private parentToChildren = new Map<string, Set<string>>();
 
   /**
@@ -111,7 +111,7 @@ export class SubagentManager {
 
     // Depth check: prevent subagents from spawning nested subagents.
     const isParentASubagent = [...this.subagents.values()].some(
-      (s) => s.state.conversationId === config.parentSessionId,
+      (s) => s.state.conversationId === config.parentConversationId,
     );
     if (isParentASubagent) {
       throw new Error(
@@ -206,16 +206,16 @@ export class SubagentManager {
     this.subagents.set(subagentId, managed);
 
     // Track parent → child relationship.
-    if (!this.parentToChildren.has(config.parentSessionId)) {
-      this.parentToChildren.set(config.parentSessionId, new Set());
+    if (!this.parentToChildren.has(config.parentConversationId)) {
+      this.parentToChildren.set(config.parentConversationId, new Set());
     }
-    this.parentToChildren.get(config.parentSessionId)!.add(subagentId);
+    this.parentToChildren.get(config.parentConversationId)!.add(subagentId);
 
     // Notify client that a subagent was spawned.
     parentSendToClient({
       type: "subagent_spawned",
       subagentId,
-      parentSessionId: config.parentSessionId,
+      parentConversationId: config.parentConversationId,
       label: config.label,
       objective: config.objective,
     } as ServerMessage);
@@ -223,7 +223,7 @@ export class SubagentManager {
     log.info(
       {
         subagentId,
-        parentSessionId: config.parentSessionId,
+        parentConversationId: config.parentConversationId,
         label: config.label,
       },
       "Subagent spawned",
@@ -293,22 +293,22 @@ export class SubagentManager {
   abort(
     subagentId: string,
     parentSendToClient?: (msg: ServerMessage) => void,
-    callerSessionId?: string,
+    callerConversationId?: string,
     options?: { suppressNotification?: boolean },
   ): boolean {
     const managed = this.subagents.get(subagentId);
     if (!managed) return false;
     if (TERMINAL_STATUSES.has(managed.state.status)) return false;
-    // If a caller session is specified, verify ownership.
+    // If a caller conversation is specified, verify ownership.
     if (
-      callerSessionId &&
-      managed.state.config.parentSessionId !== callerSessionId
+      callerConversationId &&
+      managed.state.config.parentConversationId !== callerConversationId
     ) {
       log.warn(
         {
           subagentId,
-          callerSessionId,
-          parentSessionId: managed.state.config.parentSessionId,
+          callerConversationId,
+          parentConversationId: managed.state.config.parentConversationId,
         },
         "Abort rejected: caller does not own this subagent",
       );
@@ -336,7 +336,7 @@ export class SubagentManager {
           // notification routes to the parent session's socket, not the
           // aborting socket (which may be a different conversation after switching).
           this.onSubagentFinished(
-            managed.state.config.parentSessionId,
+            managed.state.config.parentConversationId,
             message,
             managed.parentSendToClient,
             {
@@ -363,10 +363,10 @@ export class SubagentManager {
    * Called when the parent session is aborted or evicted.
    */
   abortAllForParent(
-    parentSessionId: string,
+    parentConversationId: string,
     parentSendToClient?: (msg: ServerMessage) => void,
   ): number {
-    const children = this.parentToChildren.get(parentSessionId);
+    const children = this.parentToChildren.get(parentConversationId);
     if (!children) return 0;
 
     let count = 0;
@@ -427,8 +427,8 @@ export class SubagentManager {
     return this.subagents.get(subagentId)?.state;
   }
 
-  getChildrenOf(parentSessionId: string): SubagentState[] {
-    const children = this.parentToChildren.get(parentSessionId);
+  getChildrenOf(parentConversationId: string): SubagentState[] {
+    const children = this.parentToChildren.get(parentConversationId);
     if (!children) return [];
     return [...children]
       .map((id) => this.subagents.get(id)?.state)
@@ -447,10 +447,10 @@ export class SubagentManager {
    * Called when the parent client reconnects to a new socket.
    */
   updateParentSender(
-    parentSessionId: string,
+    parentConversationId: string,
     newSendToClient: (msg: ServerMessage) => void,
   ): void {
-    const children = this.parentToChildren.get(parentSessionId);
+    const children = this.parentToChildren.get(parentConversationId);
     if (!children) return;
 
     for (const childId of children) {
@@ -479,7 +479,7 @@ export class SubagentManager {
     this.subagents.delete(subagentId);
 
     // Remove from parent tracking.
-    const parentId = managed.state.config.parentSessionId;
+    const parentId = managed.state.config.parentConversationId;
     const siblings = this.parentToChildren.get(parentId);
     if (siblings) {
       siblings.delete(subagentId);
@@ -569,7 +569,7 @@ export class SubagentManager {
 
     try {
       this.onSubagentFinished(
-        config.parentSessionId,
+        config.parentConversationId,
         message,
         parentSendToClient,
         notification,

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -28,7 +28,7 @@ export interface SubagentConfig {
   /** Unique subagent identifier (UUID). */
   id: string;
   /** The parent Conversation's conversationId. */
-  parentSessionId: string;
+  parentConversationId: string;
   /** Human-readable label (e.g. "Research competitor pricing"). */
   label: string;
   /** The task objective for this subagent. */
@@ -37,7 +37,7 @@ export interface SubagentConfig {
   context?: string;
   /** Optional system prompt override. Falls back to a default subagent prompt. */
   systemPromptOverride?: string;
-  /** Optional skill IDs to pre-activate on the subagent session. */
+  /** Optional skill IDs to pre-activate on the subagent conversation. */
   preactivatedSkillIds?: string[];
   /** Whether the parent should present the result to the user. Defaults to true. */
   sendResultToUser?: boolean;
@@ -48,7 +48,7 @@ export interface SubagentConfig {
 export interface SubagentState {
   config: SubagentConfig;
   status: SubagentStatus;
-  /** The subagent's own conversationId (different from parentSessionId). */
+  /** The subagent's own conversationId (different from parentConversationId). */
   conversationId: string;
   /** Error message if status is 'failed'. */
   error?: string;

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -19,7 +19,7 @@ export async function executeSubagentMessage(
 
   // Ownership check: only the parent session can message a subagent.
   const state = manager.getState(subagentId);
-  if (!state || state.config.parentSessionId !== context.conversationId) {
+  if (!state || state.config.parentConversationId !== context.conversationId) {
     return {
       content: `Could not send message to subagent "${subagentId}". It may not exist or be in a terminal state.`,
       isError: true,

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -21,7 +21,7 @@ export async function executeSubagentRead(
   }
 
   // Ownership check: only the parent session can read a subagent's output.
-  if (state.config.parentSessionId !== context.conversationId) {
+  if (state.config.parentConversationId !== context.conversationId) {
     return {
       content: `No subagent found with ID "${subagentId}".`,
       isError: true,

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -31,7 +31,7 @@ export async function executeSubagentSpawn(
   try {
     const subagentId = await manager.spawn(
       {
-        parentSessionId: context.conversationId,
+        parentConversationId: context.conversationId,
         label,
         objective,
         context: extraContext,

--- a/assistant/src/tools/subagent/status.ts
+++ b/assistant/src/tools/subagent/status.ts
@@ -10,7 +10,10 @@ export async function executeSubagentStatus(
 
   if (subagentId) {
     const state = manager.getState(subagentId);
-    if (!state || state.config.parentSessionId !== context.conversationId) {
+    if (
+      !state ||
+      state.config.parentConversationId !== context.conversationId
+    ) {
       return {
         content: `No subagent found with ID "${subagentId}".`,
         isError: true,

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1929,7 +1929,7 @@ extension ChatViewModel {
             onWatchCompleteRequest?(msg)
 
         case .subagentSpawned(let msg):
-            guard belongsToConversation(msg.parentSessionId) else { return }
+            guard belongsToConversation(msg.parentConversationId) else { return }
             let info = SubagentInfo(id: msg.subagentId, label: msg.label, status: .running, parentMessageId: currentAssistantMessageId)
             activeSubagents.append(info)
             subagentDetailStore.recordSpawned(subagentId: msg.subagentId, objective: msg.objective)

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4113,14 +4113,14 @@ public struct SubagentMessageRequest: Codable, Sendable {
 public struct SubagentSpawned: Codable, Sendable {
     public let type: String
     public let subagentId: String
-    public let parentSessionId: String
+    public let parentConversationId: String
     public let label: String
     public let objective: String
 
-    public init(type: String, subagentId: String, parentSessionId: String, label: String, objective: String) {
+    public init(type: String, subagentId: String, parentConversationId: String, label: String, objective: String) {
         self.type = type
         self.subagentId = subagentId
-        self.parentSessionId = parentSessionId
+        self.parentConversationId = parentConversationId
         self.label = label
         self.objective = objective
     }

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -86,7 +86,7 @@ extension HTTPTransport {
 
         // The abort endpoint requires a conversationId in the body.
         // Translate client-local session ID → server conversation ID so the
-        // server's ownership check (parentSessionId) passes.
+        // server's ownership check (parentConversationId) passes.
         var body: [String: Any] = [:]
         if let conversationId = conversationId {
             body["conversationId"] = serverSessionId(forLocal: conversationId)
@@ -123,7 +123,7 @@ extension HTTPTransport {
         applyAuth(&request)
 
         // Translate client-local session ID → server conversation ID so the
-        // server's ownership check (parentSessionId) passes.
+        // server's ownership check (parentConversationId) passes.
         var body: [String: Any] = ["content": content]
         if let conversationId = conversationId {
             body["conversationId"] = serverSessionId(forLocal: conversationId)

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1535,15 +1535,15 @@ public final class HTTPTransport {
                 with: "\"conversationId\": \"\(localId)\""
             )
         }
-        if let parentSessionId = extractJsonStringValue(from: jsonString, key: "parentSessionId"),
-           let localId = serverToLocalConversationMap[parentSessionId] {
+        if let parentConversationId = extractJsonStringValue(from: jsonString, key: "parentConversationId"),
+           let localId = serverToLocalConversationMap[parentConversationId] {
             jsonString = jsonString.replacingOccurrences(
-                of: "\"parentSessionId\":\"\(parentSessionId)\"",
-                with: "\"parentSessionId\":\"\(localId)\""
+                of: "\"parentConversationId\":\"\(parentConversationId)\"",
+                with: "\"parentConversationId\":\"\(localId)\""
             )
             jsonString = jsonString.replacingOccurrences(
-                of: "\"parentSessionId\": \"\(parentSessionId)\"",
-                with: "\"parentSessionId\": \"\(localId)\""
+                of: "\"parentConversationId\": \"\(parentConversationId)\"",
+                with: "\"parentConversationId\": \"\(localId)\""
             )
         }
 


### PR DESCRIPTION
## Summary
- Rename `parentSessionId` → `parentConversationId` across all subagent types, manager, tools, routes, and tests
- Rename `callerSessionId` → `callerConversationId` in manager
- Update Swift `GeneratedAPITypes.swift`, `HTTPDaemonClient.swift`, `HTTPDaemonClient+Subagents.swift`, `ChatViewModel+MessageHandling.swift` atomically

Part of plan: conv-remaining-symbols.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
