### PR TITLE
fix: replace hardcoded indentation literal with VSpacing.lg design token

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
@@ -32,7 +32,7 @@ struct FileTreeRowLabel: View {
                 .foregroundColor(VColor.contentDefault)
                 .fixedSize(horizontal: true, vertical: false)
         }
-        .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
+        .padding(.leading, CGFloat(depth) * VSpacing.lg + VSpacing.sm)
         .padding(.trailing, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(minWidth: minRowWidth, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -482,7 +482,7 @@ private struct WorkspaceTreeRow: View {
                                 .onSubmit { submitRename() }
                                 .onExitCommand { state.renamingPath = nil }
                         }
-                        .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
+                        .padding(.leading, CGFloat(depth) * VSpacing.lg + VSpacing.sm)
                         .padding(.trailing, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .frame(minWidth: minRowWidth, alignment: .leading)


### PR DESCRIPTION
## Summary
- Replace hardcoded `16` with `VSpacing.lg` design token in `FileTreeRowLabel.swift` (addressing PR #17380 review feedback)
- Apply the same fix to the existing inline layout in `WorkspacePanel.swift` which had the same issue

Addresses review feedback from #17380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
