### PR TITLE
fix: check legacy UserDefaults keys before writing privacy defaults in OnboardingState

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -156,10 +156,14 @@ final class OnboardingState {
         // Opt in to usage data and performance reports by default for new users.
         // Previously handled by ImproveExperienceStepView.onAppear; that view was
         // removed so we set the defaults here to keep the same behavior.
-        if UserDefaults.standard.object(forKey: "collectUsageData") == nil {
+        // Also check legacy keys so we don't override an existing opt-out from
+        // users who haven't yet been migrated by syncPrivacyConfig().
+        if UserDefaults.standard.object(forKey: "collectUsageData") == nil
+            && UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
             UserDefaults.standard.set(true, forKey: "collectUsageData")
         }
-        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil {
+        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil
+            && UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
             UserDefaults.standard.set(true, forKey: "sendDiagnostics")
         }
     }


### PR DESCRIPTION
## Summary
- Fixes a race condition where `OnboardingState.init()` could silently re-enable telemetry for users who previously opted out under legacy UserDefaults keys (`collectUsageDataEnabled` / `sendPerformanceReports`)
- The init now checks both canonical and legacy keys before writing defaults, matching the fallback pattern used everywhere else in the codebase (e.g. `SettingsStore`, `AppDelegate+DaemonSetup`)
- Addresses review feedback on #17500

## Test plan
- [x] Verify new users (no keys present) still get opted in by default
- [x] Verify users with canonical keys set are unaffected
- [x] Verify users with only legacy opt-out keys are not overridden

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
