### PR TITLE
fix: use VIconView and correlate invite-call with current invite (#16208)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -31,6 +31,9 @@ struct ContactDetailView: View {
     @State private var inviteInProgress: String?
     @State private var inviteCallInProgress = false
     @State private var inviteCallTriggered = false
+    /// The invite ID for which the call was triggered, used to correlate
+    /// async call completion with the currently displayed invite.
+    @State private var inviteCallInviteId: String?
     @State private var inviteResult: (
         type: String,
         inviteId: String,
@@ -712,7 +715,7 @@ struct ContactDetailView: View {
                     if type == "phone", let result = inviteResult {
                         if inviteCallTriggered {
                             HStack(spacing: VSpacing.sm) {
-                                Image(systemName: "checkmark.circle.fill")
+                                VIconView(.circleCheck, size: 14)
                                     .foregroundColor(VColor.systemPositiveStrong)
                                 Text("Call started")
                                     .font(VFont.caption)
@@ -1097,6 +1100,7 @@ struct ContactDetailView: View {
         inviteResult = nil
         inviteCallInProgress = false
         inviteCallTriggered = false
+        inviteCallInviteId = nil
         inviteCodeRevealed = false
         inviteHandleInput = ""
         Task {
@@ -1142,9 +1146,18 @@ struct ContactDetailView: View {
     private func triggerInviteCallAction(inviteId: String) {
         guard let daemonClient, !inviteCallInProgress else { return }
         inviteCallInProgress = true
+        inviteCallInviteId = inviteId
         Task {
             do {
                 let success = try await daemonClient.triggerInviteCall(inviteId: inviteId)
+                // Only apply success if the currently displayed invite still
+                // matches the one we triggered the call for. If the user
+                // switched to a different invite before this async request
+                // returned, discard the stale result.
+                guard inviteResult?.inviteId == inviteId else {
+                    inviteCallInProgress = false
+                    return
+                }
                 if success {
                     inviteCallTriggered = true
                 } else {
@@ -1152,6 +1165,10 @@ struct ContactDetailView: View {
                     inviteErrorChannel = "phone"
                 }
             } catch {
+                guard inviteResult?.inviteId == inviteId else {
+                    inviteCallInProgress = false
+                    return
+                }
                 inviteError = "Failed to initiate call: \(error.localizedDescription)"
                 inviteErrorChannel = "phone"
             }


### PR DESCRIPTION
## Summary
- Replaces `Image(systemName: "checkmark.circle.fill")` with `VIconView(.circleCheck, size: 14)` per AGENTS.md icon rules
- Adds invite-specific correlation so call completion only applies to the matching invite
- Prevents stale async results from incorrectly marking a different invite as "Call started"

## Original prompt
Address reviewer feedback on PR #16208: VIconView usage and invite-call correlation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
