### PR TITLE
fix: add 'Failed to disconnect' prefix to Slack disconnect error message (#16234)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1145,7 +1145,7 @@ public final class SettingsStore: ObservableObject {
                 self.fetchChannelSetupStatus()
             } catch {
                 self.slackChannelSaveInProgress = false
-                self.slackChannelError = error.localizedDescription
+                self.slackChannelError = "Failed to disconnect: \(error.localizedDescription)"
                 self.fetchChannelSetupStatus()
                 log.error("Failed to clear Slack channel config: \(error)")
             }


### PR DESCRIPTION
## Summary
- Add 'Failed to disconnect:' prefix to the catch-block error message in clearSlackChannelConfig() for consistency with the HTTP error path and saveSlackChannelConfig()

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
