### PR TITLE
fix: recompute avatar transparency when image changes (#16259)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -23,6 +23,9 @@ struct CreatureView: View {
                 .offset(y: bounceOffset)
                 .scaleEffect(appeared ? 1.0 : 0.0)
                 .opacity(appeared ? 1.0 : 0.0)
+                .onChange(of: appearance.fullAvatarImage) {
+                    avatarIsTransparent = VAvatarImage.imageHasTransparency(appearance.fullAvatarImage)
+                }
                 .onAppear {
                     avatarIsTransparent = VAvatarImage.imageHasTransparency(appearance.fullAvatarImage)
                     if animated {


### PR DESCRIPTION
## Summary
- Add onChange(of: appearance.fullAvatarImage) to recompute avatarIsTransparent when the avatar image changes, preventing stale clip/border behavior

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
