### PR TITLE
fix: make success log and CLI output conditional on ASCII sidecar write

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -16,7 +16,7 @@ export interface CharacterTraits {
 }
 
 export type TraitsSyncResult =
-  | { ok: true }
+  | { ok: true; asciiWritten: boolean }
   | {
       ok: false;
       reason: "invalid_traits" | "render_error";
@@ -26,11 +26,13 @@ export type TraitsSyncResult =
 /**
  * Renders avatar-image.png and character-ascii.txt from the given traits,
  * writing each file atomically.  Does NOT touch character-traits.json.
+ *
+ * Returns `true` if the ASCII sidecar was also written successfully.
  */
 function renderAndWriteAvatarFiles(
   traits: CharacterTraits,
   avatarDir: string,
-): void {
+): boolean {
   const pngPath = join(avatarDir, "avatar-image.png");
 
   // Render PNG first — this validates trait IDs (composeSvg throws on
@@ -56,11 +58,13 @@ function renderAndWriteAvatarFiles(
     const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
     writeFileSync(asciiTmp, asciiArt);
     renameSync(asciiTmp, asciiPath);
+    return true;
   } catch (asciiErr) {
     log.warn(
       { err: asciiErr },
       "Failed to write ASCII sidecar — primary files still written",
     );
+    return false;
   }
 }
 
@@ -98,7 +102,7 @@ export function writeTraitsAndRenderAvatar(
 
     // Render avatar files first — validates trait IDs before committing
     // the traits file, so we never leave traits and PNG out of sync.
-    renderAndWriteAvatarFiles(traits, avatarDir);
+    const asciiWritten = renderAndWriteAvatarFiles(traits, avatarDir);
 
     // Write traits file atomically (after successful render)
     const traitsJson = JSON.stringify(traits, null, 2);
@@ -112,9 +116,11 @@ export function writeTraitsAndRenderAvatar(
         eyeStyle: traits.eyeStyle,
         color: traits.color,
       },
-      "Wrote character traits, regenerated avatar PNG, and updated ASCII art",
+      asciiWritten
+        ? "Wrote character traits, regenerated avatar PNG, and updated ASCII art"
+        : "Wrote character traits and regenerated avatar PNG",
     );
-    return { ok: true };
+    return { ok: true, asciiWritten };
   } catch (err) {
     log.error({ err }, "Failed to write traits / render avatar");
     return {

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -152,7 +152,9 @@ Examples:
         log.info(`Files written to: ${avatarDir}`);
         log.info(`  character-traits.json`);
         log.info(`  avatar-image.png`);
-        log.info(`  character-ascii.txt`);
+        if (result.asciiWritten) {
+          log.info(`  character-ascii.txt`);
+        }
       },
     );
 


### PR DESCRIPTION
## Summary
- `renderAndWriteAvatarFiles` now returns a boolean indicating whether the ASCII sidecar was written successfully
- `TraitsSyncResult` success case includes `asciiWritten` field
- Log message in `writeTraitsAndRenderAvatar` is conditional on ASCII success
- CLI avatar update command only lists `character-ascii.txt` when it was actually written

Addresses bot review feedback on #17325.

## Test plan
- [x] Verified lint and formatting pass via pre-commit hook
- [ ] CI will validate type-checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
