### PR TITLE
refactor: remove dead Tool interface from avatar-generator

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -95,17 +95,14 @@ mock.module("@google/genai", () => ({
 }));
 
 // Import after all mocks are set up
-import { setAvatarTool } from "../tools/system/avatar-generator.js";
+import { generateAndSaveAvatar } from "../tools/system/avatar-generator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function executeAvatar(description: string) {
-  return setAvatarTool.execute(
-    { description },
-    {} as Parameters<typeof setAvatarTool.execute>[1],
-  );
+  return generateAndSaveAvatar(description);
 }
 
 /** Standard successful Gemini generateContent response. */

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -45,7 +45,7 @@ mock.module("node:fs", () => ({
 }));
 
 // Import after mocking
-import { setAvatarTool } from "../tools/system/avatar-generator.js";
+import { generateAndSaveAvatar } from "../tools/system/avatar-generator.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,17 +59,14 @@ function successResult() {
 }
 
 function executeAvatar(description: string) {
-  return setAvatarTool.execute(
-    { description },
-    {} as Parameters<typeof setAvatarTool.execute>[1],
-  );
+  return generateAndSaveAvatar(description);
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("setAvatarTool", () => {
+describe("generateAndSaveAvatar", () => {
   beforeEach(() => {
     mockRouterResult = successResult();
     mockRouterError = undefined;

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -47,7 +47,7 @@ import {
   REASON_SKIP_SET,
 } from "../../tools/schema-transforms.js";
 import { isSideEffectTool } from "../../tools/side-effects.js";
-import { setAvatarTool } from "../../tools/system/avatar-generator.js";
+import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
 import { pathExists } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -87,11 +87,7 @@ async function handleGenerateAvatar(description: string): Promise<Response> {
   log.info({ description }, "Generating avatar via HTTP request");
 
   try {
-    const result = await setAvatarTool.execute(
-      { description },
-      // Minimal tool context -- avatar generation needs no session context
-      {} as Parameters<typeof setAvatarTool.execute>[1],
-    );
+    const result = await generateAndSaveAvatar(description);
 
     if (result.isError) {
       return httpError("INTERNAL_ERROR", result.content, 500);

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -4,101 +4,76 @@ import { dirname, join } from "node:path";
 
 import { generateAvatar } from "../../media/avatar-router.js";
 import { mapGeminiError } from "../../media/gemini-image-service.js";
-import { RiskLevel } from "../../permissions/types.js";
-import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("avatar-generator");
-
-const TOOL_NAME = "set_avatar";
 
 /** Canonical path where the custom avatar PNG is stored. */
 function getAvatarPath(): string {
   return join(getWorkspaceDir(), "data", "avatar", "avatar-image.png");
 }
 
-export const setAvatarTool: Tool = {
-  name: TOOL_NAME,
-  description:
-    "Generate a custom avatar image from a text description. " +
-    "Saves the result as the assistant's avatar.",
-  category: "system",
-  defaultRiskLevel: RiskLevel.Low,
+export interface AvatarGenerationResult {
+  content: string;
+  isError: boolean;
+}
 
-  getDefinition(): ToolDefinition {
+/**
+ * Generate a custom avatar image from a text description and save it
+ * as the assistant's avatar PNG.
+ *
+ * Used by the HTTP route handler at POST /v1/settings/avatar/generate.
+ */
+export async function generateAndSaveAvatar(
+  description: string,
+): Promise<AvatarGenerationResult> {
+  if (typeof description !== "string" || description.trim() === "") {
     return {
-      name: TOOL_NAME,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          description: {
-            type: "string",
-            description:
-              "A text description of the desired avatar appearance, " +
-              'e.g. "a friendly purple cat with green eyes wearing a tiny hat".',
-          },
-        },
-        required: ["description"],
-      },
+      content: "Error: description is required and must be a non-empty string.",
+      isError: true,
     };
-  },
+  }
 
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    const description = input.description;
-    if (typeof description !== "string" || description.trim() === "") {
+  try {
+    log.info({ description: description.trim() }, "Generating avatar");
+
+    const prompt =
+      `Create an avatar image based on this description: ${description.trim()}\n\n` +
+      "Style: cute, friendly, work-safe illustration. " +
+      "Vibrant but soft colors. Simple and recognizable at small sizes (28px). " +
+      "Circular or rounded composition filling the canvas. " +
+      "Subtle background color (not white or transparent).";
+
+    const result = await generateAvatar(prompt);
+    if (!result.imageBase64) {
       return {
-        content:
-          "Error: description is required and must be a non-empty string.",
+        content: "Error: No image data returned. Please try again.",
         isError: true,
       };
     }
+    const pngBuffer = Buffer.from(result.imageBase64, "base64");
 
-    try {
-      log.info({ description: description.trim() }, "Generating avatar");
+    const avatarPath = getAvatarPath();
+    const avatarDir = dirname(avatarPath);
 
-      const prompt =
-        `Create an avatar image based on this description: ${description.trim()}\n\n` +
-        "Style: cute, friendly, work-safe illustration. " +
-        "Vibrant but soft colors. Simple and recognizable at small sizes (28px). " +
-        "Circular or rounded composition filling the canvas. " +
-        "Subtle background color (not white or transparent).";
+    const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
+    mkdirSync(avatarDir, { recursive: true });
+    writeFileSync(tmpPath, pngBuffer);
+    renameSync(tmpPath, avatarPath);
 
-      const result = await generateAvatar(prompt);
-      if (!result.imageBase64) {
-        return {
-          content: "Error: No image data returned. Please try again.",
-          isError: true,
-        };
-      }
-      const pngBuffer = Buffer.from(result.imageBase64, "base64");
+    log.info({ avatarPath }, "Avatar saved successfully");
 
-      const avatarPath = getAvatarPath();
-      const avatarDir = dirname(avatarPath);
-
-      const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
-      mkdirSync(avatarDir, { recursive: true });
-      writeFileSync(tmpPath, pngBuffer);
-      renameSync(tmpPath, avatarPath);
-
-      log.info({ avatarPath }, "Avatar saved successfully");
-
-      return {
-        content: "Avatar updated! Your new avatar will appear shortly.",
-        isError: false,
-      };
-    } catch (error) {
-      const message = mapGeminiError(error);
-      log.error({ error: message }, "Avatar generation failed");
-      return {
-        content: `Avatar generation failed: ${message}`,
-        isError: true,
-      };
-    }
-  },
-};
+    return {
+      content: "Avatar updated! Your new avatar will appear shortly.",
+      isError: false,
+    };
+  } catch (error) {
+    const message = mapGeminiError(error);
+    log.error({ error: message }, "Avatar generation failed");
+    return {
+      content: `Avatar generation failed: ${message}`,
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #16872 (dead code removal)
- Refactors `avatar-generator.ts` to export a plain `generateAndSaveAvatar` function instead of a `Tool` object
- Removes dead `Tool` interface wrapper (name, description, getDefinition, category, defaultRiskLevel) that was no longer registered in the tool registry
- Updates `settings-routes.ts` and test files to use the new function directly

## Test plan
- [ ] Existing `avatar-generator.test.ts` passes with updated imports
- [ ] Existing `avatar-e2e.test.ts` passes with updated imports
- [ ] `POST /v1/settings/avatar/generate` endpoint continues to work correctly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
