### PR TITLE
fix: add accessibility modifiers, reset JSON tree state, remove String copy

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -128,6 +128,7 @@ struct JSONTreeView: View {
             let result = parseJSON(content)
             root = result
             if case .success(let node) = result {
+                expandedPaths = []
                 autoExpandInitial(node)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
@@ -206,7 +206,7 @@ private func parseInlineSegments(_ text: String) -> [InlineSegment] {
 
     while !remaining.isEmpty {
         let nsRange = NSRange(remaining.startIndex..<remaining.endIndex, in: text)
-        guard let match = regex.firstMatch(in: String(text), range: nsRange) else {
+        guard let match = regex.firstMatch(in: text, range: nsRange) else {
             // No more matches — rest is plain text
             if !remaining.isEmpty {
                 segments.append(.plain(String(remaining)))
@@ -370,6 +370,7 @@ struct MarkdownPreviewView: View {
                 HStack(alignment: .top, spacing: VSpacing.xs) {
                     Text("\u{2022}")
                         .foregroundColor(VColor.contentTertiary)
+                        .accessibilityHidden(true)
                     renderInlineMarkdown(item)
                         .font(VFont.body)
                         .foregroundColor(VColor.contentDefault)
@@ -399,6 +400,7 @@ struct MarkdownPreviewView: View {
             Rectangle()
                 .fill(VColor.primaryBase)
                 .frame(width: 3)
+                .accessibilityHidden(true)
             renderInlineMarkdown(text)
                 .font(VFont.body)
                 .foregroundColor(VColor.contentSecondary)


### PR DESCRIPTION
## Summary
- Add .accessibilityHidden(true) to decorative bullet and blockquote bar in MarkdownPreviewView
- Reset expandedPaths before autoExpandInitial when JSON content changes
- Remove unnecessary String(text) copy in parseInlineSegments

Part of plan: rich-file-viewer-plan.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
