### PR TITLE
fix: harden avatar render-from-traits atomicity and null guard

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
@@ -19,14 +19,58 @@ export type TraitsSyncResult =
   | { ok: true }
   | {
       ok: false;
-      reason: "missing_traits" | "invalid_traits" | "render_error";
+      reason: "invalid_traits" | "render_error";
       message: string;
     };
+
+/**
+ * Renders avatar-image.png and character-ascii.txt from the given traits,
+ * writing each file atomically.  Does NOT touch character-traits.json.
+ */
+function renderAndWriteAvatarFiles(
+  traits: CharacterTraits,
+  avatarDir: string,
+): void {
+  const pngPath = join(avatarDir, "avatar-image.png");
+
+  // Render PNG first — this validates trait IDs (composeSvg throws on
+  // unknown components), so we fail before writing anything to disk.
+  const pngBuffer = renderCharacterPng(
+    traits.bodyShape,
+    traits.eyeStyle,
+    traits.color,
+  );
+  const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
+  writeFileSync(pngTmp, pngBuffer);
+  renameSync(pngTmp, pngPath);
+
+  // Render and write ASCII art — isolated so a failure here doesn't cause
+  // the primary operation to report failure.
+  try {
+    const asciiPath = join(avatarDir, "character-ascii.txt");
+    const asciiArt = renderCharacterAscii(
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
+    );
+    const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
+    writeFileSync(asciiTmp, asciiArt);
+    renameSync(asciiTmp, asciiPath);
+  } catch (asciiErr) {
+    log.warn(
+      { err: asciiErr },
+      "Failed to write ASCII sidecar — primary files still written",
+    );
+  }
+}
 
 /**
  * Writes character-traits.json, regenerates avatar-image.png, and updates
  * character-ascii.txt in one atomic operation.  Accepts the trait values
  * directly so callers don't need to touch the filesystem first.
+ *
+ * Renders the PNG before writing the traits file so that if rendering fails
+ * (e.g. unknown component IDs), neither file is modified.
  */
 export function writeTraitsAndRenderAvatar(
   traits: CharacterTraits,
@@ -48,45 +92,19 @@ export function writeTraitsAndRenderAvatar(
 
   const avatarDir = join(getWorkspaceDir(), "data", "avatar");
   const traitsPath = join(avatarDir, "character-traits.json");
-  const pngPath = join(avatarDir, "avatar-image.png");
 
   try {
     mkdirSync(avatarDir, { recursive: true });
 
-    // Write traits file atomically
+    // Render avatar files first — validates trait IDs before committing
+    // the traits file, so we never leave traits and PNG out of sync.
+    renderAndWriteAvatarFiles(traits, avatarDir);
+
+    // Write traits file atomically (after successful render)
     const traitsJson = JSON.stringify(traits, null, 2);
     const traitsTmp = `${traitsPath}.${randomUUID()}.tmp`;
     writeFileSync(traitsTmp, traitsJson);
     renameSync(traitsTmp, traitsPath);
-
-    // Render and write PNG atomically
-    const pngBuffer = renderCharacterPng(
-      traits.bodyShape,
-      traits.eyeStyle,
-      traits.color,
-    );
-    const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
-    writeFileSync(pngTmp, pngBuffer);
-    renameSync(pngTmp, pngPath);
-
-    // Render and write ASCII art atomically — isolated so a failure here
-    // doesn't cause the primary operation (traits JSON + PNG) to report failure.
-    try {
-      const asciiPath = join(avatarDir, "character-ascii.txt");
-      const asciiArt = renderCharacterAscii(
-        traits.bodyShape,
-        traits.eyeStyle,
-        traits.color,
-      );
-      const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
-      writeFileSync(asciiTmp, asciiArt);
-      renameSync(asciiTmp, asciiPath);
-    } catch (asciiErr) {
-      log.warn(
-        { err: asciiErr },
-        "Failed to write ASCII sidecar — primary files still written",
-      );
-    }
 
     log.info(
       {
@@ -106,40 +124,4 @@ export function writeTraitsAndRenderAvatar(
         err instanceof Error ? err.message : "Failed to render avatar PNG",
     };
   }
-}
-
-/**
- * Reads character-traits.json from the avatar directory and regenerates
- * avatar-image.png and character-ascii.txt to match. Kept for backward
- * compatibility (e.g. the client-side file watcher triggers this path).
- */
-export function syncTraitsToAvatar(): TraitsSyncResult {
-  const traitsPath = join(
-    getWorkspaceDir(),
-    "data",
-    "avatar",
-    "character-traits.json",
-  );
-
-  let traits: unknown;
-  try {
-    const raw = readFileSync(traitsPath, "utf-8");
-    traits = JSON.parse(raw);
-  } catch {
-    return {
-      ok: false,
-      reason: "missing_traits",
-      message: "No valid character-traits.json found",
-    };
-  }
-
-  if (!traits || typeof traits !== "object") {
-    return {
-      ok: false,
-      reason: "invalid_traits",
-      message: "character-traits.json does not contain a valid object",
-    };
-  }
-
-  return writeTraitsAndRenderAvatar(traits as CharacterTraits);
 }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -3,8 +3,6 @@ import { join } from "node:path";
 import { getCharacterComponents } from "../../avatar/character-components.js";
 import {
   type CharacterTraits,
-  syncTraitsToAvatar,
-  type TraitsSyncResult,
   writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { getLogger } from "../../util/logger.js";
@@ -47,33 +45,28 @@ export function avatarRouteDefinitions(): RouteDefinition[] {
       endpoint: "avatar/render-from-traits",
       method: "POST",
       handler: async ({ req }) => {
-        let result: TraitsSyncResult;
-
-        // If the request includes a JSON body with traits, write the traits
-        // file and render the PNG in one atomic operation.  Otherwise fall
-        // back to reading the existing character-traits.json from disk
-        // (backward-compat path).
-        const contentType = req.headers.get("content-type") ?? "";
-        if (contentType.includes("application/json")) {
-          let body: CharacterTraits;
-          try {
-            body = (await req.json()) as CharacterTraits;
-          } catch {
-            return httpError("BAD_REQUEST", "Invalid JSON body", 400);
-          }
-
-          if (!body.bodyShape || !body.eyeStyle || !body.color) {
-            return httpError(
-              "BAD_REQUEST",
-              "Missing required fields: bodyShape, eyeStyle, color",
-              400,
-            );
-          }
-
-          result = writeTraitsAndRenderAvatar(body);
-        } else {
-          result = syncTraitsToAvatar();
+        let body: CharacterTraits;
+        try {
+          body = (await req.json()) as CharacterTraits;
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
         }
+
+        if (
+          !body ||
+          typeof body !== "object" ||
+          !body.bodyShape ||
+          !body.eyeStyle ||
+          !body.color
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "Missing required fields: bodyShape, eyeStyle, color",
+            400,
+          );
+        }
+
+        const result = writeTraitsAndRenderAvatar(body);
 
         if (!result.ok) {
           const status = result.reason === "render_error" ? 500 : 400;


### PR DESCRIPTION
## Summary
- Renders avatar PNG before committing `character-traits.json` so a failed render never leaves the two files out of sync
- Extracts `renderAndWriteAvatarFiles()` helper that writes PNG + ASCII without touching the traits file
- Adds `!body || typeof body !== "object"` guard in the route handler so a JSON `null` body returns 400 instead of crashing with a 500 TypeError
- Removes the backward-compat no-body fallback path (per AGENTS.md: no fallback reads or old API shapes for internal interfaces)
- Removes now-dead `syncTraitsToAvatar()` function and cleans up unused imports

Addresses review feedback from #17271.

## Test plan
- [ ] Verify `POST /v1/avatar/render-from-traits` with valid JSON body still works
- [ ] Verify sending `Content-Type: application/json` with `null` body returns 400
- [ ] Verify sending invalid trait IDs returns error without corrupting traits file
- [ ] Verify `assistant avatar character update` CLI still works (uses `writeTraitsAndRenderAvatar` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
