### PR TITLE
fix: use startNewConversation() for Library empty state instead of hardcoded prompt

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -73,8 +73,7 @@ extension MainWindowView {
                     }
                 },
                 onNewConversation: {
-                    conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
-                    windowState.selection = nil
+                    startNewConversation()
                 }
             )
         case .intelligence:
@@ -272,8 +271,7 @@ extension MainWindowView {
                         }
                     },
                     onNewConversation: {
-                        conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
-                        windowState.selection = nil
+                        startNewConversation()
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
@@ -444,8 +442,7 @@ extension MainWindowView {
                     }
                 },
                 onNewConversation: {
-                    conversationManager.openConversation(message: "What kind of apps can you build?", forceNew: true)
-                    windowState.dismissOverlay()
+                    startNewConversation()
                 }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }


### PR DESCRIPTION
## Summary
- Replace hardcoded `"What kind of apps can you build?"` message in Library empty state's New Conversation button with `startNewConversation()`, consistent with the sidebar's "New thread" button
- Addresses review feedback on #17071: the hardcoded prompt violated the Assistant-Driven Judgement convention and could send an unsolicited message into existing conversations

## Test plan
- [ ] Open Library with no apps (empty state)
- [ ] Click "New Conversation" button — should open a blank conversation (no auto-sent message)
- [ ] Verify behavior matches sidebar's "New thread" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
