### PR TITLE
fix: lowercase mimeType in SyntaxLanguage.detect and clamp viewMode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
@@ -28,7 +28,8 @@ enum SyntaxLanguage: String, CaseIterable {
             break
         }
 
-        switch mimeType {
+        let mime = mimeType.lowercased()
+        switch mime {
         case "application/json":
             return .json
         case "application/javascript", "text/javascript":

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -730,6 +730,10 @@ private struct WorkspaceFileViewer: View {
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
         let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
         let readOnly = isHiddenPath(detail.path)
+        // Clamp viewMode to available modes for the current file
+        if !modes.contains(state.viewMode) {
+            Task { @MainActor in state.viewMode = modes.first ?? .source }
+        }
         return VStack(spacing: 0) {
             if modes.count > 1 {
                 HStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- Lowercase `mimeType` in `SyntaxLanguage.detect` before switching on it, matching the fix already applied to `availableViewModes`
- Clamp `viewMode` to available modes for the current file in `textViewer`, preventing stuck state if file metadata changes

Addresses PR #17622 reviewer feedback from Codex (P1: clamp view mode) and Devin (SyntaxLanguage.detect case sensitivity).

Part of plan: rich-file-viewer-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
