### PR TITLE
fix: address review feedback on conversation-scoped export

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -77,19 +77,22 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
 
     const auditQuery = db.select().from(toolInvocations);
 
-    const auditRows = conversationId
-      ? auditQuery
-          .where(
-            and(
-              eq(toolInvocations.conversationId, conversationId),
-              startTime ? gte(toolInvocations.createdAt, startTime) : undefined,
-              endTime ? lte(toolInvocations.createdAt, endTime) : undefined,
-            ),
-          )
-          .orderBy(desc(toolInvocations.createdAt))
-          .limit(limit)
-          .all()
-      : auditQuery.orderBy(desc(toolInvocations.createdAt)).limit(limit).all();
+    const timeFilters = [
+      ...(conversationId
+        ? [eq(toolInvocations.conversationId, conversationId)]
+        : []),
+      ...(startTime ? [gte(toolInvocations.createdAt, startTime)] : []),
+      ...(endTime ? [lte(toolInvocations.createdAt, endTime)] : []),
+    ];
+
+    const auditRows = (
+      timeFilters.length > 0
+        ? auditQuery.where(and(...timeFilters))
+        : auditQuery
+    )
+      .orderBy(desc(toolInvocations.createdAt))
+      .limit(limit)
+      .all();
 
     writeFileSync(
       join(staging, "audit-data.json"),
@@ -187,11 +190,9 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
         const stat = statSync(stderrPath);
         if (totalBytes + stat.size <= MAX_LOG_PAYLOAD_BYTES) {
           const content = readFileSync(stderrPath, "utf-8");
-          writeFileSync(
-            join(daemonLogsDir, "daemon-stderr.log"),
-            content,
-            "utf-8",
-          );
+          const dest = join(daemonLogsDir, "daemon-stderr.log");
+          writeFileSync(dest, content, "utf-8");
+          collectedLogFiles.push(dest);
           logFileCount++;
         }
       } catch {
@@ -220,6 +221,17 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
           matchingLines.join("\n") + "\n",
           "utf-8",
         );
+      }
+
+      // Remove full unfiltered log files — conversation-scoped exports
+      // should only include conversation-filtered.jsonl to avoid leaking
+      // data from unrelated conversations.
+      for (const logFile of collectedLogFiles) {
+        try {
+          rmSync(logFile, { force: true });
+        } catch {
+          // Best-effort removal
+        }
       }
     }
 
@@ -283,6 +295,19 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
     let archiveBytes = createTarGz(staging);
 
     while (!archiveBytes) {
+      // Conversation-scoped exports have no workspace directory to prune —
+      // if the archive still exceeds the size limit, report a clear error.
+      if (conversationId) {
+        log.error(
+          "Conversation-scoped export exceeds archive size limit with no workspace dirs to prune",
+        );
+        return httpError(
+          "INTERNAL_ERROR",
+          "Conversation export exceeds the maximum archive size",
+          500,
+        );
+      }
+
       // Find the largest top-level directory under workspace/ and remove it
       const wsDir = join(staging, "workspace");
       const largest = findLargestSubdirectory(wsDir);


### PR DESCRIPTION
## Summary
- Apply `startTime`/`endTime` filters to global (non-conversation) audit queries so time bounds are never silently ignored
- Include `daemon-stderr.log` in the conversation-filtered grep so crash logs for a specific conversation appear in filtered output
- Remove full unfiltered daemon log files from conversation-scoped exports to prevent leaking data from unrelated conversations
- Add early exit with descriptive error when conversation-scoped exports exceed the archive size limit (no workspace dirs to prune)

Addresses review feedback from #17110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
