### PR TITLE
fix: use VIcon directly in ShareDrawer to fix puzzle piece fallback icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1059,10 +1059,10 @@ private struct ShareDrawer: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ShareDrawerRow(icon: VIcon.share.rawValue, label: "Share", action: onShare)
+            ShareDrawerRow(icon: .share, label: "Share", action: onShare)
             VColor.borderBase.frame(height: 1)
                 .padding(.horizontal, VSpacing.xs)
-            ShareDrawerRow(icon: VIcon.arrowUpRight.rawValue, label: "Publish to Vercel", action: onPublish)
+            ShareDrawerRow(icon: .arrowUpRight, label: "Publish to Vercel", action: onPublish)
         }
         .padding(.vertical, VSpacing.xs)
         .frame(width: 180)
@@ -1077,7 +1077,7 @@ private struct ShareDrawer: View {
 }
 
 private struct ShareDrawerRow: View {
-    let icon: String
+    let icon: VIcon
     let label: String
     let action: () -> Void
     @State private var isHovered = false
@@ -1085,7 +1085,7 @@ private struct ShareDrawerRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: VSpacing.sm) {
-                VIconView(SFSymbolMapping.icon(forSFSymbol: icon, fallback: .puzzle), size: 12)
+                VIconView(icon, size: 12)
                     .foregroundColor(isHovered ? VColor.contentDefault : VColor.contentSecondary)
                     .frame(width: 18)
                 Text(label)


### PR DESCRIPTION
## Summary
- ShareDrawer rows were passing `VIcon.rawValue` (e.g. `"lucide-share-2"`) through `SFSymbolMapping.icon(forSFSymbol:fallback:)`, which couldn't resolve the lucide strings and fell back to `.puzzle` for both "Share" and "Publish to Vercel" menu items
- Changed `ShareDrawerRow` to accept `VIcon` directly and use `VIconView(icon)`, bypassing the SF Symbol mapping layer entirely

## Test plan
- [ ] Open an app in the workspace, click the share button in the toolbar
- [ ] Verify "Share" shows the share icon (not a puzzle piece)
- [ ] Verify "Publish to Vercel" shows the arrow-up-right icon (not a puzzle piece)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
