### PR TITLE
fix: include --provider in oauth connect error message (#16260)

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -641,7 +641,7 @@ Examples:
             // --client-id was explicitly provided but no matching app exists
             writeOutput(cmd, {
               ok: false,
-              error: `No registered app found for "${resolvedServiceKey}" with client ID "${opts.clientId}". Register it first with 'assistant oauth apps upsert --client-id ${opts.clientId}'.`,
+              error: `No registered app found for "${resolvedServiceKey}" with client ID "${opts.clientId}". Register it first with 'assistant oauth apps upsert --provider ${resolvedServiceKey} --client-id ${opts.clientId}'.`,
             });
             process.exitCode = 1;
             return;


### PR DESCRIPTION
## Summary
- Add --provider flag to the suggested upsert command in the oauth connect error message so users can copy-paste it without getting a Commander error

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
