### PR TITLE
refactor: remove redundant hardcoded color fallbacks from AvatarColor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarColors.swift
@@ -6,29 +6,7 @@ enum AvatarColor: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     @MainActor var nsColor: NSColor {
-        if let def = AvatarComponentStore.shared.color(id: rawValue) {
-            return AvatarComponentStore.hexToNSColor(def.hex)
-        }
-        return fallbackNSColor
-    }
-
-    /// Hardcoded fallback colors used before the component store is populated.
-    /// These match the original values that shipped before the store delegation
-    /// refactor so avatars remain visible while the daemon fetch is in-flight.
-    private var fallbackNSColor: NSColor {
-        switch self {
-        case .green: // color-literal-ok
-            return NSColor(srgbRed: 0x4C / 255.0, green: 0x9B / 255.0, blue: 0x50 / 255.0, alpha: 1) // color-literal-ok
-        case .orange: // color-literal-ok
-            return NSColor(srgbRed: 0xE9 / 255.0, green: 0x64 / 255.0, blue: 0x2F / 255.0, alpha: 1)
-        case .pink:
-            return NSColor(srgbRed: 0xDB / 255.0, green: 0x4B / 255.0, blue: 0x77 / 255.0, alpha: 1)
-        case .purple:
-            return NSColor(srgbRed: 0xA6 / 255.0, green: 0x65 / 255.0, blue: 0xC9 / 255.0, alpha: 1)
-        case .teal:
-            return NSColor(srgbRed: 0x0E / 255.0, green: 0x9B / 255.0, blue: 0x8B / 255.0, alpha: 1)
-        case .yellow: // color-literal-ok
-            return NSColor(srgbRed: 0xE9 / 255.0, green: 0xC9 / 255.0, blue: 0x1A / 255.0, alpha: 1)
-        }
+        guard let def = AvatarComponentStore.shared.color(id: rawValue) else { return .systemGray }
+        return AvatarComponentStore.hexToNSColor(def.hex)
     }
 }


### PR DESCRIPTION
## Summary
- Remove the hardcoded `fallbackNSColor` switch statement from AvatarColor since the store is now pre-populated from bundled JSON at build time
- Simplify `nsColor` to use `.systemGray` as the guard fallback instead of `.clear` for a visible safety net
- No hardcoded hex color values remain in AvatarColors.swift

Part of plan: avatar-bundled-fallback.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
