### PR TITLE
refactor: rename thread→conversation symbols and comments in shared Swift code

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VConversationIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VConversationIcon.swift
@@ -67,7 +67,7 @@ public struct VConversationIcon: View {
     // MARK: - Color Palette
 
     /// Conversation icon background colors from the design token palette.
-    private static let backgrounds: [Color] = VColor.threadIconBackgrounds
+    private static let backgrounds: [Color] = VColor.conversationIconBackgrounds
 
     // MARK: - Hash
 

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -145,19 +145,19 @@ struct NavigationGallerySection: View {
                 HStack(spacing: VSpacing.lg) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Default").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                        VTab(label: "Thread 1", style: .flat, onSelect: {})
+                        VTab(label: "Conversation 1", style: .flat, onSelect: {})
                     }
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Selected").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                        VTab(label: "Thread 1", isSelected: true, style: .flat, onSelect: {})
+                        VTab(label: "Conversation 1", isSelected: true, style: .flat, onSelect: {})
                     }
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Closeable").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                        VTab(label: "Thread 2", style: .flat, onSelect: {}, onClose: {})
+                        VTab(label: "Conversation 2", style: .flat, onSelect: {}, onClose: {})
                     }
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Selected + Closeable").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                        VTab(label: "Thread 2", isSelected: true, style: .flat, onSelect: {}, onClose: {})
+                        VTab(label: "Conversation 2", isSelected: true, style: .flat, onSelect: {}, onClose: {})
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -353,8 +353,8 @@ public enum VColor {
     public static let funTeal   = Color(hex: 0x0E9B8B)
     public static let funGreen  = Color(hex: 0x4C9B50)
 
-    /// Deterministic thread icon background palette — semantic compositions of existing tokens.
-    public static let threadIconBackgrounds: [Color] = [
+    /// Deterministic conversation icon background palette — semantic compositions of existing tokens.
+    public static let conversationIconBackgrounds: [Color] = [
         primaryBase, primaryHover, primaryActive,
         systemPositiveStrong, systemNegativeStrong, systemMidStrong,
         contentSecondary, contentTertiary,

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -99,7 +99,7 @@ public enum VFont {
     public static let sectionDescription = Font.custom("Inter", size: 13)
     public static let inputLabel         = Font.custom("Inter-Medium", size: 12)
 
-    /// Small label (used for thread tab names)
+    /// Small label (used for conversation tab names)
     public static let tabLabel   = Font.custom("Inter", size: 11)
 
     // MARK: - Pixel (Silkscreen — use sparingly, e.g. buttons)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -808,7 +808,7 @@ public struct ToolCallData: Identifiable, Equatable {
     public var completedAt: Date?
     /// The tool_use block ID from the daemon, for correlating confirmations to tool calls.
     public var toolUseId: String?
-    /// Persisted confirmation decision for this tool call (survives app restart / thread switch).
+    /// Persisted confirmation decision for this tool call (survives app restart / conversation switch).
     public var confirmationDecision: ToolConfirmationState?
     /// Friendly label for the confirmation (e.g. "Edit File", "Run Command").
     public var confirmationLabel: String?

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -644,13 +644,13 @@ public final class ChatViewModel: ObservableObject {
         guard hasMoreHistory, let cursor = historyCursor, let conversationId else { return false }
         isLoadingMoreMessages = true
         // Safety timeout: log a warning if the daemon is slow, but do NOT
-        // clear isLoadingMoreMessages here. Callers (ThreadConversationRestorer,
+        // clear isLoadingMoreMessages here. Callers (ConversationRestorer,
         // IOSConversationStore) use `vm.isLoadingMoreMessages` to decide whether
         // a history response is a pagination load. If the timeout clears the
         // flag before the response arrives, the late-but-valid response is
         // misclassified as an initial load and replaces all messages instead
         // of prepending. The flag is properly cleared by populateFromHistory
-        // when the response arrives, or by reconnect/thread-switch logic if
+        // when the response arrives, or by reconnect/conversation-switch logic if
         // the daemon disconnects.
         loadMoreTimeoutTask?.cancel()
         loadMoreTimeoutTask = Task { @MainActor [weak self] in
@@ -663,7 +663,7 @@ public final class ChatViewModel: ObservableObject {
         return true
     }
 
-    /// Reset pagination when the thread switches or history is reloaded.
+    /// Reset pagination when the conversation switches or history is reloaded.
     public func resetMessagePagination() {
         displayedMessageCount = Self.messagePageSize
         historyCursor = nil
@@ -690,7 +690,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Persist a captured preview image into the ChatMessage model so it survives thread switches.
+    /// Persist a captured preview image into the ChatMessage model so it survives conversation switches.
     public func updateSurfacePreviewImage(appId: String, base64: String) {
         for msgIdx in messages.indices {
             for surfIdx in messages[msgIdx].inlineSurfaces.indices {
@@ -805,7 +805,7 @@ public final class ChatViewModel: ObservableObject {
         }
         displayedMessageCount = Self.messagePageSize
         // Only mark history as unloaded if there's a session to reload from.
-        // Threads without a session (new, empty) have nothing to fetch —
+        // Conversations without a session (new, empty) have nothing to fetch —
         // resetting the flag would leave the UI stuck on a loading spinner.
         if conversationId != nil {
             isHistoryLoaded = false
@@ -979,7 +979,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         // Listen for captured app preview images and persist them into the
-        // ChatMessage model so they survive thread switches and history reloads.
+        // ChatMessage model so they survive conversation switches and history reloads.
         appPreviewCapturedObserver = NotificationCenter.default.addObserver(
             forName: Notification.Name("MainWindow.appPreviewImageCaptured"),
             object: nil,
@@ -1021,7 +1021,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// Check for a buffered deep-link message and apply it to `inputText`.
     /// Called by the view layer when this `ChatViewModel` becomes the
-    /// active/visible thread, ensuring only one VM ever consumes the message.
+    /// active/visible conversation, ensuring only one VM ever consumes the message.
     public func consumeDeepLinkIfNeeded() {
         guard let message = DeepLinkManager.pendingMessage else { return }
         DeepLinkManager.pendingMessage = nil
@@ -1062,7 +1062,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         // Fire auto-title callback on the first user message (skip slash commands
-        // like /model so the thread title isn't set to a command string)
+        // like /model so the conversation title isn't set to a command string)
         if !rawText.isEmpty, !rawText.hasPrefix("/"), let callback = onFirstUserMessage {
             onFirstUserMessage = nil
             callback(rawText)
@@ -1072,7 +1072,7 @@ public final class ChatViewModel: ObservableObject {
         onUserMessageSent?()
 
         // Block rapid-fire only when bootstrapping with a queued message.
-        // When a message-less bootstrap is in flight (e.g. private thread
+        // When a message-less bootstrap is in flight (e.g. private conversation
         // pre-allocation), adopt the user's message as the pending message
         // so it gets sent when conversation_info arrives instead of being dropped.
         if (isSending || isBootstrapping) && conversationId == nil {
@@ -1263,7 +1263,7 @@ public final class ChatViewModel: ObservableObject {
 
     private func bootstrapConversation(userMessage: String?, attachments: [UserMessageAttachment]?) {
         // Only set sending/thinking indicators when there's an actual user
-        // message; message-less session creates (e.g. private thread
+        // message; message-less session creates (e.g. private conversation
         // pre-allocation) are silent and shouldn't affect UI state.
         if userMessage != nil {
             isSending = true
@@ -1304,7 +1304,7 @@ public final class ChatViewModel: ObservableObject {
             // Subscribe to daemon stream
             self.startMessageLoop()
 
-            // Send conversation_create with correlation ID and thread type
+            // Send conversation_create with correlation ID and conversation type
             do {
                 try daemonClient.send(ConversationCreateMessage(title: nil, correlationId: correlationId, conversationType: self.conversationType, preactivatedSkillIds: self.preactivatedSkillIds))
                 // Clear one-shot preactivated skills so they don't leak into a
@@ -1542,8 +1542,8 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Create a daemon session immediately, without a user message.
-    /// Used by private threads that need a persistent session ID right away
-    /// (e.g. to store the thread in the database before the user types anything).
+    /// Used by private conversations that need a persistent session ID right away
+    /// (e.g. to store the conversation in the database before the user types anything).
     /// No-op if a session already exists or a bootstrap is already in flight.
     public func createConversationIfNeeded(conversationType: String? = nil) {
         guard conversationId == nil, !isBootstrapping else { return }
@@ -1640,7 +1640,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Cancel the queued user message without clearing `bootstrapCorrelationId`.
-    /// Used when archiving a thread before conversation_info arrives: we want to
+    /// Used when archiving a conversation before conversation_info arrives: we want to
     /// discard the pending message (so it isn't sent once the session is claimed)
     /// but preserve the correlation ID so the VM only claims its own session.
     public func cancelPendingMessage() {
@@ -2749,7 +2749,7 @@ public final class ChatViewModel: ObservableObject {
         // Surfaces are now included directly in the history response and populated above
         // Strip heavy data from old messages after a (potentially large) history load.
         trimOldMessagesIfNeeded()
-        // Fetch pending guardian prompts when history loads (thread open/restore)
+        // Fetch pending guardian prompts when history loads (conversation open/restore)
         refreshGuardianPrompts()
     }
 

--- a/clients/shared/Features/Chat/DeepLinkManager.swift
+++ b/clients/shared/Features/Chat/DeepLinkManager.swift
@@ -1,6 +1,6 @@
 /// Buffers a deep-link / Siri Shortcut message so it survives cold launch
 /// (where no `ChatViewModel` may exist yet) and is consumed only by the
-/// active thread's view model.
+/// active conversation's view model.
 public enum DeepLinkManager {
     /// The pending message text. Set by `SendMessageIntent` or the URL handler;
     /// consumed (and cleared) by the active `ChatViewModel` via

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -72,26 +72,26 @@ public struct SubagentConversationView: View {
     }
 
     public var body: some View {
-        threadContent(phase: 0)
+        conversationContent(phase: 0)
     }
 
     @ViewBuilder
-    private func threadContent(phase: Int) -> some View {
+    private func conversationContent(phase: Int) -> some View {
         HStack(alignment: .center, spacing: 0) {
-            // L-shaped connector: vertical line from parent → curves right into the thread bar
+            // L-shaped connector: vertical line from parent → curves right into the conversation bar
             LConnector()
                 .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .frame(width: 14, height: 28)
                 .padding(.trailing, VSpacing.xs)
 
-            // Thread indicator content
-            threadBar(phase: phase)
+            // Conversation indicator content
+            conversationBar(phase: phase)
         }
     }
 
-    // MARK: - Thread Bar
+    // MARK: - Conversation Bar
 
-    private func threadBar(phase: Int) -> some View {
+    private func conversationBar(phase: Int) -> some View {
         HStack(spacing: VSpacing.sm) {
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
@@ -132,7 +132,7 @@ public struct SubagentConversationView: View {
                     .accessibilityLabel("Abort subagent")
             }
 
-            // View thread arrow
+            // View conversation arrow
             VIconView(.chevronRight, size: 9)
                 .foregroundColor(isHovered ? VColor.primaryBase : VColor.contentTertiary)
         }
@@ -251,7 +251,7 @@ public struct SubagentEventsReader: View {
 // MARK: - L-Shaped Connector
 
 /// Draws a smooth L-shaped path: vertical line down from top-left, then curves
-/// right toward the thread bar. Uses a quarter-circle arc for a polished look.
+/// right toward the conversation bar. Uses a quarter-circle arc for a polished look.
 private struct LConnector: Shape {
     func path(in rect: CGRect) -> Path {
         let radius: CGFloat = 6

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// In-memory store for real-time execution trace events, keyed by session.
+/// In-memory store for real-time execution trace events, keyed by conversation.
 ///
-/// Events are grouped by `requestId` within each session, deduplicated by `eventId`,
+/// Events are grouped by `requestId` within each conversation, deduplicated by `eventId`,
 /// and ordered by `sequence` (with `timestampMs` and insertion order as tiebreakers).
 @MainActor
 public final class TraceStore: ObservableObject {
@@ -42,16 +42,16 @@ public final class TraceStore: ObservableObject {
 
     // MARK: - State
 
-    /// All events per session, in stable order.
+    /// All events per conversation, in stable order.
     /// Not @Published — updates are coalesced via `schedulePublish()` to avoid
     /// firing objectWillChange on every individual trace event during bursts.
     public private(set) var eventsByConversation: [String: [StoredEvent]] = [:]
 
-    /// The ID of the most recently ingested event per session. Unlike `eventsByConversation[sid]?.count`,
+    /// The ID of the most recently ingested event per conversation. Unlike `eventsByConversation[sid]?.count`,
     /// this always changes on ingestion even when the retention cap holds count constant.
     public private(set) var latestEventIdBySession: [String: String] = [:]
 
-    /// Set of seen eventIds per session for dedup.
+    /// Set of seen eventIds per conversation for dedup.
     private var seenIds: [String: Set<String>] = [:]
 
     /// Monotonic counter for insertion ordering tiebreaks.
@@ -71,7 +71,7 @@ public final class TraceStore: ObservableObject {
         }
     }
 
-    /// Maximum events retained per session.
+    /// Maximum events retained per conversation.
     public static let retentionCap = 5000
 
     // MARK: - Ingestion
@@ -121,7 +121,7 @@ public final class TraceStore: ObservableObject {
 
     // MARK: - Queries
 
-    /// Events for a session grouped by requestId. Events with nil requestId go under an empty-string key.
+    /// Events for a conversation grouped by requestId. Events with nil requestId go under an empty-string key.
     public func eventsByRequest(conversationId: String) -> [String: [StoredEvent]] {
         guard let events = eventsByConversation[conversationId] else { return [:] }
         return Dictionary(grouping: events) { $0.requestId ?? "" }
@@ -174,7 +174,7 @@ public final class TraceStore: ObservableObject {
 
     // MARK: - Derived Metrics (Cached)
 
-    /// Snapshot of aggregate metrics for a session, recomputed only when the
+    /// Snapshot of aggregate metrics for a conversation, recomputed only when the
     /// generation counter advances (i.e. new events were ingested).
     public struct ConversationMetrics {
         public let requestCount: Int
@@ -191,13 +191,13 @@ public final class TraceStore: ObservableObject {
         )
     }
 
-    /// Generation counter per session, incremented on each ingestion.
+    /// Generation counter per conversation, incremented on each ingestion.
     private var generationBySession: [String: Int] = [:]
 
-    /// Cached metrics per session, keyed by the generation at which they were computed.
+    /// Cached metrics per conversation, keyed by the generation at which they were computed.
     private var metricsCache: [String: (generation: Int, metrics: ConversationMetrics)] = [:]
 
-    /// Returns cached aggregate metrics for a session, recomputing only when
+    /// Returns cached aggregate metrics for a conversation, recomputing only when
     /// the generation counter has advanced since the last call.
     public func metrics(conversationId: String) -> ConversationMetrics {
         let currentGen = generationBySession[conversationId] ?? 0
@@ -248,12 +248,12 @@ public final class TraceStore: ObservableObject {
         )
     }
 
-    /// Number of unique requestIds in a session.
+    /// Number of unique requestIds in a conversation.
     public func requestCount(conversationId: String) -> Int {
         metrics(conversationId: conversationId).requestCount
     }
 
-    /// Count of `llm_call_finished` events in a session.
+    /// Count of `llm_call_finished` events in a conversation.
     public func llmCallCount(conversationId: String) -> Int {
         metrics(conversationId: conversationId).llmCallCount
     }
@@ -273,19 +273,19 @@ public final class TraceStore: ObservableObject {
         metrics(conversationId: conversationId).averageLlmLatencyMs
     }
 
-    /// Count of `tool_failed` events in a session.
+    /// Count of `tool_failed` events in a conversation.
     public func toolFailureCount(conversationId: String) -> Int {
         metrics(conversationId: conversationId).toolFailureCount
     }
 
-    // MARK: - Session Selection
+    // MARK: - Conversation Selection
 
-    /// Returns the session ID whose last event has the highest `timestampMs`,
-    /// i.e. the most recently active session. Returns `nil` if no events exist.
+    /// Returns the conversation ID whose last event has the highest `timestampMs`,
+    /// i.e. the most recently active conversation. Returns `nil` if no events exist.
     ///
-    /// Used by developer tooling to auto-select a relevant session when no
+    /// Used by developer tooling to auto-select a relevant conversation when no
     /// explicit selection context is available (e.g. when opening the debug panel
-    /// from the Settings screen rather than from an active chat thread).
+    /// from the Settings screen rather than from an active conversation).
     public var mostRecentSessionId: String? {
         eventsByConversation
             .compactMapValues { $0.last?.timestampMs }
@@ -295,7 +295,7 @@ public final class TraceStore: ObservableObject {
 
     // MARK: - Reset
 
-    /// Remove all events for a given session.
+    /// Remove all events for a given conversation.
     public func resetConversation(conversationId: String) {
         eventsByConversation.removeValue(forKey: conversationId)
         latestEventIdBySession.removeValue(forKey: conversationId)
@@ -305,7 +305,7 @@ public final class TraceStore: ObservableObject {
         schedulePublish()
     }
 
-    /// Remove all events for all sessions.
+    /// Remove all events for all conversations.
     public func resetAll() {
         eventsByConversation.removeAll()
         latestEventIdBySession.removeAll()

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -520,10 +520,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
-    /// Called when a task run creates a conversation so the client can show it as a visible chat thread.
+    /// Called when a task run creates a conversation so the client can show it as a visible chat conversation.
     public var onTaskRunConversationCreated: ((TaskRunConversationCreated) -> Void)?
 
-    /// Called when a schedule creates a conversation so the client can show it as a visible chat thread.
+    /// Called when a schedule creates a conversation so the client can show it as a visible chat conversation.
     public var onScheduleConversationCreated: ((ScheduleConversationCreated) -> Void)?
 
     /// Called when the daemon requests pairing approval from macOS.


### PR DESCRIPTION
## Summary
- Renamed `threadIconBackgrounds` → `conversationIconBackgrounds`, `threadContent`/`threadBar` → `conversationContent`/`conversationBar`
- Updated ~20 stale comments across TraceStore, DaemonClient, ChatViewModel, ChatMessage, DeepLinkManager from thread/session → conversation
- Updated gallery demo labels from 'Thread N' to 'Conversation N'

Part of plan: conv-symbol-sweep.md (PR 5 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
