### PR TITLE
fix: cancel superseded macOS CI runs instead of in-progress ones

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -18,8 +18,51 @@ on:
       - '.github/workflows/ci-main-macos.yaml'
 
 jobs:
+  check-superseded:
+    name: Skip if newer run queued
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel if a newer run exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const workflowId = 'ci-main-macos.yaml';
+            let newerExists = false;
+
+            for (const status of ['queued', 'waiting', 'in_progress']) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflowId,
+                branch,
+                status,
+                per_page: 10,
+              });
+              const newer = data.workflow_runs.filter(r => r.run_number > context.runNumber);
+              if (newer.length > 0) {
+                core.info(`Found newer ${status} run(s): ${newer.map(r => '#' + r.run_number).join(', ')}`);
+                newerExists = true;
+                break;
+              }
+            }
+
+            if (newerExists) {
+              core.info('Superseded by a newer run — cancelling.');
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+              });
+              await new Promise(r => setTimeout(r, 5000));
+              core.setFailed('Superseded by a newer run');
+            } else {
+              core.info('This is the newest run — proceeding.');
+            }
+
   changes:
     name: Detect Path Changes
+    needs: [check-superseded]
     runs-on: ubuntu-latest
     outputs:
       clients: ${{ steps.filter.outputs.clients }}


### PR DESCRIPTION
## Summary
- Add `check-superseded` gating job to `ci-main-macos.yaml` that cancels itself on startup if a newer workflow run is already queued or in-progress
- This replaces the cancel-in-progress approach which caused no run to ever finish when commits stacked up
- The newest run always completes; only older, redundant runs skip

## Original prompt
and tag dvargas92495 as the reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
