### PR TITLE
refactor: rename SessionLookup→ConversationLookup types and update stale session comments

### DIFF
--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -36,7 +36,7 @@ const log = getLogger("ces-approval-bridge");
  * Maps the existing confirmation transport decisions to CES grant semantics:
  * - `allow`          -> approved (single-use grant, no TTL)
  * - `allow_10m`      -> approved (temporary grant, 10-minute TTL)
- * - `allow_conversation` -> approved (conversation-scoped grant, no TTL but session-bound)
+ * - `allow_conversation` -> approved (conversation-scoped grant, no TTL but conversation-bound)
  * - `always_allow`   -> approved (persistent grant, no expiry)
  * - `deny`           -> denied
  * - `always_deny`    -> denied
@@ -77,8 +77,8 @@ function mapUserDecisionToCesDecision(
       };
     case "allow_conversation":
       // Conversation-scoped grants don't have a wall-clock TTL — they are bound
-      // to the session lifetime. CES handles the session binding; we pass
-      // no TTL so the grant remains active until the session ends.
+      // to the conversation lifetime. CES handles the conversation binding; we pass
+      // no TTL so the grant remains active until the conversation ends.
       return {
         grantDecision: "approved",
         ttl: undefined,

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -58,7 +58,7 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 
 - Telegram callback buttons encode `apr:<requestId>:<action>` in `callback_data`.
 - Guardian approval records in `channelGuardianApprovalRequests` link via `requestId`.
-- The conversational approval engine classifies user intent and resolves via `session.handleConfirmationResponse(requestId, decision)`.
+- The conversational approval engine classifies user intent and resolves via `conversation.handleConfirmationResponse(requestId, decision)`.
 
 ## Rate Limiting & Diagnostics
 

--- a/assistant/src/runtime/conversation-approval-overrides.ts
+++ b/assistant/src/runtime/conversation-approval-overrides.ts
@@ -1,7 +1,7 @@
 /**
  * Per-conversation temporary approval overrides.
  *
- * When a user chooses `allow_conversation` or `allow_10m`, the session records a
+ * When a user chooses `allow_conversation` or `allow_10m`, the conversation records a
  * temporary approval mode scoped to the conversation. Subsequent tool-use
  * confirmations within the same conversation can check this state to
  * auto-approve without prompting.

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -1,8 +1,8 @@
 /**
  * Route handler for surface action operations.
  *
- * POST /v1/surface-actions — dispatch a surface action to an active session.
- * Requires the session to already exist (does not create new sessions).
+ * POST /v1/surface-actions — dispatch a surface action to an active conversation.
+ * Requires the conversation to already exist (does not create new conversations).
  */
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -20,11 +20,11 @@ interface SurfaceActionTarget {
   handleSurfaceUndo?(surfaceId: string): void;
 }
 
-export type SessionLookup = (
+export type ConversationLookup = (
   conversationId: string,
 ) => SurfaceActionTarget | undefined;
 
-export type SessionLookupBySurfaceId = (
+export type ConversationLookupBySurfaceId = (
   surfaceId: string,
 ) => SurfaceActionTarget | undefined;
 
@@ -35,8 +35,8 @@ export type SessionLookupBySurfaceId = (
  */
 export async function handleSurfaceAction(
   req: Request,
-  findConversation: SessionLookup,
-  findConversationBySurfaceId?: SessionLookupBySurfaceId,
+  findConversation: ConversationLookup,
+  findConversationBySurfaceId?: ConversationLookupBySurfaceId,
 ): Promise<Response> {
   const body = (await req.json()) as {
     conversationId?: string | null;
@@ -57,16 +57,16 @@ export async function handleSurfaceAction(
     return httpError("BAD_REQUEST", "conversationId must be a string", 400);
   }
 
-  const session = conversationId
+  const conversation = conversationId
     ? findConversation(conversationId)
     : findConversationBySurfaceId?.(surfaceId);
 
-  if (!session) {
-    return httpError("NOT_FOUND", "No active session found", 404);
+  if (!conversation) {
+    return httpError("NOT_FOUND", "No active conversation found", 404);
   }
 
   try {
-    session.handleSurfaceAction(surfaceId, actionId, data);
+    conversation.handleSurfaceAction(surfaceId, actionId, data);
     log.info(
       { conversationId: conversationId ?? undefined, surfaceId, actionId },
       "Surface action handled via HTTP",
@@ -93,8 +93,8 @@ export async function handleSurfaceAction(
 export async function handleSurfaceUndo(
   req: Request,
   surfaceId: string,
-  findConversation: SessionLookup,
-  findConversationBySurfaceId?: SessionLookupBySurfaceId,
+  findConversation: ConversationLookup,
+  findConversationBySurfaceId?: ConversationLookupBySurfaceId,
 ): Promise<Response> {
   const body = (await req.json()) as {
     conversationId?: string | null;
@@ -106,24 +106,24 @@ export async function handleSurfaceUndo(
     return httpError("BAD_REQUEST", "conversationId must be a string", 400);
   }
 
-  const session = conversationId
+  const conversation = conversationId
     ? findConversation(conversationId)
     : findConversationBySurfaceId?.(surfaceId);
 
-  if (!session) {
-    return httpError("NOT_FOUND", "No active session found", 404);
+  if (!conversation) {
+    return httpError("NOT_FOUND", "No active conversation found", 404);
   }
 
-  if (!session.handleSurfaceUndo) {
+  if (!conversation.handleSurfaceUndo) {
     return httpError(
       "NOT_IMPLEMENTED",
-      "Surface undo not supported for this session type",
+      "Surface undo not supported for this conversation type",
       501,
     );
   }
 
   try {
-    session.handleSurfaceUndo(surfaceId);
+    conversation.handleSurfaceUndo(surfaceId);
     log.info({ conversationId, surfaceId }, "Surface undo handled via HTTP");
     return Response.json({ ok: true });
   } catch (err) {
@@ -136,8 +136,8 @@ export async function handleSurfaceUndo(
 }
 
 export function surfaceActionRouteDefinitions(deps: {
-  findConversation?: SessionLookup;
-  findConversationBySurfaceId?: SessionLookupBySurfaceId;
+  findConversation?: ConversationLookup;
+  findConversationBySurfaceId?: ConversationLookupBySurfaceId;
 }): RouteDefinition[] {
   return [
     {

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -2,7 +2,7 @@
  * Route handler for fetching surface content by ID.
  *
  * GET /v1/surfaces/:surfaceId — return the full surface payload from the
- * session's in-memory surface state. Used by clients to re-hydrate surfaces
+ * conversation's in-memory surface state. Used by clients to re-hydrate surfaces
  * whose data was stripped during memory compaction.
  */
 import type {
@@ -15,7 +15,7 @@ import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("surface-content-routes");
 
-/** Narrow interface for looking up surface state from a session. */
+/** Narrow interface for looking up surface state from a conversation. */
 interface SurfaceContentTarget {
   surfaceState: Map<
     string,
@@ -30,7 +30,7 @@ interface SurfaceContentTarget {
   }>;
 }
 
-export type SurfaceContentSessionLookup = (
+export type SurfaceContentConversationLookup = (
   conversationId: string,
 ) => SurfaceContentTarget | undefined;
 
@@ -39,7 +39,7 @@ export type SurfaceContentSessionLookup = (
 // ---------------------------------------------------------------------------
 
 export function surfaceContentRouteDefinitions(deps: {
-  findConversation?: SurfaceContentSessionLookup;
+  findConversation?: SurfaceContentConversationLookup;
 }): RouteDefinition[] {
   return [
     {
@@ -72,17 +72,17 @@ export function surfaceContentRouteDefinitions(deps: {
           );
         }
 
-        const session = deps.findConversation(conversationId);
-        if (!session) {
+        const conversation = deps.findConversation(conversationId);
+        if (!conversation) {
           return httpError(
             "NOT_FOUND",
-            "No active session found for this conversationId",
+            "No active conversation found for this conversationId",
             404,
           );
         }
 
-        // Look up the surface in the session's in-memory state.
-        const stored = session.surfaceState.get(surfaceId);
+        // Look up the surface in the conversation's in-memory state.
+        const stored = conversation.surfaceState.get(surfaceId);
         if (stored) {
           log.info(
             { conversationId, surfaceId },
@@ -98,7 +98,7 @@ export function surfaceContentRouteDefinitions(deps: {
 
         // Fall back to currentTurnSurfaces in case the surface hasn't been
         // committed to surfaceState yet (e.g. mid-turn).
-        const turnSurface = session.currentTurnSurfaces?.find(
+        const turnSurface = conversation.currentTurnSurfaces?.find(
           (s) => s.surfaceId === surfaceId,
         );
         if (turnSurface) {
@@ -114,7 +114,7 @@ export function surfaceContentRouteDefinitions(deps: {
           });
         }
 
-        return httpError("NOT_FOUND", "Surface not found in session", 404);
+        return httpError("NOT_FOUND", "Surface not found in conversation", 404);
       },
     },
   ];


### PR DESCRIPTION
## Summary
- Renamed `SurfaceContentSessionLookup` → `SurfaceContentConversationLookup` and `SessionLookup`/`SessionLookupBySurfaceId` → `ConversationLookup`/`ConversationLookupBySurfaceId`
- Updated stale 'session' comments to 'conversation' in approval-bridge.ts, conversation-approval-overrides.ts, and AGENTS.md

Part of plan: conv-symbol-sweep.md (PR 2 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
