### PR TITLE
feat: wire ImproveExperienceStepView into onboarding flow as step 3

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -143,7 +143,7 @@ struct APIKeyEntryStepView: View {
         APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
         saveModelToConfig("claude-opus-4-6")
-        state.isHatching = true
+        state.advance()
     }
 
     private func saveModelToConfig(_ model: String) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -27,7 +27,7 @@ struct OnboardingFlowView: View {
     }
 
     private var maxOnboardingStep: Int {
-        return 2
+        return 3
     }
 
     var body: some View {
@@ -51,7 +51,7 @@ struct OnboardingFlowView: View {
                         .ignoresSafeArea()
                     )
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
-                // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry (steps 0–2)
+                // Onboarding flow: WakeUp → HostingSelector → APIKeyEntry → ImproveExperience (steps 0–3)
                 ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
@@ -106,6 +106,8 @@ struct OnboardingFlowView: View {
                                 )
                             case 2:
                                 APIKeyEntryStepView(state: state)
+                            case 3:
+                                ImproveExperienceStepView(state: state)
                             default:
                                 EmptyView()
                             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -27,7 +27,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 12
+    private static let currentFlowVersion = 13
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -95,7 +95,7 @@ final class OnboardingState {
         case 0: return hasHatched ? 0.15 : 0.0
         case 1: return 0.20
         case 2: return 0.25
-        case 3: return 0.30
+        case 3: return 0.35
         case 4: return 0.60
         case 5: return speechGranted ? 0.70 : 0.65
         case 6: return accessibilityGranted ? 0.80 : 0.70
@@ -143,22 +143,14 @@ final class OnboardingState {
         let isManagedSignIn = MacOSClientFeatureFlagManager.shared.isEnabled("managed_sign_in_enabled")
         let maxStep: Int
         if isManagedSignIn {
-            maxStep = 2
+            maxStep = 3
         } else if onboardingVariant == .firstMeeting {
             maxStep = 4
         } else {
-            maxStep = 2
+            maxStep = 3
         }
         if currentStep > maxStep {
             currentStep = maxStep
-        }
-
-        // Opt in to usage data and diagnostics by default for new users.
-        if UserDefaults.standard.object(forKey: "collectUsageData") == nil {
-            UserDefaults.standard.set(true, forKey: "collectUsageData")
-        }
-        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil {
-            UserDefaults.standard.set(true, forKey: "sendDiagnostics")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add ImproveExperienceStepView as step 3 in the onboarding flow between API key entry and hatching
- API key entry now advances to step 3 instead of triggering hatching directly
- Bump flow version to 13 and update step clamping and crack progress mapping

Part of plan: onboarding-privacy-tos.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
