### PR TITLE
Align Memories page with Figma mock

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -48,7 +48,6 @@ struct MemoriesPanel: View {
     @StateObject private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
-    @State private var selectedKind: MemoryKind?
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
@@ -62,7 +61,6 @@ struct MemoriesPanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             filterBar
-            Divider().background(VColor.borderDisabled)
             contentView
         }
         .task { await store.loadItems() }
@@ -96,84 +94,44 @@ struct MemoriesPanel: View {
 
     @ViewBuilder
     private var filterBar: some View {
-        VStack(spacing: VSpacing.lg) {
-            // Row 1: Search, Status, Sort, New
-            HStack(spacing: VSpacing.sm) {
-                VSearchBar(placeholder: "Search memories...", text: $store.searchText)
-                    .onChange(of: store.searchText) {
-                        searchDebounceTask?.cancel()
-                        searchDebounceTask = Task {
-                            try? await Task.sleep(nanoseconds: 300_000_000)
-                            guard !Task.isCancelled else { return }
-                            await store.loadItems()
-                        }
-                    }
-
-                VDropdown(
-                    placeholder: "Status",
-                    selection: $statusFilter,
-                    options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
-                )
-                .frame(width: 110)
-                .onChange(of: statusFilter) {
-                    store.statusFilter = statusFilter.apiValue
-                    Task { await store.loadItems() }
-                }
-
-                VDropdown(
-                    placeholder: "Sort",
-                    selection: $sortOption,
-                    options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
-                )
-                .frame(width: 120)
-                .onChange(of: sortOption) {
-                    store.sortField = sortOption.sortField
-                    store.sortOrder = sortOption.sortOrder
-                    Task { await store.loadItems() }
-                }
-
-                VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
-                    showCreateSheet = true
-                }
-                .accessibilityLabel("Create new memory")
-            }
-
-            // Row 2: Topic chips
-            HStack(spacing: VSpacing.sm) {
-                Text("Topic:")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentTertiary)
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: VSpacing.xs) {
-                        VButton(
-                            label: "All",
-                            style: selectedKind == nil ? .primary : .outlined,
-                            size: .pill
-                        ) {
-                            selectedKind = nil
-                            store.kindFilter = nil
-                            Task { await store.loadItems() }
-                        }
-                        .accessibilityLabel("All filter")
-                        .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
-
-                        ForEach(MemoryKind.allCases) { kind in
-                            VButton(
-                                label: kind.label,
-                                style: selectedKind == kind ? .primary : .outlined,
-                                size: .pill
-                            ) {
-                                selectedKind = kind
-                                store.kindFilter = kind.rawValue
-                                Task { await store.loadItems() }
-                            }
-                            .accessibilityLabel("\(kind.label) filter")
-                            .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
-                        }
+        HStack(spacing: VSpacing.sm) {
+            VSearchBar(placeholder: "Search Memories", text: $store.searchText)
+                .onChange(of: store.searchText) {
+                    searchDebounceTask?.cancel()
+                    searchDebounceTask = Task {
+                        try? await Task.sleep(nanoseconds: 300_000_000)
+                        guard !Task.isCancelled else { return }
+                        await store.loadItems()
                     }
                 }
+
+            VDropdown(
+                placeholder: "Status",
+                selection: $statusFilter,
+                options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
+            )
+            .frame(width: 110)
+            .onChange(of: statusFilter) {
+                store.statusFilter = statusFilter.apiValue
+                Task { await store.loadItems() }
             }
+
+            VDropdown(
+                placeholder: "Sort",
+                selection: $sortOption,
+                options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
+            )
+            .frame(width: 120)
+            .onChange(of: sortOption) {
+                store.sortField = sortOption.sortField
+                store.sortOrder = sortOption.sortOrder
+                Task { await store.loadItems() }
+            }
+
+            VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
+                showCreateSheet = true
+            }
+            .accessibilityLabel("Create new memory")
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.top, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -138,9 +138,7 @@ struct MemoriesPanel: View {
             }
             .accessibilityLabel("Create new memory")
         }
-        .padding(.horizontal, VSpacing.md)
         .padding(.top, VSpacing.sm)
-        .padding(.bottom, VSpacing.md)
     }
 
     // MARK: - Kind Sidebar
@@ -165,7 +163,6 @@ struct MemoriesPanel: View {
             }
         }
         .frame(width: 220)
-        .padding(.leading, VSpacing.md)
     }
 
     @ViewBuilder
@@ -215,7 +212,6 @@ struct MemoriesPanel: View {
                         )
                     }
                 }
