### PR TITLE
fix: use deep merge for saveModelToConfig in Swift onboarding views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -161,6 +161,11 @@ struct APIKeyEntryStepView: View {
     }
 
     private func saveModelToConfig(_ model: String) {
-        try? WorkspaceConfigIO.merge(["services": ["inference": ["model": model]]])
+        let existingConfig = WorkspaceConfigIO.read()
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["model"] = model
+        services["inference"] = inference
+        try? WorkspaceConfigIO.merge(["services": services])
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -194,6 +194,11 @@ struct APIKeyStepView: View {
     }
 
     private func saveModelToConfig(_ model: String) {
-        try? WorkspaceConfigIO.merge(["services": ["inference": ["model": model]]])
+        let existingConfig = WorkspaceConfigIO.read()
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["model"] = model
+        services["inference"] = inference
+        try? WorkspaceConfigIO.merge(["services": services])
     }
 }


### PR DESCRIPTION
## Summary
Fixes data-loss bug where `saveModelToConfig` in both `APIKeyEntryStepView` and `APIKeyStepView` used a shallow `WorkspaceConfigIO.merge` call that replaced the entire `services` key, destroying `image-generation`, `web-search`, and other `inference` fields like `mode` and `provider`.

Now reads existing config, performs deep mutation on the `inference` sub-dict, and merges the full `services` object — matching the pattern used in `AppDelegate+AuthLifecycle.swift` and `SettingsStore.setInferenceMode`.

**Gap:** Data-loss bug in Swift saveModelToConfig
**What was expected:** saveModelToConfig should write services.inference.model without destroying other services subkeys
**What was found:** Shallow merge overwrote entire services key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
