### PR TITLE
fix: preserve link destinations in MarkdownPreviewView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
@@ -259,10 +259,17 @@ private func renderInlineMarkdown(_ text: String) -> Text {
             result = result + Text(content)
                 .font(VFont.mono)
                 .foregroundColor(VColor.systemPositiveStrong)
-        case .link(let linkText, _):
-            result = result + Text(linkText)
-                .foregroundColor(VColor.primaryBase)
-                .underline()
+        case .link(let linkText, let linkUrl):
+            if let url = URL(string: linkUrl) {
+                var attributed = AttributedString(linkText)
+                attributed.link = url
+                attributed.underlineStyle = .single
+                result = result + Text(attributed)
+            } else {
+                result = result + Text(linkText)
+                    .foregroundColor(VColor.primaryBase)
+                    .underline()
+            }
         }
     }
 
@@ -290,6 +297,7 @@ struct MarkdownPreviewView: View {
             }
             .padding(VSpacing.lg)
         }
+        .tint(VColor.primaryBase)
         .textSelection(.enabled)
         .task(id: content) {
             blocks = parseMarkdown(content)


### PR DESCRIPTION
## Summary
- Fix inline markdown renderer to retain link URLs instead of discarding them
- Links now use AttributedString with `.link` attribute for clickable behavior
- Add `.tint(VColor.primaryBase)` to MarkdownPreviewView for consistent link styling
- Invalid URLs gracefully fall back to styled-only text (no crash)

Addresses review feedback from #17594.

## Test plan
- [ ] Render markdown with links like `[docs](https://example.com)` in the preview panel
- [ ] Verify links are clickable and open in the default browser
- [ ] Verify link styling matches VColor.primaryBase with underline
- [ ] Verify malformed URLs render as styled text without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
