### PR TITLE
feat: add Cmd+N shortcut to Settings keyboard shortcuts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -266,6 +266,10 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                ShortcutRow(label: "New chat", shortcut: "⌘N")
+
+                SettingsDivider()
+
                 VToggle(
                     isOn: Binding(
                         get: { store.cmdEnterToSend },


### PR DESCRIPTION
## Summary
- Adds a "New chat" (⌘N) row to Settings > General > Keyboard Shortcuts section

## Test plan
- [ ] Open Settings > General, verify "New chat ⌘N" appears in the Keyboard Shortcuts card

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
