### PR TITLE
fix: add cancellation guard after Task.sleep in bootstrap timeout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -80,6 +80,7 @@ extension AppDelegate {
             }
             group.addTask {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                guard !Task.isCancelled else { return }
                 log.warning("Local bootstrap did not complete within \(timeout)s — proceeding with wake-up")
             }
             await group.next()


### PR DESCRIPTION
Addresses review feedback from PR #17633. Adds guard !Task.isCancelled else { return } after Task.sleep to prevent spurious timeout warnings when bootstrap completes successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
