### PR TITLE
fix: inject client IP in guardian bootstrap proxy to prevent auth bypass

### DIFF
--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -26,6 +26,7 @@ export function createChannelVerificationSessionProxyHandler(
     req: Request,
     upstreamPath: string,
     upstreamSearch: string,
+    clientIp?: string,
   ): Promise<Response> {
     const start = performance.now();
     const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
@@ -33,6 +34,12 @@ export function createChannelVerificationSessionProxyHandler(
     const reqHeaders = stripHopByHop(new Headers(req.headers));
     reqHeaders.delete("host");
     reqHeaders.delete("authorization");
+
+    // Inject the real client IP so the runtime can enforce loopback-only
+    // checks, overwriting any client-supplied value to prevent spoofing.
+    if (clientIp) {
+      reqHeaders.set("x-forwarded-for", clientIp);
+    }
 
     // Mint a short-lived service token for gateway->runtime auth.
     // The token itself proves gateway origin (aud=vellum-daemon).
@@ -139,7 +146,10 @@ export function createChannelVerificationSessionProxyHandler(
       );
     },
 
-    async handleGuardianInit(req: Request): Promise<Response> {
+    async handleGuardianInit(
+      req: Request,
+      clientIp?: string,
+    ): Promise<Response> {
       const lockPath = join(getRootDir(), "guardian-init.lock");
       if (existsSync(lockPath) || guardianInitInFlight) {
         log.warn("Guardian init rejected — already bootstrapped");
@@ -151,7 +161,12 @@ export function createChannelVerificationSessionProxyHandler(
 
       guardianInitInFlight = true;
       try {
-        const response = await proxyToRuntime(req, "/v1/guardian/init", "");
+        const response = await proxyToRuntime(
+          req,
+          "/v1/guardian/init",
+          "",
+          clientIp,
+        );
 
         if (response.status >= 200 && response.status < 300) {
           try {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -506,7 +506,8 @@ async function main() {
       path: "/v1/guardian/init",
       method: "POST",
       auth: "none",
-      handler: (req) => channelVerificationSessionProxy.handleGuardianInit(req),
+      handler: (req, _params, getClientIp) =>
+        channelVerificationSessionProxy.handleGuardianInit(req, getClientIp()),
     },
     {
       path: "/v1/channel-verification-sessions",


### PR DESCRIPTION
## Summary

- **Security fix**: The gateway's channel-verification-session proxy did not inject `X-Forwarded-For` with the real client IP when proxying `/v1/guardian/init` to the runtime, unlike the general `runtime-proxy.ts`. This allowed a remote attacker to bypass the runtime's loopback-only checks by omitting the header — the gateway would forward via localhost, passing both the `X-Forwarded-For` absence check and the peer IP loopback check.
- Adds `clientIp` parameter to `proxyToRuntime` and `handleGuardianInit` in `channel-verification-session-proxy.ts`, matching the pattern in `runtime-proxy.ts`
- Updates the `/v1/guardian/init` route handler in `gateway/src/index.ts` to pass `getClientIp()` through to the handler

## Original prompt

Fix the guardian bootstrap authentication bypass: the channel-verification-session-proxy's proxyToRuntime function does not inject X-Forwarded-For with the real client IP when forwarding to the runtime, unlike runtime-proxy.ts. This allows a remote attacker to bypass the runtime's loopback-only checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
