### PR TITLE
fix: preserve block status and displayName during invite channel reassignment (#16228)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -253,7 +253,12 @@ export function upsertContact(params: {
     .run();
 
   if (params.channels) {
-    syncChannels(contactId, params.channels, now);
+    syncChannels(
+      contactId,
+      params.channels,
+      now,
+      params.reassignConflictingChannels,
+    );
   }
 
   emitContactChange();
@@ -330,6 +335,11 @@ function syncChannels(
 
     if (conflicting) {
       if (reassignConflicting) {
+        // Preserve guardian blocks: if the existing channel is blocked, do not
+        // overwrite its status/policy — a valid invite must not bypass an
+        // explicit guardian block on a different contact.
+        const isBlocked = conflicting.status === "blocked";
+
         // Reassign the channel to the target contact. Used by invite redemption
         // to bind a redeemer's existing channel identity to the invite's target.
         const reassignSet: Record<string, unknown> = {
@@ -340,16 +350,18 @@ function syncChannels(
           reassignSet.externalUserId = ch.externalUserId;
         if (ch.externalChatId !== undefined)
           reassignSet.externalChatId = ch.externalChatId;
-        if (ch.status !== undefined) reassignSet.status = ch.status;
-        if (ch.policy !== undefined) reassignSet.policy = ch.policy;
+        if (!isBlocked) {
+          if (ch.status !== undefined) reassignSet.status = ch.status;
+          if (ch.policy !== undefined) reassignSet.policy = ch.policy;
+          if (ch.revokedReason !== undefined)
+            reassignSet.revokedReason = ch.revokedReason;
+          if (ch.blockedReason !== undefined)
+            reassignSet.blockedReason = ch.blockedReason;
+        }
         if (ch.verifiedAt !== undefined) reassignSet.verifiedAt = ch.verifiedAt;
         if (ch.verifiedVia !== undefined)
           reassignSet.verifiedVia = ch.verifiedVia;
         if (ch.inviteId !== undefined) reassignSet.inviteId = ch.inviteId;
-        if (ch.revokedReason !== undefined)
-          reassignSet.revokedReason = ch.revokedReason;
-        if (ch.blockedReason !== undefined)
-          reassignSet.blockedReason = ch.blockedReason;
 
         db.update(contactChannels)
           .set(reassignSet)

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -15,6 +15,7 @@ import {
   findContactChannel,
   findGuardianForChannel,
   getChannelById,
+  getContact,
   getContactInternal,
   updateChannelInteraction,
   updateChannelLastSeenById,
@@ -166,7 +167,17 @@ export function upsertContactChannel(params: {
     return null;
   }
 
-  const displayName = params.displayName ?? params.externalUserId ?? "Unknown";
+  let displayName = params.displayName ?? params.externalUserId ?? "Unknown";
+
+  // When binding a channel to a specific contact (invite redemption), preserve
+  // the target contact's curated displayName (e.g. "Mom") instead of overwriting
+  // it with the redeemer's externalUserId.
+  if (params.contactId) {
+    const targetContact = getContact(params.contactId);
+    if (targetContact?.displayName?.trim().length) {
+      displayName = targetContact.displayName;
+    }
+  }
 
   const canonicalId = params.externalUserId
     ? (canonicalizeInboundIdentity(


### PR DESCRIPTION
## Summary
- Preserve blocked channel status when reassigning conflicting channels during invite redemption
- Preserve target contact's curated displayName instead of overwriting with redeemer's externalUserId
- Forward reassignConflictingChannels flag in new-contact creation path of upsertContact

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
