### PR TITLE
feat: pre-populate email/name and auto-focus in Send Logs form

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -513,6 +513,7 @@ extension AppDelegate {
         }
 
         let view = LogReportFormView(
+            authManager: authManager,
             onSend: { [weak self] formData in
                 self?.dismissLogReportWindow()
                 var formData = formData

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -5,6 +5,9 @@ import VellumAssistantShared
 /// category, describe the issue, and provide an email for follow-up.
 @MainActor
 struct LogReportFormView: View {
+    enum Field { case email, name, message }
+
+    let authManager: AuthManager
     let onSend: (LogReportFormData) -> Void
     let onCancel: () -> Void
 
@@ -12,6 +15,7 @@ struct LogReportFormView: View {
     @State private var name: String = ""
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
+    @FocusState private var focusedField: Field?
 
     private var canSend: Bool {
         selectedReason != nil && !email.isEmpty
@@ -30,6 +34,21 @@ struct LogReportFormView: View {
         .padding(VSpacing.xl)
         .background(VColor.surfaceOverlay)
         .frame(width: 480)
+        .onAppear {
+            if email.isEmpty, let userEmail = authManager.currentUser?.email {
+                email = userEmail
+            }
+            if name.isEmpty, let displayName = authManager.currentUser?.display {
+                name = displayName
+            }
+            if email.isEmpty {
+                focusedField = .email
+            } else if name.isEmpty {
+                focusedField = .name
+            } else {
+                focusedField = .message
+            }
+        }
     }
 
     // MARK: - Sections
@@ -68,6 +87,7 @@ struct LogReportFormView: View {
                 text: $name,
                 leadingIcon: VIcon.user.rawValue
             )
+            .focused($focusedField, equals: .name)
         }
     }
 
@@ -82,6 +102,7 @@ struct LogReportFormView: View {
                 minHeight: 60,
                 maxHeight: 80
             )
+            .focused($focusedField, equals: .message)
         }
     }
 
@@ -95,6 +116,7 @@ struct LogReportFormView: View {
                 text: $email,
                 leadingIcon: VIcon.mail.rawValue
             )
+            .focused($focusedField, equals: .email)
         }
     }
 


### PR DESCRIPTION
## Summary
- Pre-populate email and name fields in the Send Logs form from `AuthManager.currentUser` when the user is logged in
- Auto-focus the first empty field on appear (email → name → message), so authenticated users land directly in the description field
- Fields are still editable; email persists via `@AppStorage` so manual edits are remembered

## Test plan
- [ ] Open Send Logs while logged in — email and name should be pre-filled, cursor in "What happened?"
- [ ] Open Send Logs while logged out — email field empty and focused
- [ ] Edit email, close/reopen — edited email should persist (not overwritten by account email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
