### PR TITLE
fix: send cancelled GHA notifications without @-tagging anyone

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -183,7 +183,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -192,7 +192,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -85,7 +85,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -94,7 +94,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -91,7 +91,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -100,7 +100,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -87,7 +87,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -96,7 +96,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -98,7 +98,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -107,7 +107,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -219,7 +219,7 @@ jobs:
             SLACK_ID="$GITHUB_USER"
           fi
 
-          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$SLACK_ID" = "$GITHUB_USER" ]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
           else
             echo "should_tag=true" >> $GITHUB_OUTPUT
@@ -228,7 +228,6 @@ jobs:
           echo "status=$STATUS" >> $GITHUB_OUTPUT
 
       - uses: act10ns/slack@v2
-        if: steps.slack-id.outputs.status != 'cancelled'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Removed the `if: status != 'cancelled'` guard from the Slack step in all 6 CI workflows so cancelled-run messages still post to `#build-alerts`
- Added `$STATUS = "cancelled"` to the `should_tag=false` condition so nobody gets `@`-tagged for cancelled runs

## Original prompt
no I still want the messages to go out like they were before, I just want nobody to get @ tagged for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
