### PR TITLE
feat: add organization ID to Sentry tags

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -158,6 +158,22 @@ export function getPlatformAssistantId(): string {
   return str("PLATFORM_ASSISTANT_ID") ?? _platformAssistantIdOverride ?? "";
 }
 
+let _platformOrganizationIdOverride: string | undefined;
+
+export function setPlatformOrganizationId(value: string | undefined): void {
+  _platformOrganizationIdOverride = value;
+}
+
+/**
+ * PLATFORM_ORGANIZATION_ID — UUID of the organization this assistant belongs to.
+ * Used for Sentry tagging and platform API calls.
+ */
+export function getPlatformOrganizationId(): string {
+  return (
+    str("PLATFORM_ORGANIZATION_ID") ?? _platformOrganizationIdOverride ?? ""
+  );
+}
+
 /**
  * PLATFORM_INTERNAL_API_KEY — static internal gateway key for authenticating
  * with the platform's internal gateway callback route registration endpoint.

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,5 +1,10 @@
-import { setPlatformAssistantId, setPlatformBaseUrl } from "../config/env.js";
+import {
+  setPlatformAssistantId,
+  setPlatformBaseUrl,
+  setPlatformOrganizationId,
+} from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
+import { setSentryOrganizationId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
@@ -56,6 +61,24 @@ export async function initializeProvidersAndTools(
     log.warn(
       { error: err instanceof Error ? err.message : String(err) },
       "Failed to rehydrate platform assistant ID from credential store (non-fatal)",
+    );
+  }
+
+  // Rehydrate the platform organization ID from the credential store so
+  // Sentry events include organization context after restarts.
+  try {
+    const key = credentialKey("vellum", "platform_organization_id");
+    const persisted = await getSecureKeyAsync(key);
+    const trimmed = persisted?.trim();
+    if (trimmed) {
+      setPlatformOrganizationId(trimmed);
+      setSentryOrganizationId(trimmed);
+      log.info("Rehydrated platform organization ID from credential store");
+    }
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to rehydrate platform organization ID from credential store (non-fatal)",
     );
   }
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -2,7 +2,7 @@ import { arch, hostname, platform, release } from "node:os";
 
 import * as Sentry from "@sentry/node";
 
-import { getSentryDsn } from "./config/env.js";
+import { getPlatformOrganizationId, getSentryDsn } from "./config/env.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
@@ -58,6 +58,9 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
+        ...(getPlatformOrganizationId()
+          ? { organization_id: getPlatformOrganizationId() }
+          : {}),
       },
     },
     beforeSend(event) {
@@ -91,6 +94,19 @@ export function initSentry(): void {
  */
 export async function closeSentry(): Promise<void> {
   await Sentry.close();
+}
+
+/**
+ * Set (or clear) the organization_id tag on the global Sentry scope.
+ *
+ * Called after the platform organization ID is rehydrated from the
+ * credential store or updated at runtime so that every subsequent
+ * Sentry event includes the organization context.
+ */
+export function setSentryOrganizationId(
+  organizationId: string | undefined,
+): void {
+  Sentry.setTag("organization_id", organizationId || undefined);
 }
 
 // ── Dynamic conversation-scoped Sentry tags ─────────────────────────

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -1,6 +1,7 @@
 import {
   setPlatformAssistantId,
   setPlatformBaseUrl,
+  setPlatformOrganizationId,
 } from "../../config/env.js";
 import {
   API_KEY_PROVIDERS,
@@ -8,6 +9,7 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
+import { setSentryOrganizationId } from "../../instrument.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -169,6 +171,11 @@ export async function handleAddSecret(
         const trimmed = value.trim();
         setPlatformAssistantId(trimmed || undefined);
       }
+      if (service === "vellum" && field === "platform_organization_id") {
+        const trimmed = value.trim();
+        setPlatformOrganizationId(trimmed || undefined);
+        setSentryOrganizationId(trimmed || undefined);
+      }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());
         if (service === "vellum" && field === "assistant_api_key") {
@@ -294,6 +301,10 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       if (service === "vellum" && field === "platform_assistant_id") {
         setPlatformAssistantId(undefined);
+      }
+      if (service === "vellum" && field === "platform_organization_id") {
+        setPlatformOrganizationId(undefined);
+        setSentryOrganizationId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());


### PR DESCRIPTION
## Summary
- Add `PLATFORM_ORGANIZATION_ID` env var support (with credential store rehydration) following the same pattern as `PLATFORM_ASSISTANT_ID`
- Set `organization_id` as a global Sentry tag at init time (from env) and dynamically after credential store rehydration
- Handle runtime set/delete of the org ID via the secrets HTTP API, keeping Sentry in sync

## Original prompt
add organization id to sentry logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
