### PR TITLE
fix: resolve BOOTSTRAP.md path from active instance workspace

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -91,7 +91,8 @@ struct MainWindowView: View {
 
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
     private var isBootstrapOnboardingActive: Bool {
-        FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
+        let base = daemonClient.config.instanceDir ?? NSHomeDirectory()
+        return FileManager.default.fileExists(atPath: base + "/.vellum/workspace/BOOTSTRAP.md")
     }
 
     func toggleVoiceMode() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -24,7 +24,8 @@ struct IdentityPanel: View {
 
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
     private var isBootstrapActive: Bool {
-        FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
+        let base = lockfileAssistant?.instanceDir ?? NSHomeDirectory()
+        return FileManager.default.fileExists(atPath: base + "/.vellum/workspace/BOOTSTRAP.md")
     }
 
     private let panelPadding: CGFloat = VSpacing.xl


### PR DESCRIPTION
Addresses review feedback from PR #17545. The BOOTSTRAP.md path is now resolved from the active assistant's instance directory instead of being hardcoded to the home directory, fixing multi-instance setups where the bootstrap marker lives under `<instanceDir>/.vellum/workspace/BOOTSTRAP.md`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
