### PR TITLE
fix: sleep assistant when all conversations are archived

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -619,24 +619,19 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             chatViewModels[id]?.cancelPendingMessage()
         }
 
-        // If the archived conversation was active, select an adjacent visible conversation
-        // or create a new one if none remain.
-        if activeConversationId == id {
-            // Find the position of the archived conversation among visible conversations
-            // (before archiving filtered it out) and pick the neighbor.
-            let visible = visibleConversations
-            if !visible.isEmpty {
-                // The archived conversation was at `index` in the full `conversations` array.
-                // Find the closest visible conversation by scanning neighbors.
-                let visibleAfter = conversations[index...].dropFirst().first(where: { !$0.isArchived })
-                let visibleBefore = conversations[..<index].last(where: { !$0.isArchived })
-                if let next = visibleAfter ?? visibleBefore {
-                    activeConversationId = next.id
-                } else {
-                    activeConversationId = visible.first?.id
-                }
+        // If all non-private conversations are now archived, sleep the assistant
+        // so it stops running and sending notifications.
+        if visibleConversations.isEmpty {
+            log.info("All conversations archived — sleeping assistant")
+            sleepAssistantAfterArchive()
+        } else if activeConversationId == id {
+            // The archived conversation was active — select an adjacent visible one.
+            let visibleAfter = conversations[index...].dropFirst().first(where: { !$0.isArchived })
+            let visibleBefore = conversations[..<index].last(where: { !$0.isArchived })
+            if let next = visibleAfter ?? visibleBefore {
+                activeConversationId = next.id
             } else {
-                createConversation()
+                activeConversationId = visibleConversations.first?.id
             }
         }
 
@@ -666,6 +661,21 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     func isConversationArchived(_ conversationId: String) -> Bool {
         archivedConversationIds.contains(conversationId)
+    }
+
+    /// Sleep the assistant after all conversations have been archived.
+    /// This stops the daemon process so it no longer sends notifications.
+    private func sleepAssistantAfterArchive() {
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              !assistantId.isEmpty else { return }
+        Task {
+            do {
+                try await AppDelegate.shared?.assistantCli.sleep(name: assistantId)
+                log.info("Assistant '\(assistantId, privacy: .private)' slept after all conversations archived")
+            } catch {
+                log.error("Failed to sleep assistant after archiving: \(error.localizedDescription)")
+            }
+        }
     }
 
     /// Load more conversations from the daemon (pagination).


### PR DESCRIPTION
## Summary
- When all non-private conversations are archived, sleep the assistant daemon so it stops running and sending notifications
- Previously, archiving the last conversation would create a new empty one while the daemon kept running in the background
- Uses the existing `AssistantCli.sleep()` mechanism (same as the developer tab sleep toggle)

## Original prompt
When a user archives an assistant, the assistant process should be stopped. Currently archiving is a client-side concept that hides the assistant from the UI, but the assistant keeps running and sending notifications. We need to find where archiving happens (likely in the client/gateway) and ensure the assistant is stopped (sleep/stop) when archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
