### PR TITLE
feat: daemon startup error UX

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -111,6 +111,7 @@ import {
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
+import { emitDaemonError } from "./startup-error.js";
 import { handleWatchObservation } from "./watch-handler.js";
 
 // Re-export public API so existing consumers don't need to change imports
@@ -898,6 +899,9 @@ export async function runDaemon(): Promise<void> {
   } catch (err) {
     log.error({ err }, "Daemon startup failed — cleaning up");
     cleanupPidFileIfOwner(process.pid);
+    // Emit a structured error line to stderr so both the bundled daemon
+    // binary and dev-mode daemon produce the same parseable format.
+    emitDaemonError(err);
     throw err;
   }
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -111,7 +111,6 @@ import {
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
-import { emitDaemonError } from "./startup-error.js";
 import { handleWatchObservation } from "./watch-handler.js";
 
 // Re-export public API so existing consumers don't need to change imports
@@ -899,9 +898,6 @@ export async function runDaemon(): Promise<void> {
   } catch (err) {
     log.error({ err }, "Daemon startup failed — cleaning up");
     cleanupPidFileIfOwner(process.pid);
-    // Emit a structured error line to stderr so both the bundled daemon
-    // binary and dev-mode daemon produce the same parseable format.
-    emitDaemonError(err);
     throw err;
   }
 }

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/node";
 
 import { getLogger } from "../util/logger.js";
 import { runDaemon } from "./lifecycle.js";
+import { emitDaemonError } from "./startup-error.js";
 
 runDaemon().catch(async (err) => {
   Sentry.captureException(err);
@@ -22,5 +23,8 @@ runDaemon().catch(async (err) => {
   console.error(
     "Troubleshooting: check if another assistant is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/",
   );
+  // Emit a structured error line as the last line of stderr so consumers
+  // (e.g. the macOS app) can parse it reliably.
+  emitDaemonError(err);
   process.exit(1);
 });

--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -90,11 +90,12 @@ export function categorizeDaemonError(err: unknown): DaemonStartupError {
     };
   }
 
-  // Environment validation errors thrown by validateEnv()
+  // Environment validation errors thrown by validateEnv() or its int() helper
   if (
     message.startsWith("Invalid GATEWAY_PORT") ||
     message.startsWith("Invalid RUNTIME_HTTP_PORT") ||
-    message.startsWith("Invalid ") ||
+    message.startsWith("Invalid integer for GATEWAY_PORT") ||
+    message.startsWith("Invalid integer for RUNTIME_HTTP_PORT") ||
     /\benv\b.*\bvalidat/i.test(message) ||
     /\bvalidat.*\benv\b/i.test(message)
   ) {

--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -1,0 +1,125 @@
+/**
+ * Structured startup error reporting for daemon processes.
+ *
+ * When the daemon fails to start, the last line of stderr contains a
+ * machine-readable JSON object prefixed with `DAEMON_ERROR:` so that
+ * consumers (e.g. the macOS app) can parse it reliably.
+ */
+
+/** Known error categories emitted on startup failure. */
+export type DaemonErrorCategory =
+  | "MIGRATION_FAILED"
+  | "PORT_IN_USE"
+  | "DB_LOCKED"
+  | "DB_CORRUPT"
+  | "ENV_VALIDATION"
+  | "UNKNOWN";
+
+export interface DaemonStartupError {
+  error: DaemonErrorCategory;
+  message: string;
+  detail: string;
+}
+
+const DAEMON_ERROR_PREFIX = "DAEMON_ERROR:";
+
+/**
+ * Inspect an error and return a categorized {@link DaemonStartupError}.
+ */
+export function categorizeDaemonError(err: unknown): DaemonStartupError {
+  const code = (err as { code?: string }).code ?? "";
+  const name = (err as { name?: string }).name ?? "";
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : String(err);
+
+  // SQLite constraint errors during startup are almost always migration failures
+  // (e.g. UNIQUE constraint violations when a migration re-runs).
+  if (
+    code.startsWith("SQLITE_CONSTRAINT") ||
+    (name === "SQLiteError" && message.includes("UNIQUE constraint"))
+  ) {
+    return {
+      error: "MIGRATION_FAILED",
+      message: message,
+      detail:
+        "A database migration failed due to a constraint violation during startup.",
+    };
+  }
+
+  // Generic migration detection: if the error message mentions "migration"
+  // alongside SQLite, categorize as MIGRATION_FAILED.
+  if (name === "SQLiteError" && /migration/i.test(message)) {
+    return {
+      error: "MIGRATION_FAILED",
+      message: message,
+      detail: "A database migration failed during startup.",
+    };
+  }
+
+  // Port already in use
+  if (code === "EADDRINUSE") {
+    return {
+      error: "PORT_IN_USE",
+      message: message,
+      detail:
+        "The required port is already in use. Check if another assistant is already running.",
+    };
+  }
+
+  // Database locked (another process holds the lock)
+  if (code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_LOCKED")) {
+    return {
+      error: "DB_LOCKED",
+      message: message,
+      detail:
+        "The database is locked by another process. Check if another assistant is already running.",
+    };
+  }
+
+  // Database corruption
+  if (code.startsWith("SQLITE_CORRUPT") || code.startsWith("SQLITE_NOTADB")) {
+    return {
+      error: "DB_CORRUPT",
+      message: message,
+      detail:
+        "The database appears to be corrupt. You may need to delete and recreate it.",
+    };
+  }
+
+  // Environment validation errors thrown by validateEnv()
+  if (
+    message.startsWith("Invalid GATEWAY_PORT") ||
+    message.startsWith("Invalid RUNTIME_HTTP_PORT") ||
+    message.startsWith("Invalid ") ||
+    /\benv\b.*\bvalidat/i.test(message) ||
+    /\bvalidat.*\benv\b/i.test(message)
+  ) {
+    return {
+      error: "ENV_VALIDATION",
+      message: message,
+      detail: "Environment variable validation failed during startup.",
+    };
+  }
+
+  // Fallback for uncategorized errors
+  return {
+    error: "UNKNOWN",
+    message: message,
+    detail: "An unexpected error occurred during startup.",
+  };
+}
+
+/**
+ * Write a structured error line to stderr. The line is prefixed with
+ * `DAEMON_ERROR:` followed by JSON, making it unambiguous even if other
+ * stderr output precedes it.
+ */
+export function emitDaemonError(err: unknown): void {
+  const structured = categorizeDaemonError(err);
+  const line = `${DAEMON_ERROR_PREFIX}${JSON.stringify(structured)}`;
+  process.stderr.write(line + "\n");
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -391,6 +391,7 @@ extension AppDelegate {
                         case .daemonStartupFailed(let startupError):
                             log.error("Daemon startup failed [\(startupError.category)]: \(startupError.message, privacy: .private)")
                             self.daemonStartupError = startupError
+                            MetricKitManager.reportDaemonStartupFailure(startupError)
                         default:
                             log.error("Failed to hatch assistant during daemon setup: \(error)")
                         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -386,6 +386,18 @@ extension AppDelegate {
                     let assistantName = assistant?.assistantId
                     do {
                         try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
+                    } catch let error as AssistantCli.CLIError {
+                        switch error {
+                        case .daemonStartupFailed(let startupError):
+                            log.error("Daemon startup failed [\(startupError.category)]: \(startupError.message, privacy: .private)")
+                            self.daemonStartupError = startupError
+                        default:
+                            log.error("Failed to hatch assistant during daemon setup: \(error)")
+                        }
+                        if needsLockfileEntry {
+                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
+                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                        }
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
                         if needsLockfileEntry {

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -397,13 +397,23 @@ extension AppDelegate {
                         }
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                            do {
+                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                self.daemonStartupError = nil
+                            } catch {
+                                log.error("Fallback daemon-only hatch also failed: \(error)")
+                            }
                         }
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                            do {
+                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                self.daemonStartupError = nil
+                            } catch {
+                                log.error("Fallback daemon-only hatch also failed: \(error)")
+                            }
                         }
                     }
                     if needsLockfileEntry {

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -497,7 +497,7 @@ extension AppDelegate {
         }
     }
 
-    func showLogReportWindow(scope: LogExportScope = .global) {
+    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = nil) {
         // If the window is already showing, just bring it forward.
         if let existing = logReportWindow, existing.isVisible {
             existing.makeKeyAndOrderFront(nil)
@@ -511,6 +511,7 @@ extension AppDelegate {
 
         let view = LogReportFormView(
             authManager: authManager,
+            initialReason: reason,
             onSend: { [weak self] formData in
                 self?.dismissLogReportWindow()
                 var formData = formData

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -128,6 +128,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Last time we surfaced the denied-notification permission toast.
     var lastNotificationPermissionToastAtMs: Double = 0
 
+    /// Structured error from the most recent daemon startup failure.
+    /// Populated by `setupDaemonClient()` when `hatch()` throws a
+    /// `CLIError.daemonStartupFailed`. Read by the UI (PR 3) to show a
+    /// contextual error view instead of a generic failure message.
+    @Published var daemonStartupError: DaemonStartupError?
+
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.
     var isCurrentAssistantRemote = false

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -37,6 +37,20 @@ private final class OnceFlag: @unchecked Sendable {
     }
 }
 
+/// Structured error emitted by the daemon on startup failure.
+///
+/// The daemon writes a `DAEMON_ERROR:{...}` JSON line to stderr when startup
+/// fails. This struct captures the parsed fields so the UI can display a
+/// contextual error view instead of a generic failure message.
+struct DaemonStartupError {
+    /// Error category (e.g. "MIGRATION_FAILED", "PORT_IN_USE", "UNKNOWN").
+    let category: String
+    /// Human-readable error message.
+    let message: String
+    /// Optional additional context (stack trace, conflicting PID, etc.).
+    let detail: String?
+}
+
 /// Manages all daemon lifecycle operations through the bundled CLI binary.
 ///
 /// This is the single entry point for hatching, stopping, and retiring the
@@ -48,6 +62,7 @@ final class AssistantCli {
     enum CLIError: LocalizedError {
         case binaryNotFound
         case executionFailed(String)
+        case daemonStartupFailed(DaemonStartupError)
 
         var errorDescription: String? {
             switch self {
@@ -55,6 +70,8 @@ final class AssistantCli {
                 return "CLI binary not found in app bundle"
             case .executionFailed(let message):
                 return "CLI command failed: \(message)"
+            case .daemonStartupFailed(let error):
+                return "Assistant startup failed: \(error.message)"
             }
         }
     }
@@ -118,7 +135,7 @@ final class AssistantCli {
 
         if status != 0 {
             log.error("CLI hatch failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
-            throw CLIError.executionFailed(stderr)
+            throw CLIError.daemonStartupFailed(Self.parseDaemonStartupError(from: stderr))
         }
 
         log.info("CLI hatch completed successfully")
@@ -567,6 +584,32 @@ final class AssistantCli {
     }
 
     // MARK: - Private Helpers
+
+    /// Parse a `DaemonStartupError` from the daemon's stderr output.
+    ///
+    /// Scans for the last line starting with `DAEMON_ERROR:` and parses
+    /// the trailing JSON. Falls back to an `UNKNOWN` category with the
+    /// tail of stderr when no structured marker is found (old daemon binary).
+    private static func parseDaemonStartupError(from stderr: String) -> DaemonStartupError {
+        let lines = stderr.components(separatedBy: .newlines)
+
+        // Find the last DAEMON_ERROR: line (the daemon writes exactly one,
+        // but scanning from the end is more robust).
+        if let markerLine = lines.last(where: { $0.hasPrefix("DAEMON_ERROR:") }) {
+            let jsonString = String(markerLine.dropFirst("DAEMON_ERROR:".count))
+            if let data = jsonString.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                let category = json["error"] as? String ?? "UNKNOWN"
+                let message = json["message"] as? String ?? "Unknown startup error"
+                let detail = json["detail"] as? String
+                return DaemonStartupError(category: category, message: message, detail: detail)
+            }
+        }
+
+        // Fallback for old daemon binaries that don't emit DAEMON_ERROR.
+        let fallbackMessage = String(stderr.suffix(500))
+        return DaemonStartupError(category: "UNKNOWN", message: fallbackMessage, detail: nil)
+    }
 
     /// Kill the gateway directly via PID file — fallback when CLI binary is unavailable.
     private func killGatewayViaPIDFile() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -104,6 +104,10 @@ struct ChatView: View {
     /// timeout window. Shows a failure screen instead of the loading skeleton.
     var isBootstrapTimedOut: Bool = false
 
+    /// Called when the user taps "Send Logs to Vellum" on the bootstrap
+    /// timeout view.
+    var onBootstrapSendLogs: (() -> Void)?
+
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var containerWidth: CGFloat = 0
@@ -141,7 +145,7 @@ struct ChatView: View {
                         .accessibilityLabel("Loading chat history")
                 } else if isEmptyState && isBootstrapping {
                     if isBootstrapTimedOut {
-                        ChatBootstrapTimeoutView()
+                        ChatBootstrapTimeoutView(onSendLogs: onBootstrapSendLogs)
                     } else {
                         ChatBootstrapLoadingView()
                     }
@@ -580,8 +584,10 @@ private struct ChatBootstrapLoadingView: View {
 
 /// Shown during first-launch bootstrap when the daemon fails to connect
 /// within the timeout window. Mirrors the hatch-failure pattern from
-/// onboarding: a centered error message.
+/// onboarding: a centered error message with an option to send logs.
 private struct ChatBootstrapTimeoutView: View {
+    var onSendLogs: (() -> Void)?
+
     @State private var visible = false
 
     var body: some View {
@@ -600,6 +606,12 @@ private struct ChatBootstrapTimeoutView: View {
                     .foregroundColor(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 320)
+            }
+
+            if let onSendLogs {
+                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                    onSendLogs()
+                }
             }
 
             Spacer()

--- a/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Shown when the daemon fails to start with a structured error.
+/// Displays a category-specific message, expandable technical details,
+/// and retry / send-logs actions.
+struct DaemonStartupErrorView: View {
+    let error: DaemonStartupError
+    let onRetry: () -> Void
+    let onSendLogs: () -> Void
+
+    @State private var visible = false
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            VIconView(.triangleAlert, size: 28)
+                .foregroundColor(VColor.systemNegativeHover)
+
+            VStack(spacing: VSpacing.sm) {
+                Text("Your assistant couldn\u{2019}t start")
+                    .font(.system(size: 24, weight: .regular, design: .serif))
+                    .foregroundColor(VColor.contentDefault)
+
+                Text(subtitleForCategory(error.category))
+                    .font(.system(size: 14))
+                    .foregroundColor(VColor.contentSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+            }
+
+            technicalDetails
+
+            HStack(spacing: VSpacing.md) {
+                VButton(label: "Retry", leftIcon: VIcon.refreshCw.rawValue, style: .outlined) {
+                    onRetry()
+                }
+                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                    onSendLogs()
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .opacity(visible ? 1 : 0)
+        .onAppear {
+            withAnimation(VAnimation.standard) {
+                visible = true
+            }
+        }
+    }
+
+    // MARK: - Technical Details
+
+    @ViewBuilder
+    private var technicalDetails: some View {
+        DisclosureGroup("Technical details") {
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(error.message)
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.contentTertiary)
+                        .textSelection(.enabled)
+
+                    if let detail = error.detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 120)
+        }
+        .font(VFont.caption)
+        .foregroundColor(VColor.contentSecondary)
+        .frame(maxWidth: 380)
+    }
+
+    // MARK: - Category Messages
+
+    private func subtitleForCategory(_ category: String) -> String {
+        switch category {
+        case "MIGRATION_FAILED":
+            return "A database update failed. Sending logs will help us fix this."
+        case "PORT_IN_USE":
+            return "Another process is using the assistant\u{2019}s port. Try quitting other apps and retrying."
+        case "DB_LOCKED":
+            return "The database is locked by another process. Try retrying in a moment."
+        case "DB_CORRUPT":
+            return "The database appears to be corrupted. Please send logs so we can help."
+        case "ENV_VALIDATION":
+            return "There\u{2019}s a configuration issue. Please send logs so we can help."
+        default:
+            return "Something unexpected happened. Sending logs will help us investigate."
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -356,7 +356,7 @@ struct MainWindowView: View {
             DaemonLoadingOverlayContent(
                 error: daemonStartupError,
                 onRetry: { handleDaemonRetry() },
-                onSendLogs: { AppDelegate.shared?.showLogReportWindow() }
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue) }
             )
             .transition(.opacity)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -56,6 +56,9 @@ struct MainWindowView: View {
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
+    /// Mirrors `AppDelegate.daemonStartupError` so SwiftUI re-renders the
+    /// daemon loading overlay when a structured error arrives or is cleared.
+    @State private var daemonStartupError: DaemonStartupError?
 
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
@@ -346,6 +349,26 @@ struct MainWindowView: View {
         return false
     }
 
+    /// Daemon loading overlay extracted to reduce type-checker pressure on `coreLayoutView`.
+    @ViewBuilder
+    private var daemonLoadingOverlayIfNeeded: some View {
+        if showDaemonLoading && !isSettingsOpen {
+            DaemonLoadingOverlayContent(
+                error: daemonStartupError,
+                onRetry: { handleDaemonRetry() },
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow() }
+            )
+            .transition(.opacity)
+        }
+    }
+
+    private func handleDaemonRetry() {
+        daemonStartupError = nil
+        AppDelegate.shared?.daemonStartupError = nil
+        showDaemonLoading = true
+        retryDaemonStartup()
+    }
+
     /// Top bar extracted to break up type-checker complexity.
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
@@ -466,10 +489,7 @@ struct MainWindowView: View {
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
                             .animation(nil, value: sidebarExpanded)
                             .overlay {
-                                if showDaemonLoading && !isSettingsOpen {
-                                    DaemonLoadingChatSkeleton()
-                                        .transition(.opacity)
-                                }
+                                daemonLoadingOverlayIfNeeded
                             }
                     }
                     .padding(16)
@@ -674,6 +694,14 @@ struct MainWindowView: View {
                 windowState.persistentConversationId = activeId
             }
             daemonClient.startSSE()
+            // Sync initial daemon startup error state
+            daemonStartupError = AppDelegate.shared?.daemonStartupError
+        }
+        .task {
+            guard let appDelegate = AppDelegate.shared else { return }
+            for await error in appDelegate.$daemonStartupError.values {
+                daemonStartupError = error
+            }
         }
         .onDisappear {
             sharing.errorDismissTask?.cancel()
@@ -874,6 +902,36 @@ struct MainWindowView: View {
         // SidebarInteractionState.setConversationHover(conversationId:hovering:)
     }
 
+    /// Restart the daemon process without re-hatching a new assistant.
+    /// Stops the existing daemon, then re-hatches with daemonOnly + restart
+    /// flags to avoid creating a duplicate assistant entry.
+    private func retryDaemonStartup() {
+        Task {
+            let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            guard let appDelegate = AppDelegate.shared else { return }
+            appDelegate.assistantCli.stop(name: assistantName)
+            do {
+                try await appDelegate.assistantCli.hatch(
+                    name: assistantName,
+                    daemonOnly: true,
+                    restart: true
+                )
+            } catch let error as AssistantCli.CLIError {
+                if case .daemonStartupFailed(let startupError) = error {
+                    appDelegate.daemonStartupError = startupError
+                    daemonStartupError = startupError
+                }
+                return
+            } catch {
+                return
+            }
+            // Reconnect the daemon client after a successful restart
+            if !appDelegate.daemonClient.isConnected && !appDelegate.daemonClient.isConnecting {
+                try? await appDelegate.daemonClient.connect()
+            }
+        }
+    }
+
 }
 
 // MARK: - Error Toast Overlay
@@ -937,5 +995,33 @@ private struct ErrorToastOverlay: View {
         .animation(VAnimation.fast, value: hasAPIKey)
         .animation(VAnimation.fast, value: errorManager.conversationError != nil)
         .animation(VAnimation.fast, value: errorManager.errorText != nil)
+    }
+}
+
+// MARK: - Daemon Loading Overlay Content
+
+/// Standalone view for the daemon loading overlay that shows either a
+/// structured error view or the default skeleton placeholder.
+/// Extracted from MainWindowView to reduce type-checker complexity in
+/// `coreLayoutView`.
+private struct DaemonLoadingOverlayContent: View {
+    let error: DaemonStartupError?
+    let onRetry: () -> Void
+    let onSendLogs: () -> Void
+
+    var body: some View {
+        if let error {
+            ZStack {
+                VColor.surfaceBase
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                DaemonStartupErrorView(
+                    error: error,
+                    onRetry: onRetry,
+                    onSendLogs: onSendLogs
+                )
+            }
+        } else {
+            DaemonLoadingChatSkeleton()
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -920,6 +920,7 @@ struct MainWindowView: View {
                 if case .daemonStartupFailed(let startupError) = error {
                     appDelegate.daemonStartupError = startupError
                     daemonStartupError = startupError
+                    MetricKitManager.reportDaemonStartupFailure(startupError)
                 }
                 return
             } catch {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -712,7 +712,7 @@ struct ActiveChatViewWrapper: View {
             isBootstrapping: isBootstrapping,
             isBootstrapTimedOut: isBootstrapTimedOut,
             onBootstrapSendLogs: {
-                AppDelegate.shared?.showLogReportWindow()
+                AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
             }
         )
         .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -710,7 +710,10 @@ struct ActiveChatViewWrapper: View {
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,
             loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
             isBootstrapping: isBootstrapping,
-            isBootstrapTimedOut: isBootstrapTimedOut
+            isBootstrapTimedOut: isBootstrapTimedOut,
+            onBootstrapSendLogs: {
+                AppDelegate.shared?.showLogReportWindow()
+            }
         )
         .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -8,6 +8,7 @@ struct LogReportFormView: View {
     enum Field { case email, name, message }
 
     let authManager: AuthManager
+    let initialReason: LogReportReason?
     let onSend: (LogReportFormData) -> Void
     let onCancel: () -> Void
 
@@ -16,6 +17,19 @@ struct LogReportFormView: View {
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
     @FocusState private var focusedField: Field?
+
+    init(
+        authManager: AuthManager,
+        initialReason: LogReportReason? = nil,
+        onSend: @escaping (LogReportFormData) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.authManager = authManager
+        self.initialReason = initialReason
+        self.onSend = onSend
+        self.onCancel = onCancel
+        self._selectedReason = State(initialValue: initialReason)
+    }
 
     private var canSend: Bool {
         selectedReason != nil && !email.isEmpty

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -23,6 +23,7 @@ private let log = Logger(
 /// - `auth-debug.json` — non-sensitive token expiry and refresh state for session debugging
 /// - `port-diagnostics.json` — processes listening on assistant-relevant TCP ports
 /// - `config-snapshot.json` — sanitized workspace config (API key values redacted, structure preserved)
+/// - `daemon-logs-fallback/` — when daemon is unreachable: vellum.log, recent hatch-*.log, and XDG hatch.log read directly from disk (10 MB cap)
 @MainActor
 enum LogExporter {
 
@@ -229,11 +230,16 @@ enum LogExporter {
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         let isManagedAssistant = Self.isManagedAssistant
 
+        var daemonUnreachable = false
         if isManagedAssistant, let assistantId = connectedId,
            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
             await fetchPlatformLogs(into: tempDir, assistantId: assistantId, organizationId: orgId)
         } else {
-            await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global)
+            let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global)
+            if !success {
+                daemonUnreachable = true
+                collectFallbackDaemonLogs(into: tempDir, home: home, fileManager: fileManager)
+            }
         }
 
         // 4. XDG CLI logs — ~/.config/vellum/logs/ (hatch.log, retire.log, etc.)
@@ -271,7 +277,7 @@ enum LogExporter {
         // Email is excluded from the archive since it's already sent via
         // Sentry's Feedback API (linked to the event).
         if let formData {
-            var metadata: [String: String] = [
+            var metadata: [String: Any] = [
                 "reason": formData.reason.rawValue,
                 "message": formData.message,
                 "device_id": SentryDeviceInfo.deviceId,
@@ -279,8 +285,21 @@ enum LogExporter {
             if !formData.name.isEmpty {
                 metadata["name"] = formData.name
             }
+            if daemonUnreachable {
+                metadata["daemon-unreachable"] = true
+            }
             if let data = try? JSONSerialization.data(
                 withJSONObject: metadata,
+                options: [.prettyPrinted, .sortedKeys]
+            ) {
+                try? data.write(to: tempDir.appendingPathComponent("report-metadata.json"))
+            }
+        } else if daemonUnreachable {
+            // Write a minimal manifest when no form data is available so the
+            // receiving end still knows these are raw filesystem reads.
+            let manifest: [String: Any] = ["daemon-unreachable": true]
+            if let data = try? JSONSerialization.data(
+                withJSONObject: manifest,
                 options: [.prettyPrinted, .sortedKeys]
             ) {
                 try? data.write(to: tempDir.appendingPathComponent("report-metadata.json"))
@@ -368,17 +387,18 @@ enum LogExporter {
     /// Calls POST /v1/export on the gateway to download a tar.gz archive of
     /// audit data, daemon logs, workspace files, and config snapshot.
     /// Extracts the archive into `directory/daemon-exports/`.
-    /// Silently skips if the gateway is unreachable or returns an error.
-    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async {
+    /// Returns `true` if the export succeeded, `false` if the daemon was unreachable.
+    @discardableResult
+    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async -> Bool {
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         let baseURL = LockfilePaths.resolveGatewayUrl(connectedAssistantId: connectedId)
 
         guard let token = ActorTokenManager.getToken(), !token.isEmpty else {
             log.warning("No actor token available — skipping daemon exports")
-            return
+            return false
         }
 
-        guard let url = URL(string: "\(baseURL)/v1/export") else { return }
+        guard let url = URL(string: "\(baseURL)/v1/export") else { return false }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 30
@@ -403,13 +423,143 @@ enum LogExporter {
                   (200...299).contains(http.statusCode) else {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? -1
                 log.warning("Export API failed with status \(status)")
-                return
+                return false
             }
 
             try await extractTarGzResponse(data: data, into: directory, subdirectory: "daemon-exports")
+            return true
         } catch {
             log.warning("Export API request failed: \(error.localizedDescription)")
+            return false
         }
+    }
+
+    // MARK: - Daemon Log Fallback
+
+    /// Maximum total bytes to read when collecting fallback daemon logs.
+    private static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
+
+    /// When the daemon is unreachable, reads log files directly from the
+    /// filesystem and copies them into `directory/daemon-logs-fallback/`.
+    /// Includes the main daemon log (`vellum.log`) and the 3 most recent
+    /// hatch attempt logs (`hatch-*.log`), capped at 10 MB total.
+    private nonisolated static func collectFallbackDaemonLogs(
+        into directory: URL,
+        home: String,
+        fileManager: FileManager
+    ) {
+        let fallbackDir = directory.appendingPathComponent("daemon-logs-fallback", isDirectory: true)
+        try? fileManager.createDirectory(at: fallbackDir, withIntermediateDirectories: true)
+
+        let workspaceLogDir = URL(fileURLWithPath: home)
+            .appendingPathComponent(".vellum/workspace/data/logs", isDirectory: true)
+
+        var totalBytes = 0
+
+        // 1. Main daemon log — vellum.log
+        let vellumLog = workspaceLogDir.appendingPathComponent("vellum.log")
+        if fileManager.fileExists(atPath: vellumLog.path),
+           let attrs = try? fileManager.attributesOfItem(atPath: vellumLog.path),
+           let size = attrs[.size] as? Int,
+           size > 0 {
+            let bytesToRead = min(size, fallbackLogSizeLimit - totalBytes)
+            if bytesToRead > 0 {
+                if bytesToRead >= size {
+                    try? fileManager.copyItem(
+                        at: vellumLog,
+                        to: fallbackDir.appendingPathComponent("vellum.log")
+                    )
+                } else {
+                    // Tail the file if it exceeds the remaining budget
+                    copyTail(
+                        of: vellumLog,
+                        bytes: bytesToRead,
+                        to: fallbackDir.appendingPathComponent("vellum.log")
+                    )
+                }
+                totalBytes += bytesToRead
+            }
+        }
+
+        // 2. Recent hatch attempt logs — hatch-*.log, sorted by modification time (newest first)
+        if fileManager.fileExists(atPath: workspaceLogDir.path),
+           let contents = try? fileManager.contentsOfDirectory(
+               at: workspaceLogDir,
+               includingPropertiesForKeys: [.contentModificationDateKey],
+               options: [.skipsHiddenFiles]
+           ) {
+            let hatchLogs = contents
+                .filter { $0.lastPathComponent.hasPrefix("hatch-") && $0.pathExtension == "log" }
+                .sorted { a, b in
+                    let aDate = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                    let bDate = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                    return aDate > bDate
+                }
+
+            for hatchLog in hatchLogs.prefix(3) {
+                guard totalBytes < fallbackLogSizeLimit else { break }
+                guard let attrs = try? fileManager.attributesOfItem(atPath: hatchLog.path),
+                      let size = attrs[.size] as? Int,
+                      size > 0 else { continue }
+
+                let bytesToRead = min(size, fallbackLogSizeLimit - totalBytes)
+                if bytesToRead >= size {
+                    try? fileManager.copyItem(
+                        at: hatchLog,
+                        to: fallbackDir.appendingPathComponent(hatchLog.lastPathComponent)
+                    )
+                } else {
+                    copyTail(
+                        of: hatchLog,
+                        bytes: bytesToRead,
+                        to: fallbackDir.appendingPathComponent(hatchLog.lastPathComponent)
+                    )
+                }
+                totalBytes += bytesToRead
+            }
+        }
+
+        // 3. XDG CLI hatch log — ~/.config/vellum/logs/hatch.log
+        //    Already collected under xdg-logs/ by the main export path, but verify
+        //    it exists and include in the fallback directory for completeness.
+        let xdgConfigHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+            ?? URL(fileURLWithPath: home).appendingPathComponent(".config").path
+        let xdgHatchLog = URL(fileURLWithPath: xdgConfigHome)
+            .appendingPathComponent("vellum/logs/hatch.log")
+        if fileManager.fileExists(atPath: xdgHatchLog.path),
+           totalBytes < fallbackLogSizeLimit,
+           let attrs = try? fileManager.attributesOfItem(atPath: xdgHatchLog.path),
+           let size = attrs[.size] as? Int,
+           size > 0 {
+            let bytesToRead = min(size, fallbackLogSizeLimit - totalBytes)
+            if bytesToRead >= size {
+                try? fileManager.copyItem(
+                    at: xdgHatchLog,
+                    to: fallbackDir.appendingPathComponent("xdg-hatch.log")
+                )
+            } else {
+                copyTail(
+                    of: xdgHatchLog,
+                    bytes: bytesToRead,
+                    to: fallbackDir.appendingPathComponent("xdg-hatch.log")
+                )
+            }
+            totalBytes += bytesToRead
+        }
+
+        log.info("Collected \(totalBytes) bytes of fallback daemon logs from filesystem")
+    }
+
+    /// Reads the last `bytes` bytes from `source` and writes them to `destination`.
+    private nonisolated static func copyTail(of source: URL, bytes: Int, to destination: URL) {
+        guard let handle = try? FileHandle(forReadingFrom: source) else { return }
+        defer { try? handle.close() }
+
+        let fileSize = handle.seekToEndOfFile()
+        let offset = fileSize > UInt64(bytes) ? fileSize - UInt64(bytes) : 0
+        handle.seek(toFileOffset: offset)
+        let data = handle.readData(ofLength: bytes)
+        try? data.write(to: destination)
     }
 
     // MARK: - Platform Log Helpers

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -188,6 +188,33 @@ import os
         }
     }
 
+    /// Reports a daemon startup failure to Sentry for automatic triage.
+    ///
+    /// This covers cases where the daemon crashed before its own Sentry
+    /// initialization, so the macOS client reports it on the daemon's behalf.
+    /// Events are grouped by error category (MIGRATION_FAILED, PORT_IN_USE, etc.)
+    /// using a custom fingerprint. Respects the `sendDiagnostics` privacy preference.
+    nonisolated static func reportDaemonStartupFailure(_ error: DaemonStartupError) {
+        let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+            ?? true
+        guard sendDiagnostics else { return }
+
+        let event = Event(level: .error)
+        event.message = SentryMessage(formatted: "Daemon startup failed: \(error.category)")
+        event.tags = [
+            "daemon_error_category": error.category,
+        ]
+        var extra: [String: Any] = [
+            "error_message": error.message,
+        ]
+        if let detail = error.detail {
+            extra["error_detail"] = detail
+        }
+        event.extra = extra
+        event.fingerprint = ["daemon_startup_failure", error.category]
+        captureSentryEvent(event)
+    }
+
     /// Synchronous Sentry restart — must be called from `sentrySerialQueue`.
     /// Shared by `startSentry()` and inline DSN restoration in `sendManualReport`
     /// so no queued events are dropped between close and restart.


### PR DESCRIPTION
## Summary
When the daemon fails to start (e.g. migration crash, port conflict, corrupt DB), the macOS app previously showed a skeleton loading screen indefinitely with no actionable information. This feature branch adds:

- **Structured error reporting** from the daemon process back to the macOS app via a `DAEMON_ERROR:` marker on stderr, with categorized error types (MIGRATION_FAILED, PORT_IN_USE, DB_LOCKED, DB_CORRUPT, ENV_VALIDATION, UNKNOWN)
- **Rich error view** replacing the skeleton/timeout with the actual failure reason, expandable technical details, a "Retry" button (restarts daemon without re-hatching), and a "Send Logs to Vellum" button
- **Automatic Sentry reporting** of daemon startup failures from the macOS client (respects privacy opt-out)
- **Fallback log collection** — when the daemon is unreachable, log export reads hatch/daemon logs directly from the filesystem so users can still send diagnostics

## PRs included
1. feat: emit structured startup error from daemon hatch stderr (#17765)
2. feat: include hatch logs in log export when daemon is unreachable (#17768)
3. feat: parse daemon startup error in AssistantCli and expose to AppDelegate (#17775)
4. feat: auto-report daemon startup failures to Sentry (#17779)
5. feat: show actionable error view when daemon fails to start (#17812)
6. fix: narrow ENV_VALIDATION categorization to known env error prefixes (#17815)
7. fix: remove duplicate DAEMON_ERROR emission from lifecycle.ts (#17816)
8. fix: report retry failures to Sentry in retryDaemonStartup (#17818)
9. fix: clear daemonStartupError after successful fallback hatch (#17819)
10. fix: pre-fill log report reason as connectionIssue for daemon errors (#17820)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
