### PR TITLE
fix: pre-resolve dynamic NSColors for text rendering in SwiftUI-hosted NSTextView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -28,6 +28,11 @@ struct HighlightedTextView: NSViewRepresentable {
         let scrollView = NSTextView.scrollableTextView()
         let textView = scrollView.documentView as! NSTextView
 
+        // Layer-back everything for proper compositing inside SwiftUI
+        scrollView.wantsLayer = true
+        scrollView.contentView.wantsLayer = true
+        textView.wantsLayer = true
+
         // Enable horizontal scrolling (no word wrap)
         textView.textContainer?.widthTracksTextView = false
         textView.textContainer?.containerSize = NSSize(
@@ -49,17 +54,19 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.isAutomaticTextReplacementEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
         textView.isAutomaticTextCompletionEnabled = false
+        // Resolve appearance once — dynamic NSColors may not resolve correctly
+        // inside SwiftUI-hosted NSTextViews.
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let resolvedTextColor = SyntaxTheme.resolvedBaseTextColor(isDark: isDark)
+
         textView.font = context.coordinator.baseFont
-        textView.textColor = SyntaxTheme.baseTextColor
+        textView.textColor = resolvedTextColor
         textView.backgroundColor = Self.editorBackground
-        textView.insertionPointColor = SyntaxTheme.baseTextColor
+        textView.insertionPointColor = resolvedTextColor
         textView.selectedTextAttributes = [
-            .backgroundColor: NSColor(name: nil) { appearance in
-                let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                return isDark
-                    ? NSColor(white: 1.0, alpha: 0.15)
-                    : NSColor(white: 0.0, alpha: 0.12)
-            },
+            .backgroundColor: isDark
+                ? NSColor(white: 1.0, alpha: 0.15)
+                : NSColor(white: 0.0, alpha: 0.12),
         ]
 
         textView.string = text
@@ -80,7 +87,12 @@ struct HighlightedTextView: NSViewRepresentable {
         textView.delegate = context.coordinator
         context.coordinator.textView = textView
         context.coordinator.rulerView = rulerView
-        context.coordinator.applyHighlighting()
+
+        // Defer highlighting to the next run loop iteration so the view is in the
+        // window hierarchy and effectiveAppearance resolves correctly.
+        DispatchQueue.main.async {
+            context.coordinator.applyHighlighting()
+        }
 
         return scrollView
     }
@@ -170,16 +182,23 @@ struct HighlightedTextView: NSViewRepresentable {
 
             let selectedRange = textView.selectedRange()
 
+            // Pre-resolve colors to static sRGB values. Dynamic NSColors
+            // (NSColor(name:dynamicProvider:) and NSColor(SwiftUI.Color)) stored
+            // in NSAttributedString foreground color attributes may not resolve
+            // correctly inside an NSTextView hosted in SwiftUI.
+            let isDark = textView.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            let resolvedBaseColor = SyntaxTheme.resolvedBaseTextColor(isDark: isDark)
+
             textStorage.beginEditing()
             textStorage.setAttributes(
-                [.font: baseFont, .foregroundColor: SyntaxTheme.baseTextColor],
+                [.font: baseFont, .foregroundColor: resolvedBaseColor],
                 range: NSRange(location: 0, length: fullText.utf16.count)
             )
 
             let tokens = SyntaxTokenizer.tokenize(fullText, language: language)
             for token in tokens {
                 textStorage.addAttributes(
-                    SyntaxTheme.attributes(for: token.type, baseFont: baseFont),
+                    SyntaxTheme.resolvedAttributes(for: token.type, baseFont: baseFont, isDark: isDark),
                     range: token.range
                 )
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -93,4 +93,39 @@ struct SyntaxTheme {
             .font: font,
         ]
     }
+
+    // MARK: - Resolved Attributes (for SwiftUI-hosted NSTextView)
+
+    /// Dynamic NSColors stored in NSAttributedString foreground color attributes
+    /// may not resolve correctly inside an NSTextView hosted in SwiftUI via
+    /// NSViewRepresentable. These methods pre-resolve colors to static sRGB
+    /// values based on the text view's effective appearance.
+
+    /// Returns the base text color pre-resolved for the given appearance.
+    static func resolvedBaseTextColor(isDark: Bool) -> NSColor {
+        isDark
+            ? NSColor(srgbRed: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+            : NSColor(srgbRed: 0.20, green: 0.20, blue: 0.20, alpha: 1.0)
+    }
+
+    /// Returns attributed string attributes with pre-resolved (non-dynamic) colors.
+    static func resolvedAttributes(for tokenType: SyntaxTokenType, baseFont: NSFont, isDark: Bool) -> [NSAttributedString.Key: Any] {
+        var attrs = attributes(for: tokenType, baseFont: baseFont)
+        if let color = attrs[.foregroundColor] as? NSColor {
+            attrs[.foregroundColor] = resolveColor(color, isDark: isDark)
+        }
+        return attrs
+    }
+
+    /// Resolves a potentially-dynamic NSColor into a static sRGB color.
+    private static func resolveColor(_ dynamicColor: NSColor, isDark: Bool) -> NSColor {
+        let appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)!
+        let saved = NSAppearance.current
+        NSAppearance.current = appearance
+        defer { NSAppearance.current = saved }
+        guard let resolved = dynamicColor.usingColorSpace(.sRGB) else { return dynamicColor }
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        resolved.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return NSColor(srgbRed: r, green: g, blue: b, alpha: a)
+    }
 }


### PR DESCRIPTION
## Summary
- Pre-resolves all dynamic `NSColor(name:dynamicProvider:)` and `NSColor(SwiftUI.Color)` colors to static sRGB values before storing them as `.foregroundColor` attributes in the `NSAttributedString` used by the syntax highlighter
- Adds `wantsLayer = true` on the scroll view, clip view, and text view for proper Core Animation compositing inside SwiftUI
- Defers initial `applyHighlighting()` to the next run loop iteration so the view is in the window hierarchy when `effectiveAppearance` is queried
- Resolves `textColor` and `insertionPointColor` to static colors as well

## Root cause
Dynamic `NSColor` objects stored as foreground color attributes in `NSAttributedString` don't resolve correctly when the text is drawn by an `NSTextView` hosted in SwiftUI via `NSViewRepresentable`. This caused text to render as invisible (line numbers drawn via Core Graphics in the ruler view were unaffected since they resolve colors at draw time).

## Test plan
- [ ] Open a workspace file (e.g. IDENTITY.MD) — text content should now be visible with syntax highlighting
- [ ] Switch between light and dark mode — colors should adapt
- [ ] Edit text in a non-hidden file — editing should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
