### PR TITLE
fix: add staleness protection to SkillsStore skill detail/files fetch

### DIFF
--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -94,8 +94,12 @@ public final class SkillsStore: ObservableObject {
     private var lastSearchQuery: String?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
+    private var skillDetailTask: Task<Void, Never>?
+    private var skillFilesTask: Task<Void, Never>?
     private var draftGeneration: Int = 0
     private var createGeneration: Int = 0
+    private var currentDetailSkillId: String?
+    private var currentFilesSkillId: String?
 
     // MARK: - Init
 
@@ -451,12 +455,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Fetch Skill Detail
 
     public func fetchSkillDetail(skillId: String) {
-        guard !isLoadingSkillDetail else { return }
+        skillDetailTask?.cancel()
+        currentDetailSkillId = skillId
         isLoadingSkillDetail = true
         skillDetailError = nil
+        selectedSkillDetail = nil
 
-        Task {
+        skillDetailTask = Task {
             let result = await daemonClient.httpTransport?.fetchSkillDetail(skillId: skillId)
+            guard self.currentDetailSkillId == skillId else { return }
             if let result {
                 selectedSkillDetail = result
             } else {
@@ -469,12 +476,15 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Fetch Skill Files
 
     public func fetchSkillFiles(skillId: String) {
-        guard !isLoadingSkillFiles else { return }
+        skillFilesTask?.cancel()
+        currentFilesSkillId = skillId
         isLoadingSkillFiles = true
         skillFilesError = nil
+        selectedSkillFiles = nil
 
-        Task {
+        skillFilesTask = Task {
             let result = await daemonClient.httpTransport?.fetchSkillFiles(skillId: skillId)
+            guard self.currentFilesSkillId == skillId else { return }
             if let result {
                 selectedSkillFiles = result
             } else {
@@ -487,6 +497,12 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Clear Skill Detail
 
     public func clearSkillDetail() {
+        skillDetailTask?.cancel()
+        skillFilesTask?.cancel()
+        skillDetailTask = nil
+        skillFilesTask = nil
+        currentDetailSkillId = nil
+        currentFilesSkillId = nil
         selectedSkillDetail = nil
         selectedSkillFiles = nil
         isLoadingSkillDetail = false


### PR DESCRIPTION
## Summary
- Cancel previous in-flight tasks when a new `fetchSkillDetail` or `fetchSkillFiles` call is made, instead of silently dropping the new request
- Add `currentDetailSkillId` / `currentFilesSkillId` staleness guards after `await` to prevent completed tasks from writing stale results
- Clear previous data (`selectedSkillDetail = nil`, `selectedSkillFiles = nil`) at fetch start to avoid showing wrong skill's data during load
- Cancel and nil out tracked tasks in `clearSkillDetail()` to prevent stale writes after navigation away

Addresses review feedback on #17134.

## Test plan
- [ ] Navigate rapidly between skills in the skills list and verify the detail/files always match the selected skill
- [ ] Navigate away while a fetch is in-flight and verify no stale data appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
