### PR TITLE
fix: migrate credential CLI calls to --service/--field flag format (#16271)

### DIFF
--- a/skills/amazon/scripts/session.ts
+++ b/skills/amazon/scripts/session.ts
@@ -20,7 +20,10 @@ export async function loadSession(): Promise<AmazonSession | null> {
     const { stdout } = await execFileAsync("assistant", [
       "credentials",
       "reveal",
-      "amazon:session:cookies",
+      "--service",
+      "amazon",
+      "--field",
+      "session:cookies",
     ]);
     const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
     return { cookies };
@@ -34,7 +37,10 @@ export async function saveSession(session: AmazonSession): Promise<void> {
     await execFileAsync("assistant", [
       "credentials",
       "set",
-      "amazon:session:cookies",
+      "--service",
+      "amazon",
+      "--field",
+      "session:cookies",
       JSON.stringify(session.cookies),
     ]);
   } catch (err) {
@@ -51,7 +57,10 @@ export async function clearSession(): Promise<void> {
     await execFileAsync("assistant", [
       "credentials",
       "delete",
-      "amazon:session:cookies",
+      "--service",
+      "amazon",
+      "--field",
+      "session:cookies",
     ]);
   } catch {
     // Clearing a non-existent session is fine — no-op
@@ -69,7 +78,10 @@ export async function importFromCredentialStore(
   const { stdout } = await execFileAsync("assistant", [
     "credentials",
     "reveal",
-    `${targetDomain}:session:cookies`,
+    "--service",
+    targetDomain,
+    "--field",
+    "session:cookies",
   ]);
   const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
   if (!cookies.length) {

--- a/skills/doordash/scripts/lib/session.ts
+++ b/skills/doordash/scripts/lib/session.ts
@@ -81,7 +81,10 @@ export async function importFromCredentialStore(
   const { stdout } = await execFileAsync("assistant", [
     "credentials",
     "reveal",
-    `${targetDomain}:session:cookies`,
+    "--service",
+    targetDomain,
+    "--field",
+    "session:cookies",
   ]);
   const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
   if (!cookies.length) {


### PR DESCRIPTION
## Summary
- Update all credential CLI calls in skills/amazon/scripts/session.ts and skills/doordash/scripts/lib/session.ts from old colon-format positional args to new --service/--field flag format
- The old format was broken after the CLI refactor in PR #16268

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
