### PR TITLE
chore: remove "Hatch New Assistant" and "Guardian Verification Setup" from feature flag registry

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -617,7 +617,7 @@ Release-driven update notification system that surfaces release notes to the ass
 
 The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is the canonical module for determining whether an assistant feature flag is enabled. It loads default values from the unified registry at `meta/feature-flags/feature-flag-registry.json` (bundled copy at `src/config/feature-flag-registry.json`) and resolves the effective state for each declared assistant-scope flag. Assistant feature flags are declaration-driven assistant-scoped booleans that can gate any assistant behavior; skill availability is one consumer.
 
-**Canonical key format:** `feature_flags.<flag_id>.enabled` (e.g., `feature_flags.hatch-new-assistant.enabled`).
+**Canonical key format:** `feature_flags.<flag_id>.enabled` (e.g., `feature_flags.contacts.enabled`).
 
 **Resolution priority** (highest wins):
 

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -32,9 +32,9 @@ let currentConfig: Record<string, unknown> = {
   sandbox: { enabled: false, backend: "native" },
 };
 
-const DECLARED_FLAG_ID = "hatch-new-assistant";
+const DECLARED_FLAG_ID = "contacts";
 const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
-const DECLARED_SKILL_ID = "hatch-new-assistant";
+const DECLARED_SKILL_ID = "contacts";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const realPlatform = require("../util/platform.js");
@@ -163,8 +163,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
   test("flag OFF skill does not appear in <available_skills> section", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       DECLARED_FLAG_ID,
     );
     createSkillOnDisk(
@@ -192,15 +192,15 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
   test("declared skills hidden when no flag overrides set (registry defaults to false)", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       DECLARED_FLAG_ID,
     );
     createSkillOnDisk(
-      "contacts",
-      "Contacts",
-      "View and manage contacts",
-      "contacts",
+      "email-channel",
+      "Email Channel",
+      "Email channel setup",
+      "email-channel",
     );
 
     currentConfig = {
@@ -211,42 +211,42 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     // Both skills declare feature flags with registry defaultEnabled: false
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="contacts"');
+    expect(result).not.toContain('id="email-channel"');
   });
 
   test("flagged-off skills hidden when all flags are OFF", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       DECLARED_FLAG_ID,
     );
     createSkillOnDisk(
-      "contacts",
-      "Contacts",
-      "View and manage contacts",
-      "contacts",
+      "email-channel",
+      "Email Channel",
+      "Email channel setup",
+      "email-channel",
     );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
-        "feature_flags.contacts.enabled": false,
+        "feature_flags.email-channel.enabled": false,
       },
     };
 
     const result = buildSystemPrompt();
 
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="contacts"');
+    expect(result).not.toContain('id="email-channel"');
   });
 
   test("assistantFeatureFlagValues overrides control visibility", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       DECLARED_FLAG_ID,
     );
 
@@ -337,7 +337,7 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: false for hatch-new-assistant
+    // which has defaultEnabled: false for contacts
     const config = {} as any;
 
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -154,19 +154,16 @@ describe("CES flags do not affect unrelated flags", () => {
     ).toBe(true);
   });
 
-  test("enabling all CES flags does not change hatch-new-assistant flag (defaultEnabled: false)", () => {
+  test("enabling all CES flags does not change contacts flag (defaultEnabled: false)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
     }
     const config = makeConfig(overrides);
 
-    // hatch-new-assistant defaults to false in the registry and should stay false
+    // contacts defaults to false in the registry and should stay false
     expect(
-      isAssistantFeatureFlagEnabled(
-        "feature_flags.hatch-new-assistant.enabled",
-        config,
-      ),
+      isAssistantFeatureFlagEnabled("feature_flags.contacts.enabled", config),
     ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -5,9 +5,9 @@ import type { AssistantConfig } from "../config/schema.js";
 import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
 
-const DECLARED_FLAG_ID = "hatch-new-assistant";
+const DECLARED_FLAG_ID = "contacts";
 const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
-const DECLARED_SKILL_ID = "hatch-new-assistant";
+const DECLARED_SKILL_ID = "contacts";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // hatch-new-assistant defaults to false in the registry
+    // contacts defaults to false in the registry
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
       false,
     );
@@ -212,7 +212,7 @@ describe("resolveSkillStates with feature flags", () => {
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // hatch-new-assistant registry default is false, so it's filtered out
+    // contacts registry default is false, so it's filtered out
     expect(resolved.length).toBe(0);
   });
 
@@ -270,7 +270,7 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // hatch-new-assistant and deploy explicitly false; browser explicitly true
+    // contacts and deploy explicitly false; browser explicitly true
     expect(ids).toEqual(["browser"]);
   });
 });
