### PR TITLE
M1: Remove topic filter chips and align filter bar with Figma mock

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -48,7 +48,6 @@ struct MemoriesPanel: View {
     @StateObject private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
-    @State private var selectedKind: MemoryKind?
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
@@ -62,7 +61,6 @@ struct MemoriesPanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             filterBar
-            Divider().background(VColor.borderDisabled)
             contentView
         }
         .task { await store.loadItems() }
@@ -96,84 +94,44 @@ struct MemoriesPanel: View {
 
     @ViewBuilder
     private var filterBar: some View {
-        VStack(spacing: VSpacing.lg) {
-            // Row 1: Search, Status, Sort, New
-            HStack(spacing: VSpacing.sm) {
-                VSearchBar(placeholder: "Search memories...", text: $store.searchText)
-                    .onChange(of: store.searchText) {
-                        searchDebounceTask?.cancel()
-                        searchDebounceTask = Task {
-                            try? await Task.sleep(nanoseconds: 300_000_000)
-                            guard !Task.isCancelled else { return }
-                            await store.loadItems()
-                        }
-                    }
-
-                VDropdown(
-                    placeholder: "Status",
-                    selection: $statusFilter,
-                    options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
-                )
-                .frame(width: 110)
-                .onChange(of: statusFilter) {
-                    store.statusFilter = statusFilter.apiValue
-                    Task { await store.loadItems() }
-                }
-
-                VDropdown(
-                    placeholder: "Sort",
-                    selection: $sortOption,
-                    options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
-                )
-                .frame(width: 120)
-                .onChange(of: sortOption) {
-                    store.sortField = sortOption.sortField
-                    store.sortOrder = sortOption.sortOrder
-                    Task { await store.loadItems() }
-                }
-
-                VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
-                    showCreateSheet = true
-                }
-                .accessibilityLabel("Create new memory")
-            }
-
-            // Row 2: Topic chips
-            HStack(spacing: VSpacing.sm) {
-                Text("Topic:")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentTertiary)
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: VSpacing.xs) {
-                        VButton(
-                            label: "All",
-                            style: selectedKind == nil ? .primary : .outlined,
-                            size: .pill
-                        ) {
-                            selectedKind = nil
-                            store.kindFilter = nil
-                            Task { await store.loadItems() }
-                        }
-                        .accessibilityLabel("All filter")
-                        .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
-
-                        ForEach(MemoryKind.allCases) { kind in
-                            VButton(
-                                label: kind.label,
-                                style: selectedKind == kind ? .primary : .outlined,
-                                size: .pill
-                            ) {
-                                selectedKind = kind
-                                store.kindFilter = kind.rawValue
-                                Task { await store.loadItems() }
-                            }
-                            .accessibilityLabel("\(kind.label) filter")
-                            .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
-                        }
+        HStack(spacing: VSpacing.sm) {
+            VSearchBar(placeholder: "Search Memories", text: $store.searchText)
+                .onChange(of: store.searchText) {
+                    searchDebounceTask?.cancel()
+                    searchDebounceTask = Task {
+                        try? await Task.sleep(nanoseconds: 300_000_000)
+                        guard !Task.isCancelled else { return }
+                        await store.loadItems()
                     }
                 }
+
+            VDropdown(
+                placeholder: "Status",
+                selection: $statusFilter,
+                options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
+            )
+            .frame(width: 110)
+            .onChange(of: statusFilter) {
+                store.statusFilter = statusFilter.apiValue
+                Task { await store.loadItems() }
             }
+
+            VDropdown(
+                placeholder: "Sort",
+                selection: $sortOption,
+                options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
+            )
+            .frame(width: 120)
+            .onChange(of: sortOption) {
+                store.sortField = sortOption.sortField
+                store.sortOrder = sortOption.sortOrder
+                Task { await store.loadItems() }
+            }
+
+            VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
+                showCreateSheet = true
+            }
+            .accessibilityLabel("Create new memory")
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.top, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Remove the topic/kind filter chips row (Row 2) from the Memories panel filter bar to match the Figma design mock
- Update search placeholder from "Search memories..." to "Search Memories"
- Remove Divider between filter bar and content view
- Clean up unused `selectedKind` state variable and simplify filterBar layout (VStack wrapper -> HStack directly)

Closes #17625

## Test plan
- [ ] Verify Memories panel renders with only the search/status/sort/new row
- [ ] Verify no topic filter chips appear
- [ ] Verify search placeholder reads "Search Memories"
- [ ] Verify no divider line between filter bar and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
