### PR TITLE
fix: rename sessionError local variables to conversationError in TS test files

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -700,8 +700,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
       // BUG: Currently a conversation_error IS emitted instead of retrying.
       // After PR 2 fix, there should be no conversation_error.
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
     },
   );
 
@@ -807,8 +809,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       // The reducer should be called in the convergence loop
       expect(reducerCalled).toBe(true);
       // Should recover without conversation_error
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       expect(callCount).toBe(2);
     },
   );
@@ -941,8 +945,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(capturedTargetTokens!).toBe(expectedCorrectedTarget);
 
       // Should recover without conversation_error
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       expect(callCount).toBe(2);
     },
   );
@@ -1037,8 +1043,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(reducerCalled).toBe(true);
       // Should succeed
       expect(callCount).toBe(1);
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
     },
@@ -1230,8 +1238,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(emergencyCompactCalled).toBe(true);
 
       // BUG: Currently a conversation_error IS emitted.
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
     },
   );
 
@@ -1406,8 +1416,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(agentLoopCallCount).toBe(2);
 
       // No conversation_error should be emitted
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
 
       // A context_compacted event should have been emitted
       const compacted = events.find((e) => e.type === "context_compacted");
@@ -1593,8 +1605,10 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
       expect(agentLoopCallCount).toBe(2);
 
       // No conversation_error
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
     },
   );
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -545,8 +545,10 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "run ls", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeDefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeDefined();
     });
 
     test("non-error agent loop completion does not emit conversation_error", async () => {
@@ -579,8 +581,10 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
     });
@@ -818,8 +822,10 @@ describe("session-agent-loop", () => {
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeDefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeDefined();
     });
 
     test("bounded convergence loop applies reducer tiers and recovers", async () => {
@@ -896,8 +902,10 @@ describe("session-agent-loop", () => {
 
       expect(reducerCalls).toBeGreaterThanOrEqual(1);
       expect(callCount).toBe(2);
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
     });
@@ -951,8 +959,10 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
       // Should NOT emit conversation_error
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
 
       // Should emit a graceful assistant text delta instead
       const textDeltas = events.filter(
@@ -1057,8 +1067,10 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
       // Should not produce conversation_error since auto-compress recovered
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
     });
@@ -1250,8 +1262,10 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeDefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeDefined();
     });
   });
 
@@ -1507,8 +1521,10 @@ describe("session-agent-loop", () => {
       const cancelled = events.find((e) => e.type === "generation_cancelled");
       expect(cancelled).toBeDefined();
       // Should NOT emit a conversation_error for user cancellation
-      const sessionError = events.find((e) => e.type === "conversation_error");
-      expect(sessionError).toBeUndefined();
+      const conversationError = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationError).toBeUndefined();
     });
 
     test("skips resolveAssistantAttachments when cancelled", async () => {

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -599,10 +599,10 @@ describe("provider ordering error retry", () => {
     expect(agentLoopRunCount).toBe(2);
 
     // The error must be surfaced to clients via conversation_error, not silently swallowed.
-    const sessionError = events.find((e) => e.type === "conversation_error") as
-      | { code?: string }
-      | undefined;
-    expect(sessionError).toBeDefined();
-    expect(sessionError?.code).toBe("CONTEXT_TOO_LARGE");
+    const conversationError = events.find(
+      (e) => e.type === "conversation_error",
+    ) as { code?: string } | undefined;
+    expect(conversationError).toBeDefined();
+    expect(conversationError?.code).toBe("CONTEXT_TOO_LARGE");
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-remaining-symbols.md.

**Gap:** Stale sessionError local variable names in TS test files
**What was expected:** Local variables should use conversationError to match renamed types
**What was found:** 33 occurrences of sessionError local variable in 3 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
