### PR TITLE
fix: report retry failures to Sentry in retryDaemonStartup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -920,6 +920,7 @@ struct MainWindowView: View {
                 if case .daemonStartupFailed(let startupError) = error {
                     appDelegate.daemonStartupError = startupError
                     daemonStartupError = startupError
+                    MetricKitManager.reportDaemonStartupFailure(startupError)
                 }
                 return
             } catch {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for daemon-startup-error-ux.md.

**Gap:** Retry failures not reported to Sentry
**What was expected:** All daemon startup failures reported
**What was found:** Only initial startup failures were reported, not retry failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
