### PR TITLE
refactor: update remaining session_error and sessionError stale comments across TS and Swift

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -578,7 +578,7 @@ describe("Conversation message queue", () => {
       conversationId: "conv-1",
     });
 
-    // abort() must NOT emit session_error or generic error for queued discards.
+    // abort() must NOT emit conversation_error or generic error for queued discards.
     const err2 = events2.find((e) => e.type === "error");
     expect(err2).toBeUndefined();
     const err3 = events3.find((e) => e.type === "error");
@@ -591,7 +591,7 @@ describe("Conversation message queue", () => {
     expect(sessionErr3).toBeUndefined();
   });
 
-  test("session-scoped errors emit both session_error and generic error", async () => {
+  test("conversation-scoped errors emit both conversation_error and generic error", async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -611,7 +611,7 @@ describe("Conversation message queue", () => {
     pendingRuns[0].reject(new Error("Provider returned 500"));
     await p1;
 
-    // Should emit session_error (typed, structured)
+    // Should emit conversation_error (typed, structured)
     const sessionErr = events.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeDefined();
 
@@ -1563,7 +1563,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     pendingRuns = [];
   });
 
-  test("user cancellation emits generation_cancelled, never session_error", async () => {
+  test("user cancellation emits generation_cancelled, never conversation_error", async () => {
     const msgEvents: ServerMessage[] = [];
     const session = makeSession();
     await session.loadFromDb();
@@ -1590,7 +1590,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     );
     expect(cancelEvent).toBeDefined();
 
-    // session_error must never appear on cancel
+    // conversation_error must never appear on cancel
     const sessionErr = msgEvents.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeUndefined();
   });
@@ -1646,7 +1646,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     expect(err).toBeDefined();
   });
 
-  test("provider failure during processing emits both session_error and generic error", async () => {
+  test("provider failure during processing emits both conversation_error and generic error", async () => {
     const allEvents: ServerMessage[] = [];
     const session = makeSession();
     await session.loadFromDb();
@@ -1663,7 +1663,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     pendingRuns[0].reject(new Error("Connection refused"));
     await p1;
 
-    // Should get session_error (structured)
+    // Should get conversation_error (structured)
     const sessionErr = allEvents.find((e) => e.type === "conversation_error");
     expect(sessionErr).toBeDefined();
 
@@ -1672,7 +1672,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     expect(genericErr).toBeDefined();
   });
 
-  test("cancel after queued messages produces no session_error for any queued entry", async () => {
+  test("cancel after queued messages produces no conversation_error for any queued entry", async () => {
     const session = makeSession();
     await session.loadFromDb();
 
@@ -1701,7 +1701,7 @@ describe("Regression: cancel semantics and error channel split", () => {
 
     session.abort();
 
-    // No queued message should have received session_error
+    // No queued message should have received conversation_error
     for (const events of eventsPerMsg) {
       const sessionErr = events.find((e) => e.type === "conversation_error");
       expect(sessionErr).toBeUndefined();

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1899,7 +1899,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         let errMgr = viewModel.errorManager
 
         // Combine busy-state publishers with error and message publishers.
-        // Error state: errorText or sessionError non-nil.
+        // Error state: errorText or conversationError non-nil.
         // WaitingForInput: hasPendingConfirmation (derived from messages).
         // Processing: isSending || isThinking || pendingQueuedCount > 0.
         Publishers.CombineLatest4(

--- a/clients/shared/Features/Chat/ChatErrorManager.swift
+++ b/clients/shared/Features/Chat/ChatErrorManager.swift
@@ -21,7 +21,7 @@ public final class ChatErrorManager: ObservableObject {
     /// Human-readable error string shown in the error banner.
     @Published public var errorText: String?
 
-    /// Typed session error, richer than `errorText` and used for structured retry UI.
+    /// Typed conversation error, richer than `errorText` and used for structured retry UI.
     @Published public var conversationError: ConversationError?
 
     /// Supplemental diagnostic hint shown alongside a daemon connection error.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -26,7 +26,7 @@ public final class ChatViewModel: ObservableObject {
     public let messageManager = ChatMessageManager()
     /// Owns the pending-attachment list and image-processing helpers.
     public let attachmentManager = ChatAttachmentManager()
-    /// Owns errorText, sessionError, and connection-diagnostic properties.
+    /// Owns errorText, conversationError, and connection-diagnostic properties.
     public let errorManager = ChatErrorManager()
 
     private var cancellables: Set<AnyCancellable> = []


### PR DESCRIPTION
## Summary
- Update all stale `session_error` references in test descriptions/comments to `conversation_error`
- Update stale `sessionError` property name references in Swift comments to `conversationError`

Part of plan: conv-remaining-symbols.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
