### PR TITLE
fix(acp): remove vellum sleep/wake from setup — config hot-reloads

### DIFF
--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -40,12 +40,9 @@ When the user first tries to use ACP and it's not configured, set it up automati
    }
    ```
 
-3. **Restart the daemon** so the new config is picked up (config is cached at startup):
-   ```bash
-   vellum sleep && vellum wake
-   ```
+3. **Wait a few seconds** for the config watcher to pick up the change (it hot-reloads automatically — no restart needed).
 
-4. Then retry the `acp_spawn` call.
+4. Then retry the `acp_spawn` call. Do NOT run `vellum sleep && vellum wake` — that kills the conversation.
 
 ## Critical: correct agent command
 


### PR DESCRIPTION
## Summary
- Remove `vellum sleep && vellum wake` restart step from ACP first-time setup in SKILL.md
- Config file watcher already hot-reloads changes, so no restart is needed
- Explicitly warn the assistant NOT to run sleep/wake as it kills the conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
