### PR TITLE
fix: ensure telemetry always sends assistant_id, broaden BASE_DATA_DIR path matching

### DIFF
--- a/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
+++ b/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
@@ -65,7 +65,18 @@ describe("getExternalAssistantId", () => {
     expect(getExternalAssistantId()).toBe("vellum-nice-fox");
   });
 
-  test("falls back to undefined when BASE_DATA_DIR does not match /assistants/<name>", () => {
+  test("resolves from BASE_DATA_DIR with /instances/<name> path", () => {
+    process.env.BASE_DATA_DIR = "/home/user/.vellum/instances/vellum-swift-owl";
+    expect(getExternalAssistantId()).toBe("vellum-swift-owl");
+  });
+
+  test("resolves from BASE_DATA_DIR with /instances/<name> trailing slash", () => {
+    process.env.BASE_DATA_DIR =
+      "/home/user/.vellum/instances/vellum-swift-owl/";
+    expect(getExternalAssistantId()).toBe("vellum-swift-owl");
+  });
+
+  test("falls back to undefined when BASE_DATA_DIR does not match known patterns", () => {
     process.env.BASE_DATA_DIR = "/tmp/some-other-path";
     expect(getExternalAssistantId()).toBe(undefined);
   });

--- a/assistant/src/runtime/auth/external-assistant-id.ts
+++ b/assistant/src/runtime/auth/external-assistant-id.ts
@@ -10,7 +10,7 @@
  *   1. Cached in-memory value (populated on first call)
  *   2. Most recently hatched entry in lockfile assistants array
  *      (sorted by `hatchedAt` descending) → assistantId
- *   3. BASE_DATA_DIR path matching `/assistants/<name>` suffix
+ *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
  *   4. `undefined` — callers must handle the missing value
  *
  * The value is cached in memory after the first successful read.
@@ -31,7 +31,7 @@ let cached: string | null | undefined;
  *   1. Cached in-memory value (populated on first call)
  *   2. Most recently hatched entry in lockfile assistants array
  *      (sorted by `hatchedAt` descending) → assistantId
- *   3. BASE_DATA_DIR path matching `/assistants/<name>` suffix
+ *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
  *   4. `undefined` when resolution fails entirely
  */
 export function getExternalAssistantId(): string | undefined {
@@ -72,7 +72,7 @@ export function getExternalAssistantId(): string | undefined {
   const base = getBaseDataDir();
   if (base && typeof base === "string") {
     const normalized = base.replace(/\\/g, "/").replace(/\/+$/, "");
-    const match = normalized.match(/\/assistants\/([^/]+)$/);
+    const match = normalized.match(/\/(?:assistants|instances)\/([^/]+)$/);
     if (match) {
       cached = match[1];
       log.info(

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -380,7 +380,7 @@ describe("UsageTelemetryReporter", () => {
     expect(e.recorded_at).toBe(1700000099000);
   });
 
-  test("assistant_id is omitted from payload when getExternalAssistantId returns undefined", async () => {
+  test("assistant_id falls back to 'self' when getExternalAssistantId returns undefined", async () => {
     mockGetExternalAssistantId.mockReturnValue(undefined);
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
@@ -396,7 +396,7 @@ describe("UsageTelemetryReporter", () => {
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
     expect(body.installation_id).toBe("test-device-id");
-    expect("assistant_id" in body).toBe(false);
+    expect(body.assistant_id).toBe("self");
   });
 
   test("turn events are included in the events array with type discriminator", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -154,10 +154,10 @@ export class UsageTelemetryReporter {
         ),
       ];
 
-      const assistantId = getExternalAssistantId();
+      const assistantId = getExternalAssistantId() ?? "self";
       const payload = {
         installation_id: getDeviceId(),
-        ...(assistantId != null ? { assistant_id: assistantId } : {}),
+        assistant_id: assistantId,
         events: typedEvents,
       };
 


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #17587
- Telemetry reporter now falls back to `"self"` when `getExternalAssistantId()` returns `undefined`, ensuring `assistant_id` is always present in the payload (preserving backend contract)
- Broadened `BASE_DATA_DIR` path regex to match both `/assistants/<name>` and `/instances/<name>` suffixes for more robust assistant ID resolution
- Updated tests to reflect both changes

## Test plan
- [ ] Verify `usage-telemetry-reporter.test.ts` passes (assistant_id falls back to "self")
- [ ] Verify `external-assistant-id.test.ts` passes (instances path resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
