### PR TITLE
fix: reset localBootstrapDidComplete flag before new bootstrap cycle

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -358,6 +358,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             ensureActorCredentials()
         }
 
+        // Reset before provisioning so a stale flag from a previous
+        // bootstrap cycle doesn't cause awaitLocalBootstrapCompleted to
+        // skip the wait for the new cycle's credentials.
+        localBootstrapDidComplete = false
+
         // Provision an AssistantAPIKey for local assistants so they can
         // call platform APIs.
         ensureLocalAssistantApiKey()


### PR DESCRIPTION
Address Codex review feedback from #17679.

Reset `localBootstrapDidComplete` to `false` before `ensureLocalAssistantApiKey()` in `proceedToApp()`. Without this, when `performRetireAsync()` tears down to onboarding and calls `proceedToApp(isFirstLaunch: true)` for a newly created local assistant, the stale `true` flag from the previous assistant's bootstrap causes `awaitLocalBootstrapCompleted` to skip the wait, potentially sending the wake-up greeting before credentials are provisioned.

## Test plan
- [ ] Verify that retiring and switching to a new local assistant correctly waits for credential provisioning before the wake-up greeting
- [ ] Verify normal first-launch bootstrap still works (flag starts `false`, gets set to `true` by `ensureLocalAssistantApiKey`)
- [ ] Verify the early-return optimization still works when `ensureLocalAssistantApiKey` completes before `awaitLocalBootstrapCompleted` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
