### PR TITLE
fix: restore migration 002 to preserve append-only invariant

### DIFF
--- a/assistant/src/workspace/migrations/002-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/002-backfill-installation-id.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+} from "../../memory/checkpoints.js";
+import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id.js";
+import type { WorkspaceMigration } from "./types.js";
+
+export const backfillInstallationIdMigration: WorkspaceMigration = {
+  id: "002-backfill-installation-id",
+  description:
+    "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
+  run(_workspaceDir: string): void {
+    // a. Read existing installation ID from SQLite, or generate a new one.
+    //    On fresh installs the memory_checkpoints table may not exist yet
+    //    (workspace migrations run before initializeDb), so treat errors as null.
+    let existingId: string | null = null;
+    try {
+      existingId = getMemoryCheckpoint("telemetry:installation_id");
+    } catch {
+      // Table doesn't exist yet — fresh install, no prior ID to recover.
+    }
+    const installationId = existingId || randomUUID();
+
+    // b. Read the lockfile from the standard path
+    const base = process.env.BASE_DATA_DIR?.trim() || homedir();
+    const lockPath = join(base, ".vellum.lock.json");
+    if (!existsSync(lockPath)) return;
+
+    let lockData: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      lockData = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // c. Find the assistant entry that corresponds to this daemon instance
+    const assistants = lockData.assistants as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (!Array.isArray(assistants)) return;
+
+    const externalId = getExternalAssistantId();
+    const entry = assistants.find((a) => a.assistantId === externalId);
+    if (!entry) return;
+
+    // d. If already has a truthy installationId, skip lockfile write (idempotent)
+    if (entry.installationId) {
+      // e is skipped for lockfile write, but still clean up SQLite
+      try {
+        deleteMemoryCheckpoint("telemetry:installation_id");
+      } catch {
+        // Table doesn't exist — nothing to clean up.
+      }
+      return;
+    }
+
+    // e. Set installationId on the entry and write the lockfile back
+    entry.installationId = installationId;
+    writeFileSync(lockPath, JSON.stringify(lockData, null, 2) + "\n");
+
+    // f. Delete the stale SQLite row
+    try {
+      deleteMemoryCheckpoint("telemetry:installation_id");
+    } catch {
+      // Table doesn't exist — nothing to clean up.
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,4 +1,5 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
+import { backfillInstallationIdMigration } from "./002-backfill-installation-id.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
@@ -10,6 +11,7 @@ import type { WorkspaceMigration } from "./types.js";
  */
 export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
+  backfillInstallationIdMigration,
   seedDeviceIdMigration,
   extractCollectUsageDataMigration,
   addSendDiagnosticsMigration,


### PR DESCRIPTION
## Summary
- Restores `002-backfill-installation-id.ts` migration file that was deleted in PR #17310
- Re-adds `backfillInstallationIdMigration` to `WORKSPACE_MIGRATIONS` registry between 001 and 003
- Fixes append-only migration invariant violation flagged by reviewers on #17310
- Preserves telemetry ID continuity for users upgrading from pre-002 versions (SQLite checkpoint -> lockfile -> device.json chain)

## Test plan
- [x] Migration file restored with original implementation
- [x] Registry entry re-added in correct position (between 001-avatar-rename and 003-seed-device-id)
- [x] Pre-commit hooks pass (lint, format, secrets check)
- [ ] CI validates type-checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)