### PR TITLE
fix: narrow ENV_VALIDATION categorization to known env error prefixes

### DIFF
--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -90,11 +90,12 @@ export function categorizeDaemonError(err: unknown): DaemonStartupError {
     };
   }
 
-  // Environment validation errors thrown by validateEnv()
+  // Environment validation errors thrown by validateEnv() or its int() helper
   if (
     message.startsWith("Invalid GATEWAY_PORT") ||
     message.startsWith("Invalid RUNTIME_HTTP_PORT") ||
-    message.startsWith("Invalid ") ||
+    message.startsWith("Invalid integer for GATEWAY_PORT") ||
+    message.startsWith("Invalid integer for RUNTIME_HTTP_PORT") ||
     /\benv\b.*\bvalidat/i.test(message) ||
     /\bvalidat.*\benv\b/i.test(message)
   ) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for daemon-startup-error-ux.md.

**Gap:** ENV_VALIDATION categorization overly broad
**What was expected:** Only actual env validation errors categorized as ENV_VALIDATION
**What was found:** message.startsWith('Invalid ') matched unrelated errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
