### PR TITLE
fix: align PendingInteraction key with interface (session→conversation)

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -305,7 +305,7 @@ function registerPendingInteraction(
   confirmationDetails?: ConfirmationDetails,
 ): void {
   pendingInteractions.register(requestId, {
-    session,
+    conversation: session,
     conversationId,
     kind: "confirmation",
     confirmationDetails,

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -287,7 +287,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
 
       // Manually register a pending interaction
       pendingInteractions.register("req-abc", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
         confirmationDetails: {
@@ -336,7 +336,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-once", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
       });
@@ -408,7 +408,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("secret-req-1", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "secret",
       });
@@ -584,7 +584,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
 
       // Register without confirmationDetails
       pendingInteractions.register("req-no-details", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "secret",
       });
@@ -610,7 +610,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-no-persist", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
         confirmationDetails: {
@@ -646,7 +646,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-bad-pattern", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
         confirmationDetails: {
@@ -685,7 +685,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-bad-scope", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
         confirmationDetails: {
@@ -724,7 +724,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-keep", {
-        session,
+        conversation: session,
         conversationId: "conv-1",
         kind: "confirmation",
         confirmationDetails: {
@@ -823,17 +823,17 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await startServer(() => session);
 
       pendingInteractions.register("req-a", {
-        session,
+        conversation: session,
         conversationId: "conv-x",
         kind: "confirmation",
       });
       pendingInteractions.register("req-b", {
-        session,
+        conversation: session,
         conversationId: "conv-x",
         kind: "secret",
       });
       pendingInteractions.register("req-c", {
-        session,
+        conversation: session,
         conversationId: "conv-y",
         kind: "confirmation",
       });

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -155,7 +155,7 @@ function registerPendingInteraction(
   } as unknown as Conversation;
 
   pendingInteractions.register(requestId, {
-    session: mockSession,
+    conversation: mockSession,
     conversationId,
     kind: "confirmation",
     confirmationDetails: {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -89,7 +89,7 @@ function registerPendingConfirmation(
   } as unknown as Conversation;
 
   pendingInteractions.register(requestId, {
-    session: mockSession,
+    conversation: mockSession,
     conversationId,
     kind: "confirmation",
     confirmationDetails: {
@@ -304,7 +304,7 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-1");
     expect(
-      interaction!.session.handleConfirmationResponse,
+      interaction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
   });
 
@@ -320,7 +320,7 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-1");
     expect(
-      interaction!.session.handleConfirmationResponse,
+      interaction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "deny");
   });
 
@@ -339,10 +339,10 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-newer");
     expect(
-      newerInteraction!.session.handleConfirmationResponse,
+      newerInteraction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-newer", "allow");
     expect(
-      olderInteraction!.session.handleConfirmationResponse,
+      olderInteraction!.conversation.handleConfirmationResponse,
     ).not.toHaveBeenCalled();
   });
 
@@ -393,7 +393,7 @@ describe("handleChannelDecision", () => {
 
     // The session is approved with "allow"
     expect(
-      interaction!.session.handleConfirmationResponse,
+      interaction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();
@@ -420,7 +420,7 @@ describe("handleChannelDecision", () => {
     // The decision should still be applied as a one-time approval
     expect(result.applied).toBe(true);
     expect(
-      interaction!.session.handleConfirmationResponse,
+      interaction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();
@@ -446,7 +446,7 @@ describe("handleChannelDecision", () => {
     // The current invocation should still be approved (one-time allow)
     expect(result.applied).toBe(true);
     expect(
-      interaction!.session.handleConfirmationResponse,
+      interaction!.conversation.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -271,7 +271,7 @@ describe("Telegram callback seen signals", () => {
       ensureActorScopedHistory: async () => {},
     } as unknown as import("../daemon/conversation.js").Conversation;
     pendingInteractions.register("req-cb-test", {
-      session: mockSession,
+      conversation: mockSession,
       conversationId,
       kind: "confirmation",
       confirmationDetails: {

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -128,7 +128,7 @@ function registerPendingInteraction(
   } as unknown as Conversation;
 
   pendingInteractions.register(requestId, {
-    session: mockSession,
+    conversation: mockSession,
     conversationId,
     kind: "confirmation",
     confirmationDetails: {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -132,7 +132,7 @@ function registerPendingToolApprovalInteraction(
   } as unknown as import("../daemon/conversation.js").Conversation;
 
   pendingInteractions.register(requestId, {
-    session: mockSession,
+    conversation: mockSession,
     conversationId,
     kind: "confirmation",
     confirmationDetails: {

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -429,7 +429,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     } = makePendingApprovalSession(requestId, false);
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });
@@ -489,7 +489,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     } = makePendingApprovalSession(requestId, false);
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });
@@ -557,7 +557,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     } = makePendingApprovalSession(requestId, true);
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });
@@ -617,7 +617,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     } = makePendingApprovalSession(requestId, true, { queueDepth: 2 });
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });
@@ -677,7 +677,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     } = makePendingApprovalSession(requestId, false);
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });
@@ -735,7 +735,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     );
 
     pendingInteractions.register(requestId, {
-      session,
+      conversation: session,
       conversationId,
       kind: "confirmation",
     });

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -79,6 +79,7 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => "/tmp",
   getDataDir: () => "/tmp",
+  getWorkspaceDir: () => "/tmp/workspace",
   getDbPath: () => "/tmp/assistant.db",
   ensureDataDir: () => {},
 }));

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -2168,6 +2168,7 @@ describe("buildSanitizedEnv — baseline: credential exclusion", () => {
       "GNUPGHOME",
       "INTERNAL_GATEWAY_BASE_URL",
       "VELLUM_DATA_DIR",
+      "VELLUM_WORKSPACE_DIR",
     ];
 
     const env = buildSanitizedEnv();

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -217,7 +217,7 @@ const pendingInteractionResolver: GuardianRequestResolver = {
     // Map action to the permission system's UserDecision type and notify session.
     const userDecision =
       decision.action === "reject" ? ("deny" as const) : ("allow" as const);
-    resolved.session.handleConfirmationResponse(
+    resolved.conversation.handleConfirmationResponse(
       request.id,
       userDecision,
       undefined,

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -82,7 +82,7 @@ export function makeEventSender(params: {
   return (event: ServerMessage) => {
     if (event.type === "confirmation_request") {
       pendingInteractions.register(event.requestId, {
-        session: conversation,
+        conversation,
         conversationId,
         kind: "confirmation",
         confirmationDetails: {
@@ -119,25 +119,25 @@ export function makeEventSender(params: {
       }
     } else if (event.type === "secret_request") {
       pendingInteractions.register(event.requestId, {
-        session: conversation,
+        conversation,
         conversationId,
         kind: "secret",
       });
     } else if (event.type === "host_bash_request") {
       pendingInteractions.register(event.requestId, {
-        session: conversation,
+        conversation,
         conversationId,
         kind: "host_bash",
       });
     } else if (event.type === "host_file_request") {
       pendingInteractions.register(event.requestId, {
-        session: conversation,
+        conversation,
         conversationId,
         kind: "host_file",
       });
     } else if (event.type === "host_cu_request") {
       pendingInteractions.register(event.requestId, {
-        session: conversation,
+        conversation,
         conversationId,
         kind: "host_cu",
       });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -410,7 +410,7 @@ function makeHubPublisher(
     // Register pending interactions for approval events
     if (msg.type === "confirmation_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation: session,
         conversationId,
         kind: "confirmation",
         confirmationDetails: {
@@ -465,25 +465,25 @@ function makeHubPublisher(
       }
     } else if (msg.type === "secret_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation: session,
         conversationId,
         kind: "secret",
       });
     } else if (msg.type === "host_bash_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation: session,
         conversationId,
         kind: "host_bash",
       });
     } else if (msg.type === "host_file_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation: session,
         conversationId,
         kind: "host_file",
       });
     } else if (msg.type === "host_cu_request") {
       pendingInteractions.register(msg.requestId, {
-        session,
+        conversation: session,
         conversationId,
         kind: "host_cu",
       });


### PR DESCRIPTION
## Summary
- Fix property name mismatch in `pendingInteractions.register()` calls: the `PendingInteraction` interface declares `conversation: Conversation` but registration code was passing `session` as the key, causing `resolved.conversation` to be `undefined` at runtime
- Fix `guardian-request-resolvers.ts` to access `resolved.conversation` instead of `resolved.session`
- Add missing `getWorkspaceDir` to platform mock in `tool-execution-abort-cleanup.test.ts` and `VELLUM_WORKSPACE_DIR` to safe env var allowlist in `tool-executor.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23157911484/job/67277525859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
