### PR TITLE
Fix composer button padding/spacing to match Figma

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -12,6 +12,7 @@ private let composerLog = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 200
     private let composerActionButtonSize: CGFloat = 32
+    private let composerTextToButtonsGap: CGFloat = 10
 
     // MARK: - ComposerMode
 
@@ -411,13 +412,13 @@ struct ComposerView: View {
         .padding(.leading, VSpacing.md)
         .padding(.trailing, VSpacing.sm)
         .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
+            RoundedRectangle(cornerRadius: VRadius.window)
                 .fill(VColor.surfaceOverlay)
         )
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.window))
         .overlay {
             if isComposerDropTargeted {
-                RoundedRectangle(cornerRadius: VRadius.lg)
+                RoundedRectangle(cornerRadius: VRadius.window)
                     .fill(VColor.surfaceActive)
                     .overlay {
                         HStack(spacing: VSpacing.sm) {
@@ -437,7 +438,7 @@ struct ComposerView: View {
     @ViewBuilder
     private var textEntryComposer: some View {
         standardComposerShell {
-            HStack(alignment: isSending ? .center : .bottom, spacing: VSpacing.xs) {
+            HStack(alignment: isSending ? .center : .bottom, spacing: composerTextToButtonsGap) {
                 composerTextField
                     .frame(minHeight: composerActionButtonSize)
                 composerActionButtons
@@ -447,7 +448,7 @@ struct ComposerView: View {
 
     @ViewBuilder
     private var composerActionButtons: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: VSpacing.lg) {
             if isSending && !hasPendingConfirmation {
                 VButton(
                     label: "Stop generation",
@@ -522,7 +523,7 @@ struct ComposerView: View {
                 }
             }
         }
-        .frame(minWidth: composerActionButtonSize * 3 + 2 * 2)
+        .frame(minWidth: composerActionButtonSize * 3 + VSpacing.lg * 2)
     }
 
     // MARK: - Dictation Inline Mode


### PR DESCRIPTION
## Summary
Aligns the macOS composer input's button padding, spacing, and corner radius with the Figma design mock for pixel-perfect visual parity.

## Changes
- Corner radius: VRadius.lg (12) → VRadius.window (10) in standardComposerShell
- Text-to-buttons gap: VSpacing.xs (4) → composerTextToButtonsGap (10)
- Button-to-button gap: 2 (hardcoded) → VSpacing.lg (16)
- Min buttons width formula updated for new gap

## Milestone PRs (merged into feature branch)
- #17799: M1: Fix composer button spacing and corner radius

## Project issue
Closes #17795

## Test plan
- [ ] Build macOS app and verify composer input spacing
- [ ] Verify default state (3 buttons: attach, mic, waveform) has proper spacing
- [ ] Verify typing state (attach + send) has proper spacing
- [ ] Verify working state (stop button) renders correctly
- [ ] Verify corner radius matches Figma (10pt)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
