### PR TITLE
fix: limit stale workspace cleanup to workspace subtree and gate on local ownership

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -625,22 +625,30 @@ async function hatchLocal(
     resources = await allocateLocalResources(instanceName);
   }
 
-  // Clean up stale workspace data: if the .vellum directory already exists for
-  // this instance but no lockfile entry owns it, a previous retire failed to
-  // archive it (or a managed-only retire left local data behind). Remove it so
-  // the new assistant starts with a fresh workspace.
-  if (!existingEntry) {
-    const instanceVellumDir = join(resources.instanceDir, ".vellum");
-    if (existsSync(instanceVellumDir)) {
+  // Clean up stale workspace data: if the workspace directory already exists for
+  // this instance but no local lockfile entry owns it, a previous retire failed
+  // to archive it (or a managed-only retire left local data behind). Remove the
+  // workspace subtree so the new assistant starts fresh — but preserve the rest
+  // of .vellum (e.g. protected/, credentials) which may be shared.
+  if (existingEntry?.cloud !== "local") {
+    const instanceWorkspaceDir = join(
+      resources.instanceDir,
+      ".vellum",
+      "workspace",
+    );
+    if (existsSync(instanceWorkspaceDir)) {
       const ownedByOther = loadAllAssistants().some((a) => {
         if (a.cloud !== "local" || !a.resources) return false;
-        return join(a.resources.instanceDir, ".vellum") === instanceVellumDir;
+        return (
+          join(a.resources.instanceDir, ".vellum", "workspace") ===
+          instanceWorkspaceDir
+        );
       });
       if (!ownedByOther) {
         console.log(
-          `🧹 Removing stale workspace at ${instanceVellumDir} (not owned by any assistant)...\n`,
+          `🧹 Removing stale workspace at ${instanceWorkspaceDir} (not owned by any assistant)...\n`,
         );
-        rmSync(instanceVellumDir, { recursive: true, force: true });
+        rmSync(instanceWorkspaceDir, { recursive: true, force: true });
       }
     }
   }
@@ -786,9 +794,7 @@ export async function hatch(): Promise<void> {
   }
 
   if (watch && remote !== "local") {
-    console.error(
-      "Error: --watch is only supported for local hatch targets.",
-    );
+    console.error("Error: --watch is only supported for local hatch targets.");
     process.exit(1);
   }
 


### PR DESCRIPTION
Addresses review feedback from PR #17540. Limits recursive delete to the workspace/ subtree instead of the entire .vellum root (preventing credential data loss). Gates the cleanup skip condition on local entry ownership specifically.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
