### PR TITLE
fix: use == instead of === for Swift Task comparison in BillingService

### DIFF
--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -103,7 +103,7 @@ public final class BillingService {
         bootstrapTasks[orgId] = task
         let result = await task.value
         // Only clear if this is still the current task — avoid clobbering a newer reference
-        if bootstrapTasks[orgId] === task {
+        if bootstrapTasks[orgId] == task {
             bootstrapTasks[orgId] = nil
         }
         return result


### PR DESCRIPTION
## Summary
- Replace `===` with `==` for `Task` comparison in `BillingService.bootstrapBillingSummaryIfNeeded`
- `Task` is a Swift struct (value type), so identity comparison (`===`) doesn't compile — use equality (`==`) instead
- Addresses review feedback from #17834

## Test plan
- [ ] Verify the shared client target compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
