### PR TITLE
fix: address review feedback from session-to-conversation rename

### DIFF
--- a/assistant/src/hooks/discovery.ts
+++ b/assistant/src/hooks/discovery.ts
@@ -14,6 +14,9 @@ const VALID_EVENTS = new Set<string>([
   "daemon-stop",
   "conversation-start",
   "conversation-end",
+  // Legacy aliases — existing user hooks may still reference the old names.
+  "session-start",
+  "session-end",
   "pre-llm-call",
   "post-llm-call",
   "pre-tool-execute",

--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -15,6 +15,16 @@ import type {
 
 const log = getLogger("hooks-manager");
 
+/**
+ * Legacy event name aliases so existing user hooks that reference the old
+ * session-based names still fire when the corresponding conversation event
+ * is triggered.
+ */
+const LEGACY_EVENT_ALIASES: Partial<Record<HookEventName, HookEventName[]>> = {
+  "conversation-start": ["session-start"],
+  "conversation-end": ["session-end"],
+};
+
 export class HookManager {
   private hooks: DiscoveredHook[] = [];
   private eventIndex = new Map<HookEventName, DiscoveredHook[]>();
@@ -50,8 +60,23 @@ export class HookManager {
     event: HookEventName,
     data: Record<string, unknown>,
   ): Promise<HookTriggerResult> {
-    const hooks = this.eventIndex.get(event);
-    if (!hooks || hooks.length === 0) return { blocked: false };
+    // Collect hooks registered under the canonical event name and any
+    // legacy aliases (e.g. session-start -> conversation-start).
+    const primaryHooks = this.eventIndex.get(event) ?? [];
+    const legacyAliases = LEGACY_EVENT_ALIASES[event] ?? [];
+    const aliasHooks = legacyAliases.flatMap(
+      (alias) => this.eventIndex.get(alias) ?? [],
+    );
+    // Deduplicate in case a hook subscribes to both old and new names.
+    const seen = new Set<string>();
+    const hooks: DiscoveredHook[] = [];
+    for (const h of [...primaryHooks, ...aliasHooks]) {
+      if (!seen.has(h.name)) {
+        seen.add(h.name);
+        hooks.push(h);
+      }
+    }
+    if (hooks.length === 0) return { blocked: false };
 
     const isPreEvent = event.startsWith("pre-");
     const eventData: HookEventData = { ...data, event };

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -5,6 +5,9 @@ export type HookEventName =
   // Conversation lifecycle
   | "conversation-start"
   | "conversation-end"
+  // Legacy aliases (backwards compat for existing user hooks)
+  | "session-start"
+  | "session-end"
   // LLM call lifecycle
   | "pre-llm-call"
   | "post-llm-call"

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -121,6 +121,7 @@ export function setSentryOrganizationId(
 const CONVERSATION_TAG_KEYS = [
   "assistant_id",
   "conversation_id",
+  "session_id",
   "message_count",
   "user_identifier",
 ] as const;
@@ -147,6 +148,9 @@ export function setSentryConversationContext(
 ): void {
   Sentry.setTag("assistant_id", ctx.assistantId);
   Sentry.setTag("conversation_id", ctx.conversationId);
+  // session_id mirrors conversation_id — downstream Sentry dashboards and
+  // alerts may still filter by the legacy tag name.
+  Sentry.setTag("session_id", ctx.conversationId);
   Sentry.setTag("message_count", String(ctx.messageCount));
   if (ctx.userIdentifier) {
     Sentry.setTag("user_identifier", ctx.userIdentifier);

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -32,10 +32,21 @@ struct OfflineQueuedMessage: Codable, Identifiable {
         }
     }
 
+    // Legacy coding key for pre-rename persisted messages.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case sessionId
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
-        conversationId = try container.decodeIfPresent(String.self, forKey: .conversationId)
+        // Fall back to the legacy "sessionId" key for messages queued before the rename.
+        if let cid = try container.decodeIfPresent(String.self, forKey: .conversationId) {
+            conversationId = cid
+        } else {
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            conversationId = try legacy.decodeIfPresent(String.self, forKey: .sessionId)
+        }
         text = try container.decode(String.self, forKey: .text)
         displayText = try container.decodeIfPresent(String.self, forKey: .displayText)
         attachments = try container.decode([OfflineQueuedAttachment].self, forKey: .attachments)


### PR DESCRIPTION
## Summary
- Restore `session_id` Sentry tag in `instrument.ts` -- the mechanical rename created a duplicate `conversation_id` tag and dropped the intentional `session_id` mirror tag that downstream Sentry dashboards/alerts depend on
- Add backwards compatibility for `session-start`/`session-end` hook event names in `discovery.ts`, `types.ts`, and `manager.ts` -- existing user hooks referencing the old names were silently skipped after the rename
- Add decode fallback for the legacy `sessionId` JSON key in `OfflineMessageQueue.swift` -- pre-upgrade queued messages would deserialize with `conversationId == nil` and become stranded

Addresses review feedback from #17505.

## Test plan
- [ ] Verify Sentry events include both `conversation_id` and `session_id` tags
- [ ] Verify hooks registered with `session-start`/`session-end` still fire on conversation lifecycle events
- [ ] Verify offline queued messages persisted before the rename are correctly deserialized after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
