### PR TITLE
fix: replace deprecated NSAppearance.current in SyntaxTheme

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -120,12 +120,13 @@ struct SyntaxTheme {
     /// Resolves a potentially-dynamic NSColor into a static sRGB color.
     private static func resolveColor(_ dynamicColor: NSColor, isDark: Bool) -> NSColor {
         let appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)!
-        let saved = NSAppearance.current
-        NSAppearance.current = appearance
-        defer { NSAppearance.current = saved }
-        guard let resolved = dynamicColor.usingColorSpace(.sRGB) else { return dynamicColor }
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        resolved.getRed(&r, green: &g, blue: &b, alpha: &a)
-        return NSColor(srgbRed: r, green: g, blue: b, alpha: a)
+        var result: NSColor = dynamicColor
+        appearance.performAsCurrentDrawingAppearance {
+            guard let resolved = dynamicColor.usingColorSpace(.sRGB) else { return }
+            var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+            resolved.getRed(&r, green: &g, blue: &b, alpha: &a)
+            result = NSColor(srgbRed: r, green: g, blue: b, alpha: a)
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `NSAppearance.current` get/set pattern with `performAsCurrentDrawingAppearance` in `SyntaxTheme.resolveColor()`, eliminating macOS 12.0 deprecation warnings during build.

## Original prompt
Fix deprecation warnings for `NSAppearance.current` in SyntaxTheme.swift (deprecated in macOS 12.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
