### PR TITLE
fix: replace asyncAfter with cancellable Task for avatar post-entry delay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -77,6 +77,9 @@ class AvatarLayerView: NSView {
     /// Timer that fires random twitches.
     private var twitchTask: Task<Void, Never>?
 
+    /// Task for the delayed start of breathing/blink/twitch after entry animation.
+    private var postEntryTask: Task<Void, Never>?
+
     /// Whether animations are currently active (paused when window is inactive).
     private var animationsActive = true
 
@@ -151,6 +154,7 @@ class AvatarLayerView: NSView {
     deinit {
         blinkTask?.cancel()
         twitchTask?.cancel()
+        postEntryTask?.cancel()
         for observer in notificationObservers {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -442,6 +446,7 @@ class AvatarLayerView: NSView {
         animationsActive = false
         blinkTask?.cancel()
         twitchTask?.cancel()
+        postEntryTask?.cancel()
         if configBreathingEnabled {
             let pausedTime = bodyLayer.convertTime(CACurrentMediaTime(), from: nil)
             bodyLayer.speed = 0
@@ -553,11 +558,15 @@ class AvatarLayerView: NSView {
 
         // --- Start other animations after a comfortable pause post-entry ---
         let postEntryDelay: TimeInterval = 1.1  // Entry (0.6s) + breathing pause (0.5s)
-        DispatchQueue.main.asyncAfter(deadline: .now() + postEntryDelay) { [weak self] in
-            guard let self, self.animationsActive else { return }
-            if self.configBlinkEnabled { self.startBlinkTimer() }
-            if self.configBreathingEnabled { self.startBreathing() }
-            self.startTwitchTimer()
+        postEntryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(postEntryDelay))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, self.animationsActive else { return }
+                if self.configBlinkEnabled { self.startBlinkTimer() }
+                if self.configBreathingEnabled { self.startBreathing() }
+                self.startTwitchTimer()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced `DispatchQueue.main.asyncAfter` in `performEntryAnimation()` with a cancellable `Task` stored in `postEntryTask`
- Added `postEntryTask?.cancel()` to `deinit` and `pauseAnimations()` for clean teardown
- Follows the mandatory rule in `clients/AGENTS.md`: "Store deferred async work as a cancellable Task, not DispatchQueue.asyncAfter"

Addresses review feedback from PR #16527.

## Test plan
- [ ] Verify avatar entry animation still plays correctly with the drop-bounce and eye reveal
- [ ] Verify breathing, blink, and twitch animations start after the post-entry delay
- [ ] Verify that pausing animations (window losing focus) during the post-entry delay cancels the pending task
- [ ] Verify deinit properly cancels the post-entry task

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
