### PR TITLE
feat: parse daemon startup error in AssistantCli and expose to AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -386,6 +386,18 @@ extension AppDelegate {
                     let assistantName = assistant?.assistantId
                     do {
                         try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
+                    } catch let error as AssistantCli.CLIError {
+                        switch error {
+                        case .daemonStartupFailed(let startupError):
+                            log.error("Daemon startup failed [\(startupError.category)]: \(startupError.message, privacy: .private)")
+                            self.daemonStartupError = startupError
+                        default:
+                            log.error("Failed to hatch assistant during daemon setup: \(error)")
+                        }
+                        if needsLockfileEntry {
+                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
+                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                        }
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
                         if needsLockfileEntry {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -128,6 +128,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Last time we surfaced the denied-notification permission toast.
     var lastNotificationPermissionToastAtMs: Double = 0
 
+    /// Structured error from the most recent daemon startup failure.
+    /// Populated by `setupDaemonClient()` when `hatch()` throws a
+    /// `CLIError.daemonStartupFailed`. Read by the UI (PR 3) to show a
+    /// contextual error view instead of a generic failure message.
+    @Published var daemonStartupError: DaemonStartupError?
+
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.
     var isCurrentAssistantRemote = false

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -37,6 +37,20 @@ private final class OnceFlag: @unchecked Sendable {
     }
 }
 
+/// Structured error emitted by the daemon on startup failure.
+///
+/// The daemon writes a `DAEMON_ERROR:{...}` JSON line to stderr when startup
+/// fails. This struct captures the parsed fields so the UI can display a
+/// contextual error view instead of a generic failure message.
+struct DaemonStartupError {
+    /// Error category (e.g. "MIGRATION_FAILED", "PORT_IN_USE", "UNKNOWN").
+    let category: String
+    /// Human-readable error message.
+    let message: String
+    /// Optional additional context (stack trace, conflicting PID, etc.).
+    let detail: String?
+}
+
 /// Manages all daemon lifecycle operations through the bundled CLI binary.
 ///
 /// This is the single entry point for hatching, stopping, and retiring the
@@ -48,6 +62,7 @@ final class AssistantCli {
     enum CLIError: LocalizedError {
         case binaryNotFound
         case executionFailed(String)
+        case daemonStartupFailed(DaemonStartupError)
 
         var errorDescription: String? {
             switch self {
@@ -55,6 +70,8 @@ final class AssistantCli {
                 return "CLI binary not found in app bundle"
             case .executionFailed(let message):
                 return "CLI command failed: \(message)"
+            case .daemonStartupFailed(let error):
+                return "Assistant startup failed: \(error.message)"
             }
         }
     }
@@ -118,7 +135,7 @@ final class AssistantCli {
 
         if status != 0 {
             log.error("CLI hatch failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
-            throw CLIError.executionFailed(stderr)
+            throw CLIError.daemonStartupFailed(Self.parseDaemonStartupError(from: stderr))
         }
 
         log.info("CLI hatch completed successfully")
@@ -567,6 +584,32 @@ final class AssistantCli {
     }
 
     // MARK: - Private Helpers
+
+    /// Parse a `DaemonStartupError` from the daemon's stderr output.
+    ///
+    /// Scans for the last line starting with `DAEMON_ERROR:` and parses
+    /// the trailing JSON. Falls back to an `UNKNOWN` category with the
+    /// tail of stderr when no structured marker is found (old daemon binary).
+    private static func parseDaemonStartupError(from stderr: String) -> DaemonStartupError {
+        let lines = stderr.components(separatedBy: .newlines)
+
+        // Find the last DAEMON_ERROR: line (the daemon writes exactly one,
+        // but scanning from the end is more robust).
+        if let markerLine = lines.last(where: { $0.hasPrefix("DAEMON_ERROR:") }) {
+            let jsonString = String(markerLine.dropFirst("DAEMON_ERROR:".count))
+            if let data = jsonString.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                let category = json["error"] as? String ?? "UNKNOWN"
+                let message = json["message"] as? String ?? "Unknown startup error"
+                let detail = json["detail"] as? String
+                return DaemonStartupError(category: category, message: message, detail: detail)
+            }
+        }
+
+        // Fallback for old daemon binaries that don't emit DAEMON_ERROR.
+        let fallbackMessage = String(stderr.suffix(500))
+        return DaemonStartupError(category: "UNKNOWN", message: fallbackMessage, detail: nil)
+    }
 
     /// Kill the gateway directly via PID file — fallback when CLI binary is unavailable.
     private func killGatewayViaPIDFile() {


### PR DESCRIPTION
## Summary
- Add DaemonStartupError struct to parse structured daemon error output
- Parse DAEMON_ERROR: JSON from stderr in AssistantCli.hatch() with fallback for old binaries
- Expose daemonStartupError on AppDelegate for UI consumption

Part of plan: daemon-startup-error-ux.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)