### PR TITLE
fix: share config write lock across gateway config mutation routes

### DIFF
--- a/gateway/src/http/routes/config-file-utils.ts
+++ b/gateway/src/http/routes/config-file-utils.ts
@@ -1,0 +1,73 @@
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  renameSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getRootDir } from "../../credential-reader.js";
+
+/**
+ * Serializes config writes so concurrent PATCH requests don't race on
+ * read-modify-write. Each write awaits the previous one before proceeding.
+ *
+ * This chain is shared across all config mutation routes (feature flags,
+ * privacy config, etc.) to prevent concurrent writes to the same
+ * config.json from overwriting each other's changes.
+ */
+let configWriteChain: Promise<void> = Promise.resolve();
+
+/**
+ * Enqueue a write operation onto the shared config write chain.
+ * The callback runs only after all previously enqueued writes have finished.
+ */
+export function enqueueConfigWrite(fn: () => void): void {
+  configWriteChain = configWriteChain.then(fn);
+}
+
+export function getConfigPath(): string {
+  return join(getRootDir(), "workspace", "config.json");
+}
+
+export type ConfigReadResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; reason: "malformed"; detail: string };
+
+export function readConfigFile(): ConfigReadResult {
+  const cfgPath = getConfigPath();
+  if (!existsSync(cfgPath)) {
+    return { ok: true, data: {} };
+  }
+  try {
+    const raw = readFileSync(cfgPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {
+        ok: false,
+        reason: "malformed",
+        detail: "Config file is not a JSON object",
+      };
+    }
+    return { ok: true, data: parsed };
+  } catch (err) {
+    return { ok: false, reason: "malformed", detail: String(err) };
+  }
+}
+
+/**
+ * Atomically write the config file: write to a temporary file in the same
+ * directory, then rename. This avoids partial-file corruption if the process
+ * crashes mid-write.
+ */
+export function writeConfigFileAtomic(data: Record<string, unknown>): void {
+  const cfgPath = getConfigPath();
+  const dir = dirname(cfgPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = join(dir, `.config.${randomBytes(6).toString("hex")}.tmp`);
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  renameSync(tmpPath, cfgPath);
+}

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -1,26 +1,15 @@
 import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  renameSync,
-} from "node:fs";
-import { join, dirname } from "node:path";
-import { randomBytes } from "node:crypto";
-import { getRootDir } from "../../credential-reader.js";
-import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
 import { getLogger } from "../../logger.js";
+import {
+  enqueueConfigWrite,
+  readConfigFile,
+  writeConfigFileAtomic,
+} from "./config-file-utils.js";
 
 const log = getLogger("feature-flags");
-
-/**
- * Serializes config writes so concurrent PATCH requests don't race on
- * read-modify-write. Each write awaits the previous one before proceeding.
- */
-let configWriteChain: Promise<void> = Promise.resolve();
 
 /**
  * Only allow keys matching `feature_flags.<flagId>.enabled` for the canonical format.
@@ -28,51 +17,6 @@ let configWriteChain: Promise<void> = Promise.resolve();
  * dots, hyphens, and underscores.
  */
 const ALLOWED_KEY_RE = /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/;
