### PR TITLE
fix: require at least one privacy field in request schema

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1726,6 +1726,10 @@ export function buildSchema(): Record<string, unknown> {
                     collectUsageData: { type: "boolean" },
                     sendDiagnostics: { type: "boolean" },
                   },
+                  anyOf: [
+                    { required: ["collectUsageData"] },
+                    { required: ["sendDiagnostics"] },
+                  ],
                 },
               },
             },


### PR DESCRIPTION
Addresses review feedback from PR #17494. The OpenAPI schema now requires at least one of collectUsageData or sendDiagnostics, matching the handler's runtime validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
