### PR TITLE
fix: return proper HTTP status codes for avatar render failures

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -15,17 +15,35 @@ export interface CharacterTraits {
   color: string;
 }
 
+export type TraitsSyncResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "missing_traits" | "invalid_traits" | "render_error";
+      message: string;
+    };
+
 /**
  * Writes character-traits.json, regenerates avatar-image.png, and updates
  * character-ascii.txt in one atomic operation.  Accepts the trait values
  * directly so callers don't need to touch the filesystem first.
- *
- * Returns true if all files were written successfully.
  */
-export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
-  if (!traits || typeof traits !== "object" || !traits.bodyShape || !traits.eyeStyle || !traits.color) {
+export function writeTraitsAndRenderAvatar(
+  traits: CharacterTraits,
+): TraitsSyncResult {
+  if (
+    !traits ||
+    typeof traits !== "object" ||
+    !traits.bodyShape ||
+    !traits.eyeStyle ||
+    !traits.color
+  ) {
     log.warn({ traits }, "Invalid character traits — missing required fields");
-    return false;
+    return {
+      ok: false,
+      reason: "invalid_traits",
+      message: "Missing required fields: bodyShape, eyeStyle, color",
+    };
   }
 
   const avatarDir = join(getWorkspaceDir(), "data", "avatar");
@@ -78,10 +96,15 @@ export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
       },
       "Wrote character traits, regenerated avatar PNG, and updated ASCII art",
     );
-    return true;
+    return { ok: true };
   } catch (err) {
     log.error({ err }, "Failed to write traits / render avatar");
-    return false;
+    return {
+      ok: false,
+      reason: "render_error",
+      message:
+        err instanceof Error ? err.message : "Failed to render avatar PNG",
+    };
   }
 }
 
@@ -90,7 +113,7 @@ export function writeTraitsAndRenderAvatar(traits: CharacterTraits): boolean {
  * avatar-image.png and character-ascii.txt to match. Kept for backward
  * compatibility (e.g. the client-side file watcher triggers this path).
  */
-export function syncTraitsToAvatar(): boolean {
+export function syncTraitsToAvatar(): TraitsSyncResult {
   const traitsPath = join(
     getWorkspaceDir(),
     "data",
@@ -103,11 +126,19 @@ export function syncTraitsToAvatar(): boolean {
     const raw = readFileSync(traitsPath, "utf-8");
     traits = JSON.parse(raw);
   } catch {
-    return false;
+    return {
+      ok: false,
+      reason: "missing_traits",
+      message: "No valid character-traits.json found",
+    };
   }
 
   if (!traits || typeof traits !== "object") {
-    return false;
+    return {
+      ok: false,
+      reason: "invalid_traits",
+      message: "character-traits.json does not contain a valid object",
+    };
   }
 
   return writeTraitsAndRenderAvatar(traits as CharacterTraits);

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -131,14 +131,16 @@ Examples:
           return;
         }
 
-        const success = writeTraitsAndRenderAvatar({
+        const result = writeTraitsAndRenderAvatar({
           bodyShape: opts.bodyShape,
           eyeStyle: opts.eyeStyle,
           color: opts.color,
         });
 
-        if (!success) {
-          log.error("Failed to write traits and render avatar.");
+        if (!result.ok) {
+          log.error(
+            `Failed to write traits and render avatar: ${result.message}`,
+          );
           process.exitCode = 1;
           return;
         }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -4,6 +4,7 @@ import { getCharacterComponents } from "../../avatar/character-components.js";
 import {
   type CharacterTraits,
   syncTraitsToAvatar,
+  type TraitsSyncResult,
   writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { getLogger } from "../../util/logger.js";
@@ -46,7 +47,7 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
       endpoint: "avatar/render-from-traits",
       method: "POST",
       handler: async ({ req }) => {
-        let success: boolean;
+        let result: TraitsSyncResult;
 
         // If the request includes a JSON body with traits, write the traits
         // file and render the PNG in one atomic operation.  Otherwise fall
@@ -69,17 +70,16 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
             );
           }
 
-          success = writeTraitsAndRenderAvatar(body);
+          result = writeTraitsAndRenderAvatar(body);
         } else {
-          success = syncTraitsToAvatar();
+          result = syncTraitsToAvatar();
         }
 
-        if (!success) {
-          return httpError(
-            "BAD_REQUEST",
-            "Failed to render avatar from traits",
-            400,
-          );
+        if (!result.ok) {
+          const status = result.reason === "render_error" ? 500 : 400;
+          const code =
+            result.reason === "render_error" ? "INTERNAL_ERROR" : "BAD_REQUEST";
+          return httpError(code, result.message, status);
         }
 
         publishAvatarUpdated();


### PR DESCRIPTION
## Summary
- Refactors `writeTraitsAndRenderAvatar` and `syncTraitsToAvatar` to return a `TraitsSyncResult` discriminated union instead of a boolean, distinguishing between `missing_traits`, `invalid_traits`, and `render_error` failure modes
- Updates `avatar/render-from-traits` route handler to return 400 for input validation errors (missing/invalid traits) and 500 for server-side render errors (PNG rendering failures)
- Updates CLI caller in `avatar.ts` to use the new result type with descriptive error messages

Addresses review feedback from PR #17109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
