### PR TITLE
fix: use stable conversation key and add dismissGreeting cleanup (#16225)

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1236,7 +1236,7 @@ public final class ChatViewModel: ObservableObject {
 
         greetingTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            let key = "greeting-\(UUID().uuidString)"
+            let key = "greeting"
             var result = ""
             do {
                 let stream = self.daemonClient.sendBtwMessage(
@@ -1259,6 +1259,14 @@ public final class ChatViewModel: ObservableObject {
             }
             self.isGeneratingGreeting = false
         }
+    }
+
+    /// Clear greeting state and cancel any in-flight generation.
+    public func dismissGreeting() {
+        greetingTask?.cancel()
+        greetingTask = nil
+        emptyStateGreeting = nil
+        isGeneratingGreeting = false
     }
 
     private func bootstrapConversation(userMessage: String?, attachments: [UserMessageAttachment]?) {


### PR DESCRIPTION
## Summary
- Uses a stable conversation key for greeting requests instead of per-call UUIDs to prevent phantom conversation accumulation
- Adds a `dismissGreeting()` cleanup method mirroring the `dismissBtw()` pattern for proper task cancellation

## Original prompt
Address reviewer feedback on PR #16225: stable conversation key and greeting cleanup method

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
