### PR TITLE
fix: add DB migration for integration:gmail → integration:google provider key rename

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -83,6 +83,7 @@ import {
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
   migrateRenameFollowupsThreadIdColumn,
+  migrateRenameGmailProviderKeyToGoogle,
   migrateRenameGuardianVerificationValues,
   migrateRenameInboxThreadStateTable,
   migrateRenameNotificationThreadColumns,
@@ -419,6 +420,9 @@ export function initializeDb(): void {
 
   // 71. Rename replyToThread → replyInSameConversation in sequence steps JSON blobs
   migrateRenameSequenceStepsReplyKey(database);
+
+  // 72. Rename integration:gmail → integration:google across OAuth tables
+  migrateRenameGmailProviderKeyToGoogle(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
+++ b/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
@@ -1,0 +1,43 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename the `integration:gmail` provider key to
+ * `integration:google` across all three OAuth tables.
+ *
+ * PR #16355 renamed the provider key in code but did not include a data
+ * migration. Without this, existing users who connected Gmail before the
+ * rename have their connections orphaned — runtime lookups for
+ * `integration:google` never find the old `integration:gmail` rows.
+ *
+ * FK constraints require us to update child tables (oauth_apps,
+ * oauth_connections) before the parent (oauth_providers), or disable FKs.
+ * We disable FKs for safety and update all three tables atomically.
+ */
+export function migrateRenameGmailProviderKeyToGoogle(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_gmail_provider_key_to_google_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      raw.exec("PRAGMA foreign_keys = OFF");
+      try {
+        // Update child tables first, then the parent.
+        raw.exec(
+          /*sql*/ `UPDATE oauth_connections SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+        );
+        raw.exec(
+          /*sql*/ `UPDATE oauth_apps SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+        );
+        raw.exec(
+          /*sql*/ `UPDATE oauth_providers SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+        );
+      } finally {
+        raw.exec("PRAGMA foreign_keys = ON");
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -110,6 +110,7 @@ export { migrateRenameInboxThreadStateTable } from "./165-rename-inbox-thread-st
 export { migrateRenameFollowupsThreadIdColumn } from "./166-rename-followups-thread-id.js";
 export { migrateRenameSequenceEnrollmentsThreadIdColumn } from "./167-rename-sequence-enrollments-thread-id.js";
 export { migrateRenameSequenceStepsReplyKey } from "./168-rename-sequence-steps-reply-key.js";
+export { migrateRenameGmailProviderKeyToGoogle } from "./169-rename-gmail-provider-key-to-google.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -209,6 +209,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT",
   },
+  {
+    key: "migration_rename_gmail_provider_key_to_google_v1",
+    version: 31,
+    description:
+      "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
- Adds DB migration `169-rename-gmail-provider-key-to-google.ts` that renames `integration:gmail` to `integration:google` across `oauth_providers`, `oauth_apps`, and `oauth_connections` tables
- PR #16355 renamed the provider key in code but did not include a data migration, orphaning existing Gmail connections for users who had already connected
- Migration uses `withCrashRecovery` for idempotency and temporarily disables FK constraints to safely update the primary key in the parent table

## Test plan
- [ ] Verify migration runs cleanly on a fresh database (no `integration:gmail` rows)
- [ ] Verify migration correctly renames existing `integration:gmail` rows to `integration:google` in all three tables
- [ ] Verify `seedOAuthProviders()` succeeds after migration (no duplicate key conflict)
- [ ] Verify existing Gmail connections still work after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