-                .padding(.trailing, VSpacing.md)
                 .background { OverlayScrollerStyle() }
             }
             .scrollContentBackground(.hidden)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -48,6 +48,7 @@ struct MemoriesPanel: View {
     @StateObject private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
+    @State private var selectedKind: MemoryKind?
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
@@ -61,7 +62,11 @@ struct MemoriesPanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             filterBar
-            contentView
+            HStack(alignment: .top, spacing: VSpacing.xxl) {
+                kindSidebar
+                contentView
+            }
+            .padding(.top, VSpacing.lg)
         }
         .task { await store.loadItems() }
         .task(id: focusedMemoryId) {
@@ -110,7 +115,7 @@ struct MemoriesPanel: View {
                 selection: $statusFilter,
                 options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
             )
-            .frame(width: 110)
+            .frame(width: 130)
             .onChange(of: statusFilter) {
                 store.statusFilter = statusFilter.apiValue
                 Task { await store.loadItems() }
@@ -121,7 +126,7 @@ struct MemoriesPanel: View {
                 selection: $sortOption,
                 options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
             )
-            .frame(width: 120)
+            .frame(width: 130)
             .onChange(of: sortOption) {
                 store.sortField = sortOption.sortField
                 store.sortOrder = sortOption.sortOrder
@@ -136,6 +141,48 @@ struct MemoriesPanel: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.top, VSpacing.sm)
         .padding(.bottom, VSpacing.md)
+    }
+
+    // MARK: - Kind Sidebar
+
+    @ViewBuilder
+    private var kindSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            kindSidebarItem(label: "All", isSelected: selectedKind == nil) {
+                selectedKind = nil
+                store.kindFilter = nil
+                Task { await store.loadItems() }
+            }
+            .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
+
+            ForEach(MemoryKind.allCases) { kind in
+                kindSidebarItem(label: kind.label, isSelected: selectedKind == kind) {
+                    selectedKind = kind
+                    store.kindFilter = kind.rawValue
+                    Task { await store.loadItems() }
+                }
+                .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
+            }
+        }
+        .frame(width: 220)
+        .padding(.leading, VSpacing.md)
+    }
+
+    @ViewBuilder
+    private func kindSidebarItem(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(VFont.body)
+                .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, VSpacing.sm)
+                .padding(.horizontal, VSpacing.sm)
+                .contentShape(Rectangle())
+                .background(isSelected ? VColor.surfaceActive : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) filter")
     }
 
     // MARK: - Content View
