### PR TITLE
fix: stable conversation key, empty fallback, and caching for IdentityPanel intro (#16227)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -174,7 +174,7 @@ struct IdentityPanel: View {
                     }
                 }
 
-                if !isBootstrapActive {
+                if !isBootstrapActive && introText == nil {
                     generateIntro()
                 }
             }
@@ -186,10 +186,9 @@ struct IdentityPanel: View {
 
     private func generateIntro() {
         introTask?.cancel()
-        introText = nil
 
         introTask = Task {
-            let key = "identity-intro-\(UUID().uuidString)"
+            let key = "identity-intro"
             let prompt = "Generate a very short intro for yourself (2-5 words). This should feel natural to your personality — playful, formal, chill, whatever fits you. Some examples for inspiration (don't limit yourself to these): \"I'm [name]!\", \"It's [name]\", \"Hey, I'm [name]\", \"[name] here.\", \"[name], at your service.\" Output ONLY the intro text, nothing else."
             var result = ""
             do {
@@ -201,7 +200,8 @@ struct IdentityPanel: View {
                     guard !Task.isCancelled else { return }
                     result += delta
                 }
-                self.introText = result.isEmpty ? nil : result
+                let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.introText = trimmed.isEmpty ? "I'm \(assistantDisplayName)!" : trimmed
             } catch is CancellationError {
                 return
             } catch {


### PR DESCRIPTION
## Summary
- Use a stable conversation key (`"identity-intro"`) for intro generation instead of `UUID()` per panel appearance
- Fall back to default greeting (`"I'm {name}!"`) when daemon returns empty response
- Cache intro text to avoid redundant LLM calls on subsequent panel appearances

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
