### PR TITLE
fix: use getProviderKeyAsync for consistent env var fallback and strip legacy apiKeys

### DIFF
--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -7,7 +7,7 @@ import { getRuntimeHttpPort } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import { isHttpHealthy } from "../../daemon/daemon-control.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import {
   getDbPath,
   getHooksDir,
@@ -75,7 +75,7 @@ Examples:
       const raw = loadRawConfig();
       const provider =
         typeof raw.provider === "string" ? raw.provider : "anthropic";
-      const configKey = await getSecureKeyAsync(provider);
+      const configKey = await getProviderKeyAsync(provider);
 
       if (provider === "ollama") {
         pass("Provider configured (Ollama; API key optional)");

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -303,6 +303,9 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   ensureMigratedDataDir();
   const configPath = getConfigPath();
 
+  // Strip legacy apiKeys — provider keys belong in secure storage, not plaintext config
+  delete config.apiKeys;
+
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
   cached = null; // invalidate cache

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
@@ -250,7 +250,7 @@ export async function selectEmbeddingBackend(
     };
   }
   if (requested === "ollama") {
-    const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
+    const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
     return {
       backend: getCachedOrCreate(
         "ollama",
@@ -286,7 +286,7 @@ export async function selectEmbeddingBackend(
           reason: null,
         };
       case "openai": {
-        const openaiKey = await getSecureKeyAsync("openai");
+        const openaiKey = await getProviderKeyAsync("openai");
         if (!openaiKey) continue;
         return {
           backend: getCachedOrCreate(
@@ -302,7 +302,7 @@ export async function selectEmbeddingBackend(
         };
       }
       case "gemini": {
-        const geminiKey = await getSecureKeyAsync("gemini");
+        const geminiKey = await getProviderKeyAsync("gemini");
         if (!geminiKey) continue;
         return {
           backend: getCachedOrCreate(
@@ -324,7 +324,7 @@ export async function selectEmbeddingBackend(
       }
       case "ollama": {
         if (!(await isOllamaConfigured(config))) continue;
-        const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
+        const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
         return {
           backend: getCachedOrCreate(
             "ollama",
@@ -539,7 +539,7 @@ async function selectFallbackBackends(
     if (provider === exclude) continue;
     switch (provider) {
       case "openai": {
-        const openaiKey = await getSecureKeyAsync("openai");
+        const openaiKey = await getProviderKeyAsync("openai");
         if (openaiKey) {
           backends.push(
             getCachedOrCreate(
@@ -556,7 +556,7 @@ async function selectFallbackBackends(
         break;
       }
       case "gemini": {
-        const geminiKey = await getSecureKeyAsync("gemini");
+        const geminiKey = await getProviderKeyAsync("gemini");
         if (geminiKey) {
           backends.push(
             getCachedOrCreate(
@@ -579,7 +579,7 @@ async function selectFallbackBackends(
       }
       case "ollama":
         if (await isOllamaConfigured(config)) {
-          const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
+          const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
           backends.push(
             getCachedOrCreate(
               "ollama",
@@ -627,7 +627,7 @@ export async function selectedBackendSupportsMultimodal(
 async function isOllamaConfigured(config: AssistantConfig): Promise<boolean> {
   return (
     config.provider === "ollama" ||
-    Boolean(await getSecureKeyAsync("ollama")) ||
+    Boolean(await getProviderKeyAsync("ollama")) ||
     Boolean(getOllamaBaseUrlEnv())
   );
 }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -546,6 +546,9 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
     const raw = readFileSync(configPath, "utf-8");
     const config = JSON.parse(raw) as Record<string, unknown>;
 
+    // Strip legacy apiKeys (removed from schema but may still exist in old config files)
+    delete config.apiKeys;
+
     // Strip ingress webhook secret
     if (config.ingress && typeof config.ingress === "object") {
       const ingress = config.ingress as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- **doctor.ts**: Switch from `getSecureKeyAsync` to `getProviderKeyAsync` so the doctor command correctly detects provider API keys set via environment variables (e.g. `ANTHROPIC_API_KEY`), matching how `initializeProviders` resolves keys at runtime.
- **embedding-backend.ts**: Switch from `getSecureKeyAsync` to `getProviderKeyAsync` so embedding backend selection also honors env var API keys, consistent with provider initialization.
- **log-export-routes.ts**: Strip legacy `apiKeys` field from sanitized config snapshots in diagnostic exports (defense-in-depth for old config files that may still contain plaintext keys).
- **loader.ts**: Strip legacy `apiKeys` field in `saveRawConfig` to prevent plaintext credential persistence if users write `apiKeys.*` via `config set`.

Addresses remaining feedback from PR #16524.

## Test plan
- [ ] Verify `assistant doctor` correctly reports API key status when key is only set via env var
- [ ] Verify embedding backend selection picks up provider keys from env vars
- [ ] Verify diagnostic export does not leak legacy `apiKeys` from config.json
- [ ] Verify `assistant config set apiKeys.foo bar` does not persist `apiKeys` to disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
