### PR TITLE
fix: qualify pending charges display when billing data is degraded

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -99,12 +99,12 @@ struct SettingsBillingTab: View {
                         .foregroundColor(VColor.contentDefault)
                 }
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Pending Charges")
+                    Text(summary.is_degraded ? "Pending Charges (estimated)" : "Pending Charges")
                         .font(VFont.inputLabel)
                         .foregroundColor(VColor.contentSecondary)
                     Text("$\(summary.pending_compute_usd)")
                         .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundColor(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
             }
         }


### PR DESCRIPTION
Addresses review feedback from PR #17498. When is_degraded is true, the pending charges value now shows as estimated to avoid contradicting the degradation warning banner.

- Label changes to "Pending Charges (estimated)" when degraded
- Dollar value color dimmed to contentSecondary to visually de-emphasize stale data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
