### PR TITLE
fix: honor forceNew in openConversation by bypassing reuse guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -271,8 +271,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     ///
     /// - Parameters:
     ///   - message: Text to place in the input field. When nil, the input is left unchanged.
-    ///   - forceNew: When true, always creates a fresh conversation via `createConversation()`
-    ///     even if one is already active. Defaults to false (reuse the active conversation).
+    ///   - forceNew: When true, always enters draft mode to guarantee a fresh conversation
+    ///     even if the current conversation is empty. Defaults to false (reuse the active conversation).
     ///   - autoSend: When true **and** a message is provided, the message is sent
     ///     immediately. When false the message is only placed in the input field.
     ///     Defaults to true.
@@ -287,7 +287,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         configure: ((ChatViewModel) -> Void)? = nil
     ) -> ChatViewModel? {
         if forceNew || activeViewModel == nil {
-            createConversation()
+            // When forceNew is true, call enterDraftMode() directly to bypass
+            // createConversation()'s reuse guards that no-op for empty conversations.
+            // This guarantees a fresh view model even when the current conversation is empty.
+            if forceNew {
+                enterDraftMode()
+            } else {
+                createConversation()
+            }
         }
         guard let viewModel = activeViewModel else { return nil }
         configure?(viewModel)


### PR DESCRIPTION
## Summary
- Fix `openConversation(forceNew: true)` to reliably create a fresh conversation by calling `enterDraftMode()` directly instead of `createConversation()`, which no-ops when the active conversation is empty
- Updates doc comment to reflect the corrected behavior

Addresses review feedback from PR #17267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
