### PR TITLE
fix: align route policy key and test mock fields after session->conversation rename

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -410,7 +410,7 @@ describe("relay-server", () => {
             _messageId: string,
             onEvent: (event: {
               type: string;
-              sessionId?: string;
+              conversationId?: string;
               text?: string;
             }) => void,
           ) => {
@@ -425,7 +425,7 @@ describe("relay-server", () => {
                 tokens.push(event.text);
                 onEvent({
                   type: "assistant_text_delta",
-                  sessionId: conversationId,
+                  conversationId: conversationId,
                   text: event.text,
                 });
               },
@@ -446,7 +446,10 @@ describe("relay-server", () => {
               );
             }
 
-            onEvent({ type: "message_complete", sessionId: conversationId });
+            onEvent({
+              type: "message_complete",
+              conversationId: conversationId,
+            });
           },
         };
         return session as unknown as import("../daemon/conversation.js").Conversation;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -328,8 +328,8 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "model:PUT", scopes: ["settings.write"] },
   { endpoint: "model/image-gen", scopes: ["settings.write"] },
 
-  // Session management
-  { endpoint: "sessions/reorder", scopes: ["chat.write"] },
+  // Conversation management
+  { endpoint: "conversations/reorder", scopes: ["chat.write"] },
 
   // Conversation search
   { endpoint: "conversations/search", scopes: ["chat.read"] },


### PR DESCRIPTION
## Summary
- Fix route policy key mismatch: rename `sessions/reorder` to `conversations/reorder` in the auth policy registry so the `chat.write` scope check is correctly enforced on the reorder endpoint
- Fix stale `sessionId` references in `relay-server.test.ts` mock event emissions to use `conversationId`, matching the updated `AssistantTextDelta` and `MessageComplete` interfaces

Addresses review feedback from PR #17368.

## Test plan
- [ ] Verify `conversations/reorder` endpoint correctly enforces `chat.write` scope (policy lookup no longer returns undefined)
- [ ] Verify relay-server tests pass with updated field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