@@ -157,7 +204,7 @@ struct MemoriesPanel: View {
             )
         } else {
             ScrollView {
-                LazyVStack(spacing: VSpacing.xs) {
+                LazyVStack(spacing: VSpacing.sm) {
                     ForEach(store.items) { item in
                         MemoryItemRow(
                             item: item,
@@ -168,7 +215,7 @@ struct MemoriesPanel: View {
                         )
                     }
                 }
-                .padding(VSpacing.md)
+                .padding(.trailing, VSpacing.md)
                 .background { OverlayScrollerStyle() }
             }
             .scrollContentBackground(.hidden)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -109,7 +109,7 @@ struct MemoryItemDetailSheet: View {
                     VButton(
                         label: "Delete",
                         iconOnly: VIcon.trash.rawValue,
-                        style: .ghost,
+                        style: .dangerGhost,
                         tooltip: "Delete memory"
                     ) {
                         showDeleteConfirm = true
@@ -375,7 +375,13 @@ struct MemoryItemDetailSheet: View {
     private var kindBadge: some View {
         let color = memoryKind?.color ?? VColor.contentTertiary
         let label = memoryKind?.label ?? displayItem.kind.capitalized
-        VBadge(style: .label(label), color: color)
+        Text(label)
+            .font(VFont.caption)
+            .foregroundColor(VColor.contentEmphasized)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(color.opacity(0.2))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 
     private func metadataRow(label: String, value: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -9,36 +9,39 @@ struct MemoryItemRow: View {
 
     var body: some View {
         Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                HStack(spacing: VSpacing.sm) {
-                    Text(item.subject)
-                        .font(VFont.bodyBold)
-                        .foregroundColor(VColor.contentDefault)
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(item.subject)
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.contentDefault)
 
-                    kindBadge
-
-                    Spacer()
-
-                    if item.isUserConfirmed {
-                        VIconView(.circleCheck, size: 12)
-                            .foregroundColor(VColor.systemPositiveStrong)
-                            .accessibilityLabel("User confirmed")
+                        kindTag
                     }
 
-                    Text(item.relativeLastSeen)
-                        .font(VFont.caption)
+                    Text(item.statement)
+                        .font(VFont.body)
                         .foregroundColor(VColor.contentTertiary)
+                        .lineLimit(1)
+                        .multilineTextAlignment(.leading)
                 }
 
-                Text(item.statement)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
+                Spacer()
+
+                Text(item.relativeLastSeen)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+
+                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
+                    .accessibilityLabel("Delete memory")
             }
-            .padding(VSpacing.md)
+            .padding(VSpacing.lg)
             .background(isHovered ? VColor.surfaceActive : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .stroke(VColor.borderDisabled, lineWidth: 2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
@@ -48,14 +51,21 @@ struct MemoryItemRow: View {
         .accessibilityElement(children: .combine)
     }
 
-    // MARK: - Kind Badge
+    // MARK: - Kind Tag
 
     @ViewBuilder
-    private var kindBadge: some View {
+    private var kindTag: some View {
         let memoryKind = MemoryKind(rawValue: item.kind)
         let color = memoryKind?.color ?? VColor.contentTertiary
         let label = memoryKind?.label ?? item.kind.capitalized
 
-        VBadge(style: .label(label), color: color)
+        Text(label)
+            .font(VFont.caption)
+            .foregroundColor(VColor.contentEmphasized)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(color.opacity(0.2))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .accessibilityLabel(label)
     }
 }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public struct VButton: View {
-    public enum Style: Hashable { case primary, danger, dangerOutline, outlined, ghost, contrast }
+    public enum Style: Hashable { case primary, danger, dangerOutline, dangerGhost, outlined, ghost, contrast }
     public enum Size: Hashable { case regular, compact, pill }
 
     public let label: String
@@ -94,7 +94,7 @@ public struct VButton: View {
         case .ghost, .outlined:
             if isActive { return VColor.primaryActive }
             return VColor.primaryBase
-        case .dangerOutline:
+        case .dangerOutline, .dangerGhost:
             return VColor.systemNegativeStrong
         }
     }
@@ -159,7 +159,7 @@ public struct VButtonStyle: ButtonStyle {
     private var borderLineWidth: CGFloat {
         switch style {
         case .outlined, .dangerOutline: return 2
-        case .ghost:
+        case .ghost, .dangerGhost:
             return isEnabled && isFocused ? 1.25 : 1
         default: return 0
         }
@@ -196,6 +196,11 @@ public struct VButtonStyle: ButtonStyle {
                 if isHovered { return VColor.surfaceBase }
                 return .clear
             }
+        case .dangerGhost:
+            guard isEnabled else { return .clear }
+            if isPressed { return VColor.systemNegativeWeak }
+            if isHovered { return VColor.systemNegativeWeak }
+            return .clear
         case .contrast:
             guard isEnabled else { return VColor.primaryDisabled }
             if isPressed { return VColor.contentEmphasized }
@@ -215,6 +220,9 @@ public struct VButtonStyle: ButtonStyle {
         case .ghost:
             if isHovered { return VColor.primaryActive }
             return VColor.primaryBase
+        case .dangerGhost:
+            if isHovered { return VColor.systemNegativeHover }
+            return VColor.systemNegativeStrong
         }
     }
 
@@ -236,6 +244,9 @@ public struct VButtonStyle: ButtonStyle {
         case .ghost:
             guard isEnabled, isFocused else { return .clear }
             return VColor.primaryBase.opacity(0.72)
+        case .dangerGhost:
+            guard isEnabled, isFocused else { return .clear }
+            return VColor.systemNegativeStrong.opacity(0.72)
         default:
             return .clear
         }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -91,9 +91,11 @@ public struct VButton: View {
             return VColor.auxWhite
         case .contrast:
             return VColor.contentInset
-        case .ghost, .outlined, .dangerOutline:
+        case .ghost, .outlined:
             if isActive { return VColor.primaryActive }
             return VColor.primaryBase
+        case .dangerOutline:
+            return VColor.systemNegativeStrong
         }
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -222,6 +222,7 @@ struct ButtonsGallerySection: View {
         case .outlined: return "Outlined"
         case .dangerOutline: return "Danger Outline"
         case .ghost: return "Ghost"
+        case .dangerGhost: return "Danger Ghost"
         case .contrast: return "Contrast"
         }
     }


### PR DESCRIPTION
## Summary
Updates the macOS Memories panel filter bar to match the latest Figma design mock. Removes the topic/kind filter chips row, updates the search placeholder, and removes the divider for a cleaner, simplified layout.

## Changes
- Removed "Topic:" label and all kind filter chip buttons (Row 2 in filterBar)
- Changed search placeholder from "Search memories..." to "Search Memories"
- Removed Divider between filter bar and content view
- Cleaned up unused `selectedKind` state variable
- Simplified filterBar layout from VStack with two rows to single HStack

## Milestone PRs (merged into feature branch)
- #17627: M1: Remove topic filter chips and align filter bar with Figma mock

## Project issue
Closes #17624

## Test plan
- [ ] Build macOS app and navigate to Intelligence panel > Memories tab
- [ ] Verify search bar shows "Search Memories" placeholder
- [ ] Verify no topic filter chips row is visible
- [ ] Verify no divider line between filter bar and content
- [ ] Verify Active/Newest dropdowns and + New button still work
- [ ] Verify search, filter, and sort functionality unchanged

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
