### PR TITLE
fix: complete video MIME type icon consistency across all fileIcon helpers

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -294,6 +294,7 @@ struct SkillDetailView: View {
 
     private func fileIcon(for mimeType: String) -> VIcon {
         if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
         return .file

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -228,7 +228,7 @@ extension ChatBubble {
     }
 
     func fileIcon(for mimeType: String) -> VIcon {
-        if mimeType.hasPrefix("video/") { return .film }
+        if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("audio/") { return .audioWaveform }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/pdf" { return .file }


### PR DESCRIPTION
## Summary
Addresses review feedback from #17463:

- Add missing `video/` MIME type check to `SkillDetailView.swift` (iOS) `fileIcon` helper for cross-platform consistency
- Unify `ChatBubbleAttachmentContent.swift` to use `.video` instead of `.film` for `video/` MIME types, matching the icon used in all other `fileIcon` functions

All five `fileIcon(for:)` functions across the codebase now consistently return `.video` for `video/` MIME types.

## Test plan
- [ ] Verify video file attachments in chat show `.video` icon (previously `.film`)
- [ ] Verify video files in skill file tree on iOS show `.video` icon (previously `.file` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
