### PR TITLE
fix: rename remaining session/thread→conversation in Swift HTTP layer, iOS store, and comments

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -131,7 +131,7 @@ declare -a SAFE_LINE_PATTERNS=(
     # Swift: named argument passing a variable for privateKey (e.g. `sshPrivateKey: state.sshPrivateKey,`)
     "[Pp]rivate[Kk]ey:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*[,)][[:space:]]*$"
     # Swift/Kotlin: constant declaration whose value is a camelCase identifier
-    # (e.g. `let archivedSessionsKey = "archivedSessionIds"`).
+    # (e.g. `let archivedConversationsKey = "archivedConversationIds"`).
     # These are AppStorage / UserDefaults keys, not secrets.
     # Only match known safe suffixes — NOT apiKey, secretKey, accessKey, tokenKey,
     # authKey, privateKey, encryptionKey, signingKey, or other credential-adjacent names.
@@ -152,7 +152,7 @@ declare -a SAFE_LINE_PATTERNS=(
     # Swift let/var constants used as UserDefaults key names (not secrets).
     # Only whitelist specific known key-name constants — a broad `*Key` pattern
     # would let real credentials like `let apiKey = "sk_live_..."` slip through.
-    "(private[[:space:]]+)?(let|var)[[:space:]]+(archivedSessionsKey)[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
+    "(private[[:space:]]+)?(let|var)[[:space:]]+(archivedConversationsKey)[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -170,7 +170,7 @@ matches_safe_line_pattern() {
             # Skip the guard for explicitly-allowlisted variable names that contain
             # sensitive substrings but are known UserDefaults/storage key constants.
             if printf '%s\n' "$text" | grep -iE "(let|var|val)[[:space:]]+[a-zA-Z0-9_]*[Kk]ey[[:space:]]*=" >/dev/null 2>&1; then
-                if ! printf '%s\n' "$text" | grep -E "(let|var|val)[[:space:]]+(archivedSessionsKey)[[:space:]]*[:=]" >/dev/null 2>&1; then
+                if ! printf '%s\n' "$text" | grep -E "(let|var|val)[[:space:]]+(archivedConversationsKey)[[:space:]]*[:=]" >/dev/null 2>&1; then
                     if printf '%s\n' "$text" | grep -iE "(let|var|val)[[:space:]]+[a-zA-Z0-9_]*(api|access|private|secret|client|encryption|encrypt|jwt|signing|sign|auth|hmac|master|symmetric|asymmetric|shared|session|verification|verify|decryption|decrypt|service|deploy|registry|webhook|database|db)[a-zA-Z0-9_]*[Kk]ey" >/dev/null 2>&1; then
                         continue
                     fi
@@ -319,7 +319,7 @@ if [ "${1:-}" = "--self-test" ]; then
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
     # Swift storage key constant (safe — UserDefaults key, not a secret)
-    SAFE_SWIFT_STORAGE_KEY='let archivedSessionsKey = "archivedSessionIds"'
+    SAFE_SWIFT_STORAGE_KEY='let archivedConversationsKey = "archivedConversationIds"'
     # Swift apiKey constant with alphabetic value (dangerous — must NOT be whitelisted)
     UNSAFE_SWIFT_API_KEY='let apiKey = "abcdefghijklmnopqrstuvwxyz"'
     # Swift compound key with sensitive prefix (dangerous — must NOT be whitelisted)

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -83,7 +83,7 @@ class IOSConversationStore: ObservableObject {
     @Published var isConnectedMode: Bool = false
     /// True while an additional page of conversations is being fetched from the daemon.
     @Published var isLoadingMoreConversations: Bool = false
-    /// Whether the daemon indicated more sessions exist beyond what is currently loaded.
+    /// Whether the daemon indicated more conversations exist beyond what is currently loaded.
     @Published var hasMoreConversations: Bool = false
     /// True while the first page of conversations is being fetched from the daemon.
     /// Used by the UI to show a loading indicator instead of a placeholder conversation.
@@ -108,7 +108,7 @@ class IOSConversationStore: ObservableObject {
     /// reconnect (or a `rebindDaemonClient` call). Never incremented on ordinary
     /// `loadMoreConversations` calls.
     ///
-    /// Because the daemon does not echo a request ID back in session-list responses, we
+    /// Because the daemon does not echo a request ID back in conversation-list responses, we
     /// cannot correlate individual responses to individual requests within the same
     /// connection.  What we *can* do is reject any response that arrived from the *old*
     /// connection after a reconnect has already started a fresh page-1 sequence.  This is
@@ -116,7 +116,7 @@ class IOSConversationStore: ObservableObject {
     /// generation in `expectedConversationListGeneration`; the response handler discards any
     /// response whose expected generation no longer matches the live counter.
     private var conversationListGeneration: UInt64 = 0
-    /// Generation captured at the time the most-recent page-1 session-list request was sent.
+    /// Generation captured at the time the most-recent page-1 conversation-list request was sent.
     /// The response handler compares this against `conversationListGeneration` to detect and
     /// discard stale responses from the previous connection.
     private var expectedConversationListGeneration: UInt64 = 0
@@ -128,7 +128,7 @@ class IOSConversationStore: ObservableObject {
     /// local pin/displayOrder when merging daemon data; title/archive-only edits
     /// must not overwrite daemon pin updates from other devices.
     private var locallyEditedPinConversationIds: Set<String> = []
-    /// Local seen/unread mutations must survive a stale session-list replay until
+    /// Local seen/unread mutations must survive a stale conversation-list replay until
     /// the daemon acknowledges them or returns a newer assistant reply.
     private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
 
@@ -143,18 +143,18 @@ class IOSConversationStore: ObservableObject {
     }
 
     private func applyConversationMetadata(
-        _ session: ConversationListResponseItem,
+        _ item: ConversationListResponseItem,
         to conversation: inout IOSConversation
     ) {
-        conversation.isPinned = session.isPinned ?? false
-        conversation.displayOrder = session.displayOrder.map { Int($0) }
+        conversation.isPinned = item.isPinned ?? false
+        conversation.displayOrder = item.displayOrder.map { Int($0) }
         conversation.hasUnseenLatestAssistantMessage =
-            session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+            item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
         conversation.latestAssistantMessageAt = assistantTimestamp(
-            session.assistantAttention?.latestAssistantMessageAt
+            item.assistantAttention?.latestAssistantMessageAt
         )
         conversation.lastSeenAssistantMessageAt = assistantTimestamp(
-            session.assistantAttention?.lastSeenAssistantMessageAt
+            item.assistantAttention?.lastSeenAssistantMessageAt
         )
     }
 
@@ -344,7 +344,7 @@ class IOSConversationStore: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Capture the current generation as expected and send a page-1 session-list request.
+    /// Capture the current generation as expected and send a page-1 conversation-list request.
     ///
     /// `expectedConversationListGeneration` is updated here — not in the reconnect handler — so
     /// the guard window (conversationListGeneration != expectedConversationListGeneration) remains open
@@ -375,7 +375,7 @@ class IOSConversationStore: ObservableObject {
         cancellables.removeAll()
 
         // Nil out callbacks on the old daemon before replacing the reference.
-        // In-flight HTTP responses (session-list, history, subagent-detail) are launched
+        // In-flight HTTP responses (conversation-list, history, subagent-detail) are launched
         // in fire-and-forget Tasks and are not cancelled by disconnect.  Without this,
         // a response arriving after the rebind would invoke the closures registered by
         // the previous setupDaemonCallbacks call, which capture [weak self] and would
@@ -449,7 +449,7 @@ class IOSConversationStore: ObservableObject {
 
         let filteredConversations = response.conversations.filter { $0.conversationType != "private" }
 
-        // Handle confirmed-empty first-page response: clear stale cached sessions.
+        // Handle confirmed-empty first-page response: clear stale cached conversations.
         // Only clear when hasMore is explicitly false (authoritative empty result).
         // Transient failures (HTTP errors, decode errors) emit hasMore: nil and must
         // not wipe the cache — the user should keep seeing cached conversations.
@@ -482,18 +482,18 @@ class IOSConversationStore: ObservableObject {
         isLoadingInitialConversations = false
 
         var restoredConversations: [IOSConversation] = []
-        for session in filteredConversations {
-            let effectiveCreatedAt = session.createdAt ?? session.updatedAt
+        for item in filteredConversations {
+            let effectiveCreatedAt = item.createdAt ?? item.updatedAt
             var conversation = IOSConversation(
-                title: session.title,
+                title: item.title,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
-                lastActivityAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
-                conversationId: session.id,
-                scheduleJobId: session.scheduleJobId
+                lastActivityAt: Date(timeIntervalSince1970: TimeInterval(item.updatedAt) / 1000.0),
+                conversationId: item.id,
+                scheduleJobId: item.scheduleJobId
             )
-            applyConversationMetadata(session, to: &conversation)
+            applyConversationMetadata(item, to: &conversation)
             let vm = ChatViewModel(daemonClient: daemonClient)
-            vm.conversationId = session.id
+            vm.conversationId = item.id
             viewModels[conversation.id] = vm
             restoredConversations.append(conversation)
         }
@@ -585,7 +585,7 @@ class IOSConversationStore: ObservableObject {
             }
             saveConnectedCache()
         } else {
-            // Subsequent pages: append only sessions not already in the list.
+            // Subsequent pages: append only conversations not already in the list.
             let existingConversationIds: Set<String> = Set(conversations.compactMap { conversation -> String? in
                 if let sid = conversation.conversationId { return sid }
                 return viewModels[conversation.id]?.conversationId
@@ -835,7 +835,7 @@ class IOSConversationStore: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Private conversations are excluded from the session list response filter, so they
+    /// Private conversations are excluded from the conversation list response filter, so they
     /// won't appear in the normal active conversation list.
     var privateConversations: [IOSConversation] {
         conversations.filter { $0.isPrivate }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -323,8 +323,8 @@ public final class ChatViewModel: ObservableObject {
     private var pendingGuardianActions: [String: String] = [:]
     public var conversationId: String? {
         didSet {
-            // If the daemon reconnected before this VM had a session ID, a deferred
-            // flush was requested. Now that we have a session, run it.
+            // If the daemon reconnected before this VM had a conversation ID, a deferred
+            // flush was requested. Now that we have a conversation, run it.
             if conversationId != nil && needsOfflineFlush {
                 needsOfflineFlush = false
                 flushOfflineQueue()
@@ -408,16 +408,16 @@ public final class ChatViewModel: ObservableObject {
     var secretBlockedActiveSurfaceId: String?
     var secretBlockedCurrentPage: String?
     /// Nonce sent with `conversation_create` and echoed back in `conversation_info`.
-    /// Used to ensure this ChatViewModel only claims its own session.
+    /// Used to ensure this ChatViewModel only claims its own conversation.
     var bootstrapCorrelationId: String?
     /// Conversation type sent with `conversation_create` (e.g. "private").
     /// Set by `createConversationIfNeeded(conversationType:)` and included in the
     /// message so the daemon can persist the correct conversation kind.
     public var conversationType: String?
-    /// Skill IDs to pre-activate in the session. Included in the
+    /// Skill IDs to pre-activate in the conversation. Included in the
     /// `conversation_create` request for deterministic skill activation.
     public var preactivatedSkillIds: [String]?
-    /// Whether this view model is currently bootstrapping a new session
+    /// Whether this view model is currently bootstrapping a new conversation
     /// (conversation_create sent, awaiting conversation_info). Used by ConversationManager
     /// to decide whether it's safe to release the VM on archive.
     public var isBootstrapping: Bool { bootstrapCorrelationId != nil }
@@ -488,7 +488,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// Timestamp of the most recent `toolUseStart` event received by this view model.
     /// Used by ConversationManager to route `confirmationRequest` messages to the correct
-    /// ChatViewModel when multiple conversations have active sessions.
+    /// ChatViewModel when multiple conversations are active.
     public var lastToolUseReceivedAt: Date?
 
     /// Monotonically increasing version counter for server-authoritative activity state.
@@ -515,7 +515,7 @@ public final class ChatViewModel: ObservableObject {
     /// The macOS layer should cancel the WatchSession and send a cancel to the daemon.
     public var onStopWatch: (() -> Void)?
 
-    /// Called when the daemon assigns a session ID to this chat (via conversation_info).
+    /// Called when the daemon assigns a conversation ID to this chat (via conversation_info).
     /// Used by ConversationManager to backfill ConversationModel.conversationId for new conversations.
     public var onConversationCreated: ((String) -> Void)?
 
@@ -613,7 +613,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Called when `loadPreviousMessagePage` needs to fetch an older page from the
-    /// daemon. The session restorer sets this so the daemon client request is
+    /// daemon. The conversation restorer sets this so the daemon client request is
     /// routed through the same pending-history tracking used for initial loads.
     public var onLoadMoreHistory: ((_ conversationId: String, _ beforeTimestamp: Double) -> Void)?
 
@@ -805,8 +805,8 @@ public final class ChatViewModel: ObservableObject {
             messages[i].stripHeavyContent()
         }
         displayedMessageCount = Self.messagePageSize
-        // Only mark history as unloaded if there's a session to reload from.
-        // Conversations without a session (new, empty) have nothing to fetch —
+        // Only mark history as unloaded if there's a conversation to reload from.
+        // Conversations without a conversation ID (new, empty) have nothing to fetch —
         // resetting the flag would leave the UI stuck on a loading spinner.
         if conversationId != nil {
             isHistoryLoaded = false
@@ -968,9 +968,9 @@ public final class ChatViewModel: ObservableObject {
                     self.connectionDiagnosticHint = nil
                 }
 
-                // If we already have a session ID, flush immediately. Otherwise
+                // If we already have a conversation ID, flush immediately. Otherwise
                 // defer: conversationId's didSet will trigger flushOfflineQueue() once
-                // the session is restored from history (cold-start reconnect case).
+                // the conversation is restored from history (cold-start reconnect case).
                 if self?.conversationId != nil {
                     self?.flushOfflineQueue()
                 } else {
@@ -1175,7 +1175,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         if conversationId == nil {
-            // First message: need to bootstrap session
+            // First message: need to bootstrap conversation
             pendingUserMessageDisplayText = rawText
             pendingUserMessageAutomated = hidden
             bootstrapConversation(userMessage: text, attachments: messageAttachments)
@@ -1274,7 +1274,7 @@ public final class ChatViewModel: ObservableObject {
 
     private func bootstrapConversation(userMessage: String?, attachments: [UserMessageAttachment]?) {
         // Only set sending/thinking indicators when there's an actual user
-        // message; message-less session creates (e.g. private conversation
+        // message; message-less conversation creates (e.g. private conversation
         // pre-allocation) are silent and shouldn't affect UI state.
         if userMessage != nil {
             isSending = true
@@ -1320,7 +1320,7 @@ public final class ChatViewModel: ObservableObject {
             do {
                 try daemonClient.send(ConversationCreateMessage(title: nil, correlationId: correlationId, conversationType: self.conversationType, preactivatedSkillIds: self.preactivatedSkillIds))
                 // Clear one-shot preactivated skills so they don't leak into a
-                // later session if this bootstrap is interrupted before completion.
+                // later conversation if this bootstrap is interrupted before completion.
                 self.preactivatedSkillIds = nil
             } catch {
                 log.error("Failed to send conversation_create: \(error.localizedDescription)")
@@ -1354,7 +1354,7 @@ public final class ChatViewModel: ObservableObject {
             // instead of surfacing an error. The message stays visible with a
             // "pending" indicator and is flushed automatically on reconnect.
             if queuedMessageId == nil {
-                log.info("Buffering message in offline queue (session: \(conversationId))")
+                log.info("Buffering message in offline queue (conversation: \(conversationId))")
                 OfflineMessageQueue.shared.enqueue(conversationId: conversationId, text: text, displayText: displayText, attachments: attachments, automated: automated)
                 // Mark the corresponding chat message as offline-pending so the UI
                 // can show a visual indicator. Find the last user message with this
@@ -1458,17 +1458,17 @@ public final class ChatViewModel: ObservableObject {
         guard !queue.isEmpty else { return }
 
         guard let currentConversationId = conversationId else {
-            // No session yet — defer until conversationId is populated.
+            // No conversation yet — defer until conversationId is populated.
             needsOfflineFlush = true
             return
         }
 
-        // Read the queue contents without clearing. Filter for this session only;
-        // other sessions' messages stay in the persistent store for their own VMs.
+        // Read the queue contents without clearing. Filter for this conversation only;
+        // other conversations' messages stay in the persistent store for their own VMs.
         let mine = queue.allMessages.filter { $0.conversationId == currentConversationId }
         guard !mine.isEmpty else { return }
 
-        log.info("Flushing \(mine.count) offline-queued message(s) for session \(currentConversationId)")
+        log.info("Flushing \(mine.count) offline-queued message(s) for conversation \(currentConversationId)")
 
         // Update message bubbles: clear pendingOffline status so they show as sent.
         for queued in mine {
@@ -1530,7 +1530,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Start the daemon message stream if this chat has a bound session and
+    /// Start the daemon message stream if this chat has a bound conversation and
     /// no active loop yet.
     public func ensureMessageLoopStarted() {
         guard conversationId != nil, messageLoopTask == nil else { return }
@@ -1539,12 +1539,12 @@ public final class ChatViewModel: ObservableObject {
 
     /// Send a message to the daemon without showing a user bubble in the chat.
     /// Used for automated actions like inline model picker selections.
-    /// Returns `true` if the message was sent (or a session bootstrap was started),
+    /// Returns `true` if the message was sent (or a conversation bootstrap was started),
     /// `false` if the message was silently dropped (e.g. bootstrap already in flight).
     @discardableResult
     public func sendSilently(_ text: String) -> Bool {
-        // Don't re-enter bootstrap if a session creation is already in progress —
-        // that would overwrite pendingUserMessage and orphan the in-flight session.
+        // Don't re-enter bootstrap if a conversation creation is already in progress —
+        // that would overwrite pendingUserMessage and orphan the in-flight conversation.
         if conversationId == nil && (isSending || isBootstrapping) {
             return false
         }
@@ -1556,10 +1556,10 @@ public final class ChatViewModel: ObservableObject {
         return true
     }
 
-    /// Create a daemon session immediately, without a user message.
-    /// Used by private conversations that need a persistent session ID right away
+    /// Create a daemon conversation immediately, without a user message.
+    /// Used by private conversations that need a persistent conversation ID right away
     /// (e.g. to store the conversation in the database before the user types anything).
-    /// No-op if a session already exists or a bootstrap is already in flight.
+    /// No-op if a conversation already exists or a bootstrap is already in flight.
     public func createConversationIfNeeded(conversationType: String? = nil) {
         guard conversationId == nil, !isBootstrapping else { return }
         if let conversationType {
@@ -1591,7 +1591,7 @@ public final class ChatViewModel: ObservableObject {
         // send the prompt as a regular message instead of a surface action.
         // This avoids requiring in-memory surface state on the daemon (which is
         // lost after restart) and ensures the full message send pipeline runs
-        // (session creation, hub publisher setup, SSE event delivery).
+        // (conversation creation, hub publisher setup, SSE event delivery).
         let isRelay = actionId == "relay_prompt" || actionId == "agent_prompt"
         if isRelay, let prompt = data?["prompt"]?.value as? String, !prompt.isEmpty {
             _ = sendSilently(prompt)
@@ -1647,7 +1647,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Cancel all in-flight surface refetch tasks and reset the manager's
-    /// failure counts so surfaces can be retried in the new session.
+    /// failure counts so surfaces can be retried in the new conversation.
     private func cancelRefetchTasks() {
         for task in refetchTasks.values { task.cancel() }
         refetchTasks.removeAll()
@@ -1656,8 +1656,8 @@ public final class ChatViewModel: ObservableObject {
 
     /// Cancel the queued user message without clearing `bootstrapCorrelationId`.
     /// Used when archiving a conversation before conversation_info arrives: we want to
-    /// discard the pending message (so it isn't sent once the session is claimed)
-    /// but preserve the correlation ID so the VM only claims its own session.
+    /// discard the pending message (so it isn't sent once the conversation is claimed)
+    /// but preserve the correlation ID so the VM only claims its own conversation.
     public func cancelPendingMessage() {
         pendingUserMessage = nil
         pendingUserMessageDisplayText = nil
@@ -1675,7 +1675,7 @@ public final class ChatViewModel: ObservableObject {
 
         pendingVoiceMessage = false
 
-        // If we're still bootstrapping (no session yet), cancel locally:
+        // If we're still bootstrapping (no conversation yet), cancel locally:
         // discard the pending message so it won't be sent when conversation_info
         // arrives, and reset UI state immediately since there's nothing to
         // cancel on the daemon side.
@@ -2246,7 +2246,7 @@ public final class ChatViewModel: ObservableObject {
             )
         }
 
-        // Resend — bootstrap a new session if needed (mirrors retryLastMessage)
+        // Resend — bootstrap a new conversation if needed (mirrors retryLastMessage)
         if conversationId == nil {
             pendingUserMessageAutomated = message.isHidden
             bootstrapConversation(userMessage: message.text, attachments: userAttachments)
@@ -2390,7 +2390,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Ask the daemon for a follow-up suggestion for the current session.
+    /// Ask the daemon for a follow-up suggestion for the current conversation.
     func fetchSuggestion() {
         guard let conversationId, daemonClient.isConnected else { return }
 

--- a/clients/shared/Network/HTTPDaemonClient+Conversations.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Conversations.swift
@@ -17,7 +17,7 @@ extension HTTPTransport {
             guard let self else { return false }
 
             if let msg = message as? ConversationSwitchRequest {
-                Task { await self.switchSession(conversationId: msg.conversationId) }
+                Task { await self.switchConversation(conversationId: msg.conversationId) }
                 return true
             } else if let msg = message as? ConversationRenameRequest {
                 Task { await self.renameConversation(conversationId: msg.conversationId, name: msg.title) }

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -26,11 +26,11 @@ extension HTTPTransport {
                 Task { await self.sendSecret(requestId: msg.requestId, value: msg.value, delivery: msg.delivery) }
                 return true
             } else if let msg = message as? ConversationCreateMessage {
-                // For HTTP transport, session creation is implicit — the conversationKey
-                // acts as the session. Emit a synthetic session_info so ChatViewModel
-                // records the session ID.
+                // For HTTP transport, conversation creation is implicit — the conversationKey
+                // acts as the conversation. Emit a synthetic conversation_info so ChatViewModel
+                // records the conversation ID.
                 let conversationId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
-                // Remember private sessions so sendMessage can pass conversationType to the backend.
+                // Remember private conversations so sendMessage can pass conversationType to the backend.
                 if msg.conversationType == "private" {
                     self.privateConversationIds.insert(conversationId)
                 }

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -26,12 +26,12 @@ extension HTTPTransport {
         }
     }
 
-    // MARK: - Session ID Translation
+    // MARK: - Conversation ID Translation
 
-    /// Given a client-local session ID, find the corresponding server conversation ID
+    /// Given a client-local conversation ID, find the corresponding server conversation ID
     /// by doing a reverse lookup in `serverToLocalConversationMap`. Returns the original ID
     /// if no mapping exists (the ID is already a server conversation ID, e.g. restored conversations).
-    func serverSessionId(forLocal localId: String) -> String {
+    func serverConversationId(forLocal localId: String) -> String {
         for (serverId, mappedLocalId) in serverToLocalConversationMap {
             if mappedLocalId == localId {
                 return serverId
@@ -85,11 +85,11 @@ extension HTTPTransport {
         applyAuth(&request)
 
         // The abort endpoint requires a conversationId in the body.
-        // Translate client-local session ID → server conversation ID so the
+        // Translate client-local conversation ID → server conversation ID so the
         // server's ownership check (parentConversationId) passes.
         var body: [String: Any] = [:]
         if let conversationId = conversationId {
-            body["conversationId"] = serverSessionId(forLocal: conversationId)
+            body["conversationId"] = serverConversationId(forLocal: conversationId)
         }
 
         do {
@@ -122,11 +122,11 @@ extension HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        // Translate client-local session ID → server conversation ID so the
+        // Translate client-local conversation ID → server conversation ID so the
         // server's ownership check (parentConversationId) passes.
         var body: [String: Any] = ["content": content]
         if let conversationId = conversationId {
-            body["conversationId"] = serverSessionId(forLocal: conversationId)
+            body["conversationId"] = serverConversationId(forLocal: conversationId)
         }
 
         do {

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -345,7 +345,7 @@ public final class HTTPTransport {
         case conversationSearch(query: String, limit: Int?, maxMessagesPerConversation: Int?)
         case messageContent(id: String, conversationId: String?)
         case deleteQueuedMessage(id: String, conversationId: String)
-        case sessionsReorder
+        case conversationsReorder
         // Skill management
         case skillsList
         case skillEnable(id: String)
@@ -711,7 +711,7 @@ public final class HTTPTransport {
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
             return ("/v1/messages/queued/\(idEncoded)", "conversationId=\(sEncoded)")
-        case .sessionsReorder:
+        case .conversationsReorder:
             return ("/v1/conversations/reorder", nil)
         // Skill management
         case .skillsList:
@@ -1123,7 +1123,7 @@ public final class HTTPTransport {
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
             return ("\(prefix)/messages/queued/\(idEncoded)/", "conversationId=\(sEncoded)")
-        case .sessionsReorder:
+        case .conversationsReorder:
             return ("\(prefix)/conversations/reorder/", nil)
         // Skill management
         case .skillsList:
@@ -1563,15 +1563,15 @@ public final class HTTPTransport {
         switch message {
         case .hostBashRequest(let msg):
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
-            log.warning("Ignoring host_bash_request for non-local session \(msg.conversationId, privacy: .public)")
+            log.warning("Ignoring host_bash_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
         case .hostFileRequest(let msg):
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
-            log.warning("Ignoring host_file_request for non-local session \(msg.conversationId, privacy: .public)")
+            log.warning("Ignoring host_file_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
         case .hostCuRequest(let msg):
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
-            log.warning("Ignoring host_cu_request for non-local session \(msg.conversationId, privacy: .public)")
+            log.warning("Ignoring host_cu_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
         default:
             return false
@@ -1739,7 +1739,7 @@ public final class HTTPTransport {
                             self.serverToLocalConversationMap.removeValue(forKey: key)
                         }
                     }
-                    log.info("Mapped server conversation \(serverConvId, privacy: .public) → local session \(conversationId, privacy: .public)")
+                    log.info("Mapped server conversation \(serverConvId, privacy: .public) → local conversation \(conversationId, privacy: .public)")
                 }
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
@@ -2996,7 +2996,7 @@ public final class HTTPTransport {
                     onMessage?(historyResponse)
                 }
             } catch {
-                log.error("Failed to deserialize history response for session \(conversationId, privacy: .public): \(String(describing: error), privacy: .public)")
+                log.error("Failed to deserialize history response for conversation \(conversationId, privacy: .public): \(String(describing: error), privacy: .public)")
             }
         } catch {
             log.error("Fetch history error: \(error.localizedDescription)")
@@ -3362,7 +3362,7 @@ public final class HTTPTransport {
 
     // MARK: - Conversation Management HTTP Handlers
 
-    func switchSession(conversationId: String, isRetry: Bool = false) async {
+    func switchConversation(conversationId: String, isRetry: Bool = false) async {
         guard let url = buildURL(for: .conversationsSwitch) else { return }
 
         var request = URLRequest(url: url)
@@ -3384,7 +3384,7 @@ public final class HTTPTransport {
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {
-                    await switchSession(conversationId: conversationId, isRetry: true)
+                    await switchConversation(conversationId: conversationId, isRetry: true)
                 }
             } else {
                 log.error("Conversation switch failed (HTTP \(http.statusCode))")
@@ -3749,7 +3749,7 @@ public final class HTTPTransport {
     }
 
     func reorderConversations(updates: [ReorderConversationsRequestUpdate], isRetry: Bool = false) async {
-        guard let url = buildURL(for: .sessionsReorder) else { return }
+        guard let url = buildURL(for: .conversationsReorder) else { return }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"


### PR DESCRIPTION
## Summary
- Rename switchSession→switchConversation and sessionsReorder→conversationsReorder in HTTPDaemonClient
- Rename serverSessionId→serverConversationId in HTTPDaemonClient+Subagents
- Update HTTPDaemonClient+ExistingRoutes comments
- Rename IOSConversationStore parameter/loop variable and comments
- Update ChatViewModel.swift comments from session→conversation
- Clean up stale archivedSessionsKey references in pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)