### PR TITLE
fix: stabilize composer text field width during button transitions (#17618)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -510,7 +510,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .animation(VAnimation.fast, value: canSend)
+        .frame(minWidth: composerActionButtonSize * 3 + 2 * 2)
     }
 
     // MARK: - Dictation Inline Mode


### PR DESCRIPTION
## Summary
- Reserve a fixed minimum width (100pt) for the composer action button area so the text field's available width never changes when buttons appear/disappear
- Remove `.animation(VAnimation.fast, value: canSend)` from `composerActionButtons` that was causing animated HStack width changes
- Per-button `.transition(.scale.combined(with: .opacity))` modifiers are preserved for visual polish

## Root cause
`.animation(VAnimation.fast, value: canSend)` on the button HStack caused its width to animate when buttons changed (e.g., 3 buttons to 2 on typing). During this animation, the text field width was interpolated, causing the NSTextView's text container to use a stale/intermediate width for word wrapping. Text wrapped at the wider container width but was clipped at the narrower visible width, hiding the last 3-4 characters on a line.

## Fix
Replace the animation modifier with `.frame(minWidth: composerActionButtonSize * 3 + 2 * 2)` (= 100pt), which reserves space for the widest button configuration (3 buttons x 32pt + 2 gaps x 2pt). This ensures the text field always has the same available width regardless of which buttons are shown.

## Test plan
- [ ] Type text in the composer until it wraps to a new line — verify no characters are clipped behind buttons
- [ ] Verify button transitions (empty → typing → sendable) still animate individual buttons smoothly
- [ ] Verify the 3-button state (attach + dictate + voice) looks correct with no extra spacing
- [ ] Verify the 2-button states (attach + send, attach + mic) have appropriate trailing space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
