### PR TITLE
fix: guard billing bootstrap task cleanup against clobbering newer reference

### DIFF
--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -90,7 +90,6 @@ public final class BillingService {
         }
 
         let task = Task<BillingSummaryResponse?, Never> {
-            defer { bootstrapTasks[orgId] = nil }
             do {
                 let result = try await postBootstrapBillingSummary()
                 // Only persist the flag on success so transient failures don't permanently suppress retries
@@ -102,7 +101,12 @@ public final class BillingService {
             }
         }
         bootstrapTasks[orgId] = task
-        return await task.value
+        let result = await task.value
+        // Only clear if this is still the current task — avoid clobbering a newer reference
+        if bootstrapTasks[orgId] === task {
+            bootstrapTasks[orgId] = nil
+        }
+        return result
     }
 
     /// POST to the billing summary endpoint to create the BillingAccount with initial credit.


### PR DESCRIPTION
Address Devin review feedback from #17750. Guard the defer cleanup in BillingService.bootstrapBillingSummaryIfNeeded against clobbering a newer task reference per clients/AGENTS.md rule. Check task identity before nil-ing the dictionary entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
