### PR TITLE
fix: address JSONTreeView review feedback from PR #17596

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -45,13 +45,22 @@ private func parseJSON(_ text: String) -> JSONParseResult {
     }
 }
 
+/// Escapes a JSON key for use in node ID paths, preventing ambiguity when keys
+/// contain path-separator characters like `.`, `[`, or `]`.
+private func escapeKey(_ key: String) -> String {
+    key.replacingOccurrences(of: "\\", with: "\\\\")
+       .replacingOccurrences(of: ".", with: "\\.")
+       .replacingOccurrences(of: "[", with: "\\[")
+       .replacingOccurrences(of: "]", with: "\\]")
+}
+
 /// Recursively converts a Foundation JSON object into a `JSONNode`.
 private func convert(_ value: Any, path: String) -> JSONNode {
     switch value {
     case let dict as NSDictionary:
         let sortedKeys = (dict.allKeys as? [String] ?? []).sorted()
         let entries: [(key: String, value: JSONNode)] = sortedKeys.map { key in
-            let childPath = "\(path).\(key)"
+            let childPath = "\(path).\(escapeKey(key))"
             return (key: key, value: convert(dict[key] as Any, path: childPath))
         }
         return .object(id: path, entries: entries)
@@ -127,8 +136,8 @@ struct JSONTreeView: View {
         .task(id: content) {
             let result = parseJSON(content)
             root = result
+            expandedPaths = []
             if case .success(let node) = result {
-                expandedPaths = []
                 autoExpandInitial(node)
             }
         }
@@ -243,21 +252,21 @@ private struct JSONNodeRow: View {
             primitiveRow {
                 Text("\"\(value)\"")
                     .font(VFont.mono)
-                    .foregroundColor(Color(red: 0.87, green: 0.55, blue: 0.47))
+                    .foregroundColor(VColor.syntaxString)
                     .textSelection(.enabled)
             }
         case .number(_, let value):
             primitiveRow {
                 Text("\(value)")
                     .font(VFont.mono)
-                    .foregroundColor(Color(red: 0.73, green: 0.56, blue: 0.87))
+                    .foregroundColor(VColor.syntaxNumber)
                     .textSelection(.enabled)
             }
         case .bool(_, let value):
             primitiveRow {
                 Text(value ? "true" : "false")
                     .font(VFont.mono)
-                    .foregroundColor(Color(red: 0.73, green: 0.56, blue: 0.87))
+                    .foregroundColor(VColor.syntaxNumber)
                     .bold()
                     .textSelection(.enabled)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -1,4 +1,5 @@
 import AppKit
+import VellumAssistantShared
 
 /// Maps syntax token types to appearance-aware styled text attributes.
 struct SyntaxTheme {
@@ -24,40 +25,14 @@ struct SyntaxTheme {
         dark: NSColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
     )
 
-    private static let keywordColor = adaptiveNSColor(
-        light: NSColor(red: 0.33, green: 0.25, blue: 0.80, alpha: 1.0),
-        dark: NSColor(red: 0.55, green: 0.65, blue: 0.96, alpha: 1.0)
-    )
-
-    private static let stringColor = adaptiveNSColor(
-        light: NSColor(red: 0.72, green: 0.19, blue: 0.10, alpha: 1.0),
-        dark: NSColor(red: 0.87, green: 0.55, blue: 0.47, alpha: 1.0)
-    )
-
-    private static let commentColor = adaptiveNSColor(
-        light: NSColor(red: 0.42, green: 0.47, blue: 0.42, alpha: 1.0),
-        dark: NSColor(red: 0.55, green: 0.60, blue: 0.55, alpha: 1.0)
-    )
-
-    private static let numberColor = adaptiveNSColor(
-        light: NSColor(red: 0.55, green: 0.28, blue: 0.73, alpha: 1.0),
-        dark: NSColor(red: 0.73, green: 0.56, blue: 0.87, alpha: 1.0)
-    )
-
-    private static let typeColor = adaptiveNSColor(
-        light: NSColor(red: 0.15, green: 0.55, blue: 0.52, alpha: 1.0),
-        dark: NSColor(red: 0.45, green: 0.78, blue: 0.74, alpha: 1.0)
-    )
-
-    private static let propertyColor = adaptiveNSColor(
-        light: NSColor(red: 0.35, green: 0.50, blue: 0.68, alpha: 1.0),
-        dark: NSColor(red: 0.68, green: 0.78, blue: 0.88, alpha: 1.0)
-    )
-
-    private static let linkColor = adaptiveNSColor(
-        light: NSColor(red: 0.12, green: 0.52, blue: 0.32, alpha: 1.0),
-        dark: NSColor(red: 0.30, green: 0.75, blue: 0.55, alpha: 1.0)
-    )
+    // Syntax token colors derived from the shared VColor.syntax* adaptive tokens.
+    private static let keywordColor = NSColor(VColor.syntaxKeyword)
+    private static let stringColor = NSColor(VColor.syntaxString)
+    private static let commentColor = NSColor(VColor.syntaxComment)
+    private static let numberColor = NSColor(VColor.syntaxNumber)
+    private static let typeColor = NSColor(VColor.syntaxType)
+    private static let propertyColor = NSColor(VColor.syntaxProperty)
+    private static let linkColor = NSColor(VColor.syntaxLink)
 
     // MARK: - Attribute Resolution
 

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -340,6 +340,37 @@ public enum VColor {
     public static let systemMidStrong = adaptiveColor(light: FigmaRawColor.systemLightMidStrong, dark: FigmaRawColor.systemDarkMidStrong)
     public static let systemMidWeak = adaptiveColor(light: FigmaRawColor.systemLightMidWeak, dark: FigmaRawColor.systemDarkMidWeak)
 
+    // Syntax highlighting — adaptive tokens shared by SyntaxTheme and JSONTreeView.
+    // Light values are high-contrast for light surfaces; dark values are softer pastels.
+    public static let syntaxString = adaptiveColor(
+        light: Color(.sRGB, red: 0.72, green: 0.19, blue: 0.10),
+        dark: Color(.sRGB, red: 0.87, green: 0.55, blue: 0.47)
+    )
+    public static let syntaxNumber = adaptiveColor(
+        light: Color(.sRGB, red: 0.55, green: 0.28, blue: 0.73),
+        dark: Color(.sRGB, red: 0.73, green: 0.56, blue: 0.87)
+    )
+    public static let syntaxKeyword = adaptiveColor(
+        light: Color(.sRGB, red: 0.33, green: 0.25, blue: 0.80),
+        dark: Color(.sRGB, red: 0.55, green: 0.65, blue: 0.96)
+    )
+    public static let syntaxComment = adaptiveColor(
+        light: Color(.sRGB, red: 0.42, green: 0.47, blue: 0.42),
+        dark: Color(.sRGB, red: 0.55, green: 0.60, blue: 0.55)
+    )
+    public static let syntaxType = adaptiveColor(
+        light: Color(.sRGB, red: 0.15, green: 0.55, blue: 0.52),
+        dark: Color(.sRGB, red: 0.45, green: 0.78, blue: 0.74)
+    )
+    public static let syntaxProperty = adaptiveColor(
+        light: Color(.sRGB, red: 0.35, green: 0.50, blue: 0.68),
+        dark: Color(.sRGB, red: 0.68, green: 0.78, blue: 0.88)
+    )
+    public static let syntaxLink = adaptiveColor(
+        light: Color(.sRGB, red: 0.12, green: 0.52, blue: 0.32),
+        dark: Color(.sRGB, red: 0.30, green: 0.75, blue: 0.55)
+    )
+
     // Utility: non-adaptive explicit white/black for overlays, shadows, text-on-filled
     public static let auxWhite = Color(hex: 0xFFFFFF)
     public static let auxBlack = Color(hex: 0x000000)


### PR DESCRIPTION
## Summary
- Escape JSON keys in node ID paths to prevent ambiguous expand/collapse state when keys contain path separators
- Reset expandedPaths unconditionally on content change (not just on success) to clear stale state
- Extract shared adaptive syntax color tokens (VColor.syntax*) so JSON tree values adapt to light/dark mode
- Consolidate SyntaxTheme to derive colors from shared tokens, removing duplicated RGB definitions

Addresses review feedback from #17596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
