### PR TITLE
fix: correct acp-session test expectation for user_message_chunk

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -47,7 +47,7 @@ describe("VellumAcpClientHandler", () => {
       });
     });
 
-    test("dispatches user_message_chunk as agent_message_chunk", async () => {
+    test("dispatches user_message_chunk with its own updateType", async () => {
       await handler.sessionUpdate({
         sessionId: "s1",
         update: {
@@ -59,7 +59,7 @@ describe("VellumAcpClientHandler", () => {
       expect(sent).toHaveLength(1);
       expect(sent[0]).toMatchObject({
         type: "acp_session_update",
-        updateType: "agent_message_chunk",
+        updateType: "user_message_chunk",
         content: "user text",
       });
     });


### PR DESCRIPTION
## Summary
- Fix failing test in `acp-session.test.ts` where the `user_message_chunk` case incorrectly expected `updateType: "agent_message_chunk"` instead of `"user_message_chunk"`
- The implementation correctly distinguishes between the two update types; the test expectation was wrong

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23159490145/job/67283172441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
