### PR TITLE
fix: remove dead legacy key checks from OnboardingState privacy defaults

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -153,17 +153,11 @@ final class OnboardingState {
             currentStep = maxStep
         }
 
-        // Opt in to usage data and performance reports by default for new users.
-        // Previously handled by ImproveExperienceStepView.onAppear; that view was
-        // removed so we set the defaults here to keep the same behavior.
-        // Also check legacy keys so we don't override an existing opt-out from
-        // users who haven't yet been migrated by syncPrivacyConfig().
-        if UserDefaults.standard.object(forKey: "collectUsageData") == nil
-            && UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
+        // Opt in to usage data and diagnostics by default for new users.
+        if UserDefaults.standard.object(forKey: "collectUsageData") == nil {
             UserDefaults.standard.set(true, forKey: "collectUsageData")
         }
-        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil
-            && UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
+        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil {
             UserDefaults.standard.set(true, forKey: "sendDiagnostics")
         }
     }


### PR DESCRIPTION
## Summary
- Removes dead `sendPerformanceReports` nil check from the `sendDiagnostics` default-setting guard in `OnboardingState.init()`
- Removes dead `collectUsageDataEnabled` nil check from the `collectUsageData` default-setting guard
- Cleans up the comment block that referenced these legacy keys

Addresses review feedback from PR #17506: the legacy key guards were dead code since `OnboardingState.init()` only runs for new users (who never have legacy keys), and `syncPrivacyConfig()` already handles migration for upgrade users.

## Test plan
- [x] Verified `OnboardingState.init()` is only called during onboarding (new users) or auth gate flows, never for upgrade users who already have assistants
- [x] Verified `syncPrivacyConfig()` handles all legacy key migration independently
- [x] No functional behavior change for new users: canonical key nil check still correctly writes defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
