### PR TITLE
fix: store trimmed platform assistant ID in credential store

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -156,30 +156,53 @@ export async function handleAddSecret(
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
       const key = credentialKey(service, field);
-      const stored = await setSecureKeyAsync(key, value);
-      if (!stored) {
-        return httpError(
-          "INTERNAL_ERROR",
-          "Failed to store credential in secure storage",
-          500,
-        );
-      }
-      upsertCredentialMetadata(service, field, {});
-      if (service === "vellum" && field === "platform_base_url") {
-        setPlatformBaseUrl(value);
-      }
-      if (service === "vellum" && field === "platform_assistant_id") {
-        const trimmed = value.trim();
-        setPlatformAssistantId(trimmed || undefined);
-      }
-      if (service === "vellum" && field === "platform_organization_id") {
-        const trimmed = value.trim();
-        setPlatformOrganizationId(trimmed || undefined);
-        setSentryOrganizationId(trimmed || undefined);
-      }
-      if (service === "vellum" && field === "platform_user_id") {
-        const trimmed = value.trim();
-        setPlatformUserId(trimmed || undefined);
+
+      // For identity fields, trim whitespace before persisting so the
+      // credential store matches the in-memory value.  Whitespace-only
+      // input is treated as a no-op: nothing is stored and in-memory
+      // state is cleared.
+      const TRIMMED_IDENTITY_FIELDS = new Set([
+        "platform_assistant_id",
+        "platform_organization_id",
+        "platform_user_id",
+      ]);
+      const isTrimmedIdentity =
+        service === "vellum" && TRIMMED_IDENTITY_FIELDS.has(field);
+      const effectiveValue = isTrimmedIdentity ? value.trim() : value;
+
+      if (isTrimmedIdentity && effectiveValue === "") {
+        // Whitespace-only → clear in-memory state, skip store & metadata
+        if (field === "platform_assistant_id") {
+          setPlatformAssistantId(undefined);
+        } else if (field === "platform_organization_id") {
+          setPlatformOrganizationId(undefined);
+          setSentryOrganizationId(undefined);
+        } else if (field === "platform_user_id") {
+          setPlatformUserId(undefined);
+        }
+      } else {
+        const stored = await setSecureKeyAsync(key, effectiveValue);
+        if (!stored) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Failed to store credential in secure storage",
+            500,
+          );
+        }
+        upsertCredentialMetadata(service, field, {});
+        if (service === "vellum" && field === "platform_base_url") {
+          setPlatformBaseUrl(effectiveValue);
+        }
+        if (service === "vellum" && field === "platform_assistant_id") {
+          setPlatformAssistantId(effectiveValue || undefined);
+        }
+        if (service === "vellum" && field === "platform_organization_id") {
+          setPlatformOrganizationId(effectiveValue || undefined);
+          setSentryOrganizationId(effectiveValue || undefined);
+        }
+        if (service === "vellum" && field === "platform_user_id") {
+          setPlatformUserId(effectiveValue || undefined);
+        }
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());


### PR DESCRIPTION
Address Devin review feedback from #17744. Trim the platform_assistant_id value before storing it in the credential store via setSecureKeyAsync, so the persisted value matches the in-memory trimmed version. For whitespace-only input, skip the store and metadata upsert entirely since the credential is functionally empty. Applied the same fix to platform_organization_id and platform_user_id which had the same inconsistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
