### PR TITLE
fix: address async provider review feedback from #16591

### DIFF
--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -20,7 +20,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
-import type { ModelIntent } from "../providers/types.js";
+import type { ModelIntent, Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   buildConversationCandidates,
@@ -747,6 +747,7 @@ export async function evaluateSignal(
   let decision: NotificationDecision;
   try {
     decision = await classifyWithLLM(
+      provider,
       signal,
       availableChannels,
       resolvedPreferenceContext,
@@ -777,13 +778,13 @@ export async function evaluateSignal(
 // ── LLM classification ────────────────────────────────────────────────
 
 async function classifyWithLLM(
+  provider: Provider,
   signal: NotificationSignal,
   availableChannels: NotificationChannel[],
   preferenceContext: string | undefined,
   modelIntent: ModelIntent,
   candidateSet?: ConversationCandidateSet,
 ): Promise<NotificationDecision> {
-  const provider = (await getConfiguredProvider())!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
 
   const candidateContext = candidateSet

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -31,6 +31,14 @@ const providerSelectionLog = getLogger("provider-selection");
 let fallbackWarningLogged = false;
 
 /**
+ * Cached promise for the lazy initialization path inside
+ * `resolveConfiguredProvider`. When multiple concurrent callers enter before
+ * providers are initialized, they all await the same promise instead of
+ * each triggering a redundant `initializeProviders` call.
+ */
+let lazyInitPromise: Promise<void> | null = null;
+
+/**
  * Resolve the configured provider with full selection metadata.
  * If providers haven't been initialized yet (e.g. non-daemon code paths),
  * performs a one-shot `initializeProviders(getConfig())`.
@@ -44,8 +52,13 @@ export async function resolveConfiguredProvider(): Promise<ConfiguredProviderRes
   const config = getConfig();
 
   if (listProviders().length === 0) {
+    if (!lazyInitPromise) {
+      lazyInitPromise = initializeProviders(config).finally(() => {
+        lazyInitPromise = null;
+      });
+    }
     try {
-      await initializeProviders(config);
+      await lazyInitPromise;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Pass already-resolved provider from `evaluateSignal` into `classifyWithLLM` as a parameter, eliminating a redundant `getConfiguredProvider()` call and unsafe non-null assertion
- Cache the lazy `initializeProviders` promise in `resolveConfiguredProvider` so concurrent callers share a single initialization instead of triggering redundant work

## Test plan
- [x] Pre-commit hooks pass (lint, formatting, secret scanning)
- [ ] CI type-check passes
- [ ] Existing notification decision engine tests pass unchanged (mock signature already async-compatible)

Addresses feedback from #16591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
