### PR TITLE
fix: center Logs panel empty state messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -29,6 +29,7 @@ struct DebugPanel: View {
                         subtitle: "Events will appear as the session runs",
                         icon: "waveform.path"
                     )
+                    .containerRelativeFrame([.horizontal, .vertical])
                 }
             } else {
                 VEmptyState(
@@ -36,6 +37,7 @@ struct DebugPanel: View {
                     subtitle: "Start a conversation to see trace events",
                     icon: "ant"
                 )
+                .containerRelativeFrame([.horizontal, .vertical])
             }
         }
         .onAppear { traceStore.isObserved = true }


### PR DESCRIPTION
## Summary
- The "No session selected" and "No trace events yet" empty states in the Logs (Debug) panel were pinned to the top of the content area
- Added `.containerRelativeFrame([.horizontal, .vertical])` to both empty states so they center within the ScrollView's visible area

## Original prompt
logs empty state message should be aligned in the middle vertically and horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
