### PR TITLE
fix: inject VELLUM_WORKSPACE_DIR into sanitized bash environment

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -488,6 +488,7 @@ describe("buildSanitizedEnv", () => {
       "VELLUM_DEV",
       "INTERNAL_GATEWAY_BASE_URL",
       "VELLUM_DATA_DIR",
+      "VELLUM_WORKSPACE_DIR",
     ];
     for (const key of keys) {
       expect(safeKeys).toContain(key);

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -6,7 +6,7 @@
  * Shared by the sandbox bash tool and skill sandbox runner.
  */
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
-import { getDataDir } from "../../util/platform.js";
+import { getDataDir, getWorkspaceDir } from "../../util/platform.js";
 
 const SAFE_ENV_VARS = [
   "PATH",
@@ -43,5 +43,8 @@ export function buildSanitizedEnv(): Record<string, string> {
   // Expose the runtime data directory so child processes can locate databases,
   // logs, and other instance-scoped state without re-deriving the path.
   env.VELLUM_DATA_DIR = getDataDir();
+  // Expose the workspace directory so skills and child processes can read/write
+  // workspace-scoped files (e.g. avatar traits, user data).
+  env.VELLUM_WORKSPACE_DIR = getWorkspaceDir();
   return env;
 }


### PR DESCRIPTION
## Summary
- Add `VELLUM_WORKSPACE_DIR` to `buildSanitizedEnv()` in `safe-env.ts`, importing `getWorkspaceDir` from `platform.ts`
- Update the safe-keys allowlist in `terminal-tools.test.ts` to include the new variable

Addresses review feedback from PR #16885: skills referencing `$VELLUM_WORKSPACE_DIR` (like vellum-avatar) would get an empty string because the variable was not injected into the sanitized environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
