### PR TITLE
Add missing CLI help examples

### DIFF
--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -52,6 +52,7 @@ and "assistant keys set <provider> <key>" to view and manage API keys.
 Examples:
   $ assistant config list
   $ assistant config get provider
+  $ assistant config schema provider
   $ assistant config set provider anthropic
   $ assistant config set calls.enabled true`,
   );

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -238,6 +238,7 @@ Examples:
   $ assistant credentials list --search twilio
   $ assistant credentials set --service twilio --field account_sid AC1234567890
   $ assistant credentials inspect --service twilio --field account_sid
+  $ assistant credentials reveal --service twilio --field account_sid
   $ assistant credentials delete --service twilio --field auth_token`,
   );
 


### PR DESCRIPTION
## Summary
- Add `config schema provider` example to the config command help text
- Add `credentials reveal` example to the credentials command help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
