### PR TITLE
Read/write inference mode in SettingsStore and set default during bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -314,6 +314,21 @@ extension AppDelegate {
                 case .registeredAndProvisioned(let id):
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
+
+                // Set default inference mode to "managed" if not already configured
+                let existingConfig = WorkspaceConfigIO.read()
+                if let services = existingConfig["services"] as? [String: Any],
+                   let inference = services["inference"] as? [String: Any],
+                   inference["mode"] != nil {
+                    // Already configured — don't overwrite explicit user choice
+                } else {
+                    var services = existingConfig["services"] as? [String: Any] ?? [:]
+                    var inference = services["inference"] as? [String: Any] ?? [:]
+                    inference["mode"] = "managed"
+                    services["inference"] = inference
+                    try? WorkspaceConfigIO.merge(["services": services])
+                }
+
                 self.localBootstrapDidComplete = true
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -142,6 +142,20 @@ struct APIKeyEntryStepView: View {
         APIKeyManager.setKey(trimmed, for: "anthropic")
         APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
+        // Set default inference mode to "your-own" if not already configured
+        let existingConfig = WorkspaceConfigIO.read()
+        if let services = existingConfig["services"] as? [String: Any],
+           let inference = services["inference"] as? [String: Any],
+           inference["mode"] != nil {
+            // Already configured
+        } else {
+            var services = existingConfig["services"] as? [String: Any] ?? [:]
+            var inference = services["inference"] as? [String: Any] ?? [:]
+            inference["mode"] = "your-own"
+            services["inference"] = inference
+            try? WorkspaceConfigIO.merge(["services": services])
+        }
+
         saveModelToConfig("claude-opus-4-6")
         state.isHatching = true
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -184,6 +184,10 @@ public final class SettingsStore: ObservableObject {
     /// Values: `"user-key"`, `"managed-proxy"`, or absent.
     @Published var providerRoutingSources: [String: String] = [:]
 
+    /// Current inference mode from the daemon debug endpoint.
+    /// Values: `"managed"` or `"your-own"`.
+    @Published var inferenceMode: String = "your-own"
+
     // MARK: - Platform Config State
 
     @Published var platformBaseUrl: String = ""
@@ -1828,10 +1832,29 @@ public final class SettingsStore: ObservableObject {
                       let provider = json["provider"] as? [String: Any],
                       let sources = provider["routingSources"] as? [String: String] else { return }
                 self.providerRoutingSources = sources
+                if let mode = provider["inferenceMode"] as? String {
+                    self.inferenceMode = mode
+                }
             } catch {
                 log.error("Failed to load provider routing sources: \(error)")
             }
         }
+    }
+
+    func setInferenceMode(_ mode: String) {
+        inferenceMode = mode
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["mode"] = mode
+        services["inference"] = inference
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for inference mode: \(error)")
+        }
+        scheduleRoutingSourceRefresh()
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the


### PR DESCRIPTION
## Summary
- Add inferenceMode published property to SettingsStore, populated from the debug endpoint
- Add setInferenceMode() method to write mode to workspace config with remote assistant guard
- Persist managed/your-own defaults at hatch time based on bootstrap path

Part of plan: anthropic-card-managed-toggle.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
