### PR TITLE
fix: suppress unused platformId warning in bootstrap service

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -170,7 +170,7 @@ public final class LocalAssistantBootstrapService {
 
         // Step 2: Check if we already have the key stored locally (only when we have the platform ID)
         var existingKeyInjected = false
-        if let platformId = platformAssistantId,
+        if platformAssistantId != nil,
            let existingKey = credentialStorage?.get(account: credentialAccount), !existingKey.isEmpty {
             do {
                 try await injectKeyIntoDaemon(key: existingKey)


### PR DESCRIPTION
## Summary

- Replace `if let platformId = platformAssistantId` with `if platformAssistantId != nil` since the bound value was never used, eliminating the Swift compiler warning.

## Original prompt

Fix Swift warning: `immutable value 'platformId' was never used` in `LocalAssistantBootstrapService.swift:173`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
