### PR TITLE
fix: clarify bash debug error message

### DIFF
--- a/assistant/src/cli/commands/bash.ts
+++ b/assistant/src/cli/commands/bash.ts
@@ -133,7 +133,7 @@ Examples:
         cleanupSignalFiles();
 
         if (result.error) {
-          log.error(`Spawn error: ${result.error}`);
+          log.error(result.error);
           process.exitCode = 1;
           return;
         }

--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -80,7 +80,7 @@ export function handleBashSignal(filename: string): void {
         exitCode: null,
         timedOut: false,
         error:
-          "Bash signals are disabled. Start the assistant with VELLUM_DEBUG=1 to enable.",
+          "Bash signals are disabled. The running assistant process must have been started with VELLUM_DEBUG=1 (setting it on the CLI command alone is not enough). Restart the assistant with: VELLUM_DEBUG=1 assistant start",
       });
     }
     return;


### PR DESCRIPTION
## Summary
- Updated the bash signal error message to explicitly state that the *running assistant process* must have been started with `VELLUM_DEBUG=1`, not just the CLI command
- Removed misleading "Spawn error:" prefix from CLI output since this isn't a spawn error

## Original prompt
can you update the error/instruction i saw when i used it from the CLI to make this clearer?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
