### PR TITLE
fix: add animation to update button transition and clarify restart behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -408,11 +408,11 @@ struct MainWindowView: View {
             Spacer()
             if updateManager.isUpdateAvailable {
                 VButton(
-                    label: "Update",
+                    label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",
                     leftIcon: VIcon.arrowUp.rawValue,
                     style: .primary,
                     size: .pill,
-                    tooltip: "A new version is available"
+                    tooltip: updateManager.isDeferredUpdateReady ? "Restart to install the latest version" : "A new version is available"
                 ) {
                     if updateManager.isDeferredUpdateReady {
                         NSApp.terminate(nil)
@@ -421,6 +421,7 @@ struct MainWindowView: View {
                     }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                .animation(VAnimation.fast, value: updateManager.isUpdateAvailable)
             }
             PTTKeyIndicator {
                 settingsStore.pendingSettingsTab = .voice


### PR DESCRIPTION
Addresses review feedback from PR #17529. Adds .animation() modifier so the update button transition animates properly. Changes the deferred-update label/tooltip to indicate restart behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
