### PR TITLE
fix: include userinfoUrl in seed provider upsert set

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -245,7 +245,6 @@ describe("provider operations", () => {
             required: ["repo"],
             allowAdditionalScopes: true,
           }),
-          userinfoUrl: "https://api.github.com/user/custom",
           baseUrl: "https://custom.github.com/api",
         })
         .where(eq(oauthProviders.providerKey, "github"))
@@ -258,9 +257,6 @@ describe("provider operations", () => {
         "user",
         "gist",
       ]);
-      expect(beforeReseed!.userinfoUrl).toBe(
-        "https://api.github.com/user/custom",
-      );
       expect(beforeReseed!.baseUrl).toBe("https://custom.github.com/api");
 
       // Re-seed with updated implementation fields
@@ -290,13 +286,13 @@ describe("provider operations", () => {
         required: ["repo"],
         allowAdditionalScopes: true,
       });
-      expect(row!.userinfoUrl).toBe("https://api.github.com/user/custom");
       expect(row!.baseUrl).toBe("https://custom.github.com/api");
 
       // Implementation fields should be overwritten from the seed data
       expect(row!.authUrl).toBe("https://github.com/authorize-v2");
       expect(row!.tokenUrl).toBe("https://github.com/token-v2");
       expect(row!.tokenEndpointAuthMethod).toBe("client_secret_basic");
+      expect(row!.userinfoUrl).toBe("https://api.github.com/user-v2");
       expect(JSON.parse(row!.extraParams!)).toEqual({ prompt: "login" });
       expect(row!.callbackTransport).toBe("gateway");
       expect(row!.pingUrl).toBe("https://api.github.com/user-v2");

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -44,10 +44,10 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authUrl, tokenUrl,
- * tokenEndpointAuthMethod, extraParams, callbackTransport, pingUrl)
- * propagate to existing installations on every startup, while
- * user-customizable fields (defaultScopes, scopePolicy, userinfoUrl,
- * baseUrl) are only written on the initial insert.
+ * tokenEndpointAuthMethod, userinfoUrl, extraParams, callbackTransport,
+ * pingUrl) propagate to existing installations on every startup, while
+ * user-customizable fields (defaultScopes, scopePolicy, baseUrl) are
+ * only written on the initial insert.
  */
 export function seedProviders(
   profiles: Array<{
@@ -100,6 +100,7 @@ export function seedProviders(
           authUrl,
           tokenUrl,
           tokenEndpointAuthMethod,
+          userinfoUrl,
           extraParams,
           callbackTransport,
           pingUrl,


### PR DESCRIPTION
## Summary
- Moved `userinfoUrl` from the user-customizable category to the implementation-fields category in `seedProviders()` upsert logic
- Updated the JSDoc comment to reflect the reclassification
- Updated the oauth-store test to assert `userinfoUrl` is overwritten on re-seed (implementation field behavior)

Addresses review feedback from #16337: unlike `defaultScopes` or `baseUrl`, a provider's userinfo endpoint URL is not user-customizable and should be updated when seed data changes.

## Test plan
- [ ] Verify `oauth-store.test.ts` passes with the updated assertion
- [ ] Confirm no other tests reference the old behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
