### PR TITLE
refactor: rename Thread→Conversation in macOS struct/type names

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -407,7 +407,7 @@ extension AppDelegate {
                 .filter { !$0.isArchived }
                 .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                 .prefix(3)
-                .map { QuickInputThread(id: $0.id, title: $0.title) }
+                .map { QuickInputConversation(id: $0.id, title: $0.title) }
         }
         window.showScreenPermissionPrompt = shouldShowPermissionPrompt
         if aboveDock {
@@ -455,7 +455,7 @@ extension AppDelegate {
                     .filter { !$0.isArchived }
                     .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
                     .prefix(3)
-                    .map { QuickInputThread(id: $0.id, title: $0.title) }
+                    .map { QuickInputConversation(id: $0.id, title: $0.title) }
             }
             window.setAttachment(imageData: imageData)
             window.showNearRect(selectionRect)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -790,7 +790,7 @@ struct MessageListView: View {
                         hasReceivedScrollEvent = true
                     }
                 )
-                ThreadScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
+                ConversationScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
             }
             .onPreferenceChange(ScrollViewportHeightKey.self) { height in
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
@@ -1427,7 +1427,7 @@ private struct MessageCellView: View, Equatable {
     }
 }
 
-private struct ThreadScrollbarVisibilityController: NSViewRepresentable, Equatable {
+private struct ConversationScrollbarVisibilityController: NSViewRepresentable, Equatable {
     let shouldShow: Bool
 
     func makeCoordinator() -> Coordinator {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -17,7 +17,7 @@ struct DaemonLoadingChatSkeleton: View {
 
 /// Skeleton thread rows shown in the sidebar while conversations are loading.
 /// Mimics 5 thread rows matching the height of nav items like "Things".
-struct DaemonLoadingThreadsSkeleton: View {
+struct DaemonLoadingConversationsSkeleton: View {
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
             ForEach(0..<5, id: \.self) { _ in

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -202,7 +202,7 @@ extension MainWindowView {
             sidebarSectionDivider(isExpanded: true)
 
             // MARK: Threads (scrollable)
-            SidebarThreadsHeader(
+            SidebarConversationsHeader(
                 hasUnseenThreads: conversationManager.unseenVisibleConversationCount > 0,
                 isLoading: showDaemonLoading,
                 onMarkAllSeen: {
@@ -230,12 +230,12 @@ extension MainWindowView {
             ScrollView {
                 VStack(spacing: 0) {
                     if showDaemonLoading && displayedConversations.isEmpty {
-                        DaemonLoadingThreadsSkeleton()
+                        DaemonLoadingConversationsSkeleton()
                     }
 
                     ForEach(displayedConversations) { thread in
-                        SidebarThreadItem(
-                            thread: thread,
+                        SidebarConversationItem(
+                            conversation: thread,
                             conversationManager: conversationManager,
                             windowState: windowState,
                             sidebar: sidebar,
@@ -304,8 +304,8 @@ extension MainWindowView {
                         ForEach(displayedScheduleGroups, id: \.key) { group in
                             if group.conversations.count == 1, let thread = group.conversations.first {
                                 // Single-thread group: render inline without a disclosure wrapper
-                                SidebarThreadItem(
-                                    thread: thread,
+                                SidebarConversationItem(
+                                    conversation: thread,
                                     conversationManager: conversationManager,
                                     windowState: windowState,
                                     sidebar: sidebar,
@@ -384,8 +384,8 @@ extension MainWindowView {
                                 // Expanded child rows
                                 if isGroupExpanded {
                                     ForEach(group.conversations) { thread in
-                                        SidebarThreadItem(
-                                            thread: thread,
+                                        SidebarConversationItem(
+                                            conversation: thread,
                                             conversationManager: conversationManager,
                                             windowState: windowState,
                                             sidebar: sidebar,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -569,7 +569,7 @@ struct MainWindowView: View {
                 }
                 .overlay(alignment: .topLeading) {
                     if showConversationSwitcher {
-                        ThreadSwitcherDrawer(
+                        ConversationSwitcherDrawer(
                             regularConversations: regularConversations,
                             activeConversationId: conversationManager.activeConversationId,
                             conversationManager: conversationManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1055,7 +1055,7 @@ private struct PublishedButton: View {
 // MARK: - Share Drawer
 
 /// Popover menu with "Share" and "Publish to Vercel" options.
-/// Styled to match ThreadSwitcherDrawer / DrawerMenuView.
+/// Styled to match ConversationSwitcherDrawer / DrawerMenuView.
 private struct ShareDrawer: View {
     let onShare: () -> Void
     let onPublish: () -> Void

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -317,7 +317,7 @@ struct SettingsPanel: View {
         case .billing:
             SettingsBillingTab(authManager: authManager)
         case .archivedConversations:
-            SettingsArchivedThreadsTab(conversationManager: conversationManager)
+            SettingsArchivedConversationsTab(conversationManager: conversationManager)
         case .developer:
             SettingsDeveloperTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-struct ThreadSwitcherDrawer: View {
+struct ConversationSwitcherDrawer: View {
     let regularConversations: [ConversationModel]
     let activeConversationId: UUID?
     @ObservedObject var conversationManager: ConversationManager
@@ -24,8 +24,8 @@ struct ThreadSwitcherDrawer: View {
                 .padding(.horizontal, VSpacing.xs)
 
             ForEach(regularConversations) { thread in
-                SidebarThreadItem(
-                    thread: thread,
+                SidebarConversationItem(
+                    conversation: thread,
                     conversationManager: conversationManager,
                     windowState: windowState,
                     sidebar: sidebar,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// A single thread row in the sidebar, handling hover, pin, archive, rename,
+/// A single conversation row in the sidebar, handling hover, pin, archive, rename,
 /// and drag interactions.
-struct SidebarThreadItem: View {
-    let thread: ConversationModel
+struct SidebarConversationItem: View {
+    let conversation: ConversationModel
     @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var windowState: MainWindowState
     var sidebar: SidebarInteractionState
-    /// Called when the user taps the thread row (handles selection logic).
+    /// Called when the user taps the conversation row (handles selection logic).
     var selectConversation: () -> Void
     /// Optional additional callback after selection (e.g. dismiss a popover).
     var onSelect: (() -> Void)? = nil
@@ -18,24 +18,24 @@ struct SidebarThreadItem: View {
         case .panel:
             return false
         case .conversation(let id):
-            return id == thread.id
+            return id == conversation.id
         case .appEditing(_, let conversationId):
-            return conversationId == thread.id
+            return conversationId == conversation.id
         case .app, .none:
             // No explicit conversation in selection; fall back to the persistent conversation.
-            return thread.id == windowState.persistentConversationId
+            return conversation.id == windowState.persistentConversationId
         }
     }
 
-    private var isHovered: Bool { sidebar.isHoveredConversation == thread.id }
-    private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: thread.id) }
+    private var isHovered: Bool { sidebar.isHoveredConversation == conversation.id }
+    private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: conversation.id) }
     // Reserve trailing space when hovered for archive button overlay.
-    private var hasTrailingIcon: Bool { isHovered || sidebar.conversationPendingDeletion == thread.id }
-    private var isPendingDeletion: Bool { sidebar.conversationPendingDeletion == thread.id }
+    private var hasTrailingIcon: Bool { isHovered || sidebar.conversationPendingDeletion == conversation.id }
+    private var isPendingDeletion: Bool { sidebar.conversationPendingDeletion == conversation.id }
     private var canMarkUnread: Bool {
-        !thread.hasUnseenLatestAssistantMessage &&
-            thread.conversationId != nil &&
-            thread.latestAssistantMessageAt != nil
+        !conversation.hasUnseenLatestAssistantMessage &&
+            conversation.conversationId != nil &&
+            conversation.latestAssistantMessageAt != nil
     }
 
     var body: some View {
@@ -49,22 +49,22 @@ struct SidebarThreadItem: View {
                 if isHovered {
                     Button {
                         withAnimation(VAnimation.standard) {
-                            if thread.isPinned {
-                                conversationManager.unpinThread(id: thread.id)
+                            if conversation.isPinned {
+                                conversationManager.unpinThread(id: conversation.id)
                             } else {
-                                conversationManager.pinThread(id: thread.id)
+                                conversationManager.pinThread(id: conversation.id)
                             }
                         }
                     } label: {
                         VIconView(.pin, size: 13)
-                            .foregroundColor(thread.isPinned ? VColor.contentTertiary : VColor.contentSecondary)
+                            .foregroundColor(conversation.isPinned ? VColor.contentTertiary : VColor.contentSecondary)
                             .rotationEffect(.degrees(-45))
                             .frame(width: 20, height: 20)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .transition(.opacity)
-                    .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
+                    .accessibilityLabel(conversation.isPinned ? "Unpin \(conversation.title)" : "Pin \(conversation.title)")
                 } else {
                     switch interactionState {
                     case .processing:
@@ -80,12 +80,12 @@ struct SidebarThreadItem: View {
                             .frame(width: 20, height: 20)
                             .transition(.opacity)
                     case .idle:
-                        if thread.hasUnseenLatestAssistantMessage {
+                        if conversation.hasUnseenLatestAssistantMessage {
                             VBadge(style: .dot, color: VColor.systemNegativeHover)
                                 .accessibilityLabel("Unread")
                                 .frame(width: 20, height: 20)
                                 .transition(.opacity)
-                        } else if thread.isPinned {
+                        } else if conversation.isPinned {
                             VIconView(.pin, size: 13)
                                 .foregroundColor(VColor.contentTertiary)
                                 .rotationEffect(.degrees(-45))
@@ -97,16 +97,16 @@ struct SidebarThreadItem: View {
                         }
                     }
                 }
-                if thread.kind == .private {
+                if conversation.kind == .private {
                     VIconView(.lock, size: 13)
                         .foregroundColor(VColor.primaryBase.opacity(0.7))
                 }
-                Text(thread.title)
+                Text(conversation.title)
                     .font(.system(size: 13))
                     .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .help(thread.title)
+                    .help(conversation.title)
 
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -119,7 +119,7 @@ struct SidebarThreadItem: View {
                     VColor.surfaceActive
                 } else if isHovered {
                     VColor.surfaceBase
-                } else if thread.kind == .private {
+                } else if conversation.kind == .private {
                     VColor.primaryBase.opacity(0.04)
                 } else {
                     VColor.surfaceBase.opacity(0)
@@ -134,22 +134,22 @@ struct SidebarThreadItem: View {
             onSelect?()
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel("Conversation: \(thread.title)")
+        .accessibilityLabel("Conversation: \(conversation.title)")
         .accessibilityAction(.default) {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if sidebar.conversationPendingDeletion == thread.id {
+            if sidebar.conversationPendingDeletion == conversation.id {
                 VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    conversationManager.archiveConversation(id: thread.id)
+                    conversationManager.archiveConversation(id: conversation.id)
                     sidebar.conversationPendingDeletion = nil
                 }
                 .fixedSize()
                 .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Confirm archive \(thread.title)")
+                .accessibilityLabel("Confirm archive \(conversation.title)")
             } else if isHovered {
                 Button {
-                    sidebar.conversationPendingDeletion = thread.id
+                    sidebar.conversationPendingDeletion = conversation.id
                 } label: {
                     VIconView(.archive, size: 13)
                         .foregroundColor(VColor.contentSecondary)
@@ -158,35 +158,35 @@ struct SidebarThreadItem: View {
                 }
                 .buttonStyle(.plain)
                 .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Archive \(thread.title)")
+                .accessibilityLabel("Archive \(conversation.title)")
             }
         }
         .padding(.horizontal, 0)
         .contextMenu {
             Button {
                 withAnimation(VAnimation.standard) {
-                    if thread.isPinned {
-                        conversationManager.unpinThread(id: thread.id)
+                    if conversation.isPinned {
+                        conversationManager.unpinThread(id: conversation.id)
                     } else {
-                        conversationManager.pinThread(id: thread.id)
+                        conversationManager.pinThread(id: conversation.id)
                     }
                 }
             } label: {
-                Label { Text(thread.isPinned ? "Unpin thread" : "Pin thread") } icon: { VIconView(thread.isPinned ? .pinOff : .pin, size: 14) }
+                Label { Text(conversation.isPinned ? "Unpin thread" : "Pin thread") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
-                sidebar.renamingConversationId = thread.id
-                sidebar.renameText = thread.title
+                sidebar.renamingConversationId = conversation.id
+                sidebar.renameText = conversation.title
             } label: {
                 Label { Text("Rename thread") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
-                conversationManager.archiveConversation(id: thread.id)
+                conversationManager.archiveConversation(id: conversation.id)
             } label: {
                 Label { Text("Archive thread") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
-                conversationManager.markConversationUnread(conversationId: thread.id)
+                conversationManager.markConversationUnread(conversationId: conversation.id)
             } label: {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
@@ -195,25 +195,25 @@ struct SidebarThreadItem: View {
             Divider()
 
             Button {
-                guard let conversationId = thread.conversationId else { return }
-                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: thread.title))
+                guard let conversationId = conversation.conversationId else { return }
+                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
             } label: {
                 Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
             }
-            .disabled(thread.conversationId == nil || LogExporter.isManagedAssistant)
+            .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
         }
         .pointerCursor()
         .onHover { hovering in
             withAnimation(VAnimation.fast) {
-                sidebar.setConversationHover(conversationId: thread.id, hovering: hovering)
+                sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
             }
         }
         .onDrag {
-            sidebar.draggingConversationId = thread.id
-            return NSItemProvider(object: thread.id.uuidString as NSString)
+            sidebar.draggingConversationId = conversation.id
+            return NSItemProvider(object: conversation.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {
-                if thread.isPinned {
+                if conversation.isPinned {
                     VIconView(.pin, size: 13)
                         .foregroundColor(VColor.contentTertiary)
                         .rotationEffect(.degrees(-45))
@@ -221,7 +221,7 @@ struct SidebarThreadItem: View {
                 } else {
                     Color.clear.frame(width: 20, height: 20)
                 }
-                Text(thread.title)
+                Text(conversation.title)
                     .font(.system(size: 13))
                     .foregroundColor(VColor.contentDefault)
                     .lineLimit(1)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-struct SidebarThreadsHeader: View {
+struct SidebarConversationsHeader: View {
     let hasUnseenThreads: Bool
     var isLoading: Bool = false
     let onMarkAllSeen: () -> Void

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Lightweight model for recent conversations shown in the quick input dropdown.
-struct QuickInputThread: Identifiable {
+struct QuickInputConversation: Identifiable {
     let id: UUID
     let title: String
 }
@@ -17,7 +17,7 @@ struct QuickInputView: View {
     let onAllowScreenRecording: (() -> Void)?
     let onMicrophoneToggle: (() -> Void)?
     let onNotificationToggle: (() -> Void)?
-    let recentConversations: [QuickInputThread]
+    let recentConversations: [QuickInputConversation]
     let attachedImage: NSImage?
     let showScreenPermissionPrompt: Bool
 
@@ -36,7 +36,7 @@ struct QuickInputView: View {
         onAllowScreenRecording: (() -> Void)? = nil,
         onMicrophoneToggle: (() -> Void)? = nil,
         onNotificationToggle: (() -> Void)? = nil,
-        recentConversations: [QuickInputThread] = [],
+        recentConversations: [QuickInputConversation] = [],
         attachedImage: NSImage? = nil,
         showScreenPermissionPrompt: Bool = false
     ) {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -50,7 +50,7 @@ final class QuickInputWindow {
     /// Callback invoked when the user selects an existing conversation (navigates to it).
     var onSelectConversation: ((UUID) -> Void)?
     /// Recent conversations to show in the dropdown.
-    var recentConversations: [QuickInputThread] = []
+    var recentConversations: [QuickInputConversation] = []
     /// When true, show a screen recording permission prompt below the bar.
     var showScreenPermissionPrompt = false
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-struct SettingsArchivedThreadsTab: View {
+struct SettingsArchivedConversationsTab: View {
     @ObservedObject var conversationManager: ConversationManager
 
     var body: some View {
@@ -18,7 +18,7 @@ struct SettingsArchivedThreadsTab: View {
                         if index > 0 {
                             SettingsDivider()
                         }
-                        ArchivedThreadRow(thread: thread) {
+                        ArchivedConversationRow(conversation: thread) {
                             conversationManager.unarchiveConversation(id: thread.id)
                         }
                     }
@@ -34,8 +34,8 @@ struct SettingsArchivedThreadsTab: View {
 
 // MARK: - Archived Conversation Row
 
-private struct ArchivedThreadRow: View {
-    let thread: ConversationModel
+private struct ArchivedConversationRow: View {
+    let conversation: ConversationModel
     let onUnarchive: () -> Void
 
     private static let dateFormatter: DateFormatter = {
@@ -47,13 +47,13 @@ private struct ArchivedThreadRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(thread.title)
+                Text(conversation.title)
                     .font(VFont.body)
                     .foregroundColor(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                Text("\(Self.dateFormatter.string(from: thread.createdAt)) · \(thread.source ?? "vellum-assistant")")
+                Text("\(Self.dateFormatter.string(from: conversation.createdAt)) · \(conversation.source ?? "vellum-assistant")")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
                     .lineLimit(1)


### PR DESCRIPTION
## Summary
- Renamed 8 struct/type names: ThreadSwitcherDrawer, SidebarThreadItem, SidebarThreadsHeader, DaemonLoadingThreadsSkeleton, QuickInputThread, SettingsArchivedThreadsTab, ArchivedThreadRow, ThreadScrollbarVisibilityController → Conversation equivalents
- Updated all call sites across the macOS codebase

Part of plan: conv-symbol-sweep.md (PR 3 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
