### PR TITLE
fix: skip daemon greeting when SOUL greeting present (#16233)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -124,7 +124,9 @@ struct ChatEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
-            onRequestGreeting?()
+            if soulGreeting == nil {
+                onRequestGreeting?()
+            }
             withAnimation(.easeOut(duration: 0.5)) {
                 visible = true
             }


### PR DESCRIPTION
## Summary
- Only request daemon greeting when no SOUL greeting is available, avoiding unnecessary LLM calls
- The `defaultGreetings` dead code was already cleaned up in a prior commit

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
