### PR TITLE
refactor: update stale session/thread comments in daemon TypeScript

### DIFF
--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -185,7 +185,7 @@ export async function addPointerMessage(
   // Pointer messages are assistant-generated status updates in the initiating
   // desktop conversation. Do not set userMessageChannel — doing so would mark the
   // conversation's origin channel as voice, causing it to leak into the
-  // desktop conversation list as a channel-bound session.
+  // desktop conversation list as a channel-bound conversation.
   await addMessage(
     conversationId,
     "assistant",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -172,13 +172,13 @@ export async function runDaemon(): Promise<void> {
     }
     log.info("Daemon startup: DB initialized");
 
-    // Purge private (temporary) conversations from the previous session.
+    // Purge private (temporary) conversations from the previous daemon run.
     // These are ephemeral by design and should not survive daemon restarts.
     const { count: purgedCount, deletedMemory } = purgePrivateConversations();
     if (purgedCount > 0) {
       log.info(
         { purgedCount },
-        `Purged ${purgedCount} private conversation(s) from previous session`,
+        `Purged ${purgedCount} private conversation(s) from previous daemon run`,
       );
       // Qdrant may not be ready at startup, so enqueue vector cleanup jobs
       // rather than attempting direct deletion.


### PR DESCRIPTION
## Summary
- Update comment/log in lifecycle.ts: "previous session" → "previous daemon run"
- Update comment in call-pointer-messages.ts: "channel-bound session" → "channel-bound conversation"

Part of plan: conv-sweep-remnants.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
