### PR TITLE
fix: add env var fallback for provider API key lookups

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -27,7 +27,7 @@ import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
@@ -53,7 +53,7 @@ export async function buildModelInfoEvent(): Promise<ServerMessage> {
   const configured: string[] = ["ollama"];
   for (const p of API_KEY_PROVIDERS) {
     if (p === "ollama") continue;
-    if (await getSecureKeyAsync(p)) {
+    if (await getProviderKeyAsync(p)) {
       configured.push(p);
     }
   }

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -12,7 +12,7 @@ import {
   saveRawConfig,
 } from "../config/loader.js";
 import { initializeProviders } from "../providers/registry.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLocalIPv4 } from "../util/network-info.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { silentlyWithLog } from "../util/silently.js";
@@ -157,7 +157,7 @@ async function resolveProviderModelCommand(
   const name = getAssistantName();
 
   // Check if API key exists for this provider (Ollama doesn't require an API key)
-  if (provider !== "ollama" && !(await getSecureKeyAsync(provider))) {
+  if (provider !== "ollama" && !(await getProviderKeyAsync(provider))) {
     return {
       kind: "unknown",
       message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`keys set ${provider} <your-key>\``,
@@ -201,7 +201,7 @@ async function resolveModelList(): Promise<SlashResolution> {
   // Build a set of providers that have a configured API key.
   const configuredProviders = new Set<string>(["ollama"]);
   for (const p of API_KEY_PROVIDERS) {
-    if (await getSecureKeyAsync(p)) {
+    if (await getProviderKeyAsync(p)) {
       configuredProviders.add(p);
     }
   }
@@ -285,7 +285,7 @@ async function resolveModelCommand(
   }
 
   // Validate that Anthropic provider is available
-  if (!(await getSecureKeyAsync("anthropic"))) {
+  if (!(await getProviderKeyAsync("anthropic"))) {
     const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
     return {
       kind: "unknown",

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -5,7 +5,7 @@ import {
   saveRawConfig,
 } from "../../config/loader.js";
 import { initializeProviders } from "../../providers/registry.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { MODEL_TO_PROVIDER } from "../conversation-slash.js";
 import type {
   ImageGenModelSetRequest,
@@ -32,7 +32,7 @@ export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
   const configured: string[] = [];
   for (const p of API_KEY_PROVIDERS) {
-    if (await getSecureKeyAsync(p)) {
+    if (await getProviderKeyAsync(p)) {
       configured.push(p);
     }
   }
@@ -83,7 +83,7 @@ export async function setModel(
   // Validate API key before switching
   const provider = MODEL_TO_PROVIDER[modelId];
   if (provider && provider !== "ollama") {
-    if (!(await getSecureKeyAsync(provider))) {
+    if (!(await getProviderKeyAsync(provider))) {
       // Return current model_info so the client resyncs its optimistic state
       return await getModelInfo();
     }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,5 +1,5 @@
 import { wrapWithLogfire } from "../logfire.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
@@ -215,7 +215,7 @@ export async function initializeProviders(
   const streamTimeoutMs =
     (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
 
-  const anthropicKey = await getSecureKeyAsync("anthropic");
+  const anthropicKey = await getProviderKeyAsync("anthropic");
   if (anthropicKey) {
     const model = resolveModel(config, "anthropic");
     registerProvider(
@@ -252,7 +252,7 @@ export async function initializeProviders(
       routingSources.set("anthropic", "managed-proxy");
     }
   }
-  const openaiKey = await getSecureKeyAsync("openai");
+  const openaiKey = await getProviderKeyAsync("openai");
   if (openaiKey) {
     const model = resolveModel(config, "openai");
     registerProvider(
@@ -283,7 +283,7 @@ export async function initializeProviders(
       routingSources.set("openai", "managed-proxy");
     }
   }
-  const geminiKey = await getSecureKeyAsync("gemini");
+  const geminiKey = await getProviderKeyAsync("gemini");
   if (geminiKey) {
     const model = resolveModel(config, "gemini");
     registerProvider(
@@ -315,7 +315,7 @@ export async function initializeProviders(
       routingSources.set("gemini", "managed-proxy");
     }
   }
-  const ollamaKey = await getSecureKeyAsync("ollama");
+  const ollamaKey = await getProviderKeyAsync("ollama");
   if (config.provider === "ollama" || ollamaKey) {
     const model = resolveModel(config, "ollama");
     registerProvider(
@@ -331,7 +331,7 @@ export async function initializeProviders(
     );
     routingSources.set("ollama", "user-key");
   }
-  const fireworksKey = await getSecureKeyAsync("fireworks");
+  const fireworksKey = await getProviderKeyAsync("fireworks");
   if (fireworksKey) {
     const model = resolveModel(config, "fireworks");
     registerProvider(
@@ -346,7 +346,7 @@ export async function initializeProviders(
     );
     routingSources.set("fireworks", "user-key");
   }
-  const openrouterKey = await getSecureKeyAsync("openrouter");
+  const openrouterKey = await getProviderKeyAsync("openrouter");
   if (openrouterKey) {
     const model = resolveModel(config, "openrouter");
     registerProvider(

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -160,6 +160,40 @@ export async function deleteSecureKeyAsync(
 }
 
 // ---------------------------------------------------------------------------
+// Provider API key lookup — secure store + env var fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Env var names keyed by provider. The convention is `<PROVIDER>_API_KEY`.
+ * Ollama is intentionally omitted — it doesn't require an API key.
+ */
+const PROVIDER_ENV_VARS: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  gemini: "GEMINI_API_KEY",
+  fireworks: "FIREWORKS_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  brave: "BRAVE_API_KEY",
+  perplexity: "PERPLEXITY_API_KEY",
+};
+
+/**
+ * Retrieve a provider API key, checking secure storage first and falling
+ * back to the corresponding `<PROVIDER>_API_KEY` environment variable.
+ *
+ * Use this instead of raw `getSecureKeyAsync` when looking up provider
+ * API keys so that env-var-only setups continue to work.
+ */
+export async function getProviderKeyAsync(
+  provider: string,
+): Promise<string | undefined> {
+  const stored = await getSecureKeyAsync(provider);
+  if (stored) return stored;
+  const envVar = PROVIDER_ENV_VARS[provider];
+  return envVar ? process.env[envVar] : undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `getProviderKeyAsync` helper to `secure-keys.ts` that wraps `getSecureKeyAsync` with a fallback to `process.env.<PROVIDER>_API_KEY` environment variables
- Switches all provider API key lookups in `conversation-slash.ts`, `conversation-process.ts`, `config-model.ts`, and `providers/registry.ts` from `getSecureKeyAsync` to `getProviderKeyAsync`
- Fixes env-var-only setups where `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. were no longer recognized for slash-based model switching, `model_info` events, and provider initialization

Addresses review feedback from #16509.

## Test plan
- [ ] Verify env-var-only provider setup (e.g. `ANTHROPIC_API_KEY` in env, no secure store key) can switch models via `/opus`, `/gpt4` etc.
- [ ] Verify `buildModelInfoEvent` reports env-var-backed providers in `configuredProviders`
- [ ] Verify `getModelInfo` (GET /v1/model) reports env-var-backed providers
- [ ] Verify `initializeProviders` initializes providers from env var keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
