### PR TITLE
fix: restore keyboard input in secure credential panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -54,7 +54,7 @@ final class SecretPromptManager {
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = .preferredContentSize
 
-        let panel = NSPanel(
+        let panel = KeyablePanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 300),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -99,6 +99,7 @@ final class SecretPromptManager {
 
         panels[message.requestId] = panel
         panelPresenter(panel)
+        panel.makeKey()
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
     }
@@ -317,4 +318,12 @@ struct SecretPromptView: View {
                 .foregroundColor(VColor.contentTertiary)
         }
     }
+}
+
+// MARK: - KeyablePanel
+
+/// Borderless NSPanel subclass that accepts key window status,
+/// allowing SecureField (and other text inputs) to receive keyboard focus.
+private final class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
 }


### PR DESCRIPTION
## Summary
- The styling rework in #17599 changed the panel's `styleMask` from `[.titled, .nonactivatingPanel, .utilityWindow, .hudWindow]` to `[.borderless, .nonactivatingPanel]`, which broke keyboard input — a borderless `NSPanel` with `.nonactivatingPanel` can't become key window, so `SecureField` silently ignores all typing
- Fix: subclass `NSPanel` with `canBecomeKey = true` and call `makeKey()` on presentation

## Test plan
- [ ] Trigger a secure credential prompt (e.g. Gemini API key)
- [ ] Verify you can type into the SecureField
- [ ] Verify the panel still floats above other windows
- [ ] Verify Cancel and Save buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
