### PR TITLE
fix: move Save button into file viewer status bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -54,10 +54,18 @@ struct ReadOnlyCodeContent: View {
 }
 
 /// Header bar showing file icon, name, and size for file content viewers.
-struct FileContentHeaderBar: View {
+struct FileContentHeaderBar<Trailing: View>: View {
     let icon: VIcon
     let fileName: String
     let fileSize: String
+    let trailing: Trailing
+
+    init(icon: VIcon, fileName: String, fileSize: String, @ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
+        self.icon = icon
+        self.fileName = fileName
+        self.fileSize = fileSize
+        self.trailing = trailing()
+    }
 
     var body: some View {
         HStack(spacing: VSpacing.sm) {
@@ -70,6 +78,7 @@ struct FileContentHeaderBar: View {
             Text(fileSize)
                 .font(VFont.small)
                 .foregroundColor(VColor.contentTertiary)
+            trailing
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -688,17 +688,39 @@ private struct WorkspaceFileViewer: View {
     @ViewBuilder
     private func fileContent(_ detail: WorkspaceFileResponse) -> some View {
         let mime = detail.mimeType.lowercased()
+        let isText = !detail.isBinary && detail.content != nil
+        let readOnly = isText && isHiddenPath(detail.path)
 
         VStack(spacing: 0) {
             FileContentHeaderBar(
                 icon: fileIcon(for: mime),
                 fileName: detail.name,
                 fileSize: formatFileSize(detail.size)
-            )
+            ) {
+                if isText && readOnly {
+                    Text("Read-only")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                } else if isText && state.isDirty {
+                    Button {
+                        Task { await saveFile(path: detail.path) }
+                    } label: {
+                        HStack(spacing: VSpacing.xs) {
+                            if state.isSaving {
+                                ProgressView().controlSize(.small)
+                            }
+                            Text("Save")
+                                .font(VFont.bodyMedium)
+                        }
+                    }
+                    .disabled(state.isSaving)
+                    .keyboardShortcut("s", modifiers: .command)
+                }
+            }
             Divider().background(VColor.borderBase)
 
-            if !detail.isBinary, detail.content != nil {
-                textViewer(detail)
+            if isText {
+                textViewer(detail, readOnly: readOnly)
             } else if mime.hasPrefix("image/") {
                 imageViewer(detail)
             } else if mime.hasPrefix("video/") {
@@ -719,53 +741,21 @@ private struct WorkspaceFileViewer: View {
         return .file
     }
 
-    private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
-        let readOnly = isHiddenPath(detail.path)
-        return VStack(spacing: 0) {
-            if readOnly {
-                HStack {
-                    Spacer()
-                    Text("Read-only")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                        .padding(.trailing, VSpacing.md)
-                        .padding(.vertical, VSpacing.xs)
+    @ViewBuilder
+    private func textViewer(_ detail: WorkspaceFileResponse, readOnly: Bool) -> some View {
+        if readOnly {
+            ReadOnlyCodeContent(content: detail.content ?? "")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            TextEditor(text: $state.editableContent)
+                .font(VFont.mono)
+                .foregroundColor(VColor.contentDefault)
+                .scrollContentBackground(.hidden)
+                .padding(VSpacing.md)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onChange(of: state.editableContent) { _, newValue in
+                    state.isDirty = newValue != state.originalContent
                 }
-            } else if state.isDirty {
-                HStack {
-                    Spacer()
-                    Button {
-                        Task { await saveFile(path: detail.path) }
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            if state.isSaving {
-                                ProgressView().controlSize(.small)
-                            }
-                            Text("Save")
-                                .font(VFont.bodyMedium)
-                        }
-                    }
-                    .disabled(state.isSaving)
-                    .keyboardShortcut("s", modifiers: .command)
-                    .padding(.trailing, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                }
-            }
-
-            if readOnly {
-                ReadOnlyCodeContent(content: detail.content ?? "")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                TextEditor(text: $state.editableContent)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentDefault)
-                    .scrollContentBackground(.hidden)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .onChange(of: state.editableContent) { _, newValue in
-                        state.isDirty = newValue != state.originalContent
-                    }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Added a generic trailing view parameter to `FileContentHeaderBar` so callers can inject extra controls into the status bar
- Moved the Save button and Read-only label from a separate row below the divider into the header bar, to the right of the file size
- Simplified `textViewer` to only render the content area (no longer responsible for the action bar)

## Original prompt
The Save button should appear on the right of the status bar with name and file size instead of below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
