### PR TITLE
fix: preserve backward compat for session-to-conversation persisted state

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -68,6 +68,16 @@ private struct PersistedConversation: Codable {
     var hasUnseenLatestAssistantMessage: Bool?
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
+
+    // Map conversationId to the legacy "sessionId" JSON key so that
+    // existing UserDefaults data (encoded before the rename) decodes
+    // correctly on upgrade instead of silently dropping all cached
+    // conversations.
+    enum CodingKeys: String, CodingKey {
+        case id, title, createdAt, lastActivityAt, isArchived, isPinned, displayOrder, isPrivate
+        case conversationId = "sessionId"
+        case scheduleJobId, hasUnseenLatestAssistantMessage, latestAssistantMessageAt, lastSeenAssistantMessageAt
+    }
 }
 
 // MARK: - IOSConversationStore

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,7 +6,9 @@ import os
 import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
-private let archivedConversationsKey = "archivedConversationIds"
+// Keep the legacy UserDefaults key so existing persisted archive
+// state is preserved across the session-to-conversation rename.
+private let archivedConversationsKey = "archivedSessionIds"
 
 // MARK: - Conversation Client Protocol
 


### PR DESCRIPTION
## Summary
- Add CodingKeys enum to PersistedConversation (iOS) so the `conversationId` property decodes from the legacy `"sessionId"` JSON key in UserDefaults
- Restore the original `"archivedSessionIds"` UserDefaults key in ConversationManager (macOS) so archived-conversation state is not lost on upgrade
- Addresses review feedback from PR #17382 about persisted-state breakage violating AGENTS.md migration rules

## Test plan
- [ ] Verify iOS connected-mode cache loads correctly for users who had data under the old `sessionId` key
- [ ] Verify macOS archived conversations remain archived after upgrade (not reset due to key change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
