### PR TITLE
Rename Debug to Logs in sidebar menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -8,7 +8,7 @@ struct DebugPanel: View {
     var onClose: () -> Void
 
     var body: some View {
-        VSidePanel(title: "Debug", onClose: onClose, pinnedContent: {
+        VSidePanel(title: "Logs", onClose: onClose, pinnedContent: {
             if let conversationId = activeSessionId {
                 metricsStrip(conversationId: conversationId)
                 Divider().background(VColor.borderBase)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -66,7 +66,7 @@ struct DrawerMenuView: View {
 
                 SidebarPrimaryRow(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
 
-                SidebarPrimaryRow(icon: VIcon.bug.rawValue, label: "Debug", action: onDebug)
+                SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
                 SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
             }


### PR DESCRIPTION
## Summary
- Rename the "Debug" sidebar menu item to "Logs" and change its icon from `bug` to `scrollText`
- Update the corresponding side panel title from "Debug" to "Logs" for consistency

## Original prompt
Help me update this "Debug" option to instead be "Logs" and update the icon, too

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
