### PR TITLE
fix: update remaining user-facing 'conversation' strings to 'thread'

### DIFF
--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -21,9 +21,9 @@ struct PrivateConversationsSection: View {
         Form {
             if store.privateConversations.isEmpty {
                 Section {
-                    Text("No private conversations yet.")
+                    Text("No private threads yet.")
                         .foregroundStyle(.secondary)
-                    Text("Private conversations are excluded from your main chat history. Use them for sensitive conversations that you don't want mixed with your regular conversations.")
+                    Text("Private threads are excluded from your main chat history. Use them for sensitive threads that you don't want mixed with your regular threads.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -54,9 +54,9 @@ struct PrivateConversationsSection: View {
                         }
                     }
                 } header: {
-                    Text("Private Conversations")
+                    Text("Private Threads")
                 } footer: {
-                    Text("These conversations are not included in your regular chat history and are excluded from session restoration.")
+                    Text("These threads are not included in your regular chat history and are excluded from session restoration.")
                 }
             }
 
@@ -65,20 +65,20 @@ struct PrivateConversationsSection: View {
                     newConversationName = ""
                     showingCreateSheet = true
                 } label: {
-                    Label { Text("New Private Conversation") } icon: { VIconView(.shield, size: 14) }
+                    Label { Text("New Private Thread") } icon: { VIconView(.shield, size: 14) }
                 }
             }
         }
-        .navigationTitle("Private Conversations")
+        .navigationTitle("Private Threads")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showingCreateSheet) {
             createConversationSheet
         }
-        .alert("Rename Conversation", isPresented: Binding(
+        .alert("Rename Thread", isPresented: Binding(
             get: { renamingConversation != nil },
             set: { if !$0 { renamingConversation = nil } }
         )) {
-            TextField("Conversation name", text: $renameText)
+            TextField("Thread name", text: $renameText)
             Button("Cancel", role: .cancel) { renamingConversation = nil }
             Button("Save") {
                 if let conversation = renamingConversation, !renameText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -87,9 +87,9 @@ struct PrivateConversationsSection: View {
                 renamingConversation = nil
             }
         } message: {
-            Text("Enter a new name for this private conversation.")
+            Text("Enter a new name for this private thread.")
         }
-        .alert("Delete Conversation", isPresented: $showingDeleteConfirmation) {
+        .alert("Delete Thread", isPresented: $showingDeleteConfirmation) {
             Button("Cancel", role: .cancel) { conversationToDelete = nil }
             Button("Delete", role: .destructive) {
                 if let conversation = conversationToDelete {
@@ -139,13 +139,13 @@ struct PrivateConversationsSection: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Conversation name", text: $newConversationName)
+                    TextField("Thread name", text: $newConversationName)
                         .autocapitalization(.words)
                 } footer: {
-                    Text("Give this private conversation a name so you can identify it later.")
+                    Text("Give this private thread a name so you can identify it later.")
                 }
             }
-            .navigationTitle("New Private Conversation")
+            .navigationTitle("New Private Thread")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -156,7 +156,7 @@ struct PrivateConversationsSection: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Create") {
                         let name = newConversationName.trimmingCharacters(in: .whitespacesAndNewlines)
-                        _ = store.newPrivateConversation(name: name.isEmpty ? "Private Conversation" : name)
+                        _ = store.newPrivateConversation(name: name.isEmpty ? "Private Thread" : name)
                         showingCreateSheet = false
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -123,7 +123,7 @@ extension MainWindowView {
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .clipped()
-        .alert("Rename Conversation", isPresented: Binding(
+        .alert("Rename Thread", isPresented: Binding(
             get: { sidebar.renamingConversationId != nil },
             set: { if !$0 { sidebar.renamingConversationId = nil } }
         )) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -191,7 +191,7 @@ struct MainWindowView: View {
         guard !markdown.isEmpty else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(markdown, forType: .string)
-        windowState.showToast(message: "Conversation copied to clipboard", style: .success)
+        windowState.showToast(message: "Thread copied to clipboard", style: .success)
     }
 
     private var conversationHeaderPresentation: ConversationHeaderPresentation {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -12,7 +12,7 @@ struct ConversationSwitcherDrawer: View {
 
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
-            Text("\(regularConversations.count) conversations")
+            Text("\(regularConversations.count) threads")
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -134,7 +134,7 @@ struct SidebarConversationItem: View {
             onSelect?()
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel("Conversation: \(conversation.title)")
+        .accessibilityLabel("Thread: \(conversation.title)")
         .accessibilityAction(.default) {
             selectConversation()
         }
@@ -198,7 +198,7 @@ struct SidebarConversationItem: View {
                 guard let conversationId = conversation.conversationId else { return }
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
             } label: {
-                Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
+                Label { Text("Send Logs for Thread") } icon: { VIconView(.upload, size: 14) }
             }
             .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -8,7 +8,7 @@ struct SettingsArchivedConversationsTab: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             if conversationManager.archivedConversations.isEmpty {
                 VEmptyState(
-                    title: "No archived conversations",
+                    title: "No archived threads",
                     subtitle: "Threads you archive will appear here.",
                     icon: VIcon.archive.rawValue
                 )


### PR DESCRIPTION
## Summary
- Fixes alert title "Rename Conversation" → "Rename Thread" in macOS sidebar (reported as bug in PR #17597 review)
- Updates all remaining user-facing "conversation" strings to "thread" across macOS and iOS clients
- macOS: accessibility labels, context menu items, switcher drawer count, clipboard toast, archived threads empty state
- iOS: rename/delete alert titles, private threads section headers, navigation titles, create sheet labels

## Test plan
- [ ] Verify macOS rename alert shows "Rename Thread" title and "Enter a new name for this thread" body
- [ ] Verify macOS context menu "Send Logs for Thread" label
- [ ] Verify macOS conversation switcher drawer shows "N threads"
- [ ] Verify macOS clipboard toast says "Thread copied to clipboard"
- [ ] Verify macOS archived threads empty state says "No archived threads"
- [ ] Verify iOS private threads section uses "thread" terminology throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
