### PR TITLE
fix: preserve app cache when apps-list fetch fails

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -464,14 +464,16 @@ extension AppDelegate {
             for await message in stream {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
-                    self.cachedApps = response.apps
-                    let daemonItems = response.apps.map {
-                        AppListManager.AppItem_Daemon(
-                            id: $0.id, name: $0.name, description: $0.description,
-                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                        )
+                    if response.success {
+                        self.cachedApps = response.apps
+                        let daemonItems = response.apps.map {
+                            AppListManager.AppItem_Daemon(
+                                id: $0.id, name: $0.name, description: $0.description,
+                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                            )
+                        }
+                        self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     }
-                    self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     return
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -539,13 +539,15 @@ struct AppsGridView: View {
             for await message in stream {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
-                    let daemonItems = response.apps.map {
-                        AppListManager.AppItem_Daemon(
-                            id: $0.id, name: $0.name, description: $0.description,
-                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                        )
+                    if response.success {
+                        let daemonItems = response.apps.map {
+                            AppListManager.AppItem_Daemon(
+                                id: $0.id, name: $0.name, description: $0.description,
+                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                            )
+                        }
+                        appListManager.syncFromDaemon(daemonItems)
                     }
-                    appListManager.syncFromDaemon(daemonItems)
                     hasFetchedLocalApps = true
                     return
                 }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -336,10 +336,13 @@ public struct AppsListRequest: Codable, Sendable {
 public struct AppsListResponse: Codable, Sendable {
     public let type: String
     public let apps: [AppsListResponseApp]
+    /// Whether the response came from a successful fetch (true) or an error fallback (false).
+    public let success: Bool
 
-    public init(type: String, apps: [AppsListResponseApp]) {
+    public init(type: String, apps: [AppsListResponseApp], success: Bool = true) {
         self.type = type
         self.apps = apps
+        self.success = success
     }
 }
 

--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -105,7 +105,8 @@ extension HTTPTransport {
         guard let url = buildURL(for: .appsList) else {
             onMessage?(.appsListResponse(AppsListResponse(
                 type: "apps_list_response",
-                apps: []
+                apps: [],
+                success: false
             )))
             return
         }
@@ -124,7 +125,8 @@ extension HTTPTransport {
                     } else {
                         onMessage?(.appsListResponse(AppsListResponse(
                             type: "apps_list_response",
-                            apps: []
+                            apps: [],
+                            success: false
                         )))
                     }
                     return
@@ -133,7 +135,8 @@ extension HTTPTransport {
                     log.error("Fetch apps list failed (\(http.statusCode))")
                     onMessage?(.appsListResponse(AppsListResponse(
                         type: "apps_list_response",
-                        apps: []
+                        apps: [],
+                        success: false
                     )))
                     return
                 }
@@ -160,7 +163,8 @@ extension HTTPTransport {
             log.error("Fetch apps list error: \(error.localizedDescription)")
             onMessage?(.appsListResponse(AppsListResponse(
                 type: "apps_list_response",
-                apps: []
+                apps: [],
+                success: false
             )))
         }
     }


### PR DESCRIPTION
Address Codex review feedback from #17695. Add a `success` flag to `AppsListResponse` so consumers can distinguish between a real empty app list and an error fallback. Only run `syncFromDaemon` when the fetch was actually successful, preventing transient errors from wiping the local app cache and pinned/order metadata.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
