### PR TITLE
refactor: fix remaining session→conversation terminology in TS tests and comments

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -246,14 +246,14 @@ describe("standalone approval endpoints — HTTP layer", () => {
   });
 
   async function startServer(
-    sessionFactory: () => Conversation,
+    conversationFactory: () => Conversation,
   ): Promise<void> {
     port = 20000 + Math.floor(Math.random() * 1000);
     server = new RuntimeHttpServer({
       port,
       bearerToken: TEST_TOKEN,
       sendMessageDeps: {
-        getOrCreateConversation: async () => sessionFactory(),
+        getOrCreateConversation: async () => conversationFactory(),
         assistantEventHub: eventHub,
         resolveAttachments: () => [],
       },

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -572,7 +572,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
 
-  test("desktop sessions do not pass approvalConversationGenerator to routeGuardianReply", async () => {
+  test("desktop conversations do not pass approvalConversationGenerator to routeGuardianReply", async () => {
     listPendingByDestinationMock.mockReturnValue([
       { id: "pending-1", kind: "access_request" },
     ]);
@@ -642,7 +642,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(routerCall.approvalConversationGenerator).toBeUndefined();
   });
 
-  test("channel sessions pass approvalConversationGenerator to routeGuardianReply", async () => {
+  test("channel conversations pass approvalConversationGenerator to routeGuardianReply", async () => {
     listPendingByDestinationMock.mockReturnValue([
       { id: "pending-1", kind: "access_request" },
     ]);

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -88,11 +88,11 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
 }
 
 /**
- * Helper to inject voice bridge deps with a given session factory.
+ * Helper to inject voice bridge deps with a given conversation factory.
  */
-function injectDeps(sessionFactory: () => Conversation): void {
+function injectDeps(conversationFactory: () => Conversation): void {
   setVoiceBridgeDeps({
-    getOrCreateConversation: async () => sessionFactory(),
+    getOrCreateConversation: async () => conversationFactory(),
     resolveAttachments: () => [],
     deriveDefaultStrictSideEffects: () => false,
   });

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -151,7 +151,7 @@ export function getOrCreateConversation(
 
     // Check if the conversationKey itself is an existing conversation ID.
     // This happens when the client loads a conversation from the conversations list
-    // and uses the server's conversationId as its local sessionId / conversationKey.
+    // and uses the server's conversationId as its local conversationKey.
     const existingConversation = tx
       .select({ id: conversations.id })
       .from(conversations)

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -165,7 +165,7 @@ function parseRequestCode(
   if (!request) return null;
 
   // Scope to the current conversation when requested, so a code belonging
-  // to a different session/conversation is not consumed here. Requests with
+  // to a different conversation is not consumed here. Requests with
   // null conversationId are global/unscoped and match any conversation.
   if (
     scopeConversationId &&


### PR DESCRIPTION
## Summary
- Rename `sessionFactory` params to `conversationFactory` in approval-routes-http and voice-session-bridge tests
- Update test names from "desktop/channel sessions" to "desktop/channel conversations" in guardian-reply tests
- Fix stale "session/conversation" and "sessionId / conversationKey" comments in guardian-reply-router and conversation-key-store

## Original prompt
fix the remaining 5 minor TS items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
