### PR TITLE
Add Cmd+F search with match highlighting to file viewer source view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -11,6 +11,10 @@ struct HighlightedTextView: View {
     let isEditable: Bool
     var onTextChange: ((String) -> Void)?
 
+    @State private var isSearchVisible = false
+    @State private var searchQuery = ""
+    @State private var currentMatchIndex = 0
+
     private static let editorBackground = adaptiveColor(
         light: Color(.sRGB, red: 0.98, green: 0.98, blue: 0.97),
         dark: Color(.sRGB, red: 0.13, green: 0.14, blue: 0.13)
@@ -26,6 +30,12 @@ struct HighlightedTextView: View {
         dark: Color(.sRGB, red: 0.45, green: 0.45, blue: 0.45)
     )
 
+    /// Total number of search matches in the text.
+    private var searchMatchCount: Int {
+        guard !searchQuery.isEmpty else { return 0 }
+        return findMatchRanges().count
+    }
+
     var body: some View {
         if isEditable {
             editableView
@@ -37,13 +47,36 @@ struct HighlightedTextView: View {
     // MARK: - Editable Mode
 
     /// TextEditor-based editable view — no line numbers but text is visible and editable.
+    /// Shows search bar with match count but does not highlight matches inline
+    /// (TextEditor doesn't support AttributedString).
     private var editableView: some View {
-        TextEditor(text: editableBinding)
-            .font(VFont.mono)
-            .foregroundStyle(VColor.contentDefault)
-            .scrollContentBackground(.hidden)
-            .background(Self.editorBackground)
-            .scrollDisabled(false)
+        VStack(spacing: 0) {
+            if isSearchVisible {
+                SourceSearchBar(
+                    searchQuery: $searchQuery,
+                    currentMatchIndex: $currentMatchIndex,
+                    matchCount: searchMatchCount,
+                    onDismiss: dismissSearch
+                )
+            }
+
+            TextEditor(text: editableBinding)
+                .font(VFont.mono)
+                .foregroundStyle(VColor.contentDefault)
+                .scrollContentBackground(.hidden)
+                .background(Self.editorBackground)
+                .scrollDisabled(false)
+        }
+        .onKeyPress("f", phases: .down) { press in
+            guard press.modifiers == .command else { return .ignored }
+            isSearchVisible = true
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            guard isSearchVisible else { return .ignored }
+            dismissSearch()
+            return .handled
+        }
     }
 
     private var editableBinding: Binding<String> {
@@ -58,9 +91,28 @@ struct HighlightedTextView: View {
 
     // MARK: - Read-Only Mode
 
-    /// Syntax-highlighted text for the read-only view.
+    /// Syntax-highlighted text for the read-only view, with search match highlighting.
     private var highlightedText: AttributedString {
-        SyntaxTheme.highlight(text, language: language)
+        var result = SyntaxTheme.highlight(text, language: language)
+
+        guard !searchQuery.isEmpty else { return result }
+
+        let matchRanges = findMatchRanges()
+        for (index, range) in matchRanges.enumerated() {
+            guard let lowerBound = AttributedString.Index(range.lowerBound, within: result),
+                  let upperBound = AttributedString.Index(range.upperBound, within: result) else {
+                continue
+            }
+
+            let attrRange = lowerBound..<upperBound
+            if index == currentMatchIndex {
+                result[attrRange].backgroundColor = VColor.primaryBase.opacity(0.3)
+            } else {
+                result[attrRange].backgroundColor = VColor.systemMidWeak
+            }
+        }
+
+        return result
     }
 
     /// Read-only view with line numbers and horizontal scrolling.
@@ -69,26 +121,70 @@ struct HighlightedTextView: View {
         let lineCount = lines.count
         let gutterWidth = gutterWidth(for: lineCount)
 
-        return GeometryReader { geometry in
-            ScrollView([.vertical]) {
-                HStack(alignment: .top, spacing: 0) {
-                    // Line number gutter — scrolls vertically, pinned horizontally
-                    lineNumberGutter(lineCount: lineCount, width: gutterWidth)
-
-                    // Text content — scrolls both directions
-                    ScrollView(.horizontal, showsIndicators: true) {
-                        Text(highlightedText)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: true, vertical: false)
-                            .padding(.vertical, VSpacing.sm)
-                            .padding(.horizontal, VSpacing.md)
-                    }
-                    .frame(minWidth: geometry.size.width - gutterWidth)
-                }
-                .frame(minHeight: geometry.size.height, alignment: .topLeading)
+        return VStack(spacing: 0) {
+            if isSearchVisible {
+                SourceSearchBar(
+                    searchQuery: $searchQuery,
+                    currentMatchIndex: $currentMatchIndex,
+                    matchCount: searchMatchCount,
+                    onDismiss: dismissSearch
+                )
             }
-            .background(Self.editorBackground)
+
+            GeometryReader { geometry in
+                ScrollView([.vertical]) {
+                    HStack(alignment: .top, spacing: 0) {
+                        // Line number gutter — scrolls vertically, pinned horizontally
+                        lineNumberGutter(lineCount: lineCount, width: gutterWidth)
+
+                        // Text content — scrolls both directions
+                        ScrollView(.horizontal, showsIndicators: true) {
+                            Text(highlightedText)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: true, vertical: false)
+                                .padding(.vertical, VSpacing.sm)
+                                .padding(.horizontal, VSpacing.md)
+                        }
+                        .frame(minWidth: geometry.size.width - gutterWidth)
+                    }
+                    .frame(minHeight: geometry.size.height, alignment: .topLeading)
+                }
+                .background(Self.editorBackground)
+            }
         }
+        .onKeyPress("f", phases: .down) { press in
+            guard press.modifiers == .command else { return .ignored }
+            isSearchVisible = true
+            return .handled
+        }
+        .onKeyPress(.escape) {
+            guard isSearchVisible else { return .ignored }
+            dismissSearch()
+            return .handled
+        }
+    }
+
+    // MARK: - Search
+
+    /// Finds all case-insensitive occurrences of `searchQuery` in `text`.
+    private func findMatchRanges() -> [Range<String.Index>] {
+        guard !searchQuery.isEmpty else { return [] }
+
+        var ranges: [Range<String.Index>] = []
+        var searchStart = text.startIndex
+
+        while searchStart < text.endIndex,
+              let range = text.range(of: searchQuery, options: .caseInsensitive, range: searchStart..<text.endIndex) {
+            ranges.append(range)
+            searchStart = range.upperBound
+        }
+
+        return ranges
+    }
+
+    private func dismissSearch() {
+        isSearchVisible = false
+        searchQuery = ""
     }
 
     // MARK: - Line Numbers
@@ -118,5 +214,82 @@ struct HighlightedTextView: View {
     private func gutterWidth(for lineCount: Int) -> CGFloat {
         let digitCount = max(3, "\(lineCount)".count)
         return CGFloat(digitCount * 8 + 16)
+    }
+}
+
+// MARK: - Source Search Bar
+
+/// Search bar for the file viewer source view. Displays match count, prev/next navigation,
+/// and a close button.
+private struct SourceSearchBar: View {
+    @Binding var searchQuery: String
+    @Binding var currentMatchIndex: Int
+    let matchCount: Int
+    let onDismiss: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.search, size: 12)
+                    .foregroundColor(VColor.contentTertiary)
+
+                TextField("Search...", text: $searchQuery)
+                    .textFieldStyle(.plain)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .focused($isFocused)
+                    .onSubmit { goToNextMatch() }
+
+                if !searchQuery.isEmpty {
+                    Text(matchCount > 0 ? "\(currentMatchIndex + 1) of \(matchCount)" : "No results")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .fixedSize()
+
+                    Button(action: goToPreviousMatch) {
+                        VIconView(.chevronUp, size: 12)
+                            .foregroundColor(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(matchCount == 0)
+                    .accessibilityLabel("Previous match")
+
+                    Button(action: goToNextMatch) {
+                        VIconView(.chevronDown, size: 12)
+                            .foregroundColor(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(matchCount == 0)
+                    .accessibilityLabel("Next match")
+                }
+
+                Button(action: onDismiss) {
+                    VIconView(.x, size: 12)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close search")
+            }
+            .padding(VSpacing.sm)
+            .background(VColor.surfaceOverlay)
+
+            Divider()
+        }
+        .onAppear { isFocused = true }
+        .onChange(of: searchQuery) { _, _ in
+            currentMatchIndex = 0
+        }
+    }
+
+    private func goToPreviousMatch() {
+        guard matchCount > 0 else { return }
+        currentMatchIndex = currentMatchIndex > 0 ? currentMatchIndex - 1 : matchCount - 1
+    }
+
+    private func goToNextMatch() {
+        guard matchCount > 0 else { return }
+        currentMatchIndex = currentMatchIndex < matchCount - 1 ? currentMatchIndex + 1 : 0
     }
 }


### PR DESCRIPTION
## Summary
- Added Cmd+F search overlay with match count, prev/next navigation, and Escape to dismiss
- Search matches highlighted in read-only view via AttributedString background colors
- Current match uses a prominent highlight; other matches use a subtle highlight
- Editable mode shows search bar with match count but skips inline highlighting

Part of plan: code-viewer-polish.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
