### PR TITLE
fix: cancel drawer balance task on disappear and scope billing key-window notification

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -80,10 +80,8 @@ struct DrawerMenuView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }
-        .onAppear {
-            Task {
-                await loadBalance()
-            }
+        .task {
+            await loadBalance()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -12,6 +12,7 @@ struct SettingsBillingTab: View {
     @State private var topUpAmount: String = ""
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
+    @State private var hostWindow: NSWindow?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -23,11 +24,14 @@ struct SettingsBillingTab: View {
         .task {
             await loadSummary()
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
+            guard let window = notification.object as? NSWindow,
+                  window === hostWindow else { return }
             Task {
                 await loadSummary()
             }
         }
+        .background(WindowReader(window: $hostWindow))
     }
 
     // MARK: - Balance Card
@@ -148,6 +152,22 @@ struct SettingsBillingTab: View {
                         .foregroundColor(VColor.systemNegativeStrong)
                 }
             }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private struct WindowReader: NSViewRepresentable {
+        @Binding var window: NSWindow?
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView()
+            DispatchQueue.main.async { self.window = view.window }
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            DispatchQueue.main.async { self.window = nsView.window }
         }
     }
 


### PR DESCRIPTION
Address review feedback from #17685. Store and cancel the balance load task in DrawerMenuView on disappear, and filter didBecomeKeyNotification in SettingsBillingTab to only trigger for the containing window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
