### PR TITLE
fix: revert accidental user-facing copy change in rename alert

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -139,7 +139,7 @@ extension MainWindowView {
                 sidebar.renamingConversationId = nil
             }
         } message: {
-            Text("Enter a new name for this conversation")
+            Text("Enter a new name for this thread")
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for macos-thread-locals.md.

**Gap:** The alert message 'Enter a new name for this thread' was accidentally changed to 'conversation', but the plan explicitly excludes user-facing copy. Reverts to match all other user-facing strings that use 'thread'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
