### PR TITLE
refactor: fix stale secure-keys docs and remove dead mock counters

### DIFF
--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -299,7 +299,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 | File                                                 | Role                                                                  |
 | ---------------------------------------------------- | --------------------------------------------------------------------- |
 | `assistant/src/tools/credentials/vault.ts`           | `credential_store` tool — store, list, delete, prompt actions         |
-| `assistant/src/security/secure-keys.ts`              | Keychain read/write via `/usr/bin/security` CLI                       |
+| `assistant/src/security/secure-keys.ts`              | Async secure key CRUD via keychain broker and encrypted file store    |
 | `assistant/src/tools/credentials/metadata-store.ts`  | JSON file metadata CRUD for credential records                        |
 | `assistant/src/tools/credentials/broker.ts`          | Brokered credential access with policy enforcement and transient send |
 | `assistant/src/tools/credentials/policy-validate.ts` | Policy input validation (allowedTools, allowedDomains)                |

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -18,14 +18,6 @@ function nextUUID(): string {
   return `00000000-0000-0000-0000-${String(idCounter).padStart(12, "0")}`;
 }
 
-// Track mock call counts
-let _getSecureKeyCalls = 0;
-let _setSecureKeyCalls = 0;
-let _deleteSecureKeyCalls = 0;
-let _listMetadataCalls = 0;
-let _getMetadataCalls = 0;
-let _getMetadataByIdCalls = 0;
-
 // ---------------------------------------------------------------------------
 // Mock secure-keys
 // ---------------------------------------------------------------------------
@@ -35,14 +27,12 @@ mock.module("../security/secure-keys.js", () => ({
     account: string,
     value: string,
   ): Promise<boolean> => {
-    _setSecureKeyCalls += 1;
     secureKeyStore.set(account, value);
     return true;
   },
   deleteSecureKeyAsync: async (
     account: string,
   ): Promise<"deleted" | "not-found" | "error"> => {
-    _deleteSecureKeyCalls += 1;
     if (secureKeyStore.has(account)) {
       secureKeyStore.delete(account);
       return "deleted";
@@ -53,7 +43,6 @@ mock.module("../security/secure-keys.js", () => ({
     return [...secureKeyStore.keys()];
   },
   getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
-    _getSecureKeyCalls += 1;
     return secureKeyStore.get(account);
   },
   _resetBackend: (): void => {},
@@ -119,7 +108,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
     service: string,
     field: string,
   ): CredentialMetadata | undefined => {
-    _getMetadataCalls += 1;
     return metadataStore.find(
       (c) => c.service === service && c.field === field,
     );
@@ -127,7 +115,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
   getCredentialMetadataById: (
     credentialId: string,
   ): CredentialMetadata | undefined => {
-    _getMetadataByIdCalls += 1;
     return metadataStore.find((c) => c.credentialId === credentialId);
   },
   deleteCredentialMetadata: (service: string, field: string): boolean => {
@@ -139,7 +126,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
     return true;
   },
   listCredentialMetadata: (): CredentialMetadata[] => {
-    _listMetadataCalls += 1;
     return [...metadataStore];
   },
 }));
@@ -275,12 +261,6 @@ describe("assistant credentials CLI", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     idCounter = 0;
-    _getSecureKeyCalls = 0;
-    _setSecureKeyCalls = 0;
-    _deleteSecureKeyCalls = 0;
-    _listMetadataCalls = 0;
-    _getMetadataCalls = 0;
-    _getMetadataByIdCalls = 0;
     disconnectOAuthProviderCalls = [];
     disconnectOAuthProviderResult = "not-found";
     process.exitCode = 0;


### PR DESCRIPTION
## Summary
- Update stale description of `secure-keys.ts` in `security.md` Key Files table — the module now routes through keychain broker and encrypted file store, not `/usr/bin/security` CLI
- Remove dead mock call counters (`_getSecureKeyCalls`, `_setSecureKeyCalls`, `_deleteSecureKeyCalls`, `_listMetadataCalls`, `_getMetadataCalls`, `_getMetadataByIdCalls`) in `credentials-cli.test.ts` that were incremented but never asserted on

Addresses review feedback from PR #16605.

## Test plan
- [ ] Verify `credentials-cli.test.ts` still passes after removing dead counters
- [ ] Confirm no remaining stale `/usr/bin/security` references in security.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
