### PR TITLE
refactor: rename remaining Session→Conversation test methods in macOS and shared tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -82,7 +82,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1) // first message only
     }
 
-    func testSendWhileSendingWithSessionAppendsMessage() {
+    func testSendWhileSendingWithConversationAppendsMessage() {
         // When a session exists, sending while isSending is allowed (daemon queues)
         viewModel.conversationId = "test-session"
         viewModel.isSending = true
@@ -160,16 +160,16 @@ final class ChatViewModelTests: XCTestCase {
         )
     }
 
-    // MARK: - Session Info
+    // MARK: - Conversation Info
 
-    func testSessionInfoStoresSessionId() {
+    func testConversationInfoStoresConversationId() {
         viewModel.bootstrapCorrelationId = "corr-1"
         let info = ConversationInfoMessage(conversationId: "test-123", title: "Test", correlationId: "corr-1")
         viewModel.handleServerMessage(.conversationInfo(info))
         XCTAssertEqual(viewModel.conversationId, "test-123")
     }
 
-    func testSessionInfoDoesNotOverwriteExistingSession() {
+    func testConversationInfoDoesNotOverwriteExistingConversation() {
         viewModel.conversationId = "first-session"
         let info = ConversationInfoMessage(conversationId: "second-session", title: "Test")
         viewModel.handleServerMessage(.conversationInfo(info))
@@ -646,7 +646,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
-    func testStopGeneratingWithNoSessionDoesNothing() {
+    func testStopGeneratingWithNoConversationDoesNothing() {
         // Not sending, no session
         viewModel.stopGenerating()
         XCTAssertFalse(viewModel.isSending)
@@ -1284,9 +1284,9 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[0].isStreaming)
     }
 
-    // MARK: - Session Isolation (Correlation ID)
+    // MARK: - Conversation Isolation (Correlation ID)
 
-    func testSessionInfoWithWrongCorrelationIdIsIgnored() {
+    func testConversationInfoWithWrongCorrelationIdIsIgnored() {
         // Simulate a ChatViewModel that has sent a session_create with a correlation ID.
         // A session_info with a different correlation ID should be ignored.
         viewModel.inputText = "Hello"
@@ -1303,7 +1303,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.conversationId, "Should not claim session_info with non-matching correlationId")
     }
 
-    func testSessionInfoWithNilCorrelationIdIsIgnoredWhenBootstrapping() {
+    func testConversationInfoWithNilCorrelationIdIsIgnoredWhenBootstrapping() {
         // When a ChatViewModel is bootstrapping (has a correlationId), a session_info
         // without any correlationId should also be rejected to prevent cross-contamination.
         viewModel.inputText = "Hello"
@@ -1318,7 +1318,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.conversationId, "Should not claim session_info without correlationId when bootstrapping with one")
     }
 
-    func testSessionInfoWithoutCorrelationIdRejectedWhenNoBootstrap() {
+    func testConversationInfoWithoutCorrelationIdRejectedWhenNoBootstrap() {
         // After removing backwards compat, session_info without a correlationId
         // is rejected even when there is no bootstrap correlationId set.
         let info = ConversationInfoMessage(conversationId: "test-session", title: "Test")
@@ -2368,7 +2368,7 @@ final class ChatViewModelTests: XCTestCase {
 
     // MARK: - createConversationIfNeeded (Message-less Session Create)
 
-    func testCreateSessionIfNeededSetsBootstrapping() {
+    func testCreateConversationIfNeededSetsBootstrapping() {
         viewModel.createConversationIfNeeded(conversationType: "private")
         XCTAssertFalse(viewModel.isSending, "Message-less session creates should not set isSending")
         XCTAssertFalse(viewModel.isThinking, "Should not show thinking for message-less session create")
@@ -2377,13 +2377,13 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isBootstrapping)
     }
 
-    func testCreateSessionIfNeededNoOpWhenSessionExists() {
+    func testCreateConversationIfNeededNoOpWhenConversationExists() {
         viewModel.conversationId = "existing-session"
         viewModel.createConversationIfNeeded(conversationType: "private")
         XCTAssertNil(viewModel.bootstrapCorrelationId, "Should not bootstrap when session already exists")
     }
 
-    func testCreateSessionIfNeededNoOpWhenAlreadyBootstrapping() {
+    func testCreateConversationIfNeededNoOpWhenAlreadyBootstrapping() {
         // Start a normal send which bootstraps
         viewModel.inputText = "Hello"
         viewModel.sendMessage()
@@ -2395,7 +2395,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.bootstrapCorrelationId, originalCorrelationId, "Should not overwrite existing bootstrap")
     }
 
-    func testCreateSessionIfNeededSessionInfoResetsState() {
+    func testCreateConversationIfNeededConversationInfoResetsState() {
         viewModel.createConversationIfNeeded(conversationType: "private")
         let correlationId = viewModel.bootstrapCorrelationId!
 
@@ -2410,7 +2410,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isBootstrapping)
     }
 
-    func testCreateSessionIfNeededOnSessionCreatedCallback() {
+    func testCreateConversationIfNeededOnConversationCreatedCallback() {
         var callbackSessionId: String?
         viewModel.onConversationCreated = { conversationId in
             callbackSessionId = conversationId
@@ -2446,7 +2446,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
     }
 
-    func testCreateSessionIfNeededWithoutConversationType() {
+    func testCreateConversationIfNeededWithoutConversationType() {
         viewModel.createConversationIfNeeded()
         XCTAssertFalse(viewModel.isSending, "Message-less session creates should not set isSending")
         XCTAssertNil(viewModel.conversationType, "conversationType should remain nil when not specified")
@@ -2475,7 +2475,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(sessionCreates.first?.conversationType, "private", "Normal send should also pass conversationType")
     }
 
-    func testCreateSessionThenSendMessageUsesClaimedSession() {
+    func testCreateConversationThenSendMessageUsesClaimedConversation() {
         // Create session without message
         viewModel.createConversationIfNeeded(conversationType: "private")
         let correlationId = viewModel.bootstrapCorrelationId!

--- a/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
@@ -22,7 +22,7 @@ final class ConversationManagerSessionLoopTests: XCTestCase {
         super.tearDown()
     }
 
-    func testSelectingSessionBackedConversationStartsMessageLoop() {
+    func testSelectingConversationIdBackedConversationStartsMessageLoop() {
         guard let conversationId = conversationManager.activeConversationId,
               let vm = conversationManager.chatViewModel(for: conversationId),
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) else {
@@ -38,7 +38,7 @@ final class ConversationManagerSessionLoopTests: XCTestCase {
         XCTAssertEqual(daemonClient.subscribers.count, 1)
     }
 
-    func testSelectingSameSessionBackedConversationDoesNotDuplicateMessageLoop() {
+    func testSelectingSameConversationIdBackedConversationDoesNotDuplicateMessageLoop() {
         guard let conversationId = conversationManager.activeConversationId,
               let vm = conversationManager.chatViewModel(for: conversationId),
               let index = conversationManager.conversations.firstIndex(where: { $0.id == conversationId }) else {

--- a/clients/macos/vellum-assistantTests/ConversationManagerRenameTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerRenameTests.swift
@@ -32,7 +32,7 @@ final class ConversationManagerRenameTests: XCTestCase {
 
     // MARK: - Rename with conversationId
 
-    func testRenameWithSessionIdSendsMessage() {
+    func testRenameWithConversationIdSendsMessage() {
         guard let thread = conversationManager.conversations.first else {
             XCTFail("Expected at least one thread")
             return

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -516,7 +516,7 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         )
     }
 
-    func testMarkConversationUnreadRemovesPendingSeenSignalForSameSession() {
+    func testMarkConversationUnreadRemovesPendingSeenSignalForSameConversation() {
         guard let firstConversationId = conversationManager.activeConversationId,
               let firstIndex = conversationManager.conversations.firstIndex(where: { $0.id == firstConversationId }) else {
             XCTFail("Expected an initial active conversation")

--- a/clients/shared/Tests/ChatTranscriptFormatterTests.swift
+++ b/clients/shared/Tests/ChatTranscriptFormatterTests.swift
@@ -19,11 +19,11 @@ final class ChatTranscriptFormatterTests: XCTestCase {
 
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: messages,
-            conversationTitle: "Test Thread",
+            conversationTitle: "Test Conversation",
             participantNames: names
         )
 
-        XCTAssertTrue(result.hasPrefix("# Test Thread"))
+        XCTAssertTrue(result.hasPrefix("# Test Conversation"))
         XCTAssertTrue(result.contains("### Noa"))
         XCTAssertTrue(result.contains("Hello!"))
         XCTAssertTrue(result.contains("### Aria"))
@@ -69,7 +69,7 @@ final class ChatTranscriptFormatterTests: XCTestCase {
     func testThreadMarkdownEmptyInputReturnsEmptyString() {
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: [],
-            conversationTitle: "Empty Thread",
+            conversationTitle: "Empty Conversation",
             participantNames: names
         )
 
@@ -84,7 +84,7 @@ final class ChatTranscriptFormatterTests: XCTestCase {
 
         let result = ChatTranscriptFormatter.conversationMarkdown(
             messages: messages,
-            conversationTitle: "Thread",
+            conversationTitle: "Conversation",
             participantNames: names
         )
 

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -311,7 +311,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
                 sourceChannel: "vellum",
                 signalType: "macos_conversation_seen",
                 confidence: "explicit",
-                source: "thread-selection",
+                source: "conversation-selection",
                 metadata: [
                     "view": AnyCodable("inbox"),
                     "attempt": AnyCodable(1),
@@ -348,7 +348,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
               "conversations": [
                 {
                   "id": "session-123",
-                  "title": "Pinned thread",
+                  "title": "Pinned conversation",
                   "createdAt": 1000,
                   "updatedAt": 2000,
                   "displayOrder": 7,


### PR DESCRIPTION
## Summary
- Renamed ~16 test methods in ChatViewModelTests from Session to Conversation (excluding message-stream filtering tests)
- Renamed test methods in ConversationManagerUnseenStateTests, ConversationManagerRenameTests, ConversationManagerConversationLoopTests
- Updated test data strings in HTTPDaemonClientUnreadTests and ChatTranscriptFormatterTests from 'thread' to 'conversation'

Part of plan: conv-symbol-sweep.md (PR 9 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
