### PR TITLE
Add HighlightedTextView as approved AppKit bridge exception

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -96,7 +96,7 @@ Prefer built-in SwiftUI primitives over custom `NSViewRepresentable` / AppKit wr
 |------|----------|----------|
 | Multi-line text input (short/medium) | `TextField(axis: .vertical)` + `.lineLimit(1...N)` | Custom `NSTextView` in `NSScrollView` |
 | Multi-line text input (scrollable) | `TextField(axis: .vertical)` inside `ScrollView` with GeometryReader height measurement (see chat composer) | Custom AppKit `NSScrollView` + `NSClipView` + `NSTextView` stack |
-| Long-form text editing | `TextEditor` (acceptable for editor-like surfaces where the user expects a full text-editing experience, e.g., contact notes, skill editing, tool permission tester) | Custom AppKit `NSScrollView` + `NSClipView` + `NSTextView` stack |
+| Long-form text editing | `TextEditor` (acceptable for editor-like surfaces where the user expects a full text-editing experience, e.g., contact notes, skill editing, tool permission tester). Exception: syntax-highlighted code views use `HighlightedTextView` (approved AppKit bridge) | Custom AppKit `NSScrollView` + `NSClipView` + `NSTextView` stack |
 | Vertical centering in text field | Native `TextField` behavior | Custom `NSClipView` subclass |
 | Auto-growing height | `ScrollView` + `GeometryReader` on inner content + `.frame(height: clamp(measured, min, max))` | Custom AppKit height sync. Note: `.lineLimit(1...N)` truncates instead of scrolling on macOS when content exceeds N lines — only use it for short-form inputs where truncation is acceptable (e.g., `VTextEditor`) |
 | Return-to-send in chat input | `.onSubmit { sendAction() }` (native SwiftUI) | `.onKeyPress(.return)` (returning `.ignored` doesn't fall back to TextField's newline behavior) |
@@ -114,6 +114,7 @@ Prefer built-in SwiftUI primitives over custom `NSViewRepresentable` / AppKit wr
 - Intercepting return-key shortcuts that SwiftUI cannot route precisely before `.onSubmit` fires, including `Cmd+Enter` send, `Shift+Return` newline, and default-mode `Option+Return` send
 - Registering window-level event monitors (`NSEvent.addLocalMonitorForEvents`)
 - Accessing `NSWindow` properties (e.g., typing redirect handlers, container view registration)
+- Syntax-highlighted text display and editing (`HighlightedTextView`) — requires `NSTextView` + `NSTextStorage` for per-token attributed text coloring, which SwiftUI's `TextEditor` and `Text` cannot provide
 
 ---
 


### PR DESCRIPTION
## Summary
- Add syntax highlighting (`HighlightedTextView`) to the approved AppKit bridge exceptions list in `clients/AGENTS.md`
- Update the SwiftUI vs AppKit reference table to note the syntax highlighting exception for long-form text editing
- Addresses bot review feedback on PR #17603 about `HighlightedTextView` violating the "Native SwiftUI over Custom AppKit" rule — the component legitimately requires `NSTextView` + `NSTextStorage` for per-token attributed text coloring

## Context
PR #17603 replaced `TextEditor` and `ReadOnlyCodeContent` with `HighlightedTextView` for syntax-highlighted code viewing/editing. Bot reviewers flagged this as violating the AppKit bridge rules. The language-change re-highlighting issue (also flagged) was already fixed in the merged PR. This PR documents the exception so future agents know syntax highlighting is an approved use of AppKit.

## Test plan
- [ ] Verify `clients/AGENTS.md` renders correctly with the new exception bullet and updated table row
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
