### PR TITLE
fix: reorder delete-before-clear in identity field clearing

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -171,16 +171,9 @@ export async function handleAddSecret(
       const effectiveValue = isTrimmedIdentity ? value.trim() : value;
 
       if (isTrimmedIdentity && effectiveValue === "") {
-        // Whitespace-only → clear in-memory state and remove stale credential
-        // from the secure store so it doesn't get rehydrated on restart.
-        if (field === "platform_assistant_id") {
-          setPlatformAssistantId(undefined);
-        } else if (field === "platform_organization_id") {
-          setPlatformOrganizationId(undefined);
-          setSentryOrganizationId(undefined);
-        } else if (field === "platform_user_id") {
-          setPlatformUserId(undefined);
-        }
+        // Whitespace-only → remove stale credential from the secure store,
+        // then clear in-memory state. Delete first so that if it fails we
+        // return 500 without having mutated in-memory identity.
         const deleteResult = await deleteSecureKeyAsync(key);
         if (deleteResult === "error") {
           return httpError(
@@ -188,6 +181,14 @@ export async function handleAddSecret(
             `Failed to delete stale credential from secure storage: ${service}:${field}`,
             500,
           );
+        }
+        if (field === "platform_assistant_id") {
+          setPlatformAssistantId(undefined);
+        } else if (field === "platform_organization_id") {
+          setPlatformOrganizationId(undefined);
+          setSentryOrganizationId(undefined);
+        } else if (field === "platform_user_id") {
+          setPlatformUserId(undefined);
         }
         deleteCredentialMetadata(service, field);
       } else {


### PR DESCRIPTION
Both Codex and Devin flagged that in-memory identity state was cleared before deleteSecureKeyAsync was called. If the delete failed, the handler returned 500 but in-memory state was already wiped. Reorders the code to call delete first, check for errors, then clear in-memory state — making the error path atomic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
