### PR TITLE
fix: update telemetry ingest path to /v1/assistants/telemetry/ingest/

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -184,9 +184,7 @@ describe("UsageTelemetryReporter", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(
-      "https://test.vellum.ai/v1/assistants/self-hosted-local/telemetry/ingest/",
-    );
+    expect(url).toBe("https://test.vellum.ai/v1/assistants/telemetry/ingest/");
     expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
       "Api-Key test-key",
     );

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -38,7 +38,7 @@ const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
-const TELEMETRY_PATH = "/v1/assistants/self-hosted-local/telemetry/ingest/";
+const TELEMETRY_PATH = "/v1/assistants/telemetry/ingest/";
 
 // ---------------------------------------------------------------------------
 // Reporter


### PR DESCRIPTION
## Summary
- Update `TELEMETRY_PATH` from `/v1/assistants/self-hosted-local/telemetry/ingest/` to `/v1/assistants/telemetry/ingest/`
- Update test assertion to match new URL

Coordinated with vellum-ai/vellum-assistant-platform#2434 which moved the server-side endpoint.

## Test plan
- [x] All 11 telemetry reporter tests pass
- [x] Pre-commit hooks pass (prettier, eslint, typecheck, Swift build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
