### PR TITLE
fix: reject non-integer --width inputs in avatar ascii command

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -250,8 +250,16 @@ Examples:
         return;
       }
 
+      if (!/^\d+$/.test(opts.width)) {
+        log.error(
+          `Invalid width: "${opts.width}". Must be a positive integer.`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const width = parseInt(opts.width, 10);
-      if (!Number.isFinite(width) || width < 1) {
+      if (width < 1) {
         log.error(
           `Invalid width: "${opts.width}". Must be a positive integer.`,
         );


### PR DESCRIPTION
## Summary
- Validates the raw `--width` string with a digits-only regex (`/^\d+$/`) before calling `parseInt`, so malformed inputs like `"40abc"` or `"2.9"` are rejected instead of silently truncated
- Addresses review feedback from PR #17324

## Test plan
- [ ] `assistant avatar character ascii --width 40` renders normally
- [ ] `assistant avatar character ascii --width 40abc` prints error
- [ ] `assistant avatar character ascii --width 2.9` prints error
- [ ] `assistant avatar character ascii --width 0` prints error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
