### PR TITLE
refactor: update stale session/thread references in Swift comments and metadata

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -424,7 +424,7 @@ struct ConversationListView: View {
                 }
             }
 
-            // Load-more trigger: appears when the daemon has additional sessions beyond
+            // Load-more trigger: appears when the daemon has additional conversations beyond
             // the current page. Becomes visible as the user scrolls toward the bottom.
             if store.hasMoreConversations || store.isLoadingMoreConversations {
                 HStack {

--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Manages private (temporary) conversations on iOS, mirroring the macOS private conversation
-/// workflow. Private conversations are backed by daemon sessions with conversationType "private"
+/// workflow. Private conversations are backed by daemon conversations with conversationType "private"
 /// so they are excluded from normal conversation restoration and the main conversation list.
 struct PrivateConversationsSection: View {
     /// Shared with the main ConversationListView so both views read from and write to the

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -94,7 +94,7 @@ enum LogExporter {
             var extra: [String: Any] = [:]
             let conversationManager = AppDelegate.shared?.mainWindow?.conversationManager
             if let activeConversation = conversationManager?.activeConversation {
-                extra["thread_title"] = activeConversation.title
+                extra["conversation_title"] = activeConversation.title
                 if let conversationId = activeConversation.conversationId {
                     tags["session_id"] = conversationId
                     // conversation_id mirrors session_id — the daemon tags its


### PR DESCRIPTION
## Summary
- Update iOS comments: "sessions" → "conversations" in ConversationListView and PrivateConversationsSection
- Rename Sentry extra tag from `thread_title` → `conversation_title` in LogExporter

Part of plan: conv-sweep-remnants.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
