### PR TITLE
fix: resolve Swift concurrency error in LogExporter

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellumai/assistant",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.16.1",
         "@anthropic-ai/claude-agent-sdk": "^0.2.42",
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.40.0",
@@ -57,6 +58,8 @@
     },
   },
   "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.76", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -27,6 +27,7 @@
     "prepack": "node ../scripts/prepack-bundled-deps.mjs"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.16.1",
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  resolvePermission,
+  VellumAcpClientHandler,
+} from "../acp/client-handler.js";
+import { AcpSessionManager } from "../acp/session-manager.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+// ---------------------------------------------------------------------------
+// VellumAcpClientHandler tests
+// ---------------------------------------------------------------------------
+
+describe("VellumAcpClientHandler", () => {
+  let sent: ServerMessage[];
+  let sendToVellum: (msg: ServerMessage) => void;
+  let pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
+  let handler: VellumAcpClientHandler;
+
+  beforeEach(() => {
+    sent = [];
+    sendToVellum = (msg) => sent.push(msg);
+    pendingPermissions = new Map();
+    handler = new VellumAcpClientHandler(
+      "session-1",
+      sendToVellum,
+      pendingPermissions,
+    );
+  });
+
+  describe("sessionUpdate", () => {
+    test("dispatches agent_message_chunk with extracted text", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "hello" },
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        type: "acp_session_update",
+        acpSessionId: "session-1",
+        updateType: "agent_message_chunk",
+        content: "hello",
+      });
+    });
+
+    test("dispatches user_message_chunk as agent_message_chunk", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "user_message_chunk",
+          content: { type: "text", text: "user text" },
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        type: "acp_session_update",
+        updateType: "agent_message_chunk",
+        content: "user text",
+      });
+    });
+
+    test("dispatches tool_call update", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-1",
+          title: "Read file",
+          kind: "read",
+          status: "running",
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        type: "acp_session_update",
+        updateType: "tool_call",
+        toolCallId: "tc-1",
+        toolTitle: "Read file",
+        toolKind: "read",
+        toolStatus: "running",
+      });
+    });
+
+    test("dispatches tool_call_update", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tc-2",
+          status: "completed",
+          content: { result: "ok" },
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        type: "acp_session_update",
+        updateType: "tool_call_update",
+        toolCallId: "tc-2",
+        toolStatus: "completed",
+      });
+    });
+
+    test("dispatches plan update", async () => {
+      const entries = [{ step: "Step 1" }];
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "plan",
+          entries,
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        type: "acp_session_update",
+        updateType: "plan",
+        content: JSON.stringify(entries),
+      });
+    });
+
+    test("ignores unhandled session update types", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "usage_update",
+          usage: { tokens: 100 },
+        } as any,
+      });
+
+      expect(sent).toHaveLength(0);
+    });
+
+    test("returns empty string when content has no text field", async () => {
+      await handler.sessionUpdate({
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "image" },
+        } as any,
+      });
+
+      expect(sent).toHaveLength(1);
+      expect((sent[0] as any).content).toBe("");
+    });
+  });
+
+  describe("requestPermission", () => {
+    test("sends permission request and resolves when permission is granted", async () => {
+      const resultPromise = handler.requestPermission({
+        toolCall: {
+          title: "Run command",
+          kind: "execute",
+          rawInput: "ls -la",
+        },
+        options: [
+          { optionId: "allow", name: "Allow", kind: "allow_once" },
+          { optionId: "deny", name: "Deny", kind: "reject_once" },
+        ],
+      } as any);
+
+      // Should have sent a permission request
+      expect(sent).toHaveLength(1);
+      const msg = sent[0] as any;
+      expect(msg.type).toBe("acp_permission_request");
+      expect(msg.acpSessionId).toBe("session-1");
+      expect(msg.toolTitle).toBe("Run command");
+      expect(msg.toolKind).toBe("execute");
+      expect(msg.options).toHaveLength(2);
+
+      // A pending permission should exist
+      expect(pendingPermissions.size).toBe(1);
+      const requestId = msg.requestId;
+
+      // Resolve the permission
+      resolvePermission(pendingPermissions, requestId, "allow");
+
+      const result = await resultPromise;
+      expect(result).toEqual({
+        outcome: { outcome: "selected", optionId: "allow" },
+      });
+      expect(pendingPermissions.size).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePermission standalone tests
+// ---------------------------------------------------------------------------
+
+describe("resolvePermission", () => {
+  test("resolves and removes the pending entry", () => {
+    let resolved = "";
+    const pending = new Map<string, { resolve: (id: string) => void }>();
+    pending.set("req-1", { resolve: (id) => (resolved = id) });
+
+    resolvePermission(pending, "req-1", "allow");
+
+    expect(resolved).toBe("allow");
+    expect(pending.size).toBe(0);
+  });
+
+  test("is a no-op when request ID is not found", () => {
+    const pending = new Map<string, { resolve: (id: string) => void }>();
+    // Should not throw
+    resolvePermission(pending, "nonexistent", "allow");
+    expect(pending.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AcpSessionManager tests
+// ---------------------------------------------------------------------------
+
+describe("AcpSessionManager", () => {
+  describe("concurrency limit", () => {
+    test("rejects spawn when max concurrent sessions reached", async () => {
+      const manager = new AcpSessionManager(0);
+      const sendToVellum = mock(() => {});
+
+      await expect(
+        manager.spawn(
+          "agent-1",
+          { command: "echo", args: ["hi"] },
+          "do something",
+          "/tmp",
+          "parent-1",
+          sendToVellum,
+        ),
+      ).rejects.toThrow(/concurrency limit reached/i);
+    });
+  });
+
+  describe("close / getStatus on missing sessions", () => {
+    test("close throws for unknown session", () => {
+      const manager = new AcpSessionManager(5);
+      expect(() => manager.close("nonexistent")).toThrow(/not found/);
+    });
+
+    test("getStatus throws for unknown specific session", () => {
+      const manager = new AcpSessionManager(5);
+      expect(() => manager.getStatus("nonexistent")).toThrow(/not found/);
+    });
+
+    test("getStatus returns empty array when no sessions exist", () => {
+      const manager = new AcpSessionManager(5);
+      expect(manager.getStatus()).toEqual([]);
+    });
+  });
+
+  describe("cancel on missing session", () => {
+    test("throws for unknown session", async () => {
+      const manager = new AcpSessionManager(5);
+      await expect(manager.cancel("nonexistent")).rejects.toThrow(/not found/);
+    });
+  });
+
+  describe("steer on missing session", () => {
+    test("throws for unknown session", async () => {
+      const manager = new AcpSessionManager(5);
+      await expect(manager.steer("nonexistent", "go left")).rejects.toThrow(
+        /not found/,
+      );
+    });
+  });
+
+  describe("resolvePermission", () => {
+    test("logs warning for unknown request ID (no throw)", () => {
+      const manager = new AcpSessionManager(5);
+      // Should not throw — just logs a warning
+      manager.resolvePermission("unknown-req", "allow");
+    });
+  });
+
+  describe("closeAll / dispose", () => {
+    test("closeAll on empty manager does not throw", () => {
+      const manager = new AcpSessionManager(5);
+      expect(() => manager.closeAll()).not.toThrow();
+    });
+
+    test("dispose on empty manager does not throw", () => {
+      const manager = new AcpSessionManager(5);
+      expect(() => manager.dispose()).not.toThrow();
+    });
+  });
+});

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -1,0 +1,198 @@
+/**
+ * ACP agent process manager.
+ *
+ * Wraps a child process running an ACP-compliant agent, managing its lifecycle
+ * and providing typed methods for the ACP client-side protocol operations.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+
+import type {
+  Agent,
+  Client,
+  InitializeResponse,
+  NewSessionResponse,
+  PromptResponse,
+} from "@agentclientprotocol/sdk";
+import * as acp from "@agentclientprotocol/sdk";
+
+import { getLogger } from "../util/logger.js";
+import type { AcpAgentConfig } from "./types.js";
+
+const log = getLogger("acp");
+
+/**
+ * Factory function type for creating ACP client handlers.
+ * PR 5 will provide the real VellumAcpClientHandler implementation.
+ */
+export type AcpClientFactory = (agent: Agent) => Client;
+
+/**
+ * Manages an ACP agent child process and its protocol connection.
+ */
+export class AcpAgentProcess {
+  private proc: ChildProcess | null = null;
+  private connection: acp.ClientSideConnection | null = null;
+
+  constructor(
+    public readonly agentId: string,
+    private readonly config: AcpAgentConfig,
+    private readonly clientFactory: AcpClientFactory,
+  ) {}
+
+  /**
+   * Spawns the agent command as a child process and sets up the ACP connection.
+   */
+  spawn(cwd: string): void {
+    log.info(
+      { agentId: this.agentId, command: this.config.command, cwd },
+      "Spawning ACP agent process",
+    );
+
+    this.proc = spawn(this.config.command, this.config.args, {
+      cwd,
+      stdio: ["pipe", "pipe", "inherit"],
+      env: { ...process.env, ...this.config.env },
+    });
+
+    const stream = acp.ndJsonStream(
+      Writable.toWeb(this.proc.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(
+        this.proc.stdout!,
+      ) as unknown as ReadableStream<Uint8Array>,
+    );
+
+    this.connection = new acp.ClientSideConnection(
+      (agent) => this.clientFactory(agent),
+      stream,
+    );
+
+    // Handle process exit
+    this.proc.on("exit", (code) => {
+      this.handleProcessExit(code);
+    });
+
+    this.proc.on("error", (err) => {
+      log.error(
+        { agentId: this.agentId, error: err.message },
+        "ACP agent process error",
+      );
+    });
+  }
+
+  /**
+   * Initializes the ACP connection by negotiating protocol version and capabilities.
+   */
+  async initialize(): Promise<InitializeResponse> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info({ agentId: this.agentId }, "Initializing ACP connection");
+
+    return this.connection.initialize({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      clientInfo: { name: "vellum", version: "1.0.0" },
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+    });
+  }
+
+  /**
+   * Creates a new ACP session in the specified working directory.
+   * Returns the session ID.
+   */
+  async createSession(cwd: string): Promise<string> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info({ agentId: this.agentId, cwd }, "Creating ACP session");
+
+    const result: NewSessionResponse = await this.connection.newSession({
+      cwd,
+      mcpServers: [],
+    });
+
+    return result.sessionId;
+  }
+
+  /**
+   * Sends a prompt to an existing ACP session.
+   * Returns the prompt response (includes stopReason).
+   */
+  async prompt(sessionId: string, text: string): Promise<PromptResponse> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info(
+      { agentId: this.agentId, sessionId },
+      "Sending prompt to ACP agent",
+    );
+
+    return this.connection.prompt({
+      sessionId,
+      prompt: [{ type: "text", text }],
+    });
+  }
+
+  /**
+   * Cancels an ongoing prompt in the specified session.
+   */
+  async cancel(sessionId: string): Promise<void> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info(
+      { agentId: this.agentId, sessionId },
+      "Cancelling ACP session prompt",
+    );
+
+    await this.connection.cancel({ sessionId });
+  }
+
+  /**
+   * Kills the child process and cleans up the connection.
+   */
+  kill(): void {
+    log.info({ agentId: this.agentId }, "Killing ACP agent process");
+
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+    this.connection = null;
+  }
+
+  /**
+   * Whether the child process is still running.
+   */
+  get isAlive(): boolean {
+    if (!this.proc) return false;
+    // ChildProcess.exitCode is null while process is still running
+    // exitCode is null while the process is still running
+    return this.proc.exitCode == null;
+  }
+
+  /**
+   * Handles process exit by logging the event.
+   */
+  private handleProcessExit(code: number | null): void {
+    if (code !== 0) {
+      log.error(
+        { agentId: this.agentId, exitCode: code },
+        "ACP agent process exited with error",
+      );
+    } else {
+      log.info(
+        { agentId: this.agentId, exitCode: code },
+        "ACP agent process exited",
+      );
+    }
+  }
+}

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -183,7 +183,7 @@ export class AcpAgentProcess {
    * Handles process exit by logging the event.
    */
   private handleProcessExit(code: number | null): void {
-    if (code !== 0) {
+    if (code != undefined && code !== 0) {
       log.error(
         { agentId: this.agentId, exitCode: code },
         "ACP agent process exited with error",
@@ -194,5 +194,8 @@ export class AcpAgentProcess {
         "ACP agent process exited",
       );
     }
+
+    this.proc = null;
+    this.connection = null;
   }
 }

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -80,7 +80,7 @@ export class VellumAcpClientHandler implements Client {
         this.sendToVellum({
           type: "acp_session_update",
           acpSessionId: this.acpSessionId,
-          updateType: "agent_message_chunk",
+          updateType: "user_message_chunk",
           content: text,
         });
         break;
@@ -208,6 +208,13 @@ export class VellumAcpClientHandler implements Client {
       signal: null,
       exitPromise: Promise.resolve(),
     };
+
+    proc.on("error", (err) => {
+      log.error({ terminalId, error: err.message }, "Terminal process error");
+      state.exited = true;
+      state.exitCode = 1;
+      state.signal = null;
+    });
 
     state.exitPromise = new Promise<void>((resolve) => {
       proc.on("exit", (code, signal) => {

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -50,6 +50,12 @@ interface TerminalState {
  */
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
+  private accumulatedText = "";
+
+  /** Returns the full agent response text accumulated from agent_message_chunk events. */
+  get responseText(): string {
+    return this.accumulatedText;
+  }
 
   constructor(
     private readonly acpSessionId: string,
@@ -62,10 +68,15 @@ export class VellumAcpClientHandler implements Client {
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
     const update = params.update;
+    log.debug(
+      { acpSessionId: this.acpSessionId, updateType: update.sessionUpdate },
+      "ACP session update received",
+    );
 
     switch (update.sessionUpdate) {
       case "agent_message_chunk": {
         const text = extractText(update.content);
+        this.accumulatedText += text;
         this.sendToVellum({
           type: "acp_session_update",
           acpSessionId: this.acpSessionId,
@@ -141,6 +152,16 @@ export class VellumAcpClientHandler implements Client {
     params: RequestPermissionRequest,
   ): Promise<RequestPermissionResponse> {
     const requestId = randomUUID();
+    log.info(
+      {
+        acpSessionId: this.acpSessionId,
+        requestId,
+        toolTitle: params.toolCall.title,
+        toolKind: params.toolCall.kind,
+        optionCount: params.options.length,
+      },
+      "ACP permission requested",
+    );
 
     const optionIdPromise = new Promise<string>((resolve) => {
       this.pendingPermissions.set(requestId, { resolve });
@@ -161,12 +182,20 @@ export class VellumAcpClientHandler implements Client {
     });
 
     const optionId = await optionIdPromise;
+    log.info(
+      { acpSessionId: this.acpSessionId, requestId, optionId },
+      "ACP permission resolved",
+    );
     return { outcome: { outcome: "selected", optionId } };
   }
 
   async readTextFile(
     params: ReadTextFileRequest,
   ): Promise<ReadTextFileResponse> {
+    log.debug(
+      { acpSessionId: this.acpSessionId, path: params.path },
+      "ACP readTextFile",
+    );
     const content = await Bun.file(params.path).text();
     return { content };
   }
@@ -174,6 +203,10 @@ export class VellumAcpClientHandler implements Client {
   async writeTextFile(
     params: WriteTextFileRequest,
   ): Promise<WriteTextFileResponse> {
+    log.info(
+      { acpSessionId: this.acpSessionId, path: params.path },
+      "ACP writeTextFile",
+    );
     await Bun.write(params.path, params.content);
     return {};
   }
@@ -182,6 +215,15 @@ export class VellumAcpClientHandler implements Client {
     params: CreateTerminalRequest,
   ): Promise<CreateTerminalResponse> {
     const terminalId = randomUUID();
+    log.info(
+      {
+        acpSessionId: this.acpSessionId,
+        terminalId,
+        command: params.command,
+        args: params.args,
+      },
+      "ACP createTerminal",
+    );
 
     const args = params.args ?? [];
     const env: Record<string, string> = { ...process.env } as Record<

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -1,0 +1,312 @@
+/**
+ * ACP client handler — bridges ACP agent events to Vellum's SSE message protocol.
+ *
+ * Implements the ACP SDK's Client interface, forwarding session updates,
+ * permission requests, file operations, and terminal management to
+ * connected Vellum clients.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+import type {
+  Client,
+  CreateTerminalRequest,
+  CreateTerminalResponse,
+  KillTerminalRequest,
+  KillTerminalResponse,
+  ReadTextFileRequest,
+  ReadTextFileResponse,
+  ReleaseTerminalRequest,
+  ReleaseTerminalResponse,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification,
+  TerminalOutputRequest,
+  TerminalOutputResponse,
+  WaitForTerminalExitRequest,
+  WaitForTerminalExitResponse,
+  WriteTextFileRequest,
+  WriteTextFileResponse,
+} from "@agentclientprotocol/sdk";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("acp:client-handler");
+
+interface TerminalState {
+  proc: ChildProcess;
+  output: string;
+  exited: boolean;
+  exitCode: number | null;
+  signal: string | null;
+  exitPromise: Promise<void>;
+}
+
+/**
+ * Vellum's ACP Client handler. Receives events from an ACP agent and
+ * forwards them as ServerMessage objects to connected Vellum clients.
+ */
+export class VellumAcpClientHandler implements Client {
+  private terminals = new Map<string, TerminalState>();
+
+  constructor(
+    private readonly acpSessionId: string,
+    private readonly sendToVellum: (msg: ServerMessage) => void,
+    private readonly pendingPermissions: Map<
+      string,
+      { resolve: (optionId: string) => void }
+    >,
+  ) {}
+
+  async sessionUpdate(params: SessionNotification): Promise<void> {
+    const update = params.update;
+
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk": {
+        const text = extractText(update.content);
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "agent_message_chunk",
+          content: text,
+        });
+        break;
+      }
+
+      case "user_message_chunk": {
+        const text = extractText(update.content);
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "agent_message_chunk",
+          content: text,
+        });
+        break;
+      }
+
+      case "tool_call": {
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "tool_call",
+          toolCallId: update.toolCallId,
+          toolTitle: update.title,
+          toolKind: update.kind,
+          toolStatus: update.status,
+        });
+        break;
+      }
+
+      case "tool_call_update": {
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "tool_call_update",
+          toolCallId: update.toolCallId,
+          toolStatus: update.status ?? undefined,
+          content: update.content ? JSON.stringify(update.content) : undefined,
+        });
+        break;
+      }
+
+      case "plan": {
+        this.sendToVellum({
+          type: "acp_session_update",
+          acpSessionId: this.acpSessionId,
+          updateType: "plan",
+          content: JSON.stringify(update.entries),
+        });
+        break;
+      }
+
+      default: {
+        // Other update types (agent_thought_chunk, available_commands_update,
+        // current_mode_update, config_option_update, session_info_update,
+        // usage_update) are not forwarded to Vellum.
+        log.debug(
+          {
+            acpSessionId: this.acpSessionId,
+            updateType: (update as { sessionUpdate: string }).sessionUpdate,
+          },
+          "Ignoring unhandled session update type",
+        );
+        break;
+      }
+    }
+  }
+
+  async requestPermission(
+    params: RequestPermissionRequest,
+  ): Promise<RequestPermissionResponse> {
+    const requestId = randomUUID();
+
+    const optionIdPromise = new Promise<string>((resolve) => {
+      this.pendingPermissions.set(requestId, { resolve });
+    });
+
+    this.sendToVellum({
+      type: "acp_permission_request",
+      acpSessionId: this.acpSessionId,
+      requestId,
+      toolTitle: params.toolCall.title ?? "Unknown tool",
+      toolKind: params.toolCall.kind ?? "other",
+      rawInput: params.toolCall.rawInput,
+      options: params.options.map((opt) => ({
+        optionId: opt.optionId,
+        name: opt.name,
+        kind: opt.kind,
+      })),
+    });
+
+    const optionId = await optionIdPromise;
+    return { outcome: { outcome: "selected", optionId } };
+  }
+
+  async readTextFile(
+    params: ReadTextFileRequest,
+  ): Promise<ReadTextFileResponse> {
+    const content = await Bun.file(params.path).text();
+    return { content };
+  }
+
+  async writeTextFile(
+    params: WriteTextFileRequest,
+  ): Promise<WriteTextFileResponse> {
+    await Bun.write(params.path, params.content);
+    return {};
+  }
+
+  async createTerminal(
+    params: CreateTerminalRequest,
+  ): Promise<CreateTerminalResponse> {
+    const terminalId = randomUUID();
+
+    const args = params.args ?? [];
+    const env: Record<string, string> = { ...process.env } as Record<
+      string,
+      string
+    >;
+    if (params.env) {
+      for (const { name, value } of params.env) {
+        env[name] = value;
+      }
+    }
+
+    const proc = spawn(params.command, args, {
+      cwd: params.cwd ?? undefined,
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+    });
+
+    const state: TerminalState = {
+      proc,
+      output: "",
+      exited: false,
+      exitCode: null,
+      signal: null,
+      exitPromise: Promise.resolve(),
+    };
+
+    state.exitPromise = new Promise<void>((resolve) => {
+      proc.on("exit", (code, signal) => {
+        state.exited = true;
+        state.exitCode = code;
+        state.signal = signal;
+        resolve();
+      });
+    });
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      state.output += chunk.toString();
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      state.output += chunk.toString();
+    });
+
+    this.terminals.set(terminalId, state);
+    return { terminalId };
+  }
+
+  async terminalOutput(
+    params: TerminalOutputRequest,
+  ): Promise<TerminalOutputResponse> {
+    const state = this.terminals.get(params.terminalId);
+    if (!state) {
+      return { output: "", truncated: false };
+    }
+
+    return {
+      output: state.output,
+      truncated: false,
+      exitStatus: state.exited
+        ? {
+            exitCode: state.exitCode,
+            signal: state.signal,
+          }
+        : null,
+    };
+  }
+
+  async waitForTerminalExit(
+    params: WaitForTerminalExitRequest,
+  ): Promise<WaitForTerminalExitResponse> {
+    const state = this.terminals.get(params.terminalId);
+    if (!state) {
+      return { exitCode: null, signal: null };
+    }
+
+    await state.exitPromise;
+    return { exitCode: state.exitCode, signal: state.signal };
+  }
+
+  async killTerminal(
+    params: KillTerminalRequest,
+  ): Promise<KillTerminalResponse> {
+    const state = this.terminals.get(params.terminalId);
+    if (state && !state.exited) {
+      state.proc.kill();
+    }
+    return {};
+  }
+
+  async releaseTerminal(
+    params: ReleaseTerminalRequest,
+  ): Promise<ReleaseTerminalResponse> {
+    const state = this.terminals.get(params.terminalId);
+    if (state) {
+      if (!state.exited) {
+        state.proc.kill();
+      }
+      this.terminals.delete(params.terminalId);
+    }
+    return {};
+  }
+}
+
+/**
+ * Resolves a pending permission request by its request ID.
+ */
+export function resolvePermission(
+  pendingPermissions: Map<string, { resolve: (optionId: string) => void }>,
+  requestId: string,
+  optionId: string,
+): void {
+  const pending = pendingPermissions.get(requestId);
+  if (pending) {
+    pending.resolve(optionId);
+    pendingPermissions.delete(requestId);
+  }
+}
+
+/**
+ * Extracts text from a ContentBlock.
+ */
+function extractText(content: { type?: string; text?: string }): string {
+  if (content && "text" in content && typeof content.text === "string") {
+    return content.text;
+  }
+  return "";
+}

--- a/assistant/src/acp/index.ts
+++ b/assistant/src/acp/index.ts
@@ -1,0 +1,44 @@
+export { AcpSessionManager } from "./session-manager.js";
+export type { AcpAgentConfig, AcpSessionState } from "./types.js";
+
+import { getConfig } from "../config/loader.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { AcpSessionManager } from "./session-manager.js";
+
+/** Singleton AcpSessionManager instance shared across the daemon. */
+let manager: AcpSessionManager | null = null;
+
+/**
+ * Returns the singleton AcpSessionManager, creating it on first call
+ * using the ACP config from getConfig().
+ */
+export function getAcpSessionManager(): AcpSessionManager {
+  if (!manager) {
+    const config = getConfig();
+    manager = new AcpSessionManager(config.acp.maxConcurrentSessions);
+  }
+  return manager;
+}
+
+/**
+ * Disposes the singleton AcpSessionManager and nulls the reference.
+ */
+export function disposeAcpSessionManager(): void {
+  if (manager) {
+    manager.dispose();
+    manager = null;
+  }
+}
+
+/**
+ * Broadcast callback set by DaemonServer constructor so ACP session events
+ * reach all connected SSE clients. Same pattern as
+ * `getSubagentManager().broadcastToAllClients` in server.ts.
+ */
+export let broadcastToAllClients: ((msg: ServerMessage) => void) | null = null;
+
+export function setBroadcastToAllClients(
+  fn: (msg: ServerMessage) => void,
+): void {
+  broadcastToAllClients = fn;
+}

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -291,10 +291,7 @@ export class AcpSessionManager {
           if (this.onAcpSessionFinished) {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
-            const sessionId = current.state.acpSessionId;
-            const notifyMessage =
-              `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}\n\n` +
-              `To resume this session later: claude --resume ${sessionId}`;
+            const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}`;
             this.onAcpSessionFinished(
               current.parentSessionId,
               notifyMessage,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -292,7 +292,9 @@ export class AcpSessionManager {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
             const sessionId = current.state.acpSessionId;
-            const notifyMessage = `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}`;
+            const notifyMessage =
+              `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}\n\n` +
+              `To resume this session later: claude --resume ${sessionId}`;
             this.onAcpSessionFinished(
               current.parentSessionId,
               notifyMessage,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -20,10 +20,24 @@ interface SessionEntry {
   pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
   sendToVellum: (msg: ServerMessage) => void;
   currentPrompt: Promise<unknown> | null;
+  parentSessionId: string;
 }
 
 export class AcpSessionManager {
   private sessions = new Map<string, SessionEntry>();
+
+  /**
+   * Optional callback to inject a completion/failure message into the parent
+   * session's conversation so the LLM sees the agent's output.
+   * Wired by DaemonServer at startup.
+   */
+  onAcpSessionFinished:
+    | ((
+        parentSessionId: string,
+        message: string,
+        sendToClient: (msg: ServerMessage) => void,
+      ) => Promise<void>)
+    | null = null;
 
   constructor(private readonly maxConcurrent: number) {}
 
@@ -49,6 +63,11 @@ export class AcpSessionManager {
     }
 
     const acpSessionId = randomUUID();
+    log.info(
+      { acpSessionId, agentId, task: task.slice(0, 200), cwd, parentSessionId },
+      "ACP spawn requested",
+    );
+
     const pendingPermissions = new Map<
       string,
       { resolve: (optionId: string) => void }
@@ -83,17 +102,29 @@ export class AcpSessionManager {
       pendingPermissions,
       sendToVellum,
       currentPrompt: null,
+      parentSessionId,
     };
 
     this.sessions.set(acpSessionId, entry);
 
     try {
+      log.info({ acpSessionId, agentId }, "ACP spawning child process");
       agentProcess.spawn(cwd);
+      log.info(
+        { acpSessionId, agentId },
+        "ACP initializing protocol connection",
+      );
       await agentProcess.initialize();
+      log.info({ acpSessionId, agentId }, "ACP creating session");
       const acpProtocolSessionId = await agentProcess.createSession(cwd);
       state.acpSessionId = acpProtocolSessionId;
       state.status = "running";
+      log.info(
+        { acpSessionId, agentId, acpProtocolSessionId },
+        "ACP session running",
+      );
     } catch (err) {
+      log.error({ acpSessionId, agentId, err }, "ACP spawn failed");
       // Kill the orphaned child process and remove the reserved slot.
       agentProcess.kill();
       this.sessions.delete(acpSessionId);
@@ -231,6 +262,7 @@ export class AcpSessionManager {
     acpProtocolSessionId: string,
     message: string,
   ): Promise<unknown> {
+    log.info({ acpSessionId, messageLen: message.length }, "ACP firing prompt");
     const promptPromise = entry.process
       .prompt(acpProtocolSessionId, message)
       .then((response) => {
@@ -245,11 +277,32 @@ export class AcpSessionManager {
             current.state.stopReason = response.stopReason;
           }
           current.currentPrompt = null;
+          log.info(
+            { acpSessionId, stopReason: response.stopReason },
+            "ACP prompt completed",
+          );
           current.sendToVellum({
             type: "acp_session_completed",
             acpSessionId,
             stopReason: response.stopReason,
           });
+
+          // Notify parent session so the LLM sees the agent's output
+          if (this.onAcpSessionFinished) {
+            const agentLabel = current.state.agentId;
+            const responseText = current.clientHandler.responseText;
+            const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}`;
+            this.onAcpSessionFinished(
+              current.parentSessionId,
+              notifyMessage,
+              current.sendToVellum,
+            ).catch((notifyErr) => {
+              log.error(
+                { acpSessionId, notifyErr },
+                "Failed to notify parent of ACP completion",
+              );
+            });
+          }
         }
       })
       .catch((err: Error) => {
@@ -263,6 +316,7 @@ export class AcpSessionManager {
             current.state.error = err.message;
           }
           current.currentPrompt = null;
+          log.error({ acpSessionId, error: err.message }, "ACP prompt failed");
           current.sendToVellum({
             type: "acp_session_error",
             acpSessionId,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1,0 +1,206 @@
+/**
+ * ACP session manager — orchestrates ACP agent process lifecycles with
+ * concurrency control, permission resolution, and session state tracking.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { getLogger } from "../util/logger.js";
+import { AcpAgentProcess } from "./agent-process.js";
+import { resolvePermission, VellumAcpClientHandler } from "./client-handler.js";
+import type { AcpAgentConfig, AcpSessionState } from "./types.js";
+
+const log = getLogger("acp:session-manager");
+
+interface SessionEntry {
+  process: AcpAgentProcess;
+  state: AcpSessionState;
+  clientHandler: VellumAcpClientHandler;
+  pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
+}
+
+export class AcpSessionManager {
+  private sessions = new Map<string, SessionEntry>();
+
+  constructor(private readonly maxConcurrent: number) {}
+
+  /**
+   * Spawns a new ACP agent session. Returns the generated acpSessionId.
+   *
+   * The prompt is fired in the background — results stream via sessionUpdate
+   * callbacks and completion/error messages are sent when the prompt finishes.
+   */
+  async spawn(
+    agentId: string,
+    agentConfig: AcpAgentConfig,
+    task: string,
+    cwd: string,
+    parentSessionId: string,
+    sendToVellum: (msg: ServerMessage) => void,
+  ): Promise<string> {
+    if (this.sessions.size >= this.maxConcurrent) {
+      throw new Error(
+        `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
+          `Close an existing session before spawning a new one.`,
+      );
+    }
+
+    const acpSessionId = randomUUID();
+    const pendingPermissions = new Map<
+      string,
+      { resolve: (optionId: string) => void }
+    >();
+
+    const clientHandler = new VellumAcpClientHandler(
+      acpSessionId,
+      sendToVellum,
+      pendingPermissions,
+    );
+
+    const process = new AcpAgentProcess(
+      agentId,
+      agentConfig,
+      (_agent) => clientHandler,
+    );
+
+    process.spawn(cwd);
+    await process.initialize();
+    const acpProtocolSessionId = await process.createSession(cwd);
+
+    const state: AcpSessionState = {
+      id: acpSessionId,
+      agentId,
+      acpSessionId: acpProtocolSessionId,
+      status: "running",
+      startedAt: Date.now(),
+    };
+
+    this.sessions.set(acpSessionId, {
+      process,
+      state,
+      clientHandler,
+      pendingPermissions,
+    });
+
+    sendToVellum({
+      type: "acp_session_spawned",
+      acpSessionId,
+      agent: agentId,
+      parentSessionId,
+    });
+
+    // Fire prompt in the background — don't await
+    process
+      .prompt(acpProtocolSessionId, task)
+      .then((response) => {
+        const entry = this.sessions.get(acpSessionId);
+        if (entry) {
+          entry.state.status = "completed";
+          entry.state.completedAt = Date.now();
+          entry.state.stopReason = response.stopReason;
+        }
+        sendToVellum({
+          type: "acp_session_completed",
+          acpSessionId,
+          stopReason: response.stopReason,
+        });
+      })
+      .catch((err: Error) => {
+        const entry = this.sessions.get(acpSessionId);
+        if (entry) {
+          entry.state.status = "failed";
+          entry.state.completedAt = Date.now();
+          entry.state.error = err.message;
+        }
+        sendToVellum({
+          type: "acp_session_error",
+          acpSessionId,
+          error: err.message,
+        });
+      });
+
+    return acpSessionId;
+  }
+
+  /**
+   * Sends a follow-up instruction to an existing session.
+   */
+  async steer(acpSessionId: string, instruction: string): Promise<void> {
+    const entry = this.sessions.get(acpSessionId);
+    if (!entry) {
+      throw new Error(`ACP session "${acpSessionId}" not found`);
+    }
+    await entry.process.prompt(entry.state.acpSessionId, instruction);
+  }
+
+  /**
+   * Cancels an ongoing prompt in the specified session.
+   */
+  async cancel(acpSessionId: string): Promise<void> {
+    const entry = this.sessions.get(acpSessionId);
+    if (!entry) {
+      throw new Error(`ACP session "${acpSessionId}" not found`);
+    }
+    await entry.process.cancel(entry.state.acpSessionId);
+    entry.state.status = "cancelled";
+    entry.state.completedAt = Date.now();
+  }
+
+  /**
+   * Kills the agent process and removes the session from tracking.
+   */
+  close(acpSessionId: string): void {
+    const entry = this.sessions.get(acpSessionId);
+    if (!entry) {
+      throw new Error(`ACP session "${acpSessionId}" not found`);
+    }
+    entry.process.kill();
+    this.sessions.delete(acpSessionId);
+  }
+
+  /**
+   * Kills all agent processes and clears the session map.
+   */
+  closeAll(): void {
+    for (const entry of this.sessions.values()) {
+      entry.process.kill();
+    }
+    this.sessions.clear();
+  }
+
+  /**
+   * Returns session state(s). If acpSessionId is provided, returns that
+   * session's state; otherwise returns all session states.
+   */
+  getStatus(acpSessionId?: string): AcpSessionState | AcpSessionState[] {
+    if (acpSessionId) {
+      const entry = this.sessions.get(acpSessionId);
+      if (!entry) {
+        throw new Error(`ACP session "${acpSessionId}" not found`);
+      }
+      return entry.state;
+    }
+    return Array.from(this.sessions.values()).map((e) => e.state);
+  }
+
+  /**
+   * Resolves a pending permission request in any session that holds it.
+   */
+  resolvePermission(requestId: string, optionId: string): void {
+    for (const entry of this.sessions.values()) {
+      if (entry.pendingPermissions.has(requestId)) {
+        resolvePermission(entry.pendingPermissions, requestId, optionId);
+        return;
+      }
+    }
+    log.warn({ requestId }, "No pending permission found for request ID");
+  }
+
+  /**
+   * Kills all processes on shutdown.
+   */
+  dispose(): void {
+    this.closeAll();
+  }
+}

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -54,7 +54,7 @@ export class AcpSessionManager {
     cwd: string,
     parentSessionId: string,
     sendToVellum: (msg: ServerMessage) => void,
-  ): Promise<string> {
+  ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
     if (this.sessions.size >= this.maxConcurrent) {
       throw new Error(
         `ACP concurrency limit reached (max ${this.maxConcurrent}). ` +
@@ -146,7 +146,7 @@ export class AcpSessionManager {
       task,
     );
 
-    return acpSessionId;
+    return { acpSessionId, protocolSessionId: state.acpSessionId };
   }
 
   /**
@@ -291,7 +291,10 @@ export class AcpSessionManager {
           if (this.onAcpSessionFinished) {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
-            const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}`;
+            const sessionId = current.state.acpSessionId;
+            const notifyMessage =
+              `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}\n\n` +
+              `To resume this session: claude --resume ${sessionId}`;
             this.onAcpSessionFinished(
               current.parentSessionId,
               notifyMessage,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -21,6 +21,7 @@ interface SessionEntry {
   sendToVellum: (msg: ServerMessage) => void;
   currentPrompt: Promise<unknown> | null;
   parentSessionId: string;
+  cwd: string;
 }
 
 export class AcpSessionManager {
@@ -103,6 +104,7 @@ export class AcpSessionManager {
       sendToVellum,
       currentPrompt: null,
       parentSessionId,
+      cwd,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -291,7 +293,10 @@ export class AcpSessionManager {
           if (this.onAcpSessionFinished) {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
-            const notifyMessage = `[ACP agent "${agentLabel}" completed]\n\n${responseText}`;
+            const sessionId = current.state.acpSessionId;
+            const notifyMessage =
+              `[ACP agent "${agentLabel}" completed]\n\n${responseText}\n\n` +
+              `To resume: cd ${current.cwd} && claude --resume ${sessionId}`;
             this.onAcpSessionFinished(
               current.parentSessionId,
               notifyMessage,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -18,6 +18,8 @@ interface SessionEntry {
   state: AcpSessionState;
   clientHandler: VellumAcpClientHandler;
   pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
+  sendToVellum: (msg: ServerMessage) => void;
+  currentPrompt: Promise<unknown> | null;
 }
 
 export class AcpSessionManager {
@@ -76,12 +78,16 @@ export class AcpSessionManager {
       startedAt: Date.now(),
     };
 
-    this.sessions.set(acpSessionId, {
+    const entry: SessionEntry = {
       process,
       state,
       clientHandler,
       pendingPermissions,
-    });
+      sendToVellum,
+      currentPrompt: null,
+    };
+
+    this.sessions.set(acpSessionId, entry);
 
     sendToVellum({
       type: "acp_session_spawned",
@@ -91,47 +97,54 @@ export class AcpSessionManager {
     });
 
     // Fire prompt in the background — don't await
-    process
-      .prompt(acpProtocolSessionId, task)
-      .then((response) => {
-        const entry = this.sessions.get(acpSessionId);
-        if (entry) {
-          entry.state.status = "completed";
-          entry.state.completedAt = Date.now();
-          entry.state.stopReason = response.stopReason;
-        }
-        sendToVellum({
-          type: "acp_session_completed",
-          acpSessionId,
-          stopReason: response.stopReason,
-        });
-      })
-      .catch((err: Error) => {
-        const entry = this.sessions.get(acpSessionId);
-        if (entry) {
-          entry.state.status = "failed";
-          entry.state.completedAt = Date.now();
-          entry.state.error = err.message;
-        }
-        sendToVellum({
-          type: "acp_session_error",
-          acpSessionId,
-          error: err.message,
-        });
-      });
+    entry.currentPrompt = this.firePromptInBackground(
+      acpSessionId,
+      entry,
+      acpProtocolSessionId,
+      task,
+    );
 
     return acpSessionId;
   }
 
   /**
    * Sends a follow-up instruction to an existing session.
+   *
+   * Cancels any in-flight prompt first, then fires the new prompt in the
+   * background with completion/error event handlers (matching spawn's pattern).
    */
   async steer(acpSessionId: string, instruction: string): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
-    await entry.process.prompt(entry.state.acpSessionId, instruction);
+
+    if (entry.state.status !== "running") {
+      throw new Error(
+        `ACP session "${acpSessionId}" is not running (status: ${entry.state.status})`,
+      );
+    }
+
+    // Cancel any in-flight prompt before starting a new one
+    if (entry.currentPrompt) {
+      try {
+        await entry.process.cancel(entry.state.acpSessionId);
+      } catch (err) {
+        log.warn(
+          { acpSessionId, err },
+          "Failed to cancel in-flight prompt before steer",
+        );
+      }
+      entry.currentPrompt = null;
+    }
+
+    // Fire new prompt in the background with event handlers
+    entry.currentPrompt = this.firePromptInBackground(
+      acpSessionId,
+      entry,
+      entry.state.acpSessionId,
+      instruction,
+    );
   }
 
   /**
@@ -195,6 +208,48 @@ export class AcpSessionManager {
       }
     }
     log.warn({ requestId }, "No pending permission found for request ID");
+  }
+
+  /**
+   * Fires a prompt in the background and wires up completion/error event
+   * handlers. Returns the promise so callers can track in-flight state.
+   */
+  private firePromptInBackground(
+    acpSessionId: string,
+    entry: SessionEntry,
+    acpProtocolSessionId: string,
+    message: string,
+  ): Promise<unknown> {
+    return entry.process
+      .prompt(acpProtocolSessionId, message)
+      .then((response) => {
+        const current = this.sessions.get(acpSessionId);
+        if (current) {
+          current.state.status = "completed";
+          current.state.completedAt = Date.now();
+          current.state.stopReason = response.stopReason;
+          current.currentPrompt = null;
+        }
+        entry.sendToVellum({
+          type: "acp_session_completed",
+          acpSessionId,
+          stopReason: response.stopReason,
+        });
+      })
+      .catch((err: Error) => {
+        const current = this.sessions.get(acpSessionId);
+        if (current) {
+          current.state.status = "failed";
+          current.state.completedAt = Date.now();
+          current.state.error = err.message;
+          current.currentPrompt = null;
+        }
+        entry.sendToVellum({
+          type: "acp_session_error",
+          acpSessionId,
+          error: err.message,
+        });
+      });
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -292,9 +292,7 @@ export class AcpSessionManager {
             const agentLabel = current.state.agentId;
             const responseText = current.clientHandler.responseText;
             const sessionId = current.state.acpSessionId;
-            const notifyMessage =
-              `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}\n\n` +
-              `To resume this session: claude --resume ${sessionId}`;
+            const notifyMessage = `[ACP agent "${agentLabel}" completed (session: ${sessionId})]\n\n${responseText}`;
             this.onAcpSessionFinished(
               current.parentSessionId,
               notifyMessage,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -60,26 +60,24 @@ export class AcpSessionManager {
       pendingPermissions,
     );
 
-    const process = new AcpAgentProcess(
+    const agentProcess = new AcpAgentProcess(
       agentId,
       agentConfig,
       (_agent) => clientHandler,
     );
 
-    process.spawn(cwd);
-    await process.initialize();
-    const acpProtocolSessionId = await process.createSession(cwd);
-
+    // Reserve a slot in the map before any async work to enforce the
+    // concurrency limit even when multiple spawn() calls race.
     const state: AcpSessionState = {
       id: acpSessionId,
       agentId,
-      acpSessionId: acpProtocolSessionId,
-      status: "running",
+      acpSessionId: "", // placeholder until createSession resolves
+      status: "initializing",
       startedAt: Date.now(),
     };
 
     const entry: SessionEntry = {
-      process,
+      process: agentProcess,
       state,
       clientHandler,
       pendingPermissions,
@@ -88,6 +86,19 @@ export class AcpSessionManager {
     };
 
     this.sessions.set(acpSessionId, entry);
+
+    try {
+      agentProcess.spawn(cwd);
+      await agentProcess.initialize();
+      const acpProtocolSessionId = await agentProcess.createSession(cwd);
+      state.acpSessionId = acpProtocolSessionId;
+      state.status = "running";
+    } catch (err) {
+      // Kill the orphaned child process and remove the reserved slot.
+      agentProcess.kill();
+      this.sessions.delete(acpSessionId);
+      throw err;
+    }
 
     sendToVellum({
       type: "acp_session_spawned",
@@ -100,7 +111,7 @@ export class AcpSessionManager {
     entry.currentPrompt = this.firePromptInBackground(
       acpSessionId,
       entry,
-      acpProtocolSessionId,
+      state.acpSessionId,
       task,
     );
 
@@ -220,36 +231,47 @@ export class AcpSessionManager {
     acpProtocolSessionId: string,
     message: string,
   ): Promise<unknown> {
-    return entry.process
+    const promptPromise = entry.process
       .prompt(acpProtocolSessionId, message)
       .then((response) => {
         const current = this.sessions.get(acpSessionId);
-        if (current) {
-          current.state.status = "completed";
-          current.state.completedAt = Date.now();
-          current.state.stopReason = response.stopReason;
+        // Only mutate state if the session still exists, this is still the
+        // current prompt (not stale from a previous steer), and the status
+        // hasn't been set to "cancelled" already.
+        if (current && current.currentPrompt === promptPromise) {
+          if (current.state.status !== "cancelled") {
+            current.state.status = "completed";
+            current.state.completedAt = Date.now();
+            current.state.stopReason = response.stopReason;
+          }
           current.currentPrompt = null;
+          current.sendToVellum({
+            type: "acp_session_completed",
+            acpSessionId,
+            stopReason: response.stopReason,
+          });
         }
-        entry.sendToVellum({
-          type: "acp_session_completed",
-          acpSessionId,
-          stopReason: response.stopReason,
-        });
       })
       .catch((err: Error) => {
         const current = this.sessions.get(acpSessionId);
-        if (current) {
-          current.state.status = "failed";
-          current.state.completedAt = Date.now();
-          current.state.error = err.message;
+        // Same guards: entry must exist, prompt must be current, and status
+        // must not have been set to "cancelled".
+        if (current && current.currentPrompt === promptPromise) {
+          if (current.state.status !== "cancelled") {
+            current.state.status = "failed";
+            current.state.completedAt = Date.now();
+            current.state.error = err.message;
+          }
           current.currentPrompt = null;
+          current.sendToVellum({
+            type: "acp_session_error",
+            acpSessionId,
+            error: err.message,
+          });
         }
-        entry.sendToVellum({
-          type: "acp_session_error",
-          acpSessionId,
-          error: err.message,
-        });
       });
+
+    return promptPromise;
   }
 
   /**

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -1,0 +1,79 @@
+/**
+ * ACP (Agent Client Protocol) types for agent session management and configuration.
+ */
+
+// Import StopReason for use in AcpSessionState
+import type { StopReason } from "@agentclientprotocol/sdk";
+
+// Re-export relevant types from the ACP SDK for convenience
+export type {
+  AgentCapabilities,
+  ClientCapabilities,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionId,
+  SessionInfo,
+  SessionNotification,
+  SessionUpdate,
+  StopReason,
+  ToolCall,
+  ToolCallContent,
+  ToolCallId,
+  ToolCallStatus,
+} from "@agentclientprotocol/sdk";
+export {
+  AgentSideConnection,
+  ClientSideConnection,
+} from "@agentclientprotocol/sdk";
+
+/**
+ * Configuration for a single ACP agent process.
+ */
+export interface AcpAgentConfig {
+  command: string;
+  args: string[];
+  description?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Top-level ACP configuration.
+ */
+export interface AcpConfig {
+  enabled: boolean;
+  maxConcurrentSessions: number;
+  agents: Record<string, AcpAgentConfig>;
+}
+
+/**
+ * Runtime state of an ACP session.
+ */
+export interface AcpSessionState {
+  id: string;
+  agentId: string;
+  acpSessionId: string;
+  status: "initializing" | "running" | "completed" | "failed" | "cancelled";
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+  stopReason?: StopReason;
+}
+
+/**
+ * Classification of a tool call's operation kind.
+ */
+export type ToolCallKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";

--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const AcpAgentConfigSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).default([]),
+  description: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+});
+
+export const AcpConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  maxConcurrentSessions: z.number().int().positive().default(4),
+  agents: z.record(z.string(), AcpAgentConfigSchema).default({}),
+});
+
+export type AcpConfig = z.infer<typeof AcpConfigSchema>;
+export type AcpAgentConfig = z.infer<typeof AcpAgentConfigSchema>;

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -40,7 +40,12 @@ When the user first tries to use ACP and it's not configured, set it up automati
    }
    ```
 
-3. Then retry the `acp_spawn` call.
+3. **Restart the daemon** so the new config is picked up (config is cached at startup):
+   ```bash
+   vellum sleep && vellum wake
+   ```
+
+4. Then retry the `acp_spawn` call.
 
 ## Critical: correct agent command
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acp
-description: Spawn external coding agents via the Agent Communication Protocol (ACP)
+description: Spawn external coding agents via the Agent Client Protocol (ACP)
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔗"
@@ -8,27 +8,42 @@ metadata:
     display-name: "ACP"
 ---
 
-ACP agent orchestration -- spawn external coding agents (Claude Code, Codex, Gemini CLI, etc.) to work on tasks.
+ACP agent orchestration — spawn external coding agents (Claude Code, Codex, Gemini CLI, etc.) to work on tasks via the Agent Client Protocol.
 
 ## Usage
 
-Use `acp_spawn` to delegate a coding task to an external agent. The agent runs as a subprocess and streams results back via SSE.
+Use `acp_spawn` to delegate a coding task to an external agent. The agent runs as a subprocess speaking the ACP protocol over stdio and streams results back.
 
 ## Configuration
 
-ACP must be enabled in the assistant config with at least one agent configured:
+ACP must be enabled in the workspace config with at least one agent configured. **Do NOT modify the ACP config** — it is pre-configured by the user.
 
-```yaml
-acp:
-  enabled: true
-  agents:
-    claude:
-      command: claude
-      args: ["-p", "..."]
+The correct config uses `claude-agent-acp` (the ACP adapter), NOT `claude -p`:
+
+```json
+{
+  "acp": {
+    "enabled": true,
+    "maxConcurrentSessions": 4,
+    "agents": {
+      "claude": {
+        "command": "claude-agent-acp",
+        "args": [],
+        "description": "Claude Code (via ACP adapter)"
+      }
+    }
+  }
+}
 ```
+
+**Important:**
+- `claude-agent-acp` is a standalone ACP adapter from `@zed-industries/claude-agent-acp` that speaks the ACP JSON-RPC protocol over stdio.
+- Do NOT change the command to `claude`, `claude -p`, or anything else. The ACP protocol requires a specific adapter.
+- Do NOT edit the user's ACP config. If ACP is not enabled or the agent is not found, report the error and let the user fix it.
 
 ## Tips
 
 - The spawned agent runs autonomously with its own tools, file editing, and terminal access.
-- Results are streamed back to the client via SSE events.
-- You will be notified when the agent completes.
+- Results are streamed back and injected into the conversation when the agent completes.
+- The completion message includes a session ID that can be used with `claude --resume <sessionId>`.
+- Use `acp_status` to check on running agents and `acp_abort` to stop them.

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -14,36 +14,43 @@ ACP agent orchestration — spawn external coding agents (Claude Code, Codex, Ge
 
 Use `acp_spawn` to delegate a coding task to an external agent. The agent runs as a subprocess speaking the ACP protocol over stdio and streams results back.
 
-## Configuration
+## First-time setup
 
-ACP must be enabled in the workspace config with at least one agent configured. **Do NOT modify the ACP config** — it is pre-configured by the user.
+When the user first tries to use ACP and it's not configured, set it up automatically:
 
-The correct config uses `claude-agent-acp` (the ACP adapter), NOT `claude -p`:
+1. **Check if `claude-agent-acp` is installed** by running `which claude-agent-acp`. If not found, install it:
+   ```bash
+   npm install -g @zed-industries/claude-agent-acp
+   ```
 
-```json
-{
-  "acp": {
-    "enabled": true,
-    "maxConcurrentSessions": 4,
-    "agents": {
-      "claude": {
-        "command": "claude-agent-acp",
-        "args": [],
-        "description": "Claude Code (via ACP adapter)"
-      }
-    }
-  }
-}
-```
+2. **Enable ACP in the workspace config** by editing the config file to add the `acp` section. The correct config is:
+   ```json
+   {
+     "acp": {
+       "enabled": true,
+       "maxConcurrentSessions": 4,
+       "agents": {
+         "claude": {
+           "command": "claude-agent-acp",
+           "args": [],
+           "description": "Claude Code (via ACP adapter)"
+         }
+       }
+     }
+   }
+   ```
 
-**Important:**
-- `claude-agent-acp` is a standalone ACP adapter from `@zed-industries/claude-agent-acp` that speaks the ACP JSON-RPC protocol over stdio.
-- Do NOT change the command to `claude`, `claude -p`, or anything else. The ACP protocol requires a specific adapter.
-- Do NOT edit the user's ACP config. If ACP is not enabled or the agent is not found, report the error and let the user fix it.
+3. Then retry the `acp_spawn` call.
+
+## Critical: correct agent command
+
+- The command MUST be `claude-agent-acp` — this is the ACP adapter from `@zed-industries/claude-agent-acp`.
+- NEVER use `claude`, `claude -p`, `claude --acp`, or any other command. Only `claude-agent-acp` speaks the ACP JSON-RPC protocol.
+- NEVER change an existing ACP config to use a different command. If the config already has `claude-agent-acp`, leave it alone.
 
 ## Tips
 
 - The spawned agent runs autonomously with its own tools, file editing, and terminal access.
 - Results are streamed back and injected into the conversation when the agent completes.
-- The completion message includes a session ID that can be used with `claude --resume <sessionId>`.
 - Use `acp_status` to check on running agents and `acp_abort` to stop them.
+- The `cwd` parameter controls where the agent works — set it to the project root the user wants the agent to operate in.

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: acp
+description: Spawn external coding agents via the Agent Communication Protocol (ACP)
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔗"
+  vellum:
+    display-name: "ACP"
+---
+
+ACP agent orchestration -- spawn external coding agents (Claude Code, Codex, Gemini CLI, etc.) to work on tasks.
+
+## Usage
+
+Use `acp_spawn` to delegate a coding task to an external agent. The agent runs as a subprocess and streams results back via SSE.
+
+## Configuration
+
+ACP must be enabled in the assistant config with at least one agent configured:
+
+```yaml
+acp:
+  enabled: true
+  agents:
+    claude:
+      command: claude
+      args: ["-p", "..."]
+```
+
+## Tips
+
+- The spawned agent runs autonomously with its own tools, file editing, and terminal access.
+- Results are streamed back to the client via SSE events.
+- You will be notified when the agent completes.

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. IMPORTANT: Do NOT modify the ACP config — the agent command (claude-agent-acp) is pre-configured. If ACP is not enabled or the agent is not found, report the error to the user instead of editing config.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If ACP is not enabled, follow the setup instructions in SKILL.md to install claude-agent-acp and configure it. The command MUST be 'claude-agent-acp' — NEVER use 'claude', 'claude -p', or 'claude --acp'.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -19,7 +19,7 @@
           },
           "cwd": {
             "type": "string",
-            "description": "Working directory for the agent (defaults to current session's working directory)"
+            "description": "Working directory for the agent. This determines where the agent runs and where its session is stored. Set this to the project/repo root the user wants the agent to work in. Defaults to current session's working directory."
           },
           "reason": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. IMPORTANT: Do NOT modify the ACP config — the agent command (claude-agent-acp) is pre-configured. If ACP is not enabled or the agent is not found, report the error to the user instead of editing config.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -30,6 +30,50 @@
       },
       "executor": "tools/acp-spawn.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "acp_status",
+      "description": "Get the status of a specific ACP session or list all ACP sessions. Only use this when the user explicitly asks about ACP session status — do NOT poll automatically, as you will be notified when sessions complete.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "acp_session_id": {
+            "type": "string",
+            "description": "Optional ACP session ID to query. If omitted, returns all ACP sessions."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief explanation of why this tool is being called"
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/acp-status.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "acp_abort",
+      "description": "Abort a running ACP session by ID. This kills the agent process and removes the session.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "acp_session_id": {
+            "type": "string",
+            "description": "The ID of the ACP session to abort."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief explanation of why this tool is being called"
+          }
+        },
+        "required": ["acp_session_id"]
+      },
+      "executor": "tools/acp-abort.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "acp_spawn",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "string",
+            "description": "Which agent to spawn (e.g. 'claude', 'codex', 'gemini'). Defaults to 'claude'."
+          },
+          "task": {
+            "type": "string",
+            "description": "The task to give the agent — what it should accomplish"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Working directory for the agent (defaults to current session's working directory)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief explanation of why this tool is being called"
+          }
+        },
+        "required": ["task"]
+      },
+      "executor": "tools/acp-spawn.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/acp/tools/acp-abort.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-abort.ts
@@ -1,0 +1,12 @@
+import { executeAcpAbort } from "../../../../tools/acp/abort.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpAbort(input, context);
+}

--- a/assistant/src/config/bundled-skills/acp/tools/acp-spawn.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-spawn.ts
@@ -1,0 +1,12 @@
+import { executeAcpSpawn } from "../../../../tools/acp/spawn.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpSpawn(input, context);
+}

--- a/assistant/src/config/bundled-skills/acp/tools/acp-status.ts
+++ b/assistant/src/config/bundled-skills/acp/tools/acp-status.ts
@@ -1,0 +1,12 @@
+import { executeAcpStatus } from "../../../../tools/acp/status.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAcpStatus(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -14,7 +14,9 @@
  */
 import type { SkillToolScript } from "../tools/skills/script-contract.js";
 // ── acp ─────────────────────────────────────────────────────────────────────────
+import * as acpAbort from "./bundled-skills/acp/tools/acp-abort.js";
 import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
+import * as acpStatus from "./bundled-skills/acp/tools/acp-status.js";
 // ── app-builder ────────────────────────────────────────────────────────────────
 import * as appCreate from "./bundled-skills/app-builder/tools/app-create.js";
 import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
@@ -186,6 +188,8 @@ import * as watcherUpdate from "./bundled-skills/watcher/tools/watcher-update.js
 export const bundledToolRegistry = new Map<string, SkillToolScript>([
   // acp
   ["acp:tools/acp-spawn.ts", acpSpawn],
+  ["acp:tools/acp-status.ts", acpStatus],
+  ["acp:tools/acp-abort.ts", acpAbort],
 
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -13,6 +13,8 @@
  *   bun run scripts/generate-bundled-tool-registry.ts
  */
 import type { SkillToolScript } from "../tools/skills/script-contract.js";
+// ── acp ─────────────────────────────────────────────────────────────────────────
+import * as acpSpawn from "./bundled-skills/acp/tools/acp-spawn.js";
 // ── app-builder ────────────────────────────────────────────────────────────────
 import * as appCreate from "./bundled-skills/app-builder/tools/app-create.js";
 import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
@@ -182,6 +184,9 @@ import * as watcherUpdate from "./bundled-skills/watcher/tools/watcher-update.js
 
 /** Key format: `skillDirBasename:executorPath` (e.g. `schedule:tools/schedule-list.ts`). */
 export const bundledToolRegistry = new Map<string, SkillToolScript>([
+  // acp
+  ["acp:tools/acp-spawn.ts", acpSpawn],
+
   // app-builder
   ["app-builder:tools/app-create.ts", appCreate],
   ["app-builder:tools/app-list.ts", appList],

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { getDataDir } from "../util/platform.js";
 
 // Re-export all domain schemas
+export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
+export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
 export type {
   CallerIdentityConfig,
   CallsConfig,
@@ -164,6 +166,7 @@ export type { WorkspaceGitConfig } from "./schemas/workspace-git.js";
 export { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
 // Imports for AssistantConfigSchema composition
+import { AcpConfigSchema } from "./acp-schema.js";
 import { CallsConfigSchema } from "./schemas/calls.js";
 import {
   SlackConfigSchema,
@@ -279,6 +282,7 @@ export const AssistantConfigSchema = z
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     swarm: SwarmConfigSchema.default(SwarmConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
+    acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),
     skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),
     workspaceGit: WorkspaceGitConfigSchema.default(
       WorkspaceGitConfigSchema.parse({}),

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -13,6 +13,7 @@
  */
 
 // Re-export domain modules (all individual types remain importable)
+export * from "./message-types/acp.js";
 export * from "./message-types/apps.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
@@ -41,6 +42,7 @@ export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
+import type { _AcpServerMessages } from "./message-types/acp.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -192,6 +194,7 @@ export type ServerMessage =
   | _InboxServerMessages
   | _PairingServerMessages
   | _NotificationsServerMessages
+  | _AcpServerMessages
   | SubagentEvent;
 
 // === Contract schema ===

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -12,7 +12,12 @@ export interface AcpSessionSpawned {
 export interface AcpSessionUpdate {
   type: "acp_session_update";
   acpSessionId: string;
-  updateType: "agent_message_chunk" | "tool_call" | "tool_call_update" | "plan";
+  updateType:
+    | "agent_message_chunk"
+    | "user_message_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "plan";
   content?: string;
   toolCallId?: string;
   toolTitle?: string;

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -1,0 +1,61 @@
+// ACP (Agent Client Protocol) session lifecycle and communication types.
+
+// === Server → Client (streamed via SSE) ===
+
+export interface AcpSessionSpawned {
+  type: "acp_session_spawned";
+  acpSessionId: string;
+  agent: string;
+  parentSessionId: string;
+}
+
+export interface AcpSessionUpdate {
+  type: "acp_session_update";
+  acpSessionId: string;
+  updateType: "agent_message_chunk" | "tool_call" | "tool_call_update" | "plan";
+  content?: string;
+  toolCallId?: string;
+  toolTitle?: string;
+  toolKind?: string;
+  toolStatus?: string;
+}
+
+export interface AcpPermissionRequest {
+  type: "acp_permission_request";
+  acpSessionId: string;
+  requestId: string;
+  toolTitle: string;
+  toolKind: string;
+  rawInput?: unknown;
+  options: Array<{
+    optionId: string;
+    name: string;
+    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>;
+}
+
+export interface AcpSessionCompleted {
+  type: "acp_session_completed";
+  acpSessionId: string;
+  stopReason:
+    | "end_turn"
+    | "max_tokens"
+    | "max_turn_requests"
+    | "refusal"
+    | "cancelled";
+}
+
+export interface AcpSessionError {
+  type: "acp_session_error";
+  acpSessionId: string;
+  error: string;
+}
+
+// --- Domain-level union alias (consumed by message-protocol.ts) ---
+
+export type _AcpServerMessages =
+  | AcpSessionSpawned
+  | AcpSessionUpdate
+  | AcpPermissionRequest
+  | AcpSessionCompleted
+  | AcpSessionError;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import {
   disposeAcpSessionManager,
+  getAcpSessionManager,
   setBroadcastToAllClients,
 } from "../acp/index.js";
 import {
@@ -361,6 +362,38 @@ export class DaemonServer {
             log.error(
               { parentConversationId, err },
               "Failed to process subagent notification in parent",
+            );
+          });
+      }
+    };
+    getAcpSessionManager().onAcpSessionFinished = async (
+      parentSessionId,
+      message,
+      sendToClient,
+    ) => {
+      const parentSession = this.sessions.get(parentSessionId);
+      if (!parentSession) {
+        log.warn(
+          { parentSessionId },
+          "ACP agent finished but parent session not found",
+        );
+        return;
+      }
+      const requestId = `acp-notify-${Date.now()}`;
+      const enqueueResult = parentSession.enqueueMessage(
+        message,
+        [],
+        sendToClient,
+        requestId,
+      );
+      if (!enqueueResult.queued && !enqueueResult.rejected) {
+        const messageId = await parentSession.persistUserMessage(message, []);
+        parentSession
+          .runAgentLoop(message, messageId, sendToClient)
+          .catch((err) => {
+            log.error(
+              { parentSessionId, err },
+              "Failed to process ACP notification in parent",
             );
           });
       }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { disposeAcpSessionManager } from "../acp/index.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -566,6 +567,7 @@ export class DaemonServer {
 
   async stop(): Promise<void> {
     getSubagentManager().disposeAll();
+    disposeAcpSessionManager();
     this.evictor.stop();
     this.configWatcher.stop();
     if (this.unsubscribeContactChange) {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,7 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { disposeAcpSessionManager } from "../acp/index.js";
+import {
+  disposeAcpSessionManager,
+  setBroadcastToAllClients,
+} from "../acp/index.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -310,6 +313,7 @@ export class DaemonServer {
     this.evictor = new ConversationEvictor(this.conversations);
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
     getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
+    setBroadcastToAllClients((msg) => this.broadcast(msg));
     this.evictor.onEvict = (conversationId: string) => {
       getSubagentManager().abortAllForParent(conversationId);
     };

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -323,6 +323,14 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "subagents/abort", scopes: ["chat.write"] },
   { endpoint: "subagents/message", scopes: ["chat.write"] },
 
+  // ACP (Agent Communication Protocol)
+  { endpoint: "acp/spawn", scopes: ["chat.write"] },
+  { endpoint: "acp/steer", scopes: ["chat.write"] },
+  { endpoint: "acp/cancel", scopes: ["chat.write"] },
+  { endpoint: "acp/close", scopes: ["chat.write"] },
+  { endpoint: "acp", scopes: ["chat.read"] },
+  { endpoint: "acp/permission", scopes: ["approval.write"] },
+
   // Model config
   { endpoint: "model:GET", scopes: ["settings.read"] },
   { endpoint: "model:PUT", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -96,6 +96,7 @@ import {
   TWILIO_WEBHOOK_RE,
   validateTwilioWebhook,
 } from "./middleware/twilio-validation.js";
+import { acpRouteDefinitions } from "./routes/acp-routes.js";
 import { appManagementRouteDefinitions } from "./routes/app-management-routes.js";
 import { handleServePage } from "./routes/app-routes.js";
 import { appRouteDefinitions } from "./routes/app-routes.js";
@@ -762,6 +763,7 @@ export class RuntimeHttpServer {
             }
           : undefined,
       ),
+      ...acpRouteDefinitions(),
       ...subagentRouteDefinitions(),
       ...conversationQueryRouteDefinitions({
         getModelSetContext: this.getModelSetContext,

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -1,0 +1,142 @@
+/**
+ * Route handlers for ACP (Agent Communication Protocol) session lifecycle.
+ *
+ * Exposes spawn, steer, cancel, close, sessions, and permission operations
+ * over HTTP.
+ */
+import {
+  broadcastToAllClients,
+  getAcpSessionManager,
+} from "../../acp/index.js";
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("acp-routes");
+
+export function acpRouteDefinitions(): RouteDefinition[] {
+  return [
+    // POST /v1/acp/spawn
+    {
+      endpoint: "acp/spawn",
+      method: "POST",
+      policyKey: "acp/spawn",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          agent?: string;
+          task?: string;
+          sessionId?: string;
+          cwd?: string;
+        };
+        if (!body.agent || !body.task || !body.sessionId) {
+          return httpError(
+            "BAD_REQUEST",
+            "agent, task, and sessionId are required",
+            400,
+          );
+        }
+        const config = getConfig();
+        if (!config.acp.enabled) {
+          return httpError("BAD_REQUEST", "ACP is not enabled", 400);
+        }
+        const agentConfig = config.acp.agents[body.agent];
+        if (!agentConfig) {
+          const available = Object.keys(config.acp.agents).join(", ") || "none";
+          return httpError(
+            "BAD_REQUEST",
+            `Unknown agent "${body.agent}". Available: ${available}`,
+            400,
+          );
+        }
+        const manager = getAcpSessionManager();
+        const sendToVellum =
+          broadcastToAllClients ?? ((_msg) => log.warn("No broadcast fn set"));
+        const acpSessionId = await manager.spawn(
+          body.agent,
+          agentConfig,
+          body.task,
+          body.cwd ?? process.cwd(),
+          body.sessionId,
+          sendToVellum,
+        );
+        return Response.json({ acpSessionId, agent: body.agent });
+      },
+    },
+
+    // POST /v1/acp/:id/steer
+    {
+      endpoint: "acp/:id/steer",
+      method: "POST",
+      policyKey: "acp/steer",
+      handler: async ({ req, params }) => {
+        const body = (await req.json()) as { instruction?: string };
+        if (!body.instruction) {
+          return httpError("BAD_REQUEST", "instruction is required", 400);
+        }
+        const manager = getAcpSessionManager();
+        await manager.steer(params.id, body.instruction);
+        return Response.json({ acpSessionId: params.id, steered: true });
+      },
+    },
+
+    // POST /v1/acp/:id/cancel
+    {
+      endpoint: "acp/:id/cancel",
+      method: "POST",
+      policyKey: "acp/cancel",
+      handler: async ({ params }) => {
+        const manager = getAcpSessionManager();
+        await manager.cancel(params.id);
+        return Response.json({ acpSessionId: params.id, cancelled: true });
+      },
+    },
+
+    // POST /v1/acp/:id/close
+    {
+      endpoint: "acp/:id/close",
+      method: "POST",
+      policyKey: "acp/close",
+      handler: async ({ params }) => {
+        const manager = getAcpSessionManager();
+        manager.close(params.id);
+        return Response.json({ acpSessionId: params.id, closed: true });
+      },
+    },
+
+    // GET /v1/acp/sessions
+    {
+      endpoint: "acp/sessions",
+      method: "GET",
+      policyKey: "acp",
+      handler: () => {
+        const manager = getAcpSessionManager();
+        const sessions = manager.getStatus();
+        return Response.json({ sessions });
+      },
+    },
+
+    // POST /v1/acp/permission
+    {
+      endpoint: "acp/permission",
+      method: "POST",
+      policyKey: "acp/permission",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          requestId?: string;
+          optionId?: string;
+        };
+        if (!body.requestId || !body.optionId) {
+          return httpError(
+            "BAD_REQUEST",
+            "requestId and optionId are required",
+            400,
+          );
+        }
+        const manager = getAcpSessionManager();
+        manager.resolvePermission(body.requestId, body.optionId);
+        return Response.json({ resolved: true });
+      },
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -49,10 +49,18 @@ export function acpRouteDefinitions(): RouteDefinition[] {
             400,
           );
         }
+        log.info(
+          {
+            agent: body.agent,
+            task: body.task?.slice(0, 100),
+            sessionId: body.sessionId,
+          },
+          "ACP spawn request received",
+        );
         const manager = getAcpSessionManager();
         const sendToVellum =
           broadcastToAllClients ?? ((_msg) => log.warn("No broadcast fn set"));
-        const acpSessionId = await manager.spawn(
+        const { acpSessionId, protocolSessionId } = await manager.spawn(
           body.agent,
           agentConfig,
           body.task,
@@ -60,7 +68,15 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           body.sessionId,
           sendToVellum,
         );
-        return Response.json({ acpSessionId, agent: body.agent });
+        log.info(
+          { acpSessionId, protocolSessionId, agent: body.agent },
+          "ACP spawn succeeded",
+        );
+        return Response.json({
+          acpSessionId,
+          protocolSessionId,
+          agent: body.agent,
+        });
       },
     },
 

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -75,7 +75,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           return httpError("BAD_REQUEST", "instruction is required", 400);
         }
         const manager = getAcpSessionManager();
-        await manager.steer(params.id, body.instruction);
+        try {
+          await manager.steer(params.id, body.instruction);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, steered: true });
       },
     },
@@ -87,7 +91,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
       policyKey: "acp/cancel",
       handler: async ({ params }) => {
         const manager = getAcpSessionManager();
-        await manager.cancel(params.id);
+        try {
+          await manager.cancel(params.id);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, cancelled: true });
       },
     },
@@ -99,7 +107,11 @@ export function acpRouteDefinitions(): RouteDefinition[] {
       policyKey: "acp/close",
       handler: async ({ params }) => {
         const manager = getAcpSessionManager();
-        manager.close(params.id);
+        try {
+          manager.close(params.id);
+        } catch {
+          return httpError("NOT_FOUND", "ACP session not found", 404);
+        }
         return Response.json({ acpSessionId: params.id, closed: true });
       },
     },

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -534,6 +534,16 @@ export async function handleSendMessage(
   };
 
   const { conversationKey, content, attachmentIds } = body;
+  log.info(
+    {
+      conversationKey,
+      sourceChannel: body.sourceChannel,
+      interface: body.interface,
+      contentLength: typeof content === "string" ? content.length : 0,
+      hasAttachments: Array.isArray(attachmentIds) && attachmentIds.length > 0,
+    },
+    "Received message via POST /v1/messages",
+  );
   if (!body.sourceChannel || typeof body.sourceChannel !== "string") {
     return httpError("BAD_REQUEST", "sourceChannel is required", 400);
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -534,16 +534,6 @@ export async function handleSendMessage(
   };
 
   const { conversationKey, content, attachmentIds } = body;
-  log.info(
-    {
-      conversationKey,
-      sourceChannel: body.sourceChannel,
-      interface: body.interface,
-      contentLength: typeof content === "string" ? content.length : 0,
-      hasAttachments: Array.isArray(attachmentIds) && attachmentIds.length > 0,
-    },
-    "Received message via POST /v1/messages",
-  );
   if (!body.sourceChannel || typeof body.sourceChannel !== "string") {
     return httpError("BAD_REQUEST", "sourceChannel is required", 400);
   }

--- a/assistant/src/tools/acp/abort.ts
+++ b/assistant/src/tools/acp/abort.ts
@@ -1,0 +1,32 @@
+import { getAcpSessionManager } from "../../acp/index.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export async function executeAcpAbort(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const acpSessionId = input.acp_session_id as string;
+  if (!acpSessionId) {
+    return { content: '"acp_session_id" is required.', isError: true };
+  }
+
+  try {
+    const manager = getAcpSessionManager();
+    manager.close(acpSessionId);
+
+    return {
+      content: JSON.stringify({
+        acpSessionId,
+        status: "aborted",
+        message: "ACP session aborted successfully.",
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Could not abort ACP session "${acpSessionId}": ${msg}`,
+      isError: true,
+    };
+  }
+}

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -40,7 +40,7 @@ export async function executeAcpSpawn(
   try {
     const manager = getAcpSessionManager();
     const cwd = (input.cwd as string) || context.workingDir;
-    const acpSessionId = await manager.spawn(
+    const { acpSessionId, protocolSessionId } = await manager.spawn(
       agent,
       agentConfig,
       task,
@@ -52,9 +52,10 @@ export async function executeAcpSpawn(
     return {
       content: JSON.stringify({
         acpSessionId,
+        protocolSessionId,
         agent,
         status: "running",
-        message: `ACP agent "${agent}" spawned. It will stream results back via SSE. You will be notified when it completes.`,
+        message: `ACP agent "${agent}" spawned. Session ID: ${protocolSessionId}. You can resume this session later with: claude --resume ${protocolSessionId}`,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -1,0 +1,65 @@
+import { getAcpSessionManager } from "../../acp/index.js";
+import { getConfig } from "../../config/loader.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export async function executeAcpSpawn(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const agent = (input.agent as string) || "claude";
+  const task = input.task as string;
+
+  if (!task) {
+    return { content: '"task" is required.', isError: true };
+  }
+
+  const config = getConfig();
+  if (!config.acp?.enabled) {
+    return { content: "ACP is not enabled in config.", isError: true };
+  }
+
+  const agentConfig = config.acp.agents[agent];
+  if (!agentConfig) {
+    const available = Object.keys(config.acp.agents).join(", ") || "none";
+    return {
+      content: `Unknown agent "${agent}". Available: ${available}`,
+      isError: true,
+    };
+  }
+
+  const sendToClient = context.sendToClient as
+    | ((msg: { type: string; [key: string]: unknown }) => void)
+    | undefined;
+  if (!sendToClient) {
+    return {
+      content: "No client connected — cannot spawn ACP agent.",
+      isError: true,
+    };
+  }
+
+  try {
+    const manager = getAcpSessionManager();
+    const cwd = (input.cwd as string) || context.workingDir;
+    const acpSessionId = await manager.spawn(
+      agent,
+      agentConfig,
+      task,
+      cwd,
+      context.sessionId,
+      sendToClient as (msg: unknown) => void,
+    );
+
+    return {
+      content: JSON.stringify({
+        acpSessionId,
+        agent,
+        status: "running",
+        message: `ACP agent "${agent}" spawned. It will stream results back via SSE. You will be notified when it completes.`,
+      }),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Failed to spawn ACP agent: ${msg}`, isError: true };
+  }
+}

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -55,7 +55,7 @@ export async function executeAcpSpawn(
         protocolSessionId,
         agent,
         status: "running",
-        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). Results stream back via SSE. You can resume this session later with: claude --resume ${protocolSessionId}`,
+        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). Results stream back via SSE. You will be notified when it completes.`,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -55,7 +55,7 @@ export async function executeAcpSpawn(
         protocolSessionId,
         agent,
         status: "running",
-        message: `ACP agent "${agent}" spawned. Session ID: ${protocolSessionId}. You can resume this session later with: claude --resume ${protocolSessionId}`,
+        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). It will stream results back via SSE. You will be notified when it completes.`,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -54,8 +54,12 @@ export async function executeAcpSpawn(
         acpSessionId,
         protocolSessionId,
         agent,
+        cwd,
         status: "running",
-        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). Results stream back via SSE. You will be notified when it completes.`,
+        message:
+          `ACP agent "${agent}" spawned (session: ${protocolSessionId}). ` +
+          `Results stream back via SSE. You will be notified when it completes. ` +
+          `To resume this session later, run: cd ${cwd} && claude --resume ${protocolSessionId}`,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -55,7 +55,7 @@ export async function executeAcpSpawn(
         protocolSessionId,
         agent,
         status: "running",
-        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). It will stream results back via SSE. You will be notified when it completes.`,
+        message: `ACP agent "${agent}" spawned (session: ${protocolSessionId}). Results stream back via SSE. You can resume this session later with: claude --resume ${protocolSessionId}`,
       }),
       isError: false,
     };

--- a/assistant/src/tools/acp/status.ts
+++ b/assistant/src/tools/acp/status.ts
@@ -1,0 +1,31 @@
+import { getAcpSessionManager } from "../../acp/index.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export async function executeAcpStatus(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const acpSessionId = input.acp_session_id as string | undefined;
+  const manager = getAcpSessionManager();
+
+  try {
+    if (acpSessionId) {
+      const state = manager.getStatus(acpSessionId);
+      return {
+        content: JSON.stringify(state),
+        isError: false,
+      };
+    }
+
+    // List all sessions.
+    const allStates = manager.getStatus();
+    if (Array.isArray(allStates) && allStates.length === 0) {
+      return { content: "No ACP sessions found.", isError: false };
+    }
+
+    return { content: JSON.stringify(allStates), isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: msg, isError: true };
+  }
+}

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -7,6 +7,7 @@ import {
   isAssistantWatchModeAvailable,
   isGatewayWatchModeAvailable,
   startLocalDaemon,
+  startLocalDaemonForeground,
   startGateway,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
@@ -25,12 +26,16 @@ export async function wake(): Promise<void> {
     console.log("");
     console.log("Options:");
     console.log(
-      "  --watch    Run assistant and gateway in watch mode (hot reload on source changes)",
+      "  --watch        Run assistant and gateway in watch mode (hot reload on source changes)",
+    );
+    console.log(
+      "  --foreground   Run assistant in foreground with logs printed to terminal",
     );
     process.exit(0);
   }
 
   const watch = args.includes("--watch");
+  const foreground = args.includes("--foreground");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
@@ -86,6 +91,11 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
+    if (foreground) {
+      await startLocalDaemonForeground(resources);
+      // startLocalDaemonForeground never returns (runs in foreground)
+      return;
+    }
     await startLocalDaemon(watch, resources);
   }
 

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -7,7 +7,6 @@ import {
   isAssistantWatchModeAvailable,
   isGatewayWatchModeAvailable,
   startLocalDaemon,
-  startLocalDaemonForeground,
   startGateway,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
@@ -26,16 +25,12 @@ export async function wake(): Promise<void> {
     console.log("");
     console.log("Options:");
     console.log(
-      "  --watch        Run assistant and gateway in watch mode (hot reload on source changes)",
-    );
-    console.log(
-      "  --foreground   Run assistant in foreground with logs printed to terminal",
+      "  --watch    Run assistant and gateway in watch mode (hot reload on source changes)",
     );
     process.exit(0);
   }
 
   const watch = args.includes("--watch");
-  const foreground = args.includes("--foreground");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
@@ -91,11 +86,6 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    if (foreground) {
-      await startLocalDaemonForeground(resources);
-      // startLocalDaemonForeground never returns (runs in foreground)
-      return;
-    }
     await startLocalDaemon(watch, resources);
   }
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -30,7 +30,7 @@ enum LogExporter {
     /// When true, conversation-scoped exports are not available because the platform API
     /// does not yet support conversation-scoped log retrieval.
     /// Uses the cached value from AppDelegate to avoid disk I/O in hot paths (e.g. SwiftUI view bodies).
-    nonisolated static var isManagedAssistant: Bool {
+    static var isManagedAssistant: Bool {
         AppDelegate.shared?.isCurrentAssistantManaged == true
     }
 
@@ -227,7 +227,7 @@ enum LogExporter {
         // 3. Assistant logs — platform API for managed, local gateway for self-hosted
         let home = NSHomeDirectory()
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        let isManagedAssistant = Self.isManagedAssistant
+        let isManagedAssistant = await MainActor.run { Self.isManagedAssistant }
 
         if isManagedAssistant, let assistantId = connectedId,
            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {


### PR DESCRIPTION
## Summary
- Remove `nonisolated` from `LogExporter.isManagedAssistant` since the enclosing enum is `@MainActor`, fixing illegal cross-actor access to `AppDelegate.shared` and `.isCurrentAssistantManaged`
- Wrap the access in `buildArchive` with `await MainActor.run { ... }` since that function is `nonisolated async`

## Test plan
- [ ] `./build.sh` compiles without errors
- [ ] `./build.sh lint` passes strict concurrency checks
- [ ] Log export (Settings → Export Logs) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
