### PR TITLE
Replace TextEditor and ReadOnlyCodeContent with HighlightedTextView in workspace file viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -101,7 +101,7 @@ struct HighlightedTextView: NSViewRepresentable {
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var textView: NSTextView?
-        var rulerView: LineNumberRulerView?
+        fileprivate var rulerView: LineNumberRulerView?
         var language: SyntaxLanguage
         var onTextChange: ((String) -> Void)?
         var isUpdatingFromSwiftUI = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -757,6 +757,7 @@ private struct WorkspaceFileViewer: View {
 
     private func sourceView(_ detail: WorkspaceFileResponse) -> some View {
         let readOnly = isHiddenPath(detail.path)
+        let language = SyntaxLanguage.detect(fileName: detail.name, mimeType: detail.mimeType)
         return VStack(spacing: 0) {
             if readOnly {
                 HStack {
@@ -789,18 +790,22 @@ private struct WorkspaceFileViewer: View {
             }
 
             if readOnly {
-                ReadOnlyCodeContent(content: detail.content ?? "")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                HighlightedTextView(
+                    text: .constant(detail.content ?? ""),
+                    language: language,
+                    isEditable: false
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                TextEditor(text: $state.editableContent)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentDefault)
-                    .scrollContentBackground(.hidden)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .onChange(of: state.editableContent) { _, newValue in
+                HighlightedTextView(
+                    text: $state.editableContent,
+                    language: language,
+                    isEditable: true,
+                    onTextChange: { newValue in
                         state.isDirty = newValue != state.originalContent
                     }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace TextEditor (editable) and ReadOnlyCodeContent (read-only) with HighlightedTextView
- Add language detection via SyntaxLanguage.detect for automatic syntax highlighting
- Move dirty tracking to HighlightedTextView's onTextChange callback
- Fix pre-existing build error: mark LineNumberRulerView property as fileprivate for access level consistency

Part of plan: rich-file-viewer-plan.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
