### PR TITLE
fix: voice invite redemption always looks up target contact displayName (#16242)

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -390,12 +390,12 @@ export function redeemVoiceInviteCode(params: {
   const STALE_INVITE = Symbol("stale_invite");
   let memberId: string | undefined;
 
-  // When the invite targets a specific contact (targetMismatch path), preserve
-  // the target contact's guardian-assigned display name if it has one.
+  // When the invite targets a specific contact, preserve the target contact's
+  // guardian-assigned display name if it has one.
   let preservedDisplayName = voiceContact?.displayName?.trim().length
     ? voiceContact.displayName
     : (invite.friendName ?? undefined);
-  if (targetMismatch && invite.contactId) {
+  if (invite.contactId) {
     const targetContact = getContact(invite.contactId);
     if (targetContact?.displayName?.trim().length) {
       preservedDisplayName = targetContact.displayName;


### PR DESCRIPTION
## Summary
- Changed voice path display-name lookup condition from targetMismatch to invite.contactId
- This ensures brand-new callers (no existing voice channel) get the target contact's guardian-assigned displayName, consistent with redeemInvite and redeemInviteByCode

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16242
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
