### PR TITLE
refactor: rename session→conversation in daemon pipeline comments and error strings

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1,7 +1,7 @@
 /**
- * Session-backed voice call controller.
+ * Conversation-backed voice call controller.
  *
- * Routes voice turns through the daemon session pipeline via
+ * Routes voice turns through the daemon conversation pipeline via
  * voice-session-bridge instead of calling provider.sendMessage() directly.
  * This gives voice calls access to tools, memory, skills, and runtime
  * injections while preserving all existing call UX behavior (control markers,
@@ -118,10 +118,10 @@ export class CallController {
   /** Conversation ID for the voice session. */
   private conversationId: string;
   /**
-   * Track whether the last message sent to the session was a user message
+   * Track whether the last message sent to the conversation was a user message
    * whose assistant response has not yet been received. This is used to
    * prevent sending consecutive user messages that would violate role
-   * alternation in the underlying session pipeline.
+   * alternation in the underlying conversation pipeline.
    */
   private lastSentWasOpener = false;
   /**
@@ -434,7 +434,7 @@ export class CallController {
   }
 
   /**
-   * Execute a single voice turn through the session pipeline and stream
+   * Execute a single voice turn through the conversation pipeline and stream
    * the response back through the relay.
    */
   private runTurn(content: string): Promise<void> {
@@ -507,7 +507,7 @@ export class CallController {
   }
 
   /**
-   * Stream TTS tokens from the session pipeline, buffering to strip
+   * Stream TTS tokens from the conversation pipeline, buffering to strip
    * control markers before they reach the relay. Returns the full
    * accumulated response text for post-turn marker detection.
    */

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -4,7 +4,7 @@
  * (which lives in the dedicated voice conversation).
  *
  * Trust-aware: trusted audiences get pointer messages routed through the
- * daemon session as a conversation turn (the assistant generates the text).
+ * daemon conversation as a conversation turn (the assistant generates the text).
  * Untrusted/unknown audiences always receive deterministic fallback text
  * written directly to the conversation store.
  */
@@ -34,7 +34,7 @@ export type PointerEvent =
 export type PointerAudienceMode = "auto" | "trusted" | "untrusted";
 
 /**
- * Daemon-injected function that sends a message through the daemon session
+ * Daemon-injected function that sends a message through the daemon conversation
  * pipeline (persistAndProcessMessage), letting the assistant generate the
  * pointer text as a natural conversation turn.
  *
@@ -157,7 +157,7 @@ export async function addPointerMessage(
     (audienceMode === "auto" && resolvePointerAudienceTrust(conversationId));
 
   if (trustedAudience && pointerMessageProcessor) {
-    // Route through the daemon session — the assistant generates the
+    // Route through the daemon conversation — the assistant generates the
     // pointer text as a natural conversation turn, shaped by context,
     // identity, and preferences.
     const instruction = buildPointerInstruction(context);

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1946,8 +1946,8 @@ export class RelayConnection {
 
     const session = getCallSession(this.callSessionId);
     if (session) {
-      // User message persistence is handled by the session pipeline
-      // (voice-session-bridge -> session.persistUserMessage) so we only
+      // User message persistence is handled by the conversation pipeline
+      // (voice-session-bridge -> conversation.persistUserMessage) so we only
       // need to fire the transcript notifier for UI subscribers here.
       fireCallTranscriptNotifier(
         session.conversationId,
@@ -1957,13 +1957,13 @@ export class RelayConnection {
       );
     }
 
-    // Route to controller for session-backed response
+    // Route to controller for conversation-backed response
     if (this.controller) {
       await this.controller.handleCallerUtterance(msg.voicePrompt, speaker);
     } else {
       // Fallback if controller not yet initialized — persist the caller's
       // transcript so it is available in conversation history once setup
-      // completes. The session pipeline normally handles persistence, but
+      // completes. The conversation pipeline normally handles persistence, but
       // this early-utterance path bypasses it entirely.
       if (session) {
         try {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1,8 +1,8 @@
 /**
- * Bridge between voice relay and the daemon session pipeline.
+ * Bridge between voice relay and the daemon conversation pipeline.
  *
  * Provides a `startVoiceTurn()` function that manages a voice turn
- * directly through the session, translating agent-loop events into
+ * directly through the conversation, translating agent-loop events into
  * simple callbacks suitable for real-time TTS streaming.
  *
  * Dependency injection follows the same module-level setter pattern used by
@@ -220,9 +220,9 @@ function buildVoiceCallControlPrompt(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Execute a single voice turn through the daemon session pipeline.
+ * Execute a single voice turn through the daemon conversation pipeline.
  *
- * Manages the session directly with voice-specific defaults:
+ * Manages the conversation directly with voice-specific defaults:
  *   - sourceChannel: 'phone'
  *   - event sink wired to the provided callbacks
  *   - abort propagated from the returned handle
@@ -267,7 +267,7 @@ export async function startVoiceTurn(
   const forceStrictSideEffects = isGuardian ? undefined : true;
 
   // Replace the [CALL_OPENING] marker with a neutral instruction before
-  // persisting. The marker must not appear as a user message in session
+  // persisting. The marker must not appear as a user message in conversation
   // history — after a barge-in interruption the next turn would replay
   // the stale marker and potentially retrigger opener behavior.
   const persistedContent =
@@ -287,7 +287,7 @@ export async function startVoiceTurn(
     isCallerGuardian,
   });
 
-  // Get or create the session
+  // Get or create the conversation
   const transport = {
     channelId: "phone" as ChannelId,
   };
@@ -304,20 +304,20 @@ export async function startVoiceTurn(
     let waited = 0;
     while (conversation.isProcessing() && waited < maxWaitMs) {
       if (opts.signal?.aborted) {
-        throw new Error("Turn aborted while waiting for session");
+        throw new Error("Turn aborted while waiting for conversation");
       }
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
       waited += pollIntervalMs;
     }
     if (opts.signal?.aborted) {
-      throw new Error("Turn aborted while waiting for session");
+      throw new Error("Turn aborted while waiting for conversation");
     }
     if (conversation.isProcessing()) {
-      throw new Error("Session is already processing a message");
+      throw new Error("Conversation is already processing a message");
     }
   }
 
-  // Configure session for this voice turn
+  // Configure conversation for this voice turn
   const strictSideEffects =
     forceStrictSideEffects ??
     deps.deriveDefaultStrictSideEffects(opts.conversationId);

--- a/assistant/src/daemon/verification-session-intent.ts
+++ b/assistant/src/daemon/verification-session-intent.ts
@@ -1,6 +1,6 @@
 // Verification session intent resolution for deterministic first-turn routing.
 // Exports `resolveVerificationSessionIntent` as the single public entry point.
-// When a direct guardian setup request is detected, the session pipeline
+// When a direct guardian setup request is detected, the conversation pipeline
 // rewrites the message to force immediate entry into the guardian-verify-setup
 // skill flow, bypassing the normal agent loop's tendency to produce conceptual
 // preambles before loading the skill.


### PR DESCRIPTION
## Summary
- Update all comments and error strings in voice-session-bridge.ts, call-controller.ts, relay-server.ts, call-pointer-messages.ts, and verification-session-intent.ts that refer to the daemon "session pipeline" to use "conversation pipeline"
- Preserves "voice session" terminology where it refers to the actual voice call session
- No functional code changes — only comments and error message strings

Part of plan: conv-terminology-rename.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
