### PR TITLE
feat: generate character-components.json at build time and pre-load in AvatarComponentStore

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -643,6 +643,12 @@ FEATURE_FLAG_REGISTRY="$SCRIPT_DIR/../../meta/feature-flags/feature-flag-registr
 if [ -f "$FEATURE_FLAG_REGISTRY" ]; then
     cp "$FEATURE_FLAG_REGISTRY" "$RESOURCES_DIR/feature-flag-registry.json"
 fi
+# Generate character-components.json for pre-daemon avatar rendering
+CHAR_COMP_SRC="$ASSISTANT_SRC_DIR/src/avatar/character-components.ts"
+if command -v bun &>/dev/null && [ -f "$CHAR_COMP_SRC" ]; then
+    echo "Generating character-components.json..."
+    bun -e "import { getCharacterComponents } from '$CHAR_COMP_SRC'; process.stdout.write(JSON.stringify(getCharacterComponents()))" > "$RESOURCES_DIR/character-components.json"
+fi
 
 # Always check resource bundles (they change independently of binaries)
 # Copy SPM resource bundles into Contents/Resources/

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentStore.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentStore.swift
@@ -22,7 +22,25 @@ final class AvatarComponentStore {
 
     // MARK: - Init
 
-    private init() {}
+    private init() {
+        loadBundledComponents()
+    }
+
+    /// Pre-populate the store from a bundled JSON file generated at build time.
+    /// Falls back silently if the file is missing (e.g. swift test without bun)
+    /// or cannot be decoded.
+    private func loadBundledComponents() {
+        guard let url = Bundle.main.resourceURL?
+            .appendingPathComponent("character-components.json"),
+              let data = try? Data(contentsOf: url),
+              let response = try? JSONDecoder().decode(
+                  AvatarComponentService.ComponentsResponse.self,
+                  from: data
+              ) else {
+            return
+        }
+        load(response)
+    }
 
     // MARK: - Loading
 


### PR DESCRIPTION
## Summary
- Add build-time generation of character-components.json from TypeScript source via bun in build.sh
- Pre-load the bundled JSON in AvatarComponentStore.init() so avatars render on the hatch screen before the daemon starts
- Gracefully skip when bun is unavailable (swift test, CI test job)

Part of plan: avatar-bundled-fallback.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
