### PR TITLE
fix: pre-fill log report reason as connectionIssue for daemon errors

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -497,7 +497,7 @@ extension AppDelegate {
         }
     }
 
-    func showLogReportWindow(scope: LogExportScope = .global) {
+    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = nil) {
         // If the window is already showing, just bring it forward.
         if let existing = logReportWindow, existing.isVisible {
             existing.makeKeyAndOrderFront(nil)
@@ -511,6 +511,7 @@ extension AppDelegate {
 
         let view = LogReportFormView(
             authManager: authManager,
+            initialReason: reason,
             onSend: { [weak self] formData in
                 self?.dismissLogReportWindow()
                 var formData = formData

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -356,7 +356,7 @@ struct MainWindowView: View {
             DaemonLoadingOverlayContent(
                 error: daemonStartupError,
                 onRetry: { handleDaemonRetry() },
-                onSendLogs: { AppDelegate.shared?.showLogReportWindow() }
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue) }
             )
             .transition(.opacity)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -712,7 +712,7 @@ struct ActiveChatViewWrapper: View {
             isBootstrapping: isBootstrapping,
             isBootstrapTimedOut: isBootstrapTimedOut,
             onBootstrapSendLogs: {
-                AppDelegate.shared?.showLogReportWindow()
+                AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
             }
         )
         .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -8,6 +8,7 @@ struct LogReportFormView: View {
     enum Field { case email, name, message }
 
     let authManager: AuthManager
+    let initialReason: LogReportReason?
     let onSend: (LogReportFormData) -> Void
     let onCancel: () -> Void
 
@@ -16,6 +17,19 @@ struct LogReportFormView: View {
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
     @FocusState private var focusedField: Field?
+
+    init(
+        authManager: AuthManager,
+        initialReason: LogReportReason? = nil,
+        onSend: @escaping (LogReportFormData) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.authManager = authManager
+        self.initialReason = initialReason
+        self.onSend = onSend
+        self.onCancel = onCancel
+        self._selectedReason = State(initialValue: initialReason)
+    }
 
     private var canSend: Bool {
         selectedReason != nil && !email.isEmpty


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for daemon-startup-error-ux.md.

**Gap:** Log report reason not pre-filled
**What was expected:** LogReportFormView opens with Connection Issue pre-selected
**What was found:** No reason was passed through

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
