### PR TITLE
feat: Library panel loading skeleton and scrollbar padding fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -161,6 +161,7 @@ struct AppsGridView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, VSpacing.lg)
         .padding(.horizontal, VSpacing.xl)
+        .accessibilityHidden(true)
     }
 
     private var skeletonSection: some View {
@@ -183,13 +184,14 @@ struct AppsGridView: View {
     private var skeletonAppCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Preview rectangle matching 16:10 aspect ratio
-            VSkeletonBone(height: 0, radius: VRadius.lg)
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.borderBase.opacity(0.5))
                 .aspectRatio(16.0 / 10.0, contentMode: .fit)
+                .vShimmer()
 
-            // Name line
-            VStack(alignment: .leading, spacing: 4) {
+            // Name and date lines
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 VSkeletonBone(width: 120, height: 12)
-                // Date line
                 VSkeletonBone(width: 80, height: 10)
             }
             .padding(.horizontal, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -101,10 +101,15 @@ struct AppsGridView: View {
 
     // MARK: - Main Content
 
+    /// Horizontal inset applied to each child inside the ScrollView so the
+    /// scrollbar indicator stays flush against the trailing edge.
+    private let scrollContentInset = EdgeInsets(top: 0, leading: VSpacing.xl, bottom: 0, trailing: VSpacing.xl)
+
     private var mainContent: some View {
         ScrollView {
             VStack(spacing: VSpacing.xxl) {
                 searchBar
+                    .padding(scrollContentInset)
 
                 let pinned = filteredPinnedApps
                 let recents = filteredRecentApps
@@ -112,14 +117,17 @@ struct AppsGridView: View {
 
                 if !pinned.isEmpty {
                     appSection(title: "Pinned", apps: pinned)
+                        .padding(scrollContentInset)
                 }
 
                 if !recents.isEmpty {
                     appSection(title: "Recents", apps: recents)
+                        .padding(scrollContentInset)
                 }
 
                 if !shared.isEmpty {
                     sharedSection(title: "Shared", apps: shared)
+                        .padding(scrollContentInset)
                 } else if isLoadingShared {
                     ProgressView()
                         .controlSize(.small)
@@ -137,7 +145,6 @@ struct AppsGridView: View {
                     .padding(.top, VSpacing.xxxl)
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
             .frame(maxWidth: .infinity)
             .padding(.top, VSpacing.lg)
             .padding(.bottom, VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -140,8 +140,8 @@ struct AppsGridView: View {
             .frame(maxWidth: maxContentWidth)
             .frame(maxWidth: .infinity)
             .padding(.top, VSpacing.lg)
-            .padding(.horizontal, VSpacing.xl)
             .padding(.bottom, VSpacing.xl)
+            .safeAreaPadding(.horizontal, VSpacing.xl)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -43,6 +43,10 @@ struct AppsGridView: View {
     /// Maximum width of the centered content area.
     private let maxContentWidth: CGFloat = 1400
 
+    private var isLoading: Bool {
+        !hasFetchedLocalApps || !hasFetchedShared
+    }
+
     var body: some View {
         Group {
             if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared && hasFetchedLocalApps {
@@ -57,12 +61,18 @@ struct AppsGridView: View {
                         Spacer()
                     }
                     .padding(.bottom, VSpacing.md)
+                    .padding(.horizontal, VSpacing.xl)
+                    .padding(.top, VSpacing.xl)
 
                     Divider().background(VColor.borderBase)
+                        .padding(.horizontal, VSpacing.xl)
 
-                    mainContent
+                    if isLoading && appListManager.apps.isEmpty && sharedApps.isEmpty {
+                        loadingSkeleton
+                    } else {
+                        mainContent
+                    }
                 }
-                .padding(VSpacing.xl)
             }
         }
         .background(VColor.surfaceBase)
@@ -130,6 +140,59 @@ struct AppsGridView: View {
             .frame(maxWidth: maxContentWidth)
             .frame(maxWidth: .infinity)
             .padding(.top, VSpacing.lg)
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.bottom, VSpacing.xl)
+        }
+    }
+
+    // MARK: - Loading Skeleton
+
+    private var loadingSkeleton: some View {
+        VStack(spacing: VSpacing.xxl) {
+            // Disabled search bar
+            VSearchBar(placeholder: "Search your library", text: .constant(""))
+                .disabled(true)
+                .opacity(0.5)
+
+            // Skeleton section mimicking "Pinned" / "Recents"
+            skeletonSection
+        }
+        .frame(maxWidth: maxContentWidth)
+        .frame(maxWidth: .infinity)
+        .padding(.top, VSpacing.lg)
+        .padding(.horizontal, VSpacing.xl)
+    }
+
+    private var skeletonSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Section title skeleton
+            VSkeletonBone(width: 80, height: 14)
+
+            // Row of two skeleton app cards
+            HStack(spacing: VSpacing.xl) {
+                skeletonAppCard
+                skeletonAppCard
+                // Spacers to match the 5-column grid — cards only fill first 2 slots
+                Spacer()
+                Spacer()
+                Spacer()
+            }
+        }
+    }
+
+    private var skeletonAppCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Preview rectangle matching 16:10 aspect ratio
+            VSkeletonBone(height: 0, radius: VRadius.lg)
+                .aspectRatio(16.0 / 10.0, contentMode: .fit)
+
+            // Name line
+            VStack(alignment: .leading, spacing: 4) {
+                VSkeletonBone(width: 120, height: 12)
+                // Date line
+                VSkeletonBone(width: 80, height: 10)
+            }
+            .padding(.horizontal, VSpacing.xs)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -140,8 +140,8 @@ struct AppsGridView: View {
             .frame(maxWidth: maxContentWidth)
             .frame(maxWidth: .infinity)
             .padding(.top, VSpacing.lg)
-            .padding(.bottom, VSpacing.xl)
             .safeAreaPadding(.horizontal, VSpacing.xl)
+            .safeAreaPadding(.bottom, VSpacing.xl)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -137,11 +137,10 @@ struct AppsGridView: View {
                     .padding(.top, VSpacing.xxxl)
                 }
             }
-            .frame(maxWidth: maxContentWidth)
+            .padding(.horizontal, VSpacing.xl)
             .frame(maxWidth: .infinity)
             .padding(.top, VSpacing.lg)
-            .safeAreaPadding(.horizontal, VSpacing.xl)
-            .safeAreaPadding(.bottom, VSpacing.xl)
+            .padding(.bottom, VSpacing.xl)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixed scrollbar positioning: moved horizontal/bottom padding inside the ScrollView content so the scrollbar sits flush against the right edge
- Added a loading skeleton shown while apps are being fetched from the daemon — displays a disabled search bar and a skeleton section with two placeholder app cards (16:10 aspect ratio rectangles + name/date skeleton lines), matching the real Library layout

## Original prompt
--safe bottom padding around scrollable container shouldn't cut the content, scroll bar has to be all the way to the right, without any spacing, everything should remain as it is. Add Loading skeleton that will copy this page pattern - Instead Pinned / Recent have a skeleton rectangle for show one app row with two app reactangles (same size as actual apps) and two underline skeleton lines same size as app name and date. Keep Library Title and Search bar(disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
