### PR TITLE
fix: use VEmptyState for skill file viewer empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -28,6 +28,11 @@ struct AgentPanelContent: View {
         globalSkillSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
+    /// Whether any files in the selected skill are viewable (non-binary with content).
+    private var hasViewableFiles: Bool {
+        skillsManager.selectedSkillFiles?.files.contains { !$0.isBinary && $0.content != nil } ?? false
+    }
+
     private var hasActiveSearch: Bool { !normalizedSkillQuery.isEmpty }
 
     var body: some View {
@@ -375,14 +380,17 @@ struct AgentPanelContent: View {
                    let content = file.content {
                     skillFileContentPane(file: file, content: content)
                 } else {
-                    // Empty state when no file is selected or loading
-                    FileViewerEmptyState()
-                        .background(VColor.surfaceOverlay)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.borderBase, lineWidth: 1)
-                        )
+                    // Empty state when no file is selected or all files are binary
+                    VEmptyState(
+                        title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                        icon: VIcon.fileText.rawValue
+                    )
+                    .background(VColor.surfaceOverlay)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 1)
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -41,23 +41,6 @@ func formatFileSize(_ bytes: Int) -> String {
     return String(format: "%.1f GB", gb)
 }
 
-/// Empty state shown when no file is selected in a file viewer pane.
-struct FileViewerEmptyState: View {
-    var body: some View {
-        VStack {
-            Spacer()
-            VIconView(.fileText, size: 32)
-                .foregroundColor(VColor.contentTertiary)
-                .padding(.bottom, VSpacing.sm)
-            Text("Select a file to view")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentTertiary)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
 /// Scrollable read-only monospace text display for file content.
 struct ReadOnlyCodeContent: View {
     let content: String

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -692,7 +692,7 @@ private struct WorkspaceFileViewer: View {
     }
 
     private var emptyState: some View {
-        FileViewerEmptyState()
+        VEmptyState(title: "Select a file to view", icon: VIcon.fileText.rawValue)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Replaced custom `FileViewerEmptyState` with existing `VEmptyState` design system component (addresses duplication concern from PR #17295 review)
- Built-in accessibility support from `VEmptyState` replaces the need for manual `.accessibilityHidden(true)` on the decorative icon
- Added context-aware empty state messaging: shows "No viewable files" when all files are binary vs "Select a file to view" when viewable files exist
- Removed dead `FileViewerEmptyState` struct from SharedFileViewerComponents.swift

Addresses review feedback on #17295.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
