### PR TITLE
fix: rename remaining session/thread to conversation in Swift tests, MARK comments, and code comments

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -12,7 +12,7 @@ struct IOSConversation: Identifiable {
     let createdAt: Date
     /// Tracks the most recent activity (message sent/received). Defaults to createdAt.
     var lastActivityAt: Date
-    /// When non-nil, this conversation is backed by a daemon session (Connected mode).
+    /// When non-nil, this conversation is backed by a daemon conversation (Connected mode).
     var conversationId: String?
     var isArchived: Bool
     var isPinned: Bool
@@ -95,11 +95,11 @@ class IOSConversationStore: ObservableObject {
     private static let persistenceKey = "ios_threads_v1"
     private static let connectedCacheKey = "ios_connected_threads_cache_v1"
     private var cancellables: Set<AnyCancellable> = []
-    /// Maps daemon session IDs to conversation IDs for history loading.
+    /// Maps daemon conversation IDs to local conversation IDs for history loading.
     private var pendingHistoryByConversationId: [String: UUID] = [:]
     /// Tracks conversation IDs that already have an activity-tracking observer to avoid duplicates.
     private var observedActivityConversationIds: Set<UUID> = []
-    /// Number of conversations per page when listing sessions from the daemon.
+    /// Number of conversations per page when listing conversations from the daemon.
     private static let conversationPageSize = 50
     private static let attentionSignalType = "ios_conversation_opened"
     /// Current offset used for the next page fetch; advances by `conversationPageSize` on each load.
@@ -310,7 +310,7 @@ class IOSConversationStore: ObservableObject {
             self.saveConnectedCache()
         }
 
-        // Fetch session list once connected. Try immediately if already connected,
+        // Fetch conversation list once connected. Try immediately if already connected,
         // otherwise wait for the daemonDidReconnect notification.
         if daemon.isConnected {
             conversationListOffset = 0
@@ -380,7 +380,7 @@ class IOSConversationStore: ObservableObject {
         // a response arriving after the rebind would invoke the closures registered by
         // the previous setupDaemonCallbacks call, which capture [weak self] and would
         // still call back into this store — potentially corrupting the conversation list with
-        // stale sessions from the old connection.
+        // stale conversations from the old connection.
         if let oldDaemon = daemonClient as? DaemonClient {
             oldDaemon.onConversationListResponse = nil
             oldDaemon.onHistoryResponse = nil
@@ -756,15 +756,15 @@ class IOSConversationStore: ObservableObject {
         viewModels[conversationLocalId] = vm
 
         // Copy conversationId from the conversation so the VM joins the existing
-        // daemon session instead of bootstrapping a new one.
+        // daemon conversation instead of bootstrapping a new one.
         if let conversation = conversations.first(where: { $0.id == conversationLocalId }) {
             vm.conversationId = conversation.conversationId
         }
 
         wireReconnectCallback(vm: vm, conversationLocalId: conversationLocalId)
 
-        // Only auto-title conversations without a daemon session (new local conversations).
-        // Daemon conversations already have titles from the session list.
+        // Only auto-title conversations without a daemon conversation (new local conversations).
+        // Daemon conversations already have titles from the conversation list.
         if conversations.first(where: { $0.id == conversationLocalId })?.conversationId == nil {
             observeForTitleGeneration(vm: vm, conversationLocalId: conversationLocalId)
         }
@@ -850,7 +850,7 @@ class IOSConversationStore: ObservableObject {
     }
 
     /// Create a new private conversation with the given name. The conversation is immediately
-    /// backed by a daemon session with conversationType "private" so it is persisted on
+    /// backed by a daemon conversation with conversationType "private" so it is persisted on
     /// the daemon side and excluded from normal conversation restoration.
     @discardableResult
     func newPrivateConversation(name: String = "Private Conversation") -> IOSConversation {

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// Integration tests for ChatViewModel from the iOS perspective.
 /// Exercises the shared state machine: initialization, message send/receive flow,
-/// streaming deltas, session lifecycle, error handling, and attachment validation.
+/// streaming deltas, conversation lifecycle, error handling, and attachment validation.
 @MainActor
 final class ChatViewModelIOSTests: XCTestCase {
 
@@ -45,7 +45,7 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
-    func testInitStartsWithNoSessionId() {
+    func testInitStartsWithNoConversationId() {
         XCTAssertNil(viewModel.conversationId)
     }
 
@@ -91,7 +91,7 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1)
     }
 
-    func testSendWhileSendingWithSessionAppendsQueuedMessage() {
+    func testSendWhileSendingWithConversationAppendsQueuedMessage() {
         viewModel.conversationId = "test-session"
         viewModel.isSending = true
 
@@ -161,11 +161,11 @@ final class ChatViewModelIOSTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
         cancelled = true
 
-        // Extract the correlation ID from the sent session_create message
-        let sessionCreates = mockClient.sentMessages.compactMap { $0 as? ConversationCreateMessage }
-        let correlationId = sessionCreates.first?.correlationId
+        // Extract the correlation ID from the sent conversation_create message
+        let conversationCreates = mockClient.sentMessages.compactMap { $0 as? ConversationCreateMessage }
+        let correlationId = conversationCreates.first?.correlationId
 
-        // Session info arrives with matching correlation ID
+        // Conversation info arrives with matching correlation ID
         let info = ConversationInfoMessage(conversationId: "new-sess", title: "Test", correlationId: correlationId)
         viewModel.handleServerMessage(.conversationInfo(info))
 
@@ -300,8 +300,8 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].role, .user)
         XCTAssertTrue(viewModel.isSending)
 
-        // Poll until session_create appears in sentMessages (message-driven wait)
-        let expectation = XCTestExpectation(description: "session_create sent")
+        // Poll until conversation_create appears in sentMessages (message-driven wait)
+        let expectation = XCTestExpectation(description: "conversation_create sent")
         var cancelled = false
         func poll() {
             guard !cancelled else { return }
@@ -315,11 +315,11 @@ final class ChatViewModelIOSTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
         cancelled = true
 
-        // Extract the correlation ID from the sent session_create message
-        let sessionCreates = mockClient.sentMessages.compactMap { $0 as? ConversationCreateMessage }
-        let correlationId = sessionCreates.first?.correlationId
+        // Extract the correlation ID from the sent conversation_create message
+        let conversationCreates = mockClient.sentMessages.compactMap { $0 as? ConversationCreateMessage }
+        let correlationId = conversationCreates.first?.correlationId
 
-        // 2. Session info arrives with matching correlation ID
+        // 2. Conversation info arrives with matching correlation ID
         let info = ConversationInfoMessage(conversationId: "cycle-sess", title: "iOS Chat", correlationId: correlationId)
         viewModel.handleServerMessage(.conversationInfo(info))
         XCTAssertEqual(viewModel.conversationId, "cycle-sess")
@@ -373,16 +373,16 @@ final class ChatViewModelIOSTests: XCTestCase {
     }
 
     func testOnConversationCreatedCallbackFires() {
-        var capturedSessionId: String?
+        var capturedConversationId: String?
         viewModel.onConversationCreated = { conversationId in
-            capturedSessionId = conversationId
+            capturedConversationId = conversationId
         }
 
         viewModel.bootstrapCorrelationId = "corr-cb"
         let info = ConversationInfoMessage(conversationId: "callback-sess", title: "Test", correlationId: "corr-cb")
         viewModel.handleServerMessage(.conversationInfo(info))
 
-        XCTAssertEqual(capturedSessionId, "callback-sess")
+        XCTAssertEqual(capturedConversationId, "callback-sess")
     }
 
     // MARK: - Cancelling Suppresses Deltas

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -167,9 +167,9 @@ final class ConversationLifecycleIOSTests: XCTestCase {
 
     func testOnConversationCreatedCallbackFiresDuringBackfill() {
         let vm = ChatViewModel(daemonClient: mockClient)
-        var capturedSessionId: String?
+        var capturedConversationId: String?
         vm.onConversationCreated = { conversationId in
-            capturedSessionId = conversationId
+            capturedConversationId = conversationId
         }
         vm.createConversationIfNeeded()
 
@@ -193,7 +193,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         let info = ConversationInfoMessage(conversationId: "callback-conv-sess", title: "Callback", correlationId: correlationId)
         vm.handleServerMessage(.conversationInfo(info))
 
-        XCTAssertEqual(capturedSessionId, "callback-conv-sess")
+        XCTAssertEqual(capturedConversationId, "callback-conv-sess")
     }
 
     // MARK: - Conversation Lifecycle: Create, Use, Archive Pattern
@@ -857,13 +857,13 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(updatedConversation.displayOrder, 1)
         XCTAssertEqual(reorderRequests.count, 1)
 
-        let updatesBySessionId = Dictionary(
+        let updatesByConversationId = Dictionary(
             uniqueKeysWithValues: reorderRequests[0].updates.map { ($0.conversationId, $0) }
         )
-        XCTAssertEqual(updatesBySessionId["connected-session-pinned"]?.displayOrder, 0)
-        XCTAssertEqual(updatesBySessionId["connected-session-pinned"]?.isPinned, true)
-        XCTAssertEqual(updatesBySessionId["connected-session-unpinned"]?.displayOrder, 1)
-        XCTAssertEqual(updatesBySessionId["connected-session-unpinned"]?.isPinned, true)
+        XCTAssertEqual(updatesByConversationId["connected-session-pinned"]?.displayOrder, 0)
+        XCTAssertEqual(updatesByConversationId["connected-session-pinned"]?.isPinned, true)
+        XCTAssertEqual(updatesByConversationId["connected-session-unpinned"]?.displayOrder, 1)
+        XCTAssertEqual(updatesByConversationId["connected-session-unpinned"]?.isPinned, true)
     }
 
     func testPinningConnectedConversationSurvivesStaleConversationListRefresh() {
@@ -953,13 +953,13 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(secondConversation.displayOrder, 0)
         XCTAssertEqual(reorderRequests.count, 1)
 
-        let updatesBySessionId = Dictionary(
+        let updatesByConversationId = Dictionary(
             uniqueKeysWithValues: reorderRequests[0].updates.map { ($0.conversationId, $0) }
         )
-        XCTAssertNil(updatesBySessionId["connected-session-first"]?.displayOrder)
-        XCTAssertEqual(updatesBySessionId["connected-session-first"]?.isPinned, false)
-        XCTAssertEqual(updatesBySessionId["connected-session-second"]?.displayOrder, 0)
-        XCTAssertEqual(updatesBySessionId["connected-session-second"]?.isPinned, true)
+        XCTAssertNil(updatesByConversationId["connected-session-first"]?.displayOrder)
+        XCTAssertEqual(updatesByConversationId["connected-session-first"]?.isPinned, false)
+        XCTAssertEqual(updatesByConversationId["connected-session-second"]?.displayOrder, 0)
+        XCTAssertEqual(updatesByConversationId["connected-session-second"]?.isPinned, true)
     }
 
     func testPinningStandaloneConversationDoesNothing() {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 extension AppDelegate {
 
-    // MARK: - Session
+    // MARK: - Conversation
 
     /// Sends the user's task as a regular message via POST /v1/messages.
     /// The model decides whether to use computer-use tools; CU execution

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -60,7 +60,7 @@ extension AppDelegate {
             self.surfaceManager.dismissSurface(msg)
         }
 
-        // Reload webviews for surfaces whose app files changed (cross-session broadcast)
+        // Reload webviews for surfaces whose app files changed (cross-conversation broadcast)
         daemonClient.onAppFilesChanged = { [weak self] appId in
             guard let self else { return }
             self.refreshAppsCache()

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -115,8 +115,8 @@ extension MainWindowView {
                         enterAppEditing(appId: appId)
                     }
                     // Route relay_prompt actions directly as chat messages so they
-                    // reach the active session instead of being lost when the surface
-                    // was opened outside a session context (e.g. via app_open).
+                    // reach the active conversation instead of being lost when the surface
+                    // was opened outside a conversation context (e.g. via app_open).
                     if actionId == "relay_prompt" || actionId == "agent_prompt",
                        let dataDict = actionData as? [String: Any],
                        let prompt = dataDict["prompt"] as? String,

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -88,7 +88,7 @@ enum LogExporter {
                 tags["client"] = "macos"
             }
 
-            // Surface active session state as tags so the Sentry event itself
+            // Surface active conversation state as tags so the Sentry event itself
             // is useful for triage without downloading the log archive.
             var extra: [String: Any] = [:]
             let conversationManager = AppDelegate.shared?.mainWindow?.conversationManager
@@ -103,7 +103,7 @@ enum LogExporter {
                     // conversation_id in the vellum-assistant-brain Sentry project.
                     // For conversation-scoped exports, conversation_id was already set
                     // to the reported conversation's ID above — don't overwrite it with
-                    // the active conversation's session ID.
+                    // the active conversation's ID.
                     if case .global = formData.scope {
                         tags["conversation_id"] = conversationId
                     }

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1187,9 +1187,9 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
-    // MARK: - Session Filtering
+    // MARK: - Conversation Filtering
 
-    func testTextDeltaFromDifferentSessionIsIgnored() {
+    func testTextDeltaFromDifferentConversationIsIgnored() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "foreign", conversationId: "other-session")))
@@ -1198,7 +1198,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0) // No messages
     }
 
-    func testTextDeltaFromSameSessionIsAccepted() {
+    func testTextDeltaFromSameConversationIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: "my-session")))
@@ -1207,7 +1207,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[0].text, "hello")
     }
 
-    func testTextDeltaWithNilSessionIdIsAccepted() {
+    func testTextDeltaWithNilConversationIdIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isThinking = true
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "hello", conversationId: nil)))
@@ -1215,7 +1215,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1)
     }
 
-    func testMessageCompleteFromDifferentSessionIsIgnored() {
+    func testMessageCompleteFromDifferentConversationIsIgnored() {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
@@ -1225,7 +1225,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isThinking)
     }
 
-    func testMessageCompleteFromSameSessionIsAccepted() {
+    func testMessageCompleteFromSameConversationIsAccepted() {
         viewModel.conversationId = "my-session"
         viewModel.isSending = true
         viewModel.isThinking = true
@@ -2366,7 +2366,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSending)
     }
 
-    // MARK: - createConversationIfNeeded (Message-less Session Create)
+    // MARK: - createConversationIfNeeded (Message-less Conversation Create)
 
     func testCreateConversationIfNeededSetsBootstrapping() {
         viewModel.createConversationIfNeeded(conversationType: "private")
@@ -2425,7 +2425,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(callbackSessionId, "callback-session", "Should fire onConversationCreated callback")
     }
 
-    func testCreateSessionIfNeededSendsConversationTypeInMessage() {
+    func testCreateConversationIfNeededSendsConversationTypeInMessage() {
         var capturedMessages: [Any] = []
         daemonClient.sendOverride = { msg in
             capturedMessages.append(msg)

--- a/clients/macos/vellum-assistantTests/TraceStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/TraceStoreTests.swift
@@ -255,10 +255,10 @@ struct TraceStoreTests {
         #expect(store.eventsByConversation.isEmpty)
     }
 
-    // MARK: - Multi-Session Isolation
+    // MARK: - Multi-Conversation Isolation
 
     @Test @MainActor
-    func sessionsAreIsolated() {
+    func conversationsAreIsolated() {
         let store = TraceStore()
         store.ingest(makeEvent(eventId: "a", conversationId: "s1", sequence: 1, kind: "tool_failed"))
         store.ingest(makeEvent(
@@ -272,13 +272,13 @@ struct TraceStoreTests {
         #expect(store.llmCallCount(conversationId: "s2") == 1)
     }
 
-    // MARK: - Session Switching Shows Correct Traces
+    // MARK: - Conversation Switching Shows Correct Traces
 
     @Test @MainActor
-    func sessionSwitchingShowsCorrectTraces() {
+    func conversationSwitchingShowsCorrectTraces() {
         let store = TraceStore()
 
-        // Populate two sessions with distinct events.
+        // Populate two conversations with distinct events.
         store.ingest(makeEvent(eventId: "s1-a", conversationId: "session-A", requestId: "rA", sequence: 1, kind: "request_received", summary: "Start A"))
         store.ingest(makeEvent(eventId: "s1-b", conversationId: "session-A", requestId: "rA", sequence: 2, kind: "llm_call_finished", summary: "LLM A"))
 
@@ -286,12 +286,12 @@ struct TraceStoreTests {
         store.ingest(makeEvent(eventId: "s2-b", conversationId: "session-B", requestId: "rB", sequence: 2, kind: "tool_started", summary: "Tool B"))
         store.ingest(makeEvent(eventId: "s2-c", conversationId: "session-B", requestId: "rB", sequence: 3, kind: "tool_failed", summary: "Fail B"))
 
-        // "Switch" to session-A — only its events are visible.
+        // "Switch" to conversation-A — only its events are visible.
         let eventsA = store.eventsByConversation["session-A"] ?? []
         #expect(eventsA.count == 2)
         #expect(eventsA.allSatisfy { $0.conversationId == "session-A" })
 
-        // "Switch" to session-B — only its events are visible.
+        // "Switch" to conversation-B — only its events are visible.
         let eventsB = store.eventsByConversation["session-B"] ?? []
         #expect(eventsB.count == 3)
         #expect(eventsB.allSatisfy { $0.conversationId == "session-B" })
@@ -303,34 +303,34 @@ struct TraceStoreTests {
         #expect(store.toolFailureCount(conversationId: "session-B") == 1)
     }
 
-    // MARK: - No Cross-Session Trace Contamination
+    // MARK: - No Cross-Conversation Trace Contamination
 
     @Test @MainActor
-    func noCrossSessionContamination() {
+    func noCrossConversationContamination() {
         let store = TraceStore()
 
-        // Session 1 events.
+        // Conversation 1 events.
         store.ingest(makeEvent(eventId: "e1", conversationId: "s1", requestId: "r1", sequence: 1, kind: "request_received"))
         store.ingest(makeEvent(eventId: "e2", conversationId: "s1", requestId: "r1", sequence: 2, kind: "llm_call_finished",
                                attributes: ["inputTokens": 100, "outputTokens": 50]))
 
-        // Session 2 events.
+        // Conversation 2 events.
         store.ingest(makeEvent(eventId: "e3", conversationId: "s2", requestId: "r2", sequence: 1, kind: "request_received"))
         store.ingest(makeEvent(eventId: "e4", conversationId: "s2", requestId: "r2", sequence: 2, kind: "tool_failed"))
 
-        // Session 1 must not see session 2's events.
+        // Conversation 1 must not see conversation 2's events.
         let grouped1 = store.eventsByRequest(conversationId: "s1")
         #expect(grouped1.count == 1)
         #expect(grouped1["r1"]?.count == 2)
         #expect(grouped1["r2"] == nil)
 
-        // Session 2 must not see session 1's events.
+        // Conversation 2 must not see conversation 1's events.
         let grouped2 = store.eventsByRequest(conversationId: "s2")
         #expect(grouped2.count == 1)
         #expect(grouped2["r2"]?.count == 2)
         #expect(grouped2["r1"] == nil)
 
-        // Adding more events to one session does not affect the other.
+        // Adding more events to one conversation does not affect the other.
         store.ingest(makeEvent(eventId: "e5", conversationId: "s1", requestId: "r1", sequence: 3, kind: "message_complete"))
         #expect(store.eventsByConversation["s1"]?.count == 3)
         #expect(store.eventsByConversation["s2"]?.count == 2)
@@ -433,7 +433,7 @@ struct TraceStoreTests {
     func daemonReconnectResetsTraceState() {
         let store = TraceStore()
 
-        // Populate with events from two sessions.
+        // Populate with events from two conversations.
         store.ingest(makeEvent(eventId: "e1", conversationId: "s1", sequence: 1))
         store.ingest(makeEvent(eventId: "e2", conversationId: "s2", sequence: 1))
         #expect(store.eventsByConversation.count == 2)
@@ -450,26 +450,26 @@ struct TraceStoreTests {
         #expect(store.eventsByConversation["s1"]?.first?.summary == "post-reset")
     }
 
-    // MARK: - Historical Traces Retained Per Session
+    // MARK: - Historical Traces Retained Per Conversation
 
     @Test @MainActor
-    func historicalTracesRetainedPerSession() {
+    func historicalTracesRetainedPerConversation() {
         let store = TraceStore()
 
-        // Build up events across multiple sessions.
+        // Build up events across multiple conversations.
         for i in 0..<10 {
             store.ingest(makeEvent(eventId: "s1-\(i)", conversationId: "s1", requestId: "r1", sequence: i))
             store.ingest(makeEvent(eventId: "s2-\(i)", conversationId: "s2", requestId: "r2", sequence: i))
             store.ingest(makeEvent(eventId: "s3-\(i)", conversationId: "s3", requestId: "r3", sequence: i))
         }
 
-        // All three sessions' traces are retained simultaneously.
+        // All three conversations' traces are retained simultaneously.
         #expect(store.eventsByConversation.count == 3)
         #expect(store.eventsByConversation["s1"]?.count == 10)
         #expect(store.eventsByConversation["s2"]?.count == 10)
         #expect(store.eventsByConversation["s3"]?.count == 10)
 
-        // Resetting one session preserves the others.
+        // Resetting one conversation preserves the others.
         store.resetConversation(conversationId: "s2")
         #expect(store.eventsByConversation.count == 2)
         #expect(store.eventsByConversation["s1"]?.count == 10)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -14,9 +14,9 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 extension ChatViewModel {
 
-    /// Returns true if the given session ID belongs to this chat conversation.
+    /// Returns true if the given conversation ID belongs to this chat conversation.
     /// Messages with a nil conversationId are always accepted; messages whose
-    /// conversationId doesn't match the current session are silently ignored
+    /// conversationId doesn't match the current conversation are silently ignored
     /// to prevent cross-conversation contamination (e.g. from a popover text_qa flow).
     func belongsToConversation(_ messageSessionId: String?) -> Bool {
         guard let messageSessionId else { return true }
@@ -526,7 +526,7 @@ extension ChatViewModel {
         switch message {
         case .conversationInfo(let info):
             // Only claim this conversation_info if:
-            // 1. We don't have a session yet, AND
+            // 1. We don't have a conversation yet, AND
             // 2. The correlation ID matches our bootstrap request.
             if conversationId == nil {
                 guard let expected = bootstrapCorrelationId,
@@ -544,7 +544,7 @@ extension ChatViewModel {
                 refreshGuardianPrompts()
 
                 // Send the queued user message, or finalize a message-less
-                // session create by clearing the bootstrap sending state.
+                // conversation create by clearing the bootstrap sending state.
                 if let pending = pendingUserMessage {
                     let attachments = pendingUserAttachments
                     let automated = pendingUserMessageAutomated
@@ -571,8 +571,8 @@ extension ChatViewModel {
                         errorText = "Failed to send message."
                     }
                 } else {
-                    // Message-less session create (e.g. private conversation
-                    // pre-allocation) — session is claimed, reset UI state.
+                    // Message-less conversation create (e.g. private conversation
+                    // pre-allocation) — conversation is claimed, reset UI state.
                     isSending = false
                     isThinking = false
                 }
@@ -1040,7 +1040,7 @@ extension ChatViewModel {
 
         case .error(let err):
             log.error("Server error: \(err.message, privacy: .private)")
-            // Only process errors relevant to this chat session. Generic daemon
+            // Only process errors relevant to this chat conversation. Generic daemon
             // errors (e.g., validation failures from unrelated message types
             // like work_item_delete) should not pollute the chat UI.
             guard isSending || isThinking || isCancelling || currentAssistantMessageId != nil || isWorkspaceRefinementInFlight else {
@@ -1718,7 +1718,7 @@ extension ChatViewModel {
             log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
 
             // Per-message send failure: mark the specific user message instead
-            // of showing a session-level error banner.
+            // of showing a conversation-level error banner.
             if let failedContent = msg.failedMessageContent {
                 if let idx = messages.lastIndex(where: { $0.role == .user && $0.text == failedContent && $0.status != .sendFailed }) {
                     messages[idx].status = .sendFailed
@@ -1761,7 +1761,7 @@ extension ChatViewModel {
                 messages[index].isStreaming = false
                 messages[index].streamingCodePreview = nil
                 messages[index].streamingCodeToolName = nil
-                // Mark preview-only tool calls as complete on session error
+                // Mark preview-only tool calls as complete on conversation error
                 for tcIdx in messages[index].toolCalls.indices {
                     let tc = messages[index].toolCalls[tcIdx]
                     if tc.toolUseId != nil && !tc.isComplete && tc.inputRawDict == nil {

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -188,11 +188,11 @@ public final class HTTPTransport {
     var serverToLocalConversationMap: [String: String] = [:]
     private let serverToLocalConversationMapCap = 500
 
-    /// Session IDs that originated from this client instance.
-    /// Host tool requests are only executed for these session IDs.
+    /// Conversation IDs that originated from this client instance.
+    /// Host tool requests are only executed for these conversation IDs.
     private var locallyOwnedConversationIds: Set<String> = []
-    /// Session IDs that belong to private (temporary) conversations.
-    /// Populated when a session_create with conversationType "private" is handled locally.
+    /// Conversation IDs that belong to private (temporary) conversations.
+    /// Populated when a conversation_create with conversationType "private" is handled locally.
     var privateConversationIds: Set<String> = []
 
     let decoder = JSONDecoder()
@@ -333,7 +333,7 @@ public final class HTTPTransport {
         case subagentDetail(id: String)
         case subagentAbort(id: String)
         case subagentMessage(id: String)
-        // Session management
+        // Conversation management
         case conversationsSwitch
         case conversationRename(id: String)
         case conversationsClear
@@ -673,7 +673,7 @@ public final class HTTPTransport {
         case .subagentMessage(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("/v1/subagents/\(encoded)/message", nil)
-        // Session management
+        // Conversation management
         case .conversationsSwitch:
             return ("/v1/conversations/switch", nil)
         case .conversationRename(let id):
@@ -1085,7 +1085,7 @@ public final class HTTPTransport {
         case .subagentMessage(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("\(prefix)/subagents/\(encoded)/message/", nil)
-        // Session management
+        // Conversation management
         case .conversationsSwitch:
             return ("\(prefix)/conversations/switch/", nil)
         case .conversationRename(let id):
@@ -1514,7 +1514,7 @@ public final class HTTPTransport {
 
     private func parseSSEData(_ data: String) {
         var jsonString = data
-        // Remap server conversation IDs to client-local session IDs via O(1) dictionary lookup
+        // Remap server conversation IDs to client-local conversation IDs via O(1) dictionary lookup
         if let conversationId = extractJsonStringValue(from: jsonString, key: "conversationId"),
            let localId = serverToLocalConversationMap[conversationId] {
             jsonString = jsonString.replacingOccurrences(
@@ -1727,7 +1727,7 @@ public final class HTTPTransport {
                 // Learn the server's conversationId for this conversation's conversationKey.
                 // For new conversations, the conversationId (used as conversationKey) differs from
                 // the server's internal conversationId. Store the mapping so parseSSEData
-                // can remap incoming events to the client's local session ID.
+                // can remap incoming events to the client's local conversation ID.
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let serverConvId = json["conversationId"] as? String,
                    serverConvId != conversationId {
@@ -2690,7 +2690,7 @@ public final class HTTPTransport {
             "surfaceId": action.surfaceId,
             "actionId": action.actionId,
         ]
-        // Omit conversationId — the server resolves the session via
+        // Omit conversationId — the server resolves the conversation via
         // findSessionBySurfaceId(surfaceId), which is reliable regardless
         // of conversationKey vs conversationId differences.
         if let data = action.data {


### PR DESCRIPTION
## Summary
- Rename TraceStoreTests MARK comments and test methods (Multi-Session to Multi-Conversation, etc.)
- Rename ChatViewModelTests MARK comments and test methods (Session Filtering to Conversation Filtering, etc.)
- Rename iOS ChatViewModelIOSTests test methods and local variables (capturedSessionId to capturedConversationId, sessionCreates to conversationCreates)
- Rename iOS ConversationLifecycleIOSTests local variables (capturedSessionId to capturedConversationId, updatesBySessionId to updatesByConversationId)
- Fix AppDelegate+Conversations.swift MARK comment (Session to Conversation)
- Fix remaining Swift code comments using thread/session when meaning conversation across HTTPDaemonClient, ChatViewModel+MessageHandling, PanelCoordinator, AppDelegate+WindowsAndSurfaces, LogExporter, and IOSConversationStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
