### PR TITLE
fix: add missing Cancel button to phone invite fallback branches

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -743,36 +743,54 @@ struct ContactDetailView: View {
             }
         } else if let shareableText = result.shareUrl ?? result.token {
             // Fallback: no invite code available, show raw token
-            HStack(spacing: VSpacing.sm) {
-                let truncated = shareableText.count > 20
-                    ? String(shareableText.prefix(20)) + "..."
-                    : shareableText
-                Text(truncated)
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.contentSecondary)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    let truncated = shareableText.count > 20
+                        ? String(shareableText.prefix(20)) + "..."
+                        : shareableText
+                    Text(truncated)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.contentSecondary)
 
-                VButton(
-                    label: inviteCopiedType == type ? "Copied!" : "Copy",
-                    icon: VIcon.copy.rawValue,
-                    style: .outlined
-                ) {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(shareableText, forType: .string)
-                    inviteCopiedType = type
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        guard !Task.isCancelled else { return }
-                        if inviteCopiedType == type {
-                            inviteCopiedType = nil
+                    VButton(
+                        label: inviteCopiedType == type ? "Copied!" : "Copy",
+                        icon: VIcon.copy.rawValue,
+                        style: .outlined
+                    ) {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(shareableText, forType: .string)
+                        inviteCopiedType = type
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            guard !Task.isCancelled else { return }
+                            if inviteCopiedType == type {
+                                inviteCopiedType = nil
+                            }
                         }
                     }
+                }
+
+                VButton(label: "Cancel", style: .outlined) {
+                    inviteExpanded.remove(type)
+                    inviteResult = nil
+                    inviteError = nil
+                    inviteErrorChannel = nil
                 }
             }
         } else {
             // Fallback: invite was created but no displayable fields are available
-            Text("Invite created but no details available")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Invite created but no details available")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentSecondary)
+
+                VButton(label: "Cancel", style: .outlined) {
+                    inviteExpanded.remove(type)
+                    inviteResult = nil
+                    inviteError = nil
+                    inviteErrorChannel = nil
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds Cancel button to the `else if let shareableText` fallback branch in `inviteResultDisplay` (when invite has a share URL/token but no invite code)
- Adds Cancel button to the bare `else` fallback branch in `inviteResultDisplay` (when invite was created but has no displayable fields)
- Both new Cancel buttons match the existing behavior: removing the channel from `inviteExpanded`, clearing `inviteResult`, `inviteError`, and `inviteErrorChannel`

Addresses review feedback from PR #16331 where bot reviewers identified that the Cancel button was missing in fallback branches, leaving users stuck.

## Test plan
- [ ] Open a phone invite flow where the invite result has only a `shareUrl`/`token` (no `inviteCode`/`voiceCode`) and verify the Cancel button appears and dismisses the UI
- [ ] Open a phone invite flow where the invite result has no displayable fields and verify the Cancel button appears and dismisses the UI
- [ ] Verify the primary branch (with invite code) still shows its Cancel button as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
