### PR TITLE
fix: resolve firstMatch immediately on failed appsListResponse to avoid 15s hang

### DIFF
--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -52,14 +52,14 @@ public final class DirectoryStore: ObservableObject {
                 return
             }
 
-            let result = await stream.firstMatch { message -> [AppItem]? in
+            let result = await stream.firstMatch { message -> (success: Bool, apps: [AppItem])? in
                 if case .appsListResponse(let response) = message {
-                    return response.success ? response.apps : nil
+                    return (success: response.success, apps: response.apps)
                 }
                 return nil
             }
-            if let apps = result {
-                self.localApps = apps
+            if let result, result.success {
+                self.localApps = result.apps
             }
             isLoadingApps = false
         }


### PR DESCRIPTION
## Summary
- Change `DirectoryStore.fetchApps()` to always resolve `firstMatch` when an `appsListResponse` arrives
- Check `response.success` after resolution instead of inside the closure
- Prevents a 15-second loading hang when the apps list fetch fails (HTTP transport only sends one response)
- Addresses review feedback from #17835

## Test plan
- [ ] Simulate a failed apps list response and verify loading resolves immediately
- [ ] Verify successful apps list responses still update `localApps` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
