### PR TITLE
fix: remove duplicate DAEMON_ERROR emission from lifecycle.ts

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -111,7 +111,6 @@ import {
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
-import { emitDaemonError } from "./startup-error.js";
 import { handleWatchObservation } from "./watch-handler.js";
 
 // Re-export public API so existing consumers don't need to change imports
@@ -899,9 +898,6 @@ export async function runDaemon(): Promise<void> {
   } catch (err) {
     log.error({ err }, "Daemon startup failed — cleaning up");
     cleanupPidFileIfOwner(process.pid);
-    // Emit a structured error line to stderr so both the bundled daemon
-    // binary and dev-mode daemon produce the same parseable format.
-    emitDaemonError(err);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for daemon-startup-error-ux.md.

**Gap:** Double DAEMON_ERROR: emission on stderr
**What was expected:** A single structured error line
**What was found:** Both lifecycle.ts and main.ts emitted the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)