### PR TITLE
fix: update stale session_error references in Swift onboarding, tests, and comments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionViewModel.swift
@@ -152,7 +152,7 @@ final class FirstMeetingIntroductionViewModel {
                 case .conversationError(let error) where error.conversationId == self.conversationId && self.conversationId != nil:
                     self.isThinking = false
                     self.streamingText = ""
-                    log.error("First meeting start failed (session_error): \(error.userMessage)")
+                    log.error("First meeting start failed (conversation_error): \(error.userMessage)")
                     self.messages.append(InterviewMessage(
                         role: .assistant,
                         text: "I'm having trouble connecting. Please try again in a moment."

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/InterviewViewModel.swift
@@ -154,7 +154,7 @@ final class InterviewViewModel {
                 case .conversationError(let error) where error.conversationId == self.conversationId && self.conversationId != nil:
                     self.isThinking = false
                     self.streamingText = ""
-                    log.error("Interview start failed (session_error): \(error.userMessage)")
+                    log.error("Interview start failed (conversation_error): \(error.userMessage)")
                     self.messages.append(InterviewMessage(
                         role: .assistant,
                         text: "I'm having trouble connecting. Please try again in a moment."
@@ -274,7 +274,7 @@ final class InterviewViewModel {
                 case .conversationError(let error) where error.conversationId == conversationId:
                     self.isThinking = false
                     self.streamingText = ""
-                    log.error("Session error during follow-up (session_error): \(error.userMessage)")
+                    log.error("Conversation error during follow-up (conversation_error): \(error.userMessage)")
                     self.messages.append(InterviewMessage(
                         role: .assistant,
                         text: "Something went wrong. Please try again."

--- a/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Interview/ProfileExtractor.swift
@@ -147,7 +147,7 @@ final class ProfileExtractor {
                 return
 
             case .conversationError(let error) where error.conversationId == conversationId:
-                log.error("Extraction session error (session_error): \(error.userMessage)")
+                log.error("Extraction conversation error (conversation_error): \(error.userMessage)")
                 return
 
             default:

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1394,7 +1394,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.conversationError(errorMsg))
 
         XCTAssertEqual(viewModel.errorText, "Provider returned 500",
-                       "session_error should populate errorText for backward compatibility")
+                       "conversation_error should populate errorText for backward compatibility")
     }
 
     func testConversationErrorFromDifferentConversationIsIgnored() {
@@ -1409,7 +1409,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.conversationError(errorMsg))
 
         XCTAssertNil(viewModel.conversationError,
-                      "session_error from a different session should be ignored")
+                      "conversation_error from a different conversation should be ignored")
         XCTAssertNil(viewModel.errorText)
     }
 
@@ -1426,7 +1426,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.conversationError(errorMsg))
 
         XCTAssertNil(viewModel.conversationError,
-                      "session_error should be ignored before session is claimed")
+                      "conversation_error should be ignored before conversation is claimed")
         XCTAssertNil(viewModel.errorText)
     }
 
@@ -1447,7 +1447,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.conversationError(errorMsg))
 
         XCTAssertFalse(viewModel.messages[0].isStreaming,
-                        "session_error should finalize streaming assistant message")
+                        "conversation_error should finalize streaming assistant message")
         XCTAssertEqual(viewModel.messages[0].text, "Partial",
                         "Partial text should be preserved")
     }
@@ -1474,7 +1474,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.conversationError(errorMsg))
 
         XCTAssertEqual(viewModel.messages[1].status, .sent,
-                        "session_error should reset processing messages to .sent")
+                        "conversation_error should reset processing messages to .sent")
     }
 
     func testDismissConversationErrorClearsBothErrorStates() {
@@ -1590,7 +1590,7 @@ final class ChatViewModelTests: XCTestCase {
         )
         viewModel.handleServerMessage(.conversationError(secondError))
         XCTAssertEqual(viewModel.conversationError?.category, .rateLimit,
-                        "Latest session_error should replace previous one")
+                        "Latest conversation_error should replace previous one")
         XCTAssertEqual(viewModel.conversationError?.message, "Rate limited")
     }
 

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -26,7 +26,7 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
     func testDocumentEditorIsNotShowingChat() {
         let state = makeState(.panel(.documentEditor))
 
-        // isShowingChat only covers full-window chat (.thread / nil); panels use isConversationVisible
+        // isShowingChat only covers full-window chat (.conversation / nil); panels use isConversationVisible
         XCTAssertFalse(state.isShowingChat,
                         "isShowingChat should be false for document editor (it's a panel)")
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -272,7 +272,7 @@ public final class ChatViewModel: ObservableObject {
         get { errorManager.conversationError }
         set { errorManager.conversationError = newValue }
     }
-    /// Whether this view model has an active error (either a session error or error text).
+    /// Whether this view model has an active error (either a conversation error or error text).
     /// Used by ConversationManager to derive `ConversationInteractionState.error`.
     public var hasActiveError: Bool {
         conversationError != nil || errorText != nil
@@ -1968,7 +1968,7 @@ public final class ChatViewModel: ObservableObject {
         secretBlockedCurrentPage = nil
     }
 
-    /// Dismiss the typed session error state. Clears both the typed error
+    /// Dismiss the typed conversation error state. Clears both the typed error
     /// and any corresponding `errorText` so the UI can return to normal.
     public func dismissConversationError() {
         conversationError = nil
@@ -1999,7 +1999,7 @@ public final class ChatViewModel: ObservableObject {
     public func retryAfterConversationError() {
         guard let error = conversationError, error.isRetryable else { return }
         guard conversationId != nil else { return }
-        // Reset sending state that may still be set if the session error arrived
+        // Reset sending state that may still be set if the conversation error arrived
         // while queued messages were pending (pendingQueuedCount > 0).
         // Without this, regenerateLastMessage() silently bails at its
         // `!isSending` guard, leaving the UI stuck with no error and no retry.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-remaining-symbols.md.

**Gap:** Stale session_error/sessionError references in Swift files + stale .thread comment
**What was expected:** All comments, log messages, and test descriptions should use conversation_error/conversationError
**What was found:** Multiple Swift files still reference session_error in log messages and test descriptions. One test file still references .thread in a comment.

### Changes
- Replace `session_error` with `conversation_error` in log messages across onboarding view models (InterviewViewModel, ProfileExtractor, FirstMeetingIntroductionViewModel)
- Replace `session_error` with `conversation_error` in test assertion descriptions (ChatViewModelTests — 6 occurrences)
- Replace `session error`/`sessionError` with `conversation error`/`conversationError` in comments (ChatViewModel — 3 occurrences)
- Replace `.thread` with `.conversation` in comment (DocumentEditorConversationVisibilityTests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
