### PR TITLE
fix: trim platform assistant ID before storing in secure override

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -47,8 +47,9 @@ export async function initializeProvidersAndTools(
   try {
     const key = credentialKey("vellum", "platform_assistant_id");
     const persisted = await getSecureKeyAsync(key);
-    if (persisted) {
-      setPlatformAssistantId(persisted);
+    const trimmed = persisted?.trim();
+    if (trimmed) {
+      setPlatformAssistantId(trimmed);
       log.info("Rehydrated platform assistant ID from credential store");
     }
   } catch (err) {

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -166,7 +166,8 @@ export async function handleAddSecret(
         setPlatformBaseUrl(value);
       }
       if (service === "vellum" && field === "platform_assistant_id") {
-        setPlatformAssistantId(value);
+        const trimmed = value.trim();
+        setPlatformAssistantId(trimmed || undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());


### PR DESCRIPTION
Address Codex review feedback from #17555. Trim whitespace from platform_assistant_id value before passing to setPlatformAssistantId, and treat empty-after-trim as a delete. Also trims during rehydration in providers-setup for defense in depth.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
