### PR TITLE
Add syntax highlighting to read-only source view using SwiftUI AttributedString

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -58,6 +58,11 @@ struct HighlightedTextView: View {
 
     // MARK: - Read-Only Mode
 
+    /// Syntax-highlighted text for the read-only view.
+    private var highlightedText: AttributedString {
+        SyntaxTheme.highlight(text, language: language)
+    }
+
     /// Read-only view with line numbers and horizontal scrolling.
     private var readOnlyView: some View {
         let lines = text.components(separatedBy: "\n")
@@ -72,9 +77,7 @@ struct HighlightedTextView: View {
 
                     // Text content — scrolls both directions
                     ScrollView(.horizontal, showsIndicators: true) {
-                        Text(text)
-                            .font(VFont.mono)
-                            .foregroundStyle(VColor.contentDefault)
+                        Text(highlightedText)
                             .textSelection(.enabled)
                             .fixedSize(horizontal: true, vertical: false)
                             .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Wire SyntaxTheme.highlight() into HighlightedTextView's read-only mode
- Replace plain Text(text) with Text(highlightedText) for syntax-colored rendering
- JS/TS keywords, strings, comments, numbers, types all render in distinct colors via VColor.syntax* tokens

Part of plan: code-viewer-polish.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
