### PR TITLE
fix: resolve external assistant ID from BASE_DATA_DIR, return undefined instead of "self"

### DIFF
--- a/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
+++ b/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for getExternalAssistantId resolution order.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Default mock: no lockfile data
+mock.module("../../../util/platform.js", () => ({
+  readLockfile: () => null,
+}));
+
+import {
+  getExternalAssistantId,
+  resetExternalAssistantIdCache,
+} from "../external-assistant-id.js";
+
+afterEach(() => {
+  resetExternalAssistantIdCache();
+  delete process.env.BASE_DATA_DIR;
+});
+
+describe("getExternalAssistantId", () => {
+  test("resolves from BASE_DATA_DIR when lockfile has no data", () => {
+    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-true-eel";
+    expect(getExternalAssistantId()).toBe("vellum-true-eel");
+  });
+
+  test("resolves from BASE_DATA_DIR with trailing slash", () => {
+    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-cool-heron/";
+    expect(getExternalAssistantId()).toBe("vellum-cool-heron");
+  });
+
+  test("resolves from BASE_DATA_DIR with Windows-style backslashes", () => {
+    process.env.BASE_DATA_DIR =
+      "C:\\Users\\user\\.local\\share\\vellum\\assistants\\vellum-nice-fox";
+    expect(getExternalAssistantId()).toBe("vellum-nice-fox");
+  });
+
+  test("falls back to undefined when BASE_DATA_DIR does not match /assistants/<name>", () => {
+    process.env.BASE_DATA_DIR = "/tmp/some-other-path";
+    expect(getExternalAssistantId()).toBe(undefined);
+  });
+
+  test("falls back to undefined when BASE_DATA_DIR is not set", () => {
+    delete process.env.BASE_DATA_DIR;
+    expect(getExternalAssistantId()).toBe(undefined);
+  });
+});

--- a/assistant/src/runtime/auth/credential-service.ts
+++ b/assistant/src/runtime/auth/credential-service.ts
@@ -107,7 +107,7 @@ function mintAccessToken(guardianPrincipalId: string): {
   expiresAt: number;
   issuedAt: number;
 } {
-  const externalAssistantId = getExternalAssistantId();
+  const externalAssistantId = getExternalAssistantId() ?? "self";
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
 
   const token = mintToken({

--- a/assistant/src/runtime/auth/external-assistant-id.ts
+++ b/assistant/src/runtime/auth/external-assistant-id.ts
@@ -1,35 +1,42 @@
 /**
  * External assistant ID resolver.
  *
- * Reads the external assistant ID from the lockfile for use in
- * edge-facing JWT tokens (aud=vellum-gateway). The external ID is
- * needed because the gateway must identify which assistant the token
- * belongs to, while the daemon internally uses 'self'.
- *
- * The value is cached in memory after the first successful read.
- * Falls back to 'self' if the lockfile is unreadable or has no
- * assistant entries.
- */
-
-import { getLogger } from "../../util/logger.js";
-import { readLockfile } from "../../util/platform.js";
-
-const log = getLogger("external-assistant-id");
-
-let cached: string | undefined;
-
-/**
- * Get the external assistant ID from the lockfile.
+ * Resolves the external assistant ID for use in edge-facing JWT tokens
+ * (aud=vellum-gateway). The external ID is needed because the gateway
+ * must identify which assistant the token belongs to, while the daemon
+ * internally uses 'self'.
  *
  * Resolution order:
  *   1. Cached in-memory value (populated on first call)
  *   2. Most recently hatched entry in lockfile assistants array
  *      (sorted by `hatchedAt` descending) → assistantId
- *   3. Fallback: 'self'
+ *   3. BASE_DATA_DIR path matching `/assistants/<name>` suffix
+ *   4. `undefined` — callers must handle the missing value
+ *
+ * The value is cached in memory after the first successful read.
  */
-export function getExternalAssistantId(): string {
+
+import { getBaseDataDir } from "../../config/env-registry.js";
+import { getLogger } from "../../util/logger.js";
+import { readLockfile } from "../../util/platform.js";
+
+const log = getLogger("external-assistant-id");
+
+let cached: string | null | undefined;
+
+/**
+ * Get the external assistant ID.
+ *
+ * Resolution order:
+ *   1. Cached in-memory value (populated on first call)
+ *   2. Most recently hatched entry in lockfile assistants array
+ *      (sorted by `hatchedAt` descending) → assistantId
+ *   3. BASE_DATA_DIR path matching `/assistants/<name>` suffix
+ *   4. `undefined` when resolution fails entirely
+ */
+export function getExternalAssistantId(): string | undefined {
   if (cached !== undefined) {
-    return cached;
+    return cached ?? undefined;
   }
 
   try {
@@ -58,14 +65,26 @@ export function getExternalAssistantId(): string {
       }
     }
   } catch (err) {
-    log.warn(
-      { err },
-      "Failed to read lockfile for external assistant ID — falling back to self",
-    );
+    log.warn({ err }, "Failed to read lockfile for external assistant ID");
   }
 
-  cached = "self";
-  return cached;
+  // Fallback: derive from BASE_DATA_DIR path
+  const base = getBaseDataDir();
+  if (base && typeof base === "string") {
+    const normalized = base.replace(/\\/g, "/").replace(/\/+$/, "");
+    const match = normalized.match(/\/assistants\/([^/]+)$/);
+    if (match) {
+      cached = match[1];
+      log.info(
+        { externalAssistantId: cached },
+        "Resolved external assistant ID from BASE_DATA_DIR",
+      );
+      return cached;
+    }
+  }
+
+  cached = null;
+  return undefined;
 }
 
 /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -154,9 +154,10 @@ export class UsageTelemetryReporter {
         ),
       ];
 
+      const assistantId = getExternalAssistantId();
       const payload = {
         installation_id: getDeviceId(),
-        assistant_id: getExternalAssistantId(),
+        assistant_id: assistantId,
         events: typedEvents,
       };
 


### PR DESCRIPTION
## Summary
- Add BASE_DATA_DIR path-parsing fallback to getExternalAssistantId() for resolving the real assistant ID when the lockfile is unavailable
- Change return type to string | undefined — return undefined instead of "self" when resolution fails entirely
- Update telemetry reporter to omit assistant_id when undefined, credential service to fall back to "self" for local JWT minting

Part of plan: fix-telemetry-assistant-id-fallback.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
