### PR TITLE
fix: clear daemonStartupError after successful fallback hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -397,13 +397,23 @@ extension AppDelegate {
                         }
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                            do {
+                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                self.daemonStartupError = nil
+                            } catch {
+                                log.error("Fallback daemon-only hatch also failed: \(error)")
+                            }
                         }
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                            do {
+                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                self.daemonStartupError = nil
+                            } catch {
+                                log.error("Fallback daemon-only hatch also failed: \(error)")
+                            }
                         }
                     }
                     if needsLockfileEntry {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for daemon-startup-error-ux.md.

**Gap:** Stale daemonStartupError persists after fallback retry success
**What was expected:** Error cleared when fallback succeeds
**What was found:** daemonStartupError was never set to nil after successful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)