### PR TITLE
refactor: rename ViewSelection.thread to .conversation and persistentThreadId to persistentConversationId in macOS

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -309,7 +309,7 @@ extension AppDelegate {
             CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
                 self?.mainWindow?.conversationManager.createConversation()
                 if let id = self?.mainWindow?.conversationManager.activeConversationId {
-                    self?.mainWindow?.windowState.selection = .thread(id)
+                    self?.mainWindow?.windowState.selection = .conversation(id)
                 }
             },
             CommandPaletteAction(id: "settings", icon: VIcon.settings.rawValue, label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
@@ -353,9 +353,9 @@ extension AppDelegate {
 
         window.onSelectSearchConversation = { [weak self] conversationId in
             Task { @MainActor in
-                let found = await self?.mainWindow?.conversationManager.selectThreadByConversationIdAsync(conversationId) ?? false
+                let found = await self?.mainWindow?.conversationManager.selectConversationByConversationIdAsync(conversationId) ?? false
                 if found, let threadId = self?.mainWindow?.conversationManager.activeConversationId {
-                    self?.mainWindow?.windowState.selection = .thread(threadId)
+                    self?.mainWindow?.windowState.selection = .conversation(threadId)
                 }
             }
         }
@@ -395,15 +395,15 @@ extension AppDelegate {
             let notify = window?.notifyOnComplete ?? false
             self?.handleQuickInputSubmitToThread(message, imageData: imageData, notifyOnComplete: notify)
         }
-        window.onSelectThread = { [weak self] threadId in
-            self?.handleQuickInputSelectThread(threadId)
+        window.onSelectConversation = { [weak self] threadId in
+            self?.handleQuickInputSelectConversation(threadId)
         }
         window.onMicrophoneToggle = { [weak self] in
             self?.voiceInput?.toggleRecording()
         }
         // Provide the 3 most recent non-archived conversations
         if let conversations = mainWindow?.conversationManager.conversations {
-            window.recentThreads = conversations
+            window.recentConversations = conversations
                 .filter { !$0.isArchived }
                 .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                 .prefix(3)
@@ -444,14 +444,14 @@ extension AppDelegate {
                 let notify = window?.notifyOnComplete ?? false
                 self?.handleQuickInputSubmitToThread(message, imageData: imgData, notifyOnComplete: notify)
             }
-            window.onSelectThread = { [weak self] threadId in
-                self?.handleQuickInputSelectThread(threadId)
+            window.onSelectConversation = { [weak self] threadId in
+                self?.handleQuickInputSelectConversation(threadId)
             }
             window.onMicrophoneToggle = { [weak self] in
                 self?.voiceInput?.toggleRecording()
             }
             if let conversations = self.mainWindow?.conversationManager.conversations {
-                window.recentThreads = conversations
+                window.recentConversations = conversations
                     .filter { !$0.isArchived }
                     .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                     .prefix(3)
@@ -472,7 +472,7 @@ extension AppDelegate {
         guard let mainWindow else { return }
         mainWindow.conversationManager.createConversation()
         if let threadId = mainWindow.conversationManager.activeConversationId {
-            mainWindow.windowState.selection = .thread(threadId)
+            mainWindow.windowState.selection = .conversation(threadId)
         }
         guard let viewModel = mainWindow.activeViewModel else { return }
 
@@ -522,7 +522,7 @@ extension AppDelegate {
         }
     }
 
-    func handleQuickInputSelectThread(_ threadId: UUID) {
+    func handleQuickInputSelectConversation(_ threadId: UUID) {
         showMainWindow()
         guard let mainWindow else { return }
         mainWindow.conversationManager.activeConversationId = threadId

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -400,7 +400,7 @@ extension AppDelegate {
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
         if let id = mainWindow?.conversationManager.activeConversationId {
-            mainWindow?.windowState.selection = .thread(id)
+            mainWindow?.windowState.selection = .conversation(id)
         }
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }
@@ -496,7 +496,7 @@ extension AppDelegate {
         // Defer window creation until after the status menu finishes dismissing,
         // otherwise macOS can swallow the makeKeyAndOrderFront during menu teardown.
         DispatchQueue.main.async { [weak self] in
-            self?.showLogReportWindow(scope: .thread(conversationId: conversationId, threadTitle: thread.title))
+            self?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: thread.title))
         }
     }
 
@@ -533,7 +533,7 @@ extension AppDelegate {
         switch scope {
         case .global:
             window.title = "Send Logs to Vellum"
-        case .thread:
+        case .conversation:
             window.title = "Send Logs for Conversation"
         }
         window.backgroundColor = NSColor(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -62,8 +62,8 @@ final class CommandPaletteWindow {
             onDismiss: { [weak self] in
                 self?.dismiss()
             },
-            onSelectRecent: { [weak self] threadId in
-                self?.onSelectConversation?(threadId)
+            onSelectRecent: { [weak self] conversationId in
+                self?.onSelectConversation?(conversationId)
             },
             onSelectConversation: { [weak self] convId in
                 self?.onSelectSearchConversation?(convId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -782,20 +782,20 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
-    /// Select a thread by its daemon conversation ID (conversationId).
-    /// Returns `true` if a matching thread was found and selected, `false` otherwise.
+    /// Select a conversation by its daemon conversation ID (conversationId).
+    /// Returns `true` if a matching conversation was found and selected, `false` otherwise.
     @discardableResult
-    func selectThreadByConversationId(_ conversationId: String) -> Bool {
+    func selectConversationByConversationId(_ conversationId: String) -> Bool {
         guard let thread = conversations.first(where: { $0.conversationId == conversationId }) else { return false }
         selectConversation(id: thread.id)
         return true
     }
 
-    /// Select a thread by session ID, fetching it on-demand from the server if not locally available.
-    /// Returns `true` if the thread was found (or fetched) and selected, `false` on failure.
-    func selectThreadByConversationIdAsync(_ conversationId: String) async -> Bool {
+    /// Select a conversation by session ID, fetching it on-demand from the server if not locally available.
+    /// Returns `true` if the conversation was found (or fetched) and selected, `false` on failure.
+    func selectConversationByConversationIdAsync(_ conversationId: String) async -> Bool {
         // Fast path: already loaded locally
-        if selectThreadByConversationId(conversationId) {
+        if selectConversationByConversationId(conversationId) {
             return true
         }
 
@@ -806,7 +806,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
         // Re-check after await — another code path (e.g. SSE session-list response)
         // may have inserted this thread while we were waiting on the network.
-        if selectThreadByConversationId(conversationId) {
+        if selectConversationByConversationId(conversationId) {
             return true
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Equatable, Sendable {
-    case chat, threadList, settings, debug, generated, avatarCustomization, apps, intelligence, usageDashboard
+    case chat, conversationList, settings, debug, generated, avatarCustomization, apps, intelligence, usageDashboard
 }
 
 extension NativePanelId: Codable {
@@ -21,6 +21,9 @@ extension NativePanelId: Codable {
         // Legacy Task Queue panel — removed, degrade gracefully
         case "taskQueue":
             self = .chat
+        // Legacy threadList panel — renamed to conversationList
+        case "threadList":
+            self = .conversationList
         default:
             guard let value = NativePanelId(rawValue: rawValue) else {
                 throw DecodingError.dataCorruptedError(
@@ -61,6 +64,9 @@ extension SlotContent: Codable {
                 self = .native(.apps)
             case "taskQueue":
                 self = .native(.chat)
+            // Legacy threadList panel — renamed to conversationList
+            case "threadList":
+                self = .native(.conversationList)
             default:
                 if let panel = NativePanelId(rawValue: rawPanel) {
                     self = .native(panel)
@@ -107,7 +113,7 @@ public struct LayoutConfig: Codable, Equatable, Sendable {
 
     public static let `default` = LayoutConfig(
         version: 1,
-        left: SlotConfig(content: .native(.threadList), width: 240, visible: true),
+        left: SlotConfig(content: .native(.conversationList), width: 240, visible: true),
         center: SlotConfig(content: .native(.chat), width: nil, visible: true),
         right: SlotConfig(content: .empty, width: 400, visible: false)
     )
@@ -154,6 +160,9 @@ extension SlotContent {
             // Legacy Task Queue panel — removed, degrade gracefully
             case "taskQueue":
                 id = .chat
+            // Legacy threadList panel — renamed to conversationList
+            case "threadList":
+                id = .conversationList
             default:
                 guard let parsed = NativePanelId(rawValue: panel) else { return nil }
                 id = parsed

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -4,9 +4,9 @@ import VellumAssistantShared
 
 /// Represents what is currently displayed in the main content area.
 enum ViewSelection: Equatable {
-    case thread(UUID)
+    case conversation(UUID)
     case app(String)  // app ID
-    case appEditing(appId: String, threadId: UUID)
+    case appEditing(appId: String, conversationId: UUID)
     case panel(SidePanelType)
 }
 
@@ -35,11 +35,11 @@ public final class MainWindowState: ObservableObject {
             let previousSelection = _lastKnownSelection
             _lastKnownSelection = selection
 
-            navigationHistory.recordTransition(from: previousSelection, to: selection, persistentThreadId: persistentThreadId)
-            // When navigating to a thread, update the persistent thread tracker.
-            // For overlays (app, appEditing, panel) and nil, leave persistentThreadId unchanged.
-            if case .thread(let id) = selection {
-                persistentThreadId = id
+            navigationHistory.recordTransition(from: previousSelection, to: selection, persistentConversationId: persistentConversationId)
+            // When navigating to a conversation, update the persistent conversation tracker.
+            // For overlays (app, appEditing, panel) and nil, leave persistentConversationId unchanged.
+            if case .conversation(let id) = selection {
+                persistentConversationId = id
             }
             // Chat dock is only relevant inside app views. Clear it when
             // navigating away so other pages never show a stale split layout.
@@ -50,8 +50,8 @@ public final class MainWindowState: ObservableObject {
         }
     }
 
-    /// Tracks the "background" thread that persists even when viewing an app or panel overlay.
-    @Published var persistentThreadId: UUID?
+    /// Tracks the "background" conversation that persists even when viewing an app or panel overlay.
+    @Published var persistentConversationId: UUID?
 
     /// Tracks which panel originated the avatar customization flow so we can return to it.
     @Published var avatarCustomizationReturnPanel: SidePanelType = .intelligence
@@ -69,7 +69,7 @@ public final class MainWindowState: ObservableObject {
     @Published var toastInfo: ToastInfo?
 
     /// Whether the main content area is showing a plain, full-window chat
-    /// (either an explicit `.thread` selection or `nil` which defaults to chat).
+    /// (either an explicit `.conversation` selection or `nil` which defaults to chat).
     ///
     /// This is **narrower** than ``isConversationVisible``: it excludes panels
     /// (including the document editor) and app-editing mode, even when those
@@ -77,18 +77,18 @@ public final class MainWindowState: ObservableObject {
     /// to know whether *any* conversation UI is on screen.
     var isShowingChat: Bool {
         switch selection {
-        case .thread, .none: return true
+        case .conversation, .none: return true
         default: return false
         }
     }
 
-    /// Whether a conversation is visible — true for thread mode,
+    /// Whether a conversation is visible — true for conversation mode,
     /// app-editing mode (which shows a chat dock alongside the app),
     /// and panel mode when the chat bubble is enabled (split-view with
     /// a live conversation alongside the panel).
     public var isConversationVisible: Bool {
         switch selection {
-        case .thread, .none, .appEditing: return true
+        case .conversation, .none, .appEditing: return true
         case .panel(let panelType):
             // Document editor has a dedicated layout that always includes chat;
             // other panels show chat only when the chat bubble toggle is active.
@@ -140,10 +140,10 @@ public final class MainWindowState: ObservableObject {
 
     // MARK: - Selection Helpers
 
-    /// Dismiss the current overlay (app, panel, etc.) and return to the persistent thread.
+    /// Dismiss the current overlay (app, panel, etc.) and return to the persistent conversation.
     func dismissOverlay() {
-        if let threadId = persistentThreadId {
-            selection = .thread(threadId)
+        if let conversationId = persistentConversationId {
+            selection = .conversation(conversationId)
         } else {
             selection = nil
         }
@@ -156,16 +156,16 @@ public final class MainWindowState: ObservableObject {
     func navigateBack() {
         guard let destination = navigationHistory.popBack(
             currentSelection: selection,
-            persistentThreadId: persistentThreadId
+            persistentConversationId: persistentConversationId
         ) else { return }
         navigationHistory.withRecordingSuppressed {
             switch destination {
             case .selection(let viewSelection):
                 self.selection = viewSelection
-            case .chatDefault(let threadSnapshot):
-                self.persistentThreadId = threadSnapshot
-                if let threadId = threadSnapshot {
-                    self.selection = .thread(threadId)
+            case .chatDefault(let conversationSnapshot):
+                self.persistentConversationId = conversationSnapshot
+                if let conversationId = conversationSnapshot {
+                    self.selection = .conversation(conversationId)
                 } else {
                     self.selection = nil
                 }
@@ -176,16 +176,16 @@ public final class MainWindowState: ObservableObject {
     func navigateForward() {
         guard let destination = navigationHistory.popForward(
             currentSelection: selection,
-            persistentThreadId: persistentThreadId
+            persistentConversationId: persistentConversationId
         ) else { return }
         navigationHistory.withRecordingSuppressed {
             switch destination {
             case .selection(let viewSelection):
                 self.selection = viewSelection
-            case .chatDefault(let threadSnapshot):
-                self.persistentThreadId = threadSnapshot
-                if let threadId = threadSnapshot {
-                    self.selection = .thread(threadId)
+            case .chatDefault(let conversationSnapshot):
+                self.persistentConversationId = conversationSnapshot
+                if let conversationId = conversationSnapshot {
+                    self.selection = .conversation(conversationId)
                 } else {
                     self.selection = nil
                 }
@@ -208,11 +208,11 @@ public final class MainWindowState: ObservableObject {
         }
     }
 
-    /// Whether a thread is currently active (either standalone or editing alongside app)
-    var activeEditingThreadId: UUID? {
+    /// Whether a conversation is currently active (either standalone or editing alongside app)
+    var activeEditingConversationId: UUID? {
         switch selection {
-        case .thread(let id): return id
-        case .appEditing(_, let threadId): return threadId
+        case .conversation(let id): return id
+        case .appEditing(_, let conversationId): return conversationId
         default: return nil
         }
     }
@@ -247,9 +247,9 @@ public final class MainWindowState: ObservableObject {
         activeDynamicParsedSurface = nil
     }
 
-    /// Transition to appEditing with a specific thread
-    func setAppEditing(appId: String, threadId: UUID) {
-        selection = .appEditing(appId: appId, threadId: threadId)
+    /// Transition to appEditing with a specific conversation
+    func setAppEditing(appId: String, conversationId: UUID) {
+        selection = .appEditing(appId: appId, conversationId: conversationId)
     }
 
     func resetLayout() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -8,10 +8,10 @@ extension MainWindowView {
 
     func selectConversation(_ thread: ConversationModel) {
         if case .appEditing(let appId, _) = windowState.selection {
-            windowState.selection = .appEditing(appId: appId, threadId: thread.id)
+            windowState.selection = .appEditing(appId: appId, conversationId: thread.id)
             conversationManager.selectConversation(id: thread.id)
         } else {
-            windowState.selection = .thread(thread.id)
+            windowState.selection = .conversation(thread.id)
             conversationManager.selectConversation(id: thread.id)
         }
     }
@@ -19,11 +19,11 @@ extension MainWindowView {
     func startNewConversation() {
         conversationManager.createConversation()
         if let id = conversationManager.activeConversationId {
-            windowState.selection = .thread(id)
+            windowState.selection = .conversation(id)
         } else {
             // Draft mode — clear selection so no sidebar thread is highlighted
             windowState.selection = nil
-            windowState.persistentThreadId = nil
+            windowState.persistentConversationId = nil
         }
     }
 
@@ -493,7 +493,7 @@ extension MainWindowView {
             )
             if switcher.showsSwitcher {
                 Button {
-                    showThreadSwitcher.toggle()
+                    showConversationSwitcher.toggle()
                 } label: {
                     ZStack(alignment: .bottomTrailing) {
                         Text(switcher.badgeText)
@@ -522,7 +522,7 @@ extension MainWindowView {
                 .accessibilityLabel(switcher.accessibilityLabel)
                 .accessibilityValue(switcher.accessibilityValue)
                 .onDisappear {
-                    showThreadSwitcher = false
+                    showConversationSwitcher = false
                 }
                 .pointerCursor()
                 .background(GeometryReader { proxy in

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -14,7 +14,7 @@ struct MainWindowView: View {
     let traceStore: TraceStore
     let usageDashboardStore: UsageDashboardStore
     @ObservedObject var windowState: MainWindowState
-    @State private var selectedThreadId: UUID?
+    @State private var selectedConversationId: UUID?
     @State var sharing = SharingState()
     @State var sidebar = SidebarInteractionState()
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
@@ -50,7 +50,7 @@ struct MainWindowView: View {
     /// Nil for returning users (no transition).
     let onSendWakeUp: (() -> Void)?
 
-    @State var showThreadSwitcher = false
+    @State var showConversationSwitcher = false
     @State var threadSwitcherTriggerFrame: CGRect = .zero
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
@@ -138,12 +138,12 @@ struct MainWindowView: View {
 
     /// Resolve a thread ID for the chat bubble toggle using strict priority:
     /// 1. activeConversationId (currently selected thread)
-    /// 2. persistentThreadId (app's last-used thread)
+    /// 2. persistentConversationId (app's last-used thread)
     /// 3. visibleConversations.first (first available thread)
     /// 4. create a new thread
     private func resolveThreadId() -> UUID {
         if let id = conversationManager.activeConversationId { return id }
-        if let id = windowState.persistentThreadId { return id }
+        if let id = windowState.persistentConversationId { return id }
         if let id = conversationManager.visibleConversations.first?.id { return id }
         conversationManager.createConversation()
         return conversationManager.activeConversationId!
@@ -152,7 +152,7 @@ struct MainWindowView: View {
     func enterAppEditing(appId: String) {
         let threadId = resolveThreadId()
         conversationManager.selectConversation(id: threadId)
-        windowState.setAppEditing(appId: appId, threadId: threadId)
+        windowState.setAppEditing(appId: appId, conversationId: threadId)
     }
 
     func exitAppEditing(appId: String) {
@@ -249,17 +249,17 @@ struct MainWindowView: View {
                 }
             }
             .onChange(of: windowState.selection) { oldSelection, newSelection in
-                // When selection transitions to .thread, ensure ConversationManager is synced
-                // so chat content targets the correct thread (e.g. after dismissOverlay).
-                // Guard against archived conversations: if the thread was archived while an
-                // overlay was open, persistentThreadId may still point to the stale ID.
-                if case .thread(let id) = newSelection {
+                // When selection transitions to .conversation, ensure ConversationManager is synced
+                // so chat content targets the correct conversation (e.g. after dismissOverlay).
+                // Guard against archived conversations: if the conversation was archived while an
+                // overlay was open, persistentConversationId may still point to the stale ID.
+                if case .conversation(let id) = newSelection {
                     if conversationManager.conversations.contains(where: { $0.id == id && !$0.isArchived }) {
                         conversationManager.selectConversation(id: id)
                     } else {
                         // Conversation was archived/deleted — fall back to the first visible conversation
                         if let fallback = conversationManager.visibleConversations.first {
-                            windowState.applySelectionCorrection(.thread(fallback.id))
+                            windowState.applySelectionCorrection(.conversation(fallback.id))
                         } else {
                             windowState.applySelectionCorrection(nil)
                         }
@@ -559,16 +559,16 @@ struct MainWindowView: View {
                     }
                 }
                 .overlay {
-                    if showThreadSwitcher {
+                    if showConversationSwitcher {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                showThreadSwitcher = false
+                                showConversationSwitcher = false
                             }
                     }
                 }
                 .overlay(alignment: .topLeading) {
-                    if showThreadSwitcher {
+                    if showConversationSwitcher {
                         ThreadSwitcherDrawer(
                             regularConversations: regularConversations,
                             activeConversationId: conversationManager.activeConversationId,
@@ -576,7 +576,7 @@ struct MainWindowView: View {
                             windowState: windowState,
                             sidebar: sidebar,
                             selectConversation: { selectConversation($0) },
-                            onDismiss: { showThreadSwitcher = false }
+                            onDismiss: { showConversationSwitcher = false }
                         )
                         .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
                         .offset(
@@ -586,10 +586,10 @@ struct MainWindowView: View {
                         .zIndex(10)
                         .transition(.opacity)
                         .onChange(of: conversationManager.activeConversationId) { _, _ in
-                            showThreadSwitcher = false
+                            showConversationSwitcher = false
                         }
                         .onChange(of: sidebarExpanded) { _, expanded in
-                            if expanded { showThreadSwitcher = false }
+                            if expanded { showConversationSwitcher = false }
                         }
                     }
                 }
@@ -666,10 +666,10 @@ struct MainWindowView: View {
             // disable it, leaving panels stuck in split mode.
             isAppChatOpen = false
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
-            selectedThreadId = conversationManager.activeConversationId
+            selectedConversationId = conversationManager.activeConversationId
             // Initialize persistent thread tracking on launch
             if let activeId = conversationManager.activeConversationId {
-                windowState.persistentThreadId = activeId
+                windowState.persistentConversationId = activeId
             }
             daemonClient.startSSE()
         }
@@ -712,21 +712,21 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             conversationManager.markActiveThreadSeenIfNeeded()
         }
-        .onChange(of: selectedThreadId) { _, newId in
+        .onChange(of: selectedConversationId) { _, newId in
             if let newId = newId {
                 conversationManager.selectConversation(id: newId)
             }
         }
         .onChange(of: conversationManager.activeConversationId) { oldId, newId in
-            // Sync activeConversationId changes back to selectedThreadId to keep sidebar selection in sync
-            selectedThreadId = newId
-            // Always sync persistentThreadId so the sidebar highlights the
+            // Sync activeConversationId changes back to selectedConversationId to keep sidebar selection in sync
+            selectedConversationId = newId
+            // Always sync persistentConversationId so the sidebar highlights the
             // correct thread — even when an overlay (.panel, .app) is active.
             // Without this, archiving the active thread while viewing a panel
-            // leaves persistentThreadId pointing at the archived (invisible) thread
+            // leaves persistentConversationId pointing at the archived (invisible) thread
             // and the sidebar shows no active highlight.
             // Clear it when entering draft mode (nil) so no thread appears active.
-            windowState.persistentThreadId = newId
+            windowState.persistentConversationId = newId
             if case .panel(.intelligence) = windowState.selection {
                 windowState.selection = nil
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
@@ -7,23 +7,23 @@ final class NavigationHistory: ObservableObject {
 
     enum HistoryEntry: Equatable {
         case selection(ViewSelection)
-        case chatDefault(threadSnapshot: UUID?)
+        case chatDefault(conversationSnapshot: UUID?)
 
         /// Whether two entries resolve to the same visible state.
-        /// `.chatDefault(threadSnapshot: T)` and `.selection(.thread(T))` both
-        /// display the same thread, so transitioning between them is a no-op.
+        /// `.chatDefault(conversationSnapshot: T)` and `.selection(.conversation(T))` both
+        /// display the same conversation, so transitioning between them is a no-op.
         func isEquivalent(to other: HistoryEntry) -> Bool {
             if self == other { return true }
-            switch (self.resolvedThread, other.resolvedThread) {
+            switch (self.resolvedConversation, other.resolvedConversation) {
             case (.some(let a), .some(let b)): return a == b
             default: return false
             }
         }
 
-        /// The thread UUID this entry resolves to, if any.
-        private var resolvedThread: UUID? {
+        /// The conversation UUID this entry resolves to, if any.
+        private var resolvedConversation: UUID? {
             switch self {
-            case .selection(.thread(let id)): return id
+            case .selection(.conversation(let id)): return id
             case .chatDefault(let snapshot): return snapshot
             default: return nil
             }
@@ -43,20 +43,20 @@ final class NavigationHistory: ObservableObject {
 
     // MARK: - Entry Conversion
 
-    func entry(for selection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry {
+    func entry(for selection: ViewSelection?, persistentConversationId: UUID?) -> HistoryEntry {
         if let selection { return .selection(selection) }
-        return .chatDefault(threadSnapshot: persistentThreadId)
+        return .chatDefault(conversationSnapshot: persistentConversationId)
     }
 
     // MARK: - Recording
 
-    func recordTransition(from: ViewSelection?, to: ViewSelection?, persistentThreadId: UUID?) {
+    func recordTransition(from: ViewSelection?, to: ViewSelection?, persistentConversationId: UUID?) {
         guard !isSuppressed else { return }
 
-        let fromEntry = entry(for: from, persistentThreadId: persistentThreadId)
-        let toEntry = entry(for: to, persistentThreadId: persistentThreadId)
+        let fromEntry = entry(for: from, persistentConversationId: persistentConversationId)
+        let toEntry = entry(for: to, persistentConversationId: persistentConversationId)
 
-        // Treat chatDefault(threadSnapshot: T) and .selection(.thread(T)) as
+        // Treat chatDefault(conversationSnapshot: T) and .selection(.conversation(T)) as
         // equivalent — they resolve to the same visible state, so recording a
         // transition between them would create a no-op back step.
         guard !fromEntry.isEquivalent(to: toEntry) else { return }
@@ -71,21 +71,21 @@ final class NavigationHistory: ObservableObject {
 
     // MARK: - Navigation
 
-    func popBack(currentSelection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry? {
+    func popBack(currentSelection: ViewSelection?, persistentConversationId: UUID?) -> HistoryEntry? {
         guard !backStack.isEmpty else { return nil }
 
         let destination = backStack.removeLast()
-        let currentEntry = entry(for: currentSelection, persistentThreadId: persistentThreadId)
+        let currentEntry = entry(for: currentSelection, persistentConversationId: persistentConversationId)
         forwardStack.append(currentEntry)
 
         return destination
     }
 
-    func popForward(currentSelection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry? {
+    func popForward(currentSelection: ViewSelection?, persistentConversationId: UUID?) -> HistoryEntry? {
         guard !forwardStack.isEmpty else { return nil }
 
         let destination = forwardStack.removeLast()
-        let currentEntry = entry(for: currentSelection, persistentThreadId: persistentThreadId)
+        let currentEntry = entry(for: currentSelection, persistentConversationId: persistentConversationId)
         backStack.append(currentEntry)
 
         return destination

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -48,7 +48,7 @@ extension MainWindowView {
                     appListManager.recordAppOpen(id: id, name: name, icon: icon, appType: appType)
                 }
             )
-        case .threadList:
+        case .conversationList:
             sidebarView
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
@@ -219,8 +219,8 @@ extension MainWindowView {
     @ViewBuilder
     func chatContentView(geometry: GeometryProxy) -> some View {
         switch windowState.selection {
-        case .thread:
-            // Show chat for this thread (conversationManager.activeViewModel is synced)
+        case .conversation:
+            // Show chat for this conversation (conversationManager.activeViewModel is synced)
             defaultChatLayout
         case .app(let appId), .appEditing(let appId, _):
             if let surface = windowState.activeDynamicParsedSurface,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -17,13 +17,13 @@ struct SidebarThreadItem: View {
         switch windowState.selection {
         case .panel:
             return false
-        case .thread(let id):
+        case .conversation(let id):
             return id == thread.id
-        case .appEditing(_, let threadId):
-            return threadId == thread.id
+        case .appEditing(_, let conversationId):
+            return conversationId == thread.id
         case .app, .none:
-            // No explicit thread in selection; fall back to the persistent thread.
-            return thread.id == windowState.persistentThreadId
+            // No explicit conversation in selection; fall back to the persistent conversation.
+            return thread.id == windowState.persistentConversationId
         }
     }
 
@@ -196,7 +196,7 @@ struct SidebarThreadItem: View {
 
             Button {
                 guard let conversationId = thread.conversationId else { return }
-                AppDelegate.shared?.showLogReportWindow(scope: .thread(conversationId: conversationId, threadTitle: thread.title))
+                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: thread.title))
             } label: {
                 Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
             }

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -11,13 +11,13 @@ struct QuickInputView: View {
     @ObservedObject var textModel: QuickInputTextModel
     let onSubmit: (String) -> Void
     let onDismiss: () -> Void
-    let onSelectThread: ((UUID, String) -> Void)?
+    let onSelectConversation: ((UUID, String) -> Void)?
     let onScreenCapture: (() -> Void)?
     let onRemoveAttachment: (() -> Void)?
     let onAllowScreenRecording: (() -> Void)?
     let onMicrophoneToggle: (() -> Void)?
     let onNotificationToggle: (() -> Void)?
-    let recentThreads: [QuickInputThread]
+    let recentConversations: [QuickInputThread]
     let attachedImage: NSImage?
     let showScreenPermissionPrompt: Bool
 
@@ -30,26 +30,26 @@ struct QuickInputView: View {
         textModel: QuickInputTextModel,
         onSubmit: @escaping (String) -> Void,
         onDismiss: @escaping () -> Void,
-        onSelectThread: ((UUID, String) -> Void)? = nil,
+        onSelectConversation: ((UUID, String) -> Void)? = nil,
         onScreenCapture: (() -> Void)? = nil,
         onRemoveAttachment: (() -> Void)? = nil,
         onAllowScreenRecording: (() -> Void)? = nil,
         onMicrophoneToggle: (() -> Void)? = nil,
         onNotificationToggle: (() -> Void)? = nil,
-        recentThreads: [QuickInputThread] = [],
+        recentConversations: [QuickInputThread] = [],
         attachedImage: NSImage? = nil,
         showScreenPermissionPrompt: Bool = false
     ) {
         self.textModel = textModel
         self.onSubmit = onSubmit
         self.onDismiss = onDismiss
-        self.onSelectThread = onSelectThread
+        self.onSelectConversation = onSelectConversation
         self.onScreenCapture = onScreenCapture
         self.onRemoveAttachment = onRemoveAttachment
         self.onAllowScreenRecording = onAllowScreenRecording
         self.onMicrophoneToggle = onMicrophoneToggle
         self.onNotificationToggle = onNotificationToggle
-        self.recentThreads = recentThreads
+        self.recentConversations = recentConversations
         self.attachedImage = attachedImage
         self.showScreenPermissionPrompt = showScreenPermissionPrompt
     }
@@ -98,7 +98,7 @@ struct QuickInputView: View {
 
                 // Text field
                 TextField(
-                    textModel.selectedThreadId != nil
+                    textModel.selectedConversationId != nil
                         ? "Continue where we left off..."
                         : "Type or hold Fn to talk",
                     text: $textModel.text
@@ -118,22 +118,22 @@ struct QuickInputView: View {
                 // "New Chat" / thread selector dropdown
                 Menu {
                     Button("New Chat") {
-                        textModel.selectedThreadId = nil
-                        textModel.selectedThreadTitle = nil
+                        textModel.selectedConversationId = nil
+                        textModel.selectedConversationTitle = nil
                     }
 
-                    if !recentThreads.isEmpty {
+                    if !recentConversations.isEmpty {
                         Divider()
 
-                        ForEach(recentThreads) { thread in
+                        ForEach(recentConversations) { thread in
                             Button(thread.title) {
-                                onSelectThread?(thread.id, thread.title)
+                                onSelectConversation?(thread.id, thread.title)
                             }
                         }
                     }
                 } label: {
                     HStack(spacing: VSpacing.xxs) {
-                        Text(textModel.selectedThreadTitle ?? "New Chat")
+                        Text(textModel.selectedConversationTitle ?? "New Chat")
                             .font(.system(size: 13, weight: .medium))
                             .foregroundColor(VColor.contentSecondary)
                             .lineLimit(1)

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -15,9 +15,9 @@ private class KeyablePanel: NSPanel {
 final class QuickInputTextModel: ObservableObject {
     @Published var text = ""
     @Published var isRecording = false
-    /// When set, the user has selected an existing thread to continue.
-    @Published var selectedThreadId: UUID?
-    @Published var selectedThreadTitle: String?
+    /// When set, the user has selected an existing conversation to continue.
+    @Published var selectedConversationId: UUID?
+    @Published var selectedConversationTitle: String?
     /// Whether to send a notification when the assistant response completes.
     @Published var notifyOnComplete: Bool = UserDefaults.standard.object(forKey: "quickInputNotifyOnComplete") as? Bool ?? true
 }
@@ -47,10 +47,10 @@ final class QuickInputWindow {
     var onMicrophoneToggle: (() -> Void)?
     /// Callback invoked when the user toggles the notification bell.
     var onNotificationToggle: (() -> Void)?
-    /// Callback invoked when the user selects an existing thread (navigates to it).
-    var onSelectThread: ((UUID) -> Void)?
+    /// Callback invoked when the user selects an existing conversation (navigates to it).
+    var onSelectConversation: ((UUID) -> Void)?
     /// Recent conversations to show in the dropdown.
-    var recentThreads: [QuickInputThread] = []
+    var recentConversations: [QuickInputThread] = []
     /// When true, show a screen recording permission prompt below the bar.
     var showScreenPermissionPrompt = false
 
@@ -167,9 +167,9 @@ final class QuickInputWindow {
         let view = QuickInputView(
             textModel: textModel,
             onSubmit: { [weak self] message in
-                if let threadId = self?.textModel.selectedThreadId {
-                    self?.onSelectThread?(threadId)
-                    // Small delay so the thread switches before we send the message
+                if let conversationId = self?.textModel.selectedConversationId {
+                    self?.onSelectConversation?(conversationId)
+                    // Small delay so the conversation switches before we send the message
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                         self?.onSubmitToThread?(message, self?.attachedImageData)
                     }
@@ -181,9 +181,9 @@ final class QuickInputWindow {
             onDismiss: { [weak self] in
                 self?.dismiss()
             },
-            onSelectThread: { [weak self] threadId, threadTitle in
-                self?.textModel.selectedThreadId = threadId
-                self?.textModel.selectedThreadTitle = threadTitle
+            onSelectConversation: { [weak self] conversationId, conversationTitle in
+                self?.textModel.selectedConversationId = conversationId
+                self?.textModel.selectedConversationTitle = conversationTitle
             },
             onScreenCapture: { [weak self] in
                 self?.startScreenSelection()
@@ -201,7 +201,7 @@ final class QuickInputWindow {
                 self.textModel.notifyOnComplete.toggle()
                 UserDefaults.standard.set(self.textModel.notifyOnComplete, forKey: "quickInputNotifyOnComplete")
             },
-            recentThreads: recentThreads,
+            recentConversations: recentConversations,
             attachedImage: attachedImage,
             showScreenPermissionPrompt: showScreenPermissionPrompt
         )

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -60,8 +60,8 @@ enum LogExporter {
             let event = Event(level: .info)
             let errorTitle: String
             switch formData.scope {
-            case .thread(_, let threadTitle, _, _):
-                errorTitle = "\(formData.reason.displayName) log report (thread: \(threadTitle))"
+            case .conversation(_, let conversationTitle, _, _):
+                errorTitle = "\(formData.reason.displayName) log report (conversation: \(conversationTitle))"
             case .global:
                 errorTitle = "\(formData.reason.displayName) log report"
             }
@@ -76,9 +76,9 @@ enum LogExporter {
                 "source": "log_report",
                 "report_reason": formData.reason.rawValue,
             ]
-            if case .thread(let conversationId, _, _, _) = formData.scope {
+            if case .conversation(let conversationId, _, _, _) = formData.scope {
                 tags["conversation_id"] = conversationId
-                tags["export_scope"] = "thread"
+                tags["export_scope"] = "conversation"
             } else {
                 tags["export_scope"] = "global"
             }
@@ -386,7 +386,7 @@ enum LogExporter {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         var body: [String: Any] = ["auditLimit": 10000]
-        if case .thread(let conversationId, _, let startTime, let endTime) = scope {
+        if case .conversation(let conversationId, _, let startTime, let endTime) = scope {
             body["conversationId"] = conversationId
             if let startTime {
                 body["startTime"] = Int(startTime.timeIntervalSince1970 * 1000)

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -40,9 +40,9 @@ enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
 enum LogExportScope: Sendable {
     /// Full global export — all conversations, all data.
     case global
-    /// Scoped to a single thread/conversation.
-    case thread(conversationId: String, threadTitle: String,
-                startTime: Date? = nil, endTime: Date? = nil)
+    /// Scoped to a single conversation.
+    case conversation(conversationId: String, conversationTitle: String,
+                      startTime: Date? = nil, endTime: Date? = nil)
 }
 
 /// Aggregated form data collected from the log report sheet.

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -32,7 +32,7 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
     }
 
     func testThreadSelectionIsConversationVisible() {
-        let state = makeState(.thread(UUID()))
+        let state = makeState(.conversation(UUID()))
 
         XCTAssertTrue(state.isConversationVisible)
         XCTAssertTrue(state.isShowingChat)

--- a/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
@@ -8,7 +8,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
 
     func testShowAppsPanelSetsSelectionToApps() {
         let state = MainWindowState(hasAPIKey: false)
-        state.selection = .thread(UUID())
+        state.selection = .conversation(UUID())
 
         state.showPanel(.apps)
 
@@ -30,7 +30,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
         // Simulate a prior app-edit flow that left isAppChatOpen = true
         // by toggling the chat dock while in an app editing state.
         let threadId = UUID()
-        state.selection = .appEditing(appId: "test-app", threadId: threadId)
+        state.selection = .appEditing(appId: "test-app", conversationId: threadId)
 
         // Now navigate to apps panel.
         state.showPanel(.apps)
@@ -45,9 +45,9 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     func testDismissOverlayClearsAppChatState() {
         let state = MainWindowState(hasAPIKey: false)
         let threadId = UUID()
-        state.selection = .thread(threadId)
+        state.selection = .conversation(threadId)
         // Navigate to app editing then dismiss.
-        state.selection = .appEditing(appId: "test-app", threadId: threadId)
+        state.selection = .appEditing(appId: "test-app", conversationId: threadId)
         state.dismissOverlay()
 
         // After dismissing, navigating to apps should not show conversation.

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -7,7 +7,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     func testBackForwardAcrossThreadPanelApp() {
         let state = MainWindowState(hasAPIKey: false)
         let id1 = UUID()
-        state.selection = .thread(id1)
+        state.selection = .conversation(id1)
         state.selection = .panel(.settings)
         state.selection = .app("myapp")
 
@@ -15,7 +15,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         state.navigateBack()
         XCTAssertEqual(state.selection, .panel(.settings))
         state.navigateBack()
-        XCTAssertEqual(state.selection, .thread(id1))
+        XCTAssertEqual(state.selection, .conversation(id1))
 
         // Forward twice
         state.navigateForward()
@@ -42,20 +42,20 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     func testBackToChatDefaultRestoresThread() {
         let state = MainWindowState(hasAPIKey: false)
         let someId = UUID()
-        state.persistentThreadId = someId
-        // selection is nil (chat default), persistentThreadId is someId
+        state.persistentConversationId = someId
+        // selection is nil (chat default), persistentConversationId is someId
         state.selection = .panel(.settings)
         // back should restore chat default with snapshot
         state.navigateBack()
-        XCTAssertEqual(state.selection, .thread(someId))
+        XCTAssertEqual(state.selection, .conversation(someId))
     }
 
     func testNavigateBackDoesNotReRecord() {
         let state = MainWindowState(hasAPIKey: false)
         let idA = UUID()
         let idB = UUID()
-        state.selection = .thread(idA)
-        state.selection = .thread(idB)
+        state.selection = .conversation(idA)
+        state.selection = .conversation(idB)
         state.navigateBack()
         // Back stack should now have 1 entry: nil->A creates [chatDefault(nil)], A->B creates [chatDefault(nil), A]
         // navigateBack pops A, so back is [chatDefault(nil)]
@@ -72,7 +72,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
 
     func testBackToChatDefaultNilResolvesToNilSelection() {
         let state = MainWindowState(hasAPIKey: false)
-        // selection is nil, persistentThreadId is nil
+        // selection is nil, persistentConversationId is nil
         state.selection = .panel(.settings)
         state.navigateBack()
         XCTAssertNil(state.selection)

--- a/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
@@ -10,7 +10,7 @@ final class NavigationHistoryTests: XCTestCase {
         let history = NavigationHistory()
         let id = UUID()
 
-        history.recordTransition(from: .thread(id), to: .thread(id), persistentThreadId: nil)
+        history.recordTransition(from: .conversation(id), to: .conversation(id), persistentConversationId: nil)
 
         XCTAssertTrue(history.backStack.isEmpty)
     }
@@ -19,8 +19,8 @@ final class NavigationHistoryTests: XCTestCase {
         let history = NavigationHistory()
         let id = UUID()
 
-        // nil selection with persistentThreadId == id → .thread(id) should be no-op
-        history.recordTransition(from: nil, to: .thread(id), persistentThreadId: id)
+        // nil selection with persistentConversationId == id → .conversation(id) should be no-op
+        history.recordTransition(from: nil, to: .conversation(id), persistentConversationId: id)
 
         XCTAssertTrue(history.backStack.isEmpty)
     }
@@ -32,9 +32,9 @@ final class NavigationHistoryTests: XCTestCase {
         let someId = UUID()
 
         // from nil selection (chat default) to settings panel
-        history.recordTransition(from: nil, to: .panel(.settings), persistentThreadId: someId)
+        history.recordTransition(from: nil, to: .panel(.settings), persistentConversationId: someId)
 
-        XCTAssertEqual(history.backStack, [.chatDefault(threadSnapshot: someId)])
+        XCTAssertEqual(history.backStack, [.chatDefault(conversationSnapshot: someId)])
     }
 
     // MARK: - Round-trip
@@ -46,30 +46,30 @@ final class NavigationHistoryTests: XCTestCase {
         let idC = UUID()
 
         // Record A -> B -> C
-        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
-        history.recordTransition(from: .thread(idB), to: .thread(idC), persistentThreadId: nil)
+        history.recordTransition(from: .conversation(idA), to: .conversation(idB), persistentConversationId: nil)
+        history.recordTransition(from: .conversation(idB), to: .conversation(idC), persistentConversationId: nil)
 
         // backStack should be [A, B], forwardStack empty
         XCTAssertEqual(history.backStack.count, 2)
         XCTAssertTrue(history.forwardStack.isEmpty)
 
         // Pop back from C -> should return B
-        let first = history.popBack(currentSelection: .thread(idC), persistentThreadId: nil)
-        XCTAssertEqual(first, .selection(.thread(idB)))
-        XCTAssertEqual(history.forwardStack, [.selection(.thread(idC))])
+        let first = history.popBack(currentSelection: .conversation(idC), persistentConversationId: nil)
+        XCTAssertEqual(first, .selection(.conversation(idB)))
+        XCTAssertEqual(history.forwardStack, [.selection(.conversation(idC))])
 
         // Pop back from B -> should return A
-        let second = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
-        XCTAssertEqual(second, .selection(.thread(idA)))
-        XCTAssertEqual(history.forwardStack, [.selection(.thread(idC)), .selection(.thread(idB))])
+        let second = history.popBack(currentSelection: .conversation(idB), persistentConversationId: nil)
+        XCTAssertEqual(second, .selection(.conversation(idA)))
+        XCTAssertEqual(history.forwardStack, [.selection(.conversation(idC)), .selection(.conversation(idB))])
 
         // Pop forward from A -> should return B
-        let third = history.popForward(currentSelection: .thread(idA), persistentThreadId: nil)
-        XCTAssertEqual(third, .selection(.thread(idB)))
+        let third = history.popForward(currentSelection: .conversation(idA), persistentConversationId: nil)
+        XCTAssertEqual(third, .selection(.conversation(idB)))
 
         // Pop forward from B -> should return C
-        let fourth = history.popForward(currentSelection: .thread(idB), persistentThreadId: nil)
-        XCTAssertEqual(fourth, .selection(.thread(idC)))
+        let fourth = history.popForward(currentSelection: .conversation(idB), persistentConversationId: nil)
+        XCTAssertEqual(fourth, .selection(.conversation(idC)))
 
         // Forward stack should be empty, back stack should have [A, B]
         XCTAssertTrue(history.forwardStack.isEmpty)
@@ -85,14 +85,14 @@ final class NavigationHistoryTests: XCTestCase {
         let idC = UUID()
 
         // Record A -> B, then pop back
-        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
-        _ = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
+        history.recordTransition(from: .conversation(idA), to: .conversation(idB), persistentConversationId: nil)
+        _ = history.popBack(currentSelection: .conversation(idB), persistentConversationId: nil)
 
         // Forward stack should have B
         XCTAssertFalse(history.forwardStack.isEmpty)
 
         // Fresh navigation from A -> C should clear forward stack
-        history.recordTransition(from: .thread(idA), to: .thread(idC), persistentThreadId: nil)
+        history.recordTransition(from: .conversation(idA), to: .conversation(idC), persistentConversationId: nil)
 
         XCTAssertTrue(history.forwardStack.isEmpty)
     }
@@ -105,7 +105,7 @@ final class NavigationHistoryTests: XCTestCase {
         let idB = UUID()
 
         history.withRecordingSuppressed {
-            history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+            history.recordTransition(from: .conversation(idA), to: .conversation(idB), persistentConversationId: nil)
         }
 
         XCTAssertTrue(history.backStack.isEmpty)
@@ -122,9 +122,9 @@ final class NavigationHistoryTests: XCTestCase {
             let toId = UUID()
             // Use unique IDs so no transition is a no-op
             history.recordTransition(
-                from: .thread(fromId),
-                to: .thread(toId),
-                persistentThreadId: nil
+                from: .conversation(fromId),
+                to: .conversation(toId),
+                persistentConversationId: nil
             )
         }
 
@@ -136,8 +136,8 @@ final class NavigationHistoryTests: XCTestCase {
     func testEmptyStacksReturnNil() {
         let history = NavigationHistory()
 
-        XCTAssertNil(history.popBack(currentSelection: nil, persistentThreadId: nil))
-        XCTAssertNil(history.popForward(currentSelection: nil, persistentThreadId: nil))
+        XCTAssertNil(history.popBack(currentSelection: nil, persistentConversationId: nil))
+        XCTAssertNil(history.popForward(currentSelection: nil, persistentConversationId: nil))
     }
 
     // MARK: - Computed properties
@@ -150,12 +150,12 @@ final class NavigationHistoryTests: XCTestCase {
 
         let idA = UUID()
         let idB = UUID()
-        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+        history.recordTransition(from: .conversation(idA), to: .conversation(idB), persistentConversationId: nil)
 
         XCTAssertTrue(history.canGoBack)
         XCTAssertFalse(history.canGoForward)
 
-        _ = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
+        _ = history.popBack(currentSelection: .conversation(idB), persistentConversationId: nil)
 
         XCTAssertFalse(history.canGoBack)
         XCTAssertTrue(history.canGoForward)
@@ -166,11 +166,11 @@ final class NavigationHistoryTests: XCTestCase {
     func testBackToChatDefaultNilSnapshotResolvesToNil() {
         let history = NavigationHistory()
 
-        // Record from nil selection with nil persistentThreadId to settings
-        history.recordTransition(from: nil, to: .panel(.settings), persistentThreadId: nil)
+        // Record from nil selection with nil persistentConversationId to settings
+        history.recordTransition(from: nil, to: .panel(.settings), persistentConversationId: nil)
 
-        let destination = history.popBack(currentSelection: .panel(.settings), persistentThreadId: nil)
+        let destination = history.popBack(currentSelection: .panel(.settings), persistentConversationId: nil)
 
-        XCTAssertEqual(destination, .chatDefault(threadSnapshot: nil))
+        XCTAssertEqual(destination, .chatDefault(conversationSnapshot: nil))
     }
 }


### PR DESCRIPTION
## Summary
- Rename ViewSelection.thread enum case to .conversation and ~15 related symbols from thread to conversation terminology across macOS source and test files
- Add backward-compatible Codable decoding for legacy "threadList" string values in NativePanelId, SlotContent Codable init, and SlotContent.from(wire:)
- Update all pattern matches, property references, function names, and test assertions across 19 files

Part of plan: conv-remaining-symbols.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
