### PR TITLE
fix: eliminate Sendable closure warnings in AppDelegate+Bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -72,32 +72,18 @@ extension AppDelegate {
     /// or until the timeout expires. This ensures managed-proxy credentials are provisioned
     /// before the wake-up greeting triggers an LLM call.
     func awaitLocalBootstrapCompleted(timeout: TimeInterval) async {
-        await withCheckedContinuation { continuation in
-            var resumed = false
-            var observer: (any NSObjectProtocol)?
-            observer = NotificationCenter.default.addObserver(
-                forName: .localBootstrapCompleted,
-                object: nil,
-                queue: .main
-            ) { _ in
-                guard !resumed else { return }
-                resumed = true
-                if let obs = observer {
-                    NotificationCenter.default.removeObserver(obs)
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await _ in NotificationCenter.default.notifications(named: .localBootstrapCompleted) {
+                    return
                 }
-                continuation.resume()
             }
-
-            Task {
+            group.addTask {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                guard !resumed else { return }
-                resumed = true
-                if let obs = observer {
-                    NotificationCenter.default.removeObserver(obs)
-                }
                 log.warning("Local bootstrap did not complete within \(timeout)s — proceeding with wake-up")
-                continuation.resume()
             }
+            await group.next()
+            group.cancelAll()
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced `NotificationCenter.addObserver` + `withCheckedContinuation` pattern in `awaitLocalBootstrapCompleted` with the modern `NotificationCenter.notifications(named:)` async sequence + `withTaskGroup` race
- Eliminates 3 Swift compiler warnings: non-Sendable `NSObjectProtocol` capture, mutation-after-capture, and the `@preconcurrency` suggestion

## Original prompt
Fix Swift Sendable closure warnings in `AppDelegate+Bootstrap.swift` during macOS build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
