### PR TITLE
fix: replace inline adaptiveColor calls with VColor semantic tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -15,20 +15,9 @@ struct HighlightedTextView: View {
     @State private var searchQuery = ""
     @State private var currentMatchIndex = 0
 
-    private static let editorBackground = adaptiveColor(
-        light: Color(.sRGB, red: 0.98, green: 0.98, blue: 0.97),
-        dark: Color(.sRGB, red: 0.13, green: 0.14, blue: 0.13)
-    )
-
-    private static let gutterBackground = adaptiveColor(
-        light: Color(.sRGB, red: 0.94, green: 0.94, blue: 0.94),
-        dark: Color(.sRGB, red: 0.12, green: 0.12, blue: 0.12)
-    )
-
-    private static let gutterTextColor = adaptiveColor(
-        light: Color(.sRGB, red: 0.55, green: 0.55, blue: 0.55),
-        dark: Color(.sRGB, red: 0.45, green: 0.45, blue: 0.45)
-    )
+    private static let editorBackground = VColor.surfaceOverlay
+    private static let gutterBackground = VColor.surfaceBase
+    private static let gutterTextColor = VColor.contentTertiary
 
     /// Total number of search matches in the text.
     private var searchMatchCount: Int {


### PR DESCRIPTION
## Summary
- Replace 3 inline `adaptiveColor()` calls in `HighlightedTextView.swift` with semantic design tokens (`VColor.surfaceOverlay`, `VColor.surfaceBase`, `VColor.contentTertiary`)
- Fixes the "Design token guard" CI step which enforces that `adaptiveColor()` is only used inside token definition files

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23164612484/job/67301243241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
