### PR TITLE
fix: critical session-to-conversation renames (iOS notification key, PendingInteraction, TraceStore)

### DIFF
--- a/assistant/src/__tests__/clipboard.test.ts
+++ b/assistant/src/__tests__/clipboard.test.ts
@@ -2,32 +2,32 @@ import { describe, expect, test } from "bun:test";
 
 import {
   extractLastCodeBlock,
-  formatSessionForExport,
+  formatConversationForExport,
 } from "../util/clipboard.js";
 
-describe("formatSessionForExport", () => {
+describe("formatConversationForExport", () => {
   test("formats user and assistant messages", () => {
     const messages = [
       { role: "user", text: "Hello" },
       { role: "assistant", text: "Hi there!" },
     ];
-    expect(formatSessionForExport(messages)).toBe(
+    expect(formatConversationForExport(messages)).toBe(
       "you> Hello\n\nassistant> Hi there!",
     );
   });
 
   test("handles a single message", () => {
     const messages = [{ role: "user", text: "Just me" }];
-    expect(formatSessionForExport(messages)).toBe("you> Just me");
+    expect(formatConversationForExport(messages)).toBe("you> Just me");
   });
 
   test("handles empty messages array", () => {
-    expect(formatSessionForExport([])).toBe("");
+    expect(formatConversationForExport([])).toBe("");
   });
 
   test("preserves multiline message text", () => {
     const messages = [{ role: "assistant", text: "Line 1\nLine 2\nLine 3" }];
-    expect(formatSessionForExport(messages)).toBe(
+    expect(formatConversationForExport(messages)).toBe(
       "assistant> Line 1\nLine 2\nLine 3",
     );
   });

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -39,7 +39,7 @@ import {
 import {
   copyToClipboard,
   extractLastCodeBlock,
-  formatSessionForExport,
+  formatConversationForExport,
 } from "./util/clipboard.js";
 import { formatDiff, formatNewFileDiff } from "./util/diff.js";
 import { getHistoryPath, getSignalsDir } from "./util/platform.js";
@@ -899,7 +899,7 @@ export async function startCli(): Promise<void> {
             process.stdout.write("\n  No messages to copy.\n\n");
           } else {
             try {
-              const formatted = formatSessionForExport(msg.messages);
+              const formatted = formatConversationForExport(msg.messages);
               copyToClipboard(formatted);
               process.stdout.write(
                 `\n  Copied session (${msg.messages.length} messages) to clipboard.\n\n`,
@@ -1076,7 +1076,7 @@ export async function startCli(): Promise<void> {
             };
           });
           try {
-            const formatted = formatSessionForExport(rendered);
+            const formatted = formatConversationForExport(rendered);
             copyToClipboard(formatted);
             process.stdout.write(
               `\n  Copied session (${rawMessages.length} messages) to clipboard.\n\n`,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -149,16 +149,16 @@ function resolveCanonicalRequestSourceType(
  * Build an onEvent callback that registers pending interactions when the agent
  * loop emits confirmation_request, secret_request, host_bash_request, or
  * host_file_request events. This ensures that channel approval interception
- * can look up the session by requestId.
+ * can look up the conversation by requestId.
  */
 function makePendingInteractionRegistrar(
-  session: Conversation,
+  conversation: Conversation,
   conversationId: string,
 ): (msg: ServerMessage) => void {
   return (msg: ServerMessage) => {
     if (msg.type === "confirmation_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation,
         conversationId,
         kind: "confirmation",
         confirmationDetails: {
@@ -176,7 +176,7 @@ function makePendingInteractionRegistrar(
       // Create a canonical guardian request so HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
       try {
-        const trustContext = session.trustContext;
+        const trustContext = conversation.trustContext;
         const sourceChannel = trustContext?.sourceChannel ?? "vellum";
         const canonicalRequest = createCanonicalGuardianRequest({
           id: msg.requestId,
@@ -202,7 +202,8 @@ function makePendingInteractionRegistrar(
             trustContext,
             conversationId,
             toolName: msg.toolName,
-            assistantId: session.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+            assistantId:
+              conversation.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
           });
         }
       } catch (err) {
@@ -213,25 +214,25 @@ function makePendingInteractionRegistrar(
       }
     } else if (msg.type === "secret_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation,
         conversationId,
         kind: "secret",
       });
     } else if (msg.type === "host_bash_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation,
         conversationId,
         kind: "host_bash",
       });
     } else if (msg.type === "host_file_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation,
         conversationId,
         kind: "host_file",
       });
     } else if (msg.type === "host_cu_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation,
         conversationId,
         kind: "host_cu",
       });

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -214,16 +214,19 @@ export function handleChannelDecision(
     // still proceeds as a one-time approval (falls through to session call).
   }
 
-  // Resolve the interaction to get the session and remove from tracker
+  // Resolve the interaction to get the conversation and remove from tracker
   const resolved = pendingInteractions.resolve(info.requestId);
   if (!resolved) return { applied: false };
 
   // Map channel-level action to the permission system's UserDecision type.
   const userDecision = mapApprovalActionToUserDecision(decision.action);
   if (decisionContext === undefined) {
-    resolved.session.handleConfirmationResponse(info.requestId, userDecision);
+    resolved.conversation.handleConfirmationResponse(
+      info.requestId,
+      userDecision,
+    );
   } else {
-    resolved.session.handleConfirmationResponse(
+    resolved.conversation.handleConfirmationResponse(
       info.requestId,
       userDecision,
       undefined,

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,12 +1,12 @@
 /**
- * In-memory tracker that maps requestId to session info for pending
+ * In-memory tracker that maps requestId to conversation info for pending
  * confirmation, secret, host_bash, host_file, and host_cu interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
  * host_bash_request, host_file_request, or host_cu_request, the onEvent
  * callback registers the interaction here. Standalone HTTP endpoints
  * (/v1/confirm, /v1/secret, /v1/trust-rules, /v1/host-bash-result,
- * /v1/host-file-result, /v1/host-cu-result) look up the session from this
+ * /v1/host-file-result, /v1/host-cu-result) look up the conversation from this
  * tracker to resolve the interaction.
  */
 
@@ -28,7 +28,7 @@ export interface ConfirmationDetails {
 }
 
 export interface PendingInteraction {
-  session: Conversation;
+  conversation: Conversation;
   conversationId: string;
   kind: "confirmation" | "secret" | "host_bash" | "host_file" | "host_cu";
   confirmationDetails?: ConfirmationDetails;
@@ -80,7 +80,7 @@ export function getByConversation(
 }
 
 /**
- * Remove pending confirmation and secret interactions for a given session.
+ * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
  * host_bash, host_file, and host_cu interactions are intentionally skipped
@@ -90,10 +90,10 @@ export function getByConversation(
  * /v1/host-cu-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  */
-export function removeByConversation(session: Conversation): void {
+export function removeByConversation(conversation: Conversation): void {
   for (const [requestId, interaction] of pending) {
     if (
-      interaction.session === session &&
+      interaction.conversation === conversation &&
       interaction.kind !== "host_bash" &&
       interaction.kind !== "host_file" &&
       interaction.kind !== "host_cu"

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -129,7 +129,7 @@ export async function handleConfirm(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.session.handleConfirmationResponse(
+  interaction.conversation.handleConfirmationResponse(
     requestId,
     decision as UserDecision,
     selectedPattern,
@@ -186,7 +186,7 @@ export async function handleSecret(
     );
   }
 
-  interaction.session.handleSecretResponse(
+  interaction.conversation.handleSecretResponse(
     requestId,
     value,
     delivery as "store" | "transient_send" | undefined,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -794,7 +794,7 @@ export async function handleSendMessage(
         mapping.conversationId,
       )) {
         if (
-          interaction.session === session &&
+          interaction.conversation === session &&
           interaction.kind === "confirmation"
         ) {
           session.emitConfirmationStateChanged({
@@ -825,7 +825,7 @@ export async function handleSendMessage(
       mapping.conversationId,
     )) {
       if (
-        interaction.session === session &&
+        interaction.conversation === session &&
         interaction.kind === "confirmation"
       ) {
         session.emitConfirmationStateChanged({

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -57,7 +57,7 @@ export async function handleHostBashResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.session.resolveHostBash(requestId, {
+  interaction.conversation.resolveHostBash(requestId, {
     stdout: stdout ?? "",
     stderr: stderr ?? "",
     exitCode: exitCode ?? null,

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -64,7 +64,7 @@ export async function handleHostCuResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.session.resolveHostCu(requestId, {
+  interaction.conversation.resolveHostCu(requestId, {
     axTree: body.axTree,
     axDiff: body.axDiff,
     screenshot: body.screenshot,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -55,7 +55,7 @@ export async function handleHostFileResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.session.resolveHostFile(requestId, {
+  interaction.conversation.resolveHostFile(requestId, {
     content: content ?? "",
     isError: isError ?? false,
   });

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -60,7 +60,7 @@ export function handleConfirmationSignal(): void {
       return;
     }
 
-    interaction.session.handleConfirmationResponse(
+    interaction.conversation.handleConfirmationResponse(
       requestId,
       decision,
       undefined,

--- a/assistant/src/util/clipboard.ts
+++ b/assistant/src/util/clipboard.ts
@@ -11,7 +11,7 @@ export function copyToClipboard(text: string): void {
   execSync(cmd, { input: text, stdio: ["pipe", "ignore", "ignore"] });
 }
 
-export function formatSessionForExport(
+export function formatConversationForExport(
   messages: Array<{ role: string; text: string }>,
 ): string {
   return messages

--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -302,7 +302,9 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
         if response.actionIdentifier == "REPLY_ACTION",
            let textResponse = response as? UNTextInputNotificationResponse {
             let replyText = textResponse.userText
-            let conversationId = response.notification.request.content.userInfo["session_id"] as? String
+            let conversationId =
+                response.notification.request.content.userInfo["conversationId"] as? String ??
+                response.notification.request.content.userInfo["conversation_id"] as? String
 
             Task { @MainActor in
                 // If not connected (e.g. background launch via notification reply with no scene

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -203,7 +203,7 @@ struct TraceTimelineIOSView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
-            .onChange(of: traceStore.latestEventIdBySession[conversationId]) { _, _ in
+            .onChange(of: traceStore.latestEventIdByConversation[conversationId]) { _, _ in
                 if isNearBottom {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("trace-bottom", anchor: .bottom)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -57,7 +57,7 @@ struct TraceTimelineView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.md)
             }
-            .onChange(of: traceStore.latestEventIdBySession[conversationId]) {
+            .onChange(of: traceStore.latestEventIdByConversation[conversationId]) {
                 if isNearBottom {
                     withAnimation(VAnimation.fast) {
                         proxy.scrollTo("trace-bottom", anchor: .bottom)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -14,17 +14,17 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 extension ChatViewModel {
 
-    /// Returns true if the given session ID belongs to this chat conversation.
+    /// Returns true if the given conversation ID belongs to this chat conversation.
     /// Messages with a nil conversationId are always accepted; messages whose
     /// conversationId doesn't match the current session are silently ignored
     /// to prevent cross-conversation contamination (e.g. from a popover text_qa flow).
-    func belongsToConversation(_ messageSessionId: String?) -> Bool {
-        guard let messageSessionId else { return true }
+    func belongsToConversation(_ messageConversationId: String?) -> Bool {
+        guard let messageConversationId else { return true }
         guard let conversationId else {
             // No conversation established yet — accept all messages
             return true
         }
-        return messageSessionId == conversationId
+        return messageConversationId == conversationId
     }
 
     /// Map daemon confirmation state string to ToolConfirmationState.
@@ -1175,8 +1175,8 @@ extension ChatViewModel {
             // Route using conversationId when available (daemon >= v1.x includes
             // the conversationId). Fall back to the timestamp-based heuristic
             // via shouldAcceptConfirmation for older daemons that omit conversationId.
-            if let msgSessionId = msg.conversationId {
-                guard conversationId != nil, belongsToConversation(msgSessionId) else { return }
+            if let msgConversationId = msg.conversationId {
+                guard conversationId != nil, belongsToConversation(msgConversationId) else { return }
             } else {
                 guard conversationId != nil,
                       lastToolUseReceivedAt != nil,

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -49,7 +49,7 @@ public final class TraceStore: ObservableObject {
 
     /// The ID of the most recently ingested event per conversation. Unlike `eventsByConversation[sid]?.count`,
     /// this always changes on ingestion even when the retention cap holds count constant.
-    public private(set) var latestEventIdBySession: [String: String] = [:]
+    public private(set) var latestEventIdByConversation: [String: String] = [:]
 
     /// Set of seen eventIds per conversation for dedup.
     private var seenIds: [String: Set<String>] = [:]
@@ -114,8 +114,8 @@ public final class TraceStore: ObservableObject {
         }
 
         eventsByConversation[sid] = events
-        latestEventIdBySession[sid] = event.id
-        generationBySession[sid, default: 0] += 1
+        latestEventIdByConversation[sid] = event.id
+        generationByConversation[sid, default: 0] += 1
         schedulePublish()
     }
 
@@ -192,7 +192,7 @@ public final class TraceStore: ObservableObject {
     }
 
     /// Generation counter per conversation, incremented on each ingestion.
-    private var generationBySession: [String: Int] = [:]
+    private var generationByConversation: [String: Int] = [:]
 
     /// Cached metrics per conversation, keyed by the generation at which they were computed.
     private var metricsCache: [String: (generation: Int, metrics: ConversationMetrics)] = [:]
@@ -200,7 +200,7 @@ public final class TraceStore: ObservableObject {
     /// Returns cached aggregate metrics for a conversation, recomputing only when
     /// the generation counter has advanced since the last call.
     public func metrics(conversationId: String) -> ConversationMetrics {
-        let currentGen = generationBySession[conversationId] ?? 0
+        let currentGen = generationByConversation[conversationId] ?? 0
         if let cached = metricsCache[conversationId], cached.generation == currentGen {
             return cached.metrics
         }
@@ -298,9 +298,9 @@ public final class TraceStore: ObservableObject {
     /// Remove all events for a given conversation.
     public func resetConversation(conversationId: String) {
         eventsByConversation.removeValue(forKey: conversationId)
-        latestEventIdBySession.removeValue(forKey: conversationId)
+        latestEventIdByConversation.removeValue(forKey: conversationId)
         seenIds.removeValue(forKey: conversationId)
-        generationBySession.removeValue(forKey: conversationId)
+        generationByConversation.removeValue(forKey: conversationId)
         metricsCache.removeValue(forKey: conversationId)
         schedulePublish()
     }
@@ -308,9 +308,9 @@ public final class TraceStore: ObservableObject {
     /// Remove all events for all conversations.
     public func resetAll() {
         eventsByConversation.removeAll()
-        latestEventIdBySession.removeAll()
+        latestEventIdByConversation.removeAll()
         seenIds.removeAll()
-        generationBySession.removeAll()
+        generationByConversation.removeAll()
         metricsCache.removeAll()
         nextInsertionIndex = 0
         schedulePublish()


### PR DESCRIPTION
## Summary
- Fix iOS push notification handler reading stale `session_id` key (now reads `conversationId` with `conversation_id` fallback, matching macOS pattern)
- Rename `PendingInteraction.session` → `conversation` + all ~10 consumer files
- Rename `TraceStore.latestEventIdBySession`/`generationBySession` → `byConversation` + iOS/macOS consumers
- Rename `formatSessionForExport` → `formatConversationForExport`
- Rename `messageSessionId`/`msgSessionId` parameters in `ChatViewModel+MessageHandling`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
