### PR TITLE
fix: use VFont.mono design token in SyntaxTheme instead of raw Font.custom

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -27,7 +27,7 @@ struct SyntaxTheme {
     /// Tokenizes `text` for `language` and returns an `AttributedString` with
     /// syntax-colored foreground colors and appropriate font variants.
     static func highlight(_ text: String, language: SyntaxLanguage) -> AttributedString {
-        let baseFont = Font.custom("DMMono-Regular", size: 13)
+        let baseFont = VFont.mono
 
         var attributedString = AttributedString(text)
         attributedString.foregroundColor = VColor.contentDefault
@@ -53,9 +53,9 @@ struct SyntaxTheme {
 
             switch token.type {
             case .heading, .bold:
-                attributedString[attrRange].font = Font.custom("DMMono-Regular", size: 13).bold()
+                attributedString[attrRange].font = VFont.mono.bold()
             case .italic:
-                attributedString[attrRange].font = Font.custom("DMMono-Regular", size: 13).italic()
+                attributedString[attrRange].font = VFont.mono.italic()
             default:
                 break
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for code-viewer-polish.md.

**Gap:** SyntaxTheme uses raw Font.custom instead of VFont.mono design token
**What was expected:** SyntaxTheme should use VFont.mono which applies kStylisticAltFiveOnSelector
**What was found:** 3 instances of Font.custom("DMMono-Regular", size: 13) bypassing stylistic alternates

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
