### PR TITLE
fix: use homedir() in getDeviceId() to ensure per-machine scoping

### DIFF
--- a/assistant/src/util/device-id.ts
+++ b/assistant/src/util/device-id.ts
@@ -14,7 +14,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { getBaseDataDir } from "../config/env-registry.js";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("device-id");
@@ -37,8 +36,7 @@ export function getDeviceId(): string {
     return cached;
   }
 
-  const base = getBaseDataDir() || homedir();
-  const vellumDir = join(base, ".vellum");
+  const vellumDir = join(homedir(), ".vellum");
   const filePath = join(vellumDir, "device.json");
   const generated = randomUUID();
 


### PR DESCRIPTION
## Summary
- Fix `getDeviceId()` to use `homedir()` instead of `getBaseDataDir() || homedir()` so the device ID is truly per-machine, not per-instance
- Remove unused `getBaseDataDir` import from `device-id.ts`
- Addresses review feedback from PR #17305 where both Devin and Codex flagged that `BASE_DATA_DIR` is instance-scoped in multi-instance mode, causing different assistant instances on the same machine to get different device IDs

## Test plan
- [ ] Verify `getDeviceId()` resolves to `~/.vellum/device.json` regardless of `BASE_DATA_DIR` setting
- [ ] Confirm multi-instance setups share a single device ID

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
