### PR TITLE
refactor: rename Thread→Conversation in macOS test class names and methods (sidebar, header, doc editor)

### DIFF
--- a/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
@@ -3,21 +3,21 @@ import XCTest
 
 final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
 
-    private func makeThread(id: UUID = UUID(), title: String = "Conversation") -> ConversationModel {
+    private func makeConversation(id: UUID = UUID(), title: String = "Conversation") -> ConversationModel {
         ConversationModel(id: id, title: title)
     }
 
     // MARK: - Draft mode (no active conversation)
 
-    func testDraftMode_withExistingThreads_showsSwitcher() {
-        let conversations = [makeThread(), makeThread()]
+    func testDraftMode_withExistingConversations_showsSwitcher() {
+        let conversations = [makeConversation(), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertTrue(sut.showsSwitcher)
         XCTAssertEqual(sut.switchTargets.count, 2)
     }
 
-    func testDraftMode_withNoThreads_hidesSwitcher() {
+    func testDraftMode_withNoConversations_hidesSwitcher() {
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: [], activeConversationId: nil)
 
         XCTAssertFalse(sut.showsSwitcher)
@@ -26,9 +26,9 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
 
     // MARK: - Active conversation
 
-    func testActiveThread_onlyThatThread_showsSwitcherWithBadge() {
+    func testActiveConversation_onlyThatConversation_showsSwitcherWithBadge() {
         let id = UUID()
-        let conversations = [makeThread(id: id)]
+        let conversations = [makeConversation(id: id)]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: id)
 
         XCTAssertTrue(sut.showsSwitcher)
@@ -36,10 +36,10 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
         XCTAssertTrue(sut.switchTargets.isEmpty)
     }
 
-    func testActiveThread_withOtherThreads_showsSwitcherAndExcludesActive() {
+    func testActiveConversation_withOtherConversations_showsSwitcherAndExcludesActive() {
         let activeId = UUID()
         let otherId = UUID()
-        let conversations = [makeThread(id: activeId, title: "Active"), makeThread(id: otherId, title: "Other")]
+        let conversations = [makeConversation(id: activeId, title: "Active"), makeConversation(id: otherId, title: "Other")]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: activeId)
 
         XCTAssertTrue(sut.showsSwitcher)
@@ -49,35 +49,35 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
 
     // MARK: - Total count and badge
 
-    func testTotalRegularThreadCount() {
-        let conversations = [makeThread(), makeThread(), makeThread()]
+    func testTotalRegularConversationCount() {
+        let conversations = [makeConversation(), makeConversation(), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.totalRegularThreadCount, 3)
     }
 
     func testBadgeText_normalCount() {
-        let conversations = [makeThread(), makeThread()]
+        let conversations = [makeConversation(), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "2")
     }
 
-    func testBadgeText_singleThread() {
-        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeThread()], activeConversationId: nil)
+    func testBadgeText_singleConversation() {
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeConversation()], activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "1")
     }
 
     func testBadgeText_capsAt99Plus() {
-        let conversations = (0..<100).map { _ in makeThread() }
+        let conversations = (0..<100).map { _ in makeConversation() }
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "99+")
     }
 
     func testBadgeText_99IsNotCapped() {
-        let conversations = (0..<99).map { _ in makeThread() }
+        let conversations = (0..<99).map { _ in makeConversation() }
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.badgeText, "99")
@@ -85,28 +85,28 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
 
     // MARK: - Accessibility
 
-    func testAccessibilityLabel_withActiveThread() {
+    func testAccessibilityLabel_withActiveConversation() {
         let id = UUID()
-        let conversations = [makeThread(id: id, title: "My Chat"), makeThread()]
+        let conversations = [makeConversation(id: id, title: "My Chat"), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: id)
 
         XCTAssertEqual(sut.accessibilityLabel, "Switch conversations: My Chat")
     }
 
     func testAccessibilityLabel_draftMode() {
-        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeThread()], activeConversationId: nil)
+        let sut = CollapsedConversationSwitcherPresentation(regularConversations: [makeConversation()], activeConversationId: nil)
 
         XCTAssertEqual(sut.accessibilityLabel, "Switch conversations")
     }
 
     func testAccessibilityValue_reflectsTotalCount() {
-        let conversations = [makeThread(), makeThread(), makeThread()]
+        let conversations = [makeConversation(), makeConversation(), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
         XCTAssertEqual(sut.accessibilityValue, "3 conversations")
     }
 
-    func testAccessibilityValue_emptyWhenNoThreads() {
+    func testAccessibilityValue_emptyWhenNoConversations() {
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: [], activeConversationId: nil)
 
         XCTAssertEqual(sut.accessibilityValue, "")

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -7,7 +7,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - No active thread / draft
 
-    func testDraftShowsNewThreadTitle() {
+    func testDraftShowsNewConversationTitle() {
         let p = ConversationHeaderPresentation(
             activeConversation: nil,
             activeViewModel: nil,
@@ -19,7 +19,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertFalse(p.canCopy)
     }
 
-    func testConversationNotVisibleShowsNewThread() {
+    func testConversationNotVisibleShowsNewConversation() {
         let thread = ConversationModel(title: "My Conversation", conversationId: "session-1")
         let p = ConversationHeaderPresentation(
             activeConversation: thread,
@@ -32,7 +32,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - Started standard thread
 
-    func testStartedStandardThreadShowsActionsMenu() {
+    func testStartedStandardConversationShowsActionsMenu() {
         let thread = ConversationModel(title: "Test Conversation", conversationId: "session-1")
         let vm = ChatViewModel(daemonClient: DaemonClient())
         let p = ConversationHeaderPresentation(
@@ -47,7 +47,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - Private thread
 
-    func testPrivateThreadHidesActionsMenu() {
+    func testPrivateConversationHidesActionsMenu() {
         let thread = ConversationModel(title: "Private Chat", conversationId: "session-2", kind: .private)
         let p = ConversationHeaderPresentation(
             activeConversation: thread,
@@ -61,7 +61,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - Not started (no conversationId, no messages)
 
-    func testUnstartedThreadDoesNotShowActions() {
+    func testUnstartedConversationDoesNotShowActions() {
         let thread = ConversationModel(title: "New Conversation")
         let vm = ChatViewModel(daemonClient: DaemonClient())
         let p = ConversationHeaderPresentation(
@@ -76,7 +76,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
 
     // MARK: - Pin state
 
-    func testPinnedThreadShowsPinnedState() {
+    func testPinnedConversationShowsPinnedState() {
         let thread = ConversationModel(title: "Pinned", conversationId: "s", isPinned: true)
         let p = ConversationHeaderPresentation(
             activeConversation: thread,

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class DocumentEditorThreadVisibilityTests: XCTestCase {
+final class DocumentEditorConversationVisibilityTests: XCTestCase {
 
     // MARK: - Helpers
 
@@ -31,7 +31,7 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
                         "isShowingChat should be false for document editor (it's a panel)")
     }
 
-    func testThreadSelectionIsConversationVisible() {
+    func testConversationSelectionIsConversationVisible() {
         let state = makeState(.conversation(UUID()))
 
         XCTAssertTrue(state.isConversationVisible)
@@ -54,11 +54,11 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
 
     // MARK: - ConversationHeaderPresentation for document editor
 
-    func testDocumentEditorShowsThreadTitleWhenActiveThreadExists() {
-        let thread = ConversationModel(title: "Doc Session Conversation", conversationId: "doc-session-1")
+    func testDocumentEditorShowsConversationTitleWhenActiveConversationExists() {
+        let conversation = ConversationModel(title: "Doc Session Conversation", conversationId: "doc-session-1")
         let vm = ChatViewModel(daemonClient: DaemonClient())
         let presentation = ConversationHeaderPresentation(
-            activeConversation: thread,
+            activeConversation: conversation,
             activeViewModel: vm,
             isConversationVisible: true  // document editor always reports conversation as visible
         )
@@ -69,7 +69,7 @@ final class DocumentEditorThreadVisibilityTests: XCTestCase {
         XCTAssertTrue(presentation.showsActionsMenu)
     }
 
-    func testDocumentEditorShowsNewThreadWhenNoActiveThread() {
+    func testDocumentEditorShowsNewConversationWhenNoActiveConversation() {
         let presentation = ConversationHeaderPresentation(
             activeConversation: nil,
             activeViewModel: nil,


### PR DESCRIPTION
## Summary
- Renamed 8 test methods and `makeThread` helper in CollapsedConversationSwitcherPresentationTests
- Renamed 6 test methods in ConversationHeaderPresentationTests
- Renamed class `DocumentEditorThreadVisibilityTests` and 3 test methods in DocumentEditorConversationVisibilityTests

Part of plan: conv-symbol-sweep.md (PR 7 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
