### PR TITLE
refactor: rename session→conversation variable in schedule-routes.ts

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -126,10 +126,10 @@ async function handleRunScheduleNow(
               "sendMessageDeps not available for schedule execution",
             );
           }
-          const session =
+          const conversation =
             await sendMessageDeps.getOrCreateConversation(conversationId);
-          session.taskRunId = taskRunId;
-          await session.processMessage(
+          conversation.taskRunId = taskRunId;
+          await conversation.processMessage(
             message,
             [],
             () => {}, // no event callback for HTTP mode
@@ -187,10 +187,10 @@ async function handleRunScheduleNow(
     if (!sendMessageDeps) {
       throw new Error("sendMessageDeps not available for schedule execution");
     }
-    const session = await sendMessageDeps.getOrCreateConversation(
+    const activeConversation = await sendMessageDeps.getOrCreateConversation(
       conversation.id,
     );
-    await session.processMessage(
+    await activeConversation.processMessage(
       schedule.message,
       [],
       () => {}, // no event callback for HTTP mode


### PR DESCRIPTION
## Summary
- Rename `session` variable to `conversation` in schedule-routes.ts (2 occurrences + downstream usages)
- First occurrence (task-based schedule): renamed to `conversation` (no name conflict in scope)
- Second occurrence (message-based schedule): renamed to `activeConversation` to avoid shadowing the existing `conversation` variable in the same scope

Part of plan: conv-sweep-remnants.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
