### PR TITLE
fix: remove unused localDocker and vps HostingMode enum cases

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -46,8 +46,6 @@ final class OnboardingState {
     enum HostingMode: String {
         case vellumCloud = "vellum-cloud"
         case local = "local"
-        case localDocker = "local-docker"
-        case vps = "vps"
     }
     var hasHatched: Bool = false
     var interviewCompleted: Bool = false


### PR DESCRIPTION
Addresses review feedback from PR #17537. Removes the dead localDocker and vps enum cases from HostingMode whose only references were removed in #17537.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
