### PR TITLE
fix: list reference files for included/child skills in skill load output

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -317,6 +317,12 @@ export class SkillLoadTool implements Tool {
             `--- Included Skill: ${childLoaded.skill.displayName} (${childId}) ---\n${childLoaded.skill.body}`,
           );
 
+          // List reference files for the included skill
+          const childRefs = listReferenceFiles(childLoaded.skill.directoryPath);
+          if (childRefs) {
+            includedBodies.push(childRefs);
+          }
+
           // Load tool schemas for the included skill (lighter sub-heading)
           const childManifest = loadToolManifest(
             childLoaded.skill.directoryPath,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-references-plan.md.

**Gap:** Included/child skills lose reference file visibility
**What was expected:** Child skills should have their reference files listed in the output
**What was found:** listReferenceFiles was only called for the top-level skill, not for child skills loaded via includes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
