### PR TITLE
feat: show actionable error view when daemon fails to start

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -104,6 +104,10 @@ struct ChatView: View {
     /// timeout window. Shows a failure screen instead of the loading skeleton.
     var isBootstrapTimedOut: Bool = false
 
+    /// Called when the user taps "Send Logs to Vellum" on the bootstrap
+    /// timeout view.
+    var onBootstrapSendLogs: (() -> Void)?
+
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var containerWidth: CGFloat = 0
@@ -141,7 +145,7 @@ struct ChatView: View {
                         .accessibilityLabel("Loading chat history")
                 } else if isEmptyState && isBootstrapping {
                     if isBootstrapTimedOut {
-                        ChatBootstrapTimeoutView()
+                        ChatBootstrapTimeoutView(onSendLogs: onBootstrapSendLogs)
                     } else {
                         ChatBootstrapLoadingView()
                     }
@@ -580,8 +584,10 @@ private struct ChatBootstrapLoadingView: View {
 
 /// Shown during first-launch bootstrap when the daemon fails to connect
 /// within the timeout window. Mirrors the hatch-failure pattern from
-/// onboarding: a centered error message.
+/// onboarding: a centered error message with an option to send logs.
 private struct ChatBootstrapTimeoutView: View {
+    var onSendLogs: (() -> Void)?
+
     @State private var visible = false
 
     var body: some View {
@@ -600,6 +606,12 @@ private struct ChatBootstrapTimeoutView: View {
                     .foregroundColor(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 320)
+            }
+
+            if let onSendLogs {
+                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                    onSendLogs()
+                }
             }
 
             Spacer()

--- a/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Shown when the daemon fails to start with a structured error.
+/// Displays a category-specific message, expandable technical details,
+/// and retry / send-logs actions.
+struct DaemonStartupErrorView: View {
+    let error: DaemonStartupError
+    let onRetry: () -> Void
+    let onSendLogs: () -> Void
+
+    @State private var visible = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            VIconView(.triangleAlert, size: 28)
+                .foregroundColor(VColor.systemNegativeHover)
+
+            VStack(spacing: VSpacing.sm) {
+                Text("Your assistant couldn\u{2019}t start")
+                    .font(.system(size: 24, weight: .regular, design: .serif))
+                    .foregroundColor(VColor.contentDefault)
+
+                Text(subtitleForCategory(error.category))
+                    .font(.system(size: 14))
+                    .foregroundColor(VColor.contentSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+            }
+
+            technicalDetails
+
+            HStack(spacing: VSpacing.md) {
+                VButton(label: "Retry", leftIcon: VIcon.refreshCw.rawValue, style: .outlined) {
+                    onRetry()
+                }
+                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                    onSendLogs()
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .opacity(visible ? 1 : 0)
+        .onAppear {
+            withAnimation(VAnimation.standard) {
+                visible = true
+            }
+        }
+    }
+
+    // MARK: - Technical Details
+
+    @ViewBuilder
+    private var technicalDetails: some View {
+        DisclosureGroup("Technical details") {
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(error.message)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.contentTertiary)
+                        .textSelection(.enabled)
+
+                    if let detail = error.detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 120)
+        }
+        .font(VFont.caption)
+        .foregroundColor(VColor.contentSecondary)
+        .frame(maxWidth: 380)
+    }
+
+    // MARK: - Category Messages
+
+    private func subtitleForCategory(_ category: String) -> String {
+        switch category {
+        case "MIGRATION_FAILED":
+            return "A database update failed. Sending logs will help us fix this."
+        case "PORT_IN_USE":
+            return "Another process is using the assistant\u{2019}s port. Try quitting other apps and retrying."
+        case "DB_LOCKED":
+            return "The database is locked by another process. Try retrying in a moment."
+        case "DB_CORRUPT":
+            return "The database appears to be corrupted. Please send logs so we can help."
+        case "ENV_VALIDATION":
+            return "There\u{2019}s a configuration issue. Please send logs so we can help."
+        default:
+            return "Something unexpected happened. Sending logs will help us investigate."
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -56,6 +56,9 @@ struct MainWindowView: View {
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
+    /// Mirrors `AppDelegate.daemonStartupError` so SwiftUI re-renders the
+    /// daemon loading overlay when a structured error arrives or is cleared.
+    @State private var daemonStartupError: DaemonStartupError?
 
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
@@ -346,6 +349,26 @@ struct MainWindowView: View {
         return false
     }
 
+    /// Daemon loading overlay extracted to reduce type-checker pressure on `coreLayoutView`.
+    @ViewBuilder
+    private var daemonLoadingOverlayIfNeeded: some View {
+        if showDaemonLoading && !isSettingsOpen {
+            DaemonLoadingOverlayContent(
+                error: daemonStartupError,
+                onRetry: { handleDaemonRetry() },
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow() }
+            )
+            .transition(.opacity)
+        }
+    }
+
+    private func handleDaemonRetry() {
+        daemonStartupError = nil
+        AppDelegate.shared?.daemonStartupError = nil
+        showDaemonLoading = true
+        retryDaemonStartup()
+    }
+
     /// Top bar extracted to break up type-checker complexity.
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
@@ -466,10 +489,7 @@ struct MainWindowView: View {
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
                             .animation(nil, value: sidebarExpanded)
                             .overlay {
-                                if showDaemonLoading && !isSettingsOpen {
-                                    DaemonLoadingChatSkeleton()
-                                        .transition(.opacity)
-                                }
+                                daemonLoadingOverlayIfNeeded
                             }
                     }
                     .padding(16)
@@ -674,6 +694,14 @@ struct MainWindowView: View {
                 windowState.persistentConversationId = activeId
             }
             daemonClient.startSSE()
+            // Sync initial daemon startup error state
+            daemonStartupError = AppDelegate.shared?.daemonStartupError
+        }
+        .task {
+            guard let appDelegate = AppDelegate.shared else { return }
+            for await error in appDelegate.$daemonStartupError.values {
+                daemonStartupError = error
+            }
         }
         .onDisappear {
             sharing.errorDismissTask?.cancel()
@@ -874,6 +902,36 @@ struct MainWindowView: View {
         // SidebarInteractionState.setConversationHover(conversationId:hovering:)
     }
 
+    /// Restart the daemon process without re-hatching a new assistant.
+    /// Stops the existing daemon, then re-hatches with daemonOnly + restart
+    /// flags to avoid creating a duplicate assistant entry.
+    private func retryDaemonStartup() {
+        Task {
+            let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            guard let appDelegate = AppDelegate.shared else { return }
+            appDelegate.assistantCli.stop(name: assistantName)
+            do {
+                try await appDelegate.assistantCli.hatch(
+                    name: assistantName,
+                    daemonOnly: true,
+                    restart: true
+                )
+            } catch let error as AssistantCli.CLIError {
+                if case .daemonStartupFailed(let startupError) = error {
+                    appDelegate.daemonStartupError = startupError
+                    daemonStartupError = startupError
+                }
+                return
+            } catch {
+                return
+            }
+            // Reconnect the daemon client after a successful restart
+            if !appDelegate.daemonClient.isConnected && !appDelegate.daemonClient.isConnecting {
+                try? await appDelegate.daemonClient.connect()
+            }
+        }
+    }
+
 }
 
 // MARK: - Error Toast Overlay
@@ -937,5 +995,33 @@ private struct ErrorToastOverlay: View {
         .animation(VAnimation.fast, value: hasAPIKey)
         .animation(VAnimation.fast, value: errorManager.conversationError != nil)
         .animation(VAnimation.fast, value: errorManager.errorText != nil)
+    }
+}
+
+// MARK: - Daemon Loading Overlay Content
+
+/// Standalone view for the daemon loading overlay that shows either a
+/// structured error view or the default skeleton placeholder.
+/// Extracted from MainWindowView to reduce type-checker complexity in
+/// `coreLayoutView`.
+private struct DaemonLoadingOverlayContent: View {
+    let error: DaemonStartupError?
+    let onRetry: () -> Void
+    let onSendLogs: () -> Void
+
+    var body: some View {
+        if let error {
+            ZStack {
+                VColor.surfaceBase
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                DaemonStartupErrorView(
+                    error: error,
+                    onRetry: onRetry,
+                    onSendLogs: onSendLogs
+                )
+            }
+        } else {
+            DaemonLoadingChatSkeleton()
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -710,7 +710,10 @@ struct ActiveChatViewWrapper: View {
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,
             loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
             isBootstrapping: isBootstrapping,
-            isBootstrapTimedOut: isBootstrapTimedOut
+            isBootstrapTimedOut: isBootstrapTimedOut,
+            onBootstrapSendLogs: {
+                AppDelegate.shared?.showLogReportWindow()
+            }
         )
         .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
     }


### PR DESCRIPTION
## Summary
- Add `DaemonStartupErrorView` that replaces the skeleton loading overlay when a structured daemon startup error is detected, showing category-specific messages, expandable technical details, and Retry / Send Logs actions
- Wire the error view into `MainWindowView`'s daemon loading overlay via `DaemonLoadingOverlayContent`, observing `AppDelegate.daemonStartupError` through a `.task` async sequence
- Add a "Send Logs to Vellum" button to `ChatBootstrapTimeoutView` for the bootstrap timeout case

Part of plan: daemon-startup-error-ux.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
