### PR TITLE
fix: extract duplicated setServiceField into shared config utility

### DIFF
--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Safely set a nested field on a raw config object's `services` map.
+ *
+ * Ensures the `services` and service-level objects exist before writing,
+ * so callers don't need to guard against undefined intermediate keys.
+ *
+ * Example: `setServiceField(raw, "inference", "model", "claude-sonnet-4-6")`
+ * produces `raw.services.inference.model = "claude-sonnet-4-6"`.
+ */
+export function setServiceField(
+  raw: Record<string, unknown>,
+  service: string,
+  field: string,
+  value: unknown,
+): void {
+  const services =
+    (raw.services as Record<string, Record<string, unknown>>) ?? {};
+  const svc = services[service] ?? {};
+  svc[field] = value;
+  services[service] = svc;
+  raw.services = services;
+}

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -11,6 +11,7 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../config/loader.js";
+import { setServiceField } from "../config/raw-config-utils.js";
 import { initializeProviders } from "../providers/registry.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLocalIPv4 } from "../util/network-info.js";
@@ -22,20 +23,6 @@ import type { PairingStore } from "./pairing-store.js";
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
   | { kind: "unknown"; message: string; qrFilename?: string };
-
-function setServiceField(
-  raw: Record<string, unknown>,
-  service: string,
-  field: string,
-  value: unknown,
-): void {
-  const services =
-    (raw.services as Record<string, Record<string, unknown>>) ?? {};
-  const svc = services[service] ?? {};
-  svc[field] = value;
-  services[service] = svc;
-  raw.services = services;
-}
 
 // ── /pair command — module-level pairing context ────────────────────
 

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -4,6 +4,7 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
+import { setServiceField } from "../../config/raw-config-utils.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { MODEL_TO_PROVIDER } from "../conversation-slash.js";
@@ -16,24 +17,6 @@ import {
   type HandlerContext,
   log,
 } from "./shared.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function setServiceField(
-  raw: Record<string, unknown>,
-  service: string,
-  field: string,
-  value: unknown,
-): void {
-  const services =
-    (raw.services as Record<string, Record<string, unknown>>) ?? {};
-  const svc = services[service] ?? {};
-  svc[field] = value;
-  services[service] = svc;
-  raw.services = services;
-}
 
 // ---------------------------------------------------------------------------
 // Shared business logic (transport-agnostic)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-managed-toggle.md.

**Gap:** Duplicated setServiceField helper function
**What was expected:** Shared utility functions should not be duplicated
**What was found:** setServiceField is identically defined in conversation-slash.ts and config-model.ts

- Extracted `setServiceField` into `assistant/src/config/raw-config-utils.ts`
- Updated both `conversation-slash.ts` and `handlers/config-model.ts` to import from the shared module
- Removed duplicate local definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
