### PR TITLE
test: add lockfile resolution test for getExternalAssistantId

### DIFF
--- a/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
+++ b/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
@@ -10,9 +10,11 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
-// Default mock: no lockfile data
+// Controllable mock for readLockfile — defaults to null (no lockfile data)
+const mockReadLockfile = mock(() => null as Record<string, unknown> | null);
+
 mock.module("../../../util/platform.js", () => ({
-  readLockfile: () => null,
+  readLockfile: mockReadLockfile,
 }));
 
 import {
@@ -22,10 +24,31 @@ import {
 
 afterEach(() => {
   resetExternalAssistantIdCache();
+  mockReadLockfile.mockReset();
+  mockReadLockfile.mockImplementation(() => null);
   delete process.env.BASE_DATA_DIR;
 });
 
 describe("getExternalAssistantId", () => {
+  test("resolves from lockfile assistants array (most recently hatched)", () => {
+    mockReadLockfile.mockImplementation(() => ({
+      assistants: [
+        { assistantId: "vellum-old-fox", hatchedAt: "2025-01-01T00:00:00Z" },
+        { assistantId: "vellum-new-eel", hatchedAt: "2025-06-15T12:00:00Z" },
+      ],
+    }));
+    expect(getExternalAssistantId()).toBe("vellum-new-eel");
+  });
+
+  test("resolves from lockfile with single assistant entry", () => {
+    mockReadLockfile.mockImplementation(() => ({
+      assistants: [
+        { assistantId: "vellum-solo-cat", hatchedAt: "2025-03-01T00:00:00Z" },
+      ],
+    }));
+    expect(getExternalAssistantId()).toBe("vellum-solo-cat");
+  });
+
   test("resolves from BASE_DATA_DIR when lockfile has no data", () => {
     process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-true-eel";
     expect(getExternalAssistantId()).toBe("vellum-true-eel");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-telemetry-assistant-id-fallback.md.

**Gap:** No test for lockfile resolution path
**What was expected:** Test coverage for the primary lockfile-based resolution in getExternalAssistantId()
**What was found:** Test file only covered BASE_DATA_DIR fallback and undefined fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
