### PR TITLE
fix: smooth content section transition on sidebar collapse

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -464,7 +464,7 @@ struct MainWindowView: View {
 
                         chatContentView(geometry: geometry)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                            .animation(nil, value: sidebarExpanded)
+                            .animation(VAnimation.panel, value: sidebarExpanded)
                             .overlay {
                                 if showDaemonLoading && !isSettingsOpen {
                                     DaemonLoadingChatSkeleton()


### PR DESCRIPTION
## Summary
- The content section next to the sidebar had `.animation(nil, value: sidebarExpanded)` which disabled its width transition during sidebar collapse/expand
- Changed to `.animation(VAnimation.panel, value: sidebarExpanded)` to match the sidebar's spring animation, so both animate in sync

## Original prompt
--safe https://linear.app/vellum/issue/LUM-210/side-nav-collapse-animation-feels-less-smooth problem with that one, that content section isn't animated, so when we collapsing side bar, it goes "rough". We need to add same timing transition for width of content section that sidebar has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
