### PR TITLE
Wire MarkdownPreviewView into file viewer preview mode for Markdown files

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -59,6 +59,12 @@ final class WorkspaceBrowserState {
             isDirty = false
             isSaving = false
             isLoadingFile = false
+
+            // Default read-only markdown files to preview mode
+            let ext = (targetPath as NSString).pathExtension.lowercased()
+            if (ext == "md" || ext == "markdown") && isHiddenPath(targetPath) {
+                viewMode = .preview
+            }
         }
         fileLoadTask = task
     }
@@ -800,9 +806,7 @@ private struct WorkspaceFileViewer: View {
     }
 
     private func previewView(_ detail: WorkspaceFileResponse) -> some View {
-        Text("Preview not yet available")
-            .font(VFont.body)
-            .foregroundColor(VColor.contentTertiary)
+        MarkdownPreviewView(content: detail.content ?? "")
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Replace preview mode placeholder with MarkdownPreviewView for markdown files
- Default read-only markdown files to Preview mode on open

Part of plan: rich-file-viewer-plan.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
