### PR TITLE
fix: use local organizationId variable in 409 recovery path

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -145,12 +145,11 @@ public final class LocalAssistantBootstrapService {
             if case .serverError(let statusCode, _) = error, statusCode == 409 {
                 // Try to resolve platform assistant ID from cache for key re-sync
                 if let storage = credentialStorage,
-                   let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
                    let uid = try? await resolveUserId(),
                    let cachedId = PlatformAssistantIdResolver.resolve(
                        lockfileAssistantId: runtimeAssistantId,
                        isManaged: false,
-                       organizationId: orgId,
+                       organizationId: organizationId,
                        userId: uid,
                        credentialStorage: storage
                    ) {


### PR DESCRIPTION
Addresses review feedback from PR #17526. Replaces UserDefaults read with the already-resolved local organizationId variable in the 409 recovery handler, preventing race conditions during async suspension.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
