### PR TITLE
fix: use editableContent for preview/tree views and lowercase mimeType

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -11,10 +11,11 @@ enum FileViewMode: String, Hashable {
 
 func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode] {
     let ext = (fileName as NSString).pathExtension.lowercased()
-    if ext == "md" || ext == "markdown" || mimeType == "text/markdown" {
+    let mime = mimeType.lowercased()
+    if ext == "md" || ext == "markdown" || mime == "text/markdown" {
         return [.source, .preview]
     }
-    if ext == "json" || mimeType == "application/json" {
+    if ext == "json" || mime == "application/json" {
         return [.source, .tree]
     }
     return [.source]

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -811,12 +811,12 @@ private struct WorkspaceFileViewer: View {
     }
 
     private func previewView(_ detail: WorkspaceFileResponse) -> some View {
-        MarkdownPreviewView(content: detail.content ?? "")
+        MarkdownPreviewView(content: state.editableContent)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func treeView(_ detail: WorkspaceFileResponse) -> some View {
-        JSONTreeView(content: detail.content ?? "")
+        JSONTreeView(content: state.editableContent)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Use state.editableContent instead of detail.content for preview and tree views so edits are reflected when switching modes
- Lowercase mimeType in availableViewModes for case-insensitive comparison

Part of plan: rich-file-viewer-plan.md (review fix round 1)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
