### PR TITLE
fix: treat legacy entries without cloud field as local in workspace cleanup

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -630,7 +630,10 @@ async function hatchLocal(
   // to archive it (or a managed-only retire left local data behind). Remove the
   // workspace subtree so the new assistant starts fresh — but preserve the rest
   // of .vellum (e.g. protected/, credentials) which may be shared.
-  if (existingEntry?.cloud !== "local") {
+  if (
+    !existingEntry ||
+    (existingEntry.cloud != null && existingEntry.cloud !== "local")
+  ) {
     const instanceWorkspaceDir = join(
       resources.instanceDir,
       ".vellum",
@@ -638,7 +641,8 @@ async function hatchLocal(
     );
     if (existsSync(instanceWorkspaceDir)) {
       const ownedByOther = loadAllAssistants().some((a) => {
-        if (a.cloud !== "local" || !a.resources) return false;
+        if ((a.cloud != null && a.cloud !== "local") || !a.resources)
+          return false;
         return (
           join(a.resources.instanceDir, ".vellum", "workspace") ===
           instanceWorkspaceDir


### PR DESCRIPTION
Address Codex review feedback from #17683. Update stale workspace cleanup to treat entries with missing cloud field as local (matching migrateLegacyEntry behavior), preventing accidental deletion of legacy assistant workspaces.

The condition `existingEntry?.cloud !== 'local'` treated undefined cloud (legacy entries) as non-local, incorrectly entering the deletion path. Similarly, the `ownedByOther` predicate skipped legacy entries. Both now use `cloud != null && cloud !== 'local'` to correctly identify non-local entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
