### PR TITLE
fix: rename session→conversation in TS daemon variables, logger names, tests, and comments

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -273,7 +273,7 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     const state = makeState(subagentId);
     injectFakeSubagent(manager, subagentId, state);
 
-    // Patch the fake session to simulate a successful agent loop.
+    // Patch the fake conversation to simulate a successful agent loop.
     const managed = asInternals(manager).subagents.get(subagentId)!;
     managed.conversation.persistUserMessage = () => "msg-1";
     managed.conversation.runAgentLoop = async () => {};
@@ -306,7 +306,7 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     const state = makeState(subagentId);
     injectFakeSubagent(manager, subagentId, state);
 
-    // Patch the fake session to simulate a failure.
+    // Patch the fake conversation to simulate a failure.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
     managed.conversation.persistUserMessage = () => "msg-1";
@@ -419,7 +419,7 @@ describe("SubagentManager abort race guard", () => {
     const state = makeState(subagentId, { status: "aborted" });
     injectFakeSubagent(manager, subagentId, state);
 
-    // Patch session to simulate successful completion after abort.
+    // Patch conversation to simulate successful completion after abort.
     const managed = asInternals(manager).subagents.get(subagentId)!;
 
     managed.conversation.persistUserMessage = () => "msg-1";

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -282,7 +282,7 @@ describe("Subagent tool ownership validation", () => {
   const manager = getSubagentManager();
   injectSubagent(manager, subagentId, ownerSession);
 
-  test("status rejects non-owner session", async () => {
+  test("status rejects non-owner conversation", async () => {
     const result = await executeSubagentStatus(
       { subagent_id: subagentId },
       makeContext(otherSession),
@@ -291,7 +291,7 @@ describe("Subagent tool ownership validation", () => {
     expect(result.content).toContain("No subagent found");
   });
 
-  test("status succeeds for owner session", async () => {
+  test("status succeeds for owner conversation", async () => {
     const result = await executeSubagentStatus(
       { subagent_id: subagentId },
       makeContext(ownerSession),
@@ -299,7 +299,7 @@ describe("Subagent tool ownership validation", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("message rejects non-owner session", async () => {
+  test("message rejects non-owner conversation", async () => {
     const result = await executeSubagentMessage(
       { subagent_id: subagentId, content: "hello" },
       makeContext(otherSession),
@@ -308,7 +308,7 @@ describe("Subagent tool ownership validation", () => {
     expect(result.content).toContain("Could not send");
   });
 
-  test("read rejects non-owner session", async () => {
+  test("read rejects non-owner conversation", async () => {
     const result = await executeSubagentRead(
       { subagent_id: subagentId },
       makeContext(otherSession),
@@ -317,7 +317,7 @@ describe("Subagent tool ownership validation", () => {
     expect(result.content).toContain("No subagent found");
   });
 
-  test("abort rejects non-owner session", async () => {
+  test("abort rejects non-owner conversation", async () => {
     const result = await executeSubagentAbort(
       { subagent_id: subagentId },
       makeContext(otherSession),
@@ -326,7 +326,7 @@ describe("Subagent tool ownership validation", () => {
     expect(result.content).toContain("Could not abort");
   });
 
-  test("abort succeeds for owner session", async () => {
+  test("abort succeeds for owner conversation", async () => {
     const result = await executeSubagentAbort(
       { subagent_id: subagentId },
       makeContext(ownerSession),
@@ -435,7 +435,7 @@ describe("Subagent message success path", () => {
   const ownerSession = "msg-owner-sess";
   const subagentId = "msg-sub-1";
 
-  test("message succeeds for owner session with running subagent", async () => {
+  test("message succeeds for owner conversation with running subagent", async () => {
     const manager = getSubagentManager();
     injectSubagent(manager, subagentId, ownerSession, "running");
 

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -455,7 +455,7 @@ export type ApproveHostRead = (filePath: string) => Promise<boolean>;
  * Resolve a host directive to a draft attachment.
  *
  * Requires an absolute path. Before reading, calls the `approve` callback
- * so the session layer can gate access via the user-facing permission prompt.
+ * so the conversation layer can gate access via the user-facing permission prompt.
  */
 export async function resolveHostDirective(
   directive: DirectiveRequest,

--- a/assistant/src/daemon/context-overflow-policy.ts
+++ b/assistant/src/daemon/context-overflow-policy.ts
@@ -15,12 +15,12 @@ export interface OverflowPolicyInput {
 }
 
 /**
- * Deterministic policy resolver that maps config knobs + session interactivity
+ * Deterministic policy resolver that maps config knobs + conversation interactivity
  * to a concrete overflow action.
  *
  * The recovery pipeline calls this after standard compaction is exhausted.
- * Interactive sessions default to asking the user before compressing the
- * latest turn; non-interactive sessions auto-compress.
+ * Interactive conversations default to asking the user before compressing the
+ * latest turn; non-interactive conversations auto-compress.
  */
 export function resolveOverflowAction(
   input: OverflowPolicyInput,
@@ -40,11 +40,11 @@ export function resolveOverflowAction(
     return "fail_gracefully";
   }
 
-  // For non-interactive sessions, compress without asking.
+  // For non-interactive conversations, compress without asking.
   if (!isInteractive) {
     return "auto_compress_latest_turn";
   }
 
-  // Interactive sessions ask for approval before compressing.
+  // Interactive conversations ask for approval before compressing.
   return "request_user_approval";
 }

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1,5 +1,5 @@
 /**
- * Extracted event handler functions for the session agent loop.
+ * Extracted event handler functions for the conversation agent loop.
  *
  * Each switch case from the original monolithic event handler is now a
  * standalone exported function, making individual behaviors independently

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -123,7 +123,7 @@ import type {
 } from "./message-protocol.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 
-const log = getLogger("session-agent-loop");
+const log = getLogger("conversation-agent-loop");
 
 /**
  * Parse the actual token count reported by the provider in a context-too-large
@@ -387,7 +387,7 @@ export async function runAgentLoopImpl(
   ctx.profiler.startRequest();
   let turnStarted = false;
 
-  // Populate Sentry scope with session-specific tags so any exception
+  // Populate Sentry scope with conversation-specific tags so any exception
   // captured during this turn (e.g. inside agent/loop.ts) can be
   // filtered by conversation, assistant, or user in the dashboard.
   setSentryConversationContext({
@@ -649,9 +649,9 @@ export async function runAgentLoopImpl(
     };
 
     // Resolve the inbound actor context for the model's <inbound_actor_context>
-    // block. When the session carries enough identity info, use the unified
+    // block. When the conversation carries enough identity info, use the unified
     // actor trust resolver so member status/policy and guardian binding details
-    // are fresh for this turn. The session runtime context remains the source
+    // are fresh for this turn. The conversation runtime context remains the source
     // for policy gating; this block is model-facing grounding metadata.
     let resolvedInboundActorContext: InboundActorContext | null = null;
     if (ctx.trustContext) {
@@ -859,7 +859,7 @@ export async function runAgentLoopImpl(
 
       // Mid-loop token budget check: estimate current context size and
       // yield if we're approaching the preflight budget. This lets the
-      // session-agent-loop run compaction before the provider rejects.
+      // conversation-agent-loop run compaction before the provider rejects.
       if (overflowRecovery.enabled) {
         const midLoopThreshold = preflightBudget * 0.85;
         const estimated = estimatePromptTokens(
@@ -1767,7 +1767,7 @@ export async function runAgentLoopImpl(
 
     ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");
 
-    // Clear session tags so they don't leak into unrelated error captures
+    // Clear conversation tags so they don't leak into unrelated error captures
     // (e.g. unhandledRejection from a different async chain).
     clearSentryConversationContext();
   }

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -33,7 +33,7 @@ import {
   generateVideoThumbnailFromPath,
 } from "./video-thumbnail.js";
 
-const log = getLogger("session-attachments");
+const log = getLogger("conversation-attachments");
 
 /**
  * Approve reading a host file for assistant attachment resolution.

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -117,23 +117,23 @@ export class ConversationEvictor {
     };
 
     // Phase 1: TTL eviction — remove conversations idle longer than ttlMs.
-    for (const [id, session] of this.conversations) {
+    for (const [id, conversation] of this.conversations) {
       const lastAccessTime = this.lastAccess.get(id) ?? 0;
       if (now - lastAccessTime < this.ttlMs) continue;
-      if (session.isProcessing() || this.shouldProtect?.(id)) {
+      if (conversation.isProcessing() || this.shouldProtect?.(id)) {
         result.skipped++;
         continue;
       }
-      this.evict(id, session);
+      this.evict(id, conversation);
       result.ttlEvicted++;
     }
 
     // Phase 2: LRU eviction — if still over capacity, evict least-recently-used.
     if (this.conversations.size > this.maxConversations) {
       const sorted = this.idleConversationsByLru();
-      for (const [id, session] of sorted) {
+      for (const [id, conversation] of sorted) {
         if (this.conversations.size <= this.maxConversations) break;
-        this.evict(id, session);
+        this.evict(id, conversation);
         result.lruEvicted++;
       }
     }
@@ -153,9 +153,9 @@ export class ConversationEvictor {
           },
           "Memory pressure detected, evicting idle conversations",
         );
-        for (const [id, session] of sorted) {
+        for (const [id, conversation] of sorted) {
           if (process.memoryUsage.rss() <= this.memoryThresholdBytes) break;
-          this.evict(id, session);
+          this.evict(id, conversation);
           result.memoryEvicted++;
         }
       }
@@ -179,8 +179,8 @@ export class ConversationEvictor {
 
   // ── Internals ──────────────────────────────────────────────────────
 
-  private evict(id: string, session: EvictableConversation): void {
-    session.dispose();
+  private evict(id: string, conversation: EvictableConversation): void {
+    conversation.dispose();
     this.conversations.delete(id);
     this.lastAccess.delete(id);
     this.onEvict?.(id);
@@ -193,12 +193,12 @@ export class ConversationEvictor {
    */
   private idleConversationsByLru(): Array<[string, EvictableConversation]> {
     const idle: Array<[string, EvictableConversation, number]> = [];
-    for (const [id, session] of this.conversations) {
-      if (session.isProcessing()) continue;
+    for (const [id, conversation] of this.conversations) {
+      if (conversation.isProcessing()) continue;
       if (this.shouldProtect?.(id)) continue;
-      idle.push([id, session, this.lastAccess.get(id) ?? 0]);
+      idle.push([id, conversation, this.lastAccess.get(id) ?? 0]);
     }
     idle.sort((a, b) => a[2] - b[2]);
-    return idle.map(([id, session]) => [id, session]);
+    return idle.map(([id, conversation]) => [id, conversation]);
   }
 }

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -17,7 +17,7 @@ import { getLogger } from "../util/logger.js";
 import type { ServerMessage } from "./message-protocol.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 
-const log = getLogger("session-history");
+const log = getLogger("conversation-history");
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -369,14 +369,14 @@ export interface HistoryConversationContext {
  * Remove the last user+assistant exchange from memory and DB.
  * Returns the number of messages removed.
  */
-export function undo(session: HistoryConversationContext): number {
-  if (session.processing) return 0;
+export function undo(conversation: HistoryConversationContext): number {
+  if (conversation.processing) return 0;
 
-  const lastUserIdx = findLastUndoableUserMessageIndex(session.messages);
+  const lastUserIdx = findLastUndoableUserMessageIndex(conversation.messages);
   if (lastUserIdx === -1) return 0;
 
-  const removed = session.messages.length - lastUserIdx;
-  session.messages = session.messages.slice(0, lastUserIdx);
+  const removed = conversation.messages.length - lastUserIdx;
+  conversation.messages = conversation.messages.slice(0, lastUserIdx);
 
   // Also remove from DB. We may need to call deleteLastExchange multiple
   // times because the DB stores tool_result user messages as separate rows.
@@ -391,15 +391,15 @@ export function undo(session: HistoryConversationContext): number {
   // deleteLastExchange when the loop peeled back tool_result messages.
   let hadToolResult = false;
   do {
-    deleteLastExchange(session.conversationId);
-    if (isLastUserMessageToolResult(session.conversationId)) {
+    deleteLastExchange(conversation.conversationId);
+    if (isLastUserMessageToolResult(conversation.conversationId)) {
       hadToolResult = true;
     } else {
       break;
     }
   } while (true);
   if (hadToolResult) {
-    deleteLastExchange(session.conversationId);
+    deleteLastExchange(conversation.conversationId);
   }
 
   return removed;
@@ -413,14 +413,14 @@ export function undo(session: HistoryConversationContext): number {
  * Qdrant, then re-run the agent loop with the same user message.
  */
 export async function regenerate(
-  session: HistoryConversationContext,
+  conversation: HistoryConversationContext,
   onEvent: (msg: ServerMessage) => void,
   requestId?: string,
 ): Promise<void> {
-  if (session.processing) {
+  if (conversation.processing) {
     onEvent({ type: "error", message: "Cannot regenerate while processing" });
     if (requestId) {
-      session.traceEmitter.emit(
+      conversation.traceEmitter.emit(
         "request_error",
         "Cannot regenerate while processing",
         {
@@ -435,24 +435,28 @@ export async function regenerate(
 
   // Find the last undoable user message — everything after it is the
   // assistant's exchange that we want to regenerate.
-  const lastUserIdx = findLastUndoableUserMessageIndex(session.messages);
+  const lastUserIdx = findLastUndoableUserMessageIndex(conversation.messages);
   if (lastUserIdx === -1) {
     onEvent({ type: "error", message: "No messages to regenerate" });
     if (requestId) {
-      session.traceEmitter.emit("request_error", "No messages to regenerate", {
-        requestId,
-        status: "error",
-        attributes: { reason: "no_messages" },
-      });
+      conversation.traceEmitter.emit(
+        "request_error",
+        "No messages to regenerate",
+        {
+          requestId,
+          status: "error",
+          attributes: { reason: "no_messages" },
+        },
+      );
     }
     return;
   }
 
   // There must be at least one message after the user message (the assistant reply).
-  if (lastUserIdx >= session.messages.length - 1) {
+  if (lastUserIdx >= conversation.messages.length - 1) {
     onEvent({ type: "error", message: "No assistant response to regenerate" });
     if (requestId) {
-      session.traceEmitter.emit(
+      conversation.traceEmitter.emit(
         "request_error",
         "No assistant response to regenerate",
         {
@@ -466,11 +470,11 @@ export async function regenerate(
   }
 
   // Remove the assistant's exchange from in-memory history (keep the user message).
-  session.messages = session.messages.slice(0, lastUserIdx + 1);
+  conversation.messages = conversation.messages.slice(0, lastUserIdx + 1);
 
   // Find DB message IDs to delete: get all messages from the DB, then
   // identify the ones that come after the last user message.
-  const dbMessages = getMessages(session.conversationId);
+  const dbMessages = getMessages(conversation.conversationId);
 
   // Walk backwards to find the last real (non-tool_result) user message in the DB.
   let dbUserMsgIdx = -1;
@@ -495,7 +499,7 @@ export async function regenerate(
   if (dbUserMsgIdx === -1) {
     onEvent({ type: "error", message: "No user message found in DB" });
     if (requestId) {
-      session.traceEmitter.emit(
+      conversation.traceEmitter.emit(
         "request_error",
         "No user message found in DB",
         {
@@ -526,12 +530,12 @@ export async function regenerate(
 
   // Clean up Qdrant vectors (fire-and-forget).
   cleanupQdrantVectors(
-    session.conversationId,
+    conversation.conversationId,
     allSegmentIds,
     allOrphanedItemIds,
   ).catch((err) => {
     log.warn(
-      { err, conversationId: session.conversationId },
+      { err, conversationId: conversation.conversationId },
       "Qdrant cleanup after regenerate failed (non-fatal)",
     );
   });
@@ -539,7 +543,7 @@ export async function regenerate(
   // Re-extract the user message content for the agent loop.
   // Use all content blocks (text, image, file) so attachments are
   // preserved — not just text blocks.
-  const userMessage = session.messages[lastUserIdx];
+  const userMessage = conversation.messages[lastUserIdx];
   const textBlocks = userMessage.content.filter((b) => b.type === "text");
   const content = textBlocks
     .map((b) => (b as { type: "text"; text: string }).text)
@@ -549,17 +553,17 @@ export async function regenerate(
   onEvent({
     type: "undo_complete",
     removedCount: messagesToDelete.length,
-    conversationId: session.conversationId,
+    conversationId: conversation.conversationId,
   });
 
   // Set up processing state manually and call runAgentLoop directly,
   // bypassing processMessage to avoid duplicating the user message
   // in both this.messages and the DB.
-  session.processing = true;
-  session.abortController = new AbortController();
-  session.currentRequestId = requestId ?? uuid();
+  conversation.processing = true;
+  conversation.abortController = new AbortController();
+  conversation.currentRequestId = requestId ?? uuid();
 
-  await session.runAgentLoop(content, existingUserMessageId, onEvent, {
+  await conversation.runAgentLoop(content, existingUserMessageId, onEvent, {
     skipPreMessageRollback: true,
     isUserMessage: true,
   });

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -36,7 +36,7 @@ import type {
   UsageStats,
 } from "./message-protocol.js";
 
-const log = getLogger("session-lifecycle");
+const log = getLogger("conversation-lifecycle");
 
 function parseProvenanceTrustClass(
   metadata: string | null,

--- a/assistant/src/daemon/conversation-memory.ts
+++ b/assistant/src/daemon/conversation-memory.ts
@@ -131,7 +131,7 @@ export async function prepareMemoryContext(
       })
     : undefined;
   // Build scope policy override for non-default scopes so retrieval
-  // honours the session's memory policy regardless of the global config.
+  // honours the conversation's memory policy regardless of the global config.
   const scopePolicyOverride: ScopePolicyOverride | undefined =
     ctx.scopeId !== "default"
       ? { scopeId: ctx.scopeId, fallbackToDefault: ctx.includeDefaultFallback }

--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -51,7 +51,7 @@ export interface NotifierConversationContext {
 }
 
 /**
- * Register watch and call notifiers for a session. Call once during
+ * Register watch and call notifiers for a conversation. Call once during
  * construction; the notifier callbacks close over `ctx` so they see
  * live sendToClient/messages values.
  */
@@ -170,7 +170,7 @@ export function registerConversationNotifiers(
 
 /**
  * Unregister watch notifiers and prune watch sessions. Called during
- * abort when the session is actively processing.
+ * abort when the conversation is actively processing.
  */
 export function unregisterWatchNotifiers(conversationId: string): void {
   unregisterWatchStartNotifier(conversationId);

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -45,7 +45,7 @@ import type {
 import type { TraceEmitter } from "./trace-emitter.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
-const log = getLogger("session-process");
+const log = getLogger("conversation-process");
 
 /** Build a model_info event with fresh config data. */
 export async function buildModelInfoEvent(): Promise<ServerMessage> {
@@ -85,7 +85,7 @@ export interface ProcessConversationContext {
   readonly traceEmitter: TraceEmitter;
   currentActiveSurfaceId?: string;
   currentPage?: string;
-  /** Cumulative token usage stats for the session. */
+  /** Cumulative token usage stats for the conversation. */
   readonly usageStats: UsageStats;
   /** Request-scoped skill IDs preactivated via config or programmatic injection. */
   preactivatedSkillIds?: string[];
@@ -191,17 +191,19 @@ function resolveQueuedTurnInterfaceContext(
   return fallback;
 }
 
-/** Build a SlashContext from the current session state and config. */
-function buildSlashContext(session: ProcessConversationContext): SlashContext {
+/** Build a SlashContext from the current conversation state and config. */
+function buildSlashContext(
+  conversation: ProcessConversationContext,
+): SlashContext {
   const config = getConfig();
   return {
-    messageCount: session.messages.length,
-    inputTokens: session.usageStats.inputTokens,
-    outputTokens: session.usageStats.outputTokens,
+    messageCount: conversation.messages.length,
+    inputTokens: conversation.usageStats.inputTokens,
+    outputTokens: conversation.usageStats.outputTokens,
     maxInputTokens: config.contextWindow.maxInputTokens,
     model: config.model,
     provider: config.provider,
-    estimatedCost: session.usageStats.estimatedCost,
+    estimatedCost: conversation.usageStats.estimatedCost,
   };
 }
 
@@ -218,26 +220,26 @@ function buildSlashContext(session: ProcessConversationContext): SlashContext {
  * remaining queued messages would be stranded.
  */
 export async function drainQueue(
-  session: ProcessConversationContext,
+  conversation: ProcessConversationContext,
   reason: QueueDrainReason = "loop_complete",
 ): Promise<void> {
-  const next = session.queue.shift();
+  const next = conversation.queue.shift();
   if (!next) return;
 
   // Reset per-turn preactivation so a prior iteration (e.g. an unknown-slash
   // from a desktop source that skips runAgentLoop) can't leak CU preactivation
   // into the next queued message.
-  session.preactivatedSkillIds = undefined;
+  conversation.preactivatedSkillIds = undefined;
 
   log.info(
     {
-      conversationId: session.conversationId,
+      conversationId: conversation.conversationId,
       requestId: next.requestId,
       reason,
     },
     "Dequeuing message",
   );
-  session.traceEmitter.emit(
+  conversation.traceEmitter.emit(
     "request_dequeued",
     `Message dequeued (${reason})`,
     {
@@ -248,10 +250,10 @@ export async function drainQueue(
   );
   next.onEvent({
     type: "message_dequeued",
-    conversationId: session.conversationId,
+    conversationId: conversation.conversationId,
     requestId: next.requestId,
   });
-  session.emitActivityState(
+  conversation.emitActivityState(
     "thinking",
     "message_dequeued",
     "assistant_turn",
@@ -260,50 +262,52 @@ export async function drainQueue(
 
   const queuedTurnCtx = resolveQueuedTurnContext(
     next,
-    session.getTurnChannelContext(),
+    conversation.getTurnChannelContext(),
   );
   if (queuedTurnCtx) {
-    session.setTurnChannelContext(queuedTurnCtx);
+    conversation.setTurnChannelContext(queuedTurnCtx);
   }
 
   const queuedInterfaceCtx = resolveQueuedTurnInterfaceContext(
     next,
-    session.getTurnInterfaceContext(),
+    conversation.getTurnInterfaceContext(),
   );
   if (queuedInterfaceCtx) {
-    session.setTurnInterfaceContext(queuedInterfaceCtx);
+    conversation.setTurnInterfaceContext(queuedInterfaceCtx);
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools
   // via the desktop host proxy. Clear proxy availability so isAvailable()
   // returns false and tool execution falls back to local.
   if (next.isInteractive === false) {
-    session.clearProxyAvailability();
+    conversation.clearProxyAvailability();
   } else {
     // Restore proxy availability only for desktop-originating turns (macos/ios)
     // in case a prior non-interactive drain disabled it. Non-desktop interactive
     // interfaces (CLI, Vellum) should not re-enable desktop host proxies.
     const interfaceCtx =
-      queuedInterfaceCtx ?? session.getTurnInterfaceContext();
+      queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
     if (sourceInterface === "macos" || sourceInterface === "ios") {
-      session.restoreProxyAvailability();
-      session.addPreactivatedSkillId("computer-use");
+      conversation.restoreProxyAvailability();
+      conversation.addPreactivatedSkillId("computer-use");
     }
   }
 
   // Resolve slash commands for queued messages
   const slashResult = await resolveSlash(
     next.content,
-    buildSlashContext(session),
+    buildSlashContext(conversation),
   );
 
   // Unknown slash — persist the exchange and continue draining.
-  // Persist each message before pushing to session.messages so that a
+  // Persist each message before pushing to conversation.messages so that a
   // failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === "unknown") {
     try {
-      const drainProvenance = provenanceFromTrustContext(session.trustContext);
+      const drainProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
       const drainChannelMeta = {
         ...drainProvenance,
         ...(queuedTurnCtx
@@ -331,31 +335,31 @@ export async function drainQueue(
           )
         : JSON.stringify(userMsg.content);
       await addMessage(
-        session.conversationId,
+        conversation.conversationId,
         "user",
         contentToPersist,
         drainChannelMeta,
       );
-      session.messages.push(userMsg);
+      conversation.messages.push(userMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(
-        session.conversationId,
+        conversation.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
         drainChannelMeta,
       );
-      session.messages.push(assistantMsg);
+      conversation.messages.push(assistantMsg);
 
       if (queuedTurnCtx) {
         setConversationOriginChannelIfUnset(
-          session.conversationId,
+          conversation.conversationId,
           queuedTurnCtx.userMessageChannel,
         );
       }
       if (queuedInterfaceCtx) {
         setConversationOriginInterfaceIfUnset(
-          session.conversationId,
+          conversation.conversationId,
           queuedInterfaceCtx.userMessageInterface,
         );
       }
@@ -369,7 +373,7 @@ export async function drainQueue(
         next.onEvent(await buildModelInfoEvent());
       }
       next.onEvent({ type: "assistant_text_delta", text: slashResult.message });
-      session.traceEmitter.emit(
+      conversation.traceEmitter.emit(
         "message_complete",
         "Unknown slash command handled",
         {
@@ -379,19 +383,19 @@ export async function drainQueue(
       );
       next.onEvent({
         type: "message_complete",
-        conversationId: session.conversationId,
+        conversationId: conversation.conversationId,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(
         {
           err,
-          conversationId: session.conversationId,
+          conversationId: conversation.conversationId,
           requestId: next.requestId,
         },
         "Failed to persist unknown-slash exchange",
       );
-      session.traceEmitter.emit(
+      conversation.traceEmitter.emit(
         "request_error",
         `Unknown-slash persist failed: ${message}`,
         {
@@ -403,7 +407,7 @@ export async function drainQueue(
       next.onEvent({ type: "error", message });
     }
     // Continue draining regardless of success/failure
-    await drainQueue(session);
+    await drainQueue(conversation);
     return;
   }
 
@@ -419,13 +423,13 @@ export async function drainQueue(
     if (verificationIntent.kind === "direct_setup") {
       log.info(
         {
-          conversationId: session.conversationId,
+          conversationId: conversation.conversationId,
           channelHint: verificationIntent.channelHint,
         },
         "Verification session intent intercepted in queue — forcing skill flow",
       );
       agentLoopContent = verificationIntent.rewrittenContent;
-      session.preactivatedSkillIds = ["guardian-verify-setup"];
+      conversation.preactivatedSkillIds = ["guardian-verify-setup"];
     }
   }
 
@@ -435,7 +439,7 @@ export async function drainQueue(
   // resolves early (no runAgentLoop call), so we must continue draining.
   let userMessageId: string;
   try {
-    userMessageId = await session.persistUserMessage(
+    userMessageId = await conversation.persistUserMessage(
       resolvedContent,
       next.attachments,
       next.requestId,
@@ -447,12 +451,12 @@ export async function drainQueue(
     log.error(
       {
         err,
-        conversationId: session.conversationId,
+        conversationId: conversation.conversationId,
         requestId: next.requestId,
       },
       "Failed to persist queued message",
     );
-    session.traceEmitter.emit(
+    conversation.traceEmitter.emit(
       "request_error",
       `Queued message persist failed: ${message}`,
       {
@@ -463,19 +467,19 @@ export async function drainQueue(
     );
     next.onEvent({ type: "error", message });
     // runAgentLoop never ran, so its finally block won't clear this
-    session.preactivatedSkillIds = undefined;
+    conversation.preactivatedSkillIds = undefined;
     // Continue draining — don't strand remaining messages
-    await drainQueue(session);
+    await drainQueue(conversation);
     return;
   }
 
   // Set the active surface for the dequeued message so runAgentLoop can inject context
-  session.currentActiveSurfaceId = next.activeSurfaceId;
-  session.currentPage = next.currentPage;
+  conversation.currentActiveSurfaceId = next.activeSurfaceId;
+  conversation.currentPage = next.currentPage;
 
   // Fire-and-forget: detect notification preferences in the queued message
   // and persist any that are found, mirroring the logic in processMessage.
-  if (session.assistantId) {
+  if (conversation.assistantId) {
     extractPreferences(resolvedContent)
       .then((result) => {
         if (!result.detected) return;
@@ -489,7 +493,7 @@ export async function drainQueue(
         log.info(
           {
             count: result.preferences.length,
-            conversationId: session.conversationId,
+            conversationId: conversation.conversationId,
           },
           "Persisted extracted notification preferences (queued)",
         );
@@ -497,13 +501,13 @@ export async function drainQueue(
       .catch((err) => {
         const errMsg = err instanceof Error ? err.message : String(err);
         log.warn(
-          { err: errMsg, conversationId: session.conversationId },
+          { err: errMsg, conversationId: conversation.conversationId },
           "Background preference extraction failed (queued)",
         );
       });
   }
 
-  // Fire-and-forget: persistUserMessage set session.processing = true
+  // Fire-and-forget: persistUserMessage set conversation.processing = true
   // so subsequent messages will still be enqueued.
   // runAgentLoop's finally block will call drainQueue when this run completes.
   const drainLoopOptions: {
@@ -516,7 +520,7 @@ export async function drainQueue(
   if (agentLoopContent !== resolvedContent)
     drainLoopOptions.titleText = resolvedContent;
 
-  session
+  conversation
     .runAgentLoop(
       agentLoopContent,
       userMessageId,
@@ -528,7 +532,7 @@ export async function drainQueue(
       log.error(
         {
           err,
-          conversationId: session.conversationId,
+          conversationId: conversation.conversationId,
           requestId: next.requestId,
         },
         "Error processing queued message",
@@ -547,7 +551,7 @@ export async function drainQueue(
  * in a single call. Used by the message-handler path where blocking is expected.
  */
 export async function processMessage(
-  session: ProcessConversationContext,
+  conversation: ProcessConversationContext,
   content: string,
   attachments: UserMessageAttachment[],
   onEvent: (msg: ServerMessage) => void,
@@ -557,14 +561,14 @@ export async function processMessage(
   options?: { isInteractive?: boolean },
   displayContent?: string,
 ): Promise<string> {
-  await session.ensureActorScopedHistory();
-  session.currentActiveSurfaceId = activeSurfaceId;
-  session.currentPage = currentPage;
+  await conversation.ensureActorScopedHistory();
+  conversation.currentActiveSurfaceId = activeSurfaceId;
+  conversation.currentPage = currentPage;
   const trimmedContent = content.trim();
   const canonicalPendingRequestHintIdsForConversation =
     trimmedContent.length > 0
       ? listPendingRequestsByConversationScope(
-          session.conversationId,
+          conversation.conversationId,
           "vellum",
         ).map((request) => request.id)
       : [];
@@ -573,8 +577,8 @@ export async function processMessage(
       ? canonicalPendingRequestHintIdsForConversation
       : undefined;
 
-  // ── Canonical guardian reply router (desktop/session path) ──
-  // Desktop/session guardian replies are canonical-only. Messages consumed
+  // ── Canonical guardian reply router (desktop/conversation path) ──
+  // Desktop/conversation guardian replies are canonical-only. Messages consumed
   // by the router never hit the general agent loop.
   if (trimmedContent.length > 0) {
     const routerResult = await routeGuardianReply({
@@ -582,13 +586,13 @@ export async function processMessage(
       channel: "vellum",
       actor: {
         actorPrincipalId:
-          session.trustContext?.guardianPrincipalId ?? undefined,
-        actorExternalUserId: session.trustContext?.guardianExternalUserId,
+          conversation.trustContext?.guardianPrincipalId ?? undefined,
+        actorExternalUserId: conversation.trustContext?.guardianExternalUserId,
         channel: "vellum",
         guardianPrincipalId:
-          session.trustContext?.guardianPrincipalId ?? undefined,
+          conversation.trustContext?.guardianPrincipalId ?? undefined,
       },
-      conversationId: session.conversationId,
+      conversationId: conversation.conversationId,
       pendingRequestIds: canonicalPendingRequestIdsForConversation,
       // Desktop path: disable NL classification to avoid consuming non-decision
       // messages while a tool confirmation is pending. Deterministic code-prefix
@@ -597,7 +601,7 @@ export async function processMessage(
     });
 
     if (routerResult.consumed) {
-      const guardianIfCtx = session.getTurnInterfaceContext();
+      const guardianIfCtx = conversation.getTurnInterfaceContext();
       const routerChannelMeta = {
         userMessageChannel: "vellum" as const,
         assistantMessageChannel: "vellum" as const,
@@ -609,12 +613,12 @@ export async function processMessage(
 
       const userMsg = createUserMessage(content, attachments);
       const persisted = await addMessage(
-        session.conversationId,
+        conversation.conversationId,
         "user",
         JSON.stringify(userMsg.content),
         routerChannelMeta,
       );
-      session.messages.push(userMsg);
+      conversation.messages.push(userMsg);
 
       const replyText =
         routerResult.replyText ??
@@ -623,22 +627,22 @@ export async function processMessage(
           : "Request already resolved.");
       const assistantMsg = createAssistantMessage(replyText);
       await addMessage(
-        session.conversationId,
+        conversation.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
         routerChannelMeta,
       );
-      session.messages.push(assistantMsg);
+      conversation.messages.push(assistantMsg);
 
       onEvent({ type: "assistant_text_delta", text: replyText });
       onEvent({
         type: "message_complete",
-        conversationId: session.conversationId,
+        conversationId: conversation.conversationId,
       });
 
       log.info(
         {
-          conversationId: session.conversationId,
+          conversationId: conversation.conversationId,
           routerType: routerResult.type,
           requestId: routerResult.requestId,
         },
@@ -650,15 +654,18 @@ export async function processMessage(
   }
 
   // Resolve slash commands before persistence
-  const slashResult = await resolveSlash(content, buildSlashContext(session));
+  const slashResult = await resolveSlash(
+    content,
+    buildSlashContext(conversation),
+  );
 
   // Unknown slash command — persist the exchange (user + assistant) so the
-  // messageId is real.  Persist each message before pushing to session.messages
+  // messageId is real.  Persist each message before pushing to conversation.messages
   // so that a failed write never leaves an unpersisted message in memory.
   if (slashResult.kind === "unknown") {
-    const pmTurnCtx = session.getTurnChannelContext();
-    const pmInterfaceCtx = session.getTurnInterfaceContext();
-    const pmProvenance = provenanceFromTrustContext(session.trustContext);
+    const pmTurnCtx = conversation.getTurnChannelContext();
+    const pmInterfaceCtx = conversation.getTurnInterfaceContext();
+    const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
     const pmChannelMeta = {
       ...pmProvenance,
       ...(pmTurnCtx
@@ -682,31 +689,31 @@ export async function processMessage(
       ? JSON.stringify(createUserMessage(displayContent, attachments).content)
       : JSON.stringify(userMsg.content);
     const persisted = await addMessage(
-      session.conversationId,
+      conversation.conversationId,
       "user",
       contentToPersist,
       pmChannelMeta,
     );
-    session.messages.push(userMsg);
+    conversation.messages.push(userMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
     await addMessage(
-      session.conversationId,
+      conversation.conversationId,
       "assistant",
       JSON.stringify(assistantMsg.content),
       pmChannelMeta,
     );
-    session.messages.push(assistantMsg);
+    conversation.messages.push(assistantMsg);
 
     if (pmTurnCtx) {
       setConversationOriginChannelIfUnset(
-        session.conversationId,
+        conversation.conversationId,
         pmTurnCtx.userMessageChannel,
       );
     }
     if (pmInterfaceCtx) {
       setConversationOriginInterfaceIfUnset(
-        session.conversationId,
+        conversation.conversationId,
         pmInterfaceCtx.userMessageInterface,
       );
     }
@@ -717,7 +724,7 @@ export async function processMessage(
       onEvent(await buildModelInfoEvent());
     }
     onEvent({ type: "assistant_text_delta", text: slashResult.message });
-    session.traceEmitter.emit(
+    conversation.traceEmitter.emit(
       "message_complete",
       "Unknown slash command handled",
       {
@@ -727,7 +734,7 @@ export async function processMessage(
     );
     onEvent({
       type: "message_complete",
-      conversationId: session.conversationId,
+      conversationId: conversation.conversationId,
     });
     return persisted.id;
   }
@@ -746,19 +753,19 @@ export async function processMessage(
     if (verificationIntent.kind === "direct_setup") {
       log.info(
         {
-          conversationId: session.conversationId,
+          conversationId: conversation.conversationId,
           channelHint: verificationIntent.channelHint,
         },
         "Verification session intent intercepted — forcing skill flow",
       );
       agentLoopContent = verificationIntent.rewrittenContent;
-      session.preactivatedSkillIds = ["guardian-verify-setup"];
+      conversation.preactivatedSkillIds = ["guardian-verify-setup"];
     }
   }
 
   let userMessageId: string;
   try {
-    userMessageId = await session.persistUserMessage(
+    userMessageId = await conversation.persistUserMessage(
       resolvedContent,
       attachments,
       requestId,
@@ -769,14 +776,14 @@ export async function processMessage(
     const message = err instanceof Error ? err.message : String(err);
     onEvent({ type: "error", message });
     // runAgentLoop never ran, so its finally block won't clear this
-    session.preactivatedSkillIds = undefined;
+    conversation.preactivatedSkillIds = undefined;
     return "";
   }
 
   // Fire-and-forget: detect notification preferences in the user message
   // and persist any that are found. Runs in the background so it doesn't
   // block the main conversation flow.
-  if (session.assistantId) {
+  if (conversation.assistantId) {
     extractPreferences(resolvedContent)
       .then((result) => {
         if (!result.detected) return;
@@ -790,7 +797,7 @@ export async function processMessage(
         log.info(
           {
             count: result.preferences.length,
-            conversationId: session.conversationId,
+            conversationId: conversation.conversationId,
           },
           "Persisted extracted notification preferences",
         );
@@ -798,7 +805,7 @@ export async function processMessage(
       .catch((err) => {
         const errMsg = err instanceof Error ? err.message : String(err);
         log.warn(
-          { err: errMsg, conversationId: session.conversationId },
+          { err: errMsg, conversationId: conversation.conversationId },
           "Background preference extraction failed",
         );
       });
@@ -814,7 +821,7 @@ export async function processMessage(
   if (agentLoopContent !== resolvedContent)
     loopOptions.titleText = resolvedContent;
 
-  await session.runAgentLoop(
+  await conversation.runAgentLoop(
     agentLoopContent,
     userMessageId,
     onEvent,

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -15,7 +15,7 @@ import type {
   UserMessageAttachment,
 } from "./message-protocol.js";
 
-const log = getLogger("session-queue");
+const log = getLogger("conversation-queue");
 
 export interface QueuedMessage {
   content: string;
@@ -34,9 +34,9 @@ export interface QueuedMessage {
 }
 
 /**
- * Maximum total estimated bytes across all queued messages per session.
+ * Maximum total estimated bytes across all queued messages per conversation.
  * Limits memory consumption when a sender floods messages while the
- * session is busy.  50 MB is well above any legitimate usage.
+ * conversation is busy.  50 MB is well above any legitimate usage.
  */
 export const DEFAULT_MAX_QUEUE_BYTES = 50 * 1024 * 1024; // 50 MB
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -42,11 +42,11 @@ export interface ChannelCapabilities {
 }
 
 /**
- * Runtime trust context for an inbound actor session.
+ * Runtime trust context for an inbound actor conversation.
  *
  * Carries the resolved trust classification, guardian binding metadata, and
- * requester identity for the current session. This is the canonical trust
- * shape used by sessions, tool execution, memory gating, and channel routing.
+ * requester identity for the current conversation. This is the canonical trust
+ * shape used by conversations, tool execution, memory gating, and channel routing.
  *
  * Produced by {@link resolveActorTrust} -> {@link toTrustContext}, or by
  * the convenience wrapper {@link resolveTrustContext}.
@@ -582,7 +582,7 @@ export function injectActiveSurfaceContext(
 /**
  * Append voice call-control protocol instructions to the last user
  * message so the model knows how to emit control markers during voice
- * turns routed through the session pipeline.
+ * turns routed through the conversation pipeline.
  */
 export function injectVoiceCallControlContext(
   message: Message,
@@ -1138,7 +1138,7 @@ export function applyRuntimeInjections(
   const mode = options.mode ?? "full";
   let result = runMessages;
 
-  // For non-interactive sessions (scheduled jobs, work items), instruct the
+  // For non-interactive conversations (scheduled jobs, work items), instruct the
   // model to never ask for clarification — there is no human present to answer.
   if (options.isNonInteractive) {
     const userTail = result[result.length - 1];

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -29,7 +29,7 @@ import {
 import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory.js";
 import { getLogger } from "../util/logger.js";
 
-const log = getLogger("session-skill-tools");
+const log = getLogger("conversation-skill-tools");
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -46,7 +46,7 @@ export interface SkillToolProjection {
  * Conversation-scoped cache for skill projection. Avoids re-scanning the entire
  * conversation history and re-reading the filesystem on every agent turn.
  *
- * Each session should own its own cache instance to prevent cross-session
+ * Each conversation should own its own cache instance to prevent cross-conversation
  * state bleed.
  */
 export interface SkillProjectionCache {
@@ -63,7 +63,7 @@ export interface SkillProjectionCache {
     /** The accumulated active skill entries. */
     entries: ActiveSkillEntry[];
   };
-  /** Cached skill catalog. Invalidated when the session is marked stale
+  /** Cached skill catalog. Invalidated when the conversation is marked stale
    *  (e.g. skill directories changed on disk while a run is in progress). */
   catalog?: SkillSummary[];
 }
@@ -73,9 +73,9 @@ export interface ProjectSkillToolsOptions {
   preactivatedSkillIds?: string[];
   /**
    * Conversation-scoped tracking map of previously active skill IDs to their
-   * version hashes. Each session should own its own map to prevent
-   * cross-session state bleed when the daemon serves multiple concurrent
-   * sessions. When a skill's hash changes between turns, its tools are
+   * version hashes. Each conversation should own its own map to prevent
+   * cross-conversation state bleed when the daemon serves multiple concurrent
+   * conversations. When a skill's hash changes between turns, its tools are
    * unregistered and re-registered with the updated definitions.
    */
   previouslyActiveSkillIds?: Map<string, string>;
@@ -122,7 +122,7 @@ function loadManifestForSkill(skill: SkillSummary): SkillToolManifest | null {
 /**
  * Return active skill entries, using the projection cache when available.
  *
- * History is append-only within a session (messages are only added, never
+ * History is append-only within a conversation (messages are only added, never
  * mutated in place). If history.length hasn't changed since the last scan,
  * the cached result is returned immediately. If new messages were appended,
  * only the delta is scanned and merged. If history shrank (e.g. compression
@@ -192,8 +192,8 @@ function getCachedActiveSkills(
 /**
  * Return the skill catalog, caching it across agent turns.
  *
- * The cache is invalidated when the session is marked stale (e.g. skill
- * directories changed on disk while the session is still processing).
+ * The cache is invalidated when the conversation is marked stale (e.g. skill
+ * directories changed on disk while the conversation is still processing).
  */
 function getCachedCatalog(cache?: SkillProjectionCache): SkillSummary[] {
   if (!cache) return loadSkillCatalog();
@@ -209,7 +209,7 @@ function getCachedCatalog(cache?: SkillProjectionCache): SkillSummary[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute the set of active skill tools for the current session turn.
+ * Compute the set of active skill tools for the current conversation turn.
  *
  * 1. Derives active skill IDs from conversation history markers.
  * 2. Merges with any preactivated IDs (union).
@@ -240,7 +240,7 @@ export function projectSkillTools(
   const contextIds = contextEntries.map((e) => e.id);
   const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
 
-  // Load the catalog (cached for session lifetime) and index by ID
+  // Load the catalog (cached for conversation lifetime) and index by ID
   const catalog = getCachedCatalog(options?.cache);
   const catalogById = new Map<string, SkillSummary>();
   for (const skill of catalog) {
@@ -398,7 +398,7 @@ export function projectSkillTools(
     }
   }
 
-  // Update the session-scoped tracking map in-place — only include skills
+  // Update the conversation-scoped tracking map in-place — only include skills
   // that were successfully processed so failed skills can be retried next turn.
   prevActive.clear();
   for (const [id, hash] of successfulEntries) {
@@ -413,7 +413,7 @@ export function projectSkillTools(
 
 /**
  * Reset the projection state and unregister all skill tools tracked in the
- * given map. Used for session teardown and tests.
+ * given map. Used for conversation teardown and tests.
  */
 export function resetSkillToolProjection(
   trackedIds?: Map<string, string>,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -19,7 +19,7 @@ import type {
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
 
-const log = getLogger("session-surfaces");
+const log = getLogger("conversation-surfaces");
 
 const MAX_UNDO_DEPTH = 10;
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
@@ -590,7 +590,7 @@ export function handleSurfaceAction(
     if (result.queued) {
       log.info(
         { surfaceId, actionId, requestId },
-        "Relay prompt queued (session busy, history-restored)",
+        "Relay prompt queued (conversation busy, history-restored)",
       );
       return;
     }
@@ -632,7 +632,7 @@ export function handleSurfaceAction(
   }
 
   // content_changed is a non-terminal state update for document auto-save
-  // Save the document content and don't forward to the session
+  // Save the document content and don't forward to the conversation
   if (actionId === "content_changed") {
     handleDocumentContentChanged(ctx, surfaceId, data);
     return;
@@ -745,7 +745,7 @@ export function handleSurfaceAction(
     }
     log.info(
       { surfaceId, actionId, requestId },
-      "Surface action queued (session busy)",
+      "Surface action queued (conversation busy)",
     );
     ctx.traceEmitter.emit(
       "request_queued",
@@ -827,7 +827,7 @@ export function refreshSurfacesForApp(
     };
     stored.data = updatedData;
 
-    // Keep the persisted snapshot in sync so updates survive session restart.
+    // Keep the persisted snapshot in sync so updates survive conversation restart.
     const idx = ctx.currentTurnSurfaces.findIndex(
       (s) => s.surfaceId === surfaceId,
     );
@@ -1147,7 +1147,7 @@ export async function surfaceProxyResolver(
       data: mergedData,
     });
 
-    // Keep the persisted snapshot in sync so updates survive session restart.
+    // Keep the persisted snapshot in sync so updates survive conversation restart.
     const idx = ctx.currentTurnSurfaces.findIndex(
       (s) => s.surfaceId === surfaceId,
     );
@@ -1201,7 +1201,7 @@ export async function surfaceProxyResolver(
     if (!app) return { content: `App not found: ${appId}`, isError: true };
     // Generate a minimal fallback preview from app metadata so that the
     // surface is always rendered as a clickable preview card (not an
-    // un-clickable fallback chip) after session restart.
+    // un-clickable fallback chip) after conversation restart.
     const defaultPreview = { title: app.name, subtitle: app.description };
 
     const storedPreview = getAppPreview(app.id);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -58,7 +58,7 @@ import {
 import type { ServerMessage, UiSurfaceShow } from "./message-protocol.js";
 import { runPostExecutionSideEffects } from "./tool-side-effects.js";
 
-const log = getLogger("session-tool-setup");
+const log = getLogger("conversation-tool-setup");
 
 /**
  * Resolve the effective trust class for tool execution.
@@ -66,7 +66,7 @@ const log = getLogger("session-tool-setup");
  * When HTTP auth is disabled (dev bypass), always returns `'guardian'`
  * so that control-plane gates don't block local development.
  *
- * When no trust context is available (e.g. desktop-only sessions that
+ * When no trust context is available (e.g. desktop-only conversations that
  * don't go through channel trust resolution), defaults to `'unknown'`
  * to fail-closed.
  */
@@ -95,15 +95,15 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   allowedToolNames?: Set<string>;
   /** Conversation memory policy — used to propagate scopeId and strictSideEffects into ToolContext. */
   memoryPolicy: { scopeId: string; strictSideEffects: boolean };
-  /** True when the session has no connected client (HTTP-only path). */
+  /** True when the conversation has no connected client (HTTP-only path). */
   hasNoClient?: boolean;
-  /** When true, the session is executing a task run and must not become interactive. */
+  /** When true, the conversation is executing a task run and must not become interactive. */
   headlessLock?: boolean;
-  /** When set, this session is executing a task run. Used to retrieve ephemeral permission rules. */
+  /** When set, this conversation is executing a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
-  /** Guardian runtime context for the session — trustClass is propagated into ToolContext for control-plane policy enforcement. */
+  /** Guardian runtime context for the conversation — trustClass is propagated into ToolContext for control-plane policy enforcement. */
   trustContext?: TrustContext;
-  /** Voice/call session ID, if the session originates from a call. Propagated into ToolContext for scoped grant consumption. */
+  /** Voice/call session ID, if the conversation originates from a call. Propagated into ToolContext for scoped grant consumption. */
   callSessionId?: string;
   /** Optional proxy for delegating host_bash execution to a connected client. */
   hostBashProxy?: import("./host-bash-proxy.js").HostBashProxy;
@@ -148,7 +148,7 @@ export function createToolExecutor(
   onOutput?: (chunk: string) => void,
   toolUseId?: string,
 ) => Promise<ToolExecutionResult> {
-  // Register the session's sendToClient for browser screencast surface messages
+  // Register the conversation's sendToClient for browser screencast surface messages
   registerSessionSender(ctx.conversationId, (msg) => ctx.sendToClient(msg));
 
   return async (
@@ -455,7 +455,7 @@ export function createProxyApprovalCallback(
 
     const scopeOptions = generateScopeOptions(ctx.workingDir);
 
-    // Non-interactive sessions have no client to prompt — fast-deny to avoid
+    // Non-interactive conversations have no client to prompt — fast-deny to avoid
     // blocking for the full permission timeout before auto-denying.
     if (ctx.hasNoClient) {
       return false;
@@ -534,7 +534,7 @@ export function createProxyApprovalCallback(
 /**
  * Bundled skills that must always be active regardless of conversation
  * history or explicit preactivation. Without this, their tools are
- * unavailable in fresh sessions until `skill_load` is called.
+ * unavailable in fresh conversations until `skill_load` is called.
  */
 const DEFAULT_PREACTIVATED_SKILL_IDS = ["tasks", "notifications"];
 
@@ -576,7 +576,7 @@ const PLATFORM_TOOL_NAMES = new Set(["request_system_permission"]);
 
 /**
  * Determine whether a tool should be included in the LLM tool definitions
- * for the current turn based on session context. Tools not active for the
+ * for the current turn based on conversation context. Tools not active for the
  * current context are omitted from the definitions sent to the provider,
  * reducing noise and preventing the model from attempting calls that would
  * fail.
@@ -612,11 +612,11 @@ export function isToolActiveForContext(
  * allowedToolNames so newly-activated skill tools aren't blocked by
  * the executor's stale gate.
  *
- * Core (non-MCP) tool definitions are captured at session creation and
+ * Core (non-MCP) tool definitions are captured at conversation creation and
  * reused on each turn. MCP tool definitions are re-read from the global
- * registry on each turn so that tools registered after session creation
+ * registry on each turn so that tools registered after conversation creation
  * (e.g. via `vellum mcp reload`) are automatically picked up without
- * requiring session disposal or app restart.
+ * requiring conversation disposal or app restart.
  */
 export function createResolveToolsCallback(
   toolDefs: ToolDefinition[],
@@ -647,14 +647,14 @@ export function createResolveToolsCallback(
       return [];
     }
 
-    // Filter core tools based on current session context so that tools
+    // Filter core tools based on current conversation context so that tools
     // irrelevant to this turn (e.g. UI tools when no client is connected)
     // are omitted from the definitions sent to the provider.
     const filteredCoreDefs = coreToolDefs.filter((d) =>
       isToolActiveForContext(d.name, ctx),
     );
 
-    // Re-read MCP tool definitions from the registry each turn so sessions
+    // Re-read MCP tool definitions from the registry each turn so conversations
     // automatically pick up tools added/removed by `vellum mcp reload`.
     const currentMcpDefs = getMcpToolDefinitions();
     log.debug(

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -11,7 +11,7 @@ import { getLogger } from "../util/logger.js";
 import { resolvePricingForUsageWithOverrides } from "../util/pricing.js";
 import type { ServerMessage, UsageStats } from "./message-protocol.js";
 
-const log = getLogger("session-usage");
+const log = getLogger("conversation-usage");
 
 export interface UsageContext {
   conversationId: string;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -252,7 +252,7 @@ export class Conversation {
     this.prompter = new PermissionPrompter(sendToClient);
     this.prompter.setOnStateChanged((requestId, state, source, toolUseId) => {
       // Route through emitConfirmationStateChanged so the event reaches
-      // the client via sendToClient (wired to the SSE hub for HTTP sessions).
+      // the client via sendToClient (wired to the SSE hub for HTTP conversations).
       this.emitConfirmationStateChanged({
         conversationId: this.conversationId,
         requestId,
@@ -379,7 +379,7 @@ export class Conversation {
     await loadFromDbImpl(this);
     // Scan loaded history for attachment content blocks so that asset
     // tools are available when resuming a conversation that already had
-    // attachments. One-way: once true it stays true for the session.
+    // attachments. One-way: once true it stays true for the conversation.
     // Also picks up the hasAttachments flag set by loadFromDbImpl which
     // scans compacted (sliced-off) messages that aren't in this.messages.
     if (!this.hasAttachments && messagesContainAttachments(this.messages)) {
@@ -879,7 +879,7 @@ export class Conversation {
       await this.ensureActorScopedHistory();
     }
     // One-way flag: once an attachment arrives, asset tools stay available
-    // for the remainder of the session.
+    // for the remainder of the conversation.
     if (!this.hasAttachments && attachments.length > 0) {
       this.hasAttachments = true;
     }

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -111,14 +111,14 @@ export async function setModel(
   const config = getConfig();
   await initializeProviders(config);
 
-  // Evict idle sessions immediately; mark busy ones as stale so they
+  // Evict idle conversations immediately; mark busy ones as stale so they
   // get recreated with the new provider once they finish processing.
-  for (const [id, session] of ctx.conversations) {
-    if (!session.isProcessing()) {
-      session.dispose();
+  for (const [id, conversation] of ctx.conversations) {
+    if (!conversation.isProcessing()) {
+      conversation.dispose();
       ctx.conversations.delete(id);
     } else {
-      session.markStale();
+      conversation.markStale();
     }
   }
 

--- a/assistant/src/daemon/handlers/config-voice.ts
+++ b/assistant/src/daemon/handlers/config-voice.ts
@@ -194,7 +194,7 @@ export function normalizeActivationKey(
 }
 
 /**
- * Process a voice configuration update request from a session or client.
+ * Process a voice configuration update request from a conversation or client.
  * Validates the activation key and broadcasts the change to all connected clients.
  */
 export function handleVoiceConfigUpdate(
@@ -213,4 +213,3 @@ export function handleVoiceConfigUpdate(
     "Voice config updated: activation key",
   );
 }
-

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -77,12 +77,12 @@ export function makeEventSender(params: {
   conversationId: string;
   sourceChannel: string;
 }): (event: ServerMessage) => void {
-  const { ctx, session, conversationId, sourceChannel } = params;
+  const { ctx, session: conversation, conversationId, sourceChannel } = params;
 
   return (event: ServerMessage) => {
     if (event.type === "confirmation_request") {
       pendingInteractions.register(event.requestId, {
-        session,
+        session: conversation,
         conversationId,
         kind: "confirmation",
         confirmationDetails: {
@@ -98,7 +98,7 @@ export function makeEventSender(params: {
       });
 
       try {
-        const trustContext = session.trustContext;
+        const trustContext = conversation.trustContext;
         createCanonicalGuardianRequest({
           id: event.requestId,
           kind: "tool_approval",
@@ -119,25 +119,25 @@ export function makeEventSender(params: {
       }
     } else if (event.type === "secret_request") {
       pendingInteractions.register(event.requestId, {
-        session,
+        session: conversation,
         conversationId,
         kind: "secret",
       });
     } else if (event.type === "host_bash_request") {
       pendingInteractions.register(event.requestId, {
-        session,
+        session: conversation,
         conversationId,
         kind: "host_bash",
       });
     } else if (event.type === "host_file_request") {
       pendingInteractions.register(event.requestId, {
-        session,
+        session: conversation,
         conversationId,
         kind: "host_file",
       });
     } else if (event.type === "host_cu_request") {
       pendingInteractions.register(event.requestId, {
-        session,
+        session: conversation,
         conversationId,
         kind: "host_cu",
       });
@@ -151,13 +151,13 @@ export function handleConfirmationResponse(
   msg: ConfirmationResponse,
   ctx: HandlerContext,
 ): void {
-  // Route by requestId to the session that originated the prompt, not by
-  // the current session binding which may have changed since the
-  // request was issued (e.g. after a session switch).
-  for (const [conversationId, session] of ctx.conversations) {
-    if (session.hasPendingConfirmation(msg.requestId)) {
+  // Route by requestId to the conversation that originated the prompt, not by
+  // the current conversation binding which may have changed since the
+  // request was issued (e.g. after a conversation switch).
+  for (const [conversationId, conversation] of ctx.conversations) {
+    if (conversation.hasPendingConfirmation(msg.requestId)) {
       ctx.touchConversation(conversationId);
-      session.handleConfirmationResponse(
+      conversation.handleConfirmationResponse(
         msg.requestId,
         msg.decision,
         msg.selectedPattern,
@@ -173,7 +173,7 @@ export function handleConfirmationResponse(
 
   log.warn(
     { requestId: msg.requestId },
-    "No session found with pending confirmation for requestId",
+    "No conversation found with pending confirmation for requestId",
   );
 }
 
@@ -181,8 +181,8 @@ export function handleSecretResponse(
   msg: SecretResponse,
   ctx: HandlerContext,
 ): void {
-  // Check standalone (non-session) prompts first, since they use a dedicated
-  // requestId that won't collide with session prompts.
+  // Check standalone (non-conversation) prompts first, since they use a dedicated
+  // requestId that won't collide with conversation prompts.
   const standalone = pendingStandaloneSecrets.get(msg.requestId);
   if (standalone) {
     clearTimeout(standalone.timer);
@@ -195,30 +195,30 @@ export function handleSecretResponse(
     return;
   }
 
-  // Route by requestId to the session that originated the prompt, not by
-  // the current session binding which may have changed since the
-  // request was issued (e.g. after a session switch).
-  for (const [conversationId, session] of ctx.conversations) {
-    if (session.hasPendingSecret(msg.requestId)) {
+  // Route by requestId to the conversation that originated the prompt, not by
+  // the current conversation binding which may have changed since the
+  // request was issued (e.g. after a conversation switch).
+  for (const [conversationId, conversation] of ctx.conversations) {
+    if (conversation.hasPendingSecret(msg.requestId)) {
       ctx.touchConversation(conversationId);
-      session.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
+      conversation.handleSecretResponse(msg.requestId, msg.value, msg.delivery);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
   }
   log.warn(
     { requestId: msg.requestId },
-    "No session found with pending secret prompt for requestId",
+    "No conversation found with pending secret prompt for requestId",
   );
 }
 
 /**
- * Clear all conversations and DB conversations. Returns the number of sessions cleared.
+ * Clear all conversations and DB conversations. Returns the number of conversations cleared.
  */
 export function clearAllConversations(ctx: HandlerContext): number {
   const cleared = ctx.clearAllConversations();
   // Also clear DB conversations. When a new local connection triggers
-  // sendInitialSession, it auto-creates a conversation if none exist.
+  // sendInitialConversation, it auto-creates a conversation if none exist.
   // Without this DB clear, that auto-created row survives, contradicting
   // the "clear all conversations" intent.
   clearAll();
@@ -236,7 +236,7 @@ export async function handleConversationCreate(
     title,
     conversationType,
   });
-  const session = await ctx.getOrCreateConversation(conversation.id, {
+  const conversationObj = await ctx.getOrCreateConversation(conversation.id, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
     transport: msg.transport,
@@ -245,7 +245,7 @@ export async function handleConversationCreate(
   // Pre-activate skills before sending conversation_info so they're available
   // for the initial message processing.
   if (msg.preactivatedSkillIds?.length) {
-    session.setPreactivatedSkillIds(msg.preactivatedSkillIds);
+    conversationObj.setPreactivatedSkillIds(msg.preactivatedSkillIds);
   }
 
   ctx.send({
@@ -283,17 +283,17 @@ export async function handleConversationCreate(
       parseChannelId(msg.transport?.channelId) ?? "vellum";
     const sendEvent = makeEventSender({
       ctx,
-      session,
+      session: conversationObj,
       conversationId: conversation.id,
       sourceChannel: transportChannel,
     });
-    session.setTurnChannelContext({
+    conversationObj.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,
     });
     const transportInterface: InterfaceId =
       parseInterfaceId(msg.transport?.interfaceId) ?? "vellum";
-    session.setTurnInterfaceContext({
+    conversationObj.setTurnInterfaceContext({
       userMessageInterface: transportInterface,
       assistantMessageInterface: transportInterface,
     });
@@ -304,19 +304,19 @@ export async function handleConversationCreate(
       const proxy = new HostBashProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });
-      session.setHostBashProxy(proxy);
+      conversationObj.setHostBashProxy(proxy);
       const fileProxy = new HostFileProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });
-      session.setHostFileProxy(fileProxy);
+      conversationObj.setHostFileProxy(fileProxy);
       const cuProxy = new HostCuProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });
-      session.setHostCuProxy(cuProxy);
-      session.addPreactivatedSkillId("computer-use");
+      conversationObj.setHostCuProxy(cuProxy);
+      conversationObj.addPreactivatedSkillId("computer-use");
     }
-    session.updateClient(sendEvent, false);
-    session
+    conversationObj.updateClient(sendEvent, false);
+    conversationObj
       .processMessage(msg.initialMessage, [], sendEvent, requestId)
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -366,13 +366,13 @@ export async function switchConversation(
     return null;
   }
 
-  // If the target session is headless-locked (actively executing a task run),
+  // If the target conversation is headless-locked (actively executing a task run),
   // skip rebinding so tool confirmations stay suppressed.
-  const existingSession = ctx.conversations.get(conversationId);
-  const isHeadlessLocked = existingSession?.headlessLock;
+  const existingConversation = ctx.conversations.get(conversationId);
+  const isHeadlessLocked = existingConversation?.headlessLock;
 
   if (isHeadlessLocked) {
-    // Load the session without rebinding the client — the session stays headless
+    // Load the conversation without rebinding the client — the conversation stays headless
     await ctx.getOrCreateConversation(conversationId);
   } else {
     await ctx.getOrCreateConversation(conversationId);
@@ -441,19 +441,19 @@ export function handleConversationRename(
 }
 
 /**
- * Cancel generation for a session. Returns true if a session was found and cancelled.
+ * Cancel generation for a conversation. Returns true if a conversation was found and cancelled.
  */
 export function cancelGeneration(
   conversationId: string,
   ctx: HandlerContext,
 ): boolean {
-  const session = ctx.conversations.get(conversationId);
-  if (!session) {
+  const conversation = ctx.conversations.get(conversationId);
+  if (!conversation) {
     return false;
   }
   ctx.touchConversation(conversationId);
-  session.abort();
-  // Also abort any child subagents spawned by this session.
+  conversation.abort();
+  // Also abort any child subagents spawned by this conversation.
   // Omit sendToClient to suppress parent notifications — the parent is
   // being cancelled, so enqueuing synthetic messages would trigger
   // unwanted model activity after the user pressed stop.
@@ -462,8 +462,8 @@ export function cancelGeneration(
 }
 
 /**
- * Undo the last message in a session. Returns the removed count, or null if
- * the conversation does not exist. Restores evicted sessions from the database.
+ * Undo the last message in a conversation. Returns the removed count, or null if
+ * the conversation does not exist. Restores evicted conversations from the database.
  */
 export async function undoLastMessage(
   conversationId: string,
@@ -474,9 +474,9 @@ export async function undoLastMessage(
     return null;
   }
   conversationId = resolvedId;
-  const session = await ctx.getOrCreateConversation(conversationId);
+  const conversation = await ctx.getOrCreateConversation(conversationId);
   ctx.touchConversation(conversationId);
-  const removedCount = session.undo();
+  const removedCount = conversation.undo();
   return { removedCount };
 }
 
@@ -497,9 +497,9 @@ export async function handleUndo(
 }
 
 /**
- * Regenerate the last assistant response for a session. The caller provides
+ * Regenerate the last assistant response for a conversation. The caller provides
  * a `sendEvent` callback for delivering streaming events via HTTP/SSE.
- * Returns null if the conversation does not exist. Restores evicted sessions
+ * Returns null if the conversation does not exist. Restores evicted conversations
  * from the database when needed. Throws on regeneration errors.
  */
 export async function regenerateResponse(
@@ -508,35 +508,39 @@ export async function regenerateResponse(
   sendEvent: (event: ServerMessage) => void,
 ): Promise<{ requestId: string } | null> {
   // The caller may pass a conversation key (e.g. the macOS client's local
-  // session ID) instead of the daemon's internal conversation ID. Resolve
+  // conversation ID) instead of the daemon's internal conversation ID. Resolve
   // to the internal ID so all downstream lookups succeed.
   const resolvedId = resolveConversationId(conversationId);
   if (!resolvedId) {
     return null;
   }
   conversationId = resolvedId;
-  const session = await ctx.getOrCreateConversation(conversationId);
+  const conversation = await ctx.getOrCreateConversation(conversationId);
   ctx.touchConversation(conversationId);
-  session.updateClient(sendEvent, false);
+  conversation.updateClient(sendEvent, false);
   const requestId = uuid();
-  session.traceEmitter.emit("request_received", "Regenerate requested", {
+  conversation.traceEmitter.emit("request_received", "Regenerate requested", {
     requestId,
     status: "info",
     attributes: { source: "regenerate" },
   });
   try {
-    await session.regenerate(sendEvent, requestId);
+    await conversation.regenerate(sendEvent, requestId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, conversationId }, "Error regenerating message");
-    session.traceEmitter.emit("request_error", truncate(message, 200, ""), {
-      requestId,
-      status: "error",
-      attributes: {
-        errorClass: err instanceof Error ? err.constructor.name : "Error",
-        message: truncate(message, 500, ""),
+    conversation.traceEmitter.emit(
+      "request_error",
+      truncate(message, 200, ""),
+      {
+        requestId,
+        status: "error",
+        attributes: {
+          errorClass: err instanceof Error ? err.constructor.name : "Error",
+          message: truncate(message, 500, ""),
+        },
       },
-    });
+    );
     throw err;
   }
   return { requestId };
@@ -566,7 +570,7 @@ export function handleUsageRequest(
 // ---------------------------------------------------------------------------
 
 /**
- * Delete a queued message from a session.
+ * Delete a queued message from a conversation.
  * Returns `{ removed: true }` on success, `{ removed: false, reason }` on failure.
  */
 export function deleteQueuedMessage(
@@ -578,15 +582,15 @@ export function deleteQueuedMessage(
 ):
   | { removed: true }
   | { removed: false; reason: "session_not_found" | "message_not_found" } {
-  const session = findConversation(conversationId);
-  if (!session) {
+  const conversation = findConversation(conversationId);
+  if (!conversation) {
     log.warn(
       { conversationId, requestId },
-      "No session found for delete_queued_message",
+      "No conversation found for delete_queued_message",
     );
     return { removed: false, reason: "session_not_found" };
   }
-  const removed = session.removeQueuedMessage(requestId);
+  const removed = conversation.removeQueuedMessage(requestId);
   if (removed) {
     return { removed: true };
   }

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -23,7 +23,7 @@ export const CONFIG_RELOAD_DEBOUNCE_MS = 300;
 
 const HISTORY_ATTACHMENT_TEXT_LIMIT = 500;
 
-// Module-level map for non-session secret prompts (e.g. publish_page)
+// Module-level map for non-conversation secret prompts (e.g. publish_page)
 export const pendingStandaloneSecrets = new Map<
   string,
   {
@@ -123,7 +123,7 @@ export interface ConversationCreateOptions {
   transport?: ConversationTransportMetadata;
   assistantId?: string;
   trustContext?: TrustContext;
-  /** Normalized auth context for the session. */
+  /** Normalized auth context for the conversation. */
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
@@ -415,7 +415,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
 
 /**
  * Send a `secret_request` to the client and wait for the response,
- * outside of a session context (e.g. from handler-level code like publish_page).
+ * outside of a conversation context (e.g. from handler-level code like publish_page).
  */
 export function requestSecretStandalone(
   ctx: HandlerContext,

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -194,7 +194,7 @@ export function repairHistory(messages: Message[]): RepairResult {
   // or from other history reconstruction artifacts. The Anthropic API requires
   // strict user/assistant alternation, so consecutive same-role messages must
   // always be merged. Undo semantics for mixed tool_result+text messages are
-  // handled by isUndoableUserMessage in session.ts.
+  // handled by isUndoableUserMessage in conversation.ts.
   const merged: Message[] = [];
   for (const msg of result) {
     const prev = merged[merged.length - 1];

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -352,7 +352,7 @@ export async function runDaemon(): Promise<void> {
 
     await initializeProvidersAndTools(config);
 
-    // Start the DaemonServer (session manager) before Qdrant so HTTP
+    // Start the DaemonServer (conversation manager) before Qdrant so HTTP
     // routes can begin accepting requests while Qdrant initializes.
     log.info("Daemon startup: starting DaemonServer");
     const server = new DaemonServer();
@@ -664,7 +664,7 @@ export async function runDaemon(): Promise<void> {
       setRelayBroadcast((msg) => server.broadcast(msg));
       setPointerMessageProcessor(
         async (conversationId, instruction, requiredFacts) => {
-          const session =
+          const conversation =
             await server.getConversationForMessages(conversationId);
 
           // Constrain pointer generation to a tool-disabled path so call-
@@ -674,12 +674,12 @@ export async function runDaemon(): Promise<void> {
           // invoking any tools during the pointer agent loop.
           //
           // A depth counter (rather than a boolean) ensures that overlapping
-          // pointer requests on the same session don't clear each other's
+          // pointer requests on the same conversation don't clear each other's
           // constraint — each caller increments on entry and decrements in
           // its own finally block.
-          session.toolsDisabledDepth++;
+          conversation.toolsDisabledDepth++;
           try {
-            const messageId = await session.persistUserMessage(
+            const messageId = await conversation.persistUserMessage(
               instruction,
               [],
               undefined,
@@ -705,7 +705,7 @@ export async function runDaemon(): Promise<void> {
                 }
               }
               try {
-                await session.loadFromDb();
+                await conversation.loadFromDb();
               } catch {
                 /* best effort */
               }
@@ -731,7 +731,7 @@ export async function runDaemon(): Promise<void> {
 
             let agentLoopError: string | undefined;
             let generatedText = "";
-            await session.runAgentLoop(instruction, messageId, (msg) => {
+            await conversation.runAgentLoop(instruction, messageId, (msg) => {
               if (
                 "type" in msg &&
                 msg.type === "assistant_text_delta" &&
@@ -793,7 +793,7 @@ export async function runDaemon(): Promise<void> {
             }
           } finally {
             // Restore tool availability so subsequent turns aren't affected.
-            session.toolsDisabledDepth--;
+            conversation.toolsDisabledDepth--;
           }
         },
       );

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -132,7 +132,7 @@ import type {
 
 // === SubagentEvent -- defined here because it references ServerMessage ===
 
-/** Wraps any ServerMessage emitted by a subagent session for routing to the client. */
+/** Wraps any ServerMessage emitted by a subagent conversation for routing to the client. */
 export interface SubagentEvent {
   type: "subagent_event";
   subagentId: string;

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -159,7 +159,7 @@ export interface ConversationTitleUpdated {
   title: string;
 }
 
-/** Channel binding metadata exposed in session/conversation list APIs. */
+/** Channel binding metadata exposed in conversation list APIs. */
 export interface ChannelBinding {
   sourceChannel: ChannelId;
   externalChatId: string;

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -265,7 +265,7 @@ export interface ConfirmationStateChanged {
 /**
  * Server-side assistant activity lifecycle for thinking indicator placement.
  *
- * `activityVersion` is monotonically increasing per session. Clients must
+ * `activityVersion` is monotonically increasing per conversation. Clients must
  * ignore events with a version older than their current known version.
  */
 export interface AssistantActivityState {

--- a/assistant/src/daemon/message-types/settings.ts
+++ b/assistant/src/daemon/message-types/settings.ts
@@ -2,7 +2,7 @@
 
 // === Client → Server ===
 
-/** Request from a session or client to change the voice activation key. */
+/** Request from a conversation or client to change the voice activation key. */
 export interface VoiceConfigUpdateRequest {
   type: "voice_config_update";
   /** The desired activation key (enum value or natural-language name). */

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -255,7 +255,7 @@ export class DaemonServer {
 
   // CES (Credential Execution Service) — process-level singleton.
   // The CES sidecar accepts exactly one bootstrap connection, so we must
-  // hold that connection at the server level rather than per-session.
+  // hold that connection at the server level rather than per-conversation.
   private cesProcessManager?: CesProcessManager;
   private cesClientPromise?: Promise<CesClient | undefined>;
   private cesInitAbortController?: AbortController;
@@ -324,17 +324,17 @@ export class DaemonServer {
       sendToClient,
       notification,
     ) => {
-      const parentSession = this.conversations.get(parentConversationId);
-      if (!parentSession) {
+      const parentConversation = this.conversations.get(parentConversationId);
+      if (!parentConversation) {
         log.warn(
           { parentConversationId },
-          "Subagent finished but parent session not found",
+          "Subagent finished but parent conversation not found",
         );
         return;
       }
       const requestId = `subagent-notify-${Date.now()}`;
       const metadata = { subagentNotification: notification };
-      const enqueueResult = parentSession.enqueueMessage(
+      const enqueueResult = parentConversation.enqueueMessage(
         message,
         [],
         sendToClient,
@@ -344,13 +344,13 @@ export class DaemonServer {
         metadata,
       );
       if (!enqueueResult.queued && !enqueueResult.rejected) {
-        const messageId = await parentSession.persistUserMessage(
+        const messageId = await parentConversation.persistUserMessage(
           message,
           [],
           undefined,
           metadata,
         );
-        parentSession
+        parentConversation
           .runAgentLoop(message, messageId, sendToClient)
           .catch((err) => {
             log.error(
@@ -396,7 +396,7 @@ export class DaemonServer {
   }
 
   broadcast(msg: ServerMessage): void {
-    const conversationId = extractSessionId(msg);
+    const conversationId = extractConversationId(msg);
     this.publishAssistantEvent(msg, conversationId);
   }
 
@@ -436,10 +436,10 @@ export class DaemonServer {
     });
 
     registerCancelCallback((conversationId) => {
-      const session = this.conversations.get(conversationId);
-      if (!session) return false;
+      const conversation = this.conversations.get(conversationId);
+      if (!conversation) return false;
       this.evictor.touch(conversationId);
-      session.abort();
+      conversation.abort();
       getSubagentManager().abortAllForParent(conversationId);
       return true;
     });
@@ -452,12 +452,12 @@ export class DaemonServer {
       const { conversationId } = getOrCreateConversation(
         params.conversationKey,
       );
-      const session = await this.getOrCreateConversation(conversationId);
-      if (session.isProcessing()) {
+      const conversation = await this.getOrCreateConversation(conversationId);
+      if (conversation.isProcessing()) {
         const requestId = crypto.randomUUID();
         const resolvedChannel = resolveTurnChannel(params.sourceChannel);
         const resolvedInterface = resolveTurnInterface(params.sourceInterface);
-        const result = session.enqueueMessage(
+        const result = conversation.enqueueMessage(
           params.content,
           [],
           () => {},
@@ -573,8 +573,8 @@ export class DaemonServer {
       this.unsubscribeContactChange = null;
     }
 
-    for (const session of this.conversations.values()) {
-      session.dispose();
+    for (const conversation of this.conversations.values()) {
+      conversation.dispose();
     }
     this.conversations.clear();
 
@@ -628,8 +628,8 @@ export class DaemonServer {
       this.evictor.remove(id);
       subagentManager.abortAllForParent(id);
     }
-    for (const session of this.conversations.values()) {
-      session.dispose();
+    for (const conversation of this.conversations.values()) {
+      conversation.dispose();
     }
     this.conversations.clear();
     this.sessionOptions.clear();
@@ -641,25 +641,25 @@ export class DaemonServer {
    * conversation map. No-op if no conversation exists for the given ID.
    */
   destroyConversation(conversationId: string): void {
-    const session = this.conversations.get(conversationId);
-    if (!session) return;
+    const conversation = this.conversations.get(conversationId);
+    if (!conversation) return;
     this.evictor.remove(conversationId);
     getSubagentManager().abortAllForParent(conversationId);
-    session.dispose();
+    conversation.dispose();
     this.conversations.delete(conversationId);
     this.sessionOptions.delete(conversationId);
   }
 
   private evictConversationsForReload(): void {
     const subagentManager = getSubagentManager();
-    for (const [id, session] of this.conversations) {
-      if (!session.isProcessing()) {
+    for (const [id, conversation] of this.conversations) {
+      if (!conversation.isProcessing()) {
         subagentManager.abortAllForParent(id);
-        session.dispose();
+        conversation.dispose();
         this.conversations.delete(id);
         this.evictor.remove(id);
       } else {
-        session.markStale();
+        conversation.markStale();
       }
     }
   }
@@ -682,7 +682,7 @@ export class DaemonServer {
     conversationId: string,
     options?: ConversationCreateOptions,
   ): Promise<Conversation> {
-    let session = this.conversations.get(conversationId);
+    let conversation = this.conversations.get(conversationId);
     const sendToClient = () => {};
 
     if (options && Object.values(options).some((v) => v !== undefined)) {
@@ -692,16 +692,19 @@ export class DaemonServer {
       });
     }
 
-    if (!session || (session.isStale() && !session.isProcessing())) {
-      if (session) {
+    if (
+      !conversation ||
+      (conversation.isStale() && !conversation.isProcessing())
+    ) {
+      if (conversation) {
         getSubagentManager().abortAllForParent(conversationId);
-        session.dispose();
+        conversation.dispose();
       }
 
       const pending = this.conversationCreating.get(conversationId);
       if (pending) {
-        session = await pending;
-        return session;
+        conversation = await pending;
+        return conversation;
       }
 
       const storedOptions = this.sessionOptions.get(conversationId);
@@ -770,16 +773,16 @@ export class DaemonServer {
 
       this.conversationCreating.set(conversationId, createPromise);
       try {
-        session = await createPromise;
+        conversation = await createPromise;
       } finally {
         this.conversationCreating.delete(conversationId);
       }
       this.evictor.touch(conversationId);
     } else {
-      this.applyTransportMetadata(session, options);
+      this.applyTransportMetadata(conversation, options);
       this.evictor.touch(conversationId);
     }
-    return session;
+    return conversation;
   }
 
   // ── Handler context ────────────────────────────────────────────────
@@ -822,7 +825,7 @@ export class DaemonServer {
 
   // ── HTTP message processing ─────────────────────────────────────────
 
-  private async prepareSessionForMessage(
+  private async prepareConversationForMessage(
     conversationId: string,
     content: string,
     attachmentIds: string[] | undefined,
@@ -830,7 +833,7 @@ export class DaemonServer {
     sourceChannel: string | undefined,
     sourceInterface: string | undefined,
   ): Promise<{
-    session: Conversation;
+    conversation: Conversation;
     attachments: {
       id: string;
       filename: string;
@@ -846,9 +849,12 @@ export class DaemonServer {
       );
     }
 
-    const session = await this.getOrCreateConversation(conversationId, options);
+    const conversation = await this.getOrCreateConversation(
+      conversationId,
+      options,
+    );
 
-    if (session.isProcessing()) {
+    if (conversation.isProcessing()) {
       throw new Error("Conversation is already processing a message");
     }
 
@@ -857,13 +863,13 @@ export class DaemonServer {
       options?.transport?.channelId,
     );
     const resolvedInterface = resolveTurnInterface(sourceInterface);
-    session.setAssistantId(
+    conversation.setAssistantId(
       options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     );
-    session.setTrustContext(options?.trustContext ?? null);
-    session.setAuthContext(options?.authContext ?? null);
-    await session.ensureActorScopedHistory();
-    session.setChannelCapabilities(
+    conversation.setTrustContext(options?.trustContext ?? null);
+    conversation.setAuthContext(options?.authContext ?? null);
+    await conversation.ensureActorScopedHistory();
+    conversation.setChannelCapabilities(
       resolveChannelCapabilities(
         sourceChannel,
         sourceInterface,
@@ -872,45 +878,45 @@ export class DaemonServer {
       ),
     );
     // Only create the host bash proxy for desktop client interfaces that can
-    // execute commands on the user's machine. Non-desktop sessions (CLI,
+    // execute commands on the user's machine. Non-desktop conversations (CLI,
     // channels, headless) fall back to local execution.
     // Guard: don't replace an active proxy during concurrent turn races —
     // another request may have started processing between the isProcessing()
     // check above and the await on ensureActorScopedHistory().
     if (resolvedInterface === "macos" || resolvedInterface === "ios") {
-      if (!session.isProcessing() || !session.hostBashProxy) {
-        session.setHostBashProxy(
-          new HostBashProxy(session.getCurrentSender(), (requestId) => {
+      if (!conversation.isProcessing() || !conversation.hostBashProxy) {
+        conversation.setHostBashProxy(
+          new HostBashProxy(conversation.getCurrentSender(), (requestId) => {
             pendingInteractions.resolve(requestId);
           }),
         );
       }
-      if (!session.isProcessing() || !session.hostFileProxy) {
-        session.setHostFileProxy(
-          new HostFileProxy(session.getCurrentSender(), (requestId) => {
+      if (!conversation.isProcessing() || !conversation.hostFileProxy) {
+        conversation.setHostFileProxy(
+          new HostFileProxy(conversation.getCurrentSender(), (requestId) => {
             pendingInteractions.resolve(requestId);
           }),
         );
       }
-      if (!session.isProcessing() || !session.hostCuProxy) {
-        session.setHostCuProxy(
-          new HostCuProxy(session.getCurrentSender(), (requestId) => {
+      if (!conversation.isProcessing() || !conversation.hostCuProxy) {
+        conversation.setHostCuProxy(
+          new HostCuProxy(conversation.getCurrentSender(), (requestId) => {
             pendingInteractions.resolve(requestId);
           }),
         );
       }
-      session.addPreactivatedSkillId("computer-use");
-    } else if (!session.isProcessing()) {
-      session.setHostBashProxy(undefined);
-      session.setHostFileProxy(undefined);
-      session.setHostCuProxy(undefined);
+      conversation.addPreactivatedSkillId("computer-use");
+    } else if (!conversation.isProcessing()) {
+      conversation.setHostBashProxy(undefined);
+      conversation.setHostFileProxy(undefined);
+      conversation.setHostCuProxy(undefined);
     }
-    session.setCommandIntent(options?.commandIntent ?? null);
-    session.setTurnChannelContext({
+    conversation.setCommandIntent(options?.commandIntent ?? null);
+    conversation.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,
     });
-    session.setTurnInterfaceContext({
+    conversation.setTurnInterfaceContext({
       userMessageInterface: resolvedInterface,
       assistantMessageInterface: resolvedInterface,
     });
@@ -924,7 +930,7 @@ export class DaemonServer {
         }))
       : [];
 
-    return { session, attachments };
+    return { conversation, attachments };
   }
 
   async persistAndProcessMessage(
@@ -935,25 +941,29 @@ export class DaemonServer {
     sourceChannel?: string,
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {
-    const { session, attachments } = await this.prepareSessionForMessage(
-      conversationId,
-      content,
-      attachmentIds,
-      options,
-      sourceChannel,
-      sourceInterface,
-    );
+    const { conversation, attachments } =
+      await this.prepareConversationForMessage(
+        conversationId,
+        content,
+        attachmentIds,
+        options,
+        sourceChannel,
+        sourceInterface,
+      );
 
     const requestId = crypto.randomUUID();
-    const messageId = await session.persistUserMessage(
+    const messageId = await conversation.persistUserMessage(
       content,
       attachments,
       requestId,
     );
 
     // Register pending interactions so channel approval interception can
-    // find the session by requestId when confirmation/secret events fire.
-    const registrar = makePendingInteractionRegistrar(session, conversationId);
+    // find the conversation by requestId when confirmation/secret events fire.
+    const registrar = makePendingInteractionRegistrar(
+      conversation,
+      conversationId,
+    );
     const onEvent = options?.onEvent
       ? (msg: ServerMessage) => {
           registrar(msg);
@@ -968,10 +978,10 @@ export class DaemonServer {
         }
       : registrar;
     if (options?.isInteractive === true) {
-      session.updateClient(onEvent, false);
+      conversation.updateClient(onEvent, false);
     }
 
-    session
+    conversation
       .runAgentLoop(content, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
         isUserMessage: true,
@@ -979,9 +989,9 @@ export class DaemonServer {
       .finally(() => {
         if (
           options?.isInteractive === true &&
-          session.getCurrentSender() === onEvent
+          conversation.getCurrentSender() === onEvent
         ) {
-          session.updateClient(() => {}, true);
+          conversation.updateClient(() => {}, true);
         }
       })
       .catch((err) => {
@@ -999,21 +1009,24 @@ export class DaemonServer {
     sourceChannel?: string,
     sourceInterface?: string,
   ): Promise<{ messageId: string }> {
-    const { session, attachments } = await this.prepareSessionForMessage(
-      conversationId,
-      content,
-      attachmentIds,
-      options,
-      sourceChannel,
-      sourceInterface,
-    );
+    const { conversation, attachments } =
+      await this.prepareConversationForMessage(
+        conversationId,
+        content,
+        attachmentIds,
+        options,
+        sourceChannel,
+        sourceInterface,
+      );
 
     const slashResult = await resolveSlash(content);
 
     if (slashResult.kind === "unknown") {
-      const serverTurnCtx = session.getTurnChannelContext();
-      const serverInterfaceCtx = session.getTurnInterfaceContext();
-      const serverProvenance = provenanceFromTrustContext(session.trustContext);
+      const serverTurnCtx = conversation.getTurnChannelContext();
+      const serverInterfaceCtx = conversation.getTurnInterfaceContext();
+      const serverProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
       const serverChannelMeta = {
         ...serverProvenance,
         ...(serverTurnCtx
@@ -1037,7 +1050,7 @@ export class DaemonServer {
         JSON.stringify(userMsg.content),
         serverChannelMeta,
       );
-      session.getMessages().push(userMsg);
+      conversation.getMessages().push(userMsg);
 
       if (serverTurnCtx) {
         try {
@@ -1073,22 +1086,25 @@ export class DaemonServer {
         JSON.stringify(assistantMsg.content),
         serverChannelMeta,
       );
-      session.getMessages().push(assistantMsg);
+      conversation.getMessages().push(assistantMsg);
       return { messageId: persisted.id };
     }
 
     const resolvedContent = slashResult.content;
 
     const requestId = crypto.randomUUID();
-    const messageId = await session.persistUserMessage(
+    const messageId = await conversation.persistUserMessage(
       resolvedContent,
       attachments,
       requestId,
     );
 
     // Register pending interactions so channel approval interception can
-    // find the session by requestId when confirmation/secret events fire.
-    const registrar = makePendingInteractionRegistrar(session, conversationId);
+    // find the conversation by requestId when confirmation/secret events fire.
+    const registrar = makePendingInteractionRegistrar(
+      conversation,
+      conversationId,
+    );
     const onEvent = options?.onEvent
       ? (msg: ServerMessage) => {
           registrar(msg);
@@ -1103,20 +1119,20 @@ export class DaemonServer {
         }
       : registrar;
     if (options?.isInteractive === true) {
-      session.updateClient(onEvent, false);
+      conversation.updateClient(onEvent, false);
     }
 
     try {
-      await session.runAgentLoop(resolvedContent, messageId, onEvent, {
+      await conversation.runAgentLoop(resolvedContent, messageId, onEvent, {
         isInteractive: options?.isInteractive ?? false,
         isUserMessage: true,
       });
     } finally {
       if (
         options?.isInteractive === true &&
-        session.getCurrentSender() === onEvent
+        conversation.getCurrentSender() === onEvent
       ) {
-        session.updateClient(() => {}, true);
+        conversation.updateClient(() => {}, true);
       }
     }
 
@@ -1124,7 +1140,7 @@ export class DaemonServer {
   }
 
   /**
-   * Expose session lookup for the POST /v1/messages handler.
+   * Expose conversation lookup for the POST /v1/messages handler.
    * The handler manages busy-state checking and queueing itself.
    */
   async getConversationForMessages(
@@ -1144,14 +1160,14 @@ export class DaemonServer {
    * Look up an active conversation that owns a given surfaceId.
    */
   findConversationBySurfaceId(surfaceId: string): Conversation | undefined {
-    for (const s of this.conversations.values()) {
-      if (s.surfaceState.has(surfaceId)) return s;
+    for (const c of this.conversations.values()) {
+      if (c.surfaceState.has(surfaceId)) return c;
     }
     return undefined;
   }
 
   /**
-   * Expose the handler context for use by session management HTTP routes.
+   * Expose the handler context for use by conversation management HTTP routes.
    * The context is built on-the-fly so it always reflects the current server state.
    */
   getHandlerContext(): HandlerContext {
@@ -1160,7 +1176,7 @@ export class DaemonServer {
 }
 
 /** Extract conversationId from a ServerMessage if present. */
-function extractSessionId(msg: ServerMessage): string | undefined {
+function extractConversationId(msg: ServerMessage): string | undefined {
   const record = msg as unknown as Record<string, unknown>;
   if ("conversationId" in msg && typeof record.conversationId === "string") {
     return record.conversationId as string;

--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -14,7 +14,7 @@ export interface TraceEmitOptions {
 }
 
 /**
- * Per-session utility that builds and sends TraceEvent messages to the client.
+ * Per-conversation utility that builds and sends TraceEvent messages to the client.
  * Maintains a monotonic sequence counter so the UI can reconstruct event order
  * even if timestamps collide.
  */

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -550,13 +550,13 @@ export function workItemRouteDefinitions(
           );
         }
 
-        // Abort the session associated with this work item's current run
+        // Abort the conversation associated with this work item's current run
         const conversationId = workItem.lastRunConversationId;
         if (conversationId && deps?.findConversation) {
-          const session = deps.findConversation(conversationId);
-          if (session) {
-            session.headlessLock = false;
-            session.abort();
+          const conversation = deps.findConversation(conversationId);
+          if (conversation) {
+            conversation.headlessLock = false;
+            conversation.abort();
             getSubagentManager().abortAllForParent(conversationId);
           }
         }
@@ -689,7 +689,7 @@ export function workItemRouteDefinitions(
         publishEvent({ type: "tasks_changed" });
 
         // Execute task asynchronously
-        let session: Conversation | null = null;
+        let taskConversation: Conversation | null = null;
         const getOrCreateConversation = deps.getOrCreateConversation;
         const workItemId = params.id;
 
@@ -703,11 +703,12 @@ export function workItemRouteDefinitions(
                 approvedTools,
               },
               async (conversationId, message, taskRunId) => {
-                if (!session) {
+                if (!taskConversation) {
                   updateWorkItem(workItemId, {
                     lastRunConversationId: conversationId,
                   });
-                  session = await getOrCreateConversation(conversationId);
+                  taskConversation =
+                    await getOrCreateConversation(conversationId);
 
                   publishEvent({
                     type: "task_run_conversation_created",
@@ -715,10 +716,10 @@ export function workItemRouteDefinitions(
                     workItemId,
                     title: workItem.title,
                   });
-                  session.taskRunId = taskRunId;
-                  session.headlessLock = true;
+                  taskConversation.taskRunId = taskRunId;
+                  taskConversation.headlessLock = true;
                 }
-                await session.processMessage(
+                await taskConversation.processMessage(
                   message,
                   [],
                   (event) => {
@@ -733,8 +734,9 @@ export function workItemRouteDefinitions(
             );
 
             // Release headless lock
-            if (session) {
-              (session as { headlessLock: boolean }).headlessLock = false;
+            if (taskConversation) {
+              (taskConversation as { headlessLock: boolean }).headlessLock =
+                false;
             }
 
             // Don't overwrite cancelled status
@@ -753,8 +755,9 @@ export function workItemRouteDefinitions(
             broadcastWorkItemStatus(workItemId);
             publishEvent({ type: "tasks_changed" });
           } catch (err) {
-            if (session) {
-              (session as { headlessLock: boolean }).headlessLock = false;
+            if (taskConversation) {
+              (taskConversation as { headlessLock: boolean }).headlessLock =
+                false;
             }
             log.error({ err, workItemId }, "work_item_run_task (HTTP) failed");
             updateWorkItem(workItemId, {


### PR DESCRIPTION
## Summary
- Rename session→conversation variable names across ~10 daemon TS files where session referred to a Conversation object
- Rename session-* logger names to conversation-* across 10 files
- Rename subagent test descriptions using 'session' → 'conversation'
- Update daemon TS code comments using 'session' when meaning conversation

Part of plan: conv-symbol-sweep.md (fix round 4, gap 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
