### PR TITLE
refactor: update 3 remaining Swift comments from session→conversation

### DIFF
--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 
 /// Manages private (temporary) conversations on iOS, mirroring the macOS private conversation
 /// workflow. Private conversations are backed by daemon sessions with conversationType "private"
-/// so they are excluded from normal session restoration and the main conversation list.
+/// so they are excluded from normal conversation restoration and the main conversation list.
 struct PrivateConversationsSection: View {
     /// Shared with the main ConversationListView so both views read from and write to the
     /// same in-memory conversation list. This prevents the dual-store data-loss bug where

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -56,7 +56,7 @@ extension MainWindowView {
     }
 
     /// Groups schedule conversations by their scheduleJobId.
-    /// Conversations without a scheduleJobId are placed in individual groups keyed by their session ID.
+    /// Conversations without a scheduleJobId are placed in individual groups keyed by their conversation ID.
     var scheduleConversationGroups: [(key: String, label: String, conversations: [ConversationModel])] {
         var grouped: [String: [ConversationModel]] = [:]
         var order: [String] = []


### PR DESCRIPTION
## Summary
- Update comment in PrivateConversationsSection.swift: session restoration → conversation restoration
- Update comment in MainWindowView+Sidebar.swift: session ID → conversation ID
- User-facing strings are preserved unchanged

Part of plan: conv-sweep-final.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
