### PR TITLE
Gate un-QA'd OAuth integrations behind feature flags

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -136,6 +136,94 @@
       "label": "Managed Sign In",
       "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
       "defaultEnabled": true
+    },
+    {
+      "id": "integration-twitter",
+      "scope": "assistant",
+      "key": "feature_flags.integration-twitter.enabled",
+      "label": "Twitter / X Integration",
+      "description": "Enable the Twitter / X OAuth setup skill for connecting to the Twitter API",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-github",
+      "scope": "assistant",
+      "key": "feature_flags.integration-github.enabled",
+      "label": "GitHub Integration",
+      "description": "Enable the GitHub OAuth setup skill for connecting to GitHub",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-linear",
+      "scope": "assistant",
+      "key": "feature_flags.integration-linear.enabled",
+      "label": "Linear Integration",
+      "description": "Enable the Linear OAuth setup skill for connecting to Linear",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-spotify",
+      "scope": "assistant",
+      "key": "feature_flags.integration-spotify.enabled",
+      "label": "Spotify Integration",
+      "description": "Enable the Spotify OAuth setup skill for connecting to the Spotify API",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-todoist",
+      "scope": "assistant",
+      "key": "feature_flags.integration-todoist.enabled",
+      "label": "Todoist Integration",
+      "description": "Enable the Todoist OAuth setup skill for connecting to Todoist",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-discord",
+      "scope": "assistant",
+      "key": "feature_flags.integration-discord.enabled",
+      "label": "Discord Integration",
+      "description": "Enable the Discord OAuth setup skill for connecting to Discord",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-dropbox",
+      "scope": "assistant",
+      "key": "feature_flags.integration-dropbox.enabled",
+      "label": "Dropbox Integration",
+      "description": "Enable the Dropbox OAuth setup skill for connecting to Dropbox",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-asana",
+      "scope": "assistant",
+      "key": "feature_flags.integration-asana.enabled",
+      "label": "Asana Integration",
+      "description": "Enable the Asana OAuth setup skill for connecting to Asana",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-airtable",
+      "scope": "assistant",
+      "key": "feature_flags.integration-airtable.enabled",
+      "label": "Airtable Integration",
+      "description": "Enable the Airtable OAuth setup skill for connecting to Airtable",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-hubspot",
+      "scope": "assistant",
+      "key": "feature_flags.integration-hubspot.enabled",
+      "label": "HubSpot Integration",
+      "description": "Enable the HubSpot OAuth setup skill for connecting to HubSpot CRM",
+      "defaultEnabled": false
+    },
+    {
+      "id": "integration-figma",
+      "scope": "assistant",
+      "key": "feature_flags.integration-figma.enabled",
+      "label": "Figma Integration",
+      "description": "Enable the Figma OAuth setup skill for connecting to Figma",
+      "defaultEnabled": false
     }
   ]
 }

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Airtable OAuth Setup"
+    feature-flag: "integration-airtable"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Asana OAuth Setup"
+    feature-flag: "integration-asana"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -22,6 +22,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Airtable OAuth Setup",
+          "feature-flag": "integration-airtable",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -61,6 +62,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Asana OAuth Setup",
+          "feature-flag": "integration-asana",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -112,6 +114,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Discord OAuth Setup",
+          "feature-flag": "integration-discord",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -151,6 +154,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Dropbox OAuth Setup",
+          "feature-flag": "integration-dropbox",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -191,6 +195,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Figma OAuth Setup",
+          "feature-flag": "integration-figma",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -215,6 +220,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "GitHub OAuth Setup",
+          "feature-flag": "integration-github",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -257,6 +263,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "HubSpot OAuth Setup",
+          "feature-flag": "integration-hubspot",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -284,6 +291,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Linear OAuth Setup",
+          "feature-flag": "integration-linear",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -459,6 +467,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Spotify OAuth Setup",
+          "feature-flag": "integration-spotify",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -513,6 +522,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Todoist OAuth Setup",
+          "feature-flag": "integration-todoist",
           "includes": [
             "collaborative-oauth-flow"
           ]
@@ -543,6 +553,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Twitter / X OAuth Setup",
+          "feature-flag": "integration-twitter",
           "includes": [
             "collaborative-oauth-flow"
           ]

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Discord OAuth Setup"
+    feature-flag: "integration-discord"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Dropbox OAuth Setup"
+    feature-flag: "integration-dropbox"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Figma OAuth Setup"
+    feature-flag: "integration-figma"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "GitHub OAuth Setup"
+    feature-flag: "integration-github"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "HubSpot OAuth Setup"
+    feature-flag: "integration-hubspot"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Linear OAuth Setup"
+    feature-flag: "integration-linear"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Spotify OAuth Setup"
+    feature-flag: "integration-spotify"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Todoist OAuth Setup"
+    feature-flag: "integration-todoist"
     includes: ["collaborative-oauth-flow"]
 ---
 

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Twitter / X OAuth Setup"
+    feature-flag: "integration-twitter"
     includes: ["collaborative-oauth-flow"]
 ---
 


### PR DESCRIPTION
## Summary
- Adds 11 new feature flags (all `defaultEnabled: false`) for un-QA'd OAuth integrations: Twitter/X, GitHub, Linear, Spotify, Todoist, Discord, Dropbox, Asana, Airtable, HubSpot, Figma
- Adds `feature-flag` frontmatter to each integration's setup skill so it's filtered from the skill catalog when disabled
- Google and Notion integrations remain unflagged (already QA'd)

## Test plan
- [ ] Verify Google and Notion OAuth setup skills still appear in ConstellationView
- [ ] Verify flagged integrations (e.g. GitHub) do NOT appear in ConstellationView by default
- [ ] Enable a flag via env var (e.g. `VELLUM_FLAG_INTEGRATION_GITHUB=1`) and verify the skill appears
- [ ] Verify the agent cannot load a flagged skill when the flag is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
