### PR TITLE
fix: explicit undefined handling for assistant_id in telemetry payload

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -69,7 +69,9 @@ mock.module("../util/device-id.js", () => ({
   getDeviceId: mockGetDeviceId,
 }));
 
-const mockGetExternalAssistantId = mock(() => "test-assistant-id");
+const mockGetExternalAssistantId = mock<() => string | undefined>(
+  () => "test-assistant-id",
+);
 
 mock.module("../runtime/auth/external-assistant-id.js", () => ({
   getExternalAssistantId: mockGetExternalAssistantId,
@@ -378,6 +380,25 @@ describe("UsageTelemetryReporter", () => {
     expect(e.cache_read_input_tokens).toBe(15);
     expect(e.actor).toBe("context_compactor");
     expect(e.recorded_at).toBe(1700000099000);
+  });
+
+  test("assistant_id is omitted from payload when getExternalAssistantId returns undefined", async () => {
+    mockGetExternalAssistantId.mockReturnValue(undefined);
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.installation_id).toBe("test-device-id");
+    expect("assistant_id" in body).toBe(false);
   });
 
   test("turn events are included in the events array with type discriminator", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -157,7 +157,7 @@ export class UsageTelemetryReporter {
       const assistantId = getExternalAssistantId();
       const payload = {
         installation_id: getDeviceId(),
-        assistant_id: assistantId,
+        ...(assistantId != null ? { assistant_id: assistantId } : {}),
         events: typedEvents,
       };
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-telemetry-assistant-id-fallback.md.

**Gap:** Telemetry reporter relies on implicit JSON.stringify undefined-dropping without explicit handling or test
**What was expected:** Explicit handling and test coverage for when getExternalAssistantId() returns undefined
**What was found:** Implicit JSON.stringify behavior — correct but fragile and untested

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
