### PR TITLE
Fix: restore top alignment in two-pane skill file layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -366,7 +366,7 @@ struct AgentPanelContent: View {
             }
 
             // Two-pane content: file list + file content viewer
-            HStack(spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
                 // Left: file list (always fixed width)
                 skillFilesSection
                     .frame(width: 280, alignment: .topLeading)


### PR DESCRIPTION
## Summary
- Restores `alignment: .top` on the two-pane HStack in AgentPanel's skill file viewer
- Without this, when the file list is shorter than the content viewer, SwiftUI defaults to `.center` alignment, causing the file list to float in the middle instead of anchoring at the top
- Addresses review feedback from PR #17338

## Test plan
- [ ] Open a skill with few files and verify the file list stays top-aligned with the content viewer
- [ ] Confirm no visual regression on skills with many files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
