### PR TITLE
fix: HighlightedTextView blank text — use scrollableTextView() factory

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -12,22 +12,36 @@ struct HighlightedTextView: NSViewRepresentable {
     let isEditable: Bool
     var onTextChange: ((String) -> Void)?
 
+    private static let editorBackground = NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 0.13, green: 0.14, blue: 0.13, alpha: 1.0)
+            : NSColor(red: 0.98, green: 0.98, blue: 0.97, alpha: 1.0)
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self, language: language, onTextChange: onTextChange)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let textContainer = NSTextContainer()
-        textContainer.widthTracksTextView = false
-        textContainer.containerSize = NSSize(
+        // Use Apple's factory method — it wires up NSTextStorage, NSLayoutManager,
+        // NSTextContainer, NSTextView, NSClipView, and NSScrollView correctly.
+        let scrollView = NSTextView.scrollableTextView()
+        let textView = scrollView.documentView as! NSTextView
+
+        // Enable horizontal scrolling (no word wrap)
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isHorizontallyResizable = true
+        textView.maxSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
         )
 
-        let textView = NSTextView(frame: .zero, textContainer: textContainer)
         textView.isEditable = isEditable
         textView.isSelectable = true
-        textView.isRichText = false
         textView.usesFindPanel = true
         textView.allowsUndo = true
         textView.isAutomaticQuoteSubstitutionEnabled = false
@@ -37,7 +51,7 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.isAutomaticTextCompletionEnabled = false
         textView.font = context.coordinator.baseFont
         textView.textColor = SyntaxTheme.baseTextColor
-        textView.backgroundColor = .clear
+        textView.backgroundColor = Self.editorBackground
         textView.insertionPointColor = SyntaxTheme.baseTextColor
         textView.selectedTextAttributes = [
             .backgroundColor: NSColor(name: nil) { appearance in
@@ -47,20 +61,12 @@ struct HighlightedTextView: NSViewRepresentable {
                     : NSColor(white: 0.0, alpha: 0.12)
             },
         ]
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = true
-        textView.maxSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
 
         textView.string = text
 
-        let scrollView = NSScrollView()
-        scrollView.documentView = textView
-        scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = true
-        scrollView.drawsBackground = false
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = Self.editorBackground
         scrollView.autohidesScrollers = true
         scrollView.contentInsets = NSEdgeInsets(top: 8, left: 0, bottom: 8, right: 8)
 


### PR DESCRIPTION
## Summary
- Fix blank text rendering in the Workspace file viewer's source view
- The root cause: `NSTextContainer()` bare init creates an orphan container with no `NSTextStorage` or `NSLayoutManager`. `NSTextView(frame:textContainer:)` expects a fully wired text system, so text was silently never rendered (line numbers worked because the ruler view draws via direct Core Graphics, not through the text system)
- Switch to `NSTextView.scrollableTextView()` which properly connects NSTextStorage → NSLayoutManager → NSTextContainer → NSTextView
- Set opaque backgrounds on both the text view and scroll view for proper compositing within SwiftUI's hosting layer

## Test plan
- [ ] Open any text file in Workspace → text content should be visible with syntax highlighting
- [ ] Open a `.md` file → source view should show highlighted markdown
- [ ] Open a `.json` file → source view should show highlighted JSON
- [ ] Open a `.ts`/`.js` file → source view should show highlighted code
- [ ] Line numbers should appear correctly aligned with text lines
- [ ] Horizontal scrolling should work for long lines (no word wrap)
- [ ] Editing should work for non-read-only files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
