### PR TITLE
fix: propagate VELLUM_DEBUG through vellum wake

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -932,6 +932,7 @@ export async function startLocalDaemon(
         "TMPDIR",
         "USER",
         "LANG",
+        "VELLUM_DEBUG",
       ]) {
         if (process.env[key]) {
           daemonEnv[key] = process.env[key]!;


### PR DESCRIPTION
## Summary
- Added `VELLUM_DEBUG` to the environment variable allowlist in the compiled binary daemon startup path (`cli/src/lib/local.ts`)
- Previously, `VELLUM_DEBUG=1 vellum sleep && VELLUM_DEBUG=1 vellum wake` silently dropped the flag because it wasn't in the curated allowlist, making `assistant bash` unusable without switching to a source-tree startup

## Original prompt
yes do that please

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
