### PR TITLE
fix: use empty string for benchmark CI workflow_conclusion filter

### DIFF
--- a/.github/workflows/ci-benchmarks.yaml
+++ b/.github/workflows/ci-benchmarks.yaml
@@ -44,7 +44,7 @@ jobs:
           branch: main
           path: assistant/baseline
           if_no_artifact_found: warn
-          workflow_conclusion: completed
+          workflow_conclusion: ''
         continue-on-error: true
 
       - name: Run benchmarks


### PR DESCRIPTION
## Summary
- Addresses review feedback on #17517: `workflow_conclusion: completed` uses a GitHub API run **status** value where a **conclusion** value is expected
- While `completed` happened to work (the action checks both `run.conclusion` and `run.status`), this relied on undocumented implementation behavior
- Changed to `workflow_conclusion: ''` (empty string), which is the documented way to disable conclusion filtering and accept baselines from any completed run
- This preserves the original fix's intent (break stale-baseline failure loop) while using the correct API

## Test plan
- [ ] Verify CI benchmarks workflow runs correctly with the empty string value
- [ ] Confirm baseline download step still succeeds for runs with any conclusion

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
