### PR TITLE
fix: restrict sequence steps reply key migration to object keys only

### DIFF
--- a/assistant/src/memory/migrations/168-rename-sequence-steps-reply-key.ts
+++ b/assistant/src/memory/migrations/168-rename-sequence-steps-reply-key.ts
@@ -12,6 +12,6 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 export function migrateRenameSequenceStepsReplyKey(database: DrizzleDb): void {
   const raw = getSqliteFrom(database);
   raw.exec(
-    /*sql*/ `UPDATE sequences SET steps = REPLACE(steps, '"replyToThread"', '"replyInSameConversation"') WHERE steps LIKE '%"replyToThread"%'`,
+    /*sql*/ `UPDATE sequences SET steps = REPLACE(steps, '"replyToThread":', '"replyInSameConversation":') WHERE steps LIKE '%"replyToThread":%'`,
   );
 }


### PR DESCRIPTION
## Summary
- Narrows the SQL REPLACE in migration 168 to match `"replyToThread":` (with colon) instead of bare `"replyToThread"`, preventing unintended mutation of user-authored string values (e.g. bodyPrompt or subjectTemplate content) during the migration.
- Addresses review feedback from PR #17508.

## Test plan
- [x] Migration only rewrites JSON object keys, not string values containing `replyToThread`
- [x] Idempotency preserved (REPLACE is still a no-op when the key is absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
