### PR TITLE
fix: preserve archived state in on-demand conversation fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -820,6 +820,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             title: conversation.title,
             createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
             conversationId: conversation.id,
+            isArchived: isConversationArchived(conversation.id),
             isPinned: conversation.isPinned ?? false,
             pinnedOrder: (conversation.isPinned ?? false) ? conversation.displayOrder.map { Int($0) } : nil,
             displayOrder: conversation.displayOrder.map { Int($0) },


### PR DESCRIPTION
## Summary
- Adds `isArchived: isConversationArchived(conversation.id)` to the `ConversationModel` init in `selectConversationByConversationIdAsync`
- Prevents archived conversations from being silently unarchived when navigated to via command palette search
- Aligns with the existing pattern in `mergeServerConversationList` which already checks archive state

Addresses review feedback on #16654.

## Test plan
- [x] Verify that navigating to an archived conversation via command palette preserves its archived state
- [x] Verify non-archived conversations still work normally via command palette navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
