### PR TITLE
fix: add inline loading indicator to file viewer Save button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -712,15 +712,20 @@ private struct WorkspaceFileViewer: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 } else if isText && state.isDirty {
-                    VButton(
-                        label: "Save",
-                        style: .primary,
-                        size: .compact,
-                        isDisabled: state.isSaving
-                    ) {
-                        Task { await saveFile(path: detail.path) }
+                    HStack(spacing: VSpacing.xs) {
+                        if state.isSaving {
+                            VBusyIndicator(size: 8)
+                        }
+                        VButton(
+                            label: "Save",
+                            style: .primary,
+                            size: .compact,
+                            isDisabled: state.isSaving
+                        ) {
+                            Task { await saveFile(path: detail.path) }
+                        }
+                        .keyboardShortcut("s", modifiers: .command)
                     }
-                    .keyboardShortcut("s", modifiers: .command)
                 }
             }
             Divider().background(VColor.borderBase)


### PR DESCRIPTION
Address Devin review feedback from #17682. Add VBusyIndicator next to the VButton during save to restore inline loading feedback that was lost when migrating from plain Button to VButton.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
