### PR TITLE
feat: show assistant name as dock tooltip, synced with identity changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -123,6 +123,7 @@ final class AvatarAppearanceManager {
         loadAvatarComponents()
         watchAvatarFile()
         watchTraitsFile()
+        updateDockName()
 
         // Fire-and-forget: fetch character component definitions from the
         // daemon and populate AvatarComponentStore.shared so downstream
@@ -151,6 +152,7 @@ final class AvatarAppearanceManager {
                 self.cachedFallbackName = nil
                 self.cachedFullFallbackAvatar = nil
                 self.cachedFullFallbackName = nil
+                self.updateDockName()
             }
         }
     }
@@ -248,6 +250,8 @@ final class AvatarAppearanceManager {
     /// bundle icon without deleting any files on disk.
     /// Called during logout, retire, and switch-assistant flows.
     func resetForDisconnect() {
+        assistantName = "V"
+        updateDockName()
         customAvatarImage = nil
         characterBodyShape = nil
         characterEyeStyle = nil
@@ -450,7 +454,19 @@ final class AvatarAppearanceManager {
         source.resume()
     }
 
-    // MARK: - Dock Icon
+    // MARK: - Dock Name & Icon
+
+    /// Updates the process name so the dock tooltip shows the assistant's name
+    /// instead of the static "Vellum". Falls back to "Vellum" when no real
+    /// assistant name is available (placeholder, bootstrap sentinel, or initial).
+    private func updateDockName() {
+        let name = assistantName
+        if name == "V" || name == AssistantDisplayName.placeholder {
+            ProcessInfo.processInfo.processName = "Vellum"
+        } else {
+            ProcessInfo.processInfo.processName = name
+        }
+    }
 
     /// Updates the application dock icon to match the current avatar.
     /// When a custom avatar exists, renders it inside a macOS-style squircle mask.


### PR DESCRIPTION
## Summary
- Add updateDockName() method to AvatarAppearanceManager that sets ProcessInfo.processInfo.processName to the assistant's name
- Call it on launch, on identity_changed notifications, and on disconnect (resets to Vellum)
- Falls back to Vellum when no real assistant name is available

Part of plan: dock-tooltip-assistant-name.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
