### PR TITLE
fix: correct bootstrap wait condition and handle edge cases

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -315,9 +315,12 @@ extension AppDelegate {
                 case .registeredAndProvisioned(let id):
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
+                self.localBootstrapDidComplete = true
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
+                self.localBootstrapDidComplete = true
+                NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
                 self.mainWindow?.windowState.showToast(
                     message: "Failed to set up Vellum credentials. You may need to sign out and sign in again.",
                     style: .error

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -72,6 +72,10 @@ extension AppDelegate {
     /// or until the timeout expires. This ensures managed-proxy credentials are provisioned
     /// before the wake-up greeting triggers an LLM call.
     func awaitLocalBootstrapCompleted(timeout: TimeInterval) async {
+        if localBootstrapDidComplete {
+            log.info("Local bootstrap already completed — skipping wait")
+            return
+        }
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 for await _ in NotificationCenter.default.notifications(named: .localBootstrapCompleted) {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -137,6 +137,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// derived from the platform session, not local actor tokens.
     var isCurrentAssistantManaged = false
 
+    /// Set to `true` when `.localBootstrapCompleted` has been posted, so
+    /// `awaitLocalBootstrapCompleted` can return immediately if bootstrap
+    /// finished before the observer was registered.
+    var localBootstrapDidComplete = false
+
     @AppStorage("themePreference") private var themePreference: String = "system"
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
@@ -367,7 +372,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // If the user is signed in with a local assistant, wait for
                     // credential provisioning to complete before sending the wake-up
                     // greeting, so the managed-proxy key is available for the LLM call.
-                    if authManager.isAuthenticated && !isCurrentAssistantManaged {
+                    if authManager.isAuthenticated && !isCurrentAssistantRemote {
                         await awaitLocalBootstrapCompleted(timeout: 30)
                     }
 


### PR DESCRIPTION
Addresses review feedback from PR #17547. Fixes: (1) check `!isCurrentAssistantRemote` instead of `!isCurrentAssistantManaged` to avoid 30s timeout for remote assistants, (2) handle already-completed bootstrap before subscribing via `localBootstrapDidComplete` flag, (3) post notification on error path too so bootstrap never stalls on provisioning failures.