### PR TITLE
fix: add 400 response to invite-call schema, callInvite route variant, and bare /start test (#16251)

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -287,6 +287,41 @@ describe("telegram webhook handler: /new rejection", () => {
     expect(sendMessageCall).toBeUndefined();
   });
 
+  test("bare /start (no payload) sends ACK and forwards to runtime", async () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "12345", assistantId: "assistant-a" },
+      ],
+    });
+    installFetchMock();
+    const { handler } = createTelegramWebhookHandler(config, makeCaches());
+
+    const payload = makeTelegramPayload("/start", 2503);
+    const req = makeWebhookRequest(payload);
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify the runtime forward call was made with command intent
+    const runtimeCall = fetchCalls.find((c) => c.url.includes("/inbound"));
+    expect(runtimeCall).toBeDefined();
+    expect((runtimeCall!.body as any).sourceMetadata.commandIntent).toEqual({
+      type: "start",
+    });
+
+    // Allow fire-and-forget ACK call to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ACK is sent for bare /start (no payload)
+    const sendMessageCall = fetchCalls.find((c) =>
+      c.url.includes("/sendMessage"),
+    );
+    expect(sendMessageCall).toBeDefined();
+    expect((sendMessageCall!.body as any).text).toContain("Starting up");
+  });
+
   test("/start with routing rejection sends setup notice and does not forward", async () => {
     const config = makeConfig({ unmappedPolicy: "reject" });
     installFetchMock();

--- a/gateway/src/http/routes/contacts-control-plane-route-match.ts
+++ b/gateway/src/http/routes/contacts-control-plane-route-match.ts
@@ -8,7 +8,8 @@ export type ContactsControlPlaneRoute =
   | { kind: "listInvites" }
   | { kind: "createInvite" }
   | { kind: "redeemInvite" }
-  | { kind: "revokeInvite"; inviteId: string };
+  | { kind: "revokeInvite"; inviteId: string }
+  | { kind: "callInvite"; inviteId: string };
 
 export function matchContactsControlPlaneRoute(
   pathname: string,
@@ -43,6 +44,13 @@ export function matchContactsControlPlaneRoute(
 
   if (pathname === "/v1/contacts/invites/redeem" && method === "POST") {
     return { kind: "redeemInvite" };
+  }
+
+  const inviteCallMatch = pathname.match(
+    /^\/v1\/contacts\/invites\/([^/]+)\/call$/,
+  );
+  if (inviteCallMatch && method === "POST") {
+    return { kind: "callInvite", inviteId: inviteCallMatch[1] };
   }
 
   const inviteMatch = pathname.match(/^\/v1\/contacts\/invites\/([^/]+)$/);

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1170,6 +1170,10 @@ export function buildSchema(): Record<string, unknown> {
           },
           responses: {
             "200": { description: "Invite call initiated" },
+            "400": {
+              description:
+                "Bad request — invite not found or validation failure",
+            },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },


### PR DESCRIPTION
## Summary
- Add 400 error response to POST /v1/contacts/invites/{inviteId}/call schema entry
- Add callInvite variant to ContactsControlPlaneRoute union and matchContactsControlPlaneRoute
- Add test coverage for bare /start ACK in telegram webhook handler

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
