### PR TITLE
fix: pass assistant name to stop command on tokenless logout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -156,12 +156,12 @@ extension AppDelegate {
                     if !cleared {
                         log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed proxy state")
                         daemonClient.disconnect()
-                        assistantCli.stop()
+                        assistantCli.stop(name: connectedAssistantId)
                     }
                 } else {
                     log.warning("No actor token available during logout — stopping daemon to ensure stale credentials are not retained")
                     daemonClient.disconnect()
-                    assistantCli.stop()
+                    assistantCli.stop(name: connectedAssistantId)
                 }
             }
 
@@ -465,7 +465,7 @@ extension AppDelegate {
                 // Retire failed but user chose Force Remove — stop the daemon
                 // before cleaning up local state.
                 daemonClient.disconnect()
-                assistantCli.stop()
+                assistantCli.stop(name: name)
                 self.removeLockfileEntry(assistantId: name)
             }
 
@@ -475,7 +475,7 @@ extension AppDelegate {
             // thread and always fail because the process is already gone.
             daemonClient.disconnect()
         } else {
-            assistantCli.stop()
+            assistantCli.stop(name: assistantName)
         }
 
         // Check if other assistants remain in the lockfile.

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -241,7 +241,7 @@ final class AssistantCli {
 
     /// Non-destructive stop: kills the daemon process via the CLI without
     /// deleting ~/.vellum or deregistering the assistant.
-    func stop() {
+    func stop(name: String? = nil) {
         guard let binaryURL = cliBinaryURL else {
             log.info("No bundled CLI binary found — skipping stop (dev mode)")
             // Still try to clean up via PID file in dev mode
@@ -255,7 +255,11 @@ final class AssistantCli {
         // stop must be synchronous (called from applicationWillTerminate)
         let proc = Process()
         proc.executableURL = binaryURL
-        proc.arguments = ["sleep"]
+        var sleepArgs = ["sleep"]
+        if let name, !name.isEmpty {
+            sleepArgs.append(name)
+        }
+        proc.arguments = sleepArgs
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
 


### PR DESCRIPTION
Addresses review feedback from PR #17524. The stop command now receives the connected assistant ID so the correct daemon is stopped in multi-assistant setups.

Changes:
- `AssistantCli.stop()` now accepts an optional `name` parameter, passed through to the CLI `sleep` command
- All call sites in `performLogout()` pass `connectedAssistantId` to `stop(name:)`
- Updated `performRetireAsync()` call sites for consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
