### PR TITLE
fix: use primary VButton for file viewer Save button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -702,18 +702,14 @@ private struct WorkspaceFileViewer: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 } else if isText && state.isDirty {
-                    Button {
+                    VButton(
+                        label: "Save",
+                        style: .primary,
+                        size: .compact,
+                        isDisabled: state.isSaving
+                    ) {
                         Task { await saveFile(path: detail.path) }
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            if state.isSaving {
-                                ProgressView().controlSize(.small)
-                            }
-                            Text("Save")
-                                .font(VFont.bodyMedium)
-                        }
                     }
-                    .disabled(state.isSaving)
                     .keyboardShortcut("s", modifiers: .command)
                 }
             }


### PR DESCRIPTION
## Summary
- Replaced the plain `Button` with `VButton(style: .primary, size: .compact)` for the file viewer Save action
- The primary style makes the button more visually prominent in the status bar

## Original prompt
Can we use a primary color button for this so it's more obvious

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
