### PR TITLE
Remove unused ReadOnlyCodeContent from file viewer components

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -487,8 +487,12 @@ struct AgentPanelContent: View {
             Divider().background(VColor.borderBase)
 
             // File content
-            ReadOnlyCodeContent(content: content)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            HighlightedTextView(
+                text: .constant(content),
+                language: SyntaxLanguage.detect(fileName: file.path, mimeType: file.mimeType),
+                isEditable: false
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -29,29 +29,6 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
     }
 }
 
-/// Scrollable read-only monospace text display for file content.
-struct ReadOnlyCodeContent: View {
-    let content: String
-
-    var body: some View {
-        GeometryReader { geometry in
-            ScrollView([.vertical, .horizontal]) {
-                Text(content)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentDefault)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .padding(VSpacing.md)
-                    .frame(
-                        minWidth: geometry.size.width,
-                        minHeight: geometry.size.height,
-                        alignment: .topLeading
-                    )
-            }
-        }
-    }
-}
-
 /// Header bar showing file icon, name, and size for file content viewers.
 struct FileContentHeaderBar<Trailing: View>: View {
     let icon: VIcon


### PR DESCRIPTION
## Summary
- Removed dead `ReadOnlyCodeContent` struct from `SharedFileViewerComponents.swift`
- Replaced its single remaining caller in `AgentPanel.swift` with `HighlightedTextView`
- This view was replaced by `HighlightedTextView` and has no remaining callers

Part of plan: code-viewer-polish.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
