### PR TITLE
perf: make skill references load-on-demand instead of auto-appending

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -613,7 +613,7 @@ describe("skill_load tool", () => {
     expect(result.content).not.toContain("<loaded_skill");
   });
 
-  test("skill with references/ directory appends reference file contents", async () => {
+  test("skill with references/ directory lists reference file paths", async () => {
     // Create a skill with a references/ subdirectory
     const skillDir = join(TEST_DIR, "skills", "with-refs");
     mkdirSync(skillDir, { recursive: true });
@@ -635,16 +635,19 @@ describe("skill_load tool", () => {
     const result = await executeSkillLoad({ skill: "with-refs" });
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Main body.");
-    // Reference files should be appended with headers
-    expect(result.content).toContain("--- Reference: Guide ---");
-    expect(result.content).toContain("Detailed guide content.");
-    expect(result.content).toContain("--- Reference: Troubleshooting ---");
-    expect(result.content).toContain("Fix things here.");
-    // References must be appended in alphabetical order (Guide before Troubleshooting)
-    const guideIdx = result.content.indexOf("--- Reference: Guide ---");
-    const troubleshootIdx = result.content.indexOf(
-      "--- Reference: Troubleshooting ---",
+    // Should contain reference listing header
+    expect(result.content).toContain("## Reference Files");
+    // Should list full paths to reference files
+    expect(result.content).toContain(`${skillDir}/references/GUIDE.md`);
+    expect(result.content).toContain(
+      `${skillDir}/references/TROUBLESHOOTING.md`,
     );
+    // Should NOT contain the full file contents
+    expect(result.content).not.toContain("Detailed guide content.");
+    expect(result.content).not.toContain("Fix things here.");
+    // References must be listed in alphabetical order (GUIDE before TROUBLESHOOTING)
+    const guideIdx = result.content.indexOf("GUIDE.md");
+    const troubleshootIdx = result.content.indexOf("TROUBLESHOOTING.md");
     expect(guideIdx).toBeLessThan(troubleshootIdx);
   });
 
@@ -655,7 +658,7 @@ describe("skill_load tool", () => {
     const result = await executeSkillLoad({ skill: "no-refs" });
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Just body.");
-    expect(result.content).not.toContain("--- Reference:");
+    expect(result.content).not.toContain("## Reference Files");
   });
 
   test("references/ directory skips symlinked markdown files that escape the skill directory", async () => {
@@ -681,7 +684,7 @@ describe("skill_load tool", () => {
     const result = await executeSkillLoad({ skill: "refs-symlink" });
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Body.");
-    expect(result.content).not.toContain("--- Reference: Secret ---");
+    expect(result.content).not.toContain("secret.md");
     expect(result.content).not.toContain("TOP_SECRET_DO_NOT_LOAD");
   });
 
@@ -705,7 +708,8 @@ describe("skill_load tool", () => {
 
     const result = await executeSkillLoad({ skill: "refs-filter" });
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("--- Reference: Guide ---");
+    expect(result.content).toContain("## Reference Files");
+    expect(result.content).toContain("GUIDE.md");
     expect(result.content).not.toContain("data.json");
     expect(result.content).not.toContain('"key"');
   });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -935,15 +935,13 @@ function isEscapingSymlink(filePath: string, rootDir: string): boolean {
 }
 
 /**
- * Scan for a `references/` subdirectory within a skill directory and append
- * the contents of any `.md` files found there to the skill body. Each
- * reference file is labeled with a `--- Reference: <Name> ---` header.
- * Files are appended in alphabetical order for deterministic output.
- * Non-`.md` files are ignored. Symlinks that resolve outside the skill
- * directory are skipped. Errors are logged as warnings and the original body
- * is returned unchanged.
+ * Check for a `references/` subdirectory within a skill directory and return
+ * a formatted listing of available `.md` reference files with full absolute
+ * paths. Returns `null` if no references exist. Files are listed in
+ * alphabetical order. Non-`.md` files are ignored. Symlinks that resolve
+ * outside the skill directory are skipped.
  */
-function appendReferenceFiles(body: string, directoryPath: string): string {
+export function listReferenceFiles(directoryPath: string): string | null {
   try {
     const refsDir = join(directoryPath, "references");
     if (
@@ -951,7 +949,7 @@ function appendReferenceFiles(body: string, directoryPath: string): string {
       isEscapingSymlink(refsDir, directoryPath) ||
       !statSync(refsDir).isDirectory()
     ) {
-      return body;
+      return null;
     }
 
     const entries = readdirSync(refsDir);
@@ -960,23 +958,22 @@ function appendReferenceFiles(body: string, directoryPath: string): string {
       .filter((f) => !isEscapingSymlink(join(refsDir, f), directoryPath))
       .sort((a, b) => a.localeCompare(b));
 
-    if (mdFiles.length === 0) return body;
+    if (mdFiles.length === 0) return null;
 
-    let result = body;
+    const lines = [
+      "## Reference Files",
+      "",
+      "The following reference files are available in this skill's directory. Use `file_read` to load any that are relevant to the current task:",
+      "",
+    ];
     for (const filename of mdFiles) {
-      const fileContents = readFileSync(join(refsDir, filename), "utf-8");
-      const displayName = filename
-        .replace(/\.md$/i, "")
-        .replace(/[-_]/g, " ")
-        .replace(/\b\w/g, (c) => c.toUpperCase())
-        .replace(/\B\w+/g, (w) => w.toLowerCase());
-      result += `\n\n--- Reference: ${displayName} ---\n${fileContents}`;
+      lines.push(`- \`${join(refsDir, filename)}\``);
     }
 
-    return result;
+    return lines.join("\n");
   } catch (err) {
-    log.warn({ err, directoryPath }, "Failed to read reference files");
-    return body;
+    log.warn({ err, directoryPath }, "Failed to list reference files");
+    return null;
   }
 }
 
@@ -1006,8 +1003,6 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   loaded.body = loaded.body.replaceAll("{baseDir}", loaded.directoryPath);
   // Strip feature-gated sections based on assistant feature flags
   loaded.body = applyFeatureGatedSections(loaded.body);
-  // Auto-load reference files from references/ subdirectory
-  loaded.body = appendReferenceFiles(loaded.body, loaded.directoryPath);
   return { skill: loaded };
 }
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -5,7 +5,11 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { getConfig } from "../../config/loader.js";
 import { skillFlagKey } from "../../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../../config/skills.js";
-import { loadSkillBySelector, loadSkillCatalog } from "../../config/skills.js";
+import {
+  listReferenceFiles,
+  loadSkillBySelector,
+  loadSkillCatalog,
+} from "../../config/skills.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import {
@@ -277,6 +281,9 @@ export class SkillLoadTool implements Tool {
 
     const body = skill.body.length > 0 ? skill.body : "(No body content)";
 
+    // Build reference file listing (if any)
+    const referenceListing = listReferenceFiles(skill.directoryPath);
+
     // Load tool schemas for the main skill
     const mainManifest = loadToolManifest(skill.directoryPath);
     const toolSchemasSection = mainManifest
@@ -378,6 +385,7 @@ export class SkillLoadTool implements Tool {
         "",
         body,
         "",
+        ...(referenceListing ? [referenceListing, ""] : []),
         ...(toolSchemasSection ? [toolSchemasSection, ""] : []),
         ...(!toolSchemasSection && anyChildHasTools
           ? [


### PR DESCRIPTION
## Summary
- Remove `appendReferenceFiles` that concatenated full reference file contents onto skill body
- Add `listReferenceFiles` helper that generates a compact listing of available reference files with full paths
- Update skill load output to include reference listing so assistant can use `file_read` on demand

Part of plan: skill-references-plan.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
