### PR TITLE
fix: rename session to conversation in TS test helpers and swarm delegate

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -256,7 +256,7 @@ function makeProvider() {
   };
 }
 
-function makeSession(
+function makeConversation(
   sendToClient?: (msg: ServerMessage) => void,
   conversationId = CONV_ID,
 ): Conversation {
@@ -345,35 +345,38 @@ beforeEach(() => {
 describe("approval cascading", () => {
   test("allow_10m cascades to all pending in same conversation", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
     // Seed 3 pending confirmations
-    seedPendingConfirmation(session, "req-1");
-    seedPendingConfirmation(session, "req-2");
-    seedPendingConfirmation(session, "req-3");
+    seedPendingConfirmation(conversationObj, "req-1");
+    seedPendingConfirmation(conversationObj, "req-2");
+    seedPendingConfirmation(conversationObj, "req-3");
 
     // Register in pending-interactions tracker
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-1",
       CONV_ID,
       makeConfirmationDetails(["bash:echo hello"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-2",
       CONV_ID,
       makeConfirmationDetails(["bash:ls -la"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-3",
       CONV_ID,
       makeConfirmationDetails(["bash:cat file"]),
     );
 
     // Resolve the first with allow_10m
-    session.handleConfirmationResponse("req-1", "allow_10m");
+    conversationObj.handleConfirmationResponse("req-1", "allow_10m");
 
     // All 3 should be resolved (approved)
     const confirmMsgs = emitted.filter(
@@ -390,32 +393,35 @@ describe("approval cascading", () => {
 
   test("allow_conversation cascades to all pending in same conversation", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-a");
-    seedPendingConfirmation(session, "req-b");
-    seedPendingConfirmation(session, "req-c");
+    seedPendingConfirmation(conversationObj, "req-a");
+    seedPendingConfirmation(conversationObj, "req-b");
+    seedPendingConfirmation(conversationObj, "req-c");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-a",
       CONV_ID,
       makeConfirmationDetails(["bash:echo a"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-b",
       CONV_ID,
       makeConfirmationDetails(["bash:echo b"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-c",
       CONV_ID,
       makeConfirmationDetails(["bash:echo c"]),
     );
 
-    session.handleConfirmationResponse("req-a", "allow_conversation");
+    conversationObj.handleConfirmationResponse("req-a", "allow_conversation");
 
     const confirmMsgs = emitted.filter(
       (m) =>
@@ -431,36 +437,39 @@ describe("approval cascading", () => {
 
   test("temporary override does NOT cascade to different conversation", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-same");
-    seedPendingConfirmation(session, "req-diff");
+    seedPendingConfirmation(conversationObj, "req-same");
+    seedPendingConfirmation(conversationObj, "req-diff");
 
     // Same conversation
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-same",
       CONV_ID,
       makeConfirmationDetails(["bash:echo same"]),
     );
     // Different conversation
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-diff",
       "different-conv",
       makeConfirmationDetails(["bash:echo diff"]),
     );
 
     // Seed a primary request
-    seedPendingConfirmation(session, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-primary");
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["bash:echo primary"]),
     );
 
-    session.handleConfirmationResponse("req-primary", "allow_10m");
+    conversationObj.handleConfirmationResponse("req-primary", "allow_10m");
 
     const confirmMsgs = emitted.filter(
       (m) =>
@@ -477,43 +486,46 @@ describe("approval cascading", () => {
 
   test("always_allow cascades to pattern-matching pending", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
     // Two with matching patterns (asset_materialize:doc.pdf)
-    seedPendingConfirmation(session, "req-match-1");
-    seedPendingConfirmation(session, "req-match-2");
+    seedPendingConfirmation(conversationObj, "req-match-1");
+    seedPendingConfirmation(conversationObj, "req-match-2");
     // One with non-overlapping pattern
-    seedPendingConfirmation(session, "req-nomatch");
+    seedPendingConfirmation(conversationObj, "req-nomatch");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-match-1",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:doc.pdf"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-match-2",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:report.pdf"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-nomatch",
       CONV_ID,
       makeConfirmationDetails(["bash:rm -rf"]),
     );
 
     // Primary request
-    seedPendingConfirmation(session, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-primary");
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:image.png"]),
     );
 
-    session.handleConfirmationResponse(
+    conversationObj.handleConfirmationResponse(
       "req-primary",
       "always_allow",
       "asset_materialize:**",
@@ -534,20 +546,23 @@ describe("approval cascading", () => {
 
   test("always_allow does NOT cascade to high-risk pending confirmations", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
     // Medium-risk pending — should cascade
-    seedPendingConfirmation(session, "req-medium");
+    seedPendingConfirmation(conversationObj, "req-medium");
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-medium",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:report.pdf"]),
     );
 
     // High-risk pending — should NOT cascade via always_allow
-    seedPendingConfirmation(session, "req-high");
-    registerPendingInteraction(session, "req-high", CONV_ID, {
+    seedPendingConfirmation(conversationObj, "req-high");
+    registerPendingInteraction(conversationObj, "req-high", CONV_ID, {
       toolName: "bash",
       input: { command: "rm -rf /" },
       riskLevel: "high",
@@ -562,15 +577,15 @@ describe("approval cascading", () => {
     });
 
     // Primary request
-    seedPendingConfirmation(session, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-primary");
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:image.png"]),
     );
 
-    session.handleConfirmationResponse(
+    conversationObj.handleConfirmationResponse(
       "req-primary",
       "always_allow",
       "asset_materialize:**",
@@ -596,33 +611,36 @@ describe("approval cascading", () => {
 
   test("always_deny cascades deny to pattern-matching pending", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-match-1");
-    seedPendingConfirmation(session, "req-nomatch");
+    seedPendingConfirmation(conversationObj, "req-match-1");
+    seedPendingConfirmation(conversationObj, "req-nomatch");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-match-1",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:doc.pdf"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-nomatch",
       CONV_ID,
       makeConfirmationDetails(["bash:rm -rf"]),
     );
 
-    seedPendingConfirmation(session, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-primary");
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["asset_materialize:image.png"]),
     );
 
-    session.handleConfirmationResponse(
+    conversationObj.handleConfirmationResponse(
       "req-primary",
       "always_deny",
       "asset_materialize:**",
@@ -648,25 +666,28 @@ describe("approval cascading", () => {
 
   test("allow (one-time) does NOT cascade", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-1");
-    seedPendingConfirmation(session, "req-2");
+    seedPendingConfirmation(conversationObj, "req-1");
+    seedPendingConfirmation(conversationObj, "req-2");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-1",
       CONV_ID,
       makeConfirmationDetails(["bash:echo hello"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-2",
       CONV_ID,
       makeConfirmationDetails(["bash:echo world"]),
     );
 
-    session.handleConfirmationResponse("req-1", "allow");
+    conversationObj.handleConfirmationResponse("req-1", "allow");
 
     const confirmMsgs = emitted.filter(
       (m) =>
@@ -681,25 +702,28 @@ describe("approval cascading", () => {
 
   test("deny (one-time) does NOT cascade", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-1");
-    seedPendingConfirmation(session, "req-2");
+    seedPendingConfirmation(conversationObj, "req-1");
+    seedPendingConfirmation(conversationObj, "req-2");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-1",
       CONV_ID,
       makeConfirmationDetails(["bash:echo hello"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-2",
       CONV_ID,
       makeConfirmationDetails(["bash:echo world"]),
     );
 
-    session.handleConfirmationResponse("req-1", "deny");
+    conversationObj.handleConfirmationResponse("req-1", "deny");
 
     const confirmMsgs = emitted.filter(
       (m) =>
@@ -714,25 +738,28 @@ describe("approval cascading", () => {
 
   test("cascaded events have source 'system' and causedByRequestId", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-primary");
-    seedPendingConfirmation(session, "req-cascaded");
+    seedPendingConfirmation(conversationObj, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-cascaded");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["bash:echo primary"]),
     );
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-cascaded",
       CONV_ID,
       makeConfirmationDetails(["bash:echo cascaded"]),
     );
 
-    session.handleConfirmationResponse("req-primary", "allow_10m");
+    conversationObj.handleConfirmationResponse("req-primary", "allow_10m");
 
     const cascadedMsg = emitted.find(
       (m) =>
@@ -747,13 +774,16 @@ describe("approval cascading", () => {
 
   test("already-resolved request handled gracefully", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg), CONV_ID);
+    const conversationObj = makeConversation(
+      (msg) => emitted.push(msg),
+      CONV_ID,
+    );
 
-    seedPendingConfirmation(session, "req-primary");
-    seedPendingConfirmation(session, "req-stale");
+    seedPendingConfirmation(conversationObj, "req-primary");
+    seedPendingConfirmation(conversationObj, "req-stale");
 
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-primary",
       CONV_ID,
       makeConfirmationDetails(["bash:echo primary"]),
@@ -762,7 +792,7 @@ describe("approval cascading", () => {
     // in the prompter. We'll remove it from the prompter before cascading
     // reaches it to simulate a stale/already-resolved request.
     registerPendingInteraction(
-      session,
+      conversationObj,
       "req-stale",
       CONV_ID,
       makeConfirmationDetails(["bash:echo stale"]),
@@ -770,14 +800,14 @@ describe("approval cascading", () => {
 
     // Remove req-stale from the prompter's pending map (simulating it was
     // already resolved by another path before cascade reaches it)
-    const prompter = session["prompter"] as unknown as {
+    const prompter = conversationObj["prompter"] as unknown as {
       pending: Map<string, unknown>;
     };
     prompter.pending.delete("req-stale");
 
     // This should not throw — cascade should skip req-stale gracefully
     expect(() => {
-      session.handleConfirmationResponse("req-primary", "allow_10m");
+      conversationObj.handleConfirmationResponse("req-primary", "allow_10m");
     }).not.toThrow();
 
     // Only the primary should be resolved

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -224,7 +224,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -249,10 +249,10 @@ function makeSession(): Conversation {
 describe("abort tool result persistence", () => {
   test("abort after first of multiple tool calls still persists all required tool_result blocks", async () => {
     persistedMessages = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Run tools", [], () => {});
+    await conversation.processMessage("Run tools", [], () => {});
 
     // Find user messages in persisted data that contain tool_result
     const toolResultUserMessages = persistedMessages.filter((m) => {
@@ -308,13 +308,13 @@ describe("abort tool result persistence", () => {
 
   test("restart/reload after abort does not reproduce provider ordering errors", async () => {
     persistedMessages = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Run tools", [], () => {});
+    await conversation.processMessage("Run tools", [], () => {});
 
     // Simulate reload: the in-memory messages should be valid after repair
-    const messages = session.getMessages();
+    const messages = conversation.getMessages();
 
     // Every assistant message with tool_use should be immediately followed
     // by a user message with matching tool_result

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -245,7 +245,7 @@ function makeProvider() {
   };
 }
 
-function makeSession(
+function makeConversation(
   sendToClient?: (msg: ServerMessage) => void,
 ): Conversation {
   return new Conversation(
@@ -299,10 +299,10 @@ afterAll(() => {
 describe("centralized confirmation emissions", () => {
   test("handleConfirmationResponse emits confirmation_state_changed with approved state for allow decision", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-allow-1");
-    session.handleConfirmationResponse("req-allow-1", "allow");
+    conversation.handleConfirmationResponse("req-allow-1", "allow");
 
     const confirmMsgs = emitted.filter(
       (m) => m.type === "confirmation_state_changed",
@@ -327,10 +327,10 @@ describe("centralized confirmation emissions", () => {
 
   test("handleConfirmationResponse emits confirmation_state_changed with denied state for deny decision", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-deny-1");
-    session.handleConfirmationResponse("req-deny-1", "deny");
+    conversation.handleConfirmationResponse("req-deny-1", "deny");
 
     const confirmMsg = emitted.find(
       (m) =>
@@ -351,10 +351,10 @@ describe("centralized confirmation emissions", () => {
 
   test("handleConfirmationResponse emits assistant_activity_state with thinking phase", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-activity-1");
-    session.handleConfirmationResponse("req-activity-1", "allow");
+    conversation.handleConfirmationResponse("req-activity-1", "allow");
 
     const activityMsg = emitted.find(
       (m) =>
@@ -374,10 +374,10 @@ describe("centralized confirmation emissions", () => {
 
   test("handleConfirmationResponse passes emissionContext source", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-ctx-1");
-    session.handleConfirmationResponse(
+    conversation.handleConfirmationResponse(
       "req-ctx-1",
       "allow",
       undefined,
@@ -404,10 +404,10 @@ describe("centralized confirmation emissions", () => {
 
   test("always_deny produces denied state", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-always-deny");
-    session.handleConfirmationResponse("req-always-deny", "always_deny");
+    conversation.handleConfirmationResponse("req-always-deny", "always_deny");
 
     const confirmMsg = emitted.find(
       (m) =>
@@ -423,10 +423,10 @@ describe("centralized confirmation emissions", () => {
 
   test("always_allow produces approved state", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(session, "req-always-allow");
-    session.handleConfirmationResponse("req-always-allow", "always_allow");
+    conversation.handleConfirmationResponse("req-always-allow", "always_allow");
 
     const confirmMsg = emitted.find(
       (m) =>
@@ -444,20 +444,24 @@ describe("centralized confirmation emissions", () => {
 describe("activity version ordering", () => {
   test("emitActivityState produces monotonically increasing activityVersion", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
-    session.emitActivityState("thinking", "message_dequeued", "assistant_turn");
-    session.emitActivityState(
+    conversation.emitActivityState(
+      "thinking",
+      "message_dequeued",
+      "assistant_turn",
+    );
+    conversation.emitActivityState(
       "streaming",
       "first_text_delta",
       "assistant_turn",
     );
-    session.emitActivityState(
+    conversation.emitActivityState(
       "tool_running",
       "tool_use_start",
       "assistant_turn",
     );
-    session.emitActivityState("idle", "message_complete", "global");
+    conversation.emitActivityState("idle", "message_complete", "global");
 
     const activityMsgs = emitted.filter(
       (m) => m.type === "assistant_activity_state",
@@ -478,10 +482,14 @@ describe("activity version ordering", () => {
 
   test("handleConfirmationResponse increments activityVersion for its activity emission", () => {
     const emitted: ServerMessage[] = [];
-    const session = makeSession((msg) => emitted.push(msg));
+    const conversation = makeConversation((msg) => emitted.push(msg));
 
     // Emit a baseline activity state
-    session.emitActivityState("thinking", "message_dequeued", "assistant_turn");
+    conversation.emitActivityState(
+      "thinking",
+      "message_dequeued",
+      "assistant_turn",
+    );
 
     const baselineMsg = emitted.find(
       (m) => m.type === "assistant_activity_state",
@@ -490,7 +498,7 @@ describe("activity version ordering", () => {
 
     // Now handle a confirmation
     seedPendingConfirmation(session, "req-version-1");
-    session.handleConfirmationResponse("req-version-1", "allow");
+    conversation.handleConfirmationResponse("req-version-1", "allow");
 
     const activityMsgs = emitted.filter(
       (m) => m.type === "assistant_activity_state",
@@ -508,9 +516,13 @@ describe("activity version ordering", () => {
 describe("sendToClient receives state signals", () => {
   test("emitActivityState delivers to sendToClient", () => {
     const clientMsgs: ServerMessage[] = [];
-    const session = makeSession((msg) => clientMsgs.push(msg));
+    const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
-    session.emitActivityState("thinking", "message_dequeued", "assistant_turn");
+    conversation.emitActivityState(
+      "thinking",
+      "message_dequeued",
+      "assistant_turn",
+    );
 
     expect(
       clientMsgs.filter((m) => m.type === "assistant_activity_state"),
@@ -519,9 +531,9 @@ describe("sendToClient receives state signals", () => {
 
   test("emitConfirmationStateChanged delivers to sendToClient", () => {
     const clientMsgs: ServerMessage[] = [];
-    const session = makeSession((msg) => clientMsgs.push(msg));
+    const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
-    session.emitConfirmationStateChanged({
+    conversation.emitConfirmationStateChanged({
       conversationId: "conv-signals-test",
       requestId: "req-signal-1",
       state: "approved",
@@ -535,10 +547,10 @@ describe("sendToClient receives state signals", () => {
 
   test("handleConfirmationResponse delivers state signals to sendToClient", () => {
     const clientMsgs: ServerMessage[] = [];
-    const session = makeSession((msg) => clientMsgs.push(msg));
+    const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
     seedPendingConfirmation(session, "req-signal-confirm");
-    session.handleConfirmationResponse("req-signal-confirm", "allow");
+    conversation.handleConfirmationResponse("req-signal-confirm", "allow");
 
     const confirmSignal = clientMsgs.find(
       (m) =>

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -100,7 +100,7 @@ mock.module("../memory/conversation-queries.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     sendMessage: async () => ({
@@ -155,9 +155,9 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     // Repair should have inserted a synthetic user message with tool_result
     expect(messages).toHaveLength(4);
@@ -201,9 +201,9 @@ describe("loadFromDb history repair", () => {
       content: JSON.stringify(m.content),
     }));
 
-    const session = makeSession();
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     expect(messages).toEqual(validMessages);
   });
@@ -226,10 +226,10 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
+    const conversation = makeConversation();
     // Should not throw
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     expect(messages).toHaveLength(2);
     // The broken message should have been replaced with a text block
@@ -259,9 +259,9 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     expect(messages).toHaveLength(4);
     // String JSON should be wrapped
@@ -299,9 +299,9 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     expect(messages).toHaveLength(2);
     expect(messages[1].content).toEqual([{ type: "text", text: "Sure" }]);
@@ -363,13 +363,13 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
-    session.setTrustContext({
+    const conversation = makeConversation();
+    conversation.setTrustContext({
       trustClass: "unknown",
       sourceChannel: "telegram",
     });
-    await session.loadFromDb();
-    const messages = session.getMessages();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
 
     expect(messages).toHaveLength(2);
     expect(messages[0].role).toBe("user");
@@ -430,21 +430,21 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
+    const conversation = makeConversation();
 
-    session.setTrustContext({
+    conversation.setTrustContext({
       trustClass: "guardian",
       sourceChannel: "telegram",
     });
-    await session.ensureActorScopedHistory();
-    expect(session.getMessages()).toHaveLength(4);
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()).toHaveLength(4);
 
-    session.setTrustContext({
+    conversation.setTrustContext({
       trustClass: "unknown",
       sourceChannel: "telegram",
     });
-    await session.ensureActorScopedHistory();
-    const downgradedMessages = session.getMessages();
+    await conversation.ensureActorScopedHistory();
+    const downgradedMessages = conversation.getMessages();
     expect(downgradedMessages).toHaveLength(2);
     expect(downgradedMessages[0].content).toEqual([
       { type: "text", text: "Unverified ping" },
@@ -506,21 +506,21 @@ describe("loadFromDb history repair", () => {
       },
     ];
 
-    const session = makeSession();
+    const conversation = makeConversation();
 
-    session.setTrustContext({
+    conversation.setTrustContext({
       trustClass: "unknown",
       sourceChannel: "telegram",
     });
-    await session.ensureActorScopedHistory();
-    expect(session.getMessages()).toHaveLength(2);
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()).toHaveLength(2);
 
-    session.setTrustContext({
+    conversation.setTrustContext({
       trustClass: "guardian",
       sourceChannel: "telegram",
     });
-    await session.persistUserMessage("Guardian follow-up", []);
-    const messagesAfterPersist = session.getMessages();
+    await conversation.persistUserMessage("Guardian follow-up", []);
+    const messagesAfterPersist = conversation.getMessages();
 
     expect(messagesAfterPersist).toHaveLength(5);
     expect(messagesAfterPersist[0].content).toEqual([

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -181,7 +181,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -232,19 +232,19 @@ describe("pre-run history repair", () => {
       // but we want to verify pre-run repair also works independently
     ];
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // loadFromDb already repaired, but let's corrupt the in-memory state
     // by removing the synthetic user message to simulate a runtime drift
-    const messages = session.getMessages();
+    const messages = conversation.getMessages();
     // After load repair: [user, assistant(tool_use), user(synthetic_tool_result)]
     // Remove the synthetic user to simulate runtime corruption
     messages.pop();
 
     capturedRunMessages = [];
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage("Next question", [], (msg) =>
+    await conversation.processMessage("Next question", [], (msg) =>
       events.push(msg as unknown as Record<string, unknown>),
     );
 
@@ -284,11 +284,11 @@ describe("pre-run history repair", () => {
     };
     mockDbMessages = [];
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     capturedRunMessages = [];
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
     // Should have a user message in the captured run messages
     expect(capturedRunMessages.length).toBeGreaterThanOrEqual(1);

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -375,7 +375,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -419,11 +419,11 @@ describe("provider ordering error retry", () => {
   test("simulated strict provider error triggers exactly one retry", async () => {
     firstRunErrorMode = "ordering";
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage("Hello", [], (msg) =>
+    await conversation.processMessage("Hello", [], (msg) =>
       events.push(msg as unknown as Record<string, unknown>),
     );
 
@@ -434,11 +434,11 @@ describe("provider ordering error retry", () => {
   test("[experimental] retry succeeds with repaired history and no spurious error event", async () => {
     firstRunErrorMode = "ordering";
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage("Hello", [], (msg) =>
+    await conversation.processMessage("Hello", [], (msg) =>
       events.push(msg as unknown as Record<string, unknown>),
     );
 
@@ -451,7 +451,7 @@ describe("provider ordering error retry", () => {
     expect(errorEvents.length).toBe(0);
 
     // Should also have the assistant response in memory
-    const messages = session.getMessages();
+    const messages = conversation.getMessages();
     const lastMsg = messages[messages.length - 1];
     expect(lastMsg.role).toBe("assistant");
   });
@@ -459,11 +459,11 @@ describe("provider ordering error retry", () => {
   test("non-ordering errors do not trigger retry", async () => {
     firstRunErrorMode = "none";
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage("Hello", [], (msg) =>
+    await conversation.processMessage("Hello", [], (msg) =>
       events.push(msg as unknown as Record<string, unknown>),
     );
 
@@ -475,11 +475,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large";
     forceCompactionEnabled = true;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage(
+    await conversation.processMessage(
       "Please compare these images.",
       makeImageAttachments(8),
       (msg) => events.push(msg as unknown as Record<string, unknown>),
@@ -495,11 +495,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large";
     forceCompactionEnabled = false;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage(
+    await conversation.processMessage(
       "Please compare these images.",
       makeImageAttachments(8),
       (msg) => events.push(msg as unknown as Record<string, unknown>),
@@ -522,11 +522,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large";
     forceCompactionEnabled = false;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage("No attachments here.", [], (msg) =>
+    await conversation.processMessage("No attachments here.", [], (msg) =>
       events.push(msg as unknown as Record<string, unknown>),
     );
 
@@ -540,11 +540,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large_phrase";
     forceCompactionEnabled = true;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage(
+    await conversation.processMessage(
       "Please compare these images.",
       makeImageAttachments(4),
       (msg) => events.push(msg as unknown as Record<string, unknown>),
@@ -560,11 +560,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large_413";
     forceCompactionEnabled = true;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage(
+    await conversation.processMessage(
       "Please compare these images.",
       makeImageAttachments(8),
       (msg) => events.push(msg as unknown as Record<string, unknown>),
@@ -583,11 +583,11 @@ describe("provider ordering error retry", () => {
     firstRunErrorMode = "context_too_large_413_with_progress";
     forceCompactionEnabled = false;
 
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: Array<Record<string, unknown>> = [];
-    await session.processMessage(
+    await conversation.processMessage(
       "Run some tools then hit the limit.",
       [],
       (msg) => events.push(msg as unknown as Record<string, unknown>),

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -284,7 +284,7 @@ import type { QueueDrainReason, QueuePolicy } from "../daemon/conversation.js";
 import { Conversation } from "../daemon/conversation.js";
 import { MessageQueue } from "../daemon/conversation-queue-manager.js";
 
-type SessionWithWorkspaceDeps = Conversation & {
+type ConversationWithWorkspaceDeps = Conversation & {
   getWorkspaceGitService?: (_workspaceDir: string) => {
     ensureInitialized: () => Promise<void>;
   };
@@ -297,7 +297,7 @@ type SessionWithWorkspaceDeps = Conversation & {
   ) => Promise<void>;
 };
 
-function makeSession(
+function makeConversation(
   sendToClient?: (msg: ServerMessage) => void,
 ): Conversation {
   const provider = {
@@ -311,7 +311,7 @@ function makeSession(
       };
     },
   };
-  const session = new Conversation(
+  const conversationObj = new Conversation(
     "conv-1",
     provider,
     "system prompt",
@@ -319,11 +319,12 @@ function makeSession(
     sendToClient ?? (() => {}),
     "/tmp",
   );
-  const sessionWithWorkspaceDeps = session as SessionWithWorkspaceDeps;
-  sessionWithWorkspaceDeps.getWorkspaceGitService = () => ({
+  const conversationWithWorkspaceDeps =
+    conversationObj as ConversationWithWorkspaceDeps;
+  conversationWithWorkspaceDeps.getWorkspaceGitService = () => ({
     ensureInitialized: async () => {},
   });
-  sessionWithWorkspaceDeps.commitTurnChanges = async (
+  conversationWithWorkspaceDeps.commitTurnChanges = async (
     workspaceDir: string,
     conversationId: string,
     turnNumber: number,
@@ -334,7 +335,7 @@ function makeSession(
       await new Promise<void>(() => {});
     }
   };
-  return session;
+  return conversationObj;
 }
 
 /**
@@ -416,14 +417,14 @@ describe("Conversation message queue", () => {
   });
 
   test("second message is queued when session is busy (does not throw)", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
     const events2: ServerMessage[] = [];
 
     // Start first message — this will block on AgentLoop.run
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -434,10 +435,10 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Conversation should now be processing
-    expect(session.isProcessing()).toBe(true);
+    expect(conversation.isProcessing()).toBe(true);
 
     // Enqueue second message — should NOT throw
-    const result = session.enqueueMessage(
+    const result = conversation.enqueueMessage(
       "msg-2",
       [],
       (e) => events2.push(e),
@@ -445,7 +446,7 @@ describe("Conversation message queue", () => {
     );
     expect(result.queued).toBe(true);
     expect(result.requestId).toBe("req-2");
-    expect(session.getQueueDepth()).toBe(1);
+    expect(conversation.getQueueDepth()).toBe(1);
 
     // Complete the first message
     resolveRun(0);
@@ -466,8 +467,8 @@ describe("Conversation message queue", () => {
   });
 
   test("[experimental] queued messages are processed in FIFO order", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const processedOrder: string[] = [];
 
@@ -476,7 +477,7 @@ describe("Conversation message queue", () => {
     };
 
     // Start first message
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       makeHandler("msg-1"),
@@ -485,9 +486,9 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue two more
-    session.enqueueMessage("msg-2", [], makeHandler("msg-2"), "req-2");
-    session.enqueueMessage("msg-3", [], makeHandler("msg-3"), "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-2", [], makeHandler("msg-2"), "req-2");
+    conversation.enqueueMessage("msg-3", [], makeHandler("msg-3"), "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete first → triggers second
     resolveRun(0);
@@ -506,17 +507,17 @@ describe("Conversation message queue", () => {
   });
 
   test("message_queued and message_dequeued events are emitted", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events2: ServerMessage[] = [];
 
     // Start first message
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // Enqueue second — simulating what handleUserMessage does
-    const result = session.enqueueMessage(
+    const result = conversation.enqueueMessage(
       "msg-2",
       [],
       (e) => events2.push(e),
@@ -544,26 +545,26 @@ describe("Conversation message queue", () => {
   });
 
   test("abort() clears the queue and sends generation_cancelled for each queued message", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events2: ServerMessage[] = [];
     const events3: ServerMessage[] = [];
 
     // Start first message
-    session.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // Enqueue two more
-    session.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
-    session.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Abort
-    session.abort();
+    conversation.abort();
 
     // Queue should be empty
-    expect(session.getQueueDepth()).toBe(0);
+    expect(conversation.getQueueDepth()).toBe(0);
 
     // Both queued messages should receive session-scoped cancellation events.
     const cancel2 = events2.find((e) => e.type === "generation_cancelled");
@@ -592,13 +593,13 @@ describe("Conversation message queue", () => {
   });
 
   test("conversation-scoped errors emit both conversation_error and generic error", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events: ServerMessage[] = [];
 
     // Start a message — blocks on AgentLoop.run
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events.push(e),
@@ -621,42 +622,42 @@ describe("Conversation message queue", () => {
   });
 
   test("queue depth is reported correctly as messages are added and drained", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start first message
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
-    expect(session.getQueueDepth()).toBe(0);
+    expect(conversation.getQueueDepth()).toBe(0);
 
-    session.enqueueMessage("msg-2", [], () => {}, "req-2");
-    expect(session.getQueueDepth()).toBe(1);
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    expect(conversation.getQueueDepth()).toBe(1);
 
-    session.enqueueMessage("msg-3", [], () => {}, "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
-    session.enqueueMessage("msg-4", [], () => {}, "req-4");
-    expect(session.getQueueDepth()).toBe(3);
+    conversation.enqueueMessage("msg-4", [], () => {}, "req-4");
+    expect(conversation.getQueueDepth()).toBe(3);
 
     // Complete first → drains one from queue
     resolveRun(0);
     await p1;
     await waitForPendingRun(2);
 
-    expect(session.getQueueDepth()).toBe(2);
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete second → drains another
     resolveRun(1);
     await waitForPendingRun(3);
 
-    expect(session.getQueueDepth()).toBe(1);
+    expect(conversation.getQueueDepth()).toBe(1);
 
     // Complete third → drains last
     resolveRun(2);
     await waitForPendingRun(4);
 
-    expect(session.getQueueDepth()).toBe(0);
+    expect(conversation.getQueueDepth()).toBe(0);
 
     // Complete fourth (final queued message)
     resolveRun(3);
@@ -664,15 +665,15 @@ describe("Conversation message queue", () => {
   });
 
   test("[experimental] drain continues after a queued message fails to persist", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
     const events2: ServerMessage[] = [];
     const events3: ServerMessage[] = [];
 
     // Start first message — blocks on AgentLoop.run
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -681,10 +682,10 @@ describe("Conversation message queue", () => {
     await waitForPendingRun(1);
 
     // Enqueue a message with empty content (will fail persistUserMessage)
-    session.enqueueMessage("", [], (e) => events2.push(e), "req-2");
+    conversation.enqueueMessage("", [], (e) => events2.push(e), "req-2");
     // Enqueue a valid message after the bad one
-    session.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete first message — triggers drain. The empty message should fail
     // to persist, but the drain should continue to msg-3.
@@ -723,22 +724,22 @@ describe("Conversation queue policy helpers", () => {
   });
 
   test("hasQueuedMessages() returns false on a fresh session", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
-    expect(session.hasQueuedMessages()).toBe(false);
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    expect(conversation.hasQueuedMessages()).toBe(false);
   });
 
   test("hasQueuedMessages() returns true after enqueuing while processing", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing to make the session busy
-    session.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // Enqueue a message while processing
-    session.enqueueMessage("msg-2", [], () => {}, "req-2");
-    expect(session.hasQueuedMessages()).toBe(true);
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    expect(conversation.hasQueuedMessages()).toBe(true);
 
     // Cleanup: resolve the pending run
     resolveRun(0);
@@ -748,24 +749,24 @@ describe("Conversation queue policy helpers", () => {
   });
 
   test("canHandoffAtCheckpoint() returns false when not processing", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Not processing, no queued messages
-    expect(session.canHandoffAtCheckpoint()).toBe(false);
+    expect(conversation.canHandoffAtCheckpoint()).toBe(false);
   });
 
   test("canHandoffAtCheckpoint() returns false when processing but no queued messages", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing — but don't enqueue anything
-    session.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
-    expect(session.isProcessing()).toBe(true);
-    expect(session.hasQueuedMessages()).toBe(false);
-    expect(session.canHandoffAtCheckpoint()).toBe(false);
+    expect(conversation.isProcessing()).toBe(true);
+    expect(conversation.hasQueuedMessages()).toBe(false);
+    expect(conversation.canHandoffAtCheckpoint()).toBe(false);
 
     // Cleanup
     resolveRun(0);
@@ -773,19 +774,19 @@ describe("Conversation queue policy helpers", () => {
   });
 
   test("canHandoffAtCheckpoint() returns true when processing and queue has messages", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing
-    session.processMessage("msg-1", [], () => {}, "req-1");
+    conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // Enqueue a message
-    session.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
 
-    expect(session.isProcessing()).toBe(true);
-    expect(session.hasQueuedMessages()).toBe(true);
-    expect(session.canHandoffAtCheckpoint()).toBe(true);
+    expect(conversation.isProcessing()).toBe(true);
+    expect(conversation.hasQueuedMessages()).toBe(true);
+    expect(conversation.canHandoffAtCheckpoint()).toBe(true);
 
     // Cleanup
     resolveRun(0);
@@ -822,13 +823,13 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("[experimental] onCheckpoint yields when there is a queued message", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
 
     // Start processing first message
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -837,8 +838,8 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
-    session.enqueueMessage("msg-2", [], () => {}, "req-2");
-    expect(session.hasQueuedMessages()).toBe(true);
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
+    expect(conversation.hasQueuedMessages()).toBe(true);
 
     // The pending run should have received an onCheckpoint callback.
     // Simulate the agent loop calling it at a turn boundary.
@@ -875,14 +876,14 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("onCheckpoint returns continue when queue is empty", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing — no enqueued messages
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
-    expect(session.hasQueuedMessages()).toBe(false);
+    expect(conversation.hasQueuedMessages()).toBe(false);
 
     // The pending run should have an onCheckpoint callback
     const run = pendingRuns[0];
@@ -903,8 +904,8 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("[experimental] FIFO ordering is preserved through checkpoint handoff", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const processedOrder: string[] = [];
 
@@ -914,7 +915,7 @@ describe("Conversation checkpoint handoff", () => {
     };
 
     // Start first message
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       makeHandler("msg-1"),
@@ -923,9 +924,9 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue two messages
-    session.enqueueMessage("msg-2", [], makeHandler("msg-2"), "req-2");
-    session.enqueueMessage("msg-3", [], makeHandler("msg-3"), "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-2", [], makeHandler("msg-2"), "req-2");
+    conversation.enqueueMessage("msg-3", [], makeHandler("msg-3"), "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Simulate the agent loop yielding at the checkpoint (first run)
     const run0 = pendingRuns[0];
@@ -958,14 +959,14 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("[experimental] active run with repeated tool turns + queued message triggers checkpoint handoff", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
     const events2: ServerMessage[] = [];
 
     // Start processing first message
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -974,8 +975,8 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue a second message while the first is processing
-    session.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
-    expect(session.hasQueuedMessages()).toBe(true);
+    conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+    expect(conversation.hasQueuedMessages()).toBe(true);
 
     // Simulate tool-use turns: the agent loop calls onCheckpoint at each turn boundary.
     // Because there is a queued message, the callback should return 'yield'.
@@ -1021,8 +1022,8 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("queued messages still drain FIFO under multiple handoffs", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const dequeueOrder: string[] = [];
 
@@ -1032,7 +1033,7 @@ describe("Conversation checkpoint handoff", () => {
     };
 
     // Start processing message A
-    const pA = session.processMessage(
+    const pA = conversation.processMessage(
       "msg-A",
       [],
       (e) => eventsA.push(e),
@@ -1041,10 +1042,10 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue messages B, C, D
-    session.enqueueMessage("msg-B", [], makeHandler("B"), "req-B");
-    session.enqueueMessage("msg-C", [], makeHandler("C"), "req-C");
-    session.enqueueMessage("msg-D", [], makeHandler("D"), "req-D");
-    expect(session.getQueueDepth()).toBe(3);
+    conversation.enqueueMessage("msg-B", [], makeHandler("B"), "req-B");
+    conversation.enqueueMessage("msg-C", [], makeHandler("C"), "req-C");
+    conversation.enqueueMessage("msg-D", [], makeHandler("D"), "req-D");
+    expect(conversation.getQueueDepth()).toBe(3);
 
     // Handoff from A -> B
     const runA = pendingRuns[0];
@@ -1112,15 +1113,15 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("[experimental] queued persistence failure does not strand later messages", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const eventsA: ServerMessage[] = [];
     const eventsB: ServerMessage[] = [];
     const eventsC: ServerMessage[] = [];
 
     // Start processing message A
-    const pA = session.processMessage(
+    const pA = conversation.processMessage(
       "msg-A",
       [],
       (e) => eventsA.push(e),
@@ -1129,9 +1130,9 @@ describe("Conversation checkpoint handoff", () => {
     await waitForPendingRun(1);
 
     // Enqueue B (empty content — will fail to persist) and C (valid)
-    session.enqueueMessage("", [], (e) => eventsB.push(e), "req-B");
-    session.enqueueMessage("msg-C", [], (e) => eventsC.push(e), "req-C");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("", [], (e) => eventsB.push(e), "req-B");
+    conversation.enqueueMessage("msg-C", [], (e) => eventsC.push(e), "req-C");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete message A — triggers drain. B should fail, C should proceed.
     resolveRun(0);
@@ -1159,11 +1160,11 @@ describe("Conversation checkpoint handoff", () => {
   });
 
   test("onCheckpoint callback is passed to both initial and retry runs", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // The first run should have onCheckpoint
@@ -1204,10 +1205,10 @@ describe("Conversation usage requestId correlation", () => {
   });
 
   test("usage events recorded during a request carry that request ID", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-42");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-42");
     await waitForPendingRun(1);
 
     // Complete the run — this triggers recordUsage with the request's ID
@@ -1234,19 +1235,19 @@ describe("Terminal trace events on rejection/failure", () => {
 
   test("queued persist failure emits request_error trace", async () => {
     const traceEvents: ServerMessage[] = [];
-    const session = makeSession((msg) => {
+    const conversation = makeConversation((msg) => {
       if ("type" in msg && msg.type === "trace_event") traceEvents.push(msg);
     });
-    await session.loadFromDb();
+    await conversation.loadFromDb();
 
     // Start first message
-    const p1 = session.processMessage("msg-1", [], () => {}, "req-1");
+    const p1 = conversation.processMessage("msg-1", [], () => {}, "req-1");
     await waitForPendingRun(1);
 
     // Enqueue empty content (will fail persistUserMessage)
-    session.enqueueMessage("", [], () => {}, "req-bad");
+    conversation.enqueueMessage("", [], () => {}, "req-bad");
     // Enqueue valid message so drain continues
-    session.enqueueMessage("msg-3", [], () => {}, "req-3");
+    conversation.enqueueMessage("msg-3", [], () => {}, "req-3");
 
     // Complete first — triggers drain, empty msg fails persist
     resolveRun(0);
@@ -1285,10 +1286,10 @@ describe("Conversation host attachment directives", () => {
     try {
       const clientEvents: ServerMessage[] = [];
       const events: ServerMessage[] = [];
-      const session = makeSession((msg) => clientEvents.push(msg));
-      await session.loadFromDb();
+      const conversation = makeConversation((msg) => clientEvents.push(msg));
+      await conversation.loadFromDb();
 
-      const p1 = session.processMessage(
+      const p1 = conversation.processMessage(
         "msg-1",
         [],
         (e) => events.push(e),
@@ -1323,16 +1324,18 @@ describe("Conversation host attachment directives", () => {
         (e) => e.type === "confirmation_request",
       );
       expect(confirmation).toBeDefined();
-      session.handleConfirmationResponse(
+      conversation.handleConfirmationResponse(
         (confirmation as { requestId: string }).requestId,
         "allow",
       );
 
       await p1;
 
-      expect(session.lastAssistantAttachments).toHaveLength(1);
-      expect(session.lastAssistantAttachments[0].sourceType).toBe("host_file");
-      expect(session.lastAttachmentWarnings).toHaveLength(0);
+      expect(conversation.lastAssistantAttachments).toHaveLength(1);
+      expect(conversation.lastAssistantAttachments[0].sourceType).toBe(
+        "host_file",
+      );
+      expect(conversation.lastAttachmentWarnings).toHaveLength(0);
 
       const completion = events.find((e) => e.type === "message_complete");
       expect(completion).toBeDefined();
@@ -1348,10 +1351,10 @@ describe("Conversation host attachment directives", () => {
     try {
       const clientEvents: ServerMessage[] = [];
       const events: ServerMessage[] = [];
-      const session = makeSession((msg) => clientEvents.push(msg));
-      await session.loadFromDb();
+      const conversation = makeConversation((msg) => clientEvents.push(msg));
+      await conversation.loadFromDb();
 
-      const p1 = session.processMessage(
+      const p1 = conversation.processMessage(
         "msg-1",
         [],
         (e) => events.push(e),
@@ -1386,16 +1389,16 @@ describe("Conversation host attachment directives", () => {
         (e) => e.type === "confirmation_request",
       );
       expect(confirmation).toBeDefined();
-      session.handleConfirmationResponse(
+      conversation.handleConfirmationResponse(
         (confirmation as { requestId: string }).requestId,
         "deny",
       );
 
       await p1;
 
-      expect(session.lastAssistantAttachments).toHaveLength(0);
+      expect(conversation.lastAssistantAttachments).toHaveLength(0);
       expect(
-        session.lastAttachmentWarnings.some((w) =>
+        conversation.lastAttachmentWarnings.some((w) =>
           w.includes("access denied by user"),
         ),
       ).toBe(true);
@@ -1425,10 +1428,10 @@ describe("Conversation attachment event payloads", () => {
 
   test("message_complete includes assistant attachments", async () => {
     const events: ServerMessage[] = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events.push(e),
@@ -1482,10 +1485,10 @@ describe("Conversation attachment event payloads", () => {
 
   test("generation_handoff includes assistant attachments", async () => {
     const events1: ServerMessage[] = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -1494,7 +1497,7 @@ describe("Conversation attachment event payloads", () => {
     await waitForPendingRun(1);
 
     // Queue a second message so the first run yields via checkpoint handoff.
-    session.enqueueMessage("msg-2", [], () => {}, "req-2");
+    conversation.enqueueMessage("msg-2", [], () => {}, "req-2");
 
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
@@ -1565,11 +1568,11 @@ describe("Regression: cancel semantics and error channel split", () => {
 
   test("user cancellation emits generation_cancelled, never conversation_error", async () => {
     const msgEvents: ServerMessage[] = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Start processing a message — collect events from the per-message callback
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => msgEvents.push(e),
@@ -1578,7 +1581,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     await waitForPendingRun(1);
 
     // User cancels — sets the abort signal
-    session.abort();
+    conversation.abort();
 
     // Resolve the pending run so the abort-check path fires
     resolveRun(0);
@@ -1597,11 +1600,11 @@ describe("Regression: cancel semantics and error channel split", () => {
 
   test("post-processing failure still attempts turn-boundary commit", async () => {
     const events: ServerMessage[] = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
     linkAttachmentShouldThrow = true;
 
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events.push(e),
@@ -1648,10 +1651,10 @@ describe("Regression: cancel semantics and error channel split", () => {
 
   test("provider failure during processing emits both conversation_error and generic error", async () => {
     const allEvents: ServerMessage[] = [];
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => allEvents.push(e),
@@ -1673,12 +1676,12 @@ describe("Regression: cancel semantics and error channel split", () => {
   });
 
   test("cancel after queued messages produces no conversation_error for any queued entry", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const eventsPerMsg: ServerMessage[][] = [[], [], []];
 
-    session.processMessage(
+    conversation.processMessage(
       "msg-1",
       [],
       (e) => eventsPerMsg[0].push(e),
@@ -1686,20 +1689,20 @@ describe("Regression: cancel semantics and error channel split", () => {
     );
     await waitForPendingRun(1);
 
-    session.enqueueMessage(
+    conversation.enqueueMessage(
       "msg-2",
       [],
       (e) => eventsPerMsg[1].push(e),
       "req-2",
     );
-    session.enqueueMessage(
+    conversation.enqueueMessage(
       "msg-3",
       [],
       (e) => eventsPerMsg[2].push(e),
       "req-3",
     );
 
-    session.abort();
+    conversation.abort();
 
     // No queued message should have received conversation_error
     for (const events of eventsPerMsg) {
@@ -1709,8 +1712,8 @@ describe("Regression: cancel semantics and error channel split", () => {
   });
 
   test("commitTurnChanges never resolving within budget -> turn still completes and drains queue", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     turnCommitHangForever = true;
 
@@ -1719,7 +1722,7 @@ describe("Regression: cancel semantics and error channel split", () => {
       const events2: ServerMessage[] = [];
 
       // Start first message (promise intentionally not awaited — we test queue drain behavior)
-      const _p1 = session.processMessage(
+      const _p1 = conversation.processMessage(
         "msg-1",
         [],
         (e) => events1.push(e),
@@ -1728,7 +1731,7 @@ describe("Regression: cancel semantics and error channel split", () => {
       await waitForPendingRun(1);
 
       // Enqueue a second message while the first is processing
-      session.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
+      conversation.enqueueMessage("msg-2", [], (e) => events2.push(e), "req-2");
 
       // Complete the first agent loop run
       resolveRun(0);

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -162,7 +162,7 @@ const testAuthContext: AuthContext = {
   policyEpoch: 1,
 };
 
-function makeSession() {
+function makeConversation() {
   const persistUserMessage = mock(
     async (_content: string, _attachments: unknown[], _requestId?: string) =>
       "persisted-user-id",
@@ -178,7 +178,7 @@ function makeSession() {
   const setPreactivatedSkillIds = mock((_ids: string[] | undefined) => {});
   const events: unknown[] = [];
   const messages: unknown[] = [];
-  const session = {
+  const conversation = {
     setTrustContext: () => {},
     updateClient: (_fn: unknown, _b: boolean) => {},
     emitConfirmationStateChanged: () => {},
@@ -209,7 +209,7 @@ function makeSession() {
     },
   } as unknown as import("../daemon/conversation.js").Conversation;
   return {
-    session,
+    conversation,
     persistUserMessage,
     runAgentLoop,
     setPreactivatedSkillIds,
@@ -231,10 +231,12 @@ function makeRequest(content: string) {
   });
 }
 
-function makeDeps(session: import("../daemon/conversation.js").Conversation) {
+function makeDeps(
+  conversation: import("../daemon/conversation.js").Conversation,
+) {
   return {
     sendMessageDeps: {
-      getOrCreateConversation: async () => session,
+      getOrCreateConversation: async () => conversation,
       assistantEventHub: { publish: async () => {} } as any,
       resolveAttachments: () => [],
     },
@@ -253,10 +255,11 @@ describe("handleSendMessage slash command interception", () => {
       message: "Conversation Status\n\nContext: 5%",
     });
 
-    const { session, persistUserMessage, runAgentLoop } = makeSession();
+    const { conversation, persistUserMessage, runAgentLoop } =
+      makeConversation();
     const res = await handleSendMessage(
       makeRequest("/status"),
-      makeDeps(session),
+      makeDeps(conversation),
       testAuthContext,
     );
 
@@ -287,14 +290,14 @@ describe("handleSendMessage slash command interception", () => {
     });
 
     const {
-      session,
+      conversation,
       persistUserMessage,
       runAgentLoop,
       setPreactivatedSkillIds,
-    } = makeSession();
+    } = makeConversation();
     const res = await handleSendMessage(
       makeRequest("hello there"),
-      makeDeps(session),
+      makeDeps(conversation),
       testAuthContext,
     );
 
@@ -319,10 +322,10 @@ describe("handleSendMessage slash command interception", () => {
       content: "test",
     });
 
-    const { session } = makeSession();
+    const { conversation } = makeConversation();
     await handleSendMessage(
       makeRequest("test"),
-      makeDeps(session),
+      makeDeps(conversation),
       testAuthContext,
     );
 

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -224,7 +224,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -289,15 +289,15 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
   });
 
   test("queued slash-like input does not stall queue — passes through", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
     const eventsSlash: ServerMessage[] = [];
     const events3: ServerMessage[] = [];
 
     // Start first message — blocks on agent loop
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -306,14 +306,14 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     await waitForPendingRun(1);
 
     // Enqueue a slash-like message and a normal message after it
-    session.enqueueMessage(
+    conversation.enqueueMessage(
       "/not-a-skill",
       [],
       (e) => eventsSlash.push(e),
       "req-slash",
     );
-    session.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
-    expect(session.getQueueDepth()).toBe(2);
+    conversation.enqueueMessage("msg-3", [], (e) => events3.push(e), "req-3");
+    expect(conversation.getQueueDepth()).toBe(2);
 
     // Complete first run — triggers drain
     resolveRun(0);
@@ -343,14 +343,14 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
   });
 
   test("queued skill-name slash passes through as-is", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     const events1: ServerMessage[] = [];
     const eventsSlash: ServerMessage[] = [];
 
     // Start first message — blocks on agent loop
-    const p1 = session.processMessage(
+    const p1 = conversation.processMessage(
       "msg-1",
       [],
       (e) => events1.push(e),
@@ -359,7 +359,7 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     await waitForPendingRun(1);
 
     // Enqueue a slash command that matches a skill name — still passes through
-    session.enqueueMessage(
+    conversation.enqueueMessage(
       "/start-the-day",
       [],
       (e) => eventsSlash.push(e),

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -247,7 +247,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -280,17 +280,19 @@ describe("Conversation slash command — passthrough for unknown tokens", () => 
   });
 
   test("unknown slash-like input passes through to agent loop", async () => {
-    const session = makeSession();
-    await session.processMessage("/not-a-skill", [], () => {});
+    const conversation = makeConversation();
+    await conversation.processMessage("/not-a-skill", [], () => {});
 
     // Should go through the normal agent loop path
     expect(agentLoopRunCalled).toBe(true);
   });
 
   test("normal messages still go through standard path", async () => {
-    const session = makeSession();
+    const conversation = makeConversation();
     const events: ServerMessage[] = [];
-    await session.processMessage("hello world", [], (msg) => events.push(msg));
+    await conversation.processMessage("hello world", [], (msg) =>
+      events.push(msg),
+    );
     expect(agentLoopRunCalled).toBe(true);
   });
 });

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -236,7 +236,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -277,10 +277,10 @@ describe("Conversation workspace injection", () => {
   });
 
   test("runtime messages include workspace top-level context", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -291,10 +291,10 @@ describe("Conversation workspace injection", () => {
   });
 
   test("workspace context includes root path and directories", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -303,10 +303,10 @@ describe("Conversation workspace injection", () => {
   });
 
   test("workspace context is prepended before user text", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
     expect(runCalls).toHaveLength(1);
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
@@ -317,12 +317,12 @@ describe("Conversation workspace injection", () => {
   });
 
   test("workspace context is stripped from persisted history", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
-    const persistedMessages = session.getMessages();
+    const persistedMessages = conversation.getMessages();
     for (const msg of persistedMessages) {
       const text = messageText(msg);
       expect(text).not.toContain("<workspace_top_level>");
@@ -330,12 +330,12 @@ describe("Conversation workspace injection", () => {
   });
 
   test("no empty user messages after stripping workspace context", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
-    const persistedMessages = session.getMessages();
+    const persistedMessages = conversation.getMessages();
     const emptyUserMsgs = persistedMessages.filter(
       (m) => m.role === "user" && m.content.length === 0,
     );
@@ -351,10 +351,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
   });
 
   test("first turn computes snapshot", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
 
     expect(scanCallCount).toBe(1);
     const text = messageText(runCalls[0][runCalls[0].length - 1]);
@@ -362,23 +362,23 @@ describe("Conversation workspace dirty-refresh E2E", () => {
   });
 
   test("second turn without mutation reuses cache", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
     const afterFirst = scanCallCount;
 
-    await session.processMessage("Again", [], () => {});
+    await conversation.processMessage("Again", [], () => {});
 
     // Scanner should NOT have been called again
     expect(scanCallCount).toBe(afterFirst);
   });
 
   test("successful file_edit causes refresh next turn", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
     const afterFirst = scanCallCount;
 
     // Simulate a turn where the agent uses file_edit
@@ -391,7 +391,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: false,
       });
     };
-    await session.processMessage("Edit a file", [], () => {});
+    await conversation.processMessage("Edit a file", [], () => {});
 
     // No rescan should happen during the mutation turn itself
     const afterMutation = scanCallCount;
@@ -399,16 +399,16 @@ describe("Conversation workspace dirty-refresh E2E", () => {
 
     // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
-    await session.processMessage("What happened?", [], () => {});
+    await conversation.processMessage("What happened?", [], () => {});
 
     expect(scanCallCount).toBe(afterMutation + 1);
   });
 
   test("successful bash causes refresh next turn", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
     const afterFirst = scanCallCount;
 
     agentLoopScript = (onEvent) => {
@@ -420,7 +420,7 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: false,
       });
     };
-    await session.processMessage("Run a command", [], () => {});
+    await conversation.processMessage("Run a command", [], () => {});
 
     // No rescan should happen during the mutation turn itself
     const afterMutation = scanCallCount;
@@ -428,16 +428,16 @@ describe("Conversation workspace dirty-refresh E2E", () => {
 
     // Next turn should trigger exactly one fresh scan
     agentLoopScript = () => {};
-    await session.processMessage("What now?", [], () => {});
+    await conversation.processMessage("What now?", [], () => {});
 
     expect(scanCallCount).toBe(afterMutation + 1);
   });
 
   test("failed tool results do not trigger refresh", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    await session.processMessage("Hello", [], () => {});
+    await conversation.processMessage("Hello", [], () => {});
     const afterFirst = scanCallCount;
 
     agentLoopScript = (onEvent) => {
@@ -449,10 +449,10 @@ describe("Conversation workspace dirty-refresh E2E", () => {
         isError: true,
       });
     };
-    await session.processMessage("Try editing", [], () => {});
+    await conversation.processMessage("Try editing", [], () => {});
 
     agentLoopScript = () => {};
-    await session.processMessage("What happened?", [], () => {});
+    await conversation.processMessage("What happened?", [], () => {});
 
     // Scanner should NOT have been re-called since the tool failed
     expect(scanCallCount).toBe(afterFirst);

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -220,7 +220,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import { Conversation } from "../daemon/conversation.js";
 
-function makeSession(): Conversation {
+function makeConversation(): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -252,12 +252,12 @@ describe("Conversation workspace dirty on file mutations", () => {
   });
 
   test("successful file_write marks workspace dirty", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
     // Prime the cache so dirty=false
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -274,16 +274,16 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Write a file", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    await conversation.processMessage("Write a file", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test("successful file_edit marks workspace dirty", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -300,18 +300,18 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Edit a file", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    await conversation.processMessage("Edit a file", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test("file_write with isError still marks workspace dirty (secret-detection block)", async () => {
     // ToolExecutor can physically write the file and then flip isError=true
     // in secret-detection block mode — the filesystem has changed.
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -328,16 +328,16 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Write a file", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    await conversation.processMessage("Write a file", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test("successful bash marks workspace dirty", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -354,16 +354,16 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Run a command", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    await conversation.processMessage("Run a command", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test("failed bash still marks workspace dirty (commands can mutate before failing)", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -380,16 +380,16 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Run a command", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(true);
+    await conversation.processMessage("Run a command", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(true);
   });
 
   test("non-mutation tools do NOT mark workspace dirty", async () => {
-    const session = makeSession();
-    await session.loadFromDb();
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
 
-    session.refreshWorkspaceTopLevelContextIfNeeded();
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    conversation.refreshWorkspaceTopLevelContextIfNeeded();
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
 
     agentLoopScript = (onEvent) => {
       onEvent({
@@ -406,7 +406,7 @@ describe("Conversation workspace dirty on file mutations", () => {
       });
     };
 
-    await session.processMessage("Read a file", [], () => {});
-    expect(session.isWorkspaceTopLevelDirty()).toBe(false);
+    await conversation.processMessage("Read a file", [], () => {});
+    expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
   });
 });

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -145,7 +145,7 @@ mock.module("../util/logger.js", () => ({
 
 import { handleConfirmationResponse } from "../daemon/handlers/conversations.js";
 
-interface TestSession {
+interface TestConversation {
   messages: Array<{ role: string; content: unknown[] }>;
   setChannelCapabilities: (caps: unknown) => void;
   isProcessing: () => boolean;
@@ -173,7 +173,7 @@ interface TestSession {
   processMessage: (...args: unknown[]) => Promise<string>;
 }
 
-function createContext(session: TestSession): {
+function createContext(conversationObj: TestConversation): {
   ctx: HandlerContext;
   sent: ServerMessage[];
 } {
@@ -190,13 +190,15 @@ function createContext(session: TestSession): {
     },
     broadcast: () => {},
     clearAllConversations: () => 0,
-    getOrCreateConversation: async () => session as any,
+    getOrCreateConversation: async () => conversationObj as any,
     touchConversation: () => {},
   };
   return { ctx, sent };
 }
 
-function makeSession(overrides: Partial<TestSession> = {}): TestSession {
+function makeConversation(
+  overrides: Partial<TestConversation> = {},
+): TestConversation {
   return {
     messages: [],
     setChannelCapabilities: () => {},
@@ -237,13 +239,13 @@ describe("handleConfirmationResponse canonical status sync", () => {
   });
 
   test("syncs canonical status to approved for allow decisions", () => {
-    const session = {
+    const conversationObj = {
       hasPendingConfirmation: (requestId: string) =>
         requestId === "req-confirm-allow",
       handleConfirmationResponse: mock(() => {}),
     };
-    const { ctx } = createContext(makeSession());
-    ctx.conversations.set("conv-1", session as any);
+    const { ctx } = createContext(makeConversation());
+    ctx.conversations.set("conv-1", conversationObj as any);
 
     const msg: ConfirmationResponse = {
       type: "confirmation_response",
@@ -253,10 +255,12 @@ describe("handleConfirmationResponse canonical status sync", () => {
 
     handleConfirmationResponse(msg, ctx);
 
-    expect((session.handleConfirmationResponse as any).mock.calls.length).toBe(
-      1,
-    );
-    expect((session.handleConfirmationResponse as any).mock.calls[0]).toEqual([
+    expect(
+      (conversationObj.handleConfirmationResponse as any).mock.calls.length,
+    ).toBe(1);
+    expect(
+      (conversationObj.handleConfirmationResponse as any).mock.calls[0],
+    ).toEqual([
       "req-confirm-allow",
       "always_allow",
       undefined,

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -162,8 +162,8 @@ const testAuthContext: AuthContext = {
   policyEpoch: 1,
 };
 
-// ── Helper: create a minimal mock session ──────────────────────────────────
-function makeSession(overrides: Record<string, unknown> = {}) {
+// ── Helper: create a minimal mock conversation ─────────────────────────────
+function makeConversation(overrides: Record<string, unknown> = {}) {
   return {
     setTrustContext: () => {},
     updateClient: () => {},
@@ -209,14 +209,14 @@ function makeRequest(content: string, extra: Record<string, unknown> = {}) {
 // ── Helper: send a message through handleSendMessage ───────────────────────
 async function sendMessage(
   content: string,
-  session: import("../daemon/conversation.js").Conversation,
+  conversationObj: import("../daemon/conversation.js").Conversation,
   extra: Record<string, unknown> = {},
 ) {
   return handleSendMessage(
     makeRequest(content, extra),
     {
       sendMessageDeps: {
-        getOrCreateConversation: async () => session,
+        getOrCreateConversation: async () => conversationObj,
         assistantEventHub: { publish: async () => {} } as any,
         resolveAttachments: () => [],
       },
@@ -241,9 +241,9 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
       "Set up Telegram with my bot token 123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage(secretContent, session);
+    const res = await sendMessage(secretContent, conversation);
 
     expect(res.status).toBe(422);
     const body = (await res.json()) as {
@@ -266,9 +266,9 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
       "Here is my AWS key AKIAQRSTUVWXYZ123456 and secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage(secretContent, session);
+    const res = await sendMessage(secretContent, conversation);
 
     expect(res.status).toBe(422);
     const body = (await res.json()) as {
@@ -287,9 +287,9 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
     const secretContent = "My Stripe key is sk_live_4eC39HqLyjWDarjtT1zdp7dc";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage(secretContent, session);
+    const res = await sendMessage(secretContent, conversation);
 
     expect(res.status).toBe(422);
     const body = (await res.json()) as {
@@ -308,9 +308,9 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
     const normalContent = "What is the weather today?";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage(normalContent, session);
+    const res = await sendMessage(normalContent, conversation);
 
     expect(res.status).toBe(202);
     const body = (await res.json()) as { accepted: boolean };
@@ -340,9 +340,9 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     // legacy handleUserMessage entry point.
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage("start recording", session);
+    const res = await sendMessage("start recording", conversation);
 
     expect(res.status).toBe(202);
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
@@ -357,9 +357,9 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     // be caught.
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage("start screen recording", session, {
+    const res = await sendMessage("start screen recording", conversation, {
       commandIntent: { type: "start_recording", payload: "screen" },
     });
 
@@ -371,9 +371,9 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
   test("stop recording commands pass through to the agent loop", async () => {
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
-    const session = makeSession({ persistUserMessage, runAgentLoop });
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
 
-    const res = await sendMessage("stop recording", session);
+    const res = await sendMessage("stop recording", conversation);
 
     expect(res.status).toBe(202);
     expect(persistUserMessage).toHaveBeenCalledTimes(1);

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -2,8 +2,8 @@
  * Tests for POST /v1/messages queue-if-busy behavior and hub publishing.
  *
  * Validates that:
- * - Messages are accepted (202) when the session is idle, with hub events published.
- * - Messages are queued (202, queued: true) when the session is busy, not 409.
+ * - Messages are accepted (202) when the conversation is idle, with hub events published.
+ * - Messages are queued (202, queued: true) when the conversation is busy, not 409.
  * - SSE subscribers receive events from messages sent via this endpoint.
  */
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
@@ -86,7 +86,7 @@ initializeDb();
 // ---------------------------------------------------------------------------
 
 /** Conversation that completes its agent loop quickly and emits a text delta + message_complete. */
-function makeCompletingSession(): Conversation {
+function makeCompletingConversation(): Conversation {
   let processing = false;
   const messages: unknown[] = [];
   return {
@@ -138,8 +138,8 @@ function makeCompletingSession(): Conversation {
   } as unknown as Conversation;
 }
 
-/** Conversation that hangs forever in the agent loop (simulates a busy session). */
-function makeHangingSession(): Conversation {
+/** Conversation that hangs forever in the agent loop (simulates a busy conversation). */
+function makeHangingConversation(): Conversation {
   let processing = false;
   const messages: unknown[] = [];
   const enqueuedMessages: Array<{
@@ -200,7 +200,7 @@ function makeHangingSession(): Conversation {
   } as unknown as Conversation;
 }
 
-function makePendingApprovalSession(
+function makePendingApprovalConversation(
   requestId: string,
   processing: boolean,
   options?: { queueDepth?: number },
@@ -329,7 +329,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
   });
 
   async function startServer(
-    sessionFactory: () => Conversation,
+    conversationFactory: () => Conversation,
     options?: { approvalConversationGenerator?: ApprovalConversationGenerator },
   ): Promise<void> {
     port = 19000 + Math.floor(Math.random() * 1000);
@@ -338,7 +338,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       bearerToken: TEST_TOKEN,
       approvalConversationGenerator: options?.approvalConversationGenerator,
       sendMessageDeps: {
-        getOrCreateConversation: async () => sessionFactory(),
+        getOrCreateConversation: async () => conversationFactory(),
         assistantEventHub: eventHub,
         resolveAttachments: () => [],
       },
@@ -354,10 +354,10 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     return `http://127.0.0.1:${port}/v1/messages`;
   }
 
-  // ── Idle session: immediate processing ──────────────────────────────
+  // ── Idle conversation: immediate processing ─────────────────────────
 
-  test("returns 202 with accepted: true and messageId when session is idle", async () => {
-    await startServer(() => makeCompletingSession());
+  test("returns 202 with accepted: true and messageId when conversation is idle", async () => {
+    await startServer(() => makeCompletingConversation());
 
     const res = await fetch(messagesUrl(), {
       method: "POST",
@@ -384,10 +384,10 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     await stopServer();
   });
 
-  test("publishes events to assistantEventHub when session is idle", async () => {
+  test("publishes events to assistantEventHub when conversation is idle", async () => {
     const publishedEvents: AssistantEvent[] = [];
 
-    await startServer(() => makeCompletingSession());
+    await startServer(() => makeCompletingConversation());
 
     eventHub.subscribe({ assistantId: "self" }, (event) => {
       publishedEvents.push(event);
@@ -426,7 +426,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       enqueueMessageMock,
       denyAllPendingConfirmationsMock,
       handleConfirmationResponseMock,
-    } = makePendingApprovalSession(requestId, false);
+    } = makePendingApprovalConversation(requestId, false);
 
     pendingInteractions.register(requestId, {
       conversation,
@@ -486,7 +486,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       enqueueMessageMock,
       denyAllPendingConfirmationsMock,
       handleConfirmationResponseMock,
-    } = makePendingApprovalSession(requestId, false);
+    } = makePendingApprovalConversation(requestId, false);
 
     pendingInteractions.register(requestId, {
       conversation,
@@ -554,7 +554,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       enqueueMessageMock,
       denyAllPendingConfirmationsMock,
       handleConfirmationResponseMock,
-    } = makePendingApprovalSession(requestId, true);
+    } = makePendingApprovalConversation(requestId, true);
 
     pendingInteractions.register(requestId, {
       conversation,
@@ -614,7 +614,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       enqueueMessageMock,
       denyAllPendingConfirmationsMock,
       handleConfirmationResponseMock,
-    } = makePendingApprovalSession(requestId, true, { queueDepth: 2 });
+    } = makePendingApprovalConversation(requestId, true, { queueDepth: 2 });
 
     pendingInteractions.register(requestId, {
       conversation,
@@ -674,7 +674,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       enqueueMessageMock,
       denyAllPendingConfirmationsMock,
       handleConfirmationResponseMock,
-    } = makePendingApprovalSession(requestId, false);
+    } = makePendingApprovalConversation(requestId, false);
 
     pendingInteractions.register(requestId, {
       conversation,
@@ -729,7 +729,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     const conversationKey = "conv-inline-ambiguous";
     const { conversationId } = getOrCreateConversation(conversationKey);
     const requestId = "req-inline-ambiguous";
-    const { conversation, runAgentLoopMock } = makePendingApprovalSession(
+    const { conversation, runAgentLoopMock } = makePendingApprovalConversation(
       requestId,
       false,
     );
@@ -780,13 +780,13 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     await stopServer();
   });
 
-  // ── Busy session: queue-if-busy ─────────────────────────────────────
+  // ── Busy conversation: queue-if-busy ────────────────────────────────
 
-  test("returns 202 with queued: true when session is busy (not 409)", async () => {
-    const conversation = makeHangingSession();
+  test("returns 202 with queued: true when conversation is busy (not 409)", async () => {
+    const conversation = makeHangingConversation();
     await startServer(() => conversation);
 
-    // First message starts the agent loop and makes the session busy
+    // First message starts the agent loop and makes the conversation busy
     const res1 = await fetch(messagesUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
@@ -837,7 +837,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
   // ── Validation ──────────────────────────────────────────────────────
 
   test("returns 400 when sourceChannel is missing", async () => {
-    await startServer(() => makeCompletingSession());
+    await startServer(() => makeCompletingConversation());
 
     const res = await fetch(messagesUrl(), {
       method: "POST",
@@ -850,7 +850,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
   });
 
   test("returns 400 when content is empty", async () => {
-    await startServer(() => makeCompletingSession());
+    await startServer(() => makeCompletingConversation());
 
     const res = await fetch(messagesUrl(), {
       method: "POST",
@@ -868,7 +868,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
   });
 
   test("returns 400 when conversationKey is missing", async () => {
-    await startServer(() => makeCompletingSession());
+    await startServer(() => makeCompletingConversation());
 
     const res = await fetch(messagesUrl(), {
       method: "POST",

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -89,7 +89,7 @@ function injectSubagent(
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     ...overrides,
   };
-  const fakeSession = {
+  const fakeConversation = {
     abort: () => {},
     dispose: () => {},
     messages: [],
@@ -100,7 +100,7 @@ function injectSubagent(
     runAgentLoop: async () => {},
   };
   internals.subagents.set(subagentId, {
-    conversation: fakeSession,
+    conversation: fakeConversation,
     state,
     parentSendToClient: () => {},
   });
@@ -275,17 +275,17 @@ describe("Subagent tool execute validation", () => {
 // ── Ownership validation ────────────────────────────────────────────
 
 describe("Subagent tool ownership validation", () => {
-  const ownerSession = "owner-sess";
-  const otherSession = "other-sess";
+  const ownerConversation = "owner-sess";
+  const otherConversation = "other-sess";
   const subagentId = "owned-sub-1";
 
   const manager = getSubagentManager();
-  injectSubagent(manager, subagentId, ownerSession);
+  injectSubagent(manager, subagentId, ownerConversation);
 
   test("status rejects non-owner conversation", async () => {
     const result = await executeSubagentStatus(
       { subagent_id: subagentId },
-      makeContext(otherSession),
+      makeContext(otherConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No subagent found");
@@ -294,7 +294,7 @@ describe("Subagent tool ownership validation", () => {
   test("status succeeds for owner conversation", async () => {
     const result = await executeSubagentStatus(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
   });
@@ -302,7 +302,7 @@ describe("Subagent tool ownership validation", () => {
   test("message rejects non-owner conversation", async () => {
     const result = await executeSubagentMessage(
       { subagent_id: subagentId, content: "hello" },
-      makeContext(otherSession),
+      makeContext(otherConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Could not send");
@@ -311,7 +311,7 @@ describe("Subagent tool ownership validation", () => {
   test("read rejects non-owner conversation", async () => {
     const result = await executeSubagentRead(
       { subagent_id: subagentId },
-      makeContext(otherSession),
+      makeContext(otherConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No subagent found");
@@ -320,7 +320,7 @@ describe("Subagent tool ownership validation", () => {
   test("abort rejects non-owner conversation", async () => {
     const result = await executeSubagentAbort(
       { subagent_id: subagentId },
-      makeContext(otherSession),
+      makeContext(otherConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Could not abort");
@@ -329,7 +329,7 @@ describe("Subagent tool ownership validation", () => {
   test("abort succeeds for owner conversation", async () => {
     const result = await executeSubagentAbort(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
   });
@@ -432,16 +432,16 @@ describe("Subagent spawn success and failure", () => {
 // ── Message success path ────────────────────────────────────────────
 
 describe("Subagent message success path", () => {
-  const ownerSession = "msg-owner-sess";
+  const ownerConversation = "msg-owner-sess";
   const subagentId = "msg-sub-1";
 
   test("message succeeds for owner conversation with running subagent", async () => {
     const manager = getSubagentManager();
-    injectSubagent(manager, subagentId, ownerSession, "running");
+    injectSubagent(manager, subagentId, ownerConversation, "running");
 
     const result = await executeSubagentMessage(
       { subagent_id: subagentId, content: "Continue working on this" },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
@@ -452,11 +452,11 @@ describe("Subagent message success path", () => {
   test("message fails for terminal-state subagent", async () => {
     const manager = getSubagentManager();
     const completedId = "msg-sub-completed";
-    injectSubagent(manager, completedId, ownerSession, "completed");
+    injectSubagent(manager, completedId, ownerConversation, "completed");
 
     const result = await executeSubagentMessage(
       { subagent_id: completedId, content: "Are you there?" },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Could not send");
@@ -466,16 +466,16 @@ describe("Subagent message success path", () => {
 // ── Status detail responses ─────────────────────────────────────────
 
 describe("Subagent status detail responses", () => {
-  const ownerSession = "status-owner-sess";
+  const ownerConversation = "status-owner-sess";
 
   test("individual status returns full detail fields", async () => {
     const manager = getSubagentManager();
     const subagentId = "status-detail-1";
     const now = Date.now();
-    injectSubagent(manager, subagentId, ownerSession, "running", {
+    injectSubagent(manager, subagentId, ownerConversation, "running", {
       config: {
         id: subagentId,
-        parentConversationId: ownerSession,
+        parentConversationId: ownerConversation,
         label: "Detail test",
         objective: "test obj",
       },
@@ -486,7 +486,7 @@ describe("Subagent status detail responses", () => {
 
     const result = await executeSubagentStatus(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
@@ -501,11 +501,14 @@ describe("Subagent status detail responses", () => {
 
   test("list status returns summary of all children", async () => {
     const manager = getSubagentManager();
-    const listSession = "status-list-sess";
-    injectSubagent(manager, "list-sub-1", listSession, "running");
-    injectSubagent(manager, "list-sub-2", listSession, "completed");
+    const listConversation = "status-list-sess";
+    injectSubagent(manager, "list-sub-1", listConversation, "running");
+    injectSubagent(manager, "list-sub-2", listConversation, "completed");
 
-    const result = await executeSubagentStatus({}, makeContext(listSession));
+    const result = await executeSubagentStatus(
+      {},
+      makeContext(listConversation),
+    );
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
     expect(Array.isArray(parsed)).toBe(true);
@@ -518,13 +521,13 @@ describe("Subagent status detail responses", () => {
   test("individual status includes error field for failed subagent", async () => {
     const manager = getSubagentManager();
     const failedId = "status-failed-1";
-    injectSubagent(manager, failedId, ownerSession, "failed", {
+    injectSubagent(manager, failedId, ownerConversation, "failed", {
       error: "Rate limit exceeded",
     });
 
     const result = await executeSubagentStatus(
       { subagent_id: failedId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
@@ -536,16 +539,16 @@ describe("Subagent status detail responses", () => {
 // ── Read tool behavior ──────────────────────────────────────────────
 
 describe("Subagent read tool", () => {
-  const ownerSession = "read-owner-sess";
+  const ownerConversation = "read-owner-sess";
 
   test("read returns wait message for non-terminal subagent", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-running-1";
-    injectSubagent(manager, subagentId, ownerSession, "running");
+    injectSubagent(manager, subagentId, ownerConversation, "running");
 
     const result = await executeSubagentRead(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("still running");
@@ -555,11 +558,11 @@ describe("Subagent read tool", () => {
   test("read returns wait message for pending subagent", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-pending-1";
-    injectSubagent(manager, subagentId, ownerSession, "pending");
+    injectSubagent(manager, subagentId, ownerConversation, "pending");
 
     const result = await executeSubagentRead(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("still pending");
@@ -568,7 +571,7 @@ describe("Subagent read tool", () => {
   test("read extracts text from JSON array content blocks", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-json-array-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -590,7 +593,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toContain("Here is the result");
@@ -603,7 +606,7 @@ describe("Subagent read tool", () => {
   test("read handles plain text content", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-plain-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -613,7 +616,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toBe("Plain text response");
@@ -625,7 +628,7 @@ describe("Subagent read tool", () => {
   test("read handles string JSON content", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-str-json-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -637,7 +640,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toBe("A JSON string value");
@@ -649,7 +652,7 @@ describe("Subagent read tool", () => {
   test("read skips non-text content blocks", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-skip-blocks-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -667,7 +670,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toBe("Actual output");
@@ -680,7 +683,7 @@ describe("Subagent read tool", () => {
   test("read returns no-output message when only user/tool messages exist", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-no-output-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -693,7 +696,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toContain("no text output");
@@ -705,14 +708,14 @@ describe("Subagent read tool", () => {
   test("read returns error when no messages in DB", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-empty-db-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = () => [];
 
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(true);
       expect(result.content).toContain("No messages found");
@@ -724,13 +727,13 @@ describe("Subagent read tool", () => {
   test("read returns error when getMessages returns null", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-null-db-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = () => null;
 
     const result = await executeSubagentRead(
       { subagent_id: subagentId },
-      makeContext(ownerSession),
+      makeContext(ownerConversation),
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No messages found");
@@ -739,7 +742,7 @@ describe("Subagent read tool", () => {
   test("read works for failed subagent (terminal state)", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-failed-1";
-    injectSubagent(manager, subagentId, ownerSession, "failed");
+    injectSubagent(manager, subagentId, ownerConversation, "failed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -756,7 +759,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toContain("Partial output before failure");
@@ -768,7 +771,7 @@ describe("Subagent read tool", () => {
   test("read works for aborted subagent (terminal state)", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-aborted-1";
-    injectSubagent(manager, subagentId, ownerSession, "aborted");
+    injectSubagent(manager, subagentId, ownerConversation, "aborted");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -778,7 +781,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toBe("Output before abort");
@@ -790,7 +793,7 @@ describe("Subagent read tool", () => {
   test("read concatenates multiple assistant messages", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-multi-1";
-    injectSubagent(manager, subagentId, ownerSession, "completed");
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
       if (convId !== `conv-${subagentId}`) return null;
@@ -805,7 +808,7 @@ describe("Subagent read tool", () => {
     try {
       const result = await executeSubagentRead(
         { subagent_id: subagentId },
-        makeContext(ownerSession),
+        makeContext(ownerConversation),
       );
       expect(result.isError).toBe(false);
       expect(result.content).toContain("First response");

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -12,8 +12,8 @@ import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("swarm-delegate");
 
-/** Tracks active swarm sessions to prevent nested invocation per-session. */
-const activeSessions = new Set<string>();
+/** Tracks active swarm conversations to prevent nested invocation per-conversation. */
+const activeConversations = new Set<string>();
 
 export const swarmDelegateTool: Tool = {
   name: "swarm_delegate",
@@ -73,17 +73,17 @@ export const swarmDelegateTool: Tool = {
       return { content: "Cancelled", isError: true };
     }
 
-    // Recursion guard — scoped to session so independent sessions are not blocked
-    const sessionKey = context.conversationId;
-    if (activeSessions.has(sessionKey)) {
+    // Recursion guard — scoped to conversation so independent conversations are not blocked
+    const conversationKey = context.conversationId;
+    if (activeConversations.has(conversationKey)) {
       return {
         content:
-          "Error: A swarm is already executing in this session. Nested swarm invocation is not allowed.",
+          "Error: A swarm is already executing in this conversation. Nested swarm invocation is not allowed.",
         isError: true,
       };
     }
 
-    activeSessions.add(sessionKey);
+    activeConversations.add(conversationKey);
     try {
       const limits = resolveSwarmLimits({
         maxWorkers: maxWorkersOverride ?? config.swarm.maxWorkers,
@@ -194,12 +194,12 @@ export const swarmDelegateTool: Tool = {
         isError: true,
       };
     } finally {
-      activeSessions.delete(sessionKey);
+      activeConversations.delete(conversationKey);
     }
   },
 };
 
-/** Clear all active sessions — only for testing. */
+/** Clear all active conversations — only for testing. */
 export function _resetSwarmActive(): void {
-  activeSessions.clear();
+  activeConversations.clear();
 }


### PR DESCRIPTION
## Summary
- Rename makeSession() to makeConversation() across 15 TS test files
- Rename SessionWithWorkspaceDeps, TestSession types to ConversationWithWorkspaceDeps, TestConversation
- Rename fakeSession/ownerSession/otherSession/listSession in subagent tests
- Rename activeSessions/sessionKey in swarm delegate production code
- Rename makeCompletingSession/makeHangingSession/makePendingApprovalSession in send-endpoint-busy tests
- Rename sessionFactory parameter to conversationFactory

Part of plan: conv-symbol-sweep.md

Generated with [Claude Code](https://claude.com/claude-code)