### PR TITLE
fix: update stale set_avatar tool reference in DaemonClient.swift comment

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1531,7 +1531,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(IdentityGetRequestMessage())
     }
 
-    /// Request avatar generation via the daemon's set_avatar tool.
+    /// Request avatar generation via the daemon's avatar generation endpoint.
     public func sendGenerateAvatar(description: String) throws {
         try send(GenerateAvatarRequestMessage(description: description))
     }


### PR DESCRIPTION
## Summary
- Update comment in DaemonClient.swift that still referenced `set_avatar` as a "tool" to say "avatar generation endpoint" instead
- The `set_avatar` tool was removed from the skill system in PR #16856, but this comment was missed in the follow-up cleanups (#16872, #16888)

Addresses remaining feedback from PR #16856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
