### PR TITLE
fix: use appearance-aware colors in syntax highlighting theme

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -39,7 +39,14 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.textColor = SyntaxTheme.baseTextColor
         textView.backgroundColor = .clear
         textView.insertionPointColor = SyntaxTheme.baseTextColor
-        textView.selectedTextAttributes = [.backgroundColor: NSColor(white: 1.0, alpha: 0.15)]
+        textView.selectedTextAttributes = [
+            .backgroundColor: NSColor(name: nil) { appearance in
+                let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                return isDark
+                    ? NSColor(white: 1.0, alpha: 0.15)
+                    : NSColor(white: 0.0, alpha: 0.12)
+            },
+        ]
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = true
         textView.maxSize = NSSize(
@@ -222,8 +229,13 @@ private final class LineNumberRulerView: NSRulerView {
     }
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
-        // Fill the gutter background
-        NSColor(white: 0.12, alpha: 1.0).setFill()
+        // Fill the gutter background with an appearance-aware color
+        let gutterColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                ? NSColor(white: 0.12, alpha: 1.0)
+                : NSColor(white: 0.94, alpha: 1.0)
+        }
+        gutterColor.setFill()
         rect.fill()
 
         guard let textView = textView,
@@ -244,7 +256,11 @@ private final class LineNumberRulerView: NSRulerView {
         let text = textView.string as NSString
         let lineNumberFont = NSFont(name: "DMMono-Regular", size: 11)
             ?? NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        let lineNumberColor = NSColor(white: 0.45, alpha: 1.0)
+        let lineNumberColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                ? NSColor(white: 0.45, alpha: 1.0)
+                : NSColor(white: 0.55, alpha: 1.0)
+        }
         let attrs: [NSAttributedString.Key: Any] = [
             .font: lineNumberFont,
             .foregroundColor: lineNumberColor,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -1,40 +1,95 @@
 import AppKit
 
-/// Maps syntax token types to styled text attributes for dark backgrounds.
+/// Maps syntax token types to appearance-aware styled text attributes.
 struct SyntaxTheme {
 
-    /// Base text color for unhighlighted content on dark backgrounds.
-    static let baseTextColor = NSColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+    // MARK: - Adaptive Color Helper
+
+    /// Creates an `NSColor` that resolves to `light` or `dark` based on the
+    /// current window appearance (System / Light / Dark).
+    private static func adaptiveNSColor(
+        light: NSColor,
+        dark: NSColor
+    ) -> NSColor {
+        NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+        }
+    }
+
+    // MARK: - Token Colors
+
+    /// Base text color for unhighlighted content.
+    static let baseTextColor = adaptiveNSColor(
+        light: NSColor(red: 0.20, green: 0.20, blue: 0.20, alpha: 1.0),
+        dark: NSColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+    )
+
+    private static let keywordColor = adaptiveNSColor(
+        light: NSColor(red: 0.33, green: 0.25, blue: 0.80, alpha: 1.0),
+        dark: NSColor(red: 0.55, green: 0.65, blue: 0.96, alpha: 1.0)
+    )
+
+    private static let stringColor = adaptiveNSColor(
+        light: NSColor(red: 0.72, green: 0.19, blue: 0.10, alpha: 1.0),
+        dark: NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
+    )
+
+    private static let commentColor = adaptiveNSColor(
+        light: NSColor(red: 0.42, green: 0.47, blue: 0.42, alpha: 1.0),
+        dark: NSColor(red: 0.55, green: 0.60, blue: 0.55, alpha: 1.0)
+    )
+
+    private static let numberColor = adaptiveNSColor(
+        light: NSColor(red: 0.55, green: 0.28, blue: 0.73, alpha: 1.0),
+        dark: NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
+    )
+
+    private static let typeColor = adaptiveNSColor(
+        light: NSColor(red: 0.15, green: 0.55, blue: 0.52, alpha: 1.0),
+        dark: NSColor(red: 0.45, green: 0.78, blue: 0.74, alpha: 1.0)
+    )
+
+    private static let propertyColor = adaptiveNSColor(
+        light: NSColor(red: 0.35, green: 0.50, blue: 0.68, alpha: 1.0),
+        dark: NSColor(red: 0.68, green: 0.78, blue: 0.88, alpha: 1.0)
+    )
+
+    private static let linkColor = adaptiveNSColor(
+        light: NSColor(red: 0.12, green: 0.52, blue: 0.32, alpha: 1.0),
+        dark: NSColor(red: 0.30, green: 0.75, blue: 0.55, alpha: 1.0)
+    )
+
+    // MARK: - Attribute Resolution
 
     /// Returns attributed string attributes for the given token type.
     ///
-    /// Colors are chosen for readability against dark backgrounds. Font traits
-    /// (bold, italic) are derived from the provided base font.
+    /// Colors adapt to the current system appearance (light or dark). Font
+    /// traits (bold, italic) are derived from the provided base font.
     static func attributes(for tokenType: SyntaxTokenType, baseFont: NSFont) -> [NSAttributedString.Key: Any] {
         let color: NSColor
         var font = baseFont
 
         switch tokenType {
         case .keyword:
-            color = NSColor(red: 0.55, green: 0.65, blue: 0.96, alpha: 1.0)
+            color = keywordColor
 
         case .string:
-            color = NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
+            color = stringColor
 
         case .comment:
-            color = NSColor(red: 0.55, green: 0.60, blue: 0.55, alpha: 1.0)
+            color = commentColor
 
         case .number:
-            color = NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
+            color = numberColor
 
         case .type:
-            color = NSColor(red: 0.45, green: 0.78, blue: 0.74, alpha: 1.0)
+            color = typeColor
 
         case .property:
-            color = NSColor(red: 0.68, green: 0.78, blue: 0.88, alpha: 1.0)
+            color = propertyColor
 
         case .boolean, .null:
-            color = NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
+            color = numberColor
 
         case .heading:
             color = baseTextColor
@@ -49,10 +104,10 @@ struct SyntaxTheme {
             font = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
 
         case .codeSpan:
-            color = NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
+            color = stringColor
 
         case .link:
-            color = NSColor(red: 0.30, green: 0.75, blue: 0.55, alpha: 1.0)
+            color = linkColor
 
         case .plain:
             color = baseTextColor


### PR DESCRIPTION
## Summary
- Replace hardcoded dark-mode-only colors in `SyntaxTheme` with adaptive `NSColor` values using `NSColor(name:dynamicProvider:)` that resolve for both light and dark appearances
- Extract token colors into named static properties (`keywordColor`, `stringColor`, etc.) with light/dark pairs for cleaner organization
- Make `HighlightedTextView` selection highlight, gutter background, and line number colors appearance-aware as well

Addresses review feedback from #17593 (Codex P1: "Use appearance-aware colors for syntax highlighting").

## Test plan
- [ ] Verify syntax highlighting renders with good contrast in Dark mode
- [ ] Verify syntax highlighting renders with good contrast in Light mode
- [ ] Verify switching appearance in Settings > Appearance updates colors live
- [ ] Verify gutter line numbers and background adapt to light/dark mode

Apple refs checked (2026-03-16): NSColor(name:dynamicProvider:) for dynamic appearance resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
