### PR TITLE
fix: skip legacy assistants without instanceDir in logout daemon cleanup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -183,7 +183,8 @@ extension AppDelegate {
             // alive with potentially stale state.
             for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
                 if assistant.assistantId != connectedAssistantId {
-                    let env: [String: String]? = assistant.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                    guard let instanceDir = assistant.instanceDir else { continue }
+                    let env = ["BASE_DATA_DIR": instanceDir]
                     let pidPath = VellumAssistantShared.resolvePidPath(environment: env)
                     if let data = try? Data(contentsOf: URL(fileURLWithPath: pidPath)),
                        let pidString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),


### PR DESCRIPTION
Address review feedback from #17691. Guard against nil instanceDir in the logout daemon cleanup loop to prevent resolvePidPath from falling through to the connected assistant's PID, which could kill the wrong daemon.

When a legacy assistant has `instanceDir == nil`, the previous code set `env` to `nil` and called `resolvePidPath(environment: nil)`, which resolves using the current process environment and could point to the connected assistant's daemon PID. This restores the original guard-let pattern so we skip assistants without a known instance directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
