### PR TITLE
fix: persist billing bootstrap flag only after success and key dedup by org

### DIFF
--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -7,8 +7,8 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 public final class BillingService {
     public static let shared = BillingService()
 
-    /// In-flight bootstrap task to prevent concurrent calls for the same org.
-    private var bootstrapTask: Task<BillingSummaryResponse?, Never>?
+    /// In-flight bootstrap tasks keyed by org ID to prevent concurrent calls per org.
+    private var bootstrapTasks: [String: Task<BillingSummaryResponse?, Never>] = [:]
 
     private init() {}
 
@@ -84,23 +84,24 @@ public final class BillingService {
         // Skip if we've already attempted bootstrap for this org
         guard !UserDefaults.standard.bool(forKey: bootstrapKey(for: orgId)) else { return nil }
 
-        // Deduplicate concurrent bootstrap calls
-        if let existing = bootstrapTask {
+        // Deduplicate concurrent bootstrap calls for the same org
+        if let existing = bootstrapTasks[orgId] {
             return await existing.value
         }
 
         let task = Task<BillingSummaryResponse?, Never> {
-            defer { bootstrapTask = nil }
-            // Mark as attempted before the request so concurrent callers also skip
-            UserDefaults.standard.set(true, forKey: bootstrapKey(for: orgId))
+            defer { bootstrapTasks[orgId] = nil }
             do {
-                return try await postBootstrapBillingSummary()
+                let result = try await postBootstrapBillingSummary()
+                // Only persist the flag on success so transient failures don't permanently suppress retries
+                UserDefaults.standard.set(true, forKey: bootstrapKey(for: orgId))
+                return result
             } catch {
                 log.error("Billing bootstrap failed: \(error.localizedDescription)")
                 return nil
             }
         }
-        bootstrapTask = task
+        bootstrapTasks[orgId] = task
         return await task.value
     }
 


### PR DESCRIPTION
Address review feedback from #17686. Move bootstrap-attempted flag persistence to after successful POST (preventing permanent suppression on transient failures), and key the in-flight task dedup by organization ID to prevent cross-org response reuse.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
