### PR TITLE
fix: stabilize composer text field width to prevent input clipping (LUM-233)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -510,7 +510,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .animation(VAnimation.fast, value: canSend)
+        .frame(minWidth: composerActionButtonSize * 3 + 2 * 2)
     }
 
     // MARK: - Dictation Inline Mode


### PR DESCRIPTION
## Summary
Fix visual text clipping in the macOS composer where the last 3-4 characters on a line are hidden behind the action buttons. Root cause: animated button layout width changes caused the NSTextView text container to use a stale width for word wrapping.

## Changes
- Reserved a fixed minimum width (100pt) for the action button area so the text field width never changes during button transitions
- Removed `.animation(VAnimation.fast, value: canSend)` from the button HStack to prevent animated width changes
- Per-button `.transition(.scale.combined(with: .opacity))` preserved for visual polish

## Milestone PRs (merged into feature branch)
- #17619: fix: stabilize composer text field width during button transitions

## Project issue
Closes #17617

## Test plan
- [ ] Type a long message that fills the width of the composer — verify no characters are clipped at the right edge
- [ ] Verify button transitions (typing → send button appears, deleting → dictate/voice buttons appear) still look smooth
- [ ] Test with different window widths to ensure no clipping at any width

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
