### PR TITLE
fix: only inject x-forwarded-for for non-localhost guardian init requests

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -153,6 +153,16 @@ function isBrowserRelaySocketData(
   );
 }
 
+/** Check whether an IP address is a loopback address (127.0.0.0/8 or ::1). */
+function isLoopbackIp(ip: string): boolean {
+  const v4Mapped = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : ip;
+  if (normalized.includes(".")) {
+    return normalized.startsWith("127.");
+  }
+  return normalized.toLowerCase() === "::1";
+}
+
 function getClientIp(
   req: Request,
   server: ReturnType<typeof Bun.serve>,
@@ -506,8 +516,17 @@ async function main() {
       path: "/v1/guardian/init",
       method: "POST",
       auth: "none",
-      handler: (req, _params, getClientIp) =>
-        channelVerificationSessionProxy.handleGuardianInit(req, getClientIp()),
+      handler: (req, _params, getClientIp) => {
+        const ip = getClientIp();
+        // Only inject x-forwarded-for for non-localhost clients. The runtime
+        // rejects requests with this header to enforce loopback-only access,
+        // so setting it for localhost would break legitimate local bootstrap.
+        const remoteIp = isLoopbackIp(ip) ? undefined : ip;
+        return channelVerificationSessionProxy.handleGuardianInit(
+          req,
+          remoteIp,
+        );
+      },
     },
     {
       path: "/v1/channel-verification-sessions",


### PR DESCRIPTION
Address Codex review feedback from #17654. Only set x-forwarded-for header when the client IP is not localhost, so legitimate local clients can still bootstrap through the gateway while remote bypass attempts are still blocked.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
