### PR TITLE
Move view mode toggle into file header bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -720,6 +720,18 @@ private struct WorkspaceFileViewer: View {
                 fileName: detail.name,
                 fileSize: formatFileSize(detail.size)
             ) {
+                if isText {
+                    let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
+                    if modes.count > 1 {
+                        VSegmentedControl(
+                            items: modes.map { (label: viewModeLabel($0), tag: $0) },
+                            selection: $state.viewMode,
+                            style: .pill
+                        )
+                        .frame(width: CGFloat(modes.count) * 80)
+                    }
+                }
+
                 if isText && readOnly {
                     Text("Read-only")
                         .font(VFont.caption)
@@ -770,20 +782,6 @@ private struct WorkspaceFileViewer: View {
         let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
         let effectiveMode = modes.contains(state.viewMode) ? state.viewMode : (modes.first ?? .source)
 
-        if modes.count > 1 {
-            HStack(spacing: 0) {
-                VSegmentedControl(
-                    items: modes.map { (label: viewModeLabel($0), tag: $0) },
-                    selection: $state.viewMode,
-                    style: .pill
-                )
-                .frame(width: CGFloat(modes.count) * 100)
-                Spacer()
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-        }
-
         switch effectiveMode {
         case .source:
             sourceView(detail)
@@ -821,12 +819,12 @@ private struct WorkspaceFileViewer: View {
 
     private func previewView(_ detail: WorkspaceFileResponse) -> some View {
         MarkdownPreviewView(content: state.editableContent)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private func treeView(_ detail: WorkspaceFileResponse) -> some View {
         JSONTreeView(content: state.editableContent)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private func saveFile(path: String) async {


### PR DESCRIPTION
## Summary
- Move VSegmentedControl (Source/Preview, Source/Tree) from standalone row below header into the FileContentHeaderBar trailing content area
- Fix preview and tree view content alignment to top-leading instead of default center alignment
- Reduce toggle width from 100pt to 80pt per segment to fit the header

## Test plan
- [ ] Open a `.json` file in Workspace — Source/Tree toggle should appear in the header bar next to file size
- [ ] Open a `.md` file in Workspace — Source/Preview toggle should appear in the header bar next to file size
- [ ] Tree view content should be aligned to top-left, not centered
- [ ] Markdown preview content should be aligned to top-left, not centered
- [ ] Files with only one view mode (e.g. `.ts`) should show no toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
