### PR TITLE
fix: conditional VoiceOver accessibility mode in VEmptyState (#16269)

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
@@ -48,7 +48,7 @@ public struct VEmptyState: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .contain)
+        .accessibilityElement(children: action != nil ? .contain : .ignore)
         .accessibilityLabel("\(title). \(subtitle ?? "")")
     }
 }


### PR DESCRIPTION
## Summary
- Make accessibility children mode conditional: .contain when action button is present, .ignore for non-interactive empty states
- Preserves atomic VoiceOver announcement for ~15 existing callers without action buttons

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/16269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
