### PR TITLE
fix: propagate secure-store delete failure when clearing identity field

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -181,7 +181,14 @@ export async function handleAddSecret(
         } else if (field === "platform_user_id") {
           setPlatformUserId(undefined);
         }
-        await deleteSecureKeyAsync(key);
+        const deleteResult = await deleteSecureKeyAsync(key);
+        if (deleteResult === "error") {
+          return httpError(
+            "INTERNAL_ERROR",
+            `Failed to delete stale credential from secure storage: ${service}:${field}`,
+            500,
+          );
+        }
         deleteCredentialMetadata(service, field);
       } else {
         const stored = await setSecureKeyAsync(key, effectiveValue);


### PR DESCRIPTION
## Summary
- Check return value of deleteSecureKeyAsync when whitespace-only input clears an identity field
- Return HTTP 500 if deletion fails, matching the error handling pattern of all other deleteSecureKeyAsync calls in the file
- Prevents inconsistent state where in-memory IDs are cleared but stale credential persists on disk

Addresses review feedback from #17846

## Test plan
- [ ] Clear a platform identity field with whitespace-only input when secure store is healthy — verify success
- [ ] Simulate secure store failure during deletion — verify HTTP 500 response
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
