### PR TITLE
fix: check managed proxy fallback in provider availability checks

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -15,7 +15,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
-import { API_KEY_PROVIDERS, getConfig } from "../config/loader.js";
+import { getConfig } from "../config/loader.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
 import {
   addMessage,
@@ -25,9 +25,9 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
+import { getConfiguredProviders } from "../providers/provider-availability.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
@@ -50,18 +50,11 @@ const log = getLogger("session-process");
 /** Build a model_info event with fresh config data. */
 export async function buildModelInfoEvent(): Promise<ServerMessage> {
   const config = getConfig();
-  const configured: string[] = ["ollama"];
-  for (const p of API_KEY_PROVIDERS) {
-    if (p === "ollama") continue;
-    if (await getProviderKeyAsync(p)) {
-      configured.push(p);
-    }
-  }
   return {
     type: "model_info",
     model: config.model,
     provider: config.provider,
-    configuredProviders: configured,
+    configuredProviders: await getConfiguredProviders(),
   };
 }
 

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -5,14 +5,12 @@ import { join } from "node:path";
 import QRCode from "qrcode";
 
 import { getGatewayPort, getIngressPublicBaseUrl } from "../config/env.js";
+import { getConfig, loadRawConfig, saveRawConfig } from "../config/loader.js";
 import {
-  API_KEY_PROVIDERS,
-  getConfig,
-  loadRawConfig,
-  saveRawConfig,
-} from "../config/loader.js";
+  getConfiguredProviders,
+  isProviderAvailable,
+} from "../providers/provider-availability.js";
 import { initializeProviders } from "../providers/registry.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLocalIPv4 } from "../util/network-info.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { silentlyWithLog } from "../util/silently.js";
@@ -156,8 +154,8 @@ async function resolveProviderModelCommand(
   const config = getConfig();
   const name = getAssistantName();
 
-  // Check if API key exists for this provider (Ollama doesn't require an API key)
-  if (provider !== "ollama" && !(await getProviderKeyAsync(provider))) {
+  // Check if provider is available (secure key, env var, managed proxy, or no key needed)
+  if (!(await isProviderAvailable(provider))) {
     return {
       kind: "unknown",
       message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`keys set ${provider} <your-key>\``,
@@ -198,13 +196,8 @@ async function resolveProviderModelCommand(
 async function resolveModelList(): Promise<SlashResolution> {
   const config = getConfig();
 
-  // Build a set of providers that have a configured API key.
-  const configuredProviders = new Set<string>(["ollama"]);
-  for (const p of API_KEY_PROVIDERS) {
-    if (await getProviderKeyAsync(p)) {
-      configuredProviders.add(p);
-    }
-  }
+  // Build a set of providers that are usable (secure key, env var, or managed proxy).
+  const configuredProviders = new Set<string>(await getConfiguredProviders());
 
   const lines = ["Available models:\n"];
 
@@ -284,8 +277,8 @@ async function resolveModelCommand(
     };
   }
 
-  // Validate that Anthropic provider is available
-  if (!(await getProviderKeyAsync("anthropic"))) {
+  // Validate that Anthropic provider is available (secure key, env var, or managed proxy)
+  if (!(await isProviderAvailable("anthropic"))) {
     const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
     return {
       kind: "unknown",

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -1,11 +1,13 @@
 import {
-  API_KEY_PROVIDERS,
   getConfig,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
+import {
+  getConfiguredProviders,
+  isProviderAvailable,
+} from "../../providers/provider-availability.js";
 import { initializeProviders } from "../../providers/registry.js";
-import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { MODEL_TO_PROVIDER } from "../conversation-slash.js";
 import type {
   ImageGenModelSetRequest,
@@ -30,17 +32,10 @@ export interface ModelInfo {
 /** Return current model configuration. */
 export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
-  const configured: string[] = [];
-  for (const p of API_KEY_PROVIDERS) {
-    if (await getProviderKeyAsync(p)) {
-      configured.push(p);
-    }
-  }
-  if (!configured.includes("ollama")) configured.push("ollama");
   return {
     model: config.model,
     provider: config.provider,
-    configuredProviders: configured,
+    configuredProviders: await getConfiguredProviders(),
   };
 }
 
@@ -80,13 +75,11 @@ export async function setModel(
     }
   }
 
-  // Validate API key before switching
+  // Validate provider availability (secure key, env var, or managed proxy) before switching
   const provider = MODEL_TO_PROVIDER[modelId];
-  if (provider && provider !== "ollama") {
-    if (!(await getProviderKeyAsync(provider))) {
-      // Return current model_info so the client resyncs its optimistic state
-      return await getModelInfo();
-    }
+  if (provider && !(await isProviderAvailable(provider))) {
+    // Return current model_info so the client resyncs its optimistic state
+    return await getModelInfo();
   }
 
   // Use raw config to avoid persisting env-var API keys to disk
@@ -131,7 +124,11 @@ export async function setModel(
 
   ctx.updateConfigFingerprint();
 
-  return { model: config.model, provider: config.provider };
+  return {
+    model: config.model,
+    provider: config.provider,
+    configuredProviders: await getConfiguredProviders(),
+  };
 }
 
 /**

--- a/assistant/src/providers/provider-availability.ts
+++ b/assistant/src/providers/provider-availability.ts
@@ -1,0 +1,39 @@
+/**
+ * Provider availability checks.
+ *
+ * Determines which LLM providers are usable by checking secure storage,
+ * environment variable fallbacks, and managed proxy availability.
+ */
+
+import { API_KEY_PROVIDERS } from "../config/loader.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import { managedFallbackEnabledFor } from "./managed-proxy/context.js";
+
+/**
+ * Check whether a single provider is usable — via a user-provided key
+ * (secure storage or env var) or via the managed proxy fallback.
+ * Ollama is always considered available because it does not require an API key.
+ */
+export async function isProviderAvailable(provider: string): Promise<boolean> {
+  if (provider === "ollama") return true;
+  return !!(
+    (await getProviderKeyAsync(provider)) ||
+    (await managedFallbackEnabledFor(provider))
+  );
+}
+
+/**
+ * Build the list of providers that are usable — via a user-provided key
+ * (secure storage or env var) or via the managed proxy fallback.
+ * Ollama is always included because it does not require an API key.
+ */
+export async function getConfiguredProviders(): Promise<string[]> {
+  const configured: string[] = [];
+  for (const p of API_KEY_PROVIDERS) {
+    if (await isProviderAvailable(p)) {
+      configured.push(p);
+    }
+  }
+  if (!configured.includes("ollama")) configured.push("ollama");
+  return configured;
+}


### PR DESCRIPTION
## Summary
- Extract `isProviderAvailable` and `getConfiguredProviders` into `providers/provider-availability.ts`, checking both `getSecureKeyAsync` and `managedFallbackEnabledFor`
- Fix `getModelInfo` to include managed-proxy-backed providers in `configuredProviders`
- Fix `setModel` to accept model switches when the provider is available via managed proxy
- Fix `setModel` success path to include `configuredProviders` in the response (consistency with early-return paths)
- Apply the same fix to `conversation-process.ts` (`buildModelInfoEvent`) and `conversation-slash.ts` (slash command key checks and `/models` list)

Addresses review feedback on #16508.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` passes
- [x] `bun test src/__tests__/conversation-routes-slash-commands.test.ts` passes (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
