### PR TITLE
fix: include qdrant in isVellumProcess regex for PID validation

### DIFF
--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -13,7 +13,7 @@ function isVellumProcess(pid: number): boolean {
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return /vellum-daemon|vellum-cli|vellum-gateway|@vellumai|\/vellum\/|\/daemon\/main/.test(
+    return /vellum-daemon|vellum-cli|vellum-gateway|@vellumai|\/\.?vellum\/|\/daemon\/main|\/qdrant\/bin\/qdrant/.test(
       output,
     );
   } catch {


### PR DESCRIPTION
Addresses review feedback from PR #17538. The isVellumProcess regex now matches Qdrant binary paths (~/.vellum/workspace/data/qdrant/bin/qdrant), fixing the no-op stop during retire for default instances.

Changes:
- Updated `\/vellum\/` to `\/\.?vellum\/` to match both `/.vellum/` and `/vellum/` paths
- Added `\/qdrant\/bin\/qdrant` as an explicit match for the Qdrant binary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
