### PR TITLE
feat: sync onboarding privacy choices to daemon on first connection

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -468,6 +468,9 @@ extension AppDelegate {
                 try? await daemonClient.setPrivacyConfig(collectUsageData: syncCollectUsageData, sendDiagnostics: syncSendDiagnostics)
             }
 
+            let tosAccepted = UserDefaults.standard.bool(forKey: "tosAccepted")
+            log.info("ToS accepted: \(tosAccepted, privacy: .public)")
+
             // Clean up legacy keys and write canonical ones
             UserDefaults.standard.removeObject(forKey: "collectUsageDataEnabled")
             UserDefaults.standard.removeObject(forKey: "sendPerformanceReports")


### PR DESCRIPTION
## Summary
- Add ToS acceptance status logging on daemon startup
- Verify existing privacy sync handles onboarding opt-out choices correctly (no code changes needed — existing sync reads the same UserDefaults keys)

Part of plan: onboarding-privacy-tos.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
