### PR TITLE
fix: use strict boolean check for automated flag in message routes

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -773,7 +773,7 @@ export async function handleSendMessage(
         assistantMessageChannel: sourceChannel,
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
-        ...(body.automated ? { automated: true } : {}),
+        ...(body.automated === true ? { automated: true } : {}),
       },
       { isInteractive },
     );
@@ -877,7 +877,7 @@ export async function handleSendMessage(
         assistantMessageChannel: sourceChannel,
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
-        ...(body.automated ? { automated: true } : {}),
+        ...(body.automated === true ? { automated: true } : {}),
       };
       const userMsg = createUserMessage(rawContent, attachments);
       const persisted = await addMessage(
@@ -966,7 +966,7 @@ export async function handleSendMessage(
       resolvedContent,
       attachments,
       requestId,
-      body.automated ? { automated: true } : undefined,
+      body.automated === true ? { automated: true } : undefined,
     );
   } catch (err) {
     throw err;


### PR DESCRIPTION
Addresses review feedback from PR #17551. Changes truthiness check to === true so non-boolean values like string 'false' or number 1 don't silently suppress memory extraction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