-
-function getConfigPath(): string {
-  return join(getRootDir(), "workspace", "config.json");
-}
-
-type ConfigReadResult =
-  | { ok: true; data: Record<string, unknown> }
-  | { ok: false; reason: "malformed"; detail: string };
-
-function readConfigFile(): ConfigReadResult {
-  const cfgPath = getConfigPath();
-  if (!existsSync(cfgPath)) {
-    return { ok: true, data: {} };
-  }
-  try {
-    const raw = readFileSync(cfgPath, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {
-        ok: false,
-        reason: "malformed",
-        detail: "Config file is not a JSON object",
-      };
-    }
-    return { ok: true, data: parsed };
-  } catch (err) {
-    return { ok: false, reason: "malformed", detail: String(err) };
-  }
-}
-
-/**
- * Atomically write the config file: write to a temporary file in the same
- * directory, then rename. This avoids partial-file corruption if the process
- * crashes mid-write.
- */
-function writeConfigFileAtomic(data: Record<string, unknown>): void {
-  const cfgPath = getConfigPath();
-  const dir = dirname(cfgPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = join(dir, `.config.${randomBytes(6).toString("hex")}.tmp`);
-  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
-  renameSync(tmpPath, cfgPath);
-}
 
 /**
  * Read persisted flag values from the canonical config section.
@@ -193,7 +137,7 @@ export function createFeatureFlagsPatchHandler() {
 
     // Serialize config writes to prevent concurrent read-modify-write races
     const writeResult = new Promise<Response>((resolve) => {
-      configWriteChain = configWriteChain.then(() => {
+      enqueueConfigWrite(() => {
         try {
           const result = readConfigFile();
           if (!result.ok) {

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -1,53 +1,11 @@
-import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  renameSync,
-} from "node:fs";
-import { join, dirname } from "node:path";
-import { randomBytes } from "node:crypto";
-import { getRootDir } from "../../credential-reader.js";
 import { getLogger } from "../../logger.js";
+import {
+  enqueueConfigWrite,
+  readConfigFile,
+  writeConfigFileAtomic,
+} from "./config-file-utils.js";
 
 const log = getLogger("privacy-config");
-
-/** Serializes config writes so concurrent PATCH requests don't race. */
-let configWriteChain: Promise<void> = Promise.resolve();
-
-function getConfigPath(): string {
-  return join(getRootDir(), "workspace", "config.json");
-}
-
-function readConfigFile():
-  | { ok: true; data: Record<string, unknown> }
-  | { ok: false; detail: string } {
-  const cfgPath = getConfigPath();
-  if (!existsSync(cfgPath)) {
-    return { ok: true, data: {} };
-  }
-  try {
-    const raw = readFileSync(cfgPath, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { ok: false, detail: "Config file is not a JSON object" };
-    }
-    return { ok: true, data: parsed };
-  } catch (err) {
-    return { ok: false, detail: String(err) };
-  }
-}
-
-function writeConfigFileAtomic(data: Record<string, unknown>): void {
-  const cfgPath = getConfigPath();
-  const dir = dirname(cfgPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  const tmpPath = join(dir, `.config.${randomBytes(6).toString("hex")}.tmp`);
-  writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
-  renameSync(tmpPath, cfgPath);
-}
 
 export function createPrivacyConfigPatchHandler() {
   return async (req: Request): Promise<Response> => {
@@ -101,7 +59,7 @@ export function createPrivacyConfigPatchHandler() {
     }
 
     const writeResult = new Promise<Response>((resolve) => {
-      configWriteChain = configWriteChain.then(() => {
+      enqueueConfigWrite(() => {
         try {
           const result = readConfigFile();
           if (!result.ok) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -689,7 +689,7 @@ async function main() {
       path: "/v1/config/privacy",
       method: "PATCH",
       auth: "edge-scoped",
-      scope: "feature_flags.write",
+      scope: "settings.write",
       handler: (req) => handlePrivacyConfigPatch(req),
     },
   ];


### PR DESCRIPTION
## Summary
- Extract shared config file utilities (write chain, read, atomic write) into `gateway/src/http/routes/config-file-utils.ts` so all config.json mutation routes serialize through a single `configWriteChain`
- Fix race condition where concurrent PATCH requests to `/v1/config/privacy` and `/v1/feature-flags/:key` could overwrite each other's changes (last-writer-wins)
- Change privacy config endpoint auth scope from `feature_flags.write` to `settings.write` for correct semantic authorization

Addresses review feedback on #17450.

## Test plan
- [ ] Verify concurrent PATCH requests to privacy config and feature flags endpoints serialize correctly and do not lose writes
- [ ] Verify macOS app (actor_client_v1 profile) can still write privacy config with the `settings.write` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
