### PR TITLE
fix: non-scrollable empty logs panel + sidebar re-expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -309,18 +309,27 @@ struct MainWindowView: View {
                     sharing.publishError = nil
                 }
 
-                // Collapse the sidebar when an app opens to avoid crowding
-                if sidebarExpanded {
-                    let shouldCollapse: Bool = {
-                        switch newSelection {
-                        case .app, .appEditing: return true
-                        default: return false
-                        }
-                    }()
-                    if shouldCollapse {
-                        withAnimation(VAnimation.panel) {
-                            sidebarExpanded = false
-                        }
+                // Collapse the sidebar when an app opens to avoid crowding;
+                // re-expand when leaving an app so other panels see the sidebar.
+                let wasApp: Bool = {
+                    switch oldSelection {
+                    case .app, .appEditing: return true
+                    default: return false
+                    }
+                }()
+                let isApp: Bool = {
+                    switch newSelection {
+                    case .app, .appEditing: return true
+                    default: return false
+                    }
+                }()
+                if sidebarExpanded && isApp {
+                    withAnimation(VAnimation.panel) {
+                        sidebarExpanded = false
+                    }
+                } else if !sidebarExpanded && wasApp && !isApp {
+                    withAnimation(VAnimation.panel) {
+                        sidebarExpanded = true
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -7,6 +7,11 @@ struct DebugPanel: View {
     let activeSessionId: String?
     var onClose: () -> Void
 
+    private var hasEvents: Bool {
+        guard let conversationId = activeSessionId else { return false }
+        return !(traceStore.eventsByConversation[conversationId] ?? []).isEmpty
+    }
+
     var body: some View {
         VSidePanel(title: "Logs", onClose: onClose, pinnedContent: {
             if let conversationId = activeSessionId {
@@ -15,34 +20,34 @@ struct DebugPanel: View {
 
                 // Render timeline in pinned area so it owns its own ScrollView
                 // without nesting inside VSidePanel's scrollable content slot.
-                let events = traceStore.eventsByConversation[conversationId] ?? []
-                if !events.isEmpty {
+                if hasEvents {
                     TraceTimelineView(traceStore: traceStore, conversationId: conversationId)
                 }
             }
-        }) {
-            if let conversationId = activeSessionId {
-                let events = traceStore.eventsByConversation[conversationId] ?? []
-                if events.isEmpty {
+
+            // Empty states live in the pinned (non-scrollable) area so they
+            // stay centered and the panel doesn't scroll when there's nothing.
+            if !hasEvents {
+                Spacer()
+                if activeSessionId != nil {
                     VEmptyState(
                         title: "No trace events yet",
                         subtitle: "Events will appear as the session runs",
                         icon: "waveform.path"
                     )
-                    .containerRelativeFrame([.horizontal, .vertical]) { size, _ in
-                        CGSize(width: size.width - 2 * VSpacing.lg, height: size.height - 2 * VSpacing.lg)
-                    }
+                } else {
+                    VEmptyState(
+                        title: "No session selected",
+                        subtitle: "Start a conversation to see trace events",
+                        icon: "ant"
+                    )
                 }
-            } else {
-                VEmptyState(
-                    title: "No session selected",
-                    subtitle: "Start a conversation to see trace events",
-                    icon: "ant"
-                )
-                .containerRelativeFrame([.horizontal, .vertical]) { size, _ in
-                        CGSize(width: size.width - 2 * VSpacing.lg, height: size.height - 2 * VSpacing.lg)
-                    }
+                Spacer()
             }
+        }) {
+            // Content slot intentionally empty when no events — the empty
+            // state is rendered in pinnedContent above to avoid scrolling.
+            EmptyView()
         }
         .onAppear { traceStore.isObserved = true }
         .onDisappear { traceStore.isObserved = false }


### PR DESCRIPTION
## Summary
- Move empty state messages in DebugPanel from the scrollable content slot to the pinned area so empty logs are centered and not scrollable
- Re-expand the conversation sidebar when navigating away from an app panel (sidebar was collapsing for apps but never restoring)

## Original prompt
empty logs shouldn't be scrollable at all, just have empty message in a middle of content section. why sidebar disappeared (I think it was there when in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
