### PR TITLE
fix: rename remaining Thread→Conversation in test method names and stale comments

### DIFF
--- a/clients/macos/vellum-assistantTests/ConversationManagerBusyStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerBusyStateTests.swift
@@ -96,7 +96,7 @@ final class ConversationManagerBusyStateTests: XCTestCase {
         XCTAssertTrue(conversationManager.busyConversationIds.isEmpty)
     }
 
-    func testLRUEvictionSkipsBusyBackgroundThread() {
+    func testLRUEvictionSkipsBusyBackgroundConversation() {
         guard let originalConversationId = conversationManager.activeConversationId else {
             XCTFail("Expected initial active conversation")
             return

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -43,7 +43,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         super.tearDown()
     }
 
-    func testInactiveStandardThreadMarkedUnseenWhenAssistantReplies() {
+    func testInactiveStandardConversationMarkedUnseenWhenAssistantReplies() {
         guard let initialConversationId = conversationManager.activeConversationId else {
             XCTFail("Expected an initial active conversation")
             return
@@ -73,7 +73,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
-    func testInactiveThreadMarkedUnseenWhenAssistantContinuesSameMessageAfterSwitch() {
+    func testInactiveConversationMarkedUnseenWhenAssistantContinuesSameMessageAfterSwitch() {
         guard let initialConversationId = conversationManager.activeConversationId,
               let initialVm = conversationManager.chatViewModel(for: initialConversationId),
               let initialIndex = conversationManager.conversations.firstIndex(where: { $0.id == initialConversationId }) else {
@@ -119,7 +119,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(updated.hasUnseenLatestAssistantMessage)
     }
 
-    func testActiveThreadEmitsSeenSignalOnNewMessageAndStreamCompletion() {
+    func testActiveConversationEmitsSeenSignalOnNewMessageAndStreamCompletion() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
               let vm = conversationManager.chatViewModel(for: conversationId) else {
@@ -143,7 +143,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
     }
 
-    func testUnseenVisibleConversationCountExcludesArchivedThreads() {
+    func testUnseenVisibleConversationCountExcludesArchivedConversations() {
         // Start with the initial conversation created by setUp
         guard let conversationId = conversationManager.activeConversationId,
               conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) != nil else {
@@ -169,8 +169,8 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 0)
     }
 
-    func testUnseenVisibleConversationCountExcludesPrivateThreads() {
-        // Create a private conversation (this switches activeConversationId to the private thread)
+    func testUnseenVisibleConversationCountExcludesPrivateConversations() {
+        // Create a private conversation (this switches activeConversationId to the private conversation)
         conversationManager.createPrivateConversation()
         guard let privateId = conversationManager.activeConversationId,
               let idx = conversationManager.conversations.firstIndex(where: { $0.id == privateId }) else {
@@ -221,7 +221,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(conversationManager.unseenVisibleConversationCount, 2)
     }
 
-    func testSelectingThreadDecrementsUnseenCount() {
+    func testSelectingConversationDecrementsUnseenCount() {
         // Start with the initial conversation
         guard let firstId = conversationManager.activeConversationId else {
             XCTFail("Expected an initial active conversation")
@@ -304,7 +304,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(unreadSignals.last?.conversationId, "session-mark-unread")
     }
 
-    func testMarkConversationUnreadDoesNotEmitDuplicateSignalForUnreadThread() {
+    func testMarkConversationUnreadDoesNotEmitDuplicateSignalForUnreadConversation() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) else {
             XCTFail("Expected an initial active conversation")
@@ -422,7 +422,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.map(\.conversationId), ["session-requeue"])
     }
 
-    func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
+    func testMarkConversationUnreadIgnoresConversationsWithoutAssistantReply() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) else {
             XCTFail("Expected an initial active conversation")
@@ -438,7 +438,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         conversationManager.markConversationUnread(conversationId: conversationId)
 
         let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
-        XCTAssertTrue(unreadSignals.isEmpty, "Threads without assistant replies should not emit unread signals")
+        XCTAssertTrue(unreadSignals.isEmpty, "Conversations without assistant replies should not emit unread signals")
         XCTAssertFalse(conversationManager.conversations[index].hasUnseenLatestAssistantMessage)
     }
 
@@ -481,7 +481,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         )
     }
 
-    func testAppendThreadsPreservesLocalUnreadUntilDaemonAcknowledgesIt() {
+    func testAppendConversationsPreservesLocalUnreadUntilDaemonAcknowledgesIt() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) else {
             XCTFail("Expected an initial active conversation")
@@ -563,7 +563,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         }))
     }
 
-    func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {
+    func testActiveConversationDoesNotEmitSeenSignalOnEveryStreamingDelta() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
               let vm = conversationManager.chatViewModel(for: conversationId) else {
@@ -604,7 +604,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                        "Stream completion should emit exactly one additional seen signal")
     }
 
-    func testActiveThreadAssistantReplyClearsUnseenAndEmitsSeenSignal() {
+    func testActiveConversationAssistantReplyClearsUnseenAndEmitsSeenSignal() {
         guard let conversationId = conversationManager.activeConversationId,
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }),
               let vm = conversationManager.chatViewModel(for: conversationId) else {
@@ -627,7 +627,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.last?.conversationId, "session-active")
     }
 
-    func testAppendThreadsPreservesAssistantAttentionTimestamps() {
+    func testAppendConversationsPreservesAssistantAttentionTimestamps() {
         let response = makeConversationListResponse(
             conversations: [[
                 "id": "session-paginated",
@@ -645,14 +645,14 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
 
         conversationManager.appendConversations(from: response)
 
-        guard let appendedThread = conversationManager.conversations.first(where: { $0.conversationId == "session-paginated" }) else {
-            XCTFail("Expected appended thread")
+        guard let appendedConversation = conversationManager.conversations.first(where: { $0.conversationId == "session-paginated" }) else {
+            XCTFail("Expected appended conversation")
             return
         }
 
-        XCTAssertFalse(appendedThread.hasUnseenLatestAssistantMessage)
-        XCTAssertEqual(appendedThread.latestAssistantMessageAt?.timeIntervalSince1970, 9.0)
-        XCTAssertEqual(appendedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 9.0)
+        XCTAssertFalse(appendedConversation.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(appendedConversation.latestAssistantMessageAt?.timeIntervalSince1970, 9.0)
+        XCTAssertEqual(appendedConversation.lastSeenAssistantMessageAt?.timeIntervalSince1970, 9.0)
     }
 
     func testScheduleConversationCreatedWithUnseenFlag() {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-thread-locals.md.

**Gap 1:** 13 test method names in BusyStateTests and UnseenStateTests still used Thread instead of Conversation
**Gap 2:** Stale thread references in test comment and XCTFail assertion message

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
