### PR TITLE
refactor: rename thread/session→conversation in iOS test methods and properties

### DIFF
--- a/clients/ios/Tests/ChatTranscriptFormatterIOSTests.swift
+++ b/clients/ios/Tests/ChatTranscriptFormatterIOSTests.swift
@@ -14,7 +14,7 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
 
     // MARK: - conversationMarkdown
 
-    func testThreadMarkdownWithTitleAndMessages() {
+    func testConversationMarkdownWithTitleAndMessages() {
         let messages = [
             ChatMessage(role: .user, text: "Hello from iPhone!"),
             ChatMessage(role: .assistant, text: "Hi there, iOS user!")
@@ -22,11 +22,11 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
 
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: messages,
-            conversationTitle: "iOS Thread",
+            conversationTitle: "iOS Conversation",
             participantNames: names
         )
 
-        XCTAssertTrue(result.hasPrefix("# iOS Thread"))
+        XCTAssertTrue(result.hasPrefix("# iOS Conversation"))
         XCTAssertTrue(result.contains("### User"))
         XCTAssertTrue(result.contains("Hello from iPhone!"))
         XCTAssertTrue(result.contains("### Velly"))
@@ -34,7 +34,7 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
         XCTAssertTrue(result.contains("---"))
     }
 
-    func testThreadMarkdownWithoutTitle() {
+    func testConversationMarkdownWithoutTitle() {
         let messages = [
             ChatMessage(role: .user, text: "Hello!")
         ]
@@ -50,7 +50,7 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
         XCTAssertTrue(result.contains("Hello!"))
     }
 
-    func testThreadMarkdownSkipsEmptyTextMessages() {
+    func testConversationMarkdownSkipsEmptyTextMessages() {
         let messages = [
             ChatMessage(role: .assistant, text: ""),
             ChatMessage(role: .user, text: "Real message"),
@@ -69,17 +69,17 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
         XCTAssertFalse(result.contains("---"))
     }
 
-    func testThreadMarkdownEmptyInputReturnsEmptyString() {
+    func testConversationMarkdownEmptyInputReturnsEmptyString() {
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: [],
-            conversationTitle: "Empty Thread",
+            conversationTitle: "Empty Conversation",
             participantNames: names
         )
 
         XCTAssertEqual(result, "")
     }
 
-    func testThreadMarkdownAllEmptyTextReturnsEmptyString() {
+    func testConversationMarkdownAllEmptyTextReturnsEmptyString() {
         let messages = [
             ChatMessage(role: .assistant, text: ""),
             ChatMessage(role: .user, text: "  \n  "),
@@ -87,14 +87,14 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
 
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: messages,
-            conversationTitle: "Thread",
+            conversationTitle: "Conversation",
             participantNames: names
         )
 
         XCTAssertEqual(result, "")
     }
 
-    func testThreadMarkdownSeparatorsBetweenMessages() {
+    func testConversationMarkdownSeparatorsBetweenMessages() {
         let messages = [
             ChatMessage(role: .user, text: "First"),
             ChatMessage(role: .assistant, text: "Second"),
@@ -111,7 +111,7 @@ final class ChatTranscriptFormatterIOSTests: XCTestCase {
         XCTAssertEqual(separatorCount, 2)
     }
 
-    func testThreadMarkdownUsesCustomParticipantNames() {
+    func testConversationMarkdownUsesCustomParticipantNames() {
         let customNames = ChatTranscriptFormatter.ParticipantNames(
             assistantName: "Assistant",
             userName: "iPhone User"

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -124,23 +124,23 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(mockClient.sentMessages.count, 1)
     }
 
-    // MARK: - Session Info
+    // MARK: - Conversation Info
 
-    func testSessionInfoStoresSessionId() {
+    func testConversationInfoStoresConversationId() {
         viewModel.bootstrapCorrelationId = "corr-1"
         let info = ConversationInfoMessage(conversationId: "ios-sess-123", title: "iOS Test", correlationId: "corr-1")
         viewModel.handleServerMessage(.conversationInfo(info))
         XCTAssertEqual(viewModel.conversationId, "ios-sess-123")
     }
 
-    func testSessionInfoDoesNotOverwriteExistingSession() {
+    func testConversationInfoDoesNotOverwriteExistingConversation() {
         viewModel.conversationId = "first-session"
         let info = ConversationInfoMessage(conversationId: "second-session", title: "Test")
         viewModel.handleServerMessage(.conversationInfo(info))
         XCTAssertEqual(viewModel.conversationId, "first-session")
     }
 
-    func testSessionInfoClearsBootstrapState() {
+    func testConversationInfoClearsBootstrapState() {
         // Simulate a bootstrap scenario
         viewModel.inputText = "Hello"
         viewModel.sendMessage()
@@ -372,7 +372,7 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertEqual(callCount, 1, "onFirstUserMessage should fire only once")
     }
 
-    func testOnSessionCreatedCallbackFires() {
+    func testOnConversationCreatedCallbackFires() {
         var capturedSessionId: String?
         viewModel.onConversationCreated = { conversationId in
             capturedSessionId = conversationId

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -165,7 +165,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertTrue(vm.isBootstrapping, "Should still be bootstrapping")
     }
 
-    func testOnSessionCreatedCallbackFiresDuringBackfill() {
+    func testOnConversationCreatedCallbackFiresDuringBackfill() {
         let vm = ChatViewModel(daemonClient: mockClient)
         var capturedSessionId: String?
         vm.onConversationCreated = { conversationId in
@@ -198,7 +198,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
 
     // MARK: - Conversation Lifecycle: Create, Use, Archive Pattern
 
-    func testNewSessionReceivesAndCompletesMessages() {
+    func testNewConversationReceivesAndCompletesMessages() {
         let vm = ChatViewModel(daemonClient: mockClient)
 
         // Step 1: User sends first message (triggers bootstrap)
@@ -243,7 +243,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertFalse(vm.messages[1].isStreaming)
     }
 
-    func testMultipleMessagesInSameSession() {
+    func testMultipleMessagesInSameConversation() {
         let vm = ChatViewModel(daemonClient: mockClient)
         vm.conversationId = "existing-sess"
 
@@ -272,7 +272,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(vm.messages[3].text, "Second answer")
     }
 
-    // MARK: - Separate Sessions (Conversation Isolation)
+    // MARK: - Separate Conversations (Isolation)
 
     func testSeparateViewModelsHaveIndependentState() {
         let vm1 = ChatViewModel(daemonClient: mockClient)
@@ -314,7 +314,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
 
     // MARK: - Error Recovery in Conversation
 
-    func testErrorDuringSessionDoesNotDestroyMessages() {
+    func testErrorDuringConversationDoesNotDestroyMessages() {
         let vm = ChatViewModel(daemonClient: mockClient)
         vm.conversationId = "sess-error"
 
@@ -382,7 +382,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(cachedConversation.lastSeenAssistantMessageAt?.timeIntervalSince1970, 4.0)
     }
 
-    func testConnectedConversationMergeAppliesMetadataWhenMatchedViaViewModelSessionId() {
+    func testConnectedConversationMergeAppliesMetadataWhenMatchedViaViewModelConversationId() {
         let daemonClient = DaemonClient()
         let store = IOSConversationStore(daemonClient: daemonClient)
 
@@ -866,7 +866,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(updatesBySessionId["connected-session-unpinned"]?.isPinned, true)
     }
 
-    func testPinningConnectedConversationSurvivesStaleSessionRefresh() {
+    func testPinningConnectedConversationSurvivesStaleConversationListRefresh() {
         let daemonClient = DaemonClient()
         let store = IOSConversationStore(daemonClient: daemonClient)
         let response = makeConversationListResponse(conversations: [

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -26,9 +26,9 @@ private struct DeveloperSettingsSectionContent: View {
     @ObservedObject var traceStore: TraceStore
     @State private var showDebugPanel = false
     @State private var showUsageDashboard = false
-    // Captured once when the sheet opens so the panel stays on the same session
+    // Captured once when the sheet opens so the panel stays on the same conversation
     // even if newer trace events arrive while the sheet is visible.
-    @State private var selectedSessionId: String?
+    @State private var selectedConversationId: String?
     // Preserved across sheet presentations to avoid redundant network calls
     // and loading spinners each time the usage dashboard is opened.
     // Updated via .onChange(of: clientGeneration) when rebuildClient() fires.
@@ -40,7 +40,7 @@ private struct DeveloperSettingsSectionContent: View {
         _usageDashboardStore = State(initialValue: UsageDashboardStore())
     }
 
-    private var sessionCount: Int {
+    private var conversationCount: Int {
         traceStore.eventsByConversation.count
     }
 
@@ -51,7 +51,7 @@ private struct DeveloperSettingsSectionContent: View {
     var body: some View {
         Form {
             Section("Trace Store") {
-                LabeledContent("Sessions with events", value: "\(sessionCount)")
+                LabeledContent("Sessions with events", value: "\(conversationCount)")
                 LabeledContent("Total events", value: "\(totalEventCount)")
 
                 Button("Clear All Trace Events", role: .destructive) {
@@ -62,9 +62,9 @@ private struct DeveloperSettingsSectionContent: View {
 
             Section("Debug Panel") {
                 Button {
-                    // Snapshot the most recent session at open time so the panel
-                    // doesn't jump to a different session if newer events arrive.
-                    selectedSessionId = traceStore.mostRecentSessionId
+                    // Snapshot the most recent conversation at open time so the panel
+                    // doesn't jump to a different conversation if newer events arrive.
+                    selectedConversationId = traceStore.mostRecentSessionId
                     showDebugPanel = true
                 } label: {
                     Label { Text("Open Debug Panel") } icon: { VIconView(.bug, size: 14) }
@@ -88,7 +88,7 @@ private struct DeveloperSettingsSectionContent: View {
         .sheet(isPresented: $showDebugPanel) {
             DebugPanelView(
                 traceStore: traceStore,
-                conversationId: selectedSessionId,
+                conversationId: selectedConversationId,
                 onClose: { showDebugPanel = false }
             )
         }


### PR DESCRIPTION
## Summary
- Renamed 7 `testThreadMarkdown*` test methods and test data strings in ChatTranscriptFormatterIOSTests
- Renamed 4 `testSession*` test methods in ChatViewModelIOSTests
- Renamed 6 `testSession*` test methods in ConversationLifecycleIOSTests
- Renamed `selectedSessionId`/`sessionCount` properties in DeveloperSettingsSection

Part of plan: conv-symbol-sweep.md (PR 6 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
