### PR TITLE
fix: guard parsed traits against null/non-object JSON before dereferencing

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -23,7 +23,7 @@ export interface CharacterTraits {
  * Returns true if all files were written successfully.
  */
 export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
-  if (!traits.bodyShape || !traits.eyeStyle || !traits.color) {
+  if (!traits || typeof traits !== "object" || !traits.bodyShape || !traits.eyeStyle || !traits.color) {
     log.warn({ traits }, "Invalid character traits — missing required fields");
     return false;
   }
@@ -98,13 +98,17 @@ export function syncTraitsToAvatar(): boolean {
     "character-traits.json",
   );
 
-  let traits: CharacterTraits;
+  let traits: unknown;
   try {
     const raw = readFileSync(traitsPath, "utf-8");
-    traits = JSON.parse(raw) as CharacterTraits;
+    traits = JSON.parse(raw);
   } catch {
     return false;
   }
 
-  return writeTraitsAndRenderAvatar(traits);
+  if (!traits || typeof traits !== "object") {
+    return false;
+  }
+
+  return writeTraitsAndRenderAvatar(traits as CharacterTraits);
 }


### PR DESCRIPTION
## Summary
- Add null/type guards in `writeTraitsAndRenderAvatar()` and `syncTraitsToAvatar()` to prevent `TypeError` when `character-traits.json` contains `null` or another non-object JSON literal
- `JSON.parse("null")` succeeds without throwing, so the existing `catch` block didn't handle this case -- accessing `.bodyShape` on `null` would crash instead of returning `false` as documented

Addresses review feedback from PR #17106.

## Test plan
- [x] Verify `syncTraitsToAvatar()` returns `false` when traits file contains `null`
- [x] Verify `writeTraitsAndRenderAvatar()` returns `false` when passed a null-cast value
- [x] Existing behavior unchanged for valid traits objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
