### PR TITLE
fix: add missing queryValueAllowed property to DaemonClient

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -241,6 +241,14 @@ extension Notification.Name {
 @MainActor
 public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
+    // MARK: - Static Helpers
+
+    private static let queryValueAllowed: CharacterSet = {
+        var cs = CharacterSet.urlQueryAllowed
+        cs.remove(charactersIn: "&=+#")
+        return cs
+    }()
+
     // MARK: - Published State
 
     @Published public var isConnected: Bool = false


### PR DESCRIPTION
## Summary
- Add missing `queryValueAllowed` static property to `DaemonClient` class, matching the definition already present in `HTTPDaemonClient` and `GatewayHTTPClient`
- Fixes Swift compilation error at `DaemonClient.swift:2184` and `:2186` where `Self.queryValueAllowed` was referenced but not defined

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23163607093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
