### PR TITLE
fix: drop index before dropping contacts.last_interaction column

### DIFF
--- a/assistant/src/memory/migrations/105-contacts-and-triage.ts
+++ b/assistant/src/memory/migrations/105-contacts-and-triage.ts
@@ -8,6 +8,9 @@ export function createContactsAndTriageTables(database: DrizzleDb): void {
   // — dropped by migration 134 (contacts-notes-column). Omitting them here keeps
   //   the CREATE TABLE idempotent when initializeDb() runs a second time (e.g. the
   //   "daemon restart" tests) after migration 134 has already dropped them.
+  // Index removed: idx_contacts_last_interaction — the last_interaction column is
+  //   dropped by migration 159. Omitting the index avoids re-creating it on fresh
+  //   databases only for migration 159 to immediately drop it.
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS contacts (
       id TEXT PRIMARY KEY,
@@ -32,9 +35,6 @@ export function createContactsAndTriageTables(database: DrizzleDb): void {
 
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_contacts_display_name ON contacts(display_name)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_contacts_last_interaction ON contacts(last_interaction DESC)`,
   );
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_contact_channels_contact_id ON contact_channels(contact_id)`,

--- a/assistant/src/memory/migrations/159-drop-contact-interaction-columns.ts
+++ b/assistant/src/memory/migrations/159-drop-contact-interaction-columns.ts
@@ -8,6 +8,11 @@ export function migrateDropContactInteractionColumns(
   } catch {
     /* already dropped or doesn't exist */
   }
+
+  // Drop the index on last_interaction before dropping the column — SQLite
+  // rejects ALTER TABLE DROP COLUMN when a dependent index exists.
+  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_contacts_last_interaction`);
+
   try {
     database.run(/*sql*/ `ALTER TABLE contacts DROP COLUMN last_interaction`);
   } catch {


### PR DESCRIPTION
## Summary
- Migration 159 (`migrateDropContactInteractionColumns`) tried to drop `contacts.last_interaction` but SQLite rejects `ALTER TABLE DROP COLUMN` when a dependent index exists. The try/catch silently swallowed the error, leaving the column in place.
- Fixed by adding `DROP INDEX IF EXISTS idx_contacts_last_interaction` before the column drop in migration 159.
- Removed the index creation from migration 105 (`createContactsAndTriageTables`) since the column is dropped by migration 159 anyway — no point re-creating the index on fresh databases.

## Test plan
- [x] Verified SQLite 3.43.2 (Bun's bundled version) rejects DROP COLUMN when an index references that column
- [x] Confirmed the fix: DROP INDEX IF EXISTS before DROP COLUMN resolves the issue
- [x] Migration 135 (backfill) still works because the column remains in the CREATE TABLE

Addresses review feedback on #16522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
