### PR TITLE
fix: reload avatar state after login to restore dock icon

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -326,6 +326,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         setupDaemonClient(isFirstLaunch: isFirstLaunch)
+        // Reload avatar after reconnecting so that logout→re-login cycles
+        // repopulate the dock icon (resetForDisconnect clears it on logout).
+        AvatarAppearanceManager.shared.reloadAvatar()
         setupMenuBar()
         setupFileMenu()
         registerNavigationMonitor()


### PR DESCRIPTION
Addresses review feedback from PR #17469. After logout+re-login, the avatar was not repopulated because the post-auth path didn't call reloadAvatar(). This ensures the avatar is reloaded when proceeding to the app after authentication.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
