### PR TITLE
fix: replace leftover session→conversation refs in confirmation signals test

### DIFF
--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -301,7 +301,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-allow-1");
+    seedPendingConfirmation(conversation, "req-allow-1");
     conversation.handleConfirmationResponse("req-allow-1", "allow");
 
     const confirmMsgs = emitted.filter(
@@ -329,7 +329,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-deny-1");
+    seedPendingConfirmation(conversation, "req-deny-1");
     conversation.handleConfirmationResponse("req-deny-1", "deny");
 
     const confirmMsg = emitted.find(
@@ -353,7 +353,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-activity-1");
+    seedPendingConfirmation(conversation, "req-activity-1");
     conversation.handleConfirmationResponse("req-activity-1", "allow");
 
     const activityMsg = emitted.find(
@@ -376,7 +376,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-ctx-1");
+    seedPendingConfirmation(conversation, "req-ctx-1");
     conversation.handleConfirmationResponse(
       "req-ctx-1",
       "allow",
@@ -406,7 +406,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-always-deny");
+    seedPendingConfirmation(conversation, "req-always-deny");
     conversation.handleConfirmationResponse("req-always-deny", "always_deny");
 
     const confirmMsg = emitted.find(
@@ -425,7 +425,7 @@ describe("centralized confirmation emissions", () => {
     const emitted: ServerMessage[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
-    seedPendingConfirmation(session, "req-always-allow");
+    seedPendingConfirmation(conversation, "req-always-allow");
     conversation.handleConfirmationResponse("req-always-allow", "always_allow");
 
     const confirmMsg = emitted.find(
@@ -497,7 +497,7 @@ describe("activity version ordering", () => {
     const baselineVersion = baselineMsg.activityVersion;
 
     // Now handle a confirmation
-    seedPendingConfirmation(session, "req-version-1");
+    seedPendingConfirmation(conversation, "req-version-1");
     conversation.handleConfirmationResponse("req-version-1", "allow");
 
     const activityMsgs = emitted.filter(
@@ -549,7 +549,7 @@ describe("sendToClient receives state signals", () => {
     const clientMsgs: ServerMessage[] = [];
     const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
-    seedPendingConfirmation(session, "req-signal-confirm");
+    seedPendingConfirmation(conversation, "req-signal-confirm");
     conversation.handleConfirmationResponse("req-signal-confirm", "allow");
 
     const confirmSignal = clientMsgs.find(

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -367,32 +367,35 @@ export class DaemonServer {
       }
     };
     getAcpSessionManager().onAcpSessionFinished = async (
-      parentSessionId,
+      parentConversationId,
       message,
       sendToClient,
     ) => {
-      const parentSession = this.sessions.get(parentSessionId);
-      if (!parentSession) {
+      const parentConversation = this.conversations.get(parentConversationId);
+      if (!parentConversation) {
         log.warn(
-          { parentSessionId },
-          "ACP agent finished but parent session not found",
+          { parentConversationId },
+          "ACP agent finished but parent conversation not found",
         );
         return;
       }
       const requestId = `acp-notify-${Date.now()}`;
-      const enqueueResult = parentSession.enqueueMessage(
+      const enqueueResult = parentConversation.enqueueMessage(
         message,
         [],
         sendToClient,
         requestId,
       );
       if (!enqueueResult.queued && !enqueueResult.rejected) {
-        const messageId = await parentSession.persistUserMessage(message, []);
-        parentSession
+        const messageId = await parentConversation.persistUserMessage(
+          message,
+          [],
+        );
+        parentConversation
           .runAgentLoop(message, messageId, sendToClient)
-          .catch((err) => {
+          .catch((err: unknown) => {
             log.error(
-              { parentSessionId, err },
+              { parentConversationId, err },
               "Failed to process ACP notification in parent",
             );
           });

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -45,7 +45,7 @@ export async function executeAcpSpawn(
       agentConfig,
       task,
       cwd,
-      context.sessionId,
+      context.conversationId,
       sendToClient as (msg: unknown) => void,
     );
 


### PR DESCRIPTION
## Summary
- Fix 8 `seedPendingConfirmation(session, ...)` calls that should be `seedPendingConfirmation(conversation, ...)` in the confirmation signals test
- Fix `this.sessions` → `this.conversations` and `parentSessionId` → `parentConversationId` in `daemon/server.ts`
- Fix `context.sessionId` → `context.conversationId` in `tools/acp/spawn.ts`
- Add `err: unknown` type annotation to fix implicit `any` type error

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23159097892

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
