### PR TITLE
fix: prune stale app cache entries when daemon reports empty list

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -465,16 +465,13 @@ extension AppDelegate {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
                     self.cachedApps = response.apps
-                    // Only sync if daemon returned apps — empty response may indicate an error
-                    if !response.apps.isEmpty {
-                        let daemonItems = response.apps.map {
-                            AppListManager.AppItem_Daemon(
-                                id: $0.id, name: $0.name, description: $0.description,
-                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                            )
-                        }
-                        self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
+                    let daemonItems = response.apps.map {
+                        AppListManager.AppItem_Daemon(
+                            id: $0.id, name: $0.name, description: $0.description,
+                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                        )
                     }
+                    self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     return
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -539,16 +539,13 @@ struct AppsGridView: View {
             for await message in stream {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
-                    // Only sync if daemon returned apps — empty response may indicate an error
-                    if !response.apps.isEmpty {
-                        let daemonItems = response.apps.map {
-                            AppListManager.AppItem_Daemon(
-                                id: $0.id, name: $0.name, description: $0.description,
-                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                            )
-                        }
-                        appListManager.syncFromDaemon(daemonItems)
+                    let daemonItems = response.apps.map {
+                        AppListManager.AppItem_Daemon(
+                            id: $0.id, name: $0.name, description: $0.description,
+                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                        )
                     }
+                    appListManager.syncFromDaemon(daemonItems)
                     hasFetchedLocalApps = true
                     return
                 }


### PR DESCRIPTION
## Summary
- Removed `!response.apps.isEmpty` guard from both `syncFromDaemon` call sites (AppsGridView, AppDelegate+MenuBar)
- This allows the client to correctly prune stale cached apps (like the removed Home Base prebuilt) when the daemon reports zero apps
- The guard was originally added to protect against error responses, but it also prevented legitimate cleanup — the daemon's response is authoritative regardless of size

## Original prompt
Fix: the client's daemon sync should prune cached apps that the daemon no longer reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
