### PR TITLE
fix: skip Slack notifications for cancelled GHA runs

### DIFF
--- a/.github/config/github_slack_mapping.yaml
+++ b/.github/config/github_slack_mapping.yaml
@@ -22,7 +22,3 @@ github_to_slack_failure_notifications: # neutral good
 github_to_slack_success_notifications: # chaotic evil
 
 github_to_slack_cancelled_notifications: # chaotic neutral
-  dvargas92495: U05D5EGNNMS
-  clopen-set: U08QQU27M0W
-  m-abboud: U06CMAEKH4L
-  Shaarson: U08EREL8F18

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -192,6 +192,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -94,6 +94,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -100,6 +100,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -96,6 +96,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -107,6 +107,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -228,6 +228,7 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
+        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Added `if: steps.slack-id.outputs.status != 'cancelled'` to the Slack notification step in all 6 CI workflows, so cancelled runs produce no Slack messages at all
- Emptied `github_to_slack_cancelled_notifications` in the mapping config since it's now unused

## Original prompt
Change the GHA notification rules so that by default nobody gets notified for cancelled runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
