### PR TITLE
fix: truncate long file names in fixed-height header bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -102,6 +102,8 @@ struct FileContentHeaderBar<Trailing: View>: View {
             Text(fileName)
                 .font(VFont.captionMedium)
                 .foregroundColor(VColor.contentDefault)
+                .lineLimit(1)
+                .truncationMode(.middle)
             Spacer()
             Text(fileSize)
                 .font(VFont.small)


### PR DESCRIPTION
Address Codex review feedback from #17653. Add lineLimit(1) and truncationMode(.middle) to the fileName Text in FileContentHeaderBar to prevent wrapping and clipping in the fixed 28pt height.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
