### PR TITLE
fix: make file viewer status bar taller to fit full-size Save button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -81,6 +81,6 @@ struct FileContentHeaderBar<Trailing: View>: View {
             trailing
         }
         .padding(.horizontal, VSpacing.md)
-        .frame(height: 28)
+        .frame(height: 36)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -707,13 +707,12 @@ private struct WorkspaceFileViewer: View {
                     } label: {
                         HStack(spacing: VSpacing.xs) {
                             if state.isSaving {
-                                ProgressView().controlSize(.mini)
+                                ProgressView().controlSize(.small)
                             }
                             Text("Save")
-                                .font(VFont.captionMedium)
+                                .font(VFont.bodyMedium)
                         }
                     }
-                    .buttonStyle(.borderless)
                     .disabled(state.isSaving)
                     .keyboardShortcut("s", modifiers: .command)
                 }


### PR DESCRIPTION
## Summary
- Increased `FileContentHeaderBar` fixed height from 28pt to 36pt to accommodate the full-size Save button
- Reverted Save button to original `VFont.bodyMedium` font and default button style (removed `.buttonStyle(.borderless)` and `.captionMedium` overrides)

## Original prompt
Instead of making the save button smaller can you just make the whole status bar taller instead? Now the save button is too small

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
