### PR TITLE
fix: add user-key fallback in managed mode resolveProviderCredentials

### DIFF
--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -245,6 +245,11 @@ async function resolveProviderCredentials(
         source: "managed-proxy",
       };
     }
+    // Managed proxy unavailable for this provider; fall back to user key
+    const userKey = await getSecureKeyAsync(providerName);
+    if (userKey) {
+      return { apiKey: userKey, source: "user-key" };
+    }
     return null;
   }
   // "your-own" mode: check user key first, then try managed proxy fallback


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-managed-toggle.md.

**Gap:** resolveProviderCredentials in managed mode does not fall back to user key
**What was expected:** Managed mode should fall back to user key when proxy unavailable
**What was found:** Returns null without checking user key, breaking failover for non-managed providers like OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
