### PR TITLE
fix: gate single-file HTML app sections behind multifile feature flag

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -10,7 +10,7 @@ metadata:
       - "frontend-design"
 ---
 
-You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.
+You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build the interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.
 
 **Every app gets its own visual identity.** A plant tracker should feel earthy and green. A finance dashboard should feel precise and navy. A fitness app should feel energetic and purple. Apps should look like they were designed by a boutique studio for that specific domain — not like generic branded tools. Think standalone premium product, not template.
 
@@ -88,11 +88,9 @@ Apps are rendered inside a sandboxed WebView on macOS.
 
 <!-- feature:app-builder-multifile:start -->
 
-You can build them in two formats: **multi-file TSX** (preferred) or **single-file HTML** (legacy).
+#### Multi-file TSX projects
 
-#### Multi-file TSX projects (preferred)
-
-Use this format for any non-trivial app. You get component reuse, TypeScript type-checking, and clean file organization. The build system uses esbuild to bundle everything automatically.
+Build apps as multi-file TSX projects. You get component reuse, TypeScript type-checking, and clean file organization. The build system uses esbuild to bundle everything automatically.
 
 **Project structure:**
 
@@ -219,6 +217,8 @@ app_file_write(app_id, "src/styles.css", `.app { padding: var(--v-spacing-lg); }
 - The WebView blocks all navigation — links and form `action` attributes won't work
 <!-- feature:app-builder-multifile:end -->
 
+<!-- feature:app-builder-multifile:alt -->
+
 #### Single HTML file
 
 Write a complete, self-contained HTML document.
@@ -230,6 +230,8 @@ Write a complete, self-contained HTML document.
 - No external fonts, images, or resources — use system fonts and CSS/SVG for visuals
 - Design for 400-600px width with graceful resizing
 - The WebView blocks all navigation — links and form `action` attributes won't work
+
+<!-- feature:app-builder-multifile:alt:end -->
 
 #### Injected design system
 
@@ -420,6 +422,8 @@ Important:
 
 `localStorage` and `sessionStorage` are available for ephemeral UI state (filters, view modes, collapsed state, preferences, form drafts). Use `window.vellum.data` for persistent app records, `localStorage` for UI preferences.
 
+<!-- feature:app-builder-multifile:alt -->
+
 #### JavaScript patterns
 
 Initialize apps with clean state management:
@@ -472,7 +476,14 @@ function showView(name) {
 }
 ```
 
+<!-- feature:app-builder-multifile:alt:end -->
+
+<!-- feature:app-builder-multifile:start -->
+### 4. Create and Open the App
+<!-- feature:app-builder-multifile:end -->
+<!-- feature:app-builder-multifile:alt -->
 ### 5. Create and Open the App
+<!-- feature:app-builder-multifile:alt:end -->
 
 Call `app_create` with:
 
@@ -485,7 +496,12 @@ Call `app_create` with:
 
 The app is NOT opened in a workspace panel automatically — users open it via the 'Open App' button on the inline card.
 
+<!-- feature:app-builder-multifile:start -->
+### 5. Handle Iteration
+<!-- feature:app-builder-multifile:end -->
+<!-- feature:app-builder-multifile:alt -->
 ### 6. Handle Iteration
+<!-- feature:app-builder-multifile:alt:end -->
 
 When the user requests changes, prefer **`app_file_edit`** over rewriting the entire file.
 


### PR DESCRIPTION
## Summary
- Wraps single-file-only SKILL.md sections (Single HTML file constraints, vanilla JS patterns, JS view-swapping) in `feature:app-builder-multifile:alt` gates so they are excluded when multifile is enabled
- Removes the "two formats" framing from the multifile section to avoid suggesting single-file as a fallback
- Fixes section numbering (4/5 vs 5/6) to stay sequential regardless of which mode is active
- Generalizes intro paragraph to not reference "self-contained HTML/CSS/JS"

## Test plan
- [ ] Enable `app-builder-multifile` flag and verify the rendered SKILL.md excludes: Single HTML file section, vanilla JS patterns, vanilla JS view-swapping
- [ ] Disable the flag and verify all single-file sections appear and multifile sections are excluded
- [ ] Verify section numbering is sequential in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
