### PR TITLE
feat: add `assistant config schema [path]` CLI command

### DIFF
--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -1,0 +1,189 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-schema-cmd-test-${randomBytes(4).toString("hex")}`,
+);
+const WORKSPACE_DIR = join(TEST_DIR, "workspace");
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    TEST_DIR,
+    WORKSPACE_DIR,
+    join(TEST_DIR, "data"),
+    join(TEST_DIR, "memory"),
+    join(TEST_DIR, "memory", "knowledge"),
+    join(TEST_DIR, "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+ensureTestDir();
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+  getCliLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => TEST_DIR,
+  getWorkspaceDir: () => WORKSPACE_DIR,
+  getWorkspaceConfigPath: () => CONFIG_PATH,
+  getDataDir: () => join(TEST_DIR, "data"),
+  getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
+  ensureDataDir: () => ensureTestDir(),
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+}));
+
+import { z } from "zod";
+
+import { AssistantConfigSchema } from "../config/schema.js";
+import { getSchemaAtPath } from "../config/schema-utils.js";
+
+// ---------------------------------------------------------------------------
+// Tests: getSchemaAtPath unit tests
+// ---------------------------------------------------------------------------
+
+describe("getSchemaAtPath", () => {
+  test("returns full schema for a top-level key (provider → enum schema)", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "provider");
+    expect(result).not.toBeNull();
+    // provider is an enum with a default, so it should be parseable
+    const parsed = (result as z.ZodType).parse(undefined);
+    expect(parsed).toBe("anthropic");
+  });
+
+  test("navigates nested paths (memory.segmentation → object schema)", () => {
+    const result = getSchemaAtPath(
+      AssistantConfigSchema,
+      "memory.segmentation",
+    );
+    expect(result).not.toBeNull();
+    // Unwrap to check it has targetTokens and overlapTokens
+    let schema: any = result;
+    while (schema && !schema.shape) {
+      const inner = schema._zod?.def?.innerType;
+      if (!inner) break;
+      schema = inner;
+    }
+    expect(schema.shape).toBeDefined();
+    expect(schema.shape.targetTokens).toBeDefined();
+    expect(schema.shape.overlapTokens).toBeDefined();
+  });
+
+  test("navigates through .default() wrappers (calls → object schema)", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "calls");
+    expect(result).not.toBeNull();
+    // Unwrap to check it has shape (it's a ZodDefault wrapping ZodObject)
+    let schema: any = result;
+    while (schema && !schema.shape) {
+      const inner = schema._zod?.def?.innerType;
+      if (!inner) break;
+      schema = inner;
+    }
+    expect(schema.shape).toBeDefined();
+    expect(schema.shape.enabled).toBeDefined();
+    expect(schema.shape.voice).toBeDefined();
+    expect(schema.shape.safety).toBeDefined();
+  });
+
+  test("returns null for non-existent top-level path", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-existent nested path", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "calls.nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for path traversal through a leaf type", () => {
+    // provider is an enum, not an object — can't traverse further
+    const result = getSchemaAtPath(AssistantConfigSchema, "provider.foo");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: z.toJSONSchema integration tests
+// ---------------------------------------------------------------------------
+
+describe("z.toJSONSchema integration", () => {
+  test("full schema produces valid JSON Schema with type object and properties", () => {
+    const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
+      unrepresentable: "any",
+    }) as Record<string, unknown>;
+    expect(jsonSchema.type).toBe("object");
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    // Check that top-level keys are present
+    expect(properties.provider).toBeDefined();
+    expect(properties.model).toBeDefined();
+    expect(properties.maxTokens).toBeDefined();
+    expect(properties.calls).toBeDefined();
+    expect(properties.memory).toBeDefined();
+    expect(properties.timeouts).toBeDefined();
+    expect(properties.sandbox).toBeDefined();
+  });
+
+  test("sub-schema at calls produces JSON Schema with expected properties", () => {
+    const callsSchema = getSchemaAtPath(AssistantConfigSchema, "calls");
+    expect(callsSchema).not.toBeNull();
+    const jsonSchema = z.toJSONSchema(callsSchema!, {
+      unrepresentable: "any",
+    }) as Record<string, unknown>;
+    // Unwrap: the JSON schema may have the properties directly or nested
+    // Look for calls-specific properties
+    const properties = jsonSchema.properties as
+      | Record<string, unknown>
+      | undefined;
+    if (properties) {
+      expect(properties.enabled).toBeDefined();
+      expect(properties.voice).toBeDefined();
+      expect(properties.safety).toBeDefined();
+    } else {
+      // If it's a wrapped type, the JSON schema might have a different structure
+      // but it should still be valid JSON Schema
+      expect(jsonSchema).toBeDefined();
+    }
+  });
+
+  test("sub-schema at a leaf like maxTokens produces integer schema", () => {
+    const maxTokensSchema = getSchemaAtPath(AssistantConfigSchema, "maxTokens");
+    expect(maxTokensSchema).not.toBeNull();
+    const jsonSchema = z.toJSONSchema(maxTokensSchema!, {
+      unrepresentable: "any",
+    }) as Record<string, unknown>;
+    expect(jsonSchema.type).toBe("integer");
+  });
+});

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { z } from "zod";
 
 import {
   getNestedValue,
@@ -7,6 +8,8 @@ import {
   setNestedValue,
   syncConfigToLockfile,
 } from "../../config/loader.js";
+import { AssistantConfigSchema } from "../../config/schema.js";
+import { getSchemaAtPath } from "../../config/schema-utils.js";
 import { log } from "../logger.js";
 
 /**
@@ -122,6 +125,45 @@ Examples:
             : String(value),
         );
       }
+    });
+
+  config
+    .command("schema [path]")
+    .description("Print the JSON Schema for the config (or a sub-path)")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  path   Optional dotted path to a config key (e.g. calls, memory.segmentation)
+
+Prints the JSON Schema for the entire config object, or the sub-schema at the
+given path. Useful for understanding available fields, their types, defaults,
+and constraints.
+
+Examples:
+  $ assistant config schema
+  $ assistant config schema calls
+  $ assistant config schema memory.segmentation`,
+    )
+    .action((path?: string) => {
+      if (!path) {
+        const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
+          unrepresentable: "any",
+        });
+        log.info(JSON.stringify(jsonSchema, null, 2));
+        return;
+      }
+
+      const subSchema = getSchemaAtPath(AssistantConfigSchema, path);
+      if (!subSchema) {
+        log.error(`No schema found at path: ${path}`);
+        process.exit(1);
+      }
+
+      const jsonSchema = z.toJSONSchema(subSchema, {
+        unrepresentable: "any",
+      });
+      log.info(JSON.stringify(jsonSchema, null, 2));
     });
 
   config

--- a/assistant/src/config/schema-utils.ts
+++ b/assistant/src/config/schema-utils.ts
@@ -1,0 +1,27 @@
+import type { z } from "zod";
+
+/**
+ * Navigate a Zod schema by dotted path, unwrapping wrapper types
+ * (default, optional, nullable) to reach inner object shapes.
+ * Returns the Zod schema at the given path, or null if the path is invalid.
+ */
+export function getSchemaAtPath(
+  schema: z.ZodType,
+  path: string,
+): z.ZodType | null {
+  const keys = path.split(".");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let current: any = schema;
+  for (const key of keys) {
+    // Unwrap default/optional/nullable wrappers to find inner object shape
+    while (current && !current.shape) {
+      const inner = current._zod?.def?.innerType;
+      if (!inner) break;
+      current = inner;
+    }
+    if (!current || !current.shape) return null;
+    current = current.shape[key];
+    if (!current) return null;
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary
- Add new `assistant config schema [path]` CLI subcommand that outputs JSON Schema for config
- Add `getSchemaAtPath` utility for navigating Zod schemas by dotted path
- Uses Zod 4 built-in `z.toJSONSchema()` — no new dependencies

Part of plan: config-schema-cli-command.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
