### PR TITLE
Wire JSONTreeView into file viewer tree mode for JSON files

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -807,9 +807,7 @@ private struct WorkspaceFileViewer: View {
     }
 
     private func treeView(_ detail: WorkspaceFileResponse) -> some View {
-        Text("Tree view not yet available")
-            .font(VFont.body)
-            .foregroundColor(VColor.contentTertiary)
+        JSONTreeView(content: detail.content ?? "")
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Replace tree mode placeholder with JSONTreeView for JSON files

Part of plan: rich-file-viewer-plan.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
