### PR TITLE
M1: Fix composer button spacing and corner radius

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -410,13 +410,13 @@ struct ComposerView: View {
         .padding(.leading, VSpacing.md)
         .padding(.trailing, VSpacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
+            RoundedRectangle(cornerRadius: VRadius.window)
                 .fill(VColor.surfaceOverlay)
         )
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.window))
         .overlay {
             if isComposerDropTargeted {
-                RoundedRectangle(cornerRadius: VRadius.lg)
+                RoundedRectangle(cornerRadius: VRadius.window)
                     .fill(VColor.surfaceActive)
                     .overlay {
                         HStack(spacing: VSpacing.sm) {
@@ -436,7 +436,7 @@ struct ComposerView: View {
     @ViewBuilder
     private var textEntryComposer: some View {
         standardComposerShell {
-            HStack(alignment: isSending ? .center : .bottom, spacing: VSpacing.xs) {
+            HStack(alignment: isSending ? .center : .bottom, spacing: 10) {
                 composerTextField
                     .frame(minHeight: composerActionButtonSize)
                 composerActionButtons
@@ -446,7 +446,7 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var composerActionButtons: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: VSpacing.lg) {
             if isSending && !hasPendingConfirmation {
                 VButton(
                     label: "Stop generation",
@@ -510,7 +510,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .frame(minWidth: composerActionButtonSize * 3 + 2 * 2)
+        .frame(minWidth: composerActionButtonSize * 3 + VSpacing.lg * 2)
     }
 
     // MARK: - Dictation Inline Mode

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -12,6 +12,7 @@ private let composerLog = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 200
     private let composerActionButtonSize: CGFloat = 32
+    private let composerTextToButtonsGap: CGFloat = 10
 
     // MARK: - ComposerMode
 
@@ -436,7 +437,7 @@ struct ComposerView: View {
     @ViewBuilder
     private var textEntryComposer: some View {
         standardComposerShell {
-            HStack(alignment: isSending ? .center : .bottom, spacing: 10) {
+            HStack(alignment: isSending ? .center : .bottom, spacing: composerTextToButtonsGap) {
                 composerTextField
                     .frame(minHeight: composerActionButtonSize)
                 composerActionButtons


### PR DESCRIPTION
Align composer input with Figma design mock. Corner radius: VRadius.lg (12) → VRadius.window (10). Text-to-buttons gap: VSpacing.xs (4) → 10. Button gap: 2 → VSpacing.lg (16). Min buttons width updated accordingly. Closes #17796
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
