### PR TITLE
feat: emit structured startup error from daemon hatch stderr

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -111,6 +111,7 @@ import {
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
+import { emitDaemonError } from "./startup-error.js";
 import { handleWatchObservation } from "./watch-handler.js";
 
 // Re-export public API so existing consumers don't need to change imports
@@ -898,6 +899,9 @@ export async function runDaemon(): Promise<void> {
   } catch (err) {
     log.error({ err }, "Daemon startup failed — cleaning up");
     cleanupPidFileIfOwner(process.pid);
+    // Emit a structured error line to stderr so both the bundled daemon
+    // binary and dev-mode daemon produce the same parseable format.
+    emitDaemonError(err);
     throw err;
   }
 }

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/node";
 
 import { getLogger } from "../util/logger.js";
 import { runDaemon } from "./lifecycle.js";
+import { emitDaemonError } from "./startup-error.js";
 
 runDaemon().catch(async (err) => {
   Sentry.captureException(err);
@@ -22,5 +23,8 @@ runDaemon().catch(async (err) => {
   console.error(
     "Troubleshooting: check if another assistant is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/",
   );
+  // Emit a structured error line as the last line of stderr so consumers
+  // (e.g. the macOS app) can parse it reliably.
+  emitDaemonError(err);
   process.exit(1);
 });

--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -1,0 +1,125 @@
+/**
+ * Structured startup error reporting for daemon processes.
+ *
+ * When the daemon fails to start, the last line of stderr contains a
+ * machine-readable JSON object prefixed with `DAEMON_ERROR:` so that
+ * consumers (e.g. the macOS app) can parse it reliably.
+ */
+
+/** Known error categories emitted on startup failure. */
+export type DaemonErrorCategory =
+  | "MIGRATION_FAILED"
+  | "PORT_IN_USE"
+  | "DB_LOCKED"
+  | "DB_CORRUPT"
+  | "ENV_VALIDATION"
+  | "UNKNOWN";
+
+export interface DaemonStartupError {
+  error: DaemonErrorCategory;
+  message: string;
+  detail: string;
+}
+
+const DAEMON_ERROR_PREFIX = "DAEMON_ERROR:";
+
+/**
+ * Inspect an error and return a categorized {@link DaemonStartupError}.
+ */
+export function categorizeDaemonError(err: unknown): DaemonStartupError {
+  const code = (err as { code?: string }).code ?? "";
+  const name = (err as { name?: string }).name ?? "";
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : String(err);
+
+  // SQLite constraint errors during startup are almost always migration failures
+  // (e.g. UNIQUE constraint violations when a migration re-runs).
+  if (
+    code.startsWith("SQLITE_CONSTRAINT") ||
+    (name === "SQLiteError" && message.includes("UNIQUE constraint"))
+  ) {
+    return {
+      error: "MIGRATION_FAILED",
+      message: message,
+      detail:
+        "A database migration failed due to a constraint violation during startup.",
+    };
+  }
+
+  // Generic migration detection: if the error message mentions "migration"
+  // alongside SQLite, categorize as MIGRATION_FAILED.
+  if (name === "SQLiteError" && /migration/i.test(message)) {
+    return {
+      error: "MIGRATION_FAILED",
+      message: message,
+      detail: "A database migration failed during startup.",
+    };
+  }
+
+  // Port already in use
+  if (code === "EADDRINUSE") {
+    return {
+      error: "PORT_IN_USE",
+      message: message,
+      detail:
+        "The required port is already in use. Check if another assistant is already running.",
+    };
+  }
+
+  // Database locked (another process holds the lock)
+  if (code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_LOCKED")) {
+    return {
+      error: "DB_LOCKED",
+      message: message,
+      detail:
+        "The database is locked by another process. Check if another assistant is already running.",
+    };
+  }
+
+  // Database corruption
+  if (code.startsWith("SQLITE_CORRUPT") || code.startsWith("SQLITE_NOTADB")) {
+    return {
+      error: "DB_CORRUPT",
+      message: message,
+      detail:
+        "The database appears to be corrupt. You may need to delete and recreate it.",
+    };
+  }
+
+  // Environment validation errors thrown by validateEnv()
+  if (
+    message.startsWith("Invalid GATEWAY_PORT") ||
+    message.startsWith("Invalid RUNTIME_HTTP_PORT") ||
+    message.startsWith("Invalid ") ||
+    /\benv\b.*\bvalidat/i.test(message) ||
+    /\bvalidat.*\benv\b/i.test(message)
+  ) {
+    return {
+      error: "ENV_VALIDATION",
+      message: message,
+      detail: "Environment variable validation failed during startup.",
+    };
+  }
+
+  // Fallback for uncategorized errors
+  return {
+    error: "UNKNOWN",
+    message: message,
+    detail: "An unexpected error occurred during startup.",
+  };
+}
+
+/**
+ * Write a structured error line to stderr. The line is prefixed with
+ * `DAEMON_ERROR:` followed by JSON, making it unambiguous even if other
+ * stderr output precedes it.
+ */
+export function emitDaemonError(err: unknown): void {
+  const structured = categorizeDaemonError(err);
+  const line = `${DAEMON_ERROR_PREFIX}${JSON.stringify(structured)}`;
+  process.stderr.write(line + "\n");
+}


### PR DESCRIPTION
## Summary
- Emit structured JSON error on stderr when daemon startup fails with a `DAEMON_ERROR:` prefix
- Categorize errors into known types (MIGRATION_FAILED, PORT_IN_USE, DB_LOCKED, DB_CORRUPT, ENV_VALIDATION, UNKNOWN)
- Both bundled daemon binary and dev-mode daemon emit the same format

Part of plan: daemon-startup-error-ux.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
