### PR TITLE
refactor: migrate iOS and macOS storage keys from threads→conversations terminology

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -102,8 +102,10 @@ class IOSConversationStore: ObservableObject {
     /// ViewModels keyed by conversation ID, created lazily on first access.
     private var viewModels: [UUID: ChatViewModel] = [:]
     private var daemonClient: any DaemonClientProtocol
-    private static let persistenceKey = "ios_threads_v1"
-    private static let connectedCacheKey = "ios_connected_threads_cache_v1"
+    private static let persistenceKey = "ios_conversations_v1"
+    private static let connectedCacheKey = "ios_connected_conversations_cache_v1"
+    private static let legacyPersistenceKey = "ios_threads_v1"
+    private static let legacyConnectedCacheKey = "ios_connected_threads_cache_v1"
     private var cancellables: Set<AnyCancellable> = []
     /// Maps daemon conversation IDs to local conversation IDs for history loading.
     private var pendingHistoryByConversationId: [String: UUID] = [:]
@@ -252,8 +254,22 @@ class IOSConversationStore: ObservableObject {
             || latestLoadedAssistantMessageTimestamp(for: conversations[index].id) != nil
     }
 
+    /// One-time migration: move data from legacy "threads" keys to new "conversations" keys.
+    private static func migrateKeysIfNeeded() {
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: legacyPersistenceKey), defaults.data(forKey: persistenceKey) == nil {
+            defaults.set(data, forKey: persistenceKey)
+            defaults.removeObject(forKey: legacyPersistenceKey)
+        }
+        if let data = defaults.data(forKey: legacyConnectedCacheKey), defaults.data(forKey: connectedCacheKey) == nil {
+            defaults.set(data, forKey: connectedCacheKey)
+            defaults.removeObject(forKey: legacyConnectedCacheKey)
+        }
+    }
+
     init(daemonClient: any DaemonClientProtocol) {
         self.daemonClient = daemonClient
+        Self.migrateKeysIfNeeded()
 
         if let daemon = daemonClient as? DaemonClient {
             // Connected mode — show cached conversations instantly or spinner on first launch

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class ConversationLifecycleIOSTests: XCTestCase {
 
     private var mockClient: MockDaemonClient!
-    private let connectedCacheKey = "ios_connected_threads_cache_v1"
+    private let connectedCacheKey = "ios_connected_conversations_cache_v1"
 
     override func setUp() {
         super.setUp()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,8 +6,7 @@ import os
 import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
-// Keep the legacy UserDefaults key so existing persisted archive
-// state is preserved across the session-to-conversation rename.
+// Legacy UserDefaults key preserved from the session-to-conversation rename.
 private let archivedConversationsKey = "archivedSessionIds"
 
 // MARK: - Conversation Client Protocol
@@ -43,8 +42,8 @@ struct ConversationClient: ConversationClientProtocol {
 
 @MainActor
 final class ConversationManager: ObservableObject, ConversationRestorerDelegate {
-    @AppStorage("restoreRecentThreads") private(set) var restoreRecentConversations = true
-    @AppStorage("lastActiveThreadId") private var lastActiveConversationIdString: String?
+    @AppStorage("restoreRecentConversations") private(set) var restoreRecentConversations = true
+    @AppStorage("lastActiveConversationId") private var lastActiveConversationIdString: String?
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @Published var conversations: [ConversationModel] = []
     @Published var hasMoreConversations: Bool = false
@@ -229,7 +228,21 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         return getOrCreateViewModel(for: activeConversationId)
     }
 
+    /// One-time migration: rename legacy "thread" @AppStorage keys to "conversation" keys.
+    static func migrateStorageKeysIfNeeded() {
+        let defaults = UserDefaults.standard
+        if let value = defaults.object(forKey: "restoreRecentThreads"), defaults.object(forKey: "restoreRecentConversations") == nil {
+            defaults.set(value, forKey: "restoreRecentConversations")
+            defaults.removeObject(forKey: "restoreRecentThreads")
+        }
+        if let value = defaults.string(forKey: "lastActiveThreadId"), defaults.string(forKey: "lastActiveConversationId") == nil {
+            defaults.set(value, forKey: "lastActiveConversationId")
+            defaults.removeObject(forKey: "lastActiveThreadId")
+        }
+    }
+
     init(daemonClient: DaemonClient, conversationClient: ConversationClientProtocol = ConversationClient(), activityNotificationService: ActivityNotificationService? = nil, isFirstLaunch: Bool = false) {
+        Self.migrateStorageKeysIfNeeded()
         self.daemonClient = daemonClient
         self.conversationClient = conversationClient
         self.activityNotificationService = activityNotificationService


### PR DESCRIPTION
## Summary
- Rename iOS persistence keys from `ios_threads_v1` / `ios_connected_threads_cache_v1` to `ios_conversations_v1` / `ios_connected_conversations_cache_v1` with one-time migration
- Rename macOS @AppStorage keys from `restoreRecentThreads` / `lastActiveThreadId` to `restoreRecentConversations` / `lastActiveConversationId` with one-time migration
- Both migrations are idempotent and preserve existing user data

Part of plan: conv-terminology-rename.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
