### PR TITLE
fix: use shared setServiceField in cli.ts /model handler

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -18,6 +18,7 @@ import {
   updateStatusText,
 } from "./cli/main-screen.jsx";
 import { loadRawConfig, saveRawConfig } from "./config/loader.js";
+import { setServiceField } from "./config/raw-config-utils.js";
 import { MODEL_TO_PROVIDER } from "./daemon/conversation-slash.js";
 import { getModelInfo } from "./daemon/handlers/config-model.js";
 import { renderHistoryContent } from "./daemon/handlers/shared.js";
@@ -1125,16 +1126,14 @@ export async function startCli(): Promise<void> {
         try {
           const raw = loadRawConfig();
           const provider = MODEL_TO_PROVIDER[modelArg];
-          const services =
-            (raw.services as Record<string, Record<string, unknown>>) ?? {};
-          const inference = services.inference ?? {};
-          inference.model = modelArg;
-          if (provider) inference.provider = provider;
-          services.inference = inference;
-          raw.services = services;
+          setServiceField(raw, "inference", "model", modelArg);
+          if (provider) setServiceField(raw, "inference", "provider", provider);
           saveRawConfig(raw);
+          const existingProvider = (
+            raw.services as Record<string, Record<string, unknown>>
+          )?.inference?.provider as string | undefined;
           process.stdout.write(
-            `\n  Model: ${modelArg} (${provider ?? (inference.provider as string)})\n\n`,
+            `\n  Model: ${modelArg} (${provider ?? existingProvider})\n\n`,
           );
         } catch {
           process.stdout.write("[Failed to set model]\n");


### PR DESCRIPTION
## Summary
Replaces inline `setServiceField` reimplementation in `cli.ts` `/model` handler with an import from the shared `config/raw-config-utils.ts` utility, completing the consolidation started in PR #17886.

**Gap:** Missed setServiceField consolidation in cli.ts
**What was expected:** All callers should use the shared setServiceField utility
**What was found:** cli.ts had inline reimplementation of the same logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
