### PR TITLE
refactor: update stale session references in conversation-management-routes.ts

### DIFF
--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -1,5 +1,5 @@
 /**
- * Route handlers for session management operations.
+ * Route handlers for conversation management operations.
  *
  * POST   /v1/conversations/switch         — switch to an existing conversation
  * PATCH  /v1/conversations/:id/name       — rename a conversation
@@ -39,7 +39,7 @@ export interface ConversationManagementDeps {
   renameConversation: (conversationId: string, name: string) => boolean;
   clearAllConversations: () => number;
   cancelGeneration: (conversationId: string) => boolean;
-  /** Abort and dispose an active in-memory session (if any) before deletion. */
+  /** Abort and dispose an active in-memory conversation (if any) before deletion. */
   destroyConversation: (conversationId: string) => void;
   undoLastMessage: (
     conversationId: string,
@@ -134,7 +134,7 @@ export function conversationManagementRouteDefinitions(
             404,
           );
         }
-        // Tear down the in-memory session (abort + dispose) before removing
+        // Tear down the in-memory conversation (abort + dispose) before removing
         // persistence so that a running agent loop doesn't write to a deleted
         // conversation row, tripping FK constraints.
         deps.destroyConversation(resolvedId);
@@ -176,7 +176,7 @@ export function conversationManagementRouteDefinitions(
         if (!result) {
           return httpError(
             "NOT_FOUND",
-            `No active session for conversation ${params.id}`,
+            `No active conversation for ${params.id}`,
             404,
           );
         }
@@ -196,7 +196,7 @@ export function conversationManagementRouteDefinitions(
           if (!result) {
             return httpError(
               "NOT_FOUND",
-              `No active session for conversation ${params.id}`,
+              `No active conversation for ${params.id}`,
               404,
             );
           }


### PR DESCRIPTION
## Summary
- Update doc comment from session→conversation management operations
- Fix 2 inline comments referring to in-memory session→conversation
- Fix 2 error messages from "No active session for conversation" → "No active conversation for"

Part of plan: conv-sweep-final.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
