### PR TITLE
fix: replace gmail with valid provider names in oauth providers help text

### DIFF
--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -73,8 +73,8 @@ export function registerProviderCommands(oauth: Command): void {
 Providers define the protocol-level configuration for an OAuth integration:
 authorization URL, token URL, default scopes, and other endpoint details.
 
-They are seeded on startup for built-in integrations (e.g. Gmail, Twitter,
-Slack) but can also be registered dynamically via the "register" subcommand.
+They are seeded on startup for built-in integrations (e.g. Google, Slack,
+GitHub) but can also be registered dynamically via the "register" subcommand.
 
 Each provider is identified by a provider key (e.g. "integration:google").`,
   );
@@ -88,7 +88,7 @@ Each provider is identified by a provider key (e.g. "integration:google").`,
     .description("List all registered OAuth providers")
     .option(
       "--provider-key <key>",
-      'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "gmail,google")',
+      'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "google,slack")',
     )
     .addHelpText(
       "after",
@@ -98,8 +98,8 @@ seeded at startup and any dynamically registered via "providers register".
 
 When --provider-key is specified, only providers whose key contains the
 given substring (case-insensitive) are returned. Multiple substrings can
-be OR'd together using commas (e.g. "gmail,google" matches any provider
-whose key contains "gmail" OR "google"). Without the flag, all providers
+be OR'd together using commas (e.g. "google,slack" matches any provider
+whose key contains "google" OR "slack"). Without the flag, all providers
 are listed.
 
 Each provider row includes its key, auth URL, token URL, default scopes,
@@ -107,9 +107,9 @@ and configuration timestamps.
 
 Examples:
   $ assistant oauth providers list
-  $ assistant oauth providers list --provider-key gmail
-  $ assistant oauth providers list --provider-key "gmail,google"
-  $ assistant oauth providers list --provider-key slack --json`,
+  $ assistant oauth providers list --provider-key google
+  $ assistant oauth providers list --provider-key "google,slack"
+  $ assistant oauth providers list --provider-key notion --json`,
     )
     .action((opts: { providerKey?: string }, cmd: Command) => {
       try {


### PR DESCRIPTION
## Summary
- Replaced all `gmail` references in `oauth providers list` help text with valid provider names (`google`, `slack`, `notion`)
- Updated the parent `providers` help text to list Google, Slack, GitHub instead of Gmail, Twitter, Slack
- The actual built-in provider key is `integration:google`, not `gmail`

## Original prompt
gmail isn't a valid provider anymore, update this help text for `assistant oauth providers list --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
