### PR TITLE
perf: use cached isCurrentAssistantManaged in LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -29,9 +29,9 @@ enum LogExporter {
     /// Whether the currently connected assistant is a managed (platform-hosted) instance.
     /// When true, conversation-scoped exports are not available because the platform API
     /// does not yet support conversation-scoped log retrieval.
+    /// Uses the cached value from AppDelegate to avoid disk I/O in hot paths (e.g. SwiftUI view bodies).
     nonisolated static var isManagedAssistant: Bool {
-        guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return false }
-        return LockfileAssistant.loadByName(id)?.isManaged == true
+        AppDelegate.shared?.isCurrentAssistantManaged == true
     }
 
     /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.


### PR DESCRIPTION
## Summary
- Replace `LockfileAssistant.loadByName` disk I/O in `LogExporter.isManagedAssistant` with cached `AppDelegate.shared?.isCurrentAssistantManaged`
- Fixes synchronous file I/O on the main thread during SwiftUI view body evaluation in `SidebarConversationItem`
- `AppDelegate.isCurrentAssistantManaged` is already set once during `configureDaemonTransport` and used elsewhere (menu bar, auth lifecycle)

## Test plan
- [ ] Verify managed assistant detection still works correctly (conversation-scoped export disabled for managed assistants)
- [ ] Verify sidebar context menu renders without jank

Addresses review feedback from PR #17139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
