### PR TITLE
fix: update dynamic-skill-workflow test for browser hints migration

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -147,11 +147,12 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("skill_load");
   });
 
-  test("system prompt includes browser skill prerequisite guidance", () => {
+  test("browser skill has activation hints in available_skills XML instead of dedicated section", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    expect(result).toContain("Browser Skill Prerequisite");
-    expect(result).toContain("browser_*");
-    expect(result).toContain("skill_load");
+    // Browser routing moved from dedicated section to frontmatter hints
+    expect(result).not.toContain("Browser Skill Prerequisite");
+    expect(result).toContain('id="browser"');
+    expect(result).toContain("hints=");
   });
 });


### PR DESCRIPTION
## Summary
- The browser skill prerequisite section was removed from the system prompt in #15385 (moved to frontmatter `activation-hints`), but `dynamic-skill-workflow-prompt.test.ts` still asserted the old section existed
- Updates the test to assert the new behavior: no dedicated section, browser hints present in `<available_skills>` XML

## Test plan
- [x] `bun test src/__tests__/dynamic-skill-workflow-prompt.test.ts` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
