### PR TITLE
feat: add organization_id and user_id Sentry tags

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -13,6 +13,7 @@ extension AppDelegate {
     func startAuthenticatedFlow() {
         Task {
             await authManager.checkSession()
+            SentryDeviceInfo.updateUserTag(authManager.currentUser?.id)
             let isAuthed = authManager.isAuthenticated
             let hasKey = APIKeyManager.hasAnyKey()
             log.info("[authFlow] isAuthenticated=\(isAuthed) hasAnyKey=\(hasKey)")
@@ -316,10 +317,12 @@ extension AppDelegate {
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
                 self.localBootstrapDidComplete = true
+                SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
                 self.localBootstrapDidComplete = true
+                SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
                 self.mainWindow?.windowState.showToast(
                     message: "Failed to set up Vellum credentials. You may need to sign out and sign in again.",
@@ -359,6 +362,7 @@ extension AppDelegate {
         SentryDeviceInfo.updateAssistantTag(assistant.assistantId)
         // Clear stale org ID so the next bootstrap re-resolves it for the new assistant
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        SentryDeviceInfo.updateOrganizationTag(nil)
         // Clear stale actor token for the previous assistant
         actorTokenBootstrapTask?.cancel()
         actorTokenBootstrapTask = nil
@@ -519,6 +523,8 @@ extension AppDelegate {
         UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
         SentryDeviceInfo.updateAssistantTag(nil)
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        SentryDeviceInfo.updateOrganizationTag(nil)
+        SentryDeviceInfo.updateUserTag(nil)
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
         daemonClient.disconnect()

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -38,6 +38,11 @@ enum SentryDeviceInfo {
             } else {
                 scope.removeTag(key: "assistant_id")
             }
+            if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !orgId.isEmpty {
+                scope.setTag(value: orgId, key: "organization_id")
+            } else {
+                scope.removeTag(key: "organization_id")
+            }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
         }
     }
@@ -50,6 +55,28 @@ enum SentryDeviceInfo {
                 scope.setTag(value: id, key: "assistant_id")
             } else {
                 scope.removeTag(key: "assistant_id")
+            }
+        }
+    }
+
+    /// Updates the `organization_id` Sentry tag when the connected organization changes.
+    static func updateOrganizationTag(_ organizationId: String?) {
+        SentrySDK.configureScope { scope in
+            if let id = organizationId, !id.isEmpty {
+                scope.setTag(value: id, key: "organization_id")
+            } else {
+                scope.removeTag(key: "organization_id")
+            }
+        }
+    }
+
+    /// Updates the `user_id` Sentry tag when the authenticated user changes.
+    static func updateUserTag(_ userId: String?) {
+        SentrySDK.configureScope { scope in
+            if let id = userId, !id.isEmpty {
+                scope.setTag(value: id, key: "user_id")
+            } else {
+                scope.removeTag(key: "user_id")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Added `organization_id` and `user_id` as Sentry scope tags on the macOS app, following the same pattern as the existing `assistant_id` tag
- `organization_id` is sourced from `UserDefaults["connectedOrganizationId"]` after bootstrap completes, and cleared on assistant switch / sign-out
- `user_id` is sourced from `AuthManager.currentUser?.id` after session check, and cleared on sign-out

## Original prompt
Add organization_id and user_id Sentry tags for macOS, following the same pattern as assistant/src/telemetry/usage-telemetry-reporter.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
