### PR TITLE
refactor: rename notification_thread_created→notification_conversation_created event (TS + Swift)

### DIFF
--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -6,8 +6,8 @@
  * - Handles missing adapters gracefully
  * - Falls back to copy-composer when decision copy is missing
  * - Reports delivery results per channel
- * - Emits notification_thread_created only when a new conversation is created
- * - Does NOT emit notification_thread_created when reusing an existing conversation
+ * - Emits notification_conversation_created only when a new conversation is created
+ * - Does NOT emit notification_conversation_created when reusing an existing conversation
  * - Passes destination binding context into conversation pairing for external channels
  */
 

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -200,7 +200,7 @@ describe("ASK_GUARDIAN canonical notification path", () => {
     expect(payload.requestCode).toBeDefined();
   });
 
-  test("uses notification_thread_created callback instead of a guardian-specific dispatch path", async () => {
+  test("uses notification_conversation_created callback instead of a guardian-specific dispatch path", async () => {
     const convId = "conv-guardian-notif-2";
     ensureConversation(convId);
     mockConversationCreated = {

--- a/assistant/src/daemon/message-types/notifications.ts
+++ b/assistant/src/daemon/message-types/notifications.ts
@@ -18,7 +18,7 @@ export interface NotificationIntent {
 
 /** Server push — broadcast when a notification creates a new vellum conversation. */
 export interface NotificationConversationCreated {
-  type: "notification_thread_created";
+  type: "notification_conversation_created";
   conversationId: string;
   title: string;
   sourceEventName: string;

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -79,7 +79,7 @@ export class NotificationBroadcaster {
   ): Promise<NotificationDeliveryResult[]> {
     const destinations = resolveDestinations(decision.selectedChannels);
 
-    // Ensure vellum is processed first so the notification_thread_created
+    // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s
     // timeout) can delay it past the macOS deep-link retry window.
     const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
@@ -242,7 +242,7 @@ export class NotificationBroadcaster {
           }
         }
 
-        // Emit notification_thread_created event only when a NEW
+        // Emit notification_conversation_created event only when a NEW
         // conversation was actually created. Reusing an existing conversation
         // should not fire the event — the client already knows about the
         // conversation.

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -74,7 +74,7 @@ function getBroadcaster(): NotificationBroadcaster {
       const broadcastFn = registeredBroadcastFn;
       broadcasterInstance.setOnConversationCreated((info) => {
         broadcastFn({
-          type: "notification_thread_created",
+          type: "notification_conversation_created",
           conversationId: info.conversationId,
           title: info.title,
           sourceEventName: info.sourceEventName,
@@ -85,7 +85,7 @@ function getBroadcaster(): NotificationBroadcaster {
             conversationId: info.conversationId,
             guardianScoped: info.targetGuardianPrincipalId != null,
           },
-          "Emitted notification_thread_created push event",
+          "Emitted notification_conversation_created push event",
         );
       });
     }
@@ -168,7 +168,7 @@ export interface EmitSignalParams<TEventName extends string = string> {
   dedupeKey?: string;
   /**
    * Optional callback invoked immediately when the broadcaster pairs a vellum
-   * conversation and emits `notification_thread_created`.
+   * conversation and emits `notification_conversation_created`.
    */
   onConversationCreated?: (info: ConversationCreatedInfo) => void;
   /**
@@ -320,7 +320,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 4: Dispatch through the broadcaster
-    // Note: notification_thread_created events are emitted eagerly inside
+    // Note: notification_conversation_created events are emitted eagerly inside
     // the broadcaster as soon as vellum conversation pairing succeeds, rather
     // than after all channel deliveries complete. This avoids a race where
     // slow Telegram delivery delays the push past the macOS deep-link retry.

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -62,7 +62,7 @@ extension AppDelegate {
         if let target = msg.targetGuardianPrincipalId {
             let localId = ActorTokenManager.getGuardianPrincipalId()
             if let localId, localId != target {
-                log.info("Skipping notification_thread_created for guardian \(target) — local guardian is \(localId)")
+                log.info("Skipping notification_conversation_created for guardian \(target) — local guardian is \(localId)")
                 return
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -93,8 +93,8 @@ extension AppDelegate {
             case .notDetermined:
                 guard !hasRequestedNotificationAuthorizationFromConversationSignal else { return }
                 hasRequestedNotificationAuthorizationFromConversationSignal = true
-                log.info("Requesting notification authorization from notification_thread_created signal")
-                requestNotificationAuthorization(trigger: "notification_thread_created", showDeniedToast: true)
+                log.info("Requesting notification authorization from notification_conversation_created signal")
+                requestNotificationAuthorization(trigger: "notification_conversation_created", showDeniedToast: true)
             case .denied:
                 showNotificationPermissionSettingsToastIfNeeded()
             @unknown default:
@@ -361,7 +361,7 @@ extension AppDelegate {
         )
     }
 
-    /// Schedules a fallback local notification for any notification_thread_created
+    /// Schedules a fallback local notification for any notification_conversation_created
     /// event. If the corresponding notification_intent event arrives within the
     /// delay window, the fallback is cancelled (preventing duplicates). Guardian
     /// questions use a specific body; all other event types use a generic body.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -510,7 +510,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     }
 
     /// Create a visible thread bound to a notification-created conversation.
-    /// Called when the daemon broadcasts `notification_thread_created` so the user
+    /// Called when the daemon broadcasts `notification_conversation_created` so the user
     /// can see notification conversations and deep-link into them.
     func createNotificationConversation(conversationId: String, title: String, sourceEventName: String) {
         guard let localId = createBackgroundConversation(

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2365,7 +2365,7 @@ public enum ServerMessage: Decodable, Sendable {
         case "notification_intent":
             let message = try NotificationIntentMessage(from: decoder)
             self = .notificationIntent(message)
-        case "notification_thread_created":
+        case "notification_conversation_created":
             let message = try NotificationConversationCreated(from: decoder)
             self = .notificationConversationCreated(message)
         case "watch_started":


### PR DESCRIPTION
## Summary
- Rename SSE event type `notification_thread_created` → `notification_conversation_created` in TS message types and Swift decoding
- Update all emitters, comments, log messages, and test references

Part of plan: conv-remaining-symbols.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
