### PR TITLE
fix: stabilize file viewer status bar height when Save button appears

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -81,6 +81,6 @@ struct FileContentHeaderBar<Trailing: View>: View {
             trailing
         }
         .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.sm)
+        .frame(height: 28)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -707,12 +707,13 @@ private struct WorkspaceFileViewer: View {
                     } label: {
                         HStack(spacing: VSpacing.xs) {
                             if state.isSaving {
-                                ProgressView().controlSize(.small)
+                                ProgressView().controlSize(.mini)
                             }
                             Text("Save")
-                                .font(VFont.bodyMedium)
+                                .font(VFont.captionMedium)
                         }
                     }
+                    .buttonStyle(.borderless)
                     .disabled(state.isSaving)
                     .keyboardShortcut("s", modifiers: .command)
                 }


### PR DESCRIPTION
## Summary
- Set a fixed 28pt frame height on `FileContentHeaderBar` so it stays consistent regardless of trailing content
- Changed Save button to use `.buttonStyle(.borderless)` and `.captionMedium` font so it fits within the fixed bar height
- Reduced progress indicator to `.controlSize(.mini)` to match the compact layout

## Original prompt
The status bar should stay the same size when the save button shows up instead of expanding to be larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
