### PR TITLE
fix: preserve OPENAI_API_KEY env var fallback in transcribe-media

### DIFF
--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -449,7 +449,8 @@ export async function run(
   // Validate API key for api mode
   let openaiKey: string | undefined;
   if (mode === "api") {
-    openaiKey = await getSecureKeyAsync("openai");
+    openaiKey =
+      (await getSecureKeyAsync("openai")) ?? process.env.OPENAI_API_KEY;
     if (!openaiKey) {
       return {
         content:


### PR DESCRIPTION
## Summary
- Adds `process.env.OPENAI_API_KEY` fallback after `getSecureKeyAsync("openai")` in transcribe-media
- Restores support for users who provide their OpenAI key via environment variable rather than the secure store

## Original feedback
PR #16501 review comment from Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
