### PR TITLE
refactor: rename 'No active session' error strings to 'No active conversation'

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -486,7 +486,7 @@ export async function handleUndo(
 ): Promise<void> {
   const result = await undoLastMessage(msg.conversationId, ctx);
   if (!result) {
-    ctx.send({ type: "error", message: "No active session" });
+    ctx.send({ type: "error", message: "No active conversation" });
     return;
   }
   ctx.send({
@@ -552,7 +552,7 @@ export function handleUsageRequest(
 ): void {
   const conversation = getConversation(msg.conversationId);
   if (!conversation) {
-    ctx.send({ type: "error", message: "No active session" });
+    ctx.send({ type: "error", message: "No active conversation" });
     return;
   }
   const config = getConfig();


### PR DESCRIPTION
## Summary
Renames two "No active session" error messages to "No active conversation" in the daemon conversations handler, consistent with the session→conversation terminology refactor.

Fixes gap identified during plan review for conv-terminology-rename.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
