### PR TITLE
fix: update stale `sessions` references to `conversations` in completions and AGENTS.md

### DIFF
--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Commands in `assistant/src/cli/` are scoped to a **single running assistant instance**. They operate on the assistant's local state — config, memory, contacts, trust rules, sessions, autonomy, etc. — and run within the context of the assistant's workspace.
+Commands in `assistant/src/cli/` are scoped to a **single running assistant instance**. They operate on the assistant's local state — config, memory, contacts, trust rules, conversations, autonomy, etc. — and run within the context of the assistant's workspace.
 
 This contrasts with `cli/`, which manages the **lifecycle of assistant instances** (create, start, stop, delete) and operates across instances. See `cli/AGENTS.md`.
 
@@ -15,7 +15,7 @@ This contrasts with `cli/`, which manages the **lifecycle of assistant instances
 | Implicitly scoped to the running assistant          | Requires specifying which assistant to target   |
 | May require or start the daemon                     | Works without an assistant process running      |
 
-Examples: `config`, `contacts`, `memory`, `autonomy`, `sessions`, `doctor` belong here. `hatch`, `wake`, `sleep`, `retire`, `ps`, `ssh` belong in `cli/`.
+Examples: `config`, `contacts`, `memory`, `autonomy`, `conversations`, `doctor` belong here. `hatch`, `wake`, `sleep`, `retire`, `ps`, `ssh` belong in `cli/`.
 
 ## Conventions
 

--- a/assistant/src/cli/commands/completions.ts
+++ b/assistant/src/cli/commands/completions.ts
@@ -35,7 +35,7 @@ Examples:
     )
     .action((shell: string) => {
       const subcommands: Record<string, string[]> = {
-        sessions: ["list", "new", "export", "clear"],
+        conversations: ["list", "new", "export", "clear"],
         config: ["set", "get", "list", "validate-allowlist"],
         keys: ["list", "set", "delete"],
         trust: ["list", "remove", "clear"],
@@ -45,7 +45,7 @@ Examples:
         autonomy: ["get", "set"],
       };
       const topLevel = [
-        "sessions",
+        "conversations",
         "config",
         "keys",
         "trust",
@@ -128,7 +128,7 @@ function generateZshCompletion(
 _assistant() {
     local -a commands
     commands=(
-        'sessions:Manage sessions'
+        'conversations:Manage conversations'
         'config:Manage configuration'
         'keys:Manage API keys in secure storage'
         'trust:Manage trust rules'
@@ -169,7 +169,7 @@ function generateFishCompletion(
   script += `complete -c assistant -f\n`;
 
   const descriptions: Record<string, string> = {
-    sessions: "Manage sessions",
+    conversations: "Manage conversations",
     config: "Manage configuration",
     keys: "Manage API keys in secure storage",
     trust: "Manage trust rules",


### PR DESCRIPTION
## Summary
- Updated shell completion scripts (bash/zsh/fish) in `completions.ts` to use `conversations` instead of the old `sessions` command name
- Updated `assistant/src/cli/AGENTS.md` to reference `conversations` instead of `sessions`
- These were missed in PR #17353 which renamed the CLI `sessions` command to `conversations`

Addresses review feedback from #17353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)