### PR TITLE
fix: delete stale credential from store when whitespace-only clears identity field

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -171,7 +171,8 @@ export async function handleAddSecret(
       const effectiveValue = isTrimmedIdentity ? value.trim() : value;
 
       if (isTrimmedIdentity && effectiveValue === "") {
-        // Whitespace-only → clear in-memory state, skip store & metadata
+        // Whitespace-only → clear in-memory state and remove stale credential
+        // from the secure store so it doesn't get rehydrated on restart.
         if (field === "platform_assistant_id") {
           setPlatformAssistantId(undefined);
         } else if (field === "platform_organization_id") {
@@ -180,6 +181,8 @@ export async function handleAddSecret(
         } else if (field === "platform_user_id") {
           setPlatformUserId(undefined);
         }
+        await deleteSecureKeyAsync(key);
+        deleteCredentialMetadata(service, field);
       } else {
         const stored = await setSecureKeyAsync(key, effectiveValue);
         if (!stored) {


### PR DESCRIPTION
## Summary
- When whitespace-only input clears a trimmed identity field, now also deletes the credential from the secure store and removes its metadata
- Prevents stale platform identity from being rehydrated on daemon restart
- Addresses review feedback from #17833

## Test plan
- [ ] Set a platform_assistant_id, then clear it with whitespace-only input
- [ ] Restart the daemon and verify the identity stays cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
