### PR TITLE
fix: default Notion setup to Internal integration

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -346,11 +346,11 @@
     {
       "id": "notion-oauth-setup",
       "name": "notion-oauth-setup",
-      "description": "Set up Notion OAuth credentials for Notion integration using a collaborative guided flow",
+      "description": "Set up Notion integration credentials using a collaborative guided flow (defaults to Internal integration)",
       "metadata": {
         "emoji": "🔑",
         "vellum": {
-          "display-name": "Notion OAuth Setup",
+          "display-name": "Notion Setup",
           "includes": [
             "collaborative-oauth-flow"
           ]

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -1,35 +1,36 @@
 ---
 name: notion-oauth-setup
-description: Set up Notion OAuth credentials for Notion integration using a collaborative guided flow
+description: Set up Notion integration credentials using a collaborative guided flow (defaults to Internal integration)
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
-    display-name: "Notion OAuth Setup"
+    display-name: "Notion Setup"
     includes: ["collaborative-oauth-flow"]
 ---
 
-You are helping your user set up Notion OAuth credentials so the Notion integration can connect to their workspace.
+You are helping your user set up Notion credentials so the Notion integration can connect to their workspace.
 
 This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Notion-specific steps.
 
 ## Provider Details
 
 - **Provider key:** `integration:notion`
-- **Credential type:** Public integration (OAuth)
-- **Token endpoint auth:** `client_secret_basic` (client secret always required)
-- **Scopes:** None (Notion does not use explicit OAuth scopes)
-- **Extra params:** `owner=user`
-- **Callback transport:** Loopback (port 17323)
-- **Redirect URI:** `http://localhost:17323/oauth/callback` (must be pre-registered in Notion)
+- **Default credential type:** Internal integration (API token)
+- **No OAuth flow required** for the default path — just copy the integration secret and grant page access
 
 ## Prerequisites
 
-No public ingress or ngrok is needed — Notion uses a localhost callback on a fixed port.
+No OAuth, redirect URIs, or public ingress needed for Internal integrations. The user just needs a Notion account and workspace.
 
-## Notion-Specific Flow
+## Choosing the Flow
 
-The flow has 6 steps total, takes about 2-3 minutes.
+- **Internal integration (default):** Single-workspace, simple setup. Follow the steps below.
+- **Public integration (OAuth):** Multi-workspace distribution. Only guide to this path if the user explicitly needs OAuth for multi-workspace access. See [references/path-b-public-oauth.md](references/path-b-public-oauth.md) for that flow.
+
+## Internal Integration Flow
+
+The flow has 4 steps total, takes about 1-2 minutes.
 
 ### Step 0: Prerequisite Check
 
@@ -47,7 +48,7 @@ This is the first navigation — wait a few seconds for the page to load, then t
 
 ---
 
-### Step 2: Create a New Public Integration
+### Step 2: Create a New Integration
 
 > Look for the **"New integration"** button (or a **"+"** button) and click it.
 >
@@ -55,97 +56,70 @@ This is the first navigation — wait a few seconds for the page to load, then t
 >
 > 1. Set the name to **Vellum Assistant**
 > 2. Select your workspace from the **Associated workspace** dropdown
-> 3. For the **Type**, select **Public** — this is required for OAuth
-> 4. Click **Submit**
+> 3. Click **Create**
+
+There is no Type selector on the creation form — integrations are created as **Internal by default**, which is what we want.
 
 **Known issues:**
 
-- If "Public" is not available as a type, the user may need to check their workspace settings or plan level
 - If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it — skip ahead to Step 3
 
-**Milestone (2 of 6):** "Integration created — now let's get it configured."
+**Milestone (2 of 4):** "Integration created — now let's grab the secret and grant page access."
 
 ---
 
-### Step 3: Configure OAuth Redirect URI
+### Step 3: Copy Internal Integration Secret and Grant Page Access
 
-Notion requires the redirect URI to be pre-registered. Copy it to the clipboard first:
+After creation, the user lands on the integration's Configuration page.
 
-```
-host_bash:
-  command: |
-    echo -n "http://localhost:17323/oauth/callback" | pbcopy
-```
+#### 3a: Copy the secret
 
-Guide the user to the **Distribution** tab or section.
+> You should now see the **Configuration** tab with an **"Internal integration secret"** field. Click **Show** to reveal it, then **Copy** to copy the secret.
 
-> Now look for the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**). Click into it.
->
-> You should see a field for **Redirect URIs**. Paste this exact URL (I've copied it to your clipboard):
-> `http://localhost:17323/oauth/callback`
->
-> Then scroll down and click **Save changes**.
-
-**Known issues:**
-
-- Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use `localhost` as the domain
-- If the page shows "Internal integration" with no Distribution tab, the integration was created as Internal — they'll need to recreate it as Public
-
----
-
-### Step 4: Copy Client ID and Client Secret
-
-> Now look for the **Secrets** section on the integration page. You should see:
->
-> - **OAuth client ID**
-> - **OAuth client secret** (you may need to click **Show** to reveal it)
->
-> Copy the **Client ID** and paste it here in the chat.
-
-After receiving the Client ID, collect the secret securely:
+Collect the secret securely:
 
 ```
 credential_store prompt:
   service: "integration:notion"
-  field: "client_secret"
-  label: "Notion OAuth Client Secret"
-  description: "Copy the Client Secret from the Notion integration page and paste it here."
-  placeholder: "secret_..."
+  field: "internal_secret"
+  label: "Notion Internal Integration Secret"
+  description: "Paste the Internal Integration Secret you just copied."
+  placeholder: "ntn_..."
 ```
 
-**Milestone (4 of 6):** "Credentials collected — almost done."
+#### 3b: Grant page access
 
----
-
-### Step 5: Store Credentials and Authorize
-
-Register the OAuth app and start the authorization flow. See the collaborative guided flow reference for the exact commands (`assistant oauth apps upsert` and `assistant oauth connections connect`).
-
-> I'll save your credentials and start the Notion authorization flow now.
+> Now you need to grant the integration access to the Notion pages you want to use.
 >
-> You should see a Notion consent page asking you to **select which pages** to share with Vellum Assistant. Pick the pages or databases you'd like to connect, then click **Allow access**.
+> 1. Go to any Notion page you want to connect
+> 2. Click the **"..."** menu (top-right) or the **Share** button
+> 3. Click **"Add connections"** (or **"Connect to"**)
+> 4. Search for **Vellum Assistant** and select it
+> 5. Repeat for any other pages or databases you want accessible
+>
+> You can always add more pages later by repeating this step.
 
-**Known issues:**
-
-- If the consent page shows an error about the redirect URI, double-check that the URI in Step 3 matches exactly
-- The user can always re-authorize later to share additional pages
+**Milestone (3 of 4):** "Secret stored and pages connected — let's verify."
 
 ---
 
-### Step 6: Verify Connection
+### Step 4: Verify Connection
 
-Use the ping URL to verify the connection:
+Verify the connection works by calling the Notion API with the stored secret:
 
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    ))" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+      -H "Notion-Version: 2022-06-28" \
+      "https://api.notion.com/v1/users/me"
 ```
 
 **On success:** "Notion is connected! You can now ask me to read and write pages and databases in your Notion workspace."
+
+**On failure (401):** The secret may have been copied incorrectly. Offer to redo Step 3a.
+
+**On failure (other):** Check the error message and guide accordingly.
 
 ---
 
@@ -155,5 +129,6 @@ For non-interactive channels, see [references/path-b-manual-setup.md](references
 
 Key Notion-specific differences for Path B:
 
-- On a remote channel, the loopback callback (port 17323) is not reachable — public ingress is required instead
-- Client Secret prefix is `secret_` — use `credential_store prompt` to collect it securely; split entry is not needed since this prefix doesn't trigger channel scanners
+- No OAuth flow or redirect URIs needed for Internal integrations
+- The user copies their Internal Integration Secret and sends it via chat
+- The secret prefix is `ntn_` — use `credential_store prompt` to collect it securely

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Telegram, Slack, etc.)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. No OAuth or public ingress is needed for Internal integrations.
 
 ## Path B Step 1: Confirm and Explain
 
@@ -11,13 +11,13 @@ Tell the user:
 > Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
 >
 > 1. A Notion account with a workspace you want to connect
-> 2. About 3 minutes
+> 2. About 2 minutes
 >
 > Ready to start?
 
 If the user declines, stop.
 
-## Path B Step 2: Create a Public Integration
+## Path B Step 2: Create an Internal Integration
 
 Tell the user:
 
@@ -33,104 +33,73 @@ Tell the user:
 > 1. Click **"New integration"** (or the **"+"** button)
 > 2. Set the name to **Vellum Assistant**
 > 3. Select your workspace from the **Associated workspace** dropdown
-> 4. For the **Type**, select **Public** (this is required for OAuth)
-> 5. Click **Submit**
+> 4. Click **Create**
+>
+> The integration will be created as Internal by default — that's exactly what we want.
 >
 > Let me know when the integration is created.
 
-## Path B Step 3: Configure OAuth Redirect URI
-
-Before sending the next step, resolve the concrete callback URL:
-
-- Read the configured public gateway URL from `ingress.publicBaseUrl`.
-- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
-- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
-- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+## Path B Step 3: Copy the Internal Integration Secret
 
 Tell the user:
 
-> **Step 2: Configure the redirect URI**
+> **Step 2: Copy your integration secret**
 >
-> In your integration settings, find the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**).
+> On the integration's Configuration page, you should see an **"Internal integration secret"** field.
 >
-> In the **Redirect URIs** field, paste this exact URL:
-> `OAUTH_CALLBACK_URL`
->
-> Scroll down and click **Save changes**.
->
-> Let me know when it's saved.
-
-## Path B Step 4: Copy Credentials
-
-Tell the user:
-
-> **Step 3: Copy your credentials**
->
-> In your integration settings, find the **Secrets** section. You should see:
->
-> - **OAuth client ID**
-> - **OAuth client secret** (you may need to click **Show** to reveal it)
->
-> Send me the **Client ID** first. It looks like a UUID or alphanumeric string.
-
-Wait for the user to send the Client ID.
-
-## Path B Step 5: Store Credentials
-
-### Path B Step 5a: Client ID
-
-After the user sends the Client ID:
-
-```
-credential_store store:
-  service: "integration:notion"
-  field: "client_id"
-  value: "<the client id the user sent>"
-```
-
-### Path B Step 5b: Client Secret
-
-Tell the user:
-
-> **Step 4: Send your Client Secret**
->
-> Now send me the **Client Secret** from the Secrets section. It starts with `secret_`.
+> Click **Show** to reveal it, then copy the secret. It starts with `ntn_`.
 >
 > Send it as a standalone message with no other text.
 
-After the user sends it:
+After the user sends the secret:
+
+```
+credential_store prompt:
+  service: "integration:notion"
+  field: "internal_secret"
+  label: "Notion Internal Integration Secret"
+  description: "Paste the Internal Integration Secret."
+  placeholder: "ntn_..."
+```
+
+If using `credential_store store` instead (when the user sent it as plaintext):
 
 ```
 credential_store store:
   service: "integration:notion"
-  field: "client_secret"
-  value: "<the client secret the user sent>"
+  field: "internal_secret"
+  value: "<the secret the user sent>"
 ```
 
-## Path B Step 6: Authorize
+## Path B Step 4: Grant Page Access
 
 Tell the user:
 
-> **Step 5: Authorize Notion**
+> **Step 3: Grant page access**
 >
-> I'll generate an authorization link for you now.
+> Now you need to share your Notion pages with the integration:
+>
+> 1. Open any Notion page you want to connect
+> 2. Click the **"..."** menu (top-right) or the **Share** button
+> 3. Click **"Add connections"** (or **"Connect to"**)
+> 4. Search for **Vellum Assistant** and select it
+>
+> Repeat for any pages or databases you want accessible. You can always add more later.
+>
+> Let me know when you've shared at least one page.
+
+## Path B Step 5: Verify and Done
+
+Verify the connection:
 
 ```
-credential_store:
-  action: "oauth2_connect"
-  service: "integration:notion"
-  client_id: "<the client id the user sent>"
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+      -H "Notion-Version: 2022-06-28" \
+      "https://api.notion.com/v1/users/me"
 ```
 
-Send the returned auth URL to the user:
-
-> Open this link to authorize Vellum Assistant:
-> `<auth URL>`
->
-> You'll see a Notion consent page. Select the pages and databases you'd like to share, then click **Allow access**.
-
-## Path B Step 7: Done
-
-After authorization:
+On success:
 
 > **Notion is connected!** You can now ask me to read and write pages and databases in your Notion workspace.

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -23,8 +23,9 @@ As of early 2026, Notion does **not** offer a "Type" selector during integration
 - **Token endpoint auth:** `client_secret_basic` (client secret always required)
 - **Scopes:** None (Notion does not use explicit OAuth scopes)
 - **Extra params:** `owner=user`
-- **Callback transport:** Loopback (port 17323)
-- **Redirect URI:** `http://localhost:17323/oauth/callback` (must be pre-registered)
+- **Callback transport:** Loopback (port 17323) for interactive channels; public ingress for remote channels
+- **Redirect URI (interactive):** `http://localhost:17323/oauth/callback`
+- **Redirect URI (remote/Path B):** `<ingress.publicBaseUrl>/webhooks/oauth/callback` — resolve from the configured public gateway URL
 
 ## Public Integration Steps
 
@@ -37,12 +38,17 @@ Guide the user to find the conversion option in their integration settings. Once
 
 ### Step 2: Configure OAuth Redirect URI
 
-Copy the redirect URI to clipboard:
+Determine the correct redirect URI based on the channel:
+
+- **Interactive (macOS app, local):** Use `http://localhost:17323/oauth/callback`
+- **Remote channel (Telegram, Slack, etc.):** Read the configured public gateway URL from `ingress.publicBaseUrl`. If missing, load and run the `public-ingress` skill first. Build the URI as `<publicBaseUrl>/webhooks/oauth/callback`.
+
+Copy the resolved redirect URI to clipboard:
 
 ```
 host_bash:
   command: |
-    echo -n "http://localhost:17323/oauth/callback" | pbcopy
+    echo -n "<resolved redirect URI>" | pbcopy
 ```
 
 Guide the user to the **Distribution** tab to paste the redirect URI and save.

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -1,0 +1,94 @@
+# Public Integration (OAuth) Setup
+
+Use this path only when the user explicitly needs multi-workspace OAuth distribution. For single-workspace use, the Internal integration flow in the main SKILL.md is simpler and preferred.
+
+## Overview
+
+Public integrations use OAuth 2.0 and require:
+
+- Converting the integration from Internal to Public (via Notion's integration settings)
+- A redirect URI for the OAuth callback
+- OAuth Client ID and Client Secret (different from the Internal secret)
+
+## Important: Notion UI for Public Integrations
+
+As of early 2026, Notion does **not** offer a "Type" selector during integration creation — all integrations start as Internal. To convert to Public:
+
+1. Create the integration as Internal (per the main flow)
+2. Look for a way to convert to Public in the integration settings — Notion docs reference this option but the exact UI location may vary
+3. Once converted, a **Distribution** tab should appear with OAuth settings
+
+## Provider Details (Public)
+
+- **Token endpoint auth:** `client_secret_basic` (client secret always required)
+- **Scopes:** None (Notion does not use explicit OAuth scopes)
+- **Extra params:** `owner=user`
+- **Callback transport:** Loopback (port 17323)
+- **Redirect URI:** `http://localhost:17323/oauth/callback` (must be pre-registered)
+
+## Public Integration Steps
+
+### Step 1: Convert to Public
+
+Guide the user to find the conversion option in their integration settings. Once converted:
+
+- A **Distribution** tab should appear
+- OAuth Client ID and Client Secret become available in the **Secrets** section
+
+### Step 2: Configure OAuth Redirect URI
+
+Copy the redirect URI to clipboard:
+
+```
+host_bash:
+  command: |
+    echo -n "http://localhost:17323/oauth/callback" | pbcopy
+```
+
+Guide the user to the **Distribution** tab to paste the redirect URI and save.
+
+### Step 3: Copy Client ID and Client Secret
+
+> In the **Secrets** section, copy the **OAuth Client ID** and paste it here.
+
+After receiving the Client ID, collect the secret securely:
+
+```
+credential_store prompt:
+  service: "integration:notion"
+  field: "client_secret"
+  label: "Notion OAuth Client Secret"
+  description: "Copy the Client Secret from the Notion integration page and paste it here."
+  placeholder: "secret_..."
+```
+
+### Step 4: Store Credentials and Authorize
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:notion --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/integration:notion/client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:notion --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
+```
+
+### Step 5: Verify Connection
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+```

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -15,9 +15,11 @@ You have access to the Notion API via the stored Internal Integration Secret for
 The Notion integration secret is stored securely via `credential_store`. To make authenticated API calls, inject the secret into the Authorization header using `assistant credentials reveal`.
 
 **Step 1 — Check for credentials:**
+
 ```
 credential_store action=list
 ```
+
 Find the entry with `service: "integration:notion"` and `field: "internal_secret"`.
 
 If no such entry exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
@@ -41,18 +43,23 @@ All Notion API calls go to `https://api.notion.com/v1/`. Always include the `Not
 ## Reading Pages
 
 ### Get a page by ID
+
 ```
 GET https://api.notion.com/v1/pages/{page_id}
 ```
+
 Returns page properties. Use the page ID from a Notion URL — the last segment of the URL, e.g. for `https://notion.so/My-Page-abc123def456` the ID is `abc123def456` (formatted as UUID: `abc123de-f456-...`).
 
 ### Get page content (blocks)
+
 ```
 GET https://api.notion.com/v1/blocks/{block_id}/children?page_size=100
 ```
+
 Pages are blocks too — use the page ID as the `block_id`. Iterates through the page's child blocks. Use `start_cursor` for pagination when `has_more` is `true`.
 
 **Block types and how to render them:**
+
 - `paragraph`: Read `paragraph.rich_text[].plain_text`
 - `heading_1`, `heading_2`, `heading_3`: Read `heading_N.rich_text[].plain_text`
 - `bulleted_list_item`, `numbered_list_item`: Read `*.rich_text[].plain_text`
@@ -68,6 +75,7 @@ Pages are blocks too — use the page ID as the `block_id`. Iterates through the
 ## Searching
 
 ### Search pages and databases
+
 ```
 POST https://api.notion.com/v1/search
 {
@@ -77,6 +85,7 @@ POST https://api.notion.com/v1/search
   "page_size": 10
 }
 ```
+
 Omit `filter` to search both pages and databases. Use `filter.value: "database"` to search only databases.
 
 Returns `results[]` with `id`, `url`, `properties.title` (for pages), and `title[]` (for databases).
@@ -84,12 +93,15 @@ Returns `results[]` with `id`, `url`, `properties.title` (for pages), and `title
 ## Reading Databases
 
 ### Get database metadata
+
 ```
 GET https://api.notion.com/v1/databases/{database_id}
 ```
+
 Returns the database schema (all property definitions).
 
 ### Query a database
+
 ```
 POST https://api.notion.com/v1/databases/{database_id}/query
 {
@@ -103,9 +115,11 @@ POST https://api.notion.com/v1/databases/{database_id}/query
   "page_size": 20
 }
 ```
+
 Omit `filter` to retrieve all rows. Returns `results[]` where each item is a page (database row).
 
 **Extracting property values from database rows:**
+
 - `title`: `properties.Name.title[].plain_text`
 - `rich_text`: `properties.Notes.rich_text[].plain_text`
 - `number`: `properties.Price.number`
@@ -121,6 +135,7 @@ Omit `filter` to retrieve all rows. Returns `results[]` where each item is a pag
 ## Creating Pages
 
 ### Create a new page
+
 ```
 POST https://api.notion.com/v1/pages
 {
@@ -147,6 +162,7 @@ For database rows, use `"parent": { "database_id": "<database_id>" }` and includ
 ## Updating Pages
 
 ### Update page properties
+
 ```
 PATCH https://api.notion.com/v1/pages/{page_id}
 {
@@ -158,6 +174,7 @@ PATCH https://api.notion.com/v1/pages/{page_id}
 ```
 
 ### Append blocks to a page
+
 ```
 PATCH https://api.notion.com/v1/blocks/{block_id}/children
 {
@@ -196,6 +213,7 @@ PATCH https://api.notion.com/v1/blocks/{block_id}/children
 ```
 
 ### Update a block's content
+
 ```
 PATCH https://api.notion.com/v1/blocks/{block_id}
 {
@@ -206,6 +224,7 @@ PATCH https://api.notion.com/v1/blocks/{block_id}
 ```
 
 ### Delete (archive) a block
+
 ```
 DELETE https://api.notion.com/v1/blocks/{block_id}
 ```
@@ -213,6 +232,7 @@ DELETE https://api.notion.com/v1/blocks/{block_id}
 ## Archive / Delete Pages
 
 Notion does not permanently delete pages via the API — it archives them:
+
 ```
 PATCH https://api.notion.com/v1/pages/{page_id}
 {

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,31 +8,29 @@ metadata:
     display-name: "Notion"
 ---
 
-You have access to the Notion API via the stored OAuth token for `integration:notion`. Use `bash` with `network_mode: "proxied"` to call the Notion API — the proxy automatically injects the Bearer token for `api.notion.com`.
+You have access to the Notion API via the stored Internal Integration Secret for `integration:notion`.
 
 ## Authentication
 
-The Notion access token is stored securely and never exposed as plaintext. Use the credential proxy to inject the Bearer token automatically.
+The Notion integration secret is stored securely via `credential_store`. To make authenticated API calls, inject the secret into the Authorization header using `assistant credentials reveal`.
 
-**Step 1 — Get the credential ID:**
+**Step 1 — Check for credentials:**
 ```
 credential_store action=list
 ```
-Find the entry with `service: "integration:notion"` and `field: "access_token"`. Note its `credential_id`.
+Find the entry with `service: "integration:notion"` and `field: "internal_secret"`.
 
 If no such entry exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
 
-**Step 2 — Make authenticated API calls via the proxy:**
+**Step 2 — Make authenticated API calls:**
 
-Use `bash` with `network_mode: "proxied"` and `credential_ids: ["<credential_id>"]`. The proxy automatically injects `Authorization: Bearer <token>` and any required headers into requests to `api.notion.com`.
+Use `bash` with `assistant credentials reveal` to inject the secret into the Authorization header:
 
-Example:
 ```
 bash:
-  network_mode: proxied
-  credential_ids: ["<credential_id from step 1>"]
   command: |
     curl -s -X POST https://api.notion.com/v1/search \
+      -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       -H "Content-Type: application/json" \
       -d '{}'
@@ -228,7 +226,7 @@ When a response includes `"has_more": true`, pass `"start_cursor": response.next
 
 ## Error Handling
 
-- **401 Unauthorized**: The access token is missing or expired. Ask the user to reconnect Notion via the **notion-oauth-setup** skill.
+- **401 Unauthorized**: The integration secret is missing or invalid. Ask the user to re-run the **notion-oauth-setup** skill to update the secret.
 - **403 Forbidden**: The integration doesn't have access to the requested page or database. Remind the user that they need to share the page/database with the "Vellum Assistant" integration in Notion (via the Share menu → "Add connections").
 - **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
 - **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,11 +8,9 @@ metadata:
     display-name: "Notion"
 ---
 
-You have access to the Notion API via the stored Internal Integration Secret for `integration:notion`.
+You have access to the Notion API via stored credentials for `integration:notion`. Both Internal integration secrets and OAuth access tokens are supported.
 
 ## Authentication
-
-The Notion integration secret is stored securely via `credential_store`. To make authenticated API calls, inject the secret into the Authorization header using `assistant credentials reveal`.
 
 **Step 1 — Check for credentials:**
 
@@ -20,13 +18,16 @@ The Notion integration secret is stored securely via `credential_store`. To make
 credential_store action=list
 ```
 
-Find the entry with `service: "integration:notion"` and `field: "internal_secret"`.
+Look for an entry with `service: "integration:notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
 
-If no such entry exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
+- `field: "internal_secret"` — Internal integration (new default setup)
+- `field: "access_token"` — OAuth/Public integration (legacy setup)
+
+If neither exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-setup** skill to set it up first."
 
 **Step 2 — Make authenticated API calls:**
 
-Use `bash` with `assistant credentials reveal` to inject the secret into the Authorization header:
+Use `bash` with `assistant credentials reveal` to inject the token into the Authorization header. Substitute the correct `--field` value based on what you found in Step 1:
 
 ```
 bash:
@@ -37,6 +38,8 @@ bash:
       -H "Content-Type: application/json" \
       -d '{}'
 ```
+
+For OAuth credentials, use `--field access_token` instead.
 
 All Notion API calls go to `https://api.notion.com/v1/`. Always include the `Notion-Version: 2022-06-28` header.
 
@@ -246,7 +249,7 @@ When a response includes `"has_more": true`, pass `"start_cursor": response.next
 
 ## Error Handling
 
-- **401 Unauthorized**: The integration secret is missing or invalid. Ask the user to re-run the **notion-oauth-setup** skill to update the secret.
+- **401 Unauthorized**: The token is missing, invalid, or expired. For Internal integrations, ask the user to re-run the **notion-oauth-setup** skill. For OAuth connections, the access token may need to be refreshed or re-authorized.
 - **403 Forbidden**: The integration doesn't have access to the requested page or database. Remind the user that they need to share the page/database with the "Vellum Assistant" integration in Notion (via the Share menu → "Add connections").
 - **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
 - **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -93,7 +93,7 @@ Wait for user confirmation before proceeding.
 Guide the user through the creation flow:
 
 1. Name it "Vellum Assistant"
-2. Follow any guidance from `setup.notes` (e.g., select "Public" for Notion, "From scratch" for Slack)
+2. Follow any guidance from `setup.notes` (e.g., "From scratch" for Slack)
 3. Complete the creation
 
 Wait for confirmation.


### PR DESCRIPTION
## Summary
- Rewrote Notion setup skill to default to Internal integration (4 steps) instead of the incorrect Public/OAuth flow (6 steps), based on QA findings that Notion's UI has no Type selector and creates Internal integrations by default
- Updated the Notion API skill to authenticate via `assistant credentials reveal` for the Internal secret instead of OAuth proxy tokens
- Preserved Public/OAuth path as a separate reference doc for multi-workspace use cases

## Test plan
- [ ] Run through the Internal integration setup flow end-to-end
- [ ] Verify `credential_store prompt` stores the `internal_secret` correctly
- [ ] Verify API calls work with `assistant credentials reveal` auth injection
- [ ] Confirm Path B (manual channel setup) works for Internal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
