### PR TITLE
fix: make base URL injection failure fatal in bootstrap existing-key path

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -170,23 +170,28 @@ public final class LocalAssistantBootstrapService {
         let credentialAccount = Self.credentialAccount(for: runtimeAssistantId)
 
         // Step 2: Check if we already have the key stored locally (only when we have the platform ID)
+        var existingKeyInjected = false
         if let platformId = platformAssistantId,
            let existingKey = credentialStorage?.get(account: credentialAccount), !existingKey.isEmpty {
             do {
                 try await injectKeyIntoDaemon(key: existingKey)
                 log.info("Re-synced existing API key to daemon")
-                try? await injectPlatformAssistantIdIntoDaemon(id: platformId)
-                do {
-                    try await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
-                } catch {
-                    log.error("Failed to inject platform base URL into daemon on existing-key path: \(error.localizedDescription)")
-                    throw LocalBootstrapError.daemonInjectionFailed
-                }
-                return .registeredWithExistingKey(assistantId: platformId)
+                existingKeyInjected = true
             } catch {
                 log.warning("Failed to inject existing key into daemon, will reprovision: \(error.localizedDescription)")
                 // Fall through to Step 3 — key may be stale
             }
+        }
+
+        if existingKeyInjected, let platformId = platformAssistantId {
+            try? await injectPlatformAssistantIdIntoDaemon(id: platformId)
+            do {
+                try await injectPlatformBaseUrlIntoDaemon(url: authService.baseURL)
+            } catch {
+                log.error("Failed to inject platform base URL into daemon on existing-key path: \(error.localizedDescription)")
+                throw LocalBootstrapError.daemonInjectionFailed
+            }
+            return .registeredWithExistingKey(assistantId: platformId)
         }
 
         // Step 3: No key stored — reprovision


### PR DESCRIPTION
Addresses review feedback from PR #17501. Restructures the error handling so base URL injection failures propagate as fatal errors instead of being caught by the existing-key fallthrough that triggers unnecessary reprovisioning.

The inner do/catch for base URL injection was nested inside the outer do/catch meant only for key injection failures. When injectPlatformBaseUrlIntoDaemon threw, the outer catch swallowed it and fell through to reprovisioning, defeating the intent.

Fix: use an existingKeyInjected flag to separate key injection (fallthrough on failure) from base URL injection (fatal on failure). The base URL throw now propagates directly to the caller.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
