### PR TITLE
fix: check response.success in remaining AppsListResponse consumers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsLoader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsLoader.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 enum AppsLoader {
     enum LoadError: Error, Equatable {
         case timedOut
+        case fetchFailed
     }
 
     static func load(
@@ -21,6 +22,9 @@ enum AppsLoader {
                         throw CancellationError()
                     }
                     if case .appsListResponse(let response) = message {
+                        guard response.success else {
+                            throw LoadError.fetchFailed
+                        }
                         return response.apps
                     }
                 }

--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -54,12 +54,11 @@ public final class DirectoryStore: ObservableObject {
 
             let result = await stream.firstMatch { message -> [AppItem]? in
                 if case .appsListResponse(let response) = message {
-                    return response.apps
+                    return response.success ? response.apps : nil
                 }
                 return nil
             }
-            // Only replace if we got actual apps — empty response may be an error fallback
-            if let apps = result, !apps.isEmpty {
+            if let apps = result {
                 self.localApps = apps
             }
             isLoadingApps = false


### PR DESCRIPTION
Address Devin review feedback from #17755. Add response.success checking to AppsLoader.load() and DirectoryStore.fetchApps(), which were missed by the original PR. When success is false, preserve existing cached data instead of replacing it with an empty list from an error response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
