### PR TITLE
fix: update subagent test files for session→conversation rename

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -6,7 +6,7 @@ import type { SubagentState } from "../subagent/types.js";
 
 /** Minimal shape matching the private ManagedSubagent interface for test injection. */
 interface FakeManagedSubagent {
-  session: {
+  conversation: {
     abort: () => void;
     dispose: () => void;
     messages: Array<{
@@ -48,7 +48,7 @@ function injectFakeSubagent(
   state: SubagentState,
   parentSendToClient?: (msg: ServerMessage) => void,
 ): void {
-  const fakeSession: FakeManagedSubagent["session"] = {
+  const fakeSession: FakeManagedSubagent["conversation"] = {
     abort: () => {},
     dispose: () => {},
     messages: [],
@@ -61,7 +61,7 @@ function injectFakeSubagent(
   const parentToChildren = internals.parentToChildren;
 
   subagents.set(subagentId, {
-    session: fakeSession,
+    conversation: fakeSession,
     state,
     parentSendToClient: parentSendToClient ?? (() => {}),
   });
@@ -275,8 +275,8 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     // Patch the fake session to simulate a successful agent loop.
     const managed = asInternals(manager).subagents.get(subagentId)!;
-    managed.session.persistUserMessage = () => "msg-1";
-    managed.session.runAgentLoop = async () => {};
+    managed.conversation.persistUserMessage = () => "msg-1";
+    managed.conversation.runAgentLoop = async () => {};
 
     const notifications: { parentConversationId: string; message: string }[] =
       [];
@@ -309,8 +309,8 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     // Patch the fake session to simulate a failure.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.session.persistUserMessage = () => "msg-1";
-    managed.session.runAgentLoop = async () => {
+    managed.conversation.persistUserMessage = () => "msg-1";
+    managed.conversation.runAgentLoop = async () => {
       throw new Error("API rate limit exceeded");
     };
 
@@ -343,8 +343,8 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.session.persistUserMessage = () => "msg-1";
-    managed.session.runAgentLoop = async () => {
+    managed.conversation.persistUserMessage = () => "msg-1";
+    managed.conversation.runAgentLoop = async () => {
       throw new Error("Conversation aborted");
     };
 
@@ -422,9 +422,9 @@ describe("SubagentManager abort race guard", () => {
     // Patch session to simulate successful completion after abort.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
-    managed.session.persistUserMessage = () => "msg-1";
-    managed.session.runAgentLoop = async () => {};
-    managed.session.messages = [
+    managed.conversation.persistUserMessage = () => "msg-1";
+    managed.conversation.runAgentLoop = async () => {};
+    managed.conversation.messages = [
       { role: "assistant", content: [{ type: "text", text: "Done!" }] },
     ];
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -68,7 +68,11 @@ function injectSubagent(
   const internals = manager as unknown as {
     subagents: Map<
       string,
-      { session: unknown; state: SubagentState; parentSendToClient: () => void }
+      {
+        conversation: unknown;
+        state: SubagentState;
+        parentSendToClient: () => void;
+      }
     >;
     parentToChildren: Map<string, Set<string>>;
   };
@@ -96,7 +100,7 @@ function injectSubagent(
     runAgentLoop: async () => {},
   };
   internals.subagents.set(subagentId, {
-    session: fakeSession,
+    conversation: fakeSession,
     state,
     parentSendToClient: () => {},
   });


### PR DESCRIPTION
## Summary
- Renames `session` → `conversation` in `subagent-manager-notify.test.ts` and `subagent-tools.test.ts` to match the `ManagedSubagent` interface refactored in #17639
- Fixes `TypeError: undefined is not an object (evaluating 'managed.conversation.abort')` CI failures

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23155367155/job/67268499637

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
