### PR TITLE
fix: correct app-builder SKILL.md build trigger docs

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -151,7 +151,7 @@ useEffect(() => {
 }, []);
 ```
 
-**File workflow:** Use `app_file_write` for each source file. The build happens automatically when you call `app_open`.
+**File workflow:** Use `app_file_write` for each source file. Each write automatically triggers a recompile of the project.
 
 **Allowed third-party packages:** `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`, `lucide`. Import them directly — esbuild resolves them at build time. No CDN imports. Note: `lucide` is the vanilla JS icon library (not `lucide-react`). Use its `createElement` or `createIcons` API, or manually inline SVG — do not import JSX icon components.
 


### PR DESCRIPTION
## Summary
- Fixes inaccurate documentation in the app-builder SKILL.md multifile section
- The old text said builds happen on `app_open`; they actually trigger automatically after each `app_file_write`/`app_file_edit` via the `handleAppChange` side-effect hook

## Test plan
- [ ] Verify SKILL.md renders correctly with feature flag on and off
- [ ] Confirm multifile apps recompile on file write (existing behavior, no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
