### PR TITLE
fix: preserve hardcoded fallback colors in AvatarColor.nsColor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
@@ -6,7 +6,29 @@ enum AvatarColor: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     @MainActor var nsColor: NSColor {
-        guard let def = AvatarComponentStore.shared.color(id: rawValue) else { return .clear }
-        return AvatarComponentStore.hexToNSColor(def.hex)
+        if let def = AvatarComponentStore.shared.color(id: rawValue) {
+            return AvatarComponentStore.hexToNSColor(def.hex)
+        }
+        return fallbackNSColor
+    }
+
+    /// Hardcoded fallback colors used before the component store is populated.
+    /// These match the original values that shipped before the store delegation
+    /// refactor so avatars remain visible while the daemon fetch is in-flight.
+    private var fallbackNSColor: NSColor {
+        switch self {
+        case .green:
+            return NSColor(srgbRed: 0x4C / 255.0, green: 0x9B / 255.0, blue: 0x50 / 255.0, alpha: 1)
+        case .orange:
+            return NSColor(srgbRed: 0xE9 / 255.0, green: 0x64 / 255.0, blue: 0x2F / 255.0, alpha: 1)
+        case .pink:
+            return NSColor(srgbRed: 0xDB / 255.0, green: 0x4B / 255.0, blue: 0x77 / 255.0, alpha: 1)
+        case .purple:
+            return NSColor(srgbRed: 0xA6 / 255.0, green: 0x65 / 255.0, blue: 0xC9 / 255.0, alpha: 1)
+        case .teal:
+            return NSColor(srgbRed: 0x0E / 255.0, green: 0x9B / 255.0, blue: 0x8B / 255.0, alpha: 1)
+        case .yellow:
+            return NSColor(srgbRed: 0xE9 / 255.0, green: 0xC9 / 255.0, blue: 0x1A / 255.0, alpha: 1)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Restore hardcoded fallback colors in `AvatarColor.nsColor` so avatars remain visible before the daemon component store is populated
- The component store lookup is still preferred when available; the fallback only activates when the store returns nil (e.g. during the pre-fetch window or if the daemon is unreachable)
- Addresses review feedback from PR #17153 where both bot reviewers flagged that `nsColor` returning `.clear` causes invisible avatars

## Test plan
- [ ] Verify avatar colors render correctly on startup before daemon component fetch completes
- [ ] Verify avatar colors update to store values once the daemon fetch completes
- [ ] Verify avatar colors remain visible when daemon is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
