### PR TITLE
fix: add typeof string guard to fallback emoji assignment in skill metadata parsing

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -269,7 +269,7 @@ function parseFrontmatter(
         if (vellum && typeof vellum === "object") {
           emoji = typeof vellum.emoji === "string" ? vellum.emoji : undefined;
         }
-        if (!emoji && parsedMeta?.emoji) {
+        if (!emoji && typeof parsedMeta?.emoji === "string") {
           emoji = parsedMeta.emoji;
         }
       }


### PR DESCRIPTION
## Summary
- Adds a `typeof ... === "string"` guard to the fallback emoji assignment in the Zod-failure path of `parseFrontmatter` in `assistant/src/config/skills.ts`
- In the fallback path, `parsedMeta` is a raw cast so `parsedMeta.emoji` is not guaranteed to be a string. Without the guard, malformed frontmatter (e.g. `metadata.emoji: 123`) could propagate a non-string value into `SkillSummary` and API responses
- Addresses review feedback from PR #17273

## Test plan
- [x] Verified the fix adds the same `typeof` guard pattern already used for `vellum.emoji` on line 270
- [x] Confirmed no other unguarded raw casts of emoji exist in the file

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