@@ -281,7 +281,7 @@ describe("resolveSkillStates with feature flags", () => {
 
 describe("resolveSkillStates with frontmatter featureFlag", () => {
   test("skill with featureFlag (defaultEnabled: false) is filtered when no config override", () => {
-    // hatch-new-assistant has defaultEnabled: false in the registry
+    // contacts has defaultEnabled: false in the registry
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -14,8 +14,8 @@ const TEST_DIR = join(
 
 let currentConfig: Record<string, unknown> = {};
 
-const DECLARED_SKILL_ID = "hatch-new-assistant";
-const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
+const DECLARED_SKILL_ID = "contacts";
+const DECLARED_FLAG_KEY = "feature_flags.contacts.enabled";
 
 const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
   getRootDir: () => TEST_DIR,
@@ -124,8 +124,8 @@ describe("skill_load feature flag enforcement", () => {
   test("returns deterministic error for flag OFF skill", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -147,8 +147,8 @@ describe("skill_load feature flag enforcement", () => {
   test("loads skill normally when flag is ON", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -163,14 +163,14 @@ describe("skill_load feature flag enforcement", () => {
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Hatch New Assistant");
+    expect(result.content).toContain("Skill: Contacts");
   });
 
   test("rejects skill when flag key is absent (registry defaults to disabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Hatch New Assistant",
-      "Toggle hatch new assistant behavior",
+      "Contacts",
+      "Toggle contacts behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -184,7 +184,7 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    // hatch-new-assistant is declared in the registry with defaultEnabled: false
+    // contacts is declared in the registry with defaultEnabled: false
     expect(result.isError).toBe(true);
     expect(result.content).toContain("disabled by feature flag");
   });

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -21,8 +21,8 @@ let mockUnregisteredSkillIds: string[] = [];
 let mockSkillRefCount: Map<string, number> = new Map();
 
 let currentConfig: Record<string, unknown> = {};
-const DECLARED_SKILL_ID = "hatch-new-assistant";
-const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
+const DECLARED_SKILL_ID = "contacts";
+const DECLARED_FLAG_KEY = "feature_flags.contacts.enabled";
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2191,7 +2191,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         /// Derive a human-readable name from the flag key.
-        /// e.g. "feature_flags.hatch-new-assistant.enabled" -> "Hatch New Assistant"
+        /// e.g. "feature_flags.browser.enabled" -> "Browser"
         public var displayName: String {
             if let label = label { return label }
             var name = key

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -35,20 +35,12 @@ const TEST_REGISTRY = {
       defaultEnabled: true,
     },
     {
-      id: "guardian-verify-setup",
+      id: "contacts",
       scope: "assistant",
-      key: "feature_flags.guardian-verify-setup.enabled",
-      label: "Guardian Verification Setup",
-      description: "Guardian verification setup",
-      defaultEnabled: true,
-    },
-    {
-      id: "hatch-new-assistant",
-      scope: "assistant",
-      key: "feature_flags.hatch-new-assistant.enabled",
-      label: "Hatch New Assistant",
-      description: "Hatch new assistant",
-      defaultEnabled: true,
+      key: "feature_flags.contacts.enabled",
+      label: "Contacts",
+      description: "Contacts management",
+      defaultEnabled: false,
     },
     {
       id: "user-hosted-enabled",
@@ -160,13 +152,6 @@ describe("GET /v1/feature-flags handler", () => {
     );
     expect(browserFlag2).toBeDefined();
     expect(browserFlag2.label).toBe("Browser");
-
-    const hatchFlag = body.flags.find(
-      (f: { key: string }) =>
-        f.key === "feature_flags.hatch-new-assistant.enabled",
-    );
-    expect(hatchFlag).toBeDefined();
-    expect(hatchFlag.label).toBe("Hatch New Assistant");
   });
 
   test("does not include non-assistant-scope flags", async () => {
@@ -210,7 +195,6 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         assistantFeatureFlagValues: {
           "feature_flags.browser.enabled": false,
-          "feature_flags.guardian-verify-setup.enabled": false,
         },
       }),
     );
@@ -229,13 +213,6 @@ describe("GET /v1/feature-flags handler", () => {
     expect(browserFlag).toBeDefined();
     expect(browserFlag.enabled).toBe(false); // overridden from default true
     expect(browserFlag.defaultEnabled).toBe(true);
-
-    const guardianFlag = body.flags.find(
-      (f: { key: string }) =>
-        f.key === "feature_flags.guardian-verify-setup.enabled",
-    );
-    expect(guardianFlag).toBeDefined();
-    expect(guardianFlag.enabled).toBe(false); // overridden from default true
   });
 
   test("ignores non-boolean values in assistantFeatureFlagValues", async () => {
@@ -303,7 +280,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
         twilio: { phoneNumber: "+1234567890" },
         email: { address: "test@example.com" },
         assistantFeatureFlagValues: {
-          "feature_flags.guardian-verify-setup.enabled": true,
+          "feature_flags.contacts.enabled": true,
         },
       }),
     );
@@ -326,9 +303,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     expect(config.email).toEqual({ address: "test@example.com" });
     // New section should have both old and new values
     expect(
-      config.assistantFeatureFlagValues[
-        "feature_flags.guardian-verify-setup.enabled"
-      ],
+      config.assistantFeatureFlagValues["feature_flags.contacts.enabled"],
     ).toBe(true);
     expect(
       config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
@@ -383,7 +358,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const oldFormatKeys = [
       "skills.browser.enabled",
-      "skills.guardian-verify-setup.enabled",
+      "skills.contacts.enabled",
       "skills.my-skill.enabled",
     ];
 
@@ -459,8 +434,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const validKeys = [
       "feature_flags.browser.enabled",
-      "feature_flags.guardian-verify-setup.enabled",
-      "feature_flags.hatch-new-assistant.enabled",
+      "feature_flags.contacts.enabled",
     ];
 
     for (const key of validKeys) {
@@ -538,21 +512,21 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Write initial config
     const initial = {
       twilio: { phoneNumber: "+1234" },
-      assistantFeatureFlagValues: { "feature_flags.browser.enabled": true },
+      assistantFeatureFlagValues: { "feature_flags.contacts.enabled": true },
     };
     writeFileSync(configPath, JSON.stringify(initial));
 
     const handler = createFeatureFlagsPatchHandler();
     await handler(
       new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.guardian-verify-setup.enabled",
+        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
         {
           method: "PATCH",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ enabled: false }),
         },
       ),
-      "feature_flags.guardian-verify-setup.enabled",
+      "feature_flags.browser.enabled",
     );
 
     // Verify the file is valid JSON and contains all expected data
@@ -560,12 +534,10 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const config = JSON.parse(raw);
     expect(config.twilio).toMatchObject({ phoneNumber: "+1234" });
     expect(
-      config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
+      config.assistantFeatureFlagValues["feature_flags.contacts.enabled"],
     ).toBe(true);
     expect(
-      config.assistantFeatureFlagValues[
-        "feature_flags.guardian-verify-setup.enabled"
-      ],
+      config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
     ).toBe(false);
 
     // Verify no temp files left behind
@@ -582,8 +554,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Fire multiple concurrent PATCH requests at the same time
     const flagKeys = [
       "feature_flags.browser.enabled",
-      "feature_flags.guardian-verify-setup.enabled",
-      "feature_flags.hatch-new-assistant.enabled",
+      "feature_flags.contacts.enabled",
     ];
 
     const results = await Promise.all(

--- a/gateway/workspace/config.json
+++ b/gateway/workspace/config.json
@@ -1,7 +1,5 @@
 {
   "assistantFeatureFlagValues": {
-    "feature_flags.browser.enabled": false,
-    "feature_flags.guardian-verify-setup.enabled": false,
-    "feature_flags.hatch-new-assistant.enabled": false
+    "feature_flags.browser.enabled": false
   }
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -2,22 +2,6 @@
   "version": 1,
   "flags": [
     {
-      "id": "hatch-new-assistant",
-      "scope": "assistant",
-      "key": "feature_flags.hatch-new-assistant.enabled",
-      "label": "Hatch New Assistant",
-      "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": false
-    },
-    {
-      "id": "guardian-verify-setup",
-      "scope": "assistant",
-      "key": "feature_flags.guardian-verify-setup.enabled",
-      "label": "Guardian Verification Setup",
-      "description": "Enable guardian verification routing in the system prompt",
-      "defaultEnabled": false
-    },
-    {
       "id": "browser",
       "scope": "assistant",
       "key": "feature_flags.browser.enabled",


### PR DESCRIPTION
## Summary
- Remove `hatch-new-assistant` and `guardian-verify-setup` flag definitions from `meta/feature-flags/feature-flag-registry.json`
- Remove both flags from `gateway/workspace/config.json`
- Update all test fixtures that referenced these flags to use `contacts` instead
- Update documentation examples in ARCHITECTURE.md and DaemonClient.swift

Part of plan: ga-hatch-guardian-flags.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
