### PR TITLE
fix: restore AppKit cursor management and guard hover state on animationsActive

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -103,7 +103,9 @@ class AvatarLayerView: NSView {
     required init?(coder: NSCoder) { fatalError() }
 
     override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .pointingHand)
+        if configPokeEnabled {
+            addCursorRect(bounds, cursor: .pointingHand)
+        }
     }
 
     /// Called from SwiftUI's `.onHover` via the representable bridge.
@@ -113,7 +115,7 @@ class AvatarLayerView: NSView {
         isHovered = hovered
 
         if hovered {
-            guard animationsActive else { return }
+            guard animationsActive else { isHovered = false; return }
             guard !eyeLayers.isEmpty,
                   eyeLayers.count == widenedEyePaths.count else { return }
 


### PR DESCRIPTION
## Summary
- Makes `resetCursorRects` conditional on `configPokeEnabled` for proper AppKit cursor lifecycle management, preventing cursor stack corruption when the view is removed while hovered
- Guards `isHovered = true` on `animationsActive` in `updateHoverState` to prevent blink animation glitch when hovering an inactive window

## Original feedback
PR #16463 review comments from Codex and Devin

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
