### PR TITLE
fix: use ByteCountFormatter for locale-aware file size formatting

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -298,13 +298,5 @@ struct SkillDetailView: View {
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
         return .file
     }
-
-    private func formatFileSize(_ bytes: Int) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024.0
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024.0
-        return String(format: "%.1f MB", mb)
-    }
 }
 #endif

--- a/clients/ios/Views/WorkspaceBrowserView.swift
+++ b/clients/ios/Views/WorkspaceBrowserView.swift
@@ -371,15 +371,5 @@ struct WorkspaceBrowserView: View {
         if mimeType == "application/pdf" { return .fileText }
         return .file
     }
-
-    private func formatFileSize(_ bytes: Int) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024.0
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024.0
-        if mb < 1024 { return String(format: "%.1f MB", mb) }
-        let gb = mb / 1024.0
-        return String(format: "%.1f GB", gb)
-    }
 }
 #endif

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -170,16 +170,6 @@ struct WorkspaceFileSheet: View {
 
     // MARK: - Helpers
 
-    private func formatFileSize(_ bytes: Int) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        let kb = Double(bytes) / 1024.0
-        if kb < 1024 { return String(format: "%.1f KB", kb) }
-        let mb = kb / 1024.0
-        if mb < 1024 { return String(format: "%.1f MB", mb) }
-        let gb = mb / 1024.0
-        return String(format: "%.1f GB", gb)
-    }
-
     private func formatDate(_ isoString: String) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -29,18 +29,6 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
     }
 }
 
-/// Formats a byte count into a human-readable size string.
-/// Shows raw bytes for sizes < 1 KB (e.g. "500 B"), then "KB" / "MB" / "GB" with one decimal place.
-func formatFileSize(_ bytes: Int) -> String {
-    if bytes < 1024 { return "\(bytes) B" }
-    let kb = Double(bytes) / 1024.0
-    if kb < 1024 { return String(format: "%.1f KB", kb) }
-    let mb = kb / 1024.0
-    if mb < 1024 { return String(format: "%.1f MB", mb) }
-    let gb = mb / 1024.0
-    return String(format: "%.1f GB", gb)
-}
-
 /// Scrollable read-only monospace text display for file content.
 struct ReadOnlyCodeContent: View {
     let content: String

--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -331,12 +331,6 @@ public struct FileUploadSurfaceView: View {
         return UTType(mimeType: mimePattern)
     }
 
-    private func formatFileSize(_ bytes: Int) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: Int64(bytes))
-    }
-
     private func extractText(from file: SelectedFile) -> String? {
         let textTypes = ["text/plain", "text/csv", "text/html", "text/markdown",
                          "application/json", "application/xml"]

--- a/clients/shared/Utilities/FileSizeFormatter.swift
+++ b/clients/shared/Utilities/FileSizeFormatter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Formats a byte count into a human-readable, locale-aware size string.
+/// Uses `ByteCountFormatter` with `.file` count style for proper unit scaling
+/// and localized labels/decimal separators.
+public func formatFileSize(_ bytes: Int) -> String {
+    let formatter = ByteCountFormatter()
+    formatter.countStyle = .file
+    return formatter.string(fromByteCount: Int64(bytes))
+}


### PR DESCRIPTION
## Summary
- Replaces manual `String(format:)` file size formatting with Apple's `ByteCountFormatter` using `.file` count style
- Creates a single shared `formatFileSize` in `clients/shared/Utilities/FileSizeFormatter.swift`
- Removes 5 duplicate implementations across macOS, iOS, and shared targets
- Restores locale-aware unit labels/decimal separators and automatic scaling to GB+
- Addresses review feedback from #17458

## Test plan
- [ ] Verify file sizes display correctly in AgentPanel, WorkspacePanel, and SkillFileTreeView (macOS)
- [ ] Verify file sizes display correctly in WorkspaceBrowserView, WorkspaceFileSheet, and SkillDetailView (iOS)
- [ ] Verify file sizes display correctly in FileUploadSurfaceView (shared)
- [ ] Check that large files (>1 GB) display as "X GB" instead of "XXXX.X MB"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
