### PR TITLE
fix: gate hidden-file toggle completion by request identity (#16279)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -34,6 +34,7 @@ final class WorkspaceBrowserState {
     var pendingHiddenFilesToggle: Bool?
     var showingDirtyAlert: Bool = false
     var showHiddenFiles: Bool = UserDefaults.standard.bool(forKey: "showHiddenFiles")
+    var hiddenFilesToggleRequestId: UInt64 = 0
 
     func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
         if let response = await daemonClient.fetchWorkspaceTree(path: dirPath, showHidden: showHiddenFiles) {
@@ -210,15 +211,16 @@ struct WorkspacePanel: View {
         state.originalContent = ""
         state.isDirty = false
         state.isLoadingTree = true
-        let expectedValue = newValue
+        state.hiddenFilesToggleRequestId &+= 1
+        let requestId = state.hiddenFilesToggleRequestId
         Task {
             if let response = await daemonClient.fetchWorkspaceTree(path: "", showHidden: newValue) {
-                // Guard against stale response from a rapid toggle
-                guard state.showHiddenFiles == expectedValue else { return }
+                // Guard against stale response from a concurrent toggle (ABA pattern)
+                guard state.hiddenFilesToggleRequestId == requestId else { return }
                 state.directoryCache[""] = response.entries
             }
-            // Only clear loading if we're still on the expected toggle value
-            if state.showHiddenFiles == expectedValue {
+            // Only clear loading if this is still the latest request
+            if state.hiddenFilesToggleRequestId == requestId {
                 state.isLoadingTree = false
             }
         }


### PR DESCRIPTION
## Summary
- Add request identity counter to disambiguate concurrent hidden-file toggle requests in ABA patterns
- Only accept completion from the latest toggle request, preventing premature spinner dismissal

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
