### PR TITLE
fix: add introTask teardown, cancellation guard, and VFont token (#16226)

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -57,6 +57,9 @@ final class IdentityViewModel {
     }
 
     func tearDown() {
+        introTask?.cancel()
+        introTask = nil
+        introText = nil
         cancellables.removeAll()
         skillsStore = nil
         contactsStore = nil
@@ -90,6 +93,7 @@ final class IdentityViewModel {
                     guard !Task.isCancelled else { return }
                     result += delta
                 }
+                guard !Task.isCancelled else { return }
                 self.introText = result.isEmpty ? nil : result
             } catch is CancellationError {
                 return
@@ -143,7 +147,7 @@ struct IdentityView: View {
             if let introText = viewModel.introText {
                 Section {
                     Text(introText)
-                        .font(.system(size: 22, weight: .regular, design: .rounded))
+                        .font(VFont.introHeadline)
                         .foregroundColor(VColor.contentDefault)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .listRowBackground(Color.clear)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -92,6 +92,9 @@ public enum VFont {
     /// Large monospaced font for displaying invite codes
     public static let inviteCode = Font.system(size: 28, weight: .medium, design: .monospaced)
 
+    /// Rounded system font for identity intro text
+    public static let introHeadline = Font.system(size: adaptiveSize(22), weight: .regular, design: .rounded)
+
     /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))


### PR DESCRIPTION
## Summary
- Cancels `introTask` in `tearDown()` and clears `introText` to prevent stale UI after disconnect
- Adds cancellation guard before setting `introText` to prevent race conditions from canceled streams
- Replaces hardcoded `.system(size: 22, weight: .regular, design: .rounded)` font with `VFont.introHeadline` design token

## Original prompt
Address reviewer feedback on PR #16226: introTask lifecycle, cancellation safety, and font token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
