### PR TITLE
fix: rename remaining thread/session→conversation symbols (properties, variables, constants, test names)

### DIFF
--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -64,7 +64,7 @@ private struct DeveloperSettingsSectionContent: View {
                 Button {
                     // Snapshot the most recent conversation at open time so the panel
                     // doesn't jump to a different conversation if newer events arrive.
-                    selectedConversationId = traceStore.mostRecentSessionId
+                    selectedConversationId = traceStore.mostRecentConversationId
                     showDebugPanel = true
                 } label: {
                     Label { Text("Open Debug Panel") } icon: { VIconView(.bug, size: 14) }

--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedConversationSwitcherPresentation.swift
@@ -2,35 +2,35 @@ import Foundation
 
 struct CollapsedConversationSwitcherPresentation {
     let switchTargets: [ConversationModel]
-    let activeThreadTitle: String?
-    let totalRegularThreadCount: Int
+    let activeConversationTitle: String?
+    let totalRegularConversationCount: Int
 
-    var showsSwitcher: Bool { totalRegularThreadCount > 0 }
+    var showsSwitcher: Bool { totalRegularConversationCount > 0 }
 
     var badgeText: String {
-        if totalRegularThreadCount > 99 { return "99+" }
-        return "\(totalRegularThreadCount)"
+        if totalRegularConversationCount > 99 { return "99+" }
+        return "\(totalRegularConversationCount)"
     }
 
     var accessibilityLabel: String {
-        if let title = activeThreadTitle {
+        if let title = activeConversationTitle {
             return "Switch conversations: \(title)"
         }
         return "Switch conversations"
     }
 
     var accessibilityValue: String {
-        totalRegularThreadCount == 0 ? "" : "\(totalRegularThreadCount) conversations"
+        totalRegularConversationCount == 0 ? "" : "\(totalRegularConversationCount) conversations"
     }
 
     init(regularConversations: [ConversationModel], activeConversationId: UUID?) {
-        self.totalRegularThreadCount = regularConversations.count
+        self.totalRegularConversationCount = regularConversations.count
         if let activeId = activeConversationId {
             self.switchTargets = regularConversations.filter { $0.id != activeId }
-            self.activeThreadTitle = regularConversations.first(where: { $0.id == activeId })?.title
+            self.activeConversationTitle = regularConversations.first(where: { $0.id == activeId })?.title
         } else {
             self.switchTargets = regularConversations
-            self.activeThreadTitle = nil
+            self.activeConversationTitle = nil
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,7 +6,7 @@ import os
 import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
-private let archivedSessionsKey = "archivedConversationIds"
+private let archivedConversationsKey = "archivedConversationIds"
 
 // MARK: - Conversation Client Protocol
 
@@ -679,7 +679,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // with the daemon's row numbering regardless of client-side filtering.
         serverOffset += response.conversations.count
 
-        let recentSessions = response.conversations.filter {
+        let recentConversations = response.conversations.filter {
             $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
@@ -687,13 +687,13 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // persisted displayOrder values in the incoming batch, so legacy conversations
         // (nil displayOrder) don't collide with explicit or already-loaded ones.
         let existingMax = conversations.compactMap(\.pinnedOrder).max() ?? -1
-        let batchMax = recentSessions
+        let batchMax = recentConversations
             .filter { $0.isPinned ?? false }
             .compactMap { $0.displayOrder.map { Int($0) } }
             .max() ?? -1
         var nextPinnedOrder = max(existingMax, batchMax) + 1
 
-        for session in recentSessions {
+        for session in recentConversations {
             // If a local conversation already exists, merge server pin/order metadata.
             if let existingIdx = conversations.firstIndex(where: { $0.conversationId == session.id }) {
                 let isPinned = session.isPinned ?? false
@@ -800,7 +800,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         // Slow path: fetch the conversation via the gateway and insert it locally
-        guard let session = await conversationClient.fetchConversationById(conversationId) else {
+        guard let conversation = await conversationClient.fetchConversationById(conversationId) else {
             return false
         }
 
@@ -811,45 +811,45 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         // Don't insert external-channel or private conversations into the main sidebar
-        if session.conversationType == "private" || session.channelBinding?.sourceChannel != nil {
+        if conversation.conversationType == "private" || conversation.channelBinding?.sourceChannel != nil {
             return false
         }
 
-        let effectiveCreatedAt = session.createdAt ?? session.updatedAt
-        let conversation = ConversationModel(
-            title: session.title,
+        let effectiveCreatedAt = conversation.createdAt ?? conversation.updatedAt
+        let conversationModel = ConversationModel(
+            title: conversation.title,
             createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
-            conversationId: session.id,
-            isPinned: session.isPinned ?? false,
-            pinnedOrder: (session.isPinned ?? false) ? session.displayOrder.map { Int($0) } : nil,
-            displayOrder: session.displayOrder.map { Int($0) },
-            lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+            conversationId: conversation.id,
+            isPinned: conversation.isPinned ?? false,
+            pinnedOrder: (conversation.isPinned ?? false) ? conversation.displayOrder.map { Int($0) } : nil,
+            displayOrder: conversation.displayOrder.map { Int($0) },
+            lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(conversation.updatedAt) / 1000.0),
             kind: .standard,
-            source: session.source,
-            scheduleJobId: session.scheduleJobId,
-            hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
-            latestAssistantMessageAt: session.assistantAttention?.latestAssistantMessageAt.map {
+            source: conversation.source,
+            scheduleJobId: conversation.scheduleJobId,
+            hasUnseenLatestAssistantMessage: conversation.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
+            latestAssistantMessageAt: conversation.assistantAttention?.latestAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             },
-            lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
+            lastSeenAssistantMessageAt: conversation.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
         )
 
         let viewModel = makeViewModel()
-        viewModel.conversationId = session.id
+        viewModel.conversationId = conversation.id
         // Leave isHistoryLoaded false so history is fetched when the conversation activates
         viewModel.startMessageLoop()
 
-        conversations.insert(conversation, at: 0)
-        chatViewModels[conversation.id] = viewModel
-        subscribeToBusyState(for: conversation.id, viewModel: viewModel)
-        subscribeToAssistantActivity(for: conversation.id, viewModel: viewModel)
-        subscribeToInteractionState(for: conversation.id, viewModel: viewModel)
-        touchVMAccessOrder(conversation.id)
+        conversations.insert(conversationModel, at: 0)
+        chatViewModels[conversationModel.id] = viewModel
+        subscribeToBusyState(for: conversationModel.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: conversationModel.id, viewModel: viewModel)
+        subscribeToInteractionState(for: conversationModel.id, viewModel: viewModel)
+        touchVMAccessOrder(conversationModel.id)
         evictStaleCachedViewModels()
 
-        selectConversation(id: conversation.id)
+        selectConversation(id: conversationModel.id)
         return true
     }
 
@@ -1730,10 +1730,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     private var archivedConversationIds: Set<String> {
         get {
-            Set(UserDefaults.standard.stringArray(forKey: archivedSessionsKey) ?? [])
+            Set(UserDefaults.standard.stringArray(forKey: archivedConversationsKey) ?? [])
         }
         set {
-            UserDefaults.standard.set(Array(newValue), forKey: archivedSessionsKey)
+            UserDefaults.standard.set(Array(newValue), forKey: archivedConversationsKey)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -180,7 +180,7 @@ final class ConversationRestorer {
         // Filter out private conversations and conversations bound to external channels
         // (e.g. Telegram). External channel-bound conversations belong to their own
         // lane and should not appear in the desktop conversation list.
-        let recentSessions = response.conversations.filter {
+        let recentConversations = response.conversations.filter {
             $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
         }
 
@@ -191,12 +191,12 @@ final class ConversationRestorer {
         var restoredConversations: [ConversationModel] = []
         // Seed the fallback counter past the highest persisted pinned order
         // so legacy conversations (nil displayOrder) don't collide with explicit ones.
-        let maxPersistedPinnedOrder = recentSessions
+        let maxPersistedPinnedOrder = recentConversations
             .filter { $0.isPinned ?? false }
             .compactMap { $0.displayOrder.map { Int($0) } }
             .max() ?? -1
         var pinnedCount = maxPersistedPinnedOrder + 1
-        for session in recentSessions {
+        for session in recentConversations {
             // If a local conversation already exists (e.g. created by
             // createNotificationConversation before the session list response arrived),
             // merge server pin/order metadata into it instead of creating a duplicate.

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -125,9 +125,9 @@ struct QuickInputView: View {
                     if !recentConversations.isEmpty {
                         Divider()
 
-                        ForEach(recentConversations) { thread in
-                            Button(thread.title) {
-                                onSelectConversation?(thread.id, thread.title)
+                        ForEach(recentConversations) { conversation in
+                            Button(conversation.title) {
+                                onSelectConversation?(conversation.id, conversation.title)
                             }
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -14,12 +14,12 @@ struct SettingsArchivedConversationsTab: View {
                 )
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(conversationManager.archivedConversations.enumerated()), id: \.element.id) { index, thread in
+                    ForEach(Array(conversationManager.archivedConversations.enumerated()), id: \.element.id) { index, conversation in
                         if index > 0 {
                             SettingsDivider()
                         }
-                        ArchivedConversationRow(conversation: thread) {
-                            conversationManager.unarchiveConversation(id: thread.id)
+                        ArchivedConversationRow(conversation: conversation) {
+                            conversationManager.unarchiveConversation(id: conversation.id)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -73,16 +73,16 @@ final class DebugStateWriter {
             transport: transport
         )
 
-        let conversationSnapshots: [DebugSnapshot.ConversationInfo] = (conversationManager?.conversations ?? []).map { thread in
-            let vm = conversationManager?.chatViewModel(for: thread.id)
+        let conversationSnapshots: [DebugSnapshot.ConversationInfo] = (conversationManager?.conversations ?? []).map { conversation in
+            let vm = conversationManager?.chatViewModel(for: conversation.id)
             return DebugSnapshot.ConversationInfo(
-                id: thread.id.uuidString,
-                title: thread.title,
-                conversationId: thread.conversationId,
+                id: conversation.id.uuidString,
+                title: conversation.title,
+                conversationId: conversation.conversationId,
                 messageCount: vm?.messages.count ?? 0,
-                kind: thread.kind == .private ? "private" : "standard",
-                isArchived: thread.isArchived,
-                isPinned: thread.isPinned
+                kind: conversation.kind == .private ? "private" : "standard",
+                isArchived: conversation.isArchived,
+                isPinned: conversation.isPinned
             )
         }
 

--- a/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CollapsedConversationSwitcherPresentationTests.swift
@@ -32,7 +32,7 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: id)
 
         XCTAssertTrue(sut.showsSwitcher)
-        XCTAssertEqual(sut.totalRegularThreadCount, 1)
+        XCTAssertEqual(sut.totalRegularConversationCount, 1)
         XCTAssertTrue(sut.switchTargets.isEmpty)
     }
 
@@ -53,7 +53,7 @@ final class CollapsedConversationSwitcherPresentationTests: XCTestCase {
         let conversations = [makeConversation(), makeConversation(), makeConversation()]
         let sut = CollapsedConversationSwitcherPresentation(regularConversations: conversations, activeConversationId: nil)
 
-        XCTAssertEqual(sut.totalRegularThreadCount, 3)
+        XCTAssertEqual(sut.totalRegularConversationCount, 3)
     }
 
     func testBadgeText_normalCount() {

--- a/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerConversationLoopTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import VellumAssistantShared
 
 @MainActor
-final class ConversationManagerSessionLoopTests: XCTestCase {
+final class ConversationManagerConversationLoopTests: XCTestCase {
     private var daemonClient: DaemonClient!
     private var conversationManager: ConversationManager!
 

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -469,12 +469,12 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                 ],
             ]]
         )
-        guard let session = staleResponse.conversations.first else {
-            XCTFail("Expected response session")
+        guard let conversation = staleResponse.conversations.first else {
+            XCTFail("Expected response conversation")
             return
         }
 
-        conversationManager.mergeAssistantAttention(from: session, intoConversationAt: index)
+        conversationManager.mergeAssistantAttention(from: conversation, intoConversationAt: index)
 
         XCTAssertFalse(
             conversationManager.conversations.first(where: { $0.conversationId == "session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -64,7 +64,7 @@ final class DocumentEditorConversationVisibilityTests: XCTestCase {
         )
 
         XCTAssertEqual(presentation.displayTitle, "Doc Session Conversation",
-                        "Document editor should show actual thread title, not 'New thread'")
+                        "Document editor should show actual conversation title, not 'New thread'")
         XCTAssertTrue(presentation.isStarted)
         XCTAssertTrue(presentation.showsActionsMenu)
     }

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -286,7 +286,7 @@ public final class TraceStore: ObservableObject {
     /// Used by developer tooling to auto-select a relevant conversation when no
     /// explicit selection context is available (e.g. when opening the debug panel
     /// from the Settings screen rather than from an active conversation).
-    public var mostRecentSessionId: String? {
+    public var mostRecentConversationId: String? {
         eventsByConversation
             .compactMapValues { $0.last?.timestampMs }
             .max(by: { $0.value < $1.value })

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -332,7 +332,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         XCTAssertEqual(metadata["attempt"] as? Int, 1)
     }
 
-    func testSessionListResponsePreservesPinMetadataFromHTTPTransport() async throws {
+    func testConversationListResponsePreservesPinMetadataFromHTTPTransport() async throws {
         let responseExpectation = expectation(description: "session list response")
         var capturedResponse: ConversationListResponseMessage?
 
@@ -377,8 +377,8 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
 
         await fulfillment(of: [responseExpectation], timeout: 1.0)
 
-        let session = try XCTUnwrap(capturedResponse?.conversations.first)
-        XCTAssertEqual(session.displayOrder, 7)
-        XCTAssertEqual(session.isPinned, true)
+        let conversation = try XCTUnwrap(capturedResponse?.conversations.first)
+        XCTAssertEqual(conversation.displayOrder, 7)
+        XCTAssertEqual(conversation.isPinned, true)
     }
 }


### PR DESCRIPTION
## Summary
Fixes symbol gaps identified during plan review round 3 for conv-symbol-sweep.md:
- Rename activeThreadTitle/totalRegularThreadCount in CollapsedConversationSwitcherPresentation
- Rename ConversationManagerSessionLoopTests class to match filename
- Rename test method testSessionListResponse... in HTTPDaemonClientUnreadTests
- Rename local session/recentSessions variables across 4 files
- Rename archivedSessionsKey constant
- Rename loop variables thread→conversation in 3 files
- Rename mostRecentSessionId in TraceStore + consumer
- Fix assertion message in DocumentEditorConversationVisibilityTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
