### PR TITLE
refactor: rename session→conversation variable in voice-session-bridge.ts

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -291,18 +291,18 @@ export async function startVoiceTurn(
   const transport = {
     channelId: "phone" as ChannelId,
   };
-  const session = await deps.getOrCreateConversation(
+  const conversation = await deps.getOrCreateConversation(
     opts.conversationId,
     transport,
   );
 
-  if (session.isProcessing()) {
+  if (conversation.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait briefly for the
     // previous turn to finish aborting before giving up.
     const maxWaitMs = 3000;
     const pollIntervalMs = 50;
     let waited = 0;
-    while (session.isProcessing() && waited < maxWaitMs) {
+    while (conversation.isProcessing() && waited < maxWaitMs) {
       if (opts.signal?.aborted) {
         throw new Error("Turn aborted while waiting for session");
       }
@@ -312,7 +312,7 @@ export async function startVoiceTurn(
     if (opts.signal?.aborted) {
       throw new Error("Turn aborted while waiting for session");
     }
-    if (session.isProcessing()) {
+    if (conversation.isProcessing()) {
       throw new Error("Session is already processing a message");
     }
   }
@@ -321,26 +321,26 @@ export async function startVoiceTurn(
   const strictSideEffects =
     forceStrictSideEffects ??
     deps.deriveDefaultStrictSideEffects(opts.conversationId);
-  session.memoryPolicy = {
-    ...session.memoryPolicy,
+  conversation.memoryPolicy = {
+    ...conversation.memoryPolicy,
     strictSideEffects,
   };
-  session.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
-  session.callSessionId = opts.callSessionId;
-  session.setTrustContext(opts.trustContext ?? null);
-  session.setCommandIntent(null);
-  session.setTurnChannelContext({
+  conversation.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
+  conversation.callSessionId = opts.callSessionId;
+  conversation.setTrustContext(opts.trustContext ?? null);
+  conversation.setCommandIntent(null);
+  conversation.setTurnChannelContext({
     userMessageChannel: "phone",
     assistantMessageChannel: "phone",
   });
-  session.setChannelCapabilities(
+  conversation.setChannelCapabilities(
     resolveChannelCapabilities("phone", undefined),
   );
-  session.setVoiceCallControlPrompt(voiceCallControlPrompt);
+  conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
 
   const requestId = crypto.randomUUID();
   const turnId = crypto.randomUUID();
-  const messageId = await session.persistUserMessage(
+  const messageId = await conversation.persistUserMessage(
     persistedContent,
     [],
     requestId,
@@ -379,7 +379,7 @@ export async function startVoiceTurn(
   const autoDeny = !isGuardian;
   const autoAllow = isGuardian;
   let lastError: string | null = null;
-  session.updateClient(async (msg: ServerMessage) => {
+  conversation.updateClient(async (msg: ServerMessage) => {
     if (msg.type === "confirmation_request") {
       if (autoDeny) {
         // Non-guardian voice callers have no interactive approval UI.
@@ -419,7 +419,7 @@ export async function startVoiceTurn(
               },
               "Consumed scoped grant — allowing non-guardian voice confirmation",
             );
-            session.handleConfirmationResponse(
+            conversation.handleConfirmationResponse(
               msg.requestId,
               "allow",
               undefined,
@@ -440,7 +440,7 @@ export async function startVoiceTurn(
           { turnId, toolName: msg.toolName },
           "Auto-denying confirmation request for non-guardian voice turn (no matching scoped grant)",
         );
-        session.handleConfirmationResponse(
+        conversation.handleConfirmationResponse(
           msg.requestId,
           "deny",
           undefined,
@@ -455,7 +455,7 @@ export async function startVoiceTurn(
           { turnId, toolName: msg.toolName },
           "Auto-approving confirmation request for guardian voice turn",
         );
-        session.handleConfirmationResponse(
+        conversation.handleConfirmationResponse(
           msg.requestId,
           "allow",
           undefined,
@@ -471,7 +471,7 @@ export async function startVoiceTurn(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",
       );
-      session.handleSecretResponse(msg.requestId, undefined, "store");
+      conversation.handleSecretResponse(msg.requestId, undefined, "store");
       publishToHub(msg);
       return;
     }
@@ -482,20 +482,20 @@ export async function startVoiceTurn(
   const cleanup = () => {
     // Reset channel capabilities so a subsequent desktop session on the
     // same conversation is not incorrectly treated as a voice client.
-    session.setChannelCapabilities(null);
-    session.setTrustContext(null);
-    session.setCommandIntent(null);
-    session.setAssistantId("self");
-    session.setVoiceCallControlPrompt(null);
-    session.callSessionId = undefined;
+    conversation.setChannelCapabilities(null);
+    conversation.setTrustContext(null);
+    conversation.setCommandIntent(null);
+    conversation.setAssistantId("self");
+    conversation.setVoiceCallControlPrompt(null);
+    conversation.callSessionId = undefined;
     // Reset the session's client callback to a no-op so the stale
     // closure doesn't intercept events from future turns on the same session.
-    session.updateClient(() => {}, true);
+    conversation.updateClient(() => {}, true);
   };
 
   void (async () => {
     try {
-      await session.runAgentLoop(
+      await conversation.runAgentLoop(
         persistedContent,
         messageId,
         (msg: ServerMessage) => {
@@ -542,8 +542,8 @@ export async function startVoiceTurn(
   })();
 
   const abortFn = () => {
-    if (session.currentRequestId === requestId) {
-      session.abort();
+    if (conversation.currentRequestId === requestId) {
+      conversation.abort();
     }
   };
 


### PR DESCRIPTION
## Summary
- Rename the `session` variable to `conversation` in voice-session-bridge.ts where it holds a `Conversation` object (~46 usages)
- Variable-only rename; comments and error messages are left unchanged (they refer to the voice session concept)
- Preserve `callSessionId` references (voice/call session concept) and the filename

Part of plan: conv-sweep-final.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
