### PR TITLE
fix: consistent bot_token truthiness check and Slack connected status alignment (#16240)

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -97,11 +97,15 @@ export async function setSlackChannelConfig(
         const errHasAppToken = !!(await getSecureKeyAsync(
           credentialKey("slack_channel", "app_token"),
         ));
+        const errConn = getConnectionByProvider("slack_channel");
         return {
           success: false,
           hasBotToken: errHasBotToken,
           hasAppToken: errHasAppToken,
-          connected: errHasBotToken && errHasAppToken,
+          connected:
+            !!(errConn && errConn.status === "active") &&
+            errHasBotToken &&
+            errHasAppToken,
           error: `Slack API validation failed: ${
             data.error ?? "unknown error"
           }`,
@@ -121,11 +125,15 @@ export async function setSlackChannelConfig(
       const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
       ));
+      const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
         hasBotToken: errHasBotToken,
         hasAppToken: errHasAppToken,
-        connected: errHasBotToken && errHasAppToken,
+        connected:
+          !!(errConn && errConn.status === "active") &&
+          errHasBotToken &&
+          errHasAppToken,
         error: `Failed to validate bot token: ${message}`,
       };
     }
@@ -141,11 +149,15 @@ export async function setSlackChannelConfig(
       const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
       ));
+      const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
         hasBotToken: errHasBotToken,
         hasAppToken: errHasAppToken,
-        connected: errHasBotToken && errHasAppToken,
+        connected:
+          !!(errConn && errConn.status === "active") &&
+          errHasBotToken &&
+          errHasAppToken,
         error: "Failed to store bot token in secure storage",
       };
     }
@@ -179,11 +191,15 @@ export async function setSlackChannelConfig(
       const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
       ));
+      const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
         hasBotToken: errHasBotToken,
         hasAppToken: errHasAppToken,
-        connected: errHasBotToken && errHasAppToken,
+        connected:
+          !!(errConn && errConn.status === "active") &&
+          errHasBotToken &&
+          errHasAppToken,
         error: 'Invalid app token: must start with "xapp-"',
       };
     }
@@ -199,11 +215,15 @@ export async function setSlackChannelConfig(
       const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
       ));
+      const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
         hasBotToken: errHasBotToken,
         hasAppToken: errHasAppToken,
-        connected: errHasBotToken && errHasAppToken,
+        connected:
+          !!(errConn && errConn.status === "active") &&
+          errHasBotToken &&
+          errHasAppToken,
         error: "Failed to store app token in secure storage",
       };
     }
@@ -263,11 +283,13 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
     const hasAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
     ));
+    const conn = getConnectionByProvider("slack_channel");
     return {
       success: false,
       hasBotToken,
       hasAppToken,
-      connected: hasBotToken && hasAppToken,
+      connected:
+        !!(conn && conn.status === "active") && hasBotToken && hasAppToken,
       error: "Failed to delete Slack channel credentials from secure storage",
     };
   }

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -69,7 +69,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     const conn = getConnectionByProvider("telegram");
     if (!(conn && conn.status === "active")) return false;
     const botToken = await getBotToken();
-    if (botToken === undefined) return false;
+    if (!botToken) return false;
     const webhookSecret = await getSecureKeyAsync(
       credentialKey("telegram", "webhook_secret"),
     );


### PR DESCRIPTION
## Summary
- Use !! pattern for bot_token check in Telegram isConnected() for consistency with codebase
- Align Slack error path connected computation with GET semantics (check oauth_connection + tokens)

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16240

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
