### PR TITLE
fix: restore GEMINI_API_KEY env var fallback in media consumers

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -55,7 +55,8 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const apiKey = await getSecureKeyAsync("gemini");
+  const apiKey =
+    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
 
   // Resolve credentials: prefer direct API key, fall back to managed proxy
   let credentials: ImageGenCredentials | undefined;

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -29,7 +29,8 @@ export async function mapSegmentsForAsset(
   options: MapSegmentsOptions,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
-  const apiKey = await getSecureKeyAsync("gemini");
+  const apiKey =
+    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
 
   if (!apiKey) {
     throw new Error(
@@ -121,7 +122,8 @@ export async function run(
     let output: MapOutput;
 
     if (mode === "direct_video") {
-      const apiKey = await getSecureKeyAsync("gemini");
+      const apiKey =
+        (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
       if (!apiKey) {
         return {
           content:

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -37,7 +37,8 @@ export async function generateAppIcon(
   appDescription?: string,
 ): Promise<void> {
   const config = getConfig();
-  const apiKey = await getSecureKeyAsync("gemini");
+  const apiKey =
+    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
 
   let credentials: ImageGenCredentials | undefined;
   if (apiKey) {

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -14,7 +14,8 @@ export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
-  const geminiKey = await getSecureKeyAsync("gemini");
+  const geminiKey =
+    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
 
   let credentials: ImageGenCredentials | undefined;
   if (geminiKey) {


### PR DESCRIPTION
## Summary
- Adds `process.env.GEMINI_API_KEY` fallback after `getSecureKeyAsync("gemini")` in avatar-router, media-generate-image, app-icon-generator, and analyze-keyframes
- Restores support for env-var-only Gemini key configurations that was dropped when PR #16506 migrated from `config.apiKeys.gemini` to `getSecureKeyAsync("gemini")`

## Original feedback
PR #16506 review comments from Codex and Devin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
