### PR TITLE
fix: suppress design token guard false positives in AvatarColors.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
@@ -17,9 +17,9 @@ enum AvatarColor: String, CaseIterable, Identifiable {
     /// refactor so avatars remain visible while the daemon fetch is in-flight.
     private var fallbackNSColor: NSColor {
         switch self {
-        case .green:
-            return NSColor(srgbRed: 0x4C / 255.0, green: 0x9B / 255.0, blue: 0x50 / 255.0, alpha: 1)
-        case .orange:
+        case .green: // color-literal-ok
+            return NSColor(srgbRed: 0x4C / 255.0, green: 0x9B / 255.0, blue: 0x50 / 255.0, alpha: 1) // color-literal-ok
+        case .orange: // color-literal-ok
             return NSColor(srgbRed: 0xE9 / 255.0, green: 0x64 / 255.0, blue: 0x2F / 255.0, alpha: 1)
         case .pink:
             return NSColor(srgbRed: 0xDB / 255.0, green: 0x4B / 255.0, blue: 0x77 / 255.0, alpha: 1)
@@ -27,7 +27,7 @@ enum AvatarColor: String, CaseIterable, Identifiable {
             return NSColor(srgbRed: 0xA6 / 255.0, green: 0x65 / 255.0, blue: 0xC9 / 255.0, alpha: 1)
         case .teal:
             return NSColor(srgbRed: 0x0E / 255.0, green: 0x9B / 255.0, blue: 0x8B / 255.0, alpha: 1)
-        case .yellow:
+        case .yellow: // color-literal-ok
             return NSColor(srgbRed: 0xE9 / 255.0, green: 0xC9 / 255.0, blue: 0x1A / 255.0, alpha: 1)
         }
     }


### PR DESCRIPTION
## Summary
- The design token guard (Rule F) was falsely flagging `case .green:`, `case .orange:`, `case .yellow:` enum matches and NSColor `green:` parameter names in `AvatarColors.swift` as raw color literal violations
- Added `// color-literal-ok` suppression comments to the 4 affected lines — these are enum case matches and constructor parameters, not design token violations

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23158536556/job/67279771316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
