### PR TITLE
fix: keep Cmd+S save shortcut active in Preview and Tree view modes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -729,6 +729,7 @@ private struct WorkspaceFileViewer: View {
 
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
         let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
+        let readOnly = isHiddenPath(detail.path)
         return VStack(spacing: 0) {
             if modes.count > 1 {
                 HStack(spacing: 0) {
@@ -744,21 +745,6 @@ private struct WorkspaceFileViewer: View {
                 .padding(.vertical, VSpacing.sm)
             }
 
-            switch state.viewMode {
-            case .source:
-                sourceView(detail)
-            case .preview:
-                previewView(detail)
-            case .tree:
-                treeView(detail)
-            }
-        }
-    }
-
-    private func sourceView(_ detail: WorkspaceFileResponse) -> some View {
-        let readOnly = isHiddenPath(detail.path)
-        let language = SyntaxLanguage.detect(fileName: detail.name, mimeType: detail.mimeType)
-        return VStack(spacing: 0) {
             if readOnly {
                 HStack {
                     Spacer()
@@ -789,6 +775,21 @@ private struct WorkspaceFileViewer: View {
                 }
             }
 
+            switch state.viewMode {
+            case .source:
+                sourceView(detail)
+            case .preview:
+                previewView(detail)
+            case .tree:
+                treeView(detail)
+            }
+        }
+    }
+
+    private func sourceView(_ detail: WorkspaceFileResponse) -> some View {
+        let readOnly = isHiddenPath(detail.path)
+        let language = SyntaxLanguage.detect(fileName: detail.name, mimeType: detail.mimeType)
+        return Group {
             if readOnly {
                 HighlightedTextView(
                     text: .constant(detail.content ?? ""),


### PR DESCRIPTION
## Summary
- Move the save bar and read-only indicator from sourceView() to textViewer() so they are visible in all view modes
- This ensures Cmd+S works when viewing a dirty file in Preview or Tree mode
- Previously the save button only rendered in Source mode

Part of plan: rich-file-viewer-plan.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
