### PR TITLE
fix: reset deferred-update flag after consuming install handler

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -70,6 +70,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             return h
         }
         guard let handler else { return }
+        isDeferredUpdateReady = false
         log.info("Installing deferred update now")
         onWillInstallUpdate?()
         handler()


### PR DESCRIPTION
Addresses review feedback from PR #17525. isDeferredUpdateReady is now reset to false after installDeferredUpdateIfAvailable() consumes the handler, preventing stale update-ready UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
