### PR TITLE
Add FileViewMode infrastructure and Source/Preview/Tree toggle to workspace file viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -1,6 +1,33 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - File View Mode
+
+enum FileViewMode: String, Hashable {
+    case source
+    case preview
+    case tree
+}
+
+func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode] {
+    let ext = (fileName as NSString).pathExtension.lowercased()
+    if ext == "md" || ext == "markdown" || mimeType == "text/markdown" {
+        return [.source, .preview]
+    }
+    if ext == "json" || mimeType == "application/json" {
+        return [.source, .tree]
+    }
+    return [.source]
+}
+
+func viewModeLabel(_ mode: FileViewMode) -> String {
+    switch mode {
+    case .source: return "Source"
+    case .preview: return "Preview"
+    case .tree: return "Tree"
+    }
+}
+
 /// Formats a byte count into a human-readable size string.
 /// Shows raw bytes for sizes < 1 KB (e.g. "500 B"), then "KB" / "MB" / "GB" with one decimal place.
 func formatFileSize(_ bytes: Int) -> String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -33,6 +33,7 @@ final class WorkspaceBrowserState {
     var pendingSwitchPath: String?
     var pendingHiddenFilesToggle: Bool?
     var showingDirtyAlert: Bool = false
+    var viewMode: FileViewMode = .source
     var showHiddenFiles: Bool = UserDefaults.standard.bool(forKey: "showHiddenFiles")
 
     func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
@@ -43,6 +44,7 @@ final class WorkspaceBrowserState {
 
     func loadFile(path targetPath: String, using daemonClient: DaemonClient) async {
         selectedFilePath = targetPath
+        viewMode = .source
         isLoadingFile = true
         selectedFileDetail = nil
         isDirty = false
@@ -720,6 +722,34 @@ private struct WorkspaceFileViewer: View {
     }
 
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
+        let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
+        return VStack(spacing: 0) {
+            if modes.count > 1 {
+                HStack(spacing: 0) {
+                    VSegmentedControl(
+                        items: modes.map { (label: viewModeLabel($0), tag: $0) },
+                        selection: $state.viewMode,
+                        style: .pill
+                    )
+                    .frame(width: CGFloat(modes.count) * 100)
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+            }
+
+            switch state.viewMode {
+            case .source:
+                sourceView(detail)
+            case .preview:
+                previewView(detail)
+            case .tree:
+                treeView(detail)
+            }
+        }
+    }
+
+    private func sourceView(_ detail: WorkspaceFileResponse) -> some View {
         let readOnly = isHiddenPath(detail.path)
         return VStack(spacing: 0) {
             if readOnly {
@@ -767,6 +797,20 @@ private struct WorkspaceFileViewer: View {
                     }
             }
         }
+    }
+
+    private func previewView(_ detail: WorkspaceFileResponse) -> some View {
+        Text("Preview not yet available")
+            .font(VFont.body)
+            .foregroundColor(VColor.contentTertiary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func treeView(_ detail: WorkspaceFileResponse) -> some View {
+        Text("Tree view not yet available")
+            .font(VFont.body)
+            .foregroundColor(VColor.contentTertiary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func saveFile(path: String) async {


### PR DESCRIPTION
## Summary
- Add FileViewMode enum and helper functions to SharedFileViewerComponents
- Add VSegmentedControl toggle for markdown (Source/Preview) and JSON (Source/Tree) files
- Refactor textViewer into sourceView/previewView/treeView routing with placeholder content for Preview and Tree modes

Part of plan: rich-file-viewer-plan.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
