### PR TITLE
fix: prevent Logs empty state from being slightly scrollable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -29,7 +29,9 @@ struct DebugPanel: View {
                         subtitle: "Events will appear as the session runs",
                         icon: "waveform.path"
                     )
-                    .containerRelativeFrame([.horizontal, .vertical])
+                    .containerRelativeFrame([.horizontal, .vertical]) { size, _ in
+                        CGSize(width: size.width - 2 * VSpacing.lg, height: size.height - 2 * VSpacing.lg)
+                    }
                 }
             } else {
                 VEmptyState(
@@ -37,7 +39,9 @@ struct DebugPanel: View {
                     subtitle: "Start a conversation to see trace events",
                     icon: "ant"
                 )
-                .containerRelativeFrame([.horizontal, .vertical])
+                .containerRelativeFrame([.horizontal, .vertical]) { size, _ in
+                        CGSize(width: size.width - 2 * VSpacing.lg, height: size.height - 2 * VSpacing.lg)
+                    }
             }
         }
         .onAppear { traceStore.isObserved = true }


### PR DESCRIPTION
## Summary
- The `.containerRelativeFrame` on the Logs panel empty states sized to the full ScrollView viewport, but VSidePanel wraps content with `.padding(VSpacing.lg)` adding 32pt total, making it slightly scrollable
- Use the closure overload to subtract the padding from the frame size so the empty state fits exactly within the visible area

## Original prompt
https://github.com/vellum-ai/vellum-assistant/pull/17801/changes#r2942196898 address this feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
