### PR TITLE
fix: replace didBecomeActiveNotification with working alternatives in LSUIElement app

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -79,10 +79,7 @@ struct DrawerMenuView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }
-        .task {
-            await loadBalance()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+        .onAppear {
             Task {
                 await loadBalance()
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -23,7 +23,7 @@ struct SettingsBillingTab: View {
         .task {
             await loadSummary()
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
             Task {
                 await loadSummary()
             }


### PR DESCRIPTION
Addresses review feedback from PR #17559. `didBecomeActiveNotification` doesn't fire in LSUIElement apps (per `clients/AGENTS.md:69`).

- **DrawerMenuView**: Replaced `.task` + `didBecomeActiveNotification` with `.onAppear`, which fires each time the transient popover opens — a single handler covers both initial load and refresh-on-reopen.
- **SettingsBillingTab**: Replaced `didBecomeActiveNotification` with `NSWindow.didBecomeKeyNotification`, which reliably fires when the Settings window (which uses `.regular` activation policy) becomes key after returning from Stripe checkout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
