### PR TITLE
fix: define DEBUG flag in SPM targets to suppress dev keychain prompt

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
                 .copy("Resources/lucide-version.txt"),
             ],
             swiftSettings: [
+                .define("DEBUG", .when(configuration: .debug)),
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ],
             linkerSettings: [
@@ -75,6 +76,9 @@ let package = Package(
                 .process("Resources/initial-avatar.png"),
                 .process("Resources/vellum-app-icon.png"),
                 .process("Resources/welcome-characters.png")
+            ],
+            swiftSettings: [
+                .define("DEBUG", .when(configuration: .debug)),
             ],
             linkerSettings: [
                 .linkedFramework("ApplicationServices"),


### PR DESCRIPTION
## Summary
- Add `.define("DEBUG", .when(configuration: .debug))` to `swiftSettings` for both `VellumAssistantShared` and `VellumAssistantLib` SPM targets
- SPM doesn't define `DEBUG` automatically (unlike Xcode projects), so all `#if DEBUG` / `#if !DEBUG` guards were evaluating incorrectly
- This was causing the keychain broker to start in debug builds, triggering a macOS password dialog on every rebuild because the binary cdhash changes

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)