### PR TITLE
fix: decouple callback routing from managed proxy API key

### DIFF
--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -49,10 +49,16 @@ export function isPlatformManaged(): boolean {
 /**
  * Whether the daemon should register callback routes with the platform.
  * True when IS_CONTAINERIZED, PLATFORM_BASE_URL, and PLATFORM_ASSISTANT_ID
- * are all set.
+ * are all set. Intentionally does **not** require the managed proxy API key
+ * so that callback-only flows (OAuth transport, Telegram/Twilio callback
+ * registration) work during partial bootstrap before the key is injected.
  */
 export function shouldUsePlatformCallbacks(): boolean {
-  return getIsContainerized() && isPlatformManaged();
+  return (
+    getIsContainerized() &&
+    !!getPlatformBaseUrl() &&
+    !!getPlatformAssistantId()
+  );
 }
 
 interface RegisterCallbackRouteResponse {


### PR DESCRIPTION
Addresses review feedback from PR #17490. `shouldUsePlatformCallbacks()` no longer requires `isManagedProxyEnabledSync()`, so callback-only flows (OAuth, Telegram, Twilio) work during partial bootstrap when the API key hasn't been injected yet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
