### PR TITLE
feat: GA "Guardian Verification Setup" — remove flag gating from system prompt

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -55,9 +55,7 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     sandbox: { enabled: false, backend: "local" },
-    assistantFeatureFlagValues: {
-      "feature_flags.guardian-verify-setup.enabled": true,
-    },
+    assistantFeatureFlagValues: {},
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({}),

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -168,17 +168,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   parts.push(buildPostToolResponseSection());
   parts.push(buildExternalCommsIdentitySection());
   parts.push(buildChannelAwarenessSection());
-  const config = getConfig();
   if (!hasNoClient) parts.push(buildToolPermissionSection());
   parts.push(buildTaskScheduleReminderRoutingSection());
-  if (
-    isAssistantFeatureFlagEnabled(
-      "feature_flags.guardian-verify-setup.enabled",
-      config,
-    )
-  ) {
-    parts.push(buildVerificationRoutingSection());
-  }
+  parts.push(buildVerificationRoutingSection());
   parts.push(buildAttachmentSection());
   parts.push(buildInChatConfigurationSection());
   parts.push(buildVoiceSetupRoutingSection());


### PR DESCRIPTION
## Summary
- Remove the `isAssistantFeatureFlagEnabled` conditional that gated `buildVerificationRoutingSection()` in the system prompt
- Guardian verification routing is now always included in the system prompt
- Remove the now-unnecessary flag override from intent-routing test config

Part of plan: ga-hatch-guardian-flags.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
