### PR TITLE
fix: defer legacy UserDefaults cleanup in DeviceIdStore until file write succeeds

### DIFF
--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -43,15 +43,16 @@ public enum DeviceIdStore {
         }
 
         // 2. Migrate from legacy UserDefaults (LocalInstallationIdStore).
+        let migratingFromLegacy: Bool
         var deviceId: String
         if let legacyId = UserDefaults.standard.string(forKey: legacyUserDefaultsKey),
            !legacyId.isEmpty {
             deviceId = legacyId
-            // Clean up legacy key — the file is now the source of truth.
-            UserDefaults.standard.removeObject(forKey: legacyUserDefaultsKey)
+            migratingFromLegacy = true
         } else {
             // 3. No existing ID anywhere — generate a fresh one.
             deviceId = UUID().uuidString.lowercased()
+            migratingFromLegacy = false
         }
 
         // Persist to the shared file, preserving any other fields.
@@ -68,6 +69,17 @@ public enum DeviceIdStore {
             output.append(contentsOf: "\n".utf8)
             try? output.write(to: deviceFile, options: .atomic)
         }
+
+        // Only clean up the legacy UserDefaults key after the file write succeeds,
+        // so we don't lose the ID if the write fails (permissions, full disk, etc.).
+        if migratingFromLegacy,
+           let data = try? Data(contentsOf: deviceFile),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let writtenId = json["deviceId"] as? String,
+           writtenId == deviceId {
+            UserDefaults.standard.removeObject(forKey: legacyUserDefaultsKey)
+        }
+
         cached = deviceId
         return deviceId
     }


### PR DESCRIPTION
## Summary
- Defer deletion of the legacy `vellum_local_installation_id` UserDefaults key until after `device.json` is successfully written to disk
- Adds a read-back verification: the legacy key is only cleaned up if the written file contains the expected deviceId
- Prevents loss of device identity continuity when filesystem writes fail (permissions, full disk, etc.)

Addresses review feedback from PR #17306.

## Test plan
- [ ] Verify migration from UserDefaults works correctly when filesystem is healthy
- [ ] Verify that if the file write fails, the legacy key remains in UserDefaults for retry on next launch
- [ ] Verify read-back verification confirms written deviceId matches expected value
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
