### PR TITLE
Add regex-based syntax tokenizer for JS/TS/JSON/Markdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Supported languages for syntax highlighting.
+enum SyntaxLanguage: String, CaseIterable {
+    case javascript
+    case typescript
+    case json
+    case markdown
+    case plain
+
+    /// Detects the syntax language from a file name and/or MIME type.
+    ///
+    /// File extension takes precedence over MIME type. Returns `.plain` if
+    /// neither the extension nor the MIME type matches a known language.
+    static func detect(fileName: String, mimeType: String) -> SyntaxLanguage {
+        let ext = (fileName as NSString).pathExtension.lowercased()
+
+        switch ext {
+        case "js", "jsx", "mjs", "cjs":
+            return .javascript
+        case "ts", "tsx", "mts", "cts":
+            return .typescript
+        case "json":
+            return .json
+        case "md", "markdown":
+            return .markdown
+        default:
+            break
+        }
+
+        switch mimeType {
+        case "application/json":
+            return .json
+        case "application/javascript":
+            return .javascript
+        case "application/typescript":
+            return .typescript
+        case "text/markdown":
+            return .markdown
+        default:
+            return .plain
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+/// Maps syntax token types to styled text attributes for dark backgrounds.
+struct SyntaxTheme {
+
+    /// Base text color for unhighlighted content on dark backgrounds.
+    static let baseTextColor = NSColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+
+    /// Returns attributed string attributes for the given token type.
+    ///
+    /// Colors are chosen for readability against dark backgrounds. Font traits
+    /// (bold, italic) are derived from the provided base font.
+    static func attributes(for tokenType: SyntaxTokenType, baseFont: NSFont) -> [NSAttributedString.Key: Any] {
+        let color: NSColor
+        var font = baseFont
+
+        switch tokenType {
+        case .keyword:
+            color = NSColor(red: 0.55, green: 0.65, blue: 0.96, alpha: 1.0)
+
+        case .string:
+            color = NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
+
+        case .comment:
+            color = NSColor(red: 0.55, green: 0.60, blue: 0.55, alpha: 1.0)
+
+        case .number:
+            color = NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
+
+        case .type:
+            color = NSColor(red: 0.45, green: 0.78, blue: 0.74, alpha: 1.0)
+
+        case .property:
+            color = NSColor(red: 0.68, green: 0.78, blue: 0.88, alpha: 1.0)
+
+        case .punctuation:
+            color = baseTextColor
+
+        case .boolean, .null:
+            color = NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
+
+        case .heading:
+            color = baseTextColor
+            font = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
+
+        case .bold:
+            color = baseTextColor
+            font = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
+
+        case .italic:
+            color = baseTextColor
+            font = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
+
+        case .codeSpan:
+            color = NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
+
+        case .link:
+            color = NSColor(red: 0.30, green: 0.75, blue: 0.55, alpha: 1.0)
+
+        case .plain:
+            color = baseTextColor
+        }
+
+        return [
+            .foregroundColor: color,
+            .font: font,
+        ]
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxToken.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxToken.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Token types produced by the syntax tokenizer.
+enum SyntaxTokenType: String, CaseIterable {
+    case keyword
+    case string
+    case comment
+    case number
+    case type
+    case property
+    case punctuation
+    case boolean
+    case null
+    case heading
+    case bold
+    case italic
+    case codeSpan
+    case link
+    case plain
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTokenizer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTokenizer.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Regex-based syntax tokenizer that produces non-overlapping, sorted token ranges.
+struct SyntaxTokenizer {
+
+    /// Tokenizes the given text for the specified language.
+    ///
+    /// Returns an array of `(range, type)` tuples sorted by range location.
+    /// Ranges are non-overlapping; earlier patterns in the priority list win
+    /// when two patterns match the same region.
+    static func tokenize(_ text: String, language: SyntaxLanguage) -> [(range: NSRange, type: SyntaxTokenType)] {
+        switch language {
+        case .javascript, .typescript:
+            return tokenizeJavaScript(text)
+        case .json:
+            return tokenizeJSON(text)
+        case .markdown:
+            return tokenizeMarkdown(text)
+        case .plain:
+            return []
+        }
+    }
+
+    // MARK: - JavaScript / TypeScript
+
+    private static func tokenizeJavaScript(_ text: String) -> [(range: NSRange, type: SyntaxTokenType)] {
+        let patterns: [(pattern: String, type: SyntaxTokenType, options: NSRegularExpression.Options)] = [
+            // Template literals (before comments so `//` inside templates is not misidentified)
+            (#"`[^`]*`"#, .string, []),
+            // Double-quoted strings (before comments so `//` inside strings is not misidentified)
+            (#""(?:[^"\\]|\\.)*""#, .string, []),
+            // Single-quoted strings (before comments so `//` inside strings is not misidentified)
+            (#"'(?:[^'\\]|\\.)*'"#, .string, []),
+            // Block comments
+            (#"/\*[\s\S]*?\*/"#, .comment, [.dotMatchesLineSeparators]),
+            // Line comments
+            (#"//[^\n]*"#, .comment, []),
+            // Numbers
+            (#"\b(?:0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+\.?\d*(?:[eE][+-]?\d+)?)\b"#, .number, []),
+            // Booleans
+            (#"\b(?:true|false)\b"#, .boolean, []),
+            // Null/undefined
+            (#"\b(?:null|undefined)\b"#, .null, []),
+            // JS keywords
+            (#"\b(?:const|let|var|function|return|if|else|for|while|do|switch|case|break|continue|class|extends|new|this|super|import|export|from|default|async|await|try|catch|finally|throw|typeof|instanceof|in|of|void|delete|yield)\b"#, .keyword, []),
+            // TS keywords
+            (#"\b(?:interface|type|enum|namespace|readonly|as|is|keyof|infer|implements|declare|abstract|private|protected|public|static|override)\b"#, .keyword, []),
+            // Type-like identifiers (PascalCase)
+            (#"\b[A-Z][a-zA-Z0-9]*\b"#, .type, []),
+        ]
+
+        return applyPatterns(patterns, to: text)
+    }
+
+    // MARK: - JSON
+
+    private static func tokenizeJSON(_ text: String) -> [(range: NSRange, type: SyntaxTokenType)] {
+        let patterns: [(pattern: String, type: SyntaxTokenType, options: NSRegularExpression.Options)] = [
+            // String keys (strings followed by `:`)
+            (#""(?:[^"\\]|\\.)*"(?=\s*:)"#, .property, []),
+            // String values
+            (#""(?:[^"\\]|\\.)*""#, .string, []),
+            // Numbers
+            (#"-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?"#, .number, []),
+            // Booleans
+            (#"\b(?:true|false)\b"#, .boolean, []),
+            // Null
+            (#"\bnull\b"#, .null, []),
+        ]
+
+        return applyPatterns(patterns, to: text)
+    }
+
+    // MARK: - Markdown
+
+    private static func tokenizeMarkdown(_ text: String) -> [(range: NSRange, type: SyntaxTokenType)] {
+        let patterns: [(pattern: String, type: SyntaxTokenType, options: NSRegularExpression.Options)] = [
+            // Code fences
+            (#"```[\s\S]*?```"#, .codeSpan, [.dotMatchesLineSeparators]),
+            // Inline code
+            (#"`[^`\n]+`"#, .codeSpan, []),
+            // Headings
+            (#"^#{1,6}\s.*$"#, .heading, [.anchorsMatchLines]),
+            // Bold
+            (#"\*\*[^*]+\*\*"#, .bold, []),
+            // Italic (avoiding bold)
+            (#"(?<!\*)\*(?!\*)[^*]+(?<!\*)\*(?!\*)"#, .italic, []),
+            // Links
+            (#"\[.*?\]\(.*?\)"#, .link, []),
+        ]
+
+        return applyPatterns(patterns, to: text)
+    }
+
+    // MARK: - Shared Pattern Application
+
+    /// Applies regex patterns in priority order, skipping matches that overlap
+    /// with already-collected ranges.
+    private static func applyPatterns(
+        _ patterns: [(pattern: String, type: SyntaxTokenType, options: NSRegularExpression.Options)],
+        to text: String
+    ) -> [(range: NSRange, type: SyntaxTokenType)] {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var tokens: [(range: NSRange, type: SyntaxTokenType)] = []
+
+        for (pattern, type, options) in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+                continue
+            }
+
+            let matches = regex.matches(in: text, options: [], range: fullRange)
+            for match in matches {
+                let range = match.range
+                guard range.length > 0 else { continue }
+
+                let overlaps = tokens.contains { existing in
+                    NSIntersectionRange(existing.range, range).length > 0
+                }
+
+                if !overlaps {
+                    tokens.append((range: range, type: type))
+                }
+            }
+        }
+
+        tokens.sort { $0.range.location < $1.range.location }
+        return tokens
+    }
+}


### PR DESCRIPTION
## Summary
- Add SyntaxLanguage enum with file extension and mime type detection
- Add SyntaxTokenizer with regex-based tokenization for JS/TS, JSON, and Markdown
- Add SyntaxTheme mapping token types to NSColor attributes for dark backgrounds
- Add SyntaxTokenType enum covering keywords, strings, comments, numbers, types, and markdown elements

Part of plan: rich-file-viewer-plan.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
