### PR TITLE
fix: upgrade base packages in gateway image to patch CVE-2026-0861

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa1
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

- Add `apt-get upgrade -y` to the gateway Dockerfile runtime stage to pull in libc-bin/libc6 2.41-12+deb13u2, patching CVE-2026-0861 (glibc integer overflow in memalign, HIGH severity)
- The Trivy scan was blocking CI because the installed version (2.41-12+deb13u1) has a known fix available

## Original prompt
gateway image is failing to build because of this: CVE-2026-0861 HIGH in libc-bin/libc6, fixed version 2.41-12+deb13u2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
