### PR TITLE
fix: roll back oauth_apps insert when secret storage fails (#16252)

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -269,6 +269,9 @@ export async function upsertApp(
   if (clientSecretValue) {
     const stored = await setSecureKeyAsync(credPath, clientSecretValue);
     if (!stored) {
+      // Roll back the just-inserted row to avoid an orphaned app pointing
+      // at a non-existent client_secret in secure storage.
+      db.delete(oauthApps).where(eq(oauthApps.id, id)).run();
       throw new Error("Failed to store client_secret in secure storage");
     }
   }


### PR DESCRIPTION
## Summary
- Delete the just-inserted oauth_apps row when setSecureKeyAsync returns false, preventing orphaned app rows with missing client secrets

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
