### PR TITLE
Style secure credential popup to match design system

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -21,6 +21,7 @@ final class SecretPromptManager {
         panel.orderFront(nil)
     }
 
+
     /// Called when the user responds to a secret prompt.
     /// Parameters: (requestId, value?, delivery?) — value is nil if user cancelled.
     /// `delivery` is "store" (default) or "transient_send" for one-time use.
@@ -55,7 +56,7 @@ final class SecretPromptManager {
 
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 300),
-            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -74,18 +75,25 @@ final class SecretPromptManager {
         panel.setContentSize(NSSize(width: panelWidth, height: panelHeight))
         panel.level = .floating
         panel.isMovableByWindowBackground = true
-        panel.titleVisibility = .hidden
-        panel.titlebarAppearsTransparent = true
-        panel.alphaValue = 0.95
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
         panel.identifier = NSUserInterfaceItemIdentifier("SecureCredentialPanel")
 
-        // Position at top-right of screen
-        if let screen = NSScreen.main {
+        // Position centered over the main app window, or screen center as fallback
+        let appWindow = NSApp.windows.first { $0 is TitleBarZoomableWindow && $0.isVisible }
+        if let anchor = appWindow {
+            let anchorFrame = anchor.frame
+            let x = anchorFrame.midX - panelWidth / 2
+            let y = anchorFrame.midY - panelHeight / 2
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        } else if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
-            let x = screenFrame.maxX - panelWidth - 20
-            let y = screenFrame.maxY - panelHeight - 20
+            let x = screenFrame.midX - panelWidth / 2
+            let y = screenFrame.midY - panelHeight / 2
             panel.setFrameOrigin(NSPoint(x: x, y: y))
         }
 
@@ -192,8 +200,8 @@ struct SecretPromptView: View {
 
                 // Secure input
                 SecureField(placeholder, text: $secretValue)
-                    .textFieldStyle(.roundedBorder)
                     .font(VFont.mono)
+                    .vInputStyle()
                     .accessibilityIdentifier("secure-credential-input")
 
                 // Safety explainer
@@ -260,6 +268,7 @@ struct SecretPromptView: View {
         .frame(width: 400)
         .frame(maxHeight: 600)
         .vPanelBackground()
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.window))
     }
 
     @ViewBuilder
@@ -282,8 +291,8 @@ struct SecretPromptView: View {
             }
         }
         .padding(VSpacing.sm)
-        .background(VColor.surfaceBase.opacity(0.5))
-        .cornerRadius(6)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .textSelection(.enabled)
     }
 


### PR DESCRIPTION
## Summary
- Remove `.hudWindow` style mask that forced dark translucent appearance regardless of system theme — panel now properly supports light/dark mode
- Switch to borderless panel with rounded corners, matching the pattern used by `SessionOverlayWindow`
- Replace native `.textFieldStyle(.roundedBorder)` with `.vInputStyle()` for consistent input field styling
- Use design system tokens (`VColor.surfaceOverlay`, `VRadius.md`) instead of hardcoded values in usage context section
- Center the panel over the main app window instead of positioning in the screen corner

## Test plan
- [ ] Trigger a credential prompt and verify it appears centered over the main window
- [ ] Verify light mode styling matches the app's design system
- [ ] Verify dark mode styling matches the app's design system
- [ ] Test Save / Cancel / Send Once functionality still works
- [ ] Verify the panel is still draggable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
