### PR TITLE
fix: use @AppStorage for reactive billing visibility checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -69,6 +69,7 @@ struct SettingsPanel: View {
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
+    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
@@ -273,7 +274,7 @@ struct SettingsPanel: View {
 
     private var billingVisible: Bool {
         let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
-        return isBillingEnabled && authManager.isAuthenticated && UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
+        return isBillingEnabled && authManager.isAuthenticated && connectedOrgId != nil
     }
 
     private var settingsNav: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -13,12 +13,13 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
     @State private var bootstrapGeneration: Int = 0
+    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
 
     private var isBillingVisible: Bool {
         let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
         return authManager.isAuthenticated &&
         MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled") &&
-        UserDefaults.standard.string(forKey: "connectedOrganizationId") != nil
+        connectedOrgId != nil
     }
 
     var body: some View {


### PR DESCRIPTION
Addresses review feedback from PR #17542. Replaces raw UserDefaults reads with @AppStorage properties so billing tab visibility updates reactively after sign-in bootstrap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
