### PR TITLE
refactor: update stale session log messages in cancel and undo signals

### DIFF
--- a/assistant/src/signals/cancel.ts
+++ b/assistant/src/signals/cancel.ts
@@ -58,7 +58,7 @@ export function handleCancelSignal(): void {
     if (found) {
       log.info({ conversationId }, "Generation cancelled via signal file");
     } else {
-      log.warn({ conversationId }, "No active session for cancel signal");
+      log.warn({ conversationId }, "No active conversation for cancel signal");
     }
   } catch (err) {
     log.error({ err }, "Failed to handle cancel signal");

--- a/assistant/src/signals/conversation-undo.ts
+++ b/assistant/src/signals/conversation-undo.ts
@@ -98,8 +98,8 @@ export async function handleConversationUndoSignal(): Promise<void> {
 
     const result = await _undoLastMessage(conversationId);
     if (!result) {
-      log.warn({ conversationId }, "No active session for undo signal");
-      writeResult({ ok: false, error: "No active session", requestId });
+      log.warn({ conversationId }, "No active conversation for undo signal");
+      writeResult({ ok: false, error: "No active conversation", requestId });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Update log/error messages from "No active session" → "No active conversation" in cancel.ts and conversation-undo.ts

Part of plan: conv-sweep-remnants.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
