### PR TITLE
fix: track auto-collapse flag so sidebar re-expand respects manual preference

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -29,6 +29,10 @@ struct MainWindowView: View {
     @State private var preTemporaryChatConversationId: UUID?
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
+    /// True when the sidebar was auto-collapsed by entering an app panel.
+    /// Used to distinguish automatic collapse from manual user collapse so
+    /// we only re-expand the sidebar on app exit when it was our doing.
+    @State private var sidebarAutoCollapsedForApp = false
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     let sidebarExpandedWidth: CGFloat = 240
@@ -326,10 +330,12 @@ struct MainWindowView: View {
                 if sidebarExpanded && isApp {
                     withAnimation(VAnimation.panel) {
                         sidebarExpanded = false
+                        sidebarAutoCollapsedForApp = true
                     }
-                } else if !sidebarExpanded && wasApp && !isApp {
+                } else if sidebarAutoCollapsedForApp && wasApp && !isApp {
                     withAnimation(VAnimation.panel) {
                         sidebarExpanded = true
+                        sidebarAutoCollapsedForApp = false
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add `sidebarAutoCollapsedForApp` state flag to distinguish automatic sidebar collapse (entering app panel) from manual user collapse
- Only re-expand the sidebar when leaving an app if it was auto-collapsed, preserving user's manual preference

Addresses review feedback from #17817: both Codex and Devin flagged that the previous re-expand logic overrode the user's deliberate sidebar collapse preference.

## Original prompt
https://github.com/vellum-ai/vellum-assistant/pull/17817 address feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
