### PR TITLE
fix: preserve legacy privacy opt-outs in sendDiagnostics fallback chain

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -450,7 +450,9 @@ extension AppDelegate {
             let hasExplicitCollectUsageData = collectUsageData != nil
 
             let canonicalSendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-            let sendDiagnostics = canonicalSendDiagnostics
+            // Fall back to legacy collectUsageData keys so users who opted
+            // out via the old master switch keep Sentry disabled.
+            let sendDiagnostics = canonicalSendDiagnostics ?? collectUsageData
             let hasExplicitSendDiagnostics = sendDiagnostics != nil
 
             // Apply Sentry state based on sendDiagnostics (default true when absent)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -201,7 +201,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Gated on sendDiagnostics: if the user has previously disabled diagnostics,
         // Sentry is never initialized. Otherwise, initialize eagerly so crashes
         // before the daemon connects are captured.
+        // Falls back through legacy keys so users who opted out via the old
+        // collectUsageDataEnabled master switch keep Sentry disabled.
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+            ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+            ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
             ?? true
         if sendDiagnostics {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -141,6 +141,8 @@ struct SettingsDeveloperTab: View {
 
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+                ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+                ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
                 ?? true
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -228,6 +228,8 @@ public final class SettingsStore: ObservableObject {
     /// Whether the user has opted in to sending crash reports, error diagnostics, and
     /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
     @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+        ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+        ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
         ?? true
 
     /// Whether the user has opted in to sharing anonymized usage analytics (e.g. token counts,

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -194,6 +194,8 @@ import os
     private nonisolated static func restartSentryInline() {
         guard !SentrySDK.isEnabled else { return }
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+            ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+            ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
             ?? true
         guard sendDiagnostics else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
@@ -228,6 +230,8 @@ extension MetricKitManager: MXMetricManagerSubscriber {
 
             // Only send to Sentry if sendDiagnostics is enabled.
             let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+                ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
+                ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
                 ?? true
             guard sendDiagnostics else { continue }
 


### PR DESCRIPTION
## Summary
- Add collectUsageData and collectUsageDataEnabled as fallbacks in the sendDiagnostics UserDefaults resolution chain across all six read sites
- Prevents silently re-enabling Sentry for users who had opted out via the old collectUsageDataEnabled master privacy switch
- Addresses review feedback from PR #17485

## Files changed
- clients/macos/vellum-assistant/App/AppDelegate.swift (applicationDidFinishLaunching)
- clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift (syncPrivacyConfig)
- clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift (restartSentryInline + didReceive)
- clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift (onAppear)
- clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift (sendDiagnostics property)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
