### PR TITLE
refactor: rename SidebarInteractionState thread→conversation properties

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -34,43 +34,43 @@ final class SharingState {
 @Observable
 @MainActor
 final class SidebarInteractionState {
-    var isHoveredThread: UUID?
+    var isHoveredConversation: UUID?
     var isHoveredApp: String?
-    var threadPendingDeletion: UUID?
-    var renamingThreadId: UUID?
+    var conversationPendingDeletion: UUID?
+    var renamingConversationId: UUID?
     var renameText: String = ""
-    var showAllThreads: Bool = false
-    var showAllScheduleThreads: Bool = false
+    var showAllConversations: Bool = false
+    var showAllScheduleConversations: Bool = false
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false
     var showPreferencesDrawer: Bool = false
 
-    /// Updates thread hover state and clears stale pending-deletion when hover
-    /// moves to a different thread. Centralises the invariant so callers don't
+    /// Updates conversation hover state and clears stale pending-deletion when hover
+    /// moves to a different conversation. Centralises the invariant so callers don't
     /// need to coordinate.
-    func setThreadHover(threadId: UUID?, hovering: Bool) {
+    func setConversationHover(conversationId: UUID?, hovering: Bool) {
         if hovering {
-            // Moving to a new thread clears pending archive of the old one
-            if let pending = threadPendingDeletion, pending != threadId {
-                threadPendingDeletion = nil
+            // Moving to a new conversation clears pending archive of the old one
+            if let pending = conversationPendingDeletion, pending != conversationId {
+                conversationPendingDeletion = nil
             }
-            isHoveredThread = threadId
+            isHoveredConversation = conversationId
         } else {
-            if isHoveredThread == threadId {
-                isHoveredThread = nil
+            if isHoveredConversation == conversationId {
+                isHoveredConversation = nil
             }
-            // Leaving a pending-deletion thread clears the confirmation
-            if threadPendingDeletion == threadId {
-                threadPendingDeletion = nil
+            // Leaving a pending-deletion conversation clears the confirmation
+            if conversationPendingDeletion == conversationId {
+                conversationPendingDeletion = nil
             }
         }
     }
 
     /// Conversation ID that is currently the drop target during a drag-and-drop reorder.
-    var dropTargetThreadId: UUID?
+    var dropTargetConversationId: UUID?
     /// Conversation ID currently being dragged (set on drag start, cleared on drop).
-    var draggingThreadId: UUID?
+    var draggingConversationId: UUID?
     /// Whether the drop indicator should appear at the bottom of the target (true)
     /// or the top (false). Set based on drag direction.
     var dropIndicatorAtBottom: Bool = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -45,19 +45,19 @@ extension MainWindowView {
         conversationManager.visibleConversations.filter { $0.isScheduleConversation }
     }
 
-    var displayedThreads: [ConversationModel] {
+    var displayedConversations: [ConversationModel] {
         let all = regularConversations
-        return sidebar.showAllThreads ? all : Array(all.prefix(5))
+        return sidebar.showAllConversations ? all : Array(all.prefix(5))
     }
 
-    var displayedScheduleThreads: [ConversationModel] {
+    var displayedScheduleConversations: [ConversationModel] {
         let all = scheduleConversations
-        return sidebar.showAllScheduleThreads ? all : Array(all.prefix(3))
+        return sidebar.showAllScheduleConversations ? all : Array(all.prefix(3))
     }
 
     /// Groups schedule conversations by their scheduleJobId.
-    /// Threads without a scheduleJobId are placed in individual groups keyed by their session ID.
-    var scheduleThreadGroups: [(key: String, label: String, conversations: [ConversationModel])] {
+    /// Conversations without a scheduleJobId are placed in individual groups keyed by their session ID.
+    var scheduleConversationGroups: [(key: String, label: String, conversations: [ConversationModel])] {
         var grouped: [String: [ConversationModel]] = [:]
         var order: [String] = []
         for thread in scheduleConversations {
@@ -87,8 +87,8 @@ extension MainWindowView {
     }
 
     var displayedScheduleGroups: [(key: String, label: String, conversations: [ConversationModel])] {
-        let all = scheduleThreadGroups
-        if sidebar.showAllScheduleThreads { return all }
+        let all = scheduleConversationGroups
+        if sidebar.showAllScheduleConversations { return all }
         // Auto-expand if any hidden group has unread conversations.
         let visible = Array(all.prefix(3))
         let hidden = all.dropFirst(3)
@@ -124,22 +124,22 @@ extension MainWindowView {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .clipped()
         .alert("Rename Conversation", isPresented: Binding(
-            get: { sidebar.renamingThreadId != nil },
-            set: { if !$0 { sidebar.renamingThreadId = nil } }
+            get: { sidebar.renamingConversationId != nil },
+            set: { if !$0 { sidebar.renamingConversationId = nil } }
         )) {
             TextField("Title", text: Binding(
                 get: { sidebar.renameText },
                 set: { sidebar.renameText = $0 }
             ))
-            Button("Cancel", role: .cancel) { sidebar.renamingThreadId = nil }
+            Button("Cancel", role: .cancel) { sidebar.renamingConversationId = nil }
             Button("Save") {
-                if let id = sidebar.renamingThreadId {
+                if let id = sidebar.renamingConversationId {
                     conversationManager.renameConversation(id: id, title: sidebar.renameText)
                 }
-                sidebar.renamingThreadId = nil
+                sidebar.renamingConversationId = nil
             }
         } message: {
-            Text("Enter a new name for this thread")
+            Text("Enter a new name for this conversation")
         }
     }
 
@@ -229,11 +229,11 @@ extension MainWindowView {
 
             ScrollView {
                 VStack(spacing: 0) {
-                    if showDaemonLoading && displayedThreads.isEmpty {
+                    if showDaemonLoading && displayedConversations.isEmpty {
                         DaemonLoadingThreadsSkeleton()
                     }
 
-                    ForEach(displayedThreads) { thread in
+                    ForEach(displayedConversations) { thread in
                         SidebarThreadItem(
                             thread: thread,
                             conversationManager: conversationManager,
@@ -243,7 +243,7 @@ extension MainWindowView {
                         )
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                if sidebar.dropTargetThreadId == thread.id {
+                                if sidebar.dropTargetConversationId == thread.id {
                                     Rectangle()
                                         .fill(VColor.primaryBase)
                                         .frame(height: 2)
@@ -251,32 +251,32 @@ extension MainWindowView {
                                 }
                             }
                             .dropDestination(for: String.self) { items, _ in
-                                sidebar.dropTargetThreadId = nil
-                                sidebar.draggingThreadId = nil
+                                sidebar.dropTargetConversationId = nil
+                                sidebar.draggingConversationId = nil
                                 guard let droppedId = items.first,
                                       let sourceUUID = UUID(uuidString: droppedId),
                                       sourceUUID != thread.id else { return false }
                                 return conversationManager.moveThread(sourceId: sourceUUID, targetId: thread.id)
                             } isTargeted: { isTargeted in
-                                if isTargeted && thread.id != sidebar.draggingThreadId {
-                                    sidebar.dropTargetThreadId = thread.id
-                                    if let dragId = sidebar.draggingThreadId {
+                                if isTargeted && thread.id != sidebar.draggingConversationId {
+                                    sidebar.dropTargetConversationId = thread.id
+                                    if let dragId = sidebar.draggingConversationId {
                                         let visible = conversationManager.visibleConversations
                                         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
                                         let tIdx = visible.firstIndex(where: { $0.id == thread.id }) ?? 0
                                         sidebar.dropIndicatorAtBottom = sIdx < tIdx
                                     }
-                                } else if !isTargeted && sidebar.dropTargetThreadId == thread.id {
-                                    sidebar.dropTargetThreadId = nil
+                                } else if !isTargeted && sidebar.dropTargetConversationId == thread.id {
+                                    sidebar.dropTargetConversationId = nil
                                 }
                             }
                     }
 
                     if regularConversations.count > 5 {
                         Button {
-                            withAnimation(VAnimation.standard) { sidebar.showAllThreads.toggle() }
+                            withAnimation(VAnimation.standard) { sidebar.showAllConversations.toggle() }
                         } label: {
-                            Text(sidebar.showAllThreads ? "Show less" : "Show more")
+                            Text(sidebar.showAllConversations ? "Show less" : "Show more")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.primaryBase)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -313,7 +313,7 @@ extension MainWindowView {
                                 )
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                        if sidebar.dropTargetThreadId == thread.id {
+                                        if sidebar.dropTargetConversationId == thread.id {
                                             Rectangle()
                                                 .fill(VColor.primaryBase)
                                                 .frame(height: 2)
@@ -393,7 +393,7 @@ extension MainWindowView {
                                         )
                                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                                if sidebar.dropTargetThreadId == thread.id {
+                                                if sidebar.dropTargetConversationId == thread.id {
                                                     Rectangle()
                                                         .fill(VColor.primaryBase)
                                                         .frame(height: 2)
@@ -422,11 +422,11 @@ extension MainWindowView {
                             }
                         }
 
-                        if scheduleThreadGroups.count > 3 {
+                        if scheduleConversationGroups.count > 3 {
                             Button {
-                                withAnimation(VAnimation.standard) { sidebar.showAllScheduleThreads.toggle() }
+                                withAnimation(VAnimation.standard) { sidebar.showAllScheduleConversations.toggle() }
                             } label: {
-                                Text(sidebar.showAllScheduleThreads ? "Show less" : "Show more")
+                                Text(sidebar.showAllScheduleConversations ? "Show less" : "Show more")
                                     .font(VFont.caption)
                                     .foregroundColor(VColor.primaryBase)
                                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -216,7 +216,7 @@ struct MainWindowView: View {
     func startRenameActiveThread() {
         guard let id = conversationManager.activeConversationId,
               let thread = conversationManager.activeConversation else { return }
-        sidebar.renamingThreadId = id
+        sidebar.renamingConversationId = id
         sidebar.renameText = thread.title
     }
 
@@ -869,7 +869,7 @@ struct MainWindowView: View {
             }
         }
         // Hover→pending-deletion invariant is now owned by
-        // SidebarInteractionState.setThreadHover(threadId:hovering:)
+        // SidebarInteractionState.setConversationHover(conversationId:hovering:)
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -41,10 +41,10 @@ struct ThreadSwitcherDrawer: View {
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onDisappear {
-            if sidebar.isHoveredThread != nil {
-                sidebar.isHoveredThread = nil
+            if sidebar.isHoveredConversation != nil {
+                sidebar.isHoveredConversation = nil
             }
-            sidebar.threadPendingDeletion = nil
+            sidebar.conversationPendingDeletion = nil
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
@@ -9,7 +9,7 @@ struct ScheduleReorderDropDelegate: DropDelegate {
     let conversationManager: ConversationManager
 
     func validateDrop(info: DropInfo) -> Bool {
-        guard let dragId = sidebar.draggingThreadId,
+        guard let dragId = sidebar.draggingConversationId,
               dragId != targetThread.id,
               let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceThread.isScheduleConversation,
@@ -23,14 +23,14 @@ struct ScheduleReorderDropDelegate: DropDelegate {
     }
 
     func dropEntered(info: DropInfo) {
-        guard let dragId = sidebar.draggingThreadId,
+        guard let dragId = sidebar.draggingConversationId,
               dragId != targetThread.id,
               let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == targetThread.scheduleJobId
         else { return }
 
-        sidebar.dropTargetThreadId = targetThread.id
+        sidebar.dropTargetConversationId = targetThread.id
         let visible = conversationManager.visibleConversations
         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
         let tIdx = visible.firstIndex(where: { $0.id == targetThread.id }) ?? 0
@@ -38,15 +38,15 @@ struct ScheduleReorderDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
-        if sidebar.dropTargetThreadId == targetThread.id {
-            sidebar.dropTargetThreadId = nil
+        if sidebar.dropTargetConversationId == targetThread.id {
+            sidebar.dropTargetConversationId = nil
         }
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        let sourceId = sidebar.draggingThreadId
-        sidebar.dropTargetThreadId = nil
-        sidebar.draggingThreadId = nil
+        let sourceId = sidebar.draggingConversationId
+        sidebar.dropTargetConversationId = nil
+        sidebar.draggingConversationId = nil
         guard let sourceId = sourceId, sourceId != targetThread.id else { return false }
         return conversationManager.moveThread(sourceId: sourceId, targetId: targetThread.id)
     }
@@ -63,7 +63,7 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
 
     func validateDrop(info: DropInfo) -> Bool {
         guard let firstThread = firstThread,
-              let dragId = sidebar.draggingThreadId,
+              let dragId = sidebar.draggingConversationId,
               dragId != firstThread.id,
               let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceThread.isScheduleConversation,
@@ -78,27 +78,27 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
 
     func dropEntered(info: DropInfo) {
         guard let firstThread = firstThread,
-              let dragId = sidebar.draggingThreadId,
+              let dragId = sidebar.draggingConversationId,
               dragId != firstThread.id,
               let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceThread.isScheduleConversation,
               sourceThread.scheduleJobId == firstThread.scheduleJobId
         else { return }
 
-        sidebar.dropTargetThreadId = firstThread.id
+        sidebar.dropTargetConversationId = firstThread.id
         sidebar.dropIndicatorAtBottom = false
     }
 
     func dropExited(info: DropInfo) {
-        if let firstThread = firstThread, sidebar.dropTargetThreadId == firstThread.id {
-            sidebar.dropTargetThreadId = nil
+        if let firstThread = firstThread, sidebar.dropTargetConversationId == firstThread.id {
+            sidebar.dropTargetConversationId = nil
         }
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        let sourceId = sidebar.draggingThreadId
-        sidebar.dropTargetThreadId = nil
-        sidebar.draggingThreadId = nil
+        let sourceId = sidebar.draggingConversationId
+        sidebar.dropTargetConversationId = nil
+        sidebar.draggingConversationId = nil
         guard let firstThread = firstThread,
               let sourceId = sourceId,
               sourceId != firstThread.id

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -27,11 +27,11 @@ struct SidebarThreadItem: View {
         }
     }
 
-    private var isHovered: Bool { sidebar.isHoveredThread == thread.id }
+    private var isHovered: Bool { sidebar.isHoveredConversation == thread.id }
     private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: thread.id) }
     // Reserve trailing space when hovered for archive button overlay.
-    private var hasTrailingIcon: Bool { isHovered || sidebar.threadPendingDeletion == thread.id }
-    private var isPendingDeletion: Bool { sidebar.threadPendingDeletion == thread.id }
+    private var hasTrailingIcon: Bool { isHovered || sidebar.conversationPendingDeletion == thread.id }
+    private var isPendingDeletion: Bool { sidebar.conversationPendingDeletion == thread.id }
     private var canMarkUnread: Bool {
         !thread.hasUnseenLatestAssistantMessage &&
             thread.conversationId != nil &&
@@ -139,17 +139,17 @@ struct SidebarThreadItem: View {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if sidebar.threadPendingDeletion == thread.id {
+            if sidebar.conversationPendingDeletion == thread.id {
                 VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
                     conversationManager.archiveConversation(id: thread.id)
-                    sidebar.threadPendingDeletion = nil
+                    sidebar.conversationPendingDeletion = nil
                 }
                 .fixedSize()
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(thread.title)")
             } else if isHovered {
                 Button {
-                    sidebar.threadPendingDeletion = thread.id
+                    sidebar.conversationPendingDeletion = thread.id
                 } label: {
                     VIconView(.archive, size: 13)
                         .foregroundColor(VColor.contentSecondary)
@@ -175,7 +175,7 @@ struct SidebarThreadItem: View {
                 Label { Text(thread.isPinned ? "Unpin thread" : "Pin thread") } icon: { VIconView(thread.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
-                sidebar.renamingThreadId = thread.id
+                sidebar.renamingConversationId = thread.id
                 sidebar.renameText = thread.title
             } label: {
                 Label { Text("Rename thread") } icon: { VIconView(.pencil, size: 14) }
@@ -205,11 +205,11 @@ struct SidebarThreadItem: View {
         .pointerCursor()
         .onHover { hovering in
             withAnimation(VAnimation.fast) {
-                sidebar.setThreadHover(threadId: thread.id, hovering: hovering)
+                sidebar.setConversationHover(conversationId: thread.id, hovering: hovering)
             }
         }
         .onDrag {
-            sidebar.draggingThreadId = thread.id
+            sidebar.draggingConversationId = thread.id
             return NSItemProvider(object: thread.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Rename all SidebarInteractionState properties and methods from thread→conversation terminology
- Update computed properties: displayedThreads→displayedConversations, displayedScheduleThreads→displayedScheduleConversations, scheduleThreadGroups→scheduleConversationGroups
- Update all consumers across 6 files

Part of plan: macos-thread-locals.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
