### PR TITLE
fix: use VELLUM_DATA_DIR in vellum-avatar SKILL.md

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -80,15 +80,15 @@ The user provides a file path to an image they want to use as their avatar.
 Copy the image to the avatar location:
 
 ```bash
-mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
-cp "<user-provided-path>" "$VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png"
+mkdir -p "$VELLUM_DATA_DIR/avatar"
+cp "<user-provided-path>" "$VELLUM_DATA_DIR/avatar/avatar-image.png"
 ```
 
 Then remove the native character files, since a custom image overrides the native character:
 
 ```bash
-rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
-rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-ascii.txt"
+rm -f "$VELLUM_DATA_DIR/avatar/character-traits.json"
+rm -f "$VELLUM_DATA_DIR/avatar/character-ascii.txt"
 ```
 
 Tell the user their avatar has been updated. The client will pick up the new image automatically.
@@ -106,8 +106,8 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/settings/avatar/generate" \
 This generates an image using AI and saves it to `data/avatar/avatar-image.png`. After the image is generated, remove the native character files:
 
 ```bash
-rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
-rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-ascii.txt"
+rm -f "$VELLUM_DATA_DIR/avatar/character-traits.json"
+rm -f "$VELLUM_DATA_DIR/avatar/character-ascii.txt"
 ```
 
 The generated avatar will appear automatically in the client.


### PR DESCRIPTION
## Summary
- Replace `$VELLUM_WORKSPACE_DIR/data/avatar` with `$VELLUM_DATA_DIR/avatar` in the vellum-avatar skill's shell snippets
- `VELLUM_WORKSPACE_DIR` is not exposed in the bash tool's sanitized environment (`safe-env.ts`), so commands referencing it fail silently
- `VELLUM_DATA_DIR` is the correct env var — it resolves to `~/.vellum/workspace/data` and is injected by `buildSanitizedEnv()`

Addresses review feedback from PR #16845.

## Test plan
- [ ] Verify `$VELLUM_DATA_DIR` is set in bash tool environment by checking `safe-env.ts`
- [ ] Confirm avatar upload and AI generation paths resolve correctly with the new env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
