### PR TITLE
fix: use effectiveMode instead of mutating viewMode during view body

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -730,10 +730,7 @@ private struct WorkspaceFileViewer: View {
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
         let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
         let readOnly = isHiddenPath(detail.path)
-        // Clamp viewMode to available modes for the current file
-        if !modes.contains(state.viewMode) {
-            Task { @MainActor in state.viewMode = modes.first ?? .source }
-        }
+        let effectiveMode = modes.contains(state.viewMode) ? state.viewMode : (modes.first ?? .source)
         return VStack(spacing: 0) {
             if modes.count > 1 {
                 HStack(spacing: 0) {
@@ -779,7 +776,7 @@ private struct WorkspaceFileViewer: View {
                 }
             }
 
-            switch state.viewMode {
+            switch effectiveMode {
             case .source:
                 sourceView(detail)
             case .preview:


### PR DESCRIPTION
## Summary
- Replace the `Task { @MainActor in ... }` state mutation inside the view body (SwiftUI anti-pattern that triggers "Publishing changes from within view updates" runtime warnings) with a computed `effectiveMode` that falls back to `.source` when the current `viewMode` doesn't match available modes for the file
- No state mutation during view evaluation — the stale `viewMode` is simply ignored for rendering, and `loadFile()` handles the reset on file switch

Part of plan: rich-file-viewer-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
