### PR TITLE
refactor: rename Thread/Session→Conversation in macOS test names (private, restorer, persistence, nav)

### DIFF
--- a/clients/macos/vellum-assistantTests/ConversationManagerPrivateConversationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerPrivateConversationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ConversationManagerPrivateThreadTests: XCTestCase {
+final class ConversationManagerPrivateConversationTests: XCTestCase {
 
     private var daemonClient: DaemonClient!
     private var conversationManager: ConversationManager!
@@ -31,101 +31,101 @@ final class ConversationManagerPrivateThreadTests: XCTestCase {
 
     // MARK: - createPrivateConversation
 
-    func testCreatePrivateThreadAddsThreadWithPrivateKind() {
+    func testCreatePrivateConversationAddsConversationWithPrivateKind() {
         conversationManager.createPrivateConversation()
 
         // init enters draft mode (conversations empty), createPrivateConversation adds one
         XCTAssertEqual(conversationManager.conversations.count, 1)
-        let privateThread = conversationManager.conversations.first!
-        XCTAssertEqual(privateThread.kind, .private, "New thread should have kind .private")
+        let privateConversation = conversationManager.conversations.first!
+        XCTAssertEqual(privateConversation.kind, .private, "New conversation should have kind .private")
     }
 
-    func testCreatePrivateThreadSetsActiveThread() {
+    func testCreatePrivateConversationSetsActiveConversation() {
         conversationManager.createPrivateConversation()
 
-        let privateThread = conversationManager.conversations.first!
-        XCTAssertEqual(conversationManager.activeConversationId, privateThread.id)
+        let privateConversation = conversationManager.conversations.first!
+        XCTAssertEqual(conversationManager.activeConversationId, privateConversation.id)
     }
 
-    func testCreatePrivateThreadCallsCreateSessionIfNeeded() {
+    func testCreatePrivateConversationCallsCreateConversationIfNeeded() {
         conversationManager.createPrivateConversation()
 
         let vm = conversationManager.activeViewModel!
-        // Message-less session creates (private thread pre-allocation) don't set isSending.
+        // Message-less conversation creates (private conversation pre-allocation) don't set isSending.
         XCTAssertFalse(vm.isSending, "Message-less bootstrap should not set isSending")
-        XCTAssertTrue(vm.isBootstrapping, "Should be bootstrapping a session")
+        XCTAssertTrue(vm.isBootstrapping, "Should be bootstrapping a conversation")
         XCTAssertEqual(vm.conversationType, "private", "conversationType should be set to private")
     }
 
-    func testCreatePrivateThreadSendsSessionCreate() {
+    func testCreatePrivateConversationSendsConversationCreate() {
         conversationManager.createPrivateConversation()
 
         // Allow the async Task in bootstrapConversation to execute
-        let expectation = XCTestExpectation(description: "session_create sent")
+        let expectation = XCTestExpectation(description: "conversation_create sent")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1.0)
 
-        let sessionCreates = capturedMessages.compactMap { $0 as? ConversationCreateMessage }
-        XCTAssertEqual(sessionCreates.count, 1, "Should send exactly one session_create")
-        XCTAssertEqual(sessionCreates.first?.conversationType, "private", "session_create should include private conversationType")
-        XCTAssertNotNil(sessionCreates.first?.correlationId, "session_create should include correlationId")
+        let conversationCreates = capturedMessages.compactMap { $0 as? ConversationCreateMessage }
+        XCTAssertEqual(conversationCreates.count, 1, "Should send exactly one conversation_create")
+        XCTAssertEqual(conversationCreates.first?.conversationType, "private", "conversation_create should include private conversationType")
+        XCTAssertNotNil(conversationCreates.first?.correlationId, "conversation_create should include correlationId")
     }
 
-    func testCreatePrivateThreadDoesNotReuseEmptyStandardThread() {
+    func testCreatePrivateConversationDoesNotReuseEmptyStandardConversation() {
         // init enters draft mode (activeConversationId is nil) — createPrivateConversation
-        // should create a new private thread, not reuse the draft.
+        // should create a new private conversation, not reuse the draft.
         let draftId = conversationManager.activeConversationId
         conversationManager.createPrivateConversation()
 
         XCTAssertNotEqual(conversationManager.activeConversationId, draftId,
-                          "Should create a new thread, not reuse the draft")
+                          "Should create a new conversation, not reuse the draft")
         XCTAssertEqual(conversationManager.conversations.count, 1)
     }
 
-    // MARK: - Session backfill
+    // MARK: - Conversation ID backfill
 
-    func testPrivateThreadSessionBackfill() {
+    func testPrivateConversationIdBackfill() {
         conversationManager.createPrivateConversation()
-        let privateThread = conversationManager.conversations.first!
+        let privateConversation = conversationManager.conversations.first!
         let vm = conversationManager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
 
-        // Simulate daemon responding with session_info
+        // Simulate daemon responding with conversation_info
         let info = ConversationInfoMessage(conversationId: "private-session-42", title: "Test", correlationId: correlationId)
         vm.handleServerMessage(.conversationInfo(info))
 
-        // The thread's conversationId should be backfilled via onConversationCreated
-        let updatedThread = conversationManager.conversations.first(where: { $0.id == privateThread.id })!
-        XCTAssertEqual(updatedThread.conversationId, "private-session-42", "Session ID should be backfilled into the ConversationModel")
+        // The conversation's conversationId should be backfilled via onConversationCreated
+        let updatedConversation = conversationManager.conversations.first(where: { $0.id == privateConversation.id })!
+        XCTAssertEqual(updatedConversation.conversationId, "private-session-42", "Conversation ID should be backfilled into the ConversationModel")
         XCTAssertEqual(vm.conversationId, "private-session-42")
-        XCTAssertFalse(vm.isSending, "Should reset isSending after session_info for message-less create")
-        XCTAssertFalse(vm.isBootstrapping, "Should no longer be bootstrapping after session_info")
+        XCTAssertFalse(vm.isSending, "Should reset isSending after conversation_info for message-less create")
+        XCTAssertFalse(vm.isBootstrapping, "Should no longer be bootstrapping after conversation_info")
     }
 
-    func testPrivateThreadTitleCallbackStillWorks() {
+    func testPrivateConversationTitleCallbackStillWorks() {
         conversationManager.createPrivateConversation()
-        let privateThread = conversationManager.conversations.first!
+        let privateConversation = conversationManager.conversations.first!
         let vm = conversationManager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
 
-        // Complete the session bootstrap
+        // Complete the conversation bootstrap
         let info = ConversationInfoMessage(conversationId: "private-sess", title: "Test", correlationId: correlationId)
         vm.handleServerMessage(.conversationInfo(info))
 
         // Simulate the user sending a message — the onFirstUserMessage callback
         // should still fire and set the title to "Untitled" as a placeholder.
-        vm.inputText = "Hello private thread"
+        vm.inputText = "Hello private conversation"
         vm.sendMessage()
 
-        let updatedThread = conversationManager.conversations.first(where: { $0.id == privateThread.id })!
-        XCTAssertEqual(updatedThread.title, "Untitled", "First user message should trigger title update")
+        let updatedConversation = conversationManager.conversations.first(where: { $0.id == privateConversation.id })!
+        XCTAssertEqual(updatedConversation.title, "Untitled", "First user message should trigger title update")
     }
 
-    func testCreatePrivateThreadSetsOnSessionCreatedCallback() {
+    func testCreatePrivateConversationSetsOnConversationCreatedCallback() {
         conversationManager.createPrivateConversation()
         let vm = conversationManager.activeViewModel!
-        XCTAssertNotNil(vm.onConversationCreated, "onConversationCreated should be set for session ID backfill")
+        XCTAssertNotNil(vm.onConversationCreated, "onConversationCreated should be set for conversation ID backfill")
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -13,8 +13,8 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     var hasMoreConversations: Bool = false
     var serverOffset: Int = 0
     var viewModels: [UUID: ChatViewModel] = [:]
-    var activatedThreadId: UUID?
-    var createThreadCallCount = 0
+    var activatedConversationId: UUID?
+    var createConversationCallCount = 0
     var archivedConversationIds: Set<String> = []
     private let daemonClient: DaemonClient
 
@@ -50,16 +50,16 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     }
 
     func activateConversation(_ id: UUID) {
-        activatedThreadId = id
+        activatedConversationId = id
     }
 
     func createConversation() {
-        createThreadCallCount += 1
-        let thread = ConversationModel()
+        createConversationCallCount += 1
+        let conversation = ConversationModel()
         let vm = makeViewModel()
-        conversations.insert(thread, at: 0)
-        viewModels[thread.id] = vm
-        activatedThreadId = thread.id
+        conversations.insert(conversation, at: 0)
+        viewModels[conversation.id] = vm
+        activatedConversationId = conversation.id
     }
 
     func isConversationArchived(_ conversationId: String) -> Bool {
@@ -161,26 +161,26 @@ struct ConversationRestorerTests {
     // MARK: - History Response Routing
 
     @Test @MainActor
-    func historyResponseRoutesToCorrectThread() {
+    func historyResponseRoutesToCorrectConversation() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
 
-        // Set up two conversations with session IDs
-        let threadA = ConversationModel(title: "Conversation A", conversationId: "session-A")
-        let threadB = ConversationModel(title: "Conversation B", conversationId: "session-B")
-        delegate.conversations = [threadA, threadB]
+        // Set up two conversations with conversation IDs
+        let conversationA = ConversationModel(title: "Conversation A", conversationId: "session-A")
+        let conversationB = ConversationModel(title: "Conversation B", conversationId: "session-B")
+        delegate.conversations = [conversationA, conversationB]
 
         let vmA = delegate.makeViewModel()
         let vmB = delegate.makeViewModel()
-        delegate.viewModels[threadA.id] = vmA
-        delegate.viewModels[threadB.id] = vmB
+        delegate.viewModels[conversationA.id] = vmA
+        delegate.viewModels[conversationB.id] = vmB
 
         restorer.delegate = delegate
 
-        // Register pending history for both sessions
-        restorer.pendingHistoryByConversationId["session-A"] = threadA.id
-        restorer.pendingHistoryByConversationId["session-B"] = threadB.id
+        // Register pending history for both conversations
+        restorer.pendingHistoryByConversationId["session-A"] = conversationA.id
+        restorer.pendingHistoryByConversationId["session-B"] = conversationB.id
 
         // Deliver history for session-B
         let response = makeHistoryResponse(conversationId: "session-B", messages: [
@@ -199,7 +199,7 @@ struct ConversationRestorerTests {
 
         // session-B should be removed from pending, session-A should remain
         #expect(restorer.pendingHistoryByConversationId["session-B"] == nil)
-        #expect(restorer.pendingHistoryByConversationId["session-A"] == threadA.id)
+        #expect(restorer.pendingHistoryByConversationId["session-A"] == conversationA.id)
     }
 
     @Test @MainActor
@@ -209,10 +209,10 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ConversationModel(title: "Thread", conversationId: "session-X")
-        delegate.conversations = [thread]
+        let conversation = ConversationModel(title: "Conversation", conversationId: "session-X")
+        delegate.conversations = [conversation]
         let vm = delegate.makeViewModel()
-        delegate.viewModels[thread.id] = vm
+        delegate.viewModels[conversation.id] = vm
 
         // No pending entry for "session-stale"
         let response = makeHistoryResponse(conversationId: "session-stale", messages: [
@@ -232,19 +232,19 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let threadA = ConversationModel(title: "A", conversationId: "sa")
-        let threadB = ConversationModel(title: "B", conversationId: "sb")
-        delegate.conversations = [threadA, threadB]
+        let conversationA = ConversationModel(title: "A", conversationId: "sa")
+        let conversationB = ConversationModel(title: "B", conversationId: "sb")
+        delegate.conversations = [conversationA, conversationB]
 
         let vmA = delegate.makeViewModel()
         let vmB = delegate.makeViewModel()
-        delegate.viewModels[threadA.id] = vmA
-        delegate.viewModels[threadB.id] = vmB
+        delegate.viewModels[conversationA.id] = vmA
+        delegate.viewModels[conversationB.id] = vmB
 
-        // User views thread A, then quickly switches to B —
+        // User views conversation A, then quickly switches to B —
         // both history requests are in-flight with correct mapping.
-        restorer.pendingHistoryByConversationId["sa"] = threadA.id
-        restorer.pendingHistoryByConversationId["sb"] = threadB.id
+        restorer.pendingHistoryByConversationId["sa"] = conversationA.id
+        restorer.pendingHistoryByConversationId["sb"] = conversationB.id
 
         // Responses arrive out of order: B first, then A
         restorer.handleHistoryResponse(makeHistoryResponse(conversationId: "sb", messages: [
@@ -262,18 +262,18 @@ struct ConversationRestorerTests {
         #expect(vmB.isHistoryLoaded)
     }
 
-    // MARK: - Session Title Updates
+    // MARK: - Conversation Title Updates
 
     @Test @MainActor
-    func sessionTitleUpdatedUpdatesMatchingThread() {
+    func conversationTitleUpdatedUpdatesMatchingConversation() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ConversationModel(title: "Untitled", conversationId: "session-1")
-        delegate.conversations = [thread]
-        delegate.viewModels[thread.id] = delegate.makeViewModel()
+        let conversation = ConversationModel(title: "Untitled", conversationId: "session-1")
+        delegate.conversations = [conversation]
+        delegate.viewModels[conversation.id] = delegate.makeViewModel()
 
         restorer.handleConversationTitleUpdated(makeConversationTitleUpdated(conversationId: "session-1", title: "Plan sprint rollout"))
 
@@ -281,35 +281,35 @@ struct ConversationRestorerTests {
     }
 
     @Test @MainActor
-    func sessionTitleUpdatedIgnoresUnknownSessionId() {
+    func conversationTitleUpdatedIgnoresUnknownConversationId() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let thread = ConversationModel(title: "Untitled", conversationId: "session-1")
-        delegate.conversations = [thread]
-        delegate.viewModels[thread.id] = delegate.makeViewModel()
+        let conversation = ConversationModel(title: "Untitled", conversationId: "session-1")
+        delegate.conversations = [conversation]
+        delegate.viewModels[conversation.id] = delegate.makeViewModel()
 
         restorer.handleConversationTitleUpdated(makeConversationTitleUpdated(conversationId: "other-session", title: "Should not apply"))
 
         #expect(delegate.conversations[0].title == "Untitled")
     }
 
-    // MARK: - Session List Restoration
+    // MARK: - Conversation List Restoration
 
     @Test @MainActor
-    func sessionListCreatesRestoredThreads() {
+    func conversationListCreatesRestoredConversations() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        // Start with one empty default thread
-        let defaultThread = ConversationModel()
+        // Start with one empty default conversation
+        let defaultConversation = ConversationModel()
         let defaultVm = delegate.makeViewModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = defaultVm
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = defaultVm
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Chat 1", updatedAt: 3000),
@@ -317,11 +317,11 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Default empty thread should be replaced
+        // Default empty conversation should be replaced
         #expect(delegate.conversations.count == 2)
-        #expect(delegate.viewModels[defaultThread.id] == nil)
+        #expect(delegate.viewModels[defaultConversation.id] == nil)
 
-        // Restored conversations have correct session IDs
+        // Restored conversations have correct conversation IDs
         #expect(delegate.conversations[0].conversationId == "s1")
         #expect(delegate.conversations[1].conversationId == "s2")
         #expect(delegate.conversations[0].title == "Chat 1")
@@ -330,24 +330,24 @@ struct ConversationRestorerTests {
         #expect(delegate.viewModels[delegate.conversations[0].id] == nil)
         #expect(delegate.viewModels[delegate.conversations[1].id] == nil)
 
-        // Most recent thread should be activated
-        #expect(delegate.activatedThreadId == delegate.conversations[0].id)
+        // Most recent conversation should be activated
+        #expect(delegate.activatedConversationId == delegate.conversations[0].id)
     }
 
     @Test @MainActor
-    func sessionListPreservesAssistantAttentionTimestamps() {
+    func conversationListPreservesAssistantAttentionTimestamps() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversationDicts: [[
             "id": "s-attention",
-            "title": "Attention thread",
+            "title": "Attention conversation",
             "createdAt": 1000,
             "updatedAt": 2000,
             "assistantAttention": [
@@ -359,26 +359,26 @@ struct ConversationRestorerTests {
 
         restorer.handleConversationListResponse(response)
 
-        guard let restoredThread = delegate.conversations.first(where: { $0.conversationId == "s-attention" }) else {
-            Issue.record("Expected restored attention thread")
+        guard let restoredConversation = delegate.conversations.first(where: { $0.conversationId == "s-attention" }) else {
+            Issue.record("Expected restored attention conversation")
             return
         }
 
-        #expect(restoredThread.hasUnseenLatestAssistantMessage)
-        #expect(restoredThread.latestAssistantMessageAt?.timeIntervalSince1970 == 4.0)
-        #expect(restoredThread.lastSeenAssistantMessageAt?.timeIntervalSince1970 == 3.0)
+        #expect(restoredConversation.hasUnseenLatestAssistantMessage)
+        #expect(restoredConversation.latestAssistantMessageAt?.timeIntervalSince1970 == 4.0)
+        #expect(restoredConversation.lastSeenAssistantMessageAt?.timeIntervalSince1970 == 3.0)
     }
 
     @Test @MainActor
-    func sessionListSkipsWhenRestoreDisabled() {
+    func conversationListSkipsWhenRestoreDisabled() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         delegate.restoreRecentConversations = false
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Chat 1", updatedAt: 1000),
@@ -387,18 +387,18 @@ struct ConversationRestorerTests {
 
         // Should not modify conversations
         #expect(delegate.conversations.count == 1)
-        #expect(delegate.conversations[0].id == defaultThread.id)
-        #expect(delegate.activatedThreadId == nil)
+        #expect(delegate.conversations[0].id == defaultConversation.id)
+        #expect(delegate.activatedConversationId == nil)
     }
 
     @Test @MainActor
-    func sessionListPreservesNonEmptyDefaultThread() {
+    func conversationListPreservesNonEmptyDefaultConversation() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        // Default thread that has an active session (not empty)
+        // Default conversation that has an active conversation (not empty)
         let activeConversation = ConversationModel(title: "Active")
         let activeVm = delegate.makeViewModel()
         activeVm.conversationId = "active-session"
@@ -410,29 +410,29 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Active thread is preserved, restored thread prepended
+        // Active conversation is preserved, restored conversation prepended
         #expect(delegate.conversations.count == 2)
         #expect(delegate.conversations[1].id == activeConversation.id)
         #expect(delegate.conversations[0].conversationId == "s1")
     }
 
     @Test @MainActor
-    func sessionListRestoresAllAndSetsOffset() {
+    func conversationListRestoresAllAndSetsOffset() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
-        let sessions = (0..<10).map { i in
+        let restoredConversations = (0..<10).map { i in
             (id: "s\(i)", title: "Chat \(i)", updatedAt: 10000 - i)
         }
-        restorer.handleConversationListResponse(makeConversationListResponse(conversations: sessions))
+        restorer.handleConversationListResponse(makeConversationListResponse(conversations: restoredConversations))
 
-        // Client restores all sessions from the response; pagination is server-side
+        // Client restores all conversations from the response; pagination is server-side
         #expect(delegate.conversations.count == 10)
         #expect(delegate.serverOffset == 10)
     }
@@ -440,19 +440,19 @@ struct ConversationRestorerTests {
     // MARK: - All-Archived Restore
 
     @Test @MainActor
-    func allArchivedSessionsCreatesNewThread() {
+    func allArchivedConversationsCreatesNewConversation() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        // Mark all sessions as archived
+        // Mark all conversations as archived
         delegate.archivedConversationIds = ["s1", "s2"]
 
-        // Start with one empty default thread
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        // Start with one empty default conversation
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Chat 1", updatedAt: 3000),
@@ -460,17 +460,17 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Default thread replaced, restored conversations are archived, new thread created
-        #expect(delegate.createThreadCallCount == 1)
-        // 2 archived conversations + 1 new thread
+        // Default conversation replaced, restored conversations are archived, new conversation created
+        #expect(delegate.createConversationCallCount == 1)
+        // 2 archived conversations + 1 new conversation
         #expect(delegate.conversations.count == 3)
-        // The new thread should be active
-        #expect(delegate.activatedThreadId != nil)
-        #expect(delegate.conversations.first(where: { $0.id == delegate.activatedThreadId })?.isArchived == false)
+        // The new conversation should be active
+        #expect(delegate.activatedConversationId != nil)
+        #expect(delegate.conversations.first(where: { $0.id == delegate.activatedConversationId })?.isArchived == false)
     }
 
     @Test @MainActor
-    func allArchivedWithNonEmptyDefaultDoesNotCreateThread() {
+    func allArchivedWithNonEmptyDefaultDoesNotCreateConversation() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
@@ -478,7 +478,7 @@ struct ConversationRestorerTests {
 
         delegate.archivedConversationIds = ["s1"]
 
-        // Default thread has an active session (not empty)
+        // Default conversation has an active conversation (not empty)
         let activeConversation = ConversationModel(title: "Active")
         let activeVm = delegate.makeViewModel()
         activeVm.conversationId = "active-session"
@@ -490,8 +490,8 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Default thread preserved, no new thread created
-        #expect(delegate.createThreadCallCount == 0)
+        // Default conversation preserved, no new conversation created
+        #expect(delegate.createConversationCallCount == 0)
         #expect(delegate.conversations.count == 2)
         #expect(delegate.conversations.contains(where: { $0.id == activeConversation.id }))
     }
@@ -499,25 +499,25 @@ struct ConversationRestorerTests {
     // MARK: - Conversation Type Mapping
 
     @Test @MainActor
-    func privateThreadTypeIsExcludedFromRestore() {
+    func privateConversationTypeIsExcludedFromRestore() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Private Chat", updatedAt: 2000, conversationType: "private"),
         ])
         restorer.handleConversationListResponse(response)
 
-        // Private sessions are filtered out; empty default is removed and a new thread created
+        // Private conversations are filtered out; empty default is removed and a new conversation created
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
-        #expect(delegate.createThreadCallCount == 1)
+        #expect(delegate.createConversationCallCount == 1)
     }
 
     @Test @MainActor
@@ -527,9 +527,9 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Regular Chat", updatedAt: 2000, conversationType: nil),
@@ -547,9 +547,9 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Standard Chat", updatedAt: 2000, conversationType: "standard"),
@@ -563,15 +563,15 @@ struct ConversationRestorerTests {
     // MARK: - Channel Binding Filtering
 
     @Test @MainActor
-    func telegramBoundSessionIsExcludedFromRestore() {
+    func telegramBoundConversationIsExcludedFromRestore() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Telegram Chat", updatedAt: 2000, conversationType: nil,
@@ -579,23 +579,23 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Telegram-bound session filtered out; empty default removed; new thread created
+        // Telegram-bound conversation filtered out; empty default removed; new conversation created
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
         #expect(delegate.conversations[0].conversationId == nil)
-        #expect(delegate.createThreadCallCount == 1)
+        #expect(delegate.createConversationCallCount == 1)
     }
 
     @Test @MainActor
-    func voiceBoundSessionIsExcludedFromRestore() {
+    func voiceBoundConversationIsExcludedFromRestore() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Voice Call", updatedAt: 2000, conversationType: nil,
@@ -603,11 +603,11 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Voice-bound session filtered out; empty default removed; new thread created
+        // Voice-bound conversation filtered out; empty default removed; new conversation created
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
         #expect(delegate.conversations[0].conversationId == nil)
-        #expect(delegate.createThreadCallCount == 1)
+        #expect(delegate.createConversationCallCount == 1)
     }
 
     @Test @MainActor
@@ -617,9 +617,9 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Desktop Chat", updatedAt: 4000, conversationType: nil, channelBinding: nil),
@@ -631,13 +631,13 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Only the two desktop sessions should be restored
+        // Only the two desktop conversations should be restored
         #expect(delegate.conversations.count == 2)
         #expect(delegate.conversations[0].conversationId == "s1")
         #expect(delegate.conversations[0].title == "Desktop Chat")
         #expect(delegate.conversations[1].conversationId == "s4")
         #expect(delegate.conversations[1].title == "Another Desktop Chat")
-        #expect(delegate.createThreadCallCount == 0)
+        #expect(delegate.createConversationCallCount == 0)
     }
 
     @Test @MainActor
@@ -647,9 +647,9 @@ struct ConversationRestorerTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         let response = makeConversationListResponse(conversations: [
             (id: "s1", title: "Desktop Chat", updatedAt: 3000, conversationType: nil, channelBinding: nil),
@@ -659,12 +659,12 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Only the two desktop sessions should be restored
+        // Only the two desktop conversations should be restored
         #expect(delegate.conversations.count == 2)
         #expect(delegate.conversations[0].conversationId == "s1")
         #expect(delegate.conversations[0].title == "Desktop Chat")
         #expect(delegate.conversations[1].conversationId == "s3")
         #expect(delegate.conversations[1].title == "Another Desktop Chat")
-        #expect(delegate.createThreadCallCount == 0)
+        #expect(delegate.createConversationCallCount == 0)
     }
 }

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @MainActor
 final class MainWindowStateNavigationHistoryTests: XCTestCase {
 
-    func testBackForwardAcrossThreadPanelApp() {
+    func testBackForwardAcrossConversationPanelApp() {
         let state = MainWindowState(hasAPIKey: false)
         let id1 = UUID()
         state.selection = .conversation(id1)
@@ -39,7 +39,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         XCTAssertNil(state.selection)
     }
 
-    func testBackToChatDefaultRestoresThread() {
+    func testBackToChatDefaultRestoresConversation() {
         let state = MainWindowState(hasAPIKey: false)
         let someId = UUID()
         state.persistentConversationId = someId

--- a/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
@@ -15,7 +15,7 @@ final class NavigationHistoryTests: XCTestCase {
         XCTAssertTrue(history.backStack.isEmpty)
     }
 
-    func testChatDefaultAndThreadWithSameIdAreEquivalent() {
+    func testChatDefaultAndConversationWithSameIdAreEquivalent() {
         let history = NavigationHistory()
         let id = UUID()
 
@@ -116,7 +116,7 @@ final class NavigationHistoryTests: XCTestCase {
     func testMaxDepthEnforced() {
         let history = NavigationHistory()
 
-        // Record 55 transitions: each from thread(i) to thread(i+1)
+        // Record 55 transitions: each from conversation(i) to conversation(i+1)
         for _ in 0..<55 {
             let fromId = UUID()
             let toId = UUID()

--- a/clients/macos/vellum-assistantTests/PrivateConversationPersistenceTests.swift
+++ b/clients/macos/vellum-assistantTests/PrivateConversationPersistenceTests.swift
@@ -4,17 +4,17 @@ import Testing
 @testable import VellumAssistantShared
 
 /// End-to-end behavior tests verifying that private conversations persist correctly
-/// and reappear with the right kind after a session restore cycle.
-@Suite("PrivateThreadPersistence")
-struct PrivateThreadPersistenceTests {
+/// and reappear with the right kind after a restore cycle.
+@Suite("PrivateConversationPersistence")
+struct PrivateConversationPersistenceTests {
 
     // MARK: - End-to-end Flow
 
-    /// Verifies the full lifecycle: create a private thread via ConversationManager,
-    /// simulate the daemon assigning a session ID, then confirm the session
-    /// restorer reconstructs it as a private thread.
+    /// Verifies the full lifecycle: create a private conversation via ConversationManager,
+    /// simulate the daemon assigning a conversation ID, then confirm the
+    /// restorer reconstructs it as a private conversation.
     @Test @MainActor
-    func privateThreadCreatedAndRestoredAsPrivate() {
+    func privateConversationCreatedAndRestoredAsPrivate() {
         let dc = DaemonClient()
         dc.isConnected = true
         dc.sendOverride = { _ in }
@@ -29,11 +29,11 @@ struct PrivateThreadPersistenceTests {
         manager.createPrivateConversation()
         #expect(manager.conversations.count == 1)
 
-        let privateThread = manager.conversations.first!
-        #expect(privateThread.kind == .private)
-        #expect(manager.activeConversationId == privateThread.id)
+        let privateConversation = manager.conversations.first!
+        #expect(privateConversation.kind == .private)
+        #expect(manager.activeConversationId == privateConversation.id)
 
-        // Simulate daemon assigning a session ID via session_info callback
+        // Simulate daemon assigning a conversation ID via conversation_info callback
         let vm = manager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
         let info = ConversationInfoMessage(
@@ -43,23 +43,23 @@ struct PrivateThreadPersistenceTests {
         )
         vm.handleServerMessage(.conversationInfo(info))
 
-        // Session ID should be backfilled into the ConversationModel
-        let updatedThread = manager.conversations.first(where: { $0.id == privateThread.id })!
-        #expect(updatedThread.conversationId == "private-session-e2e")
-        #expect(updatedThread.kind == .private)
+        // Conversation ID should be backfilled into the ConversationModel
+        let updatedConversation = manager.conversations.first(where: { $0.id == privateConversation.id })!
+        #expect(updatedConversation.conversationId == "private-session-e2e")
+        #expect(updatedConversation.kind == .private)
 
-        // Now simulate a fresh restore: build a session list response
-        // that includes this session with conversationType "private", and verify
+        // Now simulate a fresh restore: build a conversation list response
+        // that includes this conversation with conversationType "private", and verify
         // the restorer creates it with .private kind.
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
-        let sessionListJSON: [String: Any] = [
+        let conversationListJSON: [String: Any] = [
             "type": "conversation_list_response",
             "conversations": [
                 [
@@ -71,21 +71,21 @@ struct PrivateThreadPersistenceTests {
                 ]
             ]
         ]
-        let data = try! JSONSerialization.data(withJSONObject: sessionListJSON)
+        let data = try! JSONSerialization.data(withJSONObject: conversationListJSON)
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private conversations are excluded from restoration — the default thread
-        // is removed (it was empty) and no private sessions are restored,
-        // so a new empty thread is created via createConversation().
+        // Private conversations are excluded from restoration — the default conversation
+        // is removed (it was empty) and no private conversations are restored,
+        // so a new empty conversation is created via createConversation().
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
     }
 
-    /// Verifies that a standard thread round-trips correctly through
-    /// create and restore (control case for the private thread test above).
+    /// Verifies that a standard conversation round-trips correctly through
+    /// create and restore (control case for the private conversation test above).
     @Test @MainActor
-    func standardThreadCreatedAndRestoredAsStandard() {
+    func standardConversationCreatedAndRestoredAsStandard() {
         let dc = DaemonClient()
         dc.isConnected = true
         dc.sendOverride = { _ in }
@@ -94,16 +94,16 @@ struct PrivateThreadPersistenceTests {
         // ConversationManager.init enters draft mode — no conversations in the array yet
         #expect(manager.conversations.isEmpty)
 
-        // Restore a session list with a standard thread
+        // Restore a conversation list with a standard conversation
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
-        let sessionListJSON: [String: Any] = [
+        let conversationListJSON: [String: Any] = [
             "type": "conversation_list_response",
             "conversations": [
                 [
@@ -115,7 +115,7 @@ struct PrivateThreadPersistenceTests {
                 ]
             ]
         ]
-        let data = try! JSONSerialization.data(withJSONObject: sessionListJSON)
+        let data = try! JSONSerialization.data(withJSONObject: conversationListJSON)
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
@@ -126,20 +126,20 @@ struct PrivateThreadPersistenceTests {
 
     // MARK: - Mixed Conversation Restore
 
-    /// Verifies that a session list containing both private and standard conversations
+    /// Verifies that a conversation list containing both private and standard conversations
     /// restores each with the correct kind.
     @Test @MainActor
-    func mixedThreadTypesRestoreCorrectly() {
+    func mixedConversationTypesRestoreCorrectly() {
         let dc = DaemonClient()
         let restorer = ConversationRestorer(daemonClient: dc)
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
-        let sessionListJSON: [String: Any] = [
+        let conversationListJSON: [String: Any] = [
             "type": "conversation_list_response",
             "conversations": [
                 ["id": "s-private-1", "title": "Private A", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
@@ -147,11 +147,11 @@ struct PrivateThreadPersistenceTests {
                 ["id": "s-private-2", "title": "Private C", "createdAt": 2000, "updatedAt": 3000, "conversationType": "private"],
             ]
         ]
-        let data = try! JSONSerialization.data(withJSONObject: sessionListJSON)
+        let data = try! JSONSerialization.data(withJSONObject: conversationListJSON)
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private conversations are filtered out before restore — only standard conversations appear
+        // Private conversations are filtered out during restore — only standard conversations appear
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
         #expect(delegate.conversations[0].conversationId == "s-standard-1")
@@ -159,8 +159,8 @@ struct PrivateThreadPersistenceTests {
 
     // MARK: - Legacy Daemon Payload Fallback
 
-    /// Older daemon versions do not include the conversationType field in session
-    /// list responses. Verify that these sessions default to .standard.
+    /// Older daemon versions do not include the conversationType field in conversation
+    /// list responses. Verify that these conversations default to .standard.
     @Test @MainActor
     func legacyPayloadWithoutConversationTypeDefaultsToStandard() {
         let dc = DaemonClient()
@@ -168,9 +168,9 @@ struct PrivateThreadPersistenceTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
         // JSON with no conversationType key at all — simulates an older daemon
         let legacyJSON: [String: Any] = [
@@ -188,8 +188,8 @@ struct PrivateThreadPersistenceTests {
         #expect(delegate.conversations[0].conversationId == "legacy-1")
     }
 
-    /// Verifies that a session list mixing legacy (no conversationType) and modern
-    /// (with conversationType) sessions restores correctly.
+    /// Verifies that a conversation list mixing legacy (no conversationType) and modern
+    /// (with conversationType) conversations restores correctly.
     @Test @MainActor
     func mixedLegacyAndModernPayloadsRestoreCorrectly() {
         let dc = DaemonClient()
@@ -197,11 +197,11 @@ struct PrivateThreadPersistenceTests {
         let delegate = MockConversationRestorerDelegate(daemonClient: dc)
         restorer.delegate = delegate
 
-        let defaultThread = ConversationModel()
-        delegate.conversations = [defaultThread]
-        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+        let defaultConversation = ConversationModel()
+        delegate.conversations = [defaultConversation]
+        delegate.viewModels[defaultConversation.id] = delegate.makeViewModel()
 
-        // Build sessions array manually: first has conversationType, second doesn't
+        // Build conversations array manually: first has conversationType, second doesn't
         let conversations: [[String: Any]] = [
             ["id": "modern-1", "title": "Modern Private", "createdAt": 4000, "updatedAt": 5000, "conversationType": "private"],
             ["id": "legacy-1", "title": "Legacy Chat", "createdAt": 3000, "updatedAt": 4000],
@@ -211,7 +211,7 @@ struct PrivateThreadPersistenceTests {
         let response = try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
         restorer.handleConversationListResponse(response)
 
-        // Private conversations are filtered out — only the legacy standard thread is restored
+        // Private conversations are filtered out — only the legacy standard conversation is restored
         #expect(delegate.conversations.count == 1)
         #expect(delegate.conversations[0].kind == .standard)
         #expect(delegate.conversations[0].title == "Legacy Chat")
@@ -219,11 +219,11 @@ struct PrivateThreadPersistenceTests {
 
     // MARK: - ConversationManager.createPrivateConversation Immediate Persistence
 
-    /// Verifies that createPrivateConversation() immediately sends a session_create
-    /// with conversationType "private" — the thread is persisted on the daemon side
+    /// Verifies that createPrivateConversation() immediately sends a conversation_create
+    /// with conversationType "private" — the conversation is persisted on the daemon side
     /// before the user sends any messages.
     @Test @MainActor
-    func privateThreadPersistsImmediatelyViaSessionCreate() {
+    func privateConversationPersistsImmediatelyViaConversationCreate() {
         let dc = DaemonClient()
         dc.isConnected = true
         var captured: [Any] = []
@@ -238,16 +238,16 @@ struct PrivateThreadPersistenceTests {
         #expect(vm.isBootstrapping)
         #expect(vm.conversationType == "private")
 
-        // The session_create is dispatched asynchronously via Task; the
+        // The conversation_create is dispatched asynchronously via Task; the
         // correlation ID and conversationType are set synchronously, confirming
         // the intent to persist immediately.
         #expect(vm.bootstrapCorrelationId != nil)
     }
 
-    /// Verifies that a private thread's kind survives the session backfill
+    /// Verifies that a private conversation's kind survives the ID backfill
     /// callback — the kind should remain .private after the daemon responds.
     @Test @MainActor
-    func privateConversationKindSurvivesSessionBackfill() {
+    func privateConversationKindSurvivesIdBackfill() {
         let dc = DaemonClient()
         dc.isConnected = true
         dc.sendOverride = { _ in }
@@ -255,13 +255,13 @@ struct PrivateThreadPersistenceTests {
         let manager = ConversationManager(daemonClient: dc)
         manager.createPrivateConversation()
 
-        let privateThread = manager.conversations.first!
-        #expect(privateThread.kind == .private)
+        let privateConversation = manager.conversations.first!
+        #expect(privateConversation.kind == .private)
 
         let vm = manager.activeViewModel!
         let correlationId = vm.bootstrapCorrelationId!
 
-        // Simulate daemon session_info response
+        // Simulate daemon conversation_info response
         let info = ConversationInfoMessage(
             conversationId: "persist-check",
             title: "Test",
@@ -270,7 +270,7 @@ struct PrivateThreadPersistenceTests {
         vm.handleServerMessage(.conversationInfo(info))
 
         // Kind must still be .private after backfill
-        let updated = manager.conversations.first(where: { $0.id == privateThread.id })!
+        let updated = manager.conversations.first(where: { $0.id == privateConversation.id })!
         #expect(updated.kind == .private)
         #expect(updated.conversationId == "persist-check")
     }


### PR DESCRIPTION
## Summary
- Renamed class `ConversationManagerPrivateThreadTests` and 8 test methods
- Renamed mock variables and 13 test methods in ConversationRestorerTests
- Renamed struct `PrivateThreadPersistenceTests` and 5 test methods
- Renamed 3 test methods across NavigationHistoryTests and MainWindowStateNavigationHistoryTests

Part of plan: conv-symbol-sweep.md (PR 8 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
