### PR TITLE
refactor: rename Thread→Conversation in macOS method names and properties

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -391,9 +391,9 @@ extension AppDelegate {
             let notify = window?.notifyOnComplete ?? false
             self?.handleQuickInputSubmit(message, imageData: imageData, notifyOnComplete: notify)
         }
-        window.onSubmitToThread = { [weak self, weak window] message, imageData in
+        window.onSubmitToConversation = { [weak self, weak window] message, imageData in
             let notify = window?.notifyOnComplete ?? false
-            self?.handleQuickInputSubmitToThread(message, imageData: imageData, notifyOnComplete: notify)
+            self?.handleQuickInputSubmitToConversation(message, imageData: imageData, notifyOnComplete: notify)
         }
         window.onSelectConversation = { [weak self] conversationId in
             self?.handleQuickInputSelectConversation(conversationId)
@@ -440,9 +440,9 @@ extension AppDelegate {
                 let notify = window?.notifyOnComplete ?? false
                 self?.handleQuickInputSubmit(message, imageData: imgData, notifyOnComplete: notify)
             }
-            window.onSubmitToThread = { [weak self, weak window] message, imgData in
+            window.onSubmitToConversation = { [weak self, weak window] message, imgData in
                 let notify = window?.notifyOnComplete ?? false
-                self?.handleQuickInputSubmitToThread(message, imageData: imgData, notifyOnComplete: notify)
+                self?.handleQuickInputSubmitToConversation(message, imageData: imgData, notifyOnComplete: notify)
             }
             window.onSelectConversation = { [weak self] conversationId in
                 self?.handleQuickInputSelectConversation(conversationId)
@@ -496,7 +496,7 @@ extension AppDelegate {
         }
     }
 
-    func handleQuickInputSubmitToThread(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+    func handleQuickInputSubmitToConversation(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
         guard let mainWindow else { return }
         if let viewModel = mainWindow.activeViewModel {
             if notifyOnComplete {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -136,11 +136,11 @@ struct MessageListView: View {
     /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
     /// restores scroll position, preventing a jump back to the bottom.
     @State private var isSuppressingBottomScroll: Bool = false
-    @State private var isThreadContentHovered: Bool = false
+    @State private var isConversationContentHovered: Bool = false
     @State private var isAppActive: Bool = NSApp.isActive
     @State private var hoverExitDebounceTask: Task<Void, Never>?
-    @State private var threadSwitchSuppressionTask: Task<Void, Never>?
-    @State private var suppressScrollbarDuringThreadSwitch: Bool = false
+    @State private var conversationSwitchSuppressionTask: Task<Void, Never>?
+    @State private var suppressScrollbarDuringConversationSwitch: Bool = false
     @State private var expandSuppressionTask: Task<Void, Never>?
     /// Tracks the last pending confirmation request ID that triggered an
     /// auto-focus handoff. Used to detect nil→non-nil transitions so we
@@ -441,15 +441,15 @@ struct MessageListView: View {
         }
     }
 
-    private var shouldShowThreadScrollbar: Bool {
-        isAppActive && isThreadContentHovered && !suppressScrollbarDuringThreadSwitch
+    private var shouldShowConversationScrollbar: Bool {
+        isAppActive && isConversationContentHovered && !suppressScrollbarDuringConversationSwitch
     }
 
     private func handleThreadContentHover(_ hovering: Bool) {
         if hovering {
             hoverExitDebounceTask?.cancel()
             hoverExitDebounceTask = nil
-            isThreadContentHovered = true
+            isConversationContentHovered = true
             return
         }
 
@@ -463,7 +463,7 @@ struct MessageListView: View {
                 return
             }
             guard !Task.isCancelled else { return }
-            isThreadContentHovered = false
+            isConversationContentHovered = false
             hoverExitDebounceTask = nil
         }
     }
@@ -790,7 +790,7 @@ struct MessageListView: View {
                         hasReceivedScrollEvent = true
                     }
                 )
-                ConversationScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
+                ConversationScrollbarVisibilityController(shouldShow: shouldShowConversationScrollbar)
             }
             .onPreferenceChange(ScrollViewportHeightKey.self) { height in
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
@@ -891,9 +891,9 @@ struct MessageListView: View {
             .onDisappear {
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
-                threadSwitchSuppressionTask?.cancel()
-                threadSwitchSuppressionTask = nil
-                suppressScrollbarDuringThreadSwitch = false
+                conversationSwitchSuppressionTask?.cancel()
+                conversationSwitchSuppressionTask = nil
+                suppressScrollbarDuringConversationSwitch = false
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
                 resizeScrollTask?.cancel()
@@ -1072,9 +1072,9 @@ struct MessageListView: View {
                 hoverExitDebounceTask = nil
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
-                threadSwitchSuppressionTask?.cancel()
-                suppressScrollbarDuringThreadSwitch = true
-                threadSwitchSuppressionTask = Task { @MainActor in
+                conversationSwitchSuppressionTask?.cancel()
+                suppressScrollbarDuringConversationSwitch = true
+                conversationSwitchSuppressionTask = Task { @MainActor in
                     // Let the newly-selected thread finish its first layout pass so
                     // the scroller style/metrics settle before allowing re-show.
                     do {
@@ -1083,10 +1083,10 @@ struct MessageListView: View {
                         return
                     }
                     guard !Task.isCancelled else { return }
-                    suppressScrollbarDuringThreadSwitch = false
-                    threadSwitchSuppressionTask = nil
+                    suppressScrollbarDuringConversationSwitch = false
+                    conversationSwitchSuppressionTask = nil
                 }
-                isThreadContentHovered = false
+                isConversationContentHovered = false
                 avatarTargetY = .infinity
                 avatarDisplayY = .infinity
                 pendingAvatarY = nil
@@ -1180,10 +1180,10 @@ struct MessageListView: View {
                 isAppActive = false
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
-                threadSwitchSuppressionTask?.cancel()
-                threadSwitchSuppressionTask = nil
-                suppressScrollbarDuringThreadSwitch = false
-                isThreadContentHovered = false
+                conversationSwitchSuppressionTask?.cancel()
+                conversationSwitchSuppressionTask = nil
+                suppressScrollbarDuringConversationSwitch = false
+                isConversationContentHovered = false
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -94,7 +94,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // Clear stale anchor when switching away from the conversation that
             // owns it — prevents the anchor from suppressing scroll-to-bottom
             // on unrelated conversation switches.
-            if let anchorThread = pendingAnchorConversationId, anchorThread != activeConversationId {
+            if let anchorConversation = pendingAnchorConversationId, anchorConversation != activeConversationId {
                 pendingAnchorMessageId = nil
                 pendingAnchorConversationId = nil
             }
@@ -567,12 +567,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Batch mutations into a single array write to avoid multiple
         // @Published objectWillChange emissions that can cause SwiftUI
         // ForEach re-entrancy crashes.
-        var thread = conversations[index]
-        thread.isPinned = false
-        thread.pinnedOrder = nil
-        thread.displayOrder = nil
-        thread.isArchived = true
-        conversations[index] = thread
+        var conversation = conversations[index]
+        conversation.isPinned = false
+        conversation.pinnedOrder = nil
+        conversation.displayOrder = nil
+        conversation.isArchived = true
+        conversations[index] = conversation
 
         if wasPinned {
             recompactPinnedOrders()
@@ -697,11 +697,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // If a local conversation already exists, merge server pin/order metadata.
             if let existingIdx = conversations.firstIndex(where: { $0.conversationId == session.id }) {
                 let isPinned = session.isPinned ?? false
-                var thread = conversations[existingIdx]
-                thread.isPinned = isPinned
-                thread.pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil
-                thread.displayOrder = session.displayOrder.map { Int($0) }
-                conversations[existingIdx] = thread
+                var conversation = conversations[existingIdx]
+                conversation.isPinned = isPinned
+                conversation.pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil
+                conversation.displayOrder = session.displayOrder.map { Int($0) }
+                conversations[existingIdx] = conversation
                 mergeAssistantAttention(from: session, intoConversationAt: existingIdx)
                 if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
                 continue
@@ -900,28 +900,28 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     // MARK: - Pinning & Ordering
 
-    func pinThread(id: UUID) {
+    func pinConversation(id: UUID) {
         guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
         let nextOrder = (conversations.compactMap(\.pinnedOrder).max() ?? -1) + 1
-        var thread = conversations[index]
-        thread.isPinned = true
-        thread.pinnedOrder = nextOrder
-        conversations[index] = thread
+        var conversation = conversations[index]
+        conversation.isPinned = true
+        conversation.pinnedOrder = nextOrder
+        conversations[index] = conversation
         sendReorderConversations()
     }
 
-    func unpinThread(id: UUID) {
+    func unpinConversation(id: UUID) {
         guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
-        var thread = conversations[index]
-        thread.isPinned = false
-        thread.pinnedOrder = nil
-        thread.displayOrder = nil
-        conversations[index] = thread
+        var conversation = conversations[index]
+        conversation.isPinned = false
+        conversation.pinnedOrder = nil
+        conversation.displayOrder = nil
+        conversations[index] = conversation
         recompactPinnedOrders()
         sendReorderConversations()
     }
 
-    func reorderPinnedThreads(from source: IndexSet, to destination: Int) {
+    func reorderPinnedConversations(from source: IndexSet, to destination: Int) {
         var pinned = visibleConversations.filter(\.isPinned)
         pinned.move(fromOffsets: source, toOffset: destination)
         var draft = conversations
@@ -936,16 +936,16 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     func updateLastInteracted(conversationId: UUID) {
         guard let index = conversations.firstIndex(where: { $0.id == conversationId }) else { return }
-        var thread = conversations[index]
-        thread.lastInteractedAt = Date()
+        var conversation = conversations[index]
+        conversation.lastInteractedAt = Date()
         // Clear explicit displayOrder so the conversation reverts to recency-based sorting.
         // This ensures actively-used conversations float to the top naturally and new conversations
         // aren't permanently stuck below explicitly-ordered conversations.
-        let hadOrder = thread.displayOrder != nil
+        let hadOrder = conversation.displayOrder != nil
         if hadOrder {
-            thread.displayOrder = nil
+            conversation.displayOrder = nil
         }
-        conversations[index] = thread
+        conversations[index] = conversation
         if hadOrder {
             sendReorderConversations()
         }
@@ -965,19 +965,19 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func moveConversation(sourceId: UUID, targetId: UUID) -> Bool {
         guard let sourceIdx = conversations.firstIndex(where: { $0.id == sourceId }),
               let targetIdx = conversations.firstIndex(where: { $0.id == targetId }) else { return false }
-        let targetThread = conversations[targetIdx]
+        let targetConversation = conversations[targetIdx]
 
         // Work on a local copy to batch all mutations into a single
         // @Published write, preventing SwiftUI ForEach re-entrancy crashes.
         var draft = conversations
 
-        if targetThread.isPinned {
+        if targetConversation.isPinned {
             // Dropping onto a pinned conversation — pin the source if needed and reorder
             let sourceWasPinned = draft[sourceIdx].isPinned
             if !sourceWasPinned {
                 draft[sourceIdx].isPinned = true
             }
-            let targetOrder = targetThread.pinnedOrder ?? 0
+            let targetOrder = targetConversation.pinnedOrder ?? 0
             let sourceOrder = sourceWasPinned ? (draft[sourceIdx].pinnedOrder ?? Int.max) : Int.max
 
             // Direction-aware: if source is above target (lower order), insert after target
@@ -1017,8 +1017,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             var reordered = unpinned.filter { $0.id != sourceId }
 
             let insertPos: Int
-            let sourceThread = draft[sourceIdx]
-            if targetThread.isScheduleConversation && !sourceThread.isScheduleConversation {
+            let sourceConversation = draft[sourceIdx]
+            if targetConversation.isScheduleConversation && !sourceConversation.isScheduleConversation {
                 // Cross-section drag: insert at section boundary
                 insertPos = reordered.firstIndex(where: { $0.isScheduleConversation }) ?? reordered.endIndex
             } else {
@@ -1043,8 +1043,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                 }
             }
 
-            if let movedThread = unpinned.first(where: { $0.id == sourceId }) ?? [draft[sourceIdx]].first {
-                reordered.insert(movedThread, at: insertPos)
+            if let movedConversation = unpinned.first(where: { $0.id == sourceId }) ?? [draft[sourceIdx]].first {
+                reordered.insert(movedConversation, at: insertPos)
             }
 
             // Assign displayOrder to ALL conversations in the reordered list. When a
@@ -1309,17 +1309,17 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
            case .unread = pendingAttentionOverrides[daemonId] {
             pendingAttentionOverrides.removeValue(forKey: daemonId)
         }
-        var thread = conversations[idx]
-        thread.hasUnseenLatestAssistantMessage = false
-        if let daemonId = thread.conversationId {
+        var conversation = conversations[idx]
+        conversation.hasUnseenLatestAssistantMessage = false
+        if let daemonId = conversation.conversationId {
             pendingAttentionOverrides[daemonId] = .seen(
-                latestAssistantMessageAt: thread.latestAssistantMessageAt
+                latestAssistantMessageAt: conversation.latestAssistantMessageAt
             )
-            thread.lastSeenAssistantMessageAt = thread.latestAssistantMessageAt
-            conversations[idx] = thread
+            conversation.lastSeenAssistantMessageAt = conversation.latestAssistantMessageAt
+            conversations[idx] = conversation
             emitConversationSeenSignal(conversationId: daemonId)
         } else {
-            conversations[idx] = thread
+            conversations[idx] = conversation
         }
     }
 
@@ -1338,10 +1338,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         pendingAttentionOverrides[daemonConversationId] = .unread(
             latestAssistantMessageAt: latestAssistantMessageAt
         )
-        var thread = conversations[idx]
-        thread.hasUnseenLatestAssistantMessage = true
-        thread.lastSeenAssistantMessageAt = nil
-        conversations[idx] = thread
+        var conversation = conversations[idx]
+        conversation.hasUnseenLatestAssistantMessage = true
+        conversation.lastSeenAssistantMessageAt = nil
+        conversations[idx] = conversation
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -6,13 +6,13 @@ import VellumAssistantShared
 
 extension MainWindowView {
 
-    func selectConversation(_ thread: ConversationModel) {
+    func selectConversation(_ conversation: ConversationModel) {
         if case .appEditing(let appId, _) = windowState.selection {
-            windowState.selection = .appEditing(appId: appId, conversationId: thread.id)
-            conversationManager.selectConversation(id: thread.id)
+            windowState.selection = .appEditing(appId: appId, conversationId: conversation.id)
+            conversationManager.selectConversation(id: conversation.id)
         } else {
-            windowState.selection = .conversation(thread.id)
-            conversationManager.selectConversation(id: thread.id)
+            windowState.selection = .conversation(conversation.id)
+            conversationManager.selectConversation(id: conversation.id)
         }
     }
 
@@ -28,8 +28,8 @@ extension MainWindowView {
     }
 
     /// Maps a conversation's interaction state to a dot color for VConversationIcon.
-    func interactionDotColor(for thread: ConversationModel) -> Color? {
-        switch conversationManager.interactionState(for: thread.id) {
+    func interactionDotColor(for conversation: ConversationModel) -> Color? {
+        switch conversationManager.interactionState(for: conversation.id) {
         case .processing: return VColor.primaryBase
         case .waitingForInput: return VColor.systemNegativeHover
         case .error: return VColor.systemNegativeStrong
@@ -60,12 +60,12 @@ extension MainWindowView {
     var scheduleConversationGroups: [(key: String, label: String, conversations: [ConversationModel])] {
         var grouped: [String: [ConversationModel]] = [:]
         var order: [String] = []
-        for thread in scheduleConversations {
-            let key = thread.scheduleJobId ?? thread.conversationId ?? thread.id.uuidString
+        for conversation in scheduleConversations {
+            let key = conversation.scheduleJobId ?? conversation.conversationId ?? conversation.id.uuidString
             if grouped[key] == nil {
                 order.append(key)
             }
-            grouped[key, default: []].append(thread)
+            grouped[key, default: []].append(conversation)
         }
         return order.compactMap { key in
             guard let conversations = grouped[key], let first = conversations.first else { return nil }
@@ -224,7 +224,7 @@ extension MainWindowView {
                         windowState.dismissToast(id: toastId)
                     }
                 },
-                onNewThread: { startNewConversation() }
+                onNewConversation: { startNewConversation() }
             )
 
             ScrollView {
@@ -233,17 +233,17 @@ extension MainWindowView {
                         DaemonLoadingConversationsSkeleton()
                     }
 
-                    ForEach(displayedConversations) { thread in
+                    ForEach(displayedConversations) { conversation in
                         SidebarConversationItem(
-                            conversation: thread,
+                            conversation: conversation,
                             conversationManager: conversationManager,
                             windowState: windowState,
                             sidebar: sidebar,
-                            selectConversation: { selectConversation(thread) }
+                            selectConversation: { selectConversation(conversation) }
                         )
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                if sidebar.dropTargetConversationId == thread.id {
+                                if sidebar.dropTargetConversationId == conversation.id {
                                     Rectangle()
                                         .fill(VColor.primaryBase)
                                         .frame(height: 2)
@@ -255,18 +255,18 @@ extension MainWindowView {
                                 sidebar.draggingConversationId = nil
                                 guard let droppedId = items.first,
                                       let sourceUUID = UUID(uuidString: droppedId),
-                                      sourceUUID != thread.id else { return false }
-                                return conversationManager.moveConversation(sourceId: sourceUUID, targetId: thread.id)
+                                      sourceUUID != conversation.id else { return false }
+                                return conversationManager.moveConversation(sourceId: sourceUUID, targetId: conversation.id)
                             } isTargeted: { isTargeted in
-                                if isTargeted && thread.id != sidebar.draggingConversationId {
-                                    sidebar.dropTargetConversationId = thread.id
+                                if isTargeted && conversation.id != sidebar.draggingConversationId {
+                                    sidebar.dropTargetConversationId = conversation.id
                                     if let dragId = sidebar.draggingConversationId {
                                         let visible = conversationManager.visibleConversations
                                         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-                                        let tIdx = visible.firstIndex(where: { $0.id == thread.id }) ?? 0
+                                        let tIdx = visible.firstIndex(where: { $0.id == conversation.id }) ?? 0
                                         sidebar.dropIndicatorAtBottom = sIdx < tIdx
                                     }
-                                } else if !isTargeted && sidebar.dropTargetConversationId == thread.id {
+                                } else if !isTargeted && sidebar.dropTargetConversationId == conversation.id {
                                     sidebar.dropTargetConversationId = nil
                                 }
                             }
@@ -302,18 +302,18 @@ extension MainWindowView {
                         .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
 
                         ForEach(displayedScheduleGroups, id: \.key) { group in
-                            if group.conversations.count == 1, let thread = group.conversations.first {
-                                // Single-thread group: render inline without a disclosure wrapper
+                            if group.conversations.count == 1, let conversation = group.conversations.first {
+                                // Single-conversation group: render inline without a disclosure wrapper
                                 SidebarConversationItem(
-                                    conversation: thread,
+                                    conversation: conversation,
                                     conversationManager: conversationManager,
                                     windowState: windowState,
                                     sidebar: sidebar,
-                                    selectConversation: { selectConversation(thread) }
+                                    selectConversation: { selectConversation(conversation) }
                                 )
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                        if sidebar.dropTargetConversationId == thread.id {
+                                        if sidebar.dropTargetConversationId == conversation.id {
                                             Rectangle()
                                                 .fill(VColor.primaryBase)
                                                 .frame(height: 2)
@@ -321,12 +321,12 @@ extension MainWindowView {
                                         }
                                     }
                                     .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
-                                        targetThread: thread,
+                                        targetConversation: conversation,
                                         sidebar: sidebar,
                                         conversationManager: conversationManager
                                     ))
                             } else {
-                                // Multi-thread group: custom disclosure styled like a nav row
+                                // Multi-conversation group: custom disclosure styled like a nav row
                                 let isGroupExpanded = sidebar.expandedScheduleGroups.contains(group.key)
                                 let hasUnread = !isGroupExpanded &&
                                     group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
@@ -383,17 +383,17 @@ extension MainWindowView {
 
                                 // Expanded child rows
                                 if isGroupExpanded {
-                                    ForEach(group.conversations) { thread in
+                                    ForEach(group.conversations) { conversation in
                                         SidebarConversationItem(
-                                            conversation: thread,
+                                            conversation: conversation,
                                             conversationManager: conversationManager,
                                             windowState: windowState,
                                             sidebar: sidebar,
-                                            selectConversation: { selectConversation(thread) }
+                                            selectConversation: { selectConversation(conversation) }
                                         )
                                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                                if sidebar.dropTargetConversationId == thread.id {
+                                                if sidebar.dropTargetConversationId == conversation.id {
                                                     Rectangle()
                                                         .fill(VColor.primaryBase)
                                                         .frame(height: 2)
@@ -401,7 +401,7 @@ extension MainWindowView {
                                                 }
                                             }
                                             .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
-                                                targetThread: thread,
+                                                targetConversation: conversation,
                                                 sidebar: sidebar,
                                                 conversationManager: conversationManager
                                             ))

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -184,7 +184,7 @@ struct MainWindowView: View {
         )
     }
 
-    func copyActiveThreadToClipboard() {
+    func copyActiveConversationToClipboard() {
         let messages = conversationManager.activeViewModel?.messages ?? []
         let title = conversationManager.activeConversation?.title
         let names = resolveParticipantNames()
@@ -199,7 +199,7 @@ struct MainWindowView: View {
         windowState.showToast(message: "Conversation copied to clipboard", style: .success)
     }
 
-    private var threadHeaderPresentation: ConversationHeaderPresentation {
+    private var conversationHeaderPresentation: ConversationHeaderPresentation {
         ConversationHeaderPresentation(
             activeConversation: conversationManager.activeConversation,
             activeViewModel: conversationManager.activeViewModel,
@@ -207,7 +207,7 @@ struct MainWindowView: View {
         )
     }
 
-    func dismissThreadDrawer() {
+    func dismissConversationDrawer() {
         withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
             showConversationActionsDrawer = false
         }
@@ -376,24 +376,24 @@ struct MainWindowView: View {
             Spacer()
             if windowState.isConversationVisible {
                 ConversationTitleActionsControl(
-                    presentation: threadHeaderPresentation,
-                    onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                    presentation: conversationHeaderPresentation,
+                    onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
                     onPin: {
                         guard let id = conversationManager.activeConversationId else { return }
-                        conversationManager.pinThread(id: id)
-                        dismissThreadDrawer()
+                        conversationManager.pinConversation(id: id)
+                        dismissConversationDrawer()
                     },
                     onUnpin: {
                         guard let id = conversationManager.activeConversationId else { return }
-                        conversationManager.unpinThread(id: id)
-                        dismissThreadDrawer()
+                        conversationManager.unpinConversation(id: id)
+                        dismissConversationDrawer()
                     },
                     onArchive: {
                         guard let id = conversationManager.activeConversationId else { return }
                         conversationManager.archiveConversation(id: id)
-                        dismissThreadDrawer()
+                        dismissConversationDrawer()
                     },
-                    onRename: { startRenameActiveThread(); dismissThreadDrawer() },
+                    onRename: { startRenameActiveThread(); dismissConversationDrawer() },
                     showDrawer: $showConversationActionsDrawer
                 )
                 .background(GeometryReader { proxy in
@@ -490,31 +490,31 @@ struct MainWindowView: View {
                     if showConversationActionsDrawer {
                         Color.clear
                             .contentShape(Rectangle())
-                            .onTapGesture { dismissThreadDrawer() }
+                            .onTapGesture { dismissConversationDrawer() }
                     }
                 }
                 .overlay(alignment: .topLeading) {
                     if showConversationActionsDrawer {
-                        let presentation = threadHeaderPresentation
+                        let presentation = conversationHeaderPresentation
                         ConversationActionsDrawer(
                             presentation: presentation,
-                            onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                            onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
                             onPin: {
                                 guard let id = conversationManager.activeConversationId else { return }
-                                conversationManager.pinThread(id: id)
-                                dismissThreadDrawer()
+                                conversationManager.pinConversation(id: id)
+                                dismissConversationDrawer()
                             },
                             onUnpin: {
                                 guard let id = conversationManager.activeConversationId else { return }
-                                conversationManager.unpinThread(id: id)
-                                dismissThreadDrawer()
+                                conversationManager.unpinConversation(id: id)
+                                dismissConversationDrawer()
                             },
                             onArchive: {
                                 guard let id = conversationManager.activeConversationId else { return }
                                 conversationManager.archiveConversation(id: id)
-                                dismissThreadDrawer()
+                                dismissConversationDrawer()
                             },
-                            onRename: { startRenameActiveThread(); dismissThreadDrawer() }
+                            onRename: { startRenameActiveThread(); dismissConversationDrawer() }
                         )
                         .offset(x: conversationTitleFrame.minX, y: conversationTitleFrame.maxY)
                         .zIndex(10)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -72,7 +72,7 @@ extension MainWindowView {
                         windowState.selection = .app(surfaceMsg.surfaceId)
                     }
                 },
-                onNewThread: {
+                onNewConversation: {
                     conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                     windowState.selection = nil
                 }
@@ -271,7 +271,7 @@ extension MainWindowView {
                             windowState.selection = .app(surfaceMsg.surfaceId)
                         }
                     },
-                    onNewThread: {
+                    onNewConversation: {
                         conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                         windowState.selection = nil
                     }
@@ -443,7 +443,7 @@ extension MainWindowView {
                         windowState.selection = .app(surfaceMsg.surfaceId)
                     }
                 },
-                onNewThread: {
+                onNewConversation: {
                     conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
                     windowState.dismissOverlay()
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -9,7 +9,7 @@ struct AppsGridView: View {
     let onOpenApp: (String) -> Void
     /// Called when the user opens a shared app (needs surface-based navigation).
     var onOpenSharedApp: ((UiSurfaceShowMessage) -> Void)?
-    var onNewThread: (() -> Void)?
+    var onNewConversation: (() -> Void)?
 
     @State private var searchText = ""
     @State private var hoveredAppId: String?
@@ -142,7 +142,7 @@ struct AppsGridView: View {
             icon: VIcon.layoutGrid.rawValue,
             actionLabel: "New Conversation",
             actionIcon: VIcon.plus.rawValue,
-            action: { onNewThread?() }
+            action: { onNewConversation?() }
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
@@ -4,16 +4,16 @@ import VellumAssistantShared
 /// Drop delegate for reordering scheduled conversations within the same schedule group.
 /// Returns `.move` operation to show a reorder cursor instead of the copy/plus icon.
 struct ScheduleReorderDropDelegate: DropDelegate {
-    let targetThread: ConversationModel
+    let targetConversation: ConversationModel
     let sidebar: SidebarInteractionState
     let conversationManager: ConversationManager
 
     func validateDrop(info: DropInfo) -> Bool {
         guard let dragId = sidebar.draggingConversationId,
-              dragId != targetThread.id,
-              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleConversation,
-              sourceThread.scheduleJobId == targetThread.scheduleJobId
+              dragId != targetConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == targetConversation.scheduleJobId
         else { return false }
         return true
     }
@@ -24,21 +24,21 @@ struct ScheduleReorderDropDelegate: DropDelegate {
 
     func dropEntered(info: DropInfo) {
         guard let dragId = sidebar.draggingConversationId,
-              dragId != targetThread.id,
-              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleConversation,
-              sourceThread.scheduleJobId == targetThread.scheduleJobId
+              dragId != targetConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == targetConversation.scheduleJobId
         else { return }
 
-        sidebar.dropTargetConversationId = targetThread.id
+        sidebar.dropTargetConversationId = targetConversation.id
         let visible = conversationManager.visibleConversations
         let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-        let tIdx = visible.firstIndex(where: { $0.id == targetThread.id }) ?? 0
+        let tIdx = visible.firstIndex(where: { $0.id == targetConversation.id }) ?? 0
         sidebar.dropIndicatorAtBottom = sIdx < tIdx
     }
 
     func dropExited(info: DropInfo) {
-        if sidebar.dropTargetConversationId == targetThread.id {
+        if sidebar.dropTargetConversationId == targetConversation.id {
             sidebar.dropTargetConversationId = nil
         }
     }
@@ -47,27 +47,27 @@ struct ScheduleReorderDropDelegate: DropDelegate {
         let sourceId = sidebar.draggingConversationId
         sidebar.dropTargetConversationId = nil
         sidebar.draggingConversationId = nil
-        guard let sourceId = sourceId, sourceId != targetThread.id else { return false }
-        return conversationManager.moveConversation(sourceId: sourceId, targetId: targetThread.id)
+        guard let sourceId = sourceId, sourceId != targetConversation.id else { return false }
+        return conversationManager.moveConversation(sourceId: sourceId, targetId: targetConversation.id)
     }
 }
 
 /// Drop delegate for the collapsed schedule group header.
-/// Targets the first thread in the group; only accepts drops from the same schedule group.
+/// Targets the first conversation in the group; only accepts drops from the same schedule group.
 struct ScheduleGroupHeaderDropDelegate: DropDelegate {
     let group: (key: String, label: String, conversations: [ConversationModel])
     let sidebar: SidebarInteractionState
     let conversationManager: ConversationManager
 
-    private var firstThread: ConversationModel? { group.conversations.first }
+    private var firstConversation: ConversationModel? { group.conversations.first }
 
     func validateDrop(info: DropInfo) -> Bool {
-        guard let firstThread = firstThread,
+        guard let firstConversation = firstConversation,
               let dragId = sidebar.draggingConversationId,
-              dragId != firstThread.id,
-              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleConversation,
-              sourceThread.scheduleJobId == firstThread.scheduleJobId
+              dragId != firstConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
         else { return false }
         return true
     }
@@ -77,20 +77,20 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
     }
 
     func dropEntered(info: DropInfo) {
-        guard let firstThread = firstThread,
+        guard let firstConversation = firstConversation,
               let dragId = sidebar.draggingConversationId,
-              dragId != firstThread.id,
-              let sourceThread = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceThread.isScheduleConversation,
-              sourceThread.scheduleJobId == firstThread.scheduleJobId
+              dragId != firstConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
         else { return }
 
-        sidebar.dropTargetConversationId = firstThread.id
+        sidebar.dropTargetConversationId = firstConversation.id
         sidebar.dropIndicatorAtBottom = false
     }
 
     func dropExited(info: DropInfo) {
-        if let firstThread = firstThread, sidebar.dropTargetConversationId == firstThread.id {
+        if let firstConversation = firstConversation, sidebar.dropTargetConversationId == firstConversation.id {
             sidebar.dropTargetConversationId = nil
         }
     }
@@ -99,10 +99,10 @@ struct ScheduleGroupHeaderDropDelegate: DropDelegate {
         let sourceId = sidebar.draggingConversationId
         sidebar.dropTargetConversationId = nil
         sidebar.draggingConversationId = nil
-        guard let firstThread = firstThread,
+        guard let firstConversation = firstConversation,
               let sourceId = sourceId,
-              sourceId != firstThread.id
+              sourceId != firstConversation.id
         else { return false }
-        return conversationManager.moveConversation(sourceId: sourceId, targetId: firstThread.id)
+        return conversationManager.moveConversation(sourceId: sourceId, targetId: firstConversation.id)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -50,9 +50,9 @@ struct SidebarConversationItem: View {
                     Button {
                         withAnimation(VAnimation.standard) {
                             if conversation.isPinned {
-                                conversationManager.unpinThread(id: conversation.id)
+                                conversationManager.unpinConversation(id: conversation.id)
                             } else {
-                                conversationManager.pinThread(id: conversation.id)
+                                conversationManager.pinConversation(id: conversation.id)
                             }
                         }
                     } label: {
@@ -166,9 +166,9 @@ struct SidebarConversationItem: View {
             Button {
                 withAnimation(VAnimation.standard) {
                     if conversation.isPinned {
-                        conversationManager.unpinThread(id: conversation.id)
+                        conversationManager.unpinConversation(id: conversation.id)
                     } else {
-                        conversationManager.pinThread(id: conversation.id)
+                        conversationManager.pinConversation(id: conversation.id)
                     }
                 }
             } label: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -5,7 +5,7 @@ struct SidebarConversationsHeader: View {
     let hasUnseenThreads: Bool
     var isLoading: Bool = false
     let onMarkAllSeen: () -> Void
-    let onNewThread: () -> Void
+    let onNewConversation: () -> Void
 
     var body: some View {
         HStack {
@@ -23,7 +23,7 @@ struct SidebarConversationsHeader: View {
                 )
                 .disabled(isLoading)
             }
-            VButton(label: "New thread", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewThread)
+            VButton(label: "New thread", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewConversation)
                 .disabled(isLoading)
                 .opacity(isLoading ? 0.4 : 1)
         }

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -42,7 +42,7 @@ final class QuickInputWindow {
     /// Includes optional image data from a screen capture.
     var onSubmit: ((String, Data?) -> Void)?
     /// Callback invoked when the user submits a message to an existing thread.
-    var onSubmitToThread: ((String, Data?) -> Void)?
+    var onSubmitToConversation: ((String, Data?) -> Void)?
     /// Callback invoked when the user taps the microphone button.
     var onMicrophoneToggle: (() -> Void)?
     /// Callback invoked when the user toggles the notification bell.
@@ -171,7 +171,7 @@ final class QuickInputWindow {
                     self?.onSelectConversation?(conversationId)
                     // Small delay so the conversation switches before we send the message
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        self?.onSubmitToThread?(message, self?.attachedImageData)
+                        self?.onSubmitToConversation?(message, self?.attachedImageData)
                     }
                 } else {
                     self?.onSubmit?(message, self?.attachedImageData)


### PR DESCRIPTION
## Summary
- Renamed methods: pinThread→pinConversation, unpinThread→unpinConversation, reorderPinnedThreads→reorderPinnedConversations, copyActiveThreadToClipboard→copyActiveConversationToClipboard, dismissThreadDrawer→dismissConversationDrawer, handleQuickInputSubmitToThread→handleQuickInputSubmitToConversation
- Renamed properties: threadHeaderPresentation, onNewThread, onSubmitToThread, isThreadContentHovered, threadSwitchSuppressionTask, suppressScrollbarDuringThreadSwitch, shouldShowThreadScrollbar, targetThread, sourceThread, firstThread, anchorThread → conversation equivalents
- Updated all local `var thread` assignments to `var conversation` in ConversationManager

Part of plan: conv-symbol-sweep.md (PR 4 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
