### PR TITLE
feat: add ImproveExperienceStepView for onboarding privacy & ToS consent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import VellumAssistantShared
+
+@MainActor
+struct ImproveExperienceStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showTitle = false
+    @State private var showContent = false
+    @State private var collectUsageData: Bool = true
+    @State private var sendDiagnostics: Bool = true
+    @State private var tosAccepted: Bool = false
+
+    var body: some View {
+        Text("Help improve Vellum")
+            .font(.system(size: 32, weight: .regular, design: .serif))
+            .foregroundColor(VColor.contentDefault)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
+
+        Text("You can change these settings at any time in Settings > Privacy.")
+            .font(.system(size: 16))
+            .foregroundColor(VColor.contentSecondary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.xxl)
+
+        VStack(spacing: VSpacing.md) {
+            VStack(spacing: VSpacing.md) {
+                // Privacy toggles card
+                VStack(spacing: VSpacing.lg) {
+                    // Usage analytics toggle
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Share usage analytics")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.contentSecondary)
+                            Text("Send anonymized usage metrics (e.g. token counts, feature adoption) to help us improve the product. No personal data or message content is included.")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                        Spacer()
+                        VToggle(isOn: $collectUsageData)
+                    }
+
+                    SettingsDivider()
+
+                    // Diagnostics toggle
+                    HStack {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Send diagnostics")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.contentSecondary)
+                            Text("Share crash reports, error diagnostics, and performance metrics (hang rate, responsiveness) to help us improve stability. No personal data or message content is included.")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                        Spacer()
+                        VToggle(isOn: $sendDiagnostics)
+                    }
+                }
+                .padding(VSpacing.lg)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+
+                // ToS consent checkbox
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    Image(systemName: tosAccepted ? "checkmark.square.fill" : "square")
+                        .font(.system(size: 18))
+                        .foregroundColor(tosAccepted ? VColor.primaryBase : VColor.contentTertiary)
+                        .onTapGesture {
+                            tosAccepted.toggle()
+                        }
+
+                    tosConsentText
+                }
+                .padding(.top, VSpacing.xs)
+
+                OnboardingButton(
+                    title: "Continue",
+                    style: .primary,
+                    disabled: !tosAccepted
+                ) {
+                    saveAndContinue()
+                }
+
+                Button(action: { goBack() }) {
+                    Text("Back")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .padding(.top, VSpacing.xs)
+            }
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+                showContent = true
+            }
+        }
+    }
+
+    // MARK: - ToS Consent Text
+
+    private var tosConsentText: some View {
+        (
+            Text("I agree to the ")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+            + Text("[Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.primaryBase)
+            + Text(" and ")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+            + Text("[Privacy Policy](https://www.vellum.ai/docs/vellum-privacy-policy)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.primaryBase)
+        )
+        .environment(\.openURL, OpenURLAction { url in
+            NSWorkspace.shared.open(url)
+            return .handled
+        })
+        .tint(VColor.primaryBase)
+    }
+
+    // MARK: - Actions
+
+    private func saveAndContinue() {
+        UserDefaults.standard.set(collectUsageData, forKey: "collectUsageData")
+        UserDefaults.standard.set(sendDiagnostics, forKey: "sendDiagnostics")
+        UserDefaults.standard.set(true, forKey: "tosAccepted")
+
+        if !sendDiagnostics {
+            MetricKitManager.closeSentry()
+        }
+
+        state.isHatching = true
+    }
+
+    private func goBack() {
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+            state.currentStep -= 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `ImproveExperienceStepView` for onboarding with privacy toggles (usage analytics, diagnostics) and ToS/Privacy Policy consent checkbox
- Follows existing onboarding step patterns (APIKeyEntryStepView) and privacy toggle patterns (SettingsPrivacyTab)
- Continue button gated on ToS acceptance; choices persisted to UserDefaults

Part of plan: onboarding-privacy-tos.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
