### PR TITLE
fix: prevent privacy sync from overwriting remote opt-outs and serialize toggle writes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -432,29 +432,50 @@ extension AppDelegate {
     /// Reads both privacy keys from UserDefaults (with legacy fallbacks),
     /// applies Sentry state based on sendDiagnostics, syncs both keys to
     /// the daemon, and cleans up legacy UserDefaults keys.
+    ///
+    /// Only syncs a key to the daemon when a value is explicitly present in
+    /// UserDefaults (including legacy keys). When no local value exists we
+    /// leave the daemon's persisted config untouched — defaulting to `true`
+    /// and pushing that upstream would silently re-enable telemetry for
+    /// users who previously opted out on a different machine or after a
+    /// UserDefaults reset.
     func syncPrivacyConfig() {
         Task {
-            // Read with legacy fallbacks for first launch after upgrade
-            let collectUsageData = UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-                ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
-                ?? true
-            let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? true
+            // Read with legacy fallbacks for first launch after upgrade.
+            // Keep track of whether a value was explicitly set vs defaulted,
+            // so we only sync explicitly-set values to the daemon.
+            let legacyCollectUsageData = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
+            let canonicalCollectUsageData = UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+            let collectUsageData = canonicalCollectUsageData ?? legacyCollectUsageData
+            let hasExplicitCollectUsageData = collectUsageData != nil
 
-            // Apply Sentry state based on sendDiagnostics
-            if !sendDiagnostics {
+            let canonicalSendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+            let sendDiagnostics = canonicalSendDiagnostics
+            let hasExplicitSendDiagnostics = sendDiagnostics != nil
+
+            // Apply Sentry state based on sendDiagnostics (default true when absent)
+            if !(sendDiagnostics ?? true) {
                 MetricKitManager.closeSentry()
             }
 
-            // Best-effort sync both keys to daemon config
-            try? await daemonClient.setPrivacyConfig(collectUsageData: collectUsageData, sendDiagnostics: sendDiagnostics)
+            // Best-effort sync to daemon config — only include keys that the
+            // user has explicitly set locally to avoid overwriting remote opt-outs.
+            let syncCollectUsageData = hasExplicitCollectUsageData ? collectUsageData : nil
+            let syncSendDiagnostics = hasExplicitSendDiagnostics ? sendDiagnostics : nil
+            if syncCollectUsageData != nil || syncSendDiagnostics != nil {
+                try? await daemonClient.setPrivacyConfig(collectUsageData: syncCollectUsageData, sendDiagnostics: syncSendDiagnostics)
+            }
 
             // Clean up legacy keys and write canonical ones
             UserDefaults.standard.removeObject(forKey: "collectUsageDataEnabled")
             UserDefaults.standard.removeObject(forKey: "sendPerformanceReports")
             UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
-            UserDefaults.standard.set(collectUsageData, forKey: "collectUsageData")
-            UserDefaults.standard.set(sendDiagnostics, forKey: "sendDiagnostics")
+            if let collectUsageData {
+                UserDefaults.standard.set(collectUsageData, forKey: "collectUsageData")
+            }
+            if let sendDiagnostics {
+                UserDefaults.standard.set(sendDiagnostics, forKey: "sendDiagnostics")
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -8,6 +8,10 @@ struct SettingsPrivacyTab: View {
     var daemonClient: DaemonClient?
     @ObservedObject var store: SettingsStore
 
+    /// Tracks the in-flight privacy sync task so rapid toggles cancel the
+    /// previous write and only the latest value reaches the daemon.
+    @State private var privacySyncTask: Task<Void, Never>?
+
     var body: some View {
         privacySection
     }
@@ -30,11 +34,7 @@ struct SettingsPrivacyTab: View {
                     get: { store.collectUsageData },
                     set: { newValue in
                         store.collectUsageData = newValue
-                        if let daemonClient {
-                            Task {
-                                try? await daemonClient.setPrivacyConfig(collectUsageData: newValue)
-                            }
-                        }
+                        syncPrivacyConfig(collectUsageData: newValue)
                     }
                 ))
             }
@@ -60,14 +60,23 @@ struct SettingsPrivacyTab: View {
                         } else {
                             MetricKitManager.closeSentry()
                         }
-                        if let daemonClient {
-                            Task {
-                                try? await daemonClient.setPrivacyConfig(sendDiagnostics: newValue)
-                            }
-                        }
+                        syncPrivacyConfig(sendDiagnostics: newValue)
                     }
                 ))
             }
+        }
+    }
+
+    // MARK: - Privacy Config Sync
+
+    /// Syncs a privacy config change to the daemon, cancelling any in-flight
+    /// sync so that only the latest toggle value wins when the user toggles
+    /// rapidly.
+    private func syncPrivacyConfig(collectUsageData: Bool? = nil, sendDiagnostics: Bool? = nil) {
+        guard let daemonClient else { return }
+        privacySyncTask?.cancel()
+        privacySyncTask = Task {
+            try? await daemonClient.setPrivacyConfig(collectUsageData: collectUsageData, sendDiagnostics: sendDiagnostics)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix privacy regression where absent UserDefaults keys defaulted to `true` and were synced to the daemon, silently re-enabling telemetry for users who previously opted out
- Serialize privacy config sync writes in SettingsPrivacyTab by cancelling in-flight tasks, ensuring only the latest toggle value reaches the daemon when toggled rapidly

Addresses review feedback from #17456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
