### PR TITLE
fix: clamp currentMatchIndex when text changes reduce search match count

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -77,6 +77,14 @@ struct HighlightedTextView: View {
             dismissSearch()
             return .handled
         }
+        .onChange(of: text) { _, _ in
+            let count = searchMatchCount
+            if count == 0 {
+                currentMatchIndex = 0
+            } else if currentMatchIndex >= count {
+                currentMatchIndex = max(0, count - 1)
+            }
+        }
     }
 
     private var editableBinding: Binding<String> {
@@ -161,6 +169,14 @@ struct HighlightedTextView: View {
             guard isSearchVisible else { return .ignored }
             dismissSearch()
             return .handled
+        }
+        .onChange(of: text) { _, _ in
+            let count = searchMatchCount
+            if count == 0 {
+                currentMatchIndex = 0
+            } else if currentMatchIndex >= count {
+                currentMatchIndex = max(0, count - 1)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for code-viewer-polish.md.

**Gap:** currentMatchIndex can exceed matchCount when text changes in editable mode
**What was expected:** Search counter should always show valid N of M where N <= M
**What was found:** Editing text that reduces matches below currentMatchIndex shows invalid counter like 6 of 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
