### PR TITLE
fix: handle existing google provider in gmail→google migration

### DIFF
--- a/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
+++ b/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
@@ -25,16 +25,37 @@ export function migrateRenameGmailProviderKeyToGoogle(
 
       raw.exec("PRAGMA foreign_keys = OFF");
       try {
-        // Update child tables first, then the parent.
-        raw.exec(
-          /*sql*/ `UPDATE oauth_connections SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
-        );
-        raw.exec(
-          /*sql*/ `UPDATE oauth_apps SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
-        );
-        raw.exec(
-          /*sql*/ `UPDATE oauth_providers SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
-        );
+        // If `integration:google` already exists (runtime seeded it after the
+        // code rename), the old `integration:gmail` rows are orphaned — just
+        // delete them instead of renaming.
+        const googleExists = raw
+          .prepare(
+            /*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = 'integration:google'`,
+          )
+          .get();
+
+        if (googleExists) {
+          raw.exec(
+            /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = 'integration:gmail'`,
+          );
+          raw.exec(
+            /*sql*/ `DELETE FROM oauth_apps WHERE provider_key = 'integration:gmail'`,
+          );
+          raw.exec(
+            /*sql*/ `DELETE FROM oauth_providers WHERE provider_key = 'integration:gmail'`,
+          );
+        } else {
+          // Update child tables first, then the parent.
+          raw.exec(
+            /*sql*/ `UPDATE oauth_connections SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+          );
+          raw.exec(
+            /*sql*/ `UPDATE oauth_apps SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+          );
+          raw.exec(
+            /*sql*/ `UPDATE oauth_providers SET provider_key = 'integration:google' WHERE provider_key = 'integration:gmail'`,
+          );
+        }
       } finally {
         raw.exec("PRAGMA foreign_keys = ON");
       }


### PR DESCRIPTION
## Summary
- Migration 169 (`rename-gmail-provider-key-to-google`) crashes on startup with `SQLITE_CONSTRAINT_PRIMARYKEY` when `integration:google` already exists in `oauth_providers`
- This happens when the runtime seeded the new provider key after the code rename, while the old `integration:gmail` rows were still present
- Fix: check if `integration:google` already exists and delete the orphaned `integration:gmail` rows instead of trying to rename them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
