### PR TITLE
Add hover tooltip to Voice Mode button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -76,6 +76,7 @@ struct ComposerView: View {
     @State private var avatarSeed: String = "default"
     /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
     @State private var preDictationText: String = ""
+    @State private var showVoiceModeHover: Bool = false
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
     @State private var liveAmplitude: Float = 0
     @State private var isComposerDropTargeted = false
@@ -497,6 +498,17 @@ struct ComposerView: View {
                     )
                     .disabled(!hasAPIKey)
                     .transition(.scale.combined(with: .opacity))
+                    .popover(isPresented: $showVoiceModeHover, arrowEdge: .top) {
+                        Text("Start a live voice conversation with your assistant. Unlike the mic button, this is a real-time back-and-forth voice call.")
+                            .font(VFont.caption)
+                            .multilineTextAlignment(.leading)
+                            .frame(width: 200)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(VSpacing.sm)
+                    }
+                    .onHover { hovering in
+                        showVoiceModeHover = hovering
+                    }
                 } else {
                     VButton(
                         label: isRecording ? "Stop recording" : "Start voice input",


### PR DESCRIPTION
Adds a popover tooltip on hover over the Voice Mode (waveform) button in the composer, explaining that it starts a live two-way voice conversation — distinct from the mic button dictation mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
