### PR TITLE
fix: correct duplicate step numbering and typo in phone-calls SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -55,11 +55,11 @@ Before making real calls, offer a quick verification. Suggest a test call to the
 
 If they agree, ask for their personal phone number and place a test call with a simple task like "Introduce yourself and confirm the call system is working."
 
-## Step 4: Guardian Verification
+## Step 5: Guardian Verification
 
 The final step is for the user to verify themselves so that they are recognized when they call you. It's also a great way for them to hear what you sound like and decide if they want you to use a different voice.
 
-Load the `guardian-verify-setup` skill and follow the isntructions for guardian verification over the `phone` channel. This will require the user to provide you with their phone number and then for you to give them a call. Say something like:
+Load the `guardian-verify-setup` skill and follow the instructions for guardian verification over the `phone` channel. This will require the user to provide you with their phone number and then for you to give them a call. Say something like:
 
 > Want to do a quick verification call now so that you can hear what I sound like and also so that I recognize your number when you call me in the future?
 > I'll show a 6 digit code here in the chat and when you answer my call, enter it using your phone's keypad.


### PR DESCRIPTION
## Summary
- Fixes duplicate "Step 4" heading in phone-calls SKILL.md: Guardian Verification is now correctly numbered as Step 5 (after Step 4: Verify Setup)
- Fixes typo: "isntructions" -> "instructions"

Addresses review feedback from #16799.

## Test plan
- [ ] Verify SKILL.md step numbering is sequential (Steps 1-5)
- [ ] Verify no typos in the instructions text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
