### PR TITLE
feat: add descriptions to all config schema fields

### DIFF
--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -1,17 +1,47 @@
 import { z } from "zod";
 
-export const AcpAgentConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).default([]),
-  description: z.string().optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const AcpAgentConfigSchema = z
+  .object({
+    command: z.string().describe("Command to spawn the ACP agent process"),
+    args: z
+      .array(z.string())
+      .default([])
+      .describe("Arguments passed to the agent command"),
+    description: z
+      .string()
+      .optional()
+      .describe("Human-readable description of what this agent does"),
+    env: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Environment variables set for the agent process"),
+  })
+  .describe("Configuration for an individual ACP agent");
 
-export const AcpConfigSchema = z.object({
-  enabled: z.boolean().default(false),
-  maxConcurrentSessions: z.number().int().positive().default(4),
-  agents: z.record(z.string(), AcpAgentConfigSchema).default({}),
-});
+export const AcpConfigSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "Whether the Agent Communication Protocol (ACP) system is enabled",
+      ),
+    maxConcurrentSessions: z
+      .number()
+      .int()
+      .positive()
+      .default(4)
+      .describe(
+        "Maximum number of ACP agent sessions that can run simultaneously",
+      ),
+    agents: z
+      .record(z.string(), AcpAgentConfigSchema)
+      .default({})
+      .describe("Map of agent names to their configurations"),
+  })
+  .describe(
+    "Agent Communication Protocol (ACP) — enables inter-agent communication and delegation",
+  );
 
 export type AcpConfig = z.infer<typeof AcpConfigSchema>;
 export type AcpAgentConfig = z.infer<typeof AcpAgentConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -228,20 +228,24 @@ export const AssistantConfigSchema = z
       .enum(VALID_PROVIDERS, {
         error: `provider must be one of: ${VALID_PROVIDERS.join(", ")}`,
       })
-      .default("anthropic"),
+      .default("anthropic")
+      .describe("LLM provider to use for inference"),
     model: z
       .string({ error: "model must be a string" })
-      .default("claude-opus-4-6"),
+      .default("claude-opus-4-6")
+      .describe("Model identifier for the primary LLM"),
     imageGenModel: z
       .string({ error: "imageGenModel must be a string" })
-      .default("gemini-2.5-flash-image"),
+      .default("gemini-2.5-flash-image")
+      .describe("Model identifier used for image generation"),
     webSearchProvider: z
       .enum(VALID_WEB_SEARCH_PROVIDERS, {
         error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(
           ", ",
         )}`,
       })
-      .default("anthropic-native"),
+      .default("anthropic-native")
+      .describe("Provider used for web search queries"),
     providerOrder: z
       .array(
         z.enum(VALID_PROVIDERS, {
@@ -250,12 +254,16 @@ export const AssistantConfigSchema = z
           )}`,
         }),
       )
-      .default([]),
+      .default([])
+      .describe(
+        "Fallback order of LLM providers — the assistant tries each in sequence if the previous one fails",
+      ),
     maxTokens: z
       .number({ error: "maxTokens must be a number" })
       .int("maxTokens must be an integer")
       .positive("maxTokens must be a positive integer")
-      .default(16000),
+      .default(16000)
+      .describe("Maximum number of output tokens per LLM response"),
     effort: EffortSchema,
     thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
     contextWindow: ContextWindowConfigSchema.default(
@@ -264,7 +272,8 @@ export const AssistantConfigSchema = z
     memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),
     dataDir: z
       .string({ error: "dataDir must be a string" })
-      .default(getDataDir()),
+      .default(getDataDir())
+      .describe("Directory for storing assistant data (database, logs, etc.)"),
     timeouts: TimeoutConfigSchema.default(TimeoutConfigSchema.parse({})),
     sandbox: SandboxConfigSchema.default(SandboxConfigSchema.parse({})),
     rateLimit: RateLimitConfigSchema.default(RateLimitConfigSchema.parse({})),
@@ -278,7 +287,12 @@ export const AssistantConfigSchema = z
     logFile: LogFileConfigSchema.default(
       LogFileConfigSchema.parse({ dir: getDataDir() + "/logs" }),
     ),
-    pricingOverrides: z.array(ModelPricingOverrideSchema).default([]),
+    pricingOverrides: z
+      .array(ModelPricingOverrideSchema)
+      .default([])
+      .describe(
+        "Custom pricing overrides for specific provider/model combinations",
+      ),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     swarm: SwarmConfigSchema.default(SwarmConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
@@ -309,9 +323,18 @@ export const AssistantConfigSchema = z
           error: "assistantFeatureFlagValues values must be booleans",
         }),
       )
-      .optional(),
-    collectUsageData: z.boolean().default(true),
-    sendDiagnostics: z.boolean().default(true),
+      .optional()
+      .describe("Feature flag overrides — map of flag names to boolean values"),
+    collectUsageData: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Whether to collect anonymous usage data to help improve the assistant",
+      ),
+    sendDiagnostics: z
+      .boolean()
+      .default(true)
+      .describe("Whether to send diagnostic/crash reports"),
   })
   .superRefine((config, ctx) => {
     if (

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -7,163 +7,230 @@ export const VALID_CALLER_IDENTITY_MODES = [
 ] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ["Deepgram", "Google"] as const;
 
-export const CallsDisclosureConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "calls.disclosure.enabled must be a boolean" })
-    .default(true),
-  text: z
-    .string({ error: "calls.disclosure.text must be a string" })
-    .default(
-      'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
+export const CallsDisclosureConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "calls.disclosure.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the assistant discloses it is calling on behalf of someone at the start of a call",
+      ),
+    text: z
+      .string({ error: "calls.disclosure.text must be a string" })
+      .default(
+        'At the very beginning of the call, introduce yourself as an assistant calling on behalf of the person you represent. Do not say "AI assistant".',
+      )
+      .describe(
+        "The instruction text used for the disclosure at the start of a call",
+      ),
+  })
+  .describe(
+    "Controls whether and how the assistant discloses its nature at the start of a phone call",
+  );
+
+export const CallsSafetyConfigSchema = z
+  .object({
+    denyCategories: z
+      .array(
+        z.string({
+          error: "calls.safety.denyCategories values must be strings",
+        }),
+      )
+      .default([])
+      .describe(
+        "Categories of calls that should be denied (e.g. for safety or compliance reasons)",
+      ),
+  })
+  .describe("Safety guardrails for phone calls");
+
+export const CallsVoiceConfigSchema = z
+  .object({
+    language: z
+      .string({ error: "calls.voice.language must be a string" })
+      .default("en-US")
+      .describe("BCP-47 language code for speech recognition and synthesis"),
+    transcriptionProvider: z
+      .enum(VALID_CALL_TRANSCRIPTION_PROVIDERS, {
+        error: `calls.voice.transcriptionProvider must be one of: ${VALID_CALL_TRANSCRIPTION_PROVIDERS.join(
+          ", ",
+        )}`,
+      })
+      .default("Deepgram")
+      .describe("Speech-to-text provider used for call transcription"),
+  })
+  .describe("Voice and speech settings for phone calls");
+
+export const CallerIdentityConfigSchema = z
+  .object({
+    allowPerCallOverride: z
+      .boolean({
+        error: "calls.callerIdentity.allowPerCallOverride must be a boolean",
+      })
+      .default(true)
+      .describe("Whether the caller ID can be overridden on a per-call basis"),
+    userNumber: z
+      .string({ error: "calls.callerIdentity.userNumber must be a string" })
+      .optional()
+      .describe(
+        "Phone number to display as the caller ID when using user_number mode",
+      ),
+  })
+  .describe("Controls which phone number is shown as the caller ID");
+
+export const CallsVerificationConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "calls.verification.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether callers must verify their identity with a code before the call proceeds",
+      ),
+    maxAttempts: z
+      .number({ error: "calls.verification.maxAttempts must be a number" })
+      .int("calls.verification.maxAttempts must be an integer")
+      .positive("calls.verification.maxAttempts must be a positive integer")
+      .default(3)
+      .describe("Maximum number of verification code attempts before failing"),
+    codeLength: z
+      .number({ error: "calls.verification.codeLength must be a number" })
+      .int("calls.verification.codeLength must be an integer")
+      .positive("calls.verification.codeLength must be a positive integer")
+      .default(6)
+      .describe("Number of digits in the verification code"),
+  })
+  .describe(
+    "Caller verification settings — requires callers to enter a code before proceeding",
+  );
+
+export const CallsConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "calls.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether phone call functionality is enabled"),
+    provider: z
+      .enum(VALID_CALL_PROVIDERS, {
+        error: `calls.provider must be one of: ${VALID_CALL_PROVIDERS.join(
+          ", ",
+        )}`,
+      })
+      .default("twilio")
+      .describe("Telephony provider used for placing and receiving calls"),
+    maxDurationSeconds: z
+      .number({ error: "calls.maxDurationSeconds must be a number" })
+      .int("calls.maxDurationSeconds must be an integer")
+      .positive("calls.maxDurationSeconds must be a positive integer")
+      .max(
+        2_147_483,
+        "calls.maxDurationSeconds must be at most 2147483 (setTimeout-safe limit)",
+      )
+      .default(3600)
+      .describe("Maximum duration of a single call in seconds"),
+    userConsultTimeoutSeconds: z
+      .number({ error: "calls.userConsultTimeoutSeconds must be a number" })
+      .int("calls.userConsultTimeoutSeconds must be an integer")
+      .positive("calls.userConsultTimeoutSeconds must be a positive integer")
+      .max(
+        2_147_483,
+        "calls.userConsultTimeoutSeconds must be at most 2147483 (setTimeout-safe limit)",
+      )
+      .default(120)
+      .describe(
+        "How long to wait for the user to respond to a consultation request during a call",
+      ),
+    ttsPlaybackDelayMs: z
+      .number({ error: "calls.ttsPlaybackDelayMs must be a number" })
+      .int("calls.ttsPlaybackDelayMs must be an integer")
+      .min(0, "calls.ttsPlaybackDelayMs must be >= 0")
+      .max(10_000, "calls.ttsPlaybackDelayMs must be at most 10000")
+      .default(3000)
+      .describe(
+        "Delay in milliseconds before starting TTS playback to allow audio buffering",
+      ),
+    accessRequestPollIntervalMs: z
+      .number({ error: "calls.accessRequestPollIntervalMs must be a number" })
+      .int("calls.accessRequestPollIntervalMs must be an integer")
+      .min(50, "calls.accessRequestPollIntervalMs must be >= 50")
+      .max(10_000, "calls.accessRequestPollIntervalMs must be at most 10000")
+      .default(500)
+      .describe(
+        "How often to poll for access request approval during a call (ms)",
+      ),
+    guardianWaitUpdateInitialIntervalMs: z
+      .number({
+        error: "calls.guardianWaitUpdateInitialIntervalMs must be a number",
+      })
+      .int("calls.guardianWaitUpdateInitialIntervalMs must be an integer")
+      .min(1000, "calls.guardianWaitUpdateInitialIntervalMs must be >= 1000")
+      .max(
+        60_000,
+        "calls.guardianWaitUpdateInitialIntervalMs must be at most 60000",
+      )
+      .default(15_000)
+      .describe(
+        "Initial interval between guardian wait status updates during a call (ms)",
+      ),
+    guardianWaitUpdateInitialWindowMs: z
+      .number({
+        error: "calls.guardianWaitUpdateInitialWindowMs must be a number",
+      })
+      .int("calls.guardianWaitUpdateInitialWindowMs must be an integer")
+      .min(1000, "calls.guardianWaitUpdateInitialWindowMs must be >= 1000")
+      .max(
+        60_000,
+        "calls.guardianWaitUpdateInitialWindowMs must be at most 60000",
+      )
+      .default(30_000)
+      .describe(
+        "Duration of the initial window for guardian wait updates before switching to steady-state (ms)",
+      ),
+    guardianWaitUpdateSteadyMinIntervalMs: z
+      .number({
+        error: "calls.guardianWaitUpdateSteadyMinIntervalMs must be a number",
+      })
+      .int("calls.guardianWaitUpdateSteadyMinIntervalMs must be an integer")
+      .min(1000, "calls.guardianWaitUpdateSteadyMinIntervalMs must be >= 1000")
+      .max(
+        60_000,
+        "calls.guardianWaitUpdateSteadyMinIntervalMs must be at most 60000",
+      )
+      .default(20_000)
+      .describe(
+        "Minimum interval between steady-state guardian wait updates (ms)",
+      ),
+    guardianWaitUpdateSteadyMaxIntervalMs: z
+      .number({
+        error: "calls.guardianWaitUpdateSteadyMaxIntervalMs must be a number",
+      })
+      .int("calls.guardianWaitUpdateSteadyMaxIntervalMs must be an integer")
+      .min(1000, "calls.guardianWaitUpdateSteadyMaxIntervalMs must be >= 1000")
+      .max(
+        60_000,
+        "calls.guardianWaitUpdateSteadyMaxIntervalMs must be at most 60000",
+      )
+      .default(30_000)
+      .describe(
+        "Maximum interval between steady-state guardian wait updates (ms)",
+      ),
+    disclosure: CallsDisclosureConfigSchema.default(
+      CallsDisclosureConfigSchema.parse({}),
     ),
-});
-
-export const CallsSafetyConfigSchema = z.object({
-  denyCategories: z
-    .array(
-      z.string({ error: "calls.safety.denyCategories values must be strings" }),
-    )
-    .default([]),
-});
-
-export const CallsVoiceConfigSchema = z.object({
-  language: z
-    .string({ error: "calls.voice.language must be a string" })
-    .default("en-US"),
-  transcriptionProvider: z
-    .enum(VALID_CALL_TRANSCRIPTION_PROVIDERS, {
-      error: `calls.voice.transcriptionProvider must be one of: ${VALID_CALL_TRANSCRIPTION_PROVIDERS.join(
-        ", ",
-      )}`,
-    })
-    .default("Deepgram"),
-});
-
-export const CallerIdentityConfigSchema = z.object({
-  allowPerCallOverride: z
-    .boolean({
-      error: "calls.callerIdentity.allowPerCallOverride must be a boolean",
-    })
-    .default(true),
-  userNumber: z
-    .string({ error: "calls.callerIdentity.userNumber must be a string" })
-    .optional(),
-});
-
-export const CallsVerificationConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "calls.verification.enabled must be a boolean" })
-    .default(false),
-  maxAttempts: z
-    .number({ error: "calls.verification.maxAttempts must be a number" })
-    .int("calls.verification.maxAttempts must be an integer")
-    .positive("calls.verification.maxAttempts must be a positive integer")
-    .default(3),
-  codeLength: z
-    .number({ error: "calls.verification.codeLength must be a number" })
-    .int("calls.verification.codeLength must be an integer")
-    .positive("calls.verification.codeLength must be a positive integer")
-    .default(6),
-});
-
-export const CallsConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "calls.enabled must be a boolean" })
-    .default(true),
-  provider: z
-    .enum(VALID_CALL_PROVIDERS, {
-      error: `calls.provider must be one of: ${VALID_CALL_PROVIDERS.join(
-        ", ",
-      )}`,
-    })
-    .default("twilio"),
-  maxDurationSeconds: z
-    .number({ error: "calls.maxDurationSeconds must be a number" })
-    .int("calls.maxDurationSeconds must be an integer")
-    .positive("calls.maxDurationSeconds must be a positive integer")
-    .max(
-      2_147_483,
-      "calls.maxDurationSeconds must be at most 2147483 (setTimeout-safe limit)",
-    )
-    .default(3600),
-  userConsultTimeoutSeconds: z
-    .number({ error: "calls.userConsultTimeoutSeconds must be a number" })
-    .int("calls.userConsultTimeoutSeconds must be an integer")
-    .positive("calls.userConsultTimeoutSeconds must be a positive integer")
-    .max(
-      2_147_483,
-      "calls.userConsultTimeoutSeconds must be at most 2147483 (setTimeout-safe limit)",
-    )
-    .default(120),
-  ttsPlaybackDelayMs: z
-    .number({ error: "calls.ttsPlaybackDelayMs must be a number" })
-    .int("calls.ttsPlaybackDelayMs must be an integer")
-    .min(0, "calls.ttsPlaybackDelayMs must be >= 0")
-    .max(10_000, "calls.ttsPlaybackDelayMs must be at most 10000")
-    .default(3000),
-  accessRequestPollIntervalMs: z
-    .number({ error: "calls.accessRequestPollIntervalMs must be a number" })
-    .int("calls.accessRequestPollIntervalMs must be an integer")
-    .min(50, "calls.accessRequestPollIntervalMs must be >= 50")
-    .max(10_000, "calls.accessRequestPollIntervalMs must be at most 10000")
-    .default(500),
-  guardianWaitUpdateInitialIntervalMs: z
-    .number({
-      error: "calls.guardianWaitUpdateInitialIntervalMs must be a number",
-    })
-    .int("calls.guardianWaitUpdateInitialIntervalMs must be an integer")
-    .min(1000, "calls.guardianWaitUpdateInitialIntervalMs must be >= 1000")
-    .max(
-      60_000,
-      "calls.guardianWaitUpdateInitialIntervalMs must be at most 60000",
-    )
-    .default(15_000),
-  guardianWaitUpdateInitialWindowMs: z
-    .number({
-      error: "calls.guardianWaitUpdateInitialWindowMs must be a number",
-    })
-    .int("calls.guardianWaitUpdateInitialWindowMs must be an integer")
-    .min(1000, "calls.guardianWaitUpdateInitialWindowMs must be >= 1000")
-    .max(
-      60_000,
-      "calls.guardianWaitUpdateInitialWindowMs must be at most 60000",
-    )
-    .default(30_000),
-  guardianWaitUpdateSteadyMinIntervalMs: z
-    .number({
-      error: "calls.guardianWaitUpdateSteadyMinIntervalMs must be a number",
-    })
-    .int("calls.guardianWaitUpdateSteadyMinIntervalMs must be an integer")
-    .min(1000, "calls.guardianWaitUpdateSteadyMinIntervalMs must be >= 1000")
-    .max(
-      60_000,
-      "calls.guardianWaitUpdateSteadyMinIntervalMs must be at most 60000",
-    )
-    .default(20_000),
-  guardianWaitUpdateSteadyMaxIntervalMs: z
-    .number({
-      error: "calls.guardianWaitUpdateSteadyMaxIntervalMs must be a number",
-    })
-    .int("calls.guardianWaitUpdateSteadyMaxIntervalMs must be an integer")
-    .min(1000, "calls.guardianWaitUpdateSteadyMaxIntervalMs must be >= 1000")
-    .max(
-      60_000,
-      "calls.guardianWaitUpdateSteadyMaxIntervalMs must be at most 60000",
-    )
-    .default(30_000),
-  disclosure: CallsDisclosureConfigSchema.default(
-    CallsDisclosureConfigSchema.parse({}),
-  ),
-  safety: CallsSafetyConfigSchema.default(CallsSafetyConfigSchema.parse({})),
-  voice: CallsVoiceConfigSchema.default(CallsVoiceConfigSchema.parse({})),
-  model: z.string({ error: "calls.model must be a string" }).optional(),
-  callerIdentity: CallerIdentityConfigSchema.default(
-    CallerIdentityConfigSchema.parse({}),
-  ),
-  verification: CallsVerificationConfigSchema.default(
-    CallsVerificationConfigSchema.parse({}),
-  ),
-});
+    safety: CallsSafetyConfigSchema.default(CallsSafetyConfigSchema.parse({})),
+    voice: CallsVoiceConfigSchema.default(CallsVoiceConfigSchema.parse({})),
+    model: z
+      .string({ error: "calls.model must be a string" })
+      .optional()
+      .describe("Override the default model for phone call conversations"),
+    callerIdentity: CallerIdentityConfigSchema.default(
+      CallerIdentityConfigSchema.parse({}),
+    ),
+    verification: CallsVerificationConfigSchema.default(
+      CallsVerificationConfigSchema.parse({}),
+    ),
+  })
+  .describe(
+    "Phone call configuration — controls telephony, voice, safety, and call behavior",
+  );
 
 export type CallsConfig = z.infer<typeof CallsConfigSchema>;
 export type CallsDisclosureConfig = z.infer<typeof CallsDisclosureConfigSchema>;

--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -1,79 +1,126 @@
 import { z } from "zod";
 
-export const TwilioConfigSchema = z.object({
-  accountSid: z
-    .string({ error: "twilio.accountSid must be a string" })
-    .default(""),
-  phoneNumber: z
-    .string({ error: "twilio.phoneNumber must be a string" })
-    .default(""),
-});
+export const TwilioConfigSchema = z
+  .object({
+    accountSid: z
+      .string({ error: "twilio.accountSid must be a string" })
+      .default("")
+      .describe("Twilio account SID for API authentication"),
+    phoneNumber: z
+      .string({ error: "twilio.phoneNumber must be a string" })
+      .default("")
+      .describe("Twilio phone number used for outbound calls and SMS"),
+  })
+  .describe("Twilio account configuration");
 
-export const WhatsAppConfigSchema = z.object({
-  phoneNumber: z
-    .string({ error: "whatsapp.phoneNumber must be a string" })
-    .default(""),
-  deliverAuthBypass: z
-    .boolean({ error: "whatsapp.deliverAuthBypass must be a boolean" })
-    .default(false),
-  timeoutMs: z
-    .number({ error: "whatsapp.timeoutMs must be a number" })
-    .int("whatsapp.timeoutMs must be an integer")
-    .positive("whatsapp.timeoutMs must be a positive integer")
-    .default(15_000),
-  maxRetries: z
-    .number({ error: "whatsapp.maxRetries must be a number" })
-    .int("whatsapp.maxRetries must be an integer")
-    .nonnegative("whatsapp.maxRetries must be a non-negative integer")
-    .default(3),
-  initialBackoffMs: z
-    .number({ error: "whatsapp.initialBackoffMs must be a number" })
-    .int("whatsapp.initialBackoffMs must be an integer")
-    .positive("whatsapp.initialBackoffMs must be a positive integer")
-    .default(1_000),
-});
+export const WhatsAppConfigSchema = z
+  .object({
+    phoneNumber: z
+      .string({ error: "whatsapp.phoneNumber must be a string" })
+      .default("")
+      .describe("WhatsApp Business phone number"),
+    deliverAuthBypass: z
+      .boolean({ error: "whatsapp.deliverAuthBypass must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to bypass authentication when delivering WhatsApp messages",
+      ),
+    timeoutMs: z
+      .number({ error: "whatsapp.timeoutMs must be a number" })
+      .int("whatsapp.timeoutMs must be an integer")
+      .positive("whatsapp.timeoutMs must be a positive integer")
+      .default(15_000)
+      .describe("Timeout for WhatsApp API requests in milliseconds"),
+    maxRetries: z
+      .number({ error: "whatsapp.maxRetries must be a number" })
+      .int("whatsapp.maxRetries must be an integer")
+      .nonnegative("whatsapp.maxRetries must be a non-negative integer")
+      .default(3)
+      .describe(
+        "Maximum number of retry attempts for failed WhatsApp API requests",
+      ),
+    initialBackoffMs: z
+      .number({ error: "whatsapp.initialBackoffMs must be a number" })
+      .int("whatsapp.initialBackoffMs must be an integer")
+      .positive("whatsapp.initialBackoffMs must be a positive integer")
+      .default(1_000)
+      .describe(
+        "Initial backoff delay between retries in milliseconds (doubles on each retry)",
+      ),
+  })
+  .describe("WhatsApp Business channel configuration");
 
-export const TelegramConfigSchema = z.object({
-  botId: z.string({ error: "telegram.botId must be a string" }).default(""),
-  botUsername: z
-    .string({ error: "telegram.botUsername must be a string" })
-    .default(""),
-  apiBaseUrl: z
-    .string({ error: "telegram.apiBaseUrl must be a string" })
-    .default("https://api.telegram.org"),
-  deliverAuthBypass: z
-    .boolean({ error: "telegram.deliverAuthBypass must be a boolean" })
-    .default(false),
-  timeoutMs: z
-    .number({ error: "telegram.timeoutMs must be a number" })
-    .int("telegram.timeoutMs must be an integer")
-    .positive("telegram.timeoutMs must be a positive integer")
-    .default(15_000),
-  maxRetries: z
-    .number({ error: "telegram.maxRetries must be a number" })
-    .int("telegram.maxRetries must be an integer")
-    .nonnegative("telegram.maxRetries must be a non-negative integer")
-    .default(3),
-  initialBackoffMs: z
-    .number({ error: "telegram.initialBackoffMs must be a number" })
-    .int("telegram.initialBackoffMs must be an integer")
-    .positive("telegram.initialBackoffMs must be a positive integer")
-    .default(1_000),
-});
+export const TelegramConfigSchema = z
+  .object({
+    botId: z
+      .string({ error: "telegram.botId must be a string" })
+      .default("")
+      .describe("Telegram bot ID"),
+    botUsername: z
+      .string({ error: "telegram.botUsername must be a string" })
+      .default("")
+      .describe("Telegram bot username (without the @ prefix)"),
+    apiBaseUrl: z
+      .string({ error: "telegram.apiBaseUrl must be a string" })
+      .default("https://api.telegram.org")
+      .describe("Base URL for the Telegram Bot API"),
+    deliverAuthBypass: z
+      .boolean({ error: "telegram.deliverAuthBypass must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to bypass authentication when delivering Telegram messages",
+      ),
+    timeoutMs: z
+      .number({ error: "telegram.timeoutMs must be a number" })
+      .int("telegram.timeoutMs must be an integer")
+      .positive("telegram.timeoutMs must be a positive integer")
+      .default(15_000)
+      .describe("Timeout for Telegram API requests in milliseconds"),
+    maxRetries: z
+      .number({ error: "telegram.maxRetries must be a number" })
+      .int("telegram.maxRetries must be an integer")
+      .nonnegative("telegram.maxRetries must be a non-negative integer")
+      .default(3)
+      .describe(
+        "Maximum number of retry attempts for failed Telegram API requests",
+      ),
+    initialBackoffMs: z
+      .number({ error: "telegram.initialBackoffMs must be a number" })
+      .int("telegram.initialBackoffMs must be an integer")
+      .positive("telegram.initialBackoffMs must be a positive integer")
+      .default(1_000)
+      .describe(
+        "Initial backoff delay between retries in milliseconds (doubles on each retry)",
+      ),
+  })
+  .describe("Telegram bot channel configuration");
 
-export const SlackConfigSchema = z.object({
-  deliverAuthBypass: z
-    .boolean({ error: "slack.deliverAuthBypass must be a boolean" })
-    .default(false),
-  teamId: z.string({ error: "slack.teamId must be a string" }).default(""),
-  teamName: z.string({ error: "slack.teamName must be a string" }).default(""),
-  botUserId: z
-    .string({ error: "slack.botUserId must be a string" })
-    .default(""),
-  botUsername: z
-    .string({ error: "slack.botUsername must be a string" })
-    .default(""),
-});
+export const SlackConfigSchema = z
+  .object({
+    deliverAuthBypass: z
+      .boolean({ error: "slack.deliverAuthBypass must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to bypass authentication when delivering Slack messages",
+      ),
+    teamId: z
+      .string({ error: "slack.teamId must be a string" })
+      .default("")
+      .describe("Slack workspace team ID"),
+    teamName: z
+      .string({ error: "slack.teamName must be a string" })
+      .default("")
+      .describe("Slack workspace team name"),
+    botUserId: z
+      .string({ error: "slack.botUserId must be a string" })
+      .default("")
+      .describe("Slack bot user ID"),
+    botUsername: z
+      .string({ error: "slack.botUsername must be a string" })
+      .default("")
+      .describe("Slack bot display name"),
+  })
+  .describe("Slack channel configuration");
 
 export type TwilioConfig = z.infer<typeof TwilioConfigSchema>;
 export type WhatsAppConfig = z.infer<typeof WhatsAppConfigSchema>;

--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -5,29 +5,44 @@ import { z } from "zod";
 // Mirrored in: clients/macos/.../OpenAIVoiceService.swift (defaultVoiceId)
 export const DEFAULT_ELEVENLABS_VOICE_ID = "ZF6FPAbjXT4488VcRRnw";
 
-export const ElevenLabsConfigSchema = z.object({
-  voiceId: z
-    .string({ error: "elevenlabs.voiceId must be a string" })
-    .min(1, "elevenlabs.voiceId must not be empty")
-    .default(DEFAULT_ELEVENLABS_VOICE_ID),
-  voiceModelId: z
-    .string({ error: "elevenlabs.voiceModelId must be a string" })
-    .default(""),
-  speed: z
-    .number({ error: "elevenlabs.speed must be a number" })
-    .min(0.7, "elevenlabs.speed must be >= 0.7")
-    .max(1.2, "elevenlabs.speed must be <= 1.2")
-    .default(1.0),
-  stability: z
-    .number({ error: "elevenlabs.stability must be a number" })
-    .min(0, "elevenlabs.stability must be >= 0")
-    .max(1, "elevenlabs.stability must be <= 1")
-    .default(0.5),
-  similarityBoost: z
-    .number({ error: "elevenlabs.similarityBoost must be a number" })
-    .min(0, "elevenlabs.similarityBoost must be >= 0")
-    .max(1, "elevenlabs.similarityBoost must be <= 1")
-    .default(0.75),
-});
+export const ElevenLabsConfigSchema = z
+  .object({
+    voiceId: z
+      .string({ error: "elevenlabs.voiceId must be a string" })
+      .min(1, "elevenlabs.voiceId must not be empty")
+      .default(DEFAULT_ELEVENLABS_VOICE_ID)
+      .describe("ElevenLabs voice ID for text-to-speech"),
+    voiceModelId: z
+      .string({ error: "elevenlabs.voiceModelId must be a string" })
+      .default("")
+      .describe(
+        "ElevenLabs model ID override (leave empty to use the default model)",
+      ),
+    speed: z
+      .number({ error: "elevenlabs.speed must be a number" })
+      .min(0.7, "elevenlabs.speed must be >= 0.7")
+      .max(1.2, "elevenlabs.speed must be <= 1.2")
+      .default(1.0)
+      .describe(
+        "Speech playback speed multiplier (0.7 = slower, 1.2 = faster)",
+      ),
+    stability: z
+      .number({ error: "elevenlabs.stability must be a number" })
+      .min(0, "elevenlabs.stability must be >= 0")
+      .max(1, "elevenlabs.stability must be <= 1")
+      .default(0.5)
+      .describe(
+        "Voice stability — higher values produce more consistent speech, lower values add expressiveness",
+      ),
+    similarityBoost: z
+      .number({ error: "elevenlabs.similarityBoost must be a number" })
+      .min(0, "elevenlabs.similarityBoost must be >= 0")
+      .max(1, "elevenlabs.similarityBoost must be <= 1")
+      .default(0.75)
+      .describe(
+        "How closely the output matches the original voice — higher values increase similarity",
+      ),
+  })
+  .describe("ElevenLabs text-to-speech configuration");
 
 export type ElevenLabsConfig = z.infer<typeof ElevenLabsConfigSchema>;

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -4,25 +4,34 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      .default(false),
+      .default(false)
+      .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })
       .int("heartbeat.intervalMs must be an integer")
       .positive("heartbeat.intervalMs must be a positive integer")
-      .default(3_600_000),
+      .default(3_600_000)
+      .describe("Time between heartbeat checks in milliseconds"),
     activeHoursStart: z
       .number({ error: "heartbeat.activeHoursStart must be a number" })
       .int("heartbeat.activeHoursStart must be an integer")
       .min(0, "heartbeat.activeHoursStart must be >= 0")
       .max(23, "heartbeat.activeHoursStart must be <= 23")
-      .optional(),
+      .optional()
+      .describe(
+        "Hour of the day (0-23) when heartbeat checks begin — must be set together with activeHoursEnd",
+      ),
     activeHoursEnd: z
       .number({ error: "heartbeat.activeHoursEnd must be a number" })
       .int("heartbeat.activeHoursEnd must be an integer")
       .min(0, "heartbeat.activeHoursEnd must be >= 0")
       .max(23, "heartbeat.activeHoursEnd must be <= 23")
-      .optional(),
+      .optional()
+      .describe(
+        "Hour of the day (0-23) when heartbeat checks stop — must be set together with activeHoursStart",
+      ),
   })
+  .describe("Periodic heartbeat configuration for health monitoring")
   .superRefine((config, ctx) => {
     const hasStart = config.activeHoursStart != null;
     const hasEnd = config.activeHoursEnd != null;

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -8,115 +8,171 @@ const VALID_LATEST_TURN_COMPRESSION_POLICIES = [
 
 export { VALID_LATEST_TURN_COMPRESSION_POLICIES };
 
-export const ThinkingConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "thinking.enabled must be a boolean" })
-    .default(false),
-  streamThinking: z
-    .boolean({ error: "thinking.streamThinking must be a boolean" })
-    .default(false),
-});
+export const ThinkingConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "thinking.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to enable extended thinking (chain-of-thought) for the model",
+      ),
+    streamThinking: z
+      .boolean({ error: "thinking.streamThinking must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to stream the model's thinking tokens to the client in real time",
+      ),
+  })
+  .describe("Extended thinking (chain-of-thought) configuration");
 
 export const EffortSchema = z
   .enum(["low", "medium", "high"], {
     error: 'effort must be "low", "medium", or "high"',
   })
-  .default("high");
+  .default("high")
+  .describe(
+    "How much effort the model should put into its response — lower effort is faster and cheaper",
+  );
 
 export type Effort = z.infer<typeof EffortSchema>;
 
-export const ContextOverflowRecoveryConfigSchema = z.object({
-  enabled: z
-    .boolean({
-      error: "contextWindow.overflowRecovery.enabled must be a boolean",
-    })
-    .default(true),
-  safetyMarginRatio: z
-    .number({
-      error:
-        "contextWindow.overflowRecovery.safetyMarginRatio must be a number",
-    })
-    .finite("contextWindow.overflowRecovery.safetyMarginRatio must be finite")
-    .gt(
-      0,
-      "contextWindow.overflowRecovery.safetyMarginRatio must be greater than 0",
-    )
-    .lt(
-      1,
-      "contextWindow.overflowRecovery.safetyMarginRatio must be less than 1",
-    )
-    .default(0.05),
-  maxAttempts: z
-    .number({
-      error: "contextWindow.overflowRecovery.maxAttempts must be a number",
-    })
-    .int("contextWindow.overflowRecovery.maxAttempts must be an integer")
-    .positive(
-      "contextWindow.overflowRecovery.maxAttempts must be a positive integer",
-    )
-    .default(3),
-  interactiveLatestTurnCompression: z
-    .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
-      error: `contextWindow.overflowRecovery.interactiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
-        ", ",
-      )}`,
-    })
-    .default("summarize"),
-  nonInteractiveLatestTurnCompression: z
-    .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
-      error: `contextWindow.overflowRecovery.nonInteractiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
-        ", ",
-      )}`,
-    })
-    .default("truncate"),
-});
+export const ContextOverflowRecoveryConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "contextWindow.overflowRecovery.enabled must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether to automatically recover when the context window overflows",
+      ),
+    safetyMarginRatio: z
+      .number({
+        error:
+          "contextWindow.overflowRecovery.safetyMarginRatio must be a number",
+      })
+      .finite("contextWindow.overflowRecovery.safetyMarginRatio must be finite")
+      .gt(
+        0,
+        "contextWindow.overflowRecovery.safetyMarginRatio must be greater than 0",
+      )
+      .lt(
+        1,
+        "contextWindow.overflowRecovery.safetyMarginRatio must be less than 1",
+      )
+      .default(0.05)
+      .describe(
+        "Fraction of the context window reserved as a safety margin to prevent overflow",
+      ),
+    maxAttempts: z
+      .number({
+        error: "contextWindow.overflowRecovery.maxAttempts must be a number",
+      })
+      .int("contextWindow.overflowRecovery.maxAttempts must be an integer")
+      .positive(
+        "contextWindow.overflowRecovery.maxAttempts must be a positive integer",
+      )
+      .default(3)
+      .describe("Maximum number of recovery attempts before giving up"),
+    interactiveLatestTurnCompression: z
+      .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
+        error: `contextWindow.overflowRecovery.interactiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
+          ", ",
+        )}`,
+      })
+      .default("summarize")
+      .describe(
+        "How to handle the latest turn during overflow recovery in interactive mode",
+      ),
+    nonInteractiveLatestTurnCompression: z
+      .enum(VALID_LATEST_TURN_COMPRESSION_POLICIES, {
+        error: `contextWindow.overflowRecovery.nonInteractiveLatestTurnCompression must be one of: ${VALID_LATEST_TURN_COMPRESSION_POLICIES.join(
+          ", ",
+        )}`,
+      })
+      .default("truncate")
+      .describe(
+        "How to handle the latest turn during overflow recovery in non-interactive (background) mode",
+      ),
+  })
+  .describe(
+    "Controls how the assistant recovers when the context window overflows",
+  );
 
-export const ContextWindowConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "contextWindow.enabled must be a boolean" })
-    .default(true),
-  maxInputTokens: z
-    .number({ error: "contextWindow.maxInputTokens must be a number" })
-    .int("contextWindow.maxInputTokens must be an integer")
-    .positive("contextWindow.maxInputTokens must be a positive integer")
-    .default(200000),
-  targetBudgetRatio: z
-    .number({ error: "contextWindow.targetBudgetRatio must be a number" })
-    .finite("contextWindow.targetBudgetRatio must be finite")
-    .gt(0, "contextWindow.targetBudgetRatio must be greater than 0")
-    .lte(1, "contextWindow.targetBudgetRatio must be less than or equal to 1")
-    .default(0.3),
-  compactThreshold: z
-    .number({ error: "contextWindow.compactThreshold must be a number" })
-    .finite("contextWindow.compactThreshold must be finite")
-    .gt(0, "contextWindow.compactThreshold must be greater than 0")
-    .lte(1, "contextWindow.compactThreshold must be less than or equal to 1")
-    .default(0.8),
-  summaryBudgetRatio: z
-    .number({ error: "contextWindow.summaryBudgetRatio must be a number" })
-    .finite("contextWindow.summaryBudgetRatio must be finite")
-    .gt(0, "contextWindow.summaryBudgetRatio must be greater than 0")
-    .lte(1, "contextWindow.summaryBudgetRatio must be less than or equal to 1")
-    .default(0.05),
-  overflowRecovery: ContextOverflowRecoveryConfigSchema.default(
-    ContextOverflowRecoveryConfigSchema.parse({}),
-  ),
-});
-
-export const ModelPricingOverrideSchema = z.object({
-  provider: z.string({ error: "pricingOverrides[].provider must be a string" }),
-  modelPattern: z.string({
-    error: "pricingOverrides[].modelPattern must be a string",
-  }),
-  inputPer1M: z
-    .number({ error: "pricingOverrides[].inputPer1M must be a number" })
-    .nonnegative("pricingOverrides[].inputPer1M must be a non-negative number"),
-  outputPer1M: z
-    .number({ error: "pricingOverrides[].outputPer1M must be a number" })
-    .nonnegative(
-      "pricingOverrides[].outputPer1M must be a non-negative number",
+export const ContextWindowConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "contextWindow.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether context window management is enabled"),
+    maxInputTokens: z
+      .number({ error: "contextWindow.maxInputTokens must be a number" })
+      .int("contextWindow.maxInputTokens must be an integer")
+      .positive("contextWindow.maxInputTokens must be a positive integer")
+      .default(200000)
+      .describe("Maximum number of input tokens allowed in the context window"),
+    targetBudgetRatio: z
+      .number({ error: "contextWindow.targetBudgetRatio must be a number" })
+      .finite("contextWindow.targetBudgetRatio must be finite")
+      .gt(0, "contextWindow.targetBudgetRatio must be greater than 0")
+      .lte(1, "contextWindow.targetBudgetRatio must be less than or equal to 1")
+      .default(0.3)
+      .describe(
+        "Target ratio of the context window to retain after compaction — must be less than compactThreshold",
+      ),
+    compactThreshold: z
+      .number({ error: "contextWindow.compactThreshold must be a number" })
+      .finite("contextWindow.compactThreshold must be finite")
+      .gt(0, "contextWindow.compactThreshold must be greater than 0")
+      .lte(1, "contextWindow.compactThreshold must be less than or equal to 1")
+      .default(0.8)
+      .describe("Context window usage ratio at which compaction is triggered"),
+    summaryBudgetRatio: z
+      .number({ error: "contextWindow.summaryBudgetRatio must be a number" })
+      .finite("contextWindow.summaryBudgetRatio must be finite")
+      .gt(0, "contextWindow.summaryBudgetRatio must be greater than 0")
+      .lte(
+        1,
+        "contextWindow.summaryBudgetRatio must be less than or equal to 1",
+      )
+      .default(0.05)
+      .describe(
+        "Fraction of the context window allocated for conversation summaries",
+      ),
+    overflowRecovery: ContextOverflowRecoveryConfigSchema.default(
+      ContextOverflowRecoveryConfigSchema.parse({}),
     ),
-});
+  })
+  .describe(
+    "Context window management — controls compaction, overflow recovery, and token budgets",
+  );
+
+export const ModelPricingOverrideSchema = z
+  .object({
+    provider: z
+      .string({ error: "pricingOverrides[].provider must be a string" })
+      .describe("Provider name to match (e.g. 'anthropic', 'openai')"),
+    modelPattern: z
+      .string({
+        error: "pricingOverrides[].modelPattern must be a string",
+      })
+      .describe("Glob pattern to match model names against"),
+    inputPer1M: z
+      .number({ error: "pricingOverrides[].inputPer1M must be a number" })
+      .nonnegative(
+        "pricingOverrides[].inputPer1M must be a non-negative number",
+      )
+      .describe("Cost per 1 million input tokens in USD"),
+    outputPer1M: z
+      .number({ error: "pricingOverrides[].outputPer1M must be a number" })
+      .nonnegative(
+        "pricingOverrides[].outputPer1M must be a non-negative number",
+      )
+      .describe("Cost per 1 million output tokens in USD"),
+  })
+  .describe(
+    "Custom pricing override for a specific provider/model combination",
+  );
 
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;
 export type ContextOverflowRecoveryConfig = z.infer<

--- a/assistant/src/config/schemas/ingress.ts
+++ b/assistant/src/config/schemas/ingress.ts
@@ -1,71 +1,107 @@
 import { z } from "zod";
 
-export const IngressWebhookConfigSchema = z.object({
-  secret: z
-    .string({ error: "ingress.webhook.secret must be a string" })
-    .default(""),
-  timeoutMs: z
-    .number({ error: "ingress.webhook.timeoutMs must be a number" })
-    .int("ingress.webhook.timeoutMs must be an integer")
-    .positive("ingress.webhook.timeoutMs must be a positive integer")
-    .default(30_000),
-  maxRetries: z
-    .number({ error: "ingress.webhook.maxRetries must be a number" })
-    .int("ingress.webhook.maxRetries must be an integer")
-    .nonnegative("ingress.webhook.maxRetries must be a non-negative integer")
-    .default(2),
-  initialBackoffMs: z
-    .number({ error: "ingress.webhook.initialBackoffMs must be a number" })
-    .int("ingress.webhook.initialBackoffMs must be an integer")
-    .positive("ingress.webhook.initialBackoffMs must be a positive integer")
-    .default(500),
-  maxPayloadBytes: z
-    .number({ error: "ingress.webhook.maxPayloadBytes must be a number" })
-    .int("ingress.webhook.maxPayloadBytes must be an integer")
-    .positive("ingress.webhook.maxPayloadBytes must be a positive integer")
-    .default(1_048_576),
-});
+export const IngressWebhookConfigSchema = z
+  .object({
+    secret: z
+      .string({ error: "ingress.webhook.secret must be a string" })
+      .default("")
+      .describe("Shared secret for HMAC webhook signature verification"),
+    timeoutMs: z
+      .number({ error: "ingress.webhook.timeoutMs must be a number" })
+      .int("ingress.webhook.timeoutMs must be an integer")
+      .positive("ingress.webhook.timeoutMs must be a positive integer")
+      .default(30_000)
+      .describe(
+        "Timeout for outgoing webhook delivery requests in milliseconds",
+      ),
+    maxRetries: z
+      .number({ error: "ingress.webhook.maxRetries must be a number" })
+      .int("ingress.webhook.maxRetries must be an integer")
+      .nonnegative("ingress.webhook.maxRetries must be a non-negative integer")
+      .default(2)
+      .describe(
+        "Maximum number of retry attempts for failed webhook deliveries",
+      ),
+    initialBackoffMs: z
+      .number({ error: "ingress.webhook.initialBackoffMs must be a number" })
+      .int("ingress.webhook.initialBackoffMs must be an integer")
+      .positive("ingress.webhook.initialBackoffMs must be a positive integer")
+      .default(500)
+      .describe(
+        "Initial backoff delay between webhook retries in milliseconds",
+      ),
+    maxPayloadBytes: z
+      .number({ error: "ingress.webhook.maxPayloadBytes must be a number" })
+      .int("ingress.webhook.maxPayloadBytes must be an integer")
+      .positive("ingress.webhook.maxPayloadBytes must be a positive integer")
+      .default(1_048_576)
+      .describe("Maximum allowed webhook payload size in bytes"),
+  })
+  .describe("Webhook configuration for ingress event delivery");
 
-export const IngressRateLimitConfigSchema = z.object({
-  maxRequestsPerMinute: z
-    .number({
-      error: "ingress.rateLimit.maxRequestsPerMinute must be a number",
-    })
-    .int("ingress.rateLimit.maxRequestsPerMinute must be an integer")
-    .nonnegative(
-      "ingress.rateLimit.maxRequestsPerMinute must be a non-negative integer",
-    )
-    .default(0),
-  maxRequestsPerHour: z
-    .number({ error: "ingress.rateLimit.maxRequestsPerHour must be a number" })
-    .int("ingress.rateLimit.maxRequestsPerHour must be an integer")
-    .nonnegative(
-      "ingress.rateLimit.maxRequestsPerHour must be a non-negative integer",
-    )
-    .default(0),
-});
+export const IngressRateLimitConfigSchema = z
+  .object({
+    maxRequestsPerMinute: z
+      .number({
+        error: "ingress.rateLimit.maxRequestsPerMinute must be a number",
+      })
+      .int("ingress.rateLimit.maxRequestsPerMinute must be an integer")
+      .nonnegative(
+        "ingress.rateLimit.maxRequestsPerMinute must be a non-negative integer",
+      )
+      .default(0)
+      .describe(
+        "Maximum number of ingress requests allowed per minute (0 = unlimited)",
+      ),
+    maxRequestsPerHour: z
+      .number({
+        error: "ingress.rateLimit.maxRequestsPerHour must be a number",
+      })
+      .int("ingress.rateLimit.maxRequestsPerHour must be an integer")
+      .nonnegative(
+        "ingress.rateLimit.maxRequestsPerHour must be a non-negative integer",
+      )
+      .default(0)
+      .describe(
+        "Maximum number of ingress requests allowed per hour (0 = unlimited)",
+      ),
+  })
+  .describe("Rate limiting for ingress requests");
 
-const IngressBaseSchema = z.object({
-  enabled: z.boolean({ error: "ingress.enabled must be a boolean" }).optional(),
-  publicBaseUrl: z
-    .string({ error: "ingress.publicBaseUrl must be a string" })
-    .refine(
-      (val) => val === "" || /^https?:\/\//i.test(val),
-      "ingress.publicBaseUrl must be an absolute URL starting with http:// or https://",
-    )
-    .default(""),
-  webhook: IngressWebhookConfigSchema.default(
-    IngressWebhookConfigSchema.parse({}),
-  ),
-  rateLimit: IngressRateLimitConfigSchema.default(
-    IngressRateLimitConfigSchema.parse({}),
-  ),
-  shutdownDrainMs: z
-    .number({ error: "ingress.shutdownDrainMs must be a number" })
-    .int("ingress.shutdownDrainMs must be an integer")
-    .nonnegative("ingress.shutdownDrainMs must be a non-negative integer")
-    .default(5_000),
-});
+const IngressBaseSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "ingress.enabled must be a boolean" })
+      .optional()
+      .describe("Whether the ingress HTTP server is enabled"),
+    publicBaseUrl: z
+      .string({ error: "ingress.publicBaseUrl must be a string" })
+      .refine(
+        (val) => val === "" || /^https?:\/\//i.test(val),
+        "ingress.publicBaseUrl must be an absolute URL starting with http:// or https://",
+      )
+      .default("")
+      .describe(
+        "Public-facing base URL for the ingress server (used in webhook callbacks)",
+      ),
+    webhook: IngressWebhookConfigSchema.default(
+      IngressWebhookConfigSchema.parse({}),
+    ),
+    rateLimit: IngressRateLimitConfigSchema.default(
+      IngressRateLimitConfigSchema.parse({}),
+    ),
+    shutdownDrainMs: z
+      .number({ error: "ingress.shutdownDrainMs must be a number" })
+      .int("ingress.shutdownDrainMs must be an integer")
+      .nonnegative("ingress.shutdownDrainMs must be a non-negative integer")
+      .default(5_000)
+      .describe(
+        "Time in milliseconds to drain in-flight requests during graceful shutdown",
+      ),
+  })
+  .describe(
+    "Ingress HTTP server configuration — handles incoming webhooks, API requests, and channel events",
+  );
 
 export const IngressConfigSchema = IngressBaseSchema.default(
   IngressBaseSchema.parse({}),

--- a/assistant/src/config/schemas/logging.ts
+++ b/assistant/src/config/schemas/logging.ts
@@ -1,21 +1,30 @@
 import { z } from "zod";
 
-export const AuditLogConfigSchema = z.object({
-  retentionDays: z
-    .number({ error: "auditLog.retentionDays must be a number" })
-    .int("auditLog.retentionDays must be an integer")
-    .nonnegative("auditLog.retentionDays must be a non-negative integer")
-    .default(0),
-});
+export const AuditLogConfigSchema = z
+  .object({
+    retentionDays: z
+      .number({ error: "auditLog.retentionDays must be a number" })
+      .int("auditLog.retentionDays must be an integer")
+      .nonnegative("auditLog.retentionDays must be a non-negative integer")
+      .default(0)
+      .describe("Number of days to retain audit log entries (0 = disabled)"),
+  })
+  .describe("Audit log configuration for tracking security-relevant events");
 
-export const LogFileConfigSchema = z.object({
-  dir: z.string({ error: "logFile.dir must be a string" }).optional(),
-  retentionDays: z
-    .number({ error: "logFile.retentionDays must be a number" })
-    .int("logFile.retentionDays must be an integer")
-    .positive("logFile.retentionDays must be a positive integer")
-    .default(30),
-});
+export const LogFileConfigSchema = z
+  .object({
+    dir: z
+      .string({ error: "logFile.dir must be a string" })
+      .optional()
+      .describe("Directory path for log file storage"),
+    retentionDays: z
+      .number({ error: "logFile.retentionDays must be a number" })
+      .int("logFile.retentionDays must be an integer")
+      .positive("logFile.retentionDays must be a positive integer")
+      .default(30)
+      .describe("Number of days to retain log files before automatic deletion"),
+  })
+  .describe("Log file storage and retention settings");
 
 export type AuditLogConfig = z.infer<typeof AuditLogConfigSchema>;
 export type LogFileConfig = z.infer<typeof LogFileConfigSchema>;

--- a/assistant/src/config/schemas/mcp.ts
+++ b/assistant/src/config/schemas/mcp.ts
@@ -1,23 +1,53 @@
 import { z } from "zod";
 
-const McpStdioTransportSchema = z.object({
-  type: z.literal("stdio"),
-  command: z.string({ error: "mcp transport command must be a string" }),
-  args: z.array(z.string()).default([]),
-  env: z.record(z.string(), z.string()).optional(),
-});
+const McpStdioTransportSchema = z
+  .object({
+    type: z.literal("stdio"),
+    command: z
+      .string({ error: "mcp transport command must be a string" })
+      .describe("Command to spawn the MCP server process"),
+    args: z
+      .array(z.string())
+      .default([])
+      .describe("Arguments passed to the MCP server command"),
+    env: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Environment variables set for the MCP server process"),
+  })
+  .describe(
+    "Stdio transport — communicates with the MCP server via stdin/stdout",
+  );
 
-const McpSseTransportSchema = z.object({
-  type: z.literal("sse"),
-  url: z.string({ error: "mcp transport url must be a string" }),
-  headers: z.record(z.string(), z.string()).optional(),
-});
+const McpSseTransportSchema = z
+  .object({
+    type: z.literal("sse"),
+    url: z
+      .string({ error: "mcp transport url must be a string" })
+      .describe("URL of the MCP SSE endpoint"),
+    headers: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Custom HTTP headers sent with SSE requests"),
+  })
+  .describe(
+    "SSE transport — connects to an MCP server over Server-Sent Events",
+  );
 
-const McpStreamableHttpTransportSchema = z.object({
-  type: z.literal("streamable-http"),
-  url: z.string({ error: "mcp transport url must be a string" }),
-  headers: z.record(z.string(), z.string()).optional(),
-});
+const McpStreamableHttpTransportSchema = z
+  .object({
+    type: z.literal("streamable-http"),
+    url: z
+      .string({ error: "mcp transport url must be a string" })
+      .describe("URL of the MCP streamable HTTP endpoint"),
+    headers: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Custom HTTP headers sent with requests"),
+  })
+  .describe(
+    "Streamable HTTP transport — connects to an MCP server over HTTP with streaming",
+  );
 
 export const McpTransportSchema = z.discriminatedUnion("type", [
   McpStdioTransportSchema,
@@ -25,35 +55,56 @@ export const McpTransportSchema = z.discriminatedUnion("type", [
   McpStreamableHttpTransportSchema,
 ]);
 
-export const McpServerConfigSchema = z.object({
-  transport: McpTransportSchema,
-  enabled: z
-    .boolean({ error: "mcp server enabled must be a boolean" })
-    .default(true),
-  defaultRiskLevel: z
-    .enum(["low", "medium", "high"], {
-      error: "mcp server defaultRiskLevel must be one of: low, medium, high",
-    })
-    .default("high"),
-  maxTools: z
-    .number({ error: "mcp server maxTools must be a number" })
-    .int()
-    .positive()
-    .default(20),
-  allowedTools: z.array(z.string()).optional(),
-  blockedTools: z.array(z.string()).optional(),
-});
+export const McpServerConfigSchema = z
+  .object({
+    transport: McpTransportSchema,
+    enabled: z
+      .boolean({ error: "mcp server enabled must be a boolean" })
+      .default(true)
+      .describe("Whether this MCP server is enabled"),
+    defaultRiskLevel: z
+      .enum(["low", "medium", "high"], {
+        error: "mcp server defaultRiskLevel must be one of: low, medium, high",
+      })
+      .default("high")
+      .describe(
+        "Default risk level assigned to tools from this server (affects approval requirements)",
+      ),
+    maxTools: z
+      .number({ error: "mcp server maxTools must be a number" })
+      .int()
+      .positive()
+      .default(20)
+      .describe("Maximum number of tools to register from this server"),
+    allowedTools: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Allowlist of tool names — only these tools will be registered (if set)",
+      ),
+    blockedTools: z
+      .array(z.string())
+      .optional()
+      .describe("Blocklist of tool names — these tools will not be registered"),
+  })
+  .describe("Configuration for an individual MCP server");
 
-export const McpConfigSchema = z.object({
-  servers: z
-    .record(z.string(), McpServerConfigSchema)
-    .default({} as Record<string, never>),
-  globalMaxTools: z
-    .number({ error: "mcp globalMaxTools must be a number" })
-    .int()
-    .positive()
-    .default(50),
-});
+export const McpConfigSchema = z
+  .object({
+    servers: z
+      .record(z.string(), McpServerConfigSchema)
+      .default({} as Record<string, never>)
+      .describe("Map of MCP server names to their configurations"),
+    globalMaxTools: z
+      .number({ error: "mcp globalMaxTools must be a number" })
+      .int()
+      .positive()
+      .default(50)
+      .describe("Maximum total number of tools across all MCP servers"),
+  })
+  .describe(
+    "Model Context Protocol (MCP) configuration — connect external tool servers",
+  );
 
 export type McpTransport = z.infer<typeof McpTransportSchema>;
 export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -1,57 +1,77 @@
 import { z } from "zod";
 
-export const MemoryJobsConfigSchema = z.object({
-  workerConcurrency: z
-    .number({ error: "memory.jobs.workerConcurrency must be a number" })
-    .int("memory.jobs.workerConcurrency must be an integer")
-    .positive("memory.jobs.workerConcurrency must be a positive integer")
-    .default(2),
-  batchSize: z
-    .number({ error: "memory.jobs.batchSize must be a number" })
-    .int("memory.jobs.batchSize must be an integer")
-    .positive("memory.jobs.batchSize must be a positive integer")
-    .default(10),
-  stalledJobTimeoutMs: z
-    .number({ error: "memory.jobs.stalledJobTimeoutMs must be a number" })
-    .int("memory.jobs.stalledJobTimeoutMs must be an integer")
-    .positive("memory.jobs.stalledJobTimeoutMs must be a positive integer")
-    .default(30 * 60 * 1000),
-});
+export const MemoryJobsConfigSchema = z
+  .object({
+    workerConcurrency: z
+      .number({ error: "memory.jobs.workerConcurrency must be a number" })
+      .int("memory.jobs.workerConcurrency must be an integer")
+      .positive("memory.jobs.workerConcurrency must be a positive integer")
+      .default(2)
+      .describe("Number of concurrent workers processing memory jobs"),
+    batchSize: z
+      .number({ error: "memory.jobs.batchSize must be a number" })
+      .int("memory.jobs.batchSize must be an integer")
+      .positive("memory.jobs.batchSize must be a positive integer")
+      .default(10)
+      .describe("Number of memory items processed per batch"),
+    stalledJobTimeoutMs: z
+      .number({ error: "memory.jobs.stalledJobTimeoutMs must be a number" })
+      .int("memory.jobs.stalledJobTimeoutMs must be an integer")
+      .positive("memory.jobs.stalledJobTimeoutMs must be a positive integer")
+      .default(30 * 60 * 1000)
+      .describe(
+        "Timeout in milliseconds after which a stalled memory job is considered failed",
+      ),
+  })
+  .describe("Memory background job processing configuration");
 
-export const MemoryRetentionConfigSchema = z.object({
-  keepRawForever: z
-    .boolean({ error: "memory.retention.keepRawForever must be a boolean" })
-    .default(true),
-});
+export const MemoryRetentionConfigSchema = z
+  .object({
+    keepRawForever: z
+      .boolean({ error: "memory.retention.keepRawForever must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to retain raw conversation data indefinitely (if false, raw data may be cleaned up after processing)",
+      ),
+  })
+  .describe("Controls how long raw memory data is retained");
 
-export const MemoryCleanupConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "memory.cleanup.enabled must be a boolean" })
-    .default(true),
-  enqueueIntervalMs: z
-    .number({ error: "memory.cleanup.enqueueIntervalMs must be a number" })
-    .int("memory.cleanup.enqueueIntervalMs must be an integer")
-    .positive("memory.cleanup.enqueueIntervalMs must be a positive integer")
-    .default(6 * 60 * 60 * 1000),
-  supersededItemRetentionMs: z
-    .number({
-      error: "memory.cleanup.supersededItemRetentionMs must be a number",
-    })
-    .int("memory.cleanup.supersededItemRetentionMs must be an integer")
-    .positive(
-      "memory.cleanup.supersededItemRetentionMs must be a positive integer",
-    )
-    .default(30 * 24 * 60 * 60 * 1000),
-  conversationRetentionDays: z
-    .number({
-      error: "memory.cleanup.conversationRetentionDays must be a number",
-    })
-    .int("memory.cleanup.conversationRetentionDays must be an integer")
-    .nonnegative(
-      "memory.cleanup.conversationRetentionDays must be non-negative",
-    )
-    .default(90),
-});
+export const MemoryCleanupConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.cleanup.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether periodic memory cleanup is enabled"),
+    enqueueIntervalMs: z
+      .number({ error: "memory.cleanup.enqueueIntervalMs must be a number" })
+      .int("memory.cleanup.enqueueIntervalMs must be an integer")
+      .positive("memory.cleanup.enqueueIntervalMs must be a positive integer")
+      .default(6 * 60 * 60 * 1000)
+      .describe("How often cleanup jobs are enqueued in milliseconds"),
+    supersededItemRetentionMs: z
+      .number({
+        error: "memory.cleanup.supersededItemRetentionMs must be a number",
+      })
+      .int("memory.cleanup.supersededItemRetentionMs must be an integer")
+      .positive(
+        "memory.cleanup.supersededItemRetentionMs must be a positive integer",
+      )
+      .default(30 * 24 * 60 * 60 * 1000)
+      .describe(
+        "How long to keep superseded memory items before deleting them (ms)",
+      ),
+    conversationRetentionDays: z
+      .number({
+        error: "memory.cleanup.conversationRetentionDays must be a number",
+      })
+      .int("memory.cleanup.conversationRetentionDays must be an integer")
+      .nonnegative(
+        "memory.cleanup.conversationRetentionDays must be non-negative",
+      )
+      .default(90)
+      .describe("Number of days to retain conversation data before cleanup"),
+  })
+  .describe("Automatic memory cleanup and garbage collection settings");
 
 export type MemoryJobsConfig = z.infer<typeof MemoryJobsConfigSchema>;
 export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;

--- a/assistant/src/config/schemas/memory-processing.ts
+++ b/assistant/src/config/schemas/memory-processing.ts
@@ -1,31 +1,52 @@
 import { z } from "zod";
 
-export const MemoryExtractionConfigSchema = z.object({
-  useLLM: z
-    .boolean({ error: "memory.extraction.useLLM must be a boolean" })
-    .default(true),
-  modelIntent: z
-    .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-      error: "memory.extraction.modelIntent must be a valid model intent",
-    })
-    .default("latency-optimized"),
-  extractFromAssistant: z
-    .boolean({
-      error: "memory.extraction.extractFromAssistant must be a boolean",
-    })
-    .default(true),
-});
+export const MemoryExtractionConfigSchema = z
+  .object({
+    useLLM: z
+      .boolean({ error: "memory.extraction.useLLM must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to use an LLM for extracting structured memory items from conversations",
+      ),
+    modelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "memory.extraction.modelIntent must be a valid model intent",
+      })
+      .default("latency-optimized")
+      .describe(
+        "Model selection strategy for extraction — trade off speed vs quality",
+      ),
+    extractFromAssistant: z
+      .boolean({
+        error: "memory.extraction.extractFromAssistant must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether to extract memory items from the assistant's own messages (in addition to user messages)",
+      ),
+  })
+  .describe("Controls how memory items are extracted from conversations");
 
-export const MemorySummarizationConfigSchema = z.object({
-  useLLM: z
-    .boolean({ error: "memory.summarization.useLLM must be a boolean" })
-    .default(true),
-  modelIntent: z
-    .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-      error: "memory.summarization.modelIntent must be a valid model intent",
-    })
-    .default("latency-optimized"),
-});
+export const MemorySummarizationConfigSchema = z
+  .object({
+    useLLM: z
+      .boolean({ error: "memory.summarization.useLLM must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to use an LLM for summarizing and consolidating memory items",
+      ),
+    modelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "memory.summarization.modelIntent must be a valid model intent",
+      })
+      .default("latency-optimized")
+      .describe(
+        "Model selection strategy for summarization — trade off speed vs quality",
+      ),
+  })
+  .describe(
+    "Controls how memory items are summarized and consolidated over time",
+  );
 
 export type MemoryExtractionConfig = z.infer<
   typeof MemoryExtractionConfigSchema

--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -1,150 +1,217 @@
 import { z } from "zod";
 
-export const MemoryDynamicBudgetConfigSchema = z.object({
-  enabled: z
-    .boolean({
-      error: "memory.retrieval.dynamicBudget.enabled must be a boolean",
-    })
-    .default(true),
-  minInjectTokens: z
-    .number({
-      error: "memory.retrieval.dynamicBudget.minInjectTokens must be a number",
-    })
-    .int("memory.retrieval.dynamicBudget.minInjectTokens must be an integer")
-    .positive(
-      "memory.retrieval.dynamicBudget.minInjectTokens must be a positive integer",
-    )
-    .default(1200),
-  maxInjectTokens: z
-    .number({
-      error: "memory.retrieval.dynamicBudget.maxInjectTokens must be a number",
-    })
-    .int("memory.retrieval.dynamicBudget.maxInjectTokens must be an integer")
-    .positive(
-      "memory.retrieval.dynamicBudget.maxInjectTokens must be a positive integer",
-    )
-    .default(10000),
-  targetHeadroomTokens: z
-    .number({
-      error:
-        "memory.retrieval.dynamicBudget.targetHeadroomTokens must be a number",
-    })
-    .int(
-      "memory.retrieval.dynamicBudget.targetHeadroomTokens must be an integer",
-    )
-    .positive(
-      "memory.retrieval.dynamicBudget.targetHeadroomTokens must be a positive integer",
-    )
-    .default(10000),
-});
+export const MemoryDynamicBudgetConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "memory.retrieval.dynamicBudget.enabled must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether to dynamically adjust the memory injection budget based on available context space",
+      ),
+    minInjectTokens: z
+      .number({
+        error:
+          "memory.retrieval.dynamicBudget.minInjectTokens must be a number",
+      })
+      .int("memory.retrieval.dynamicBudget.minInjectTokens must be an integer")
+      .positive(
+        "memory.retrieval.dynamicBudget.minInjectTokens must be a positive integer",
+      )
+      .default(1200)
+      .describe(
+        "Minimum number of tokens to inject from memory, even when context space is limited",
+      ),
+    maxInjectTokens: z
+      .number({
+        error:
+          "memory.retrieval.dynamicBudget.maxInjectTokens must be a number",
+      })
+      .int("memory.retrieval.dynamicBudget.maxInjectTokens must be an integer")
+      .positive(
+        "memory.retrieval.dynamicBudget.maxInjectTokens must be a positive integer",
+      )
+      .default(10000)
+      .describe(
+        "Maximum number of tokens to inject from memory, even when plenty of context space is available",
+      ),
+    targetHeadroomTokens: z
+      .number({
+        error:
+          "memory.retrieval.dynamicBudget.targetHeadroomTokens must be a number",
+      })
+      .int(
+        "memory.retrieval.dynamicBudget.targetHeadroomTokens must be an integer",
+      )
+      .positive(
+        "memory.retrieval.dynamicBudget.targetHeadroomTokens must be a positive integer",
+      )
+      .default(10000)
+      .describe(
+        "Number of tokens to keep free in the context window for new conversation turns",
+      ),
+  })
+  .describe(
+    "Dynamically adjusts how many memory tokens are injected based on available context space",
+  );
 
 /**
  * Per-kind freshness windows (in days). Items older than their window
  * (based on lastSeenAt) are down-ranked unless recently reinforced.
  * A value of 0 disables freshness decay for that kind.
  */
-const MemoryFreshnessConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "memory.retrieval.freshness.enabled must be a boolean" })
-    .default(true),
-  maxAgeDays: z
-    .object({
-      identity: z
-        .number({
-          error:
-            "memory.retrieval.freshness.maxAgeDays.identity must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.identity must be non-negative",
-        )
-        .default(0),
-      preference: z
-        .number({
-          error:
-            "memory.retrieval.freshness.maxAgeDays.preference must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.preference must be non-negative",
-        )
-        .default(0),
-      project: z
-        .number({
-          error:
-            "memory.retrieval.freshness.maxAgeDays.project must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.project must be non-negative",
-        )
-        .default(30),
-      decision: z
-        .number({
-          error:
-            "memory.retrieval.freshness.maxAgeDays.decision must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.decision must be non-negative",
-        )
-        .default(30),
-      constraint: z
-        .number({
-          error:
-            "memory.retrieval.freshness.maxAgeDays.constraint must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.constraint must be non-negative",
-        )
-        .default(90),
-      event: z
-        .number({
-          error: "memory.retrieval.freshness.maxAgeDays.event must be a number",
-        })
-        .nonnegative(
-          "memory.retrieval.freshness.maxAgeDays.event must be non-negative",
-        )
-        .default(30),
-    })
-    .default({
-      identity: 0,
-      preference: 0,
-      project: 30,
-      decision: 30,
-      constraint: 90,
-      event: 30,
-    }),
-  staleDecay: z
-    .number({ error: "memory.retrieval.freshness.staleDecay must be a number" })
-    .min(0, "memory.retrieval.freshness.staleDecay must be >= 0")
-    .max(1, "memory.retrieval.freshness.staleDecay must be <= 1")
-    .default(0.5),
-  reinforcementShieldDays: z
-    .number({
-      error:
-        "memory.retrieval.freshness.reinforcementShieldDays must be a number",
-    })
-    .nonnegative(
-      "memory.retrieval.freshness.reinforcementShieldDays must be non-negative",
-    )
-    .default(7),
-});
+const MemoryFreshnessConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "memory.retrieval.freshness.enabled must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether to apply freshness-based ranking to retrieved memory items",
+      ),
+    maxAgeDays: z
+      .object({
+        identity: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.identity must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.identity must be non-negative",
+          )
+          .default(0)
+          .describe(
+            "Days before identity memories are considered stale (0 = never stale)",
+          ),
+        preference: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.preference must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.preference must be non-negative",
+          )
+          .default(0)
+          .describe(
+            "Days before preference memories are considered stale (0 = never stale)",
+          ),
+        project: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.project must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.project must be non-negative",
+          )
+          .default(30)
+          .describe(
+            "Days before project memories are considered stale (0 = never stale)",
+          ),
+        decision: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.decision must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.decision must be non-negative",
+          )
+          .default(30)
+          .describe(
+            "Days before decision memories are considered stale (0 = never stale)",
+          ),
+        constraint: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.constraint must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.constraint must be non-negative",
+          )
+          .default(90)
+          .describe(
+            "Days before constraint memories are considered stale (0 = never stale)",
+          ),
+        event: z
+          .number({
+            error:
+              "memory.retrieval.freshness.maxAgeDays.event must be a number",
+          })
+          .nonnegative(
+            "memory.retrieval.freshness.maxAgeDays.event must be non-negative",
+          )
+          .default(30)
+          .describe(
+            "Days before event memories are considered stale (0 = never stale)",
+          ),
+      })
+      .default({
+        identity: 0,
+        preference: 0,
+        project: 30,
+        decision: 30,
+        constraint: 90,
+        event: 30,
+      })
+      .describe(
+        "Per-kind freshness windows in days — items older than their window are down-ranked",
+      ),
+    staleDecay: z
+      .number({
+        error: "memory.retrieval.freshness.staleDecay must be a number",
+      })
+      .min(0, "memory.retrieval.freshness.staleDecay must be >= 0")
+      .max(1, "memory.retrieval.freshness.staleDecay must be <= 1")
+      .default(0.5)
+      .describe(
+        "Score multiplier applied to stale memory items (0 = fully suppress, 1 = no decay)",
+      ),
+    reinforcementShieldDays: z
+      .number({
+        error:
+          "memory.retrieval.freshness.reinforcementShieldDays must be a number",
+      })
+      .nonnegative(
+        "memory.retrieval.freshness.reinforcementShieldDays must be non-negative",
+      )
+      .default(7)
+      .describe(
+        "Days after reinforcement during which a memory item is protected from freshness decay",
+      ),
+  })
+  .describe(
+    "Freshness-based ranking for memory retrieval — down-ranks old items unless recently reinforced",
+  );
 
-export const MemoryRetrievalConfigSchema = z.object({
-  maxInjectTokens: z
-    .number({ error: "memory.retrieval.maxInjectTokens must be a number" })
-    .int("memory.retrieval.maxInjectTokens must be an integer")
-    .positive("memory.retrieval.maxInjectTokens must be a positive integer")
-    .default(10000),
-  freshness: MemoryFreshnessConfigSchema.default(
-    MemoryFreshnessConfigSchema.parse({}),
-  ),
-  scopePolicy: z
-    .enum(["allow_global_fallback", "strict"], {
-      error:
-        'memory.retrieval.scopePolicy must be "allow_global_fallback" or "strict"',
-    })
-    .default("allow_global_fallback"),
-  dynamicBudget: MemoryDynamicBudgetConfigSchema.default(
-    MemoryDynamicBudgetConfigSchema.parse({}),
-  ),
-});
+export const MemoryRetrievalConfigSchema = z
+  .object({
+    maxInjectTokens: z
+      .number({ error: "memory.retrieval.maxInjectTokens must be a number" })
+      .int("memory.retrieval.maxInjectTokens must be an integer")
+      .positive("memory.retrieval.maxInjectTokens must be a positive integer")
+      .default(10000)
+      .describe(
+        "Maximum number of tokens to inject from long-term memory into the conversation context",
+      ),
+    freshness: MemoryFreshnessConfigSchema.default(
+      MemoryFreshnessConfigSchema.parse({}),
+    ),
+    scopePolicy: z
+      .enum(["allow_global_fallback", "strict"], {
+        error:
+          'memory.retrieval.scopePolicy must be "allow_global_fallback" or "strict"',
+      })
+      .default("allow_global_fallback")
+      .describe(
+        "Whether to fall back to global memories when scoped results are insufficient, or strictly scope results",
+      ),
+    dynamicBudget: MemoryDynamicBudgetConfigSchema.default(
+      MemoryDynamicBudgetConfigSchema.parse({}),
+    ),
+  })
+  .describe(
+    "Controls how memories are retrieved and injected into conversations",
+  );
 
 export type MemoryRetrievalConfig = z.infer<typeof MemoryRetrievalConfigSchema>;

--- a/assistant/src/config/schemas/memory-storage.ts
+++ b/assistant/src/config/schemas/memory-storage.ts
@@ -10,87 +10,121 @@ const VALID_MEMORY_EMBEDDING_PROVIDERS = [
 
 const VALID_QDRANT_QUANTIZATION = ["scalar", "none"] as const;
 
-export const MemoryEmbeddingsConfigSchema = z.object({
-  required: z
-    .boolean({ error: "memory.embeddings.required must be a boolean" })
-    .default(true),
-  provider: z
-    .enum(VALID_MEMORY_EMBEDDING_PROVIDERS, {
-      error: `memory.embeddings.provider must be one of: ${VALID_MEMORY_EMBEDDING_PROVIDERS.join(
-        ", ",
-      )}`,
-    })
-    .default("auto"),
-  localModel: z
-    .string({ error: "memory.embeddings.localModel must be a string" })
-    .default("Xenova/bge-small-en-v1.5"),
-  openaiModel: z
-    .string({ error: "memory.embeddings.openaiModel must be a string" })
-    .default("text-embedding-3-small"),
-  geminiModel: z
-    .string({ error: "memory.embeddings.geminiModel must be a string" })
-    .default("gemini-embedding-2-preview"),
-  geminiTaskType: z
-    .enum([
-      "SEMANTIC_SIMILARITY",
-      "CLASSIFICATION",
-      "CLUSTERING",
-      "RETRIEVAL_DOCUMENT",
-      "RETRIEVAL_QUERY",
-      "CODE_RETRIEVAL_QUERY",
-      "QUESTION_ANSWERING",
-      "FACT_VERIFICATION",
-    ], { error: "memory.embeddings.geminiTaskType must be a valid task type" })
-    .optional(),
-  geminiDimensions: z
-    .number({ error: "memory.embeddings.geminiDimensions must be a number" })
-    .int("memory.embeddings.geminiDimensions must be an integer")
-    .min(128, "memory.embeddings.geminiDimensions must be >= 128")
-    .max(3072, "memory.embeddings.geminiDimensions must be <= 3072")
-    .optional(),
-  ollamaModel: z
-    .string({ error: "memory.embeddings.ollamaModel must be a string" })
-    .default("nomic-embed-text"),
-});
+export const MemoryEmbeddingsConfigSchema = z
+  .object({
+    required: z
+      .boolean({ error: "memory.embeddings.required must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether embedding generation is required for memory to function (if false, memory works without embeddings)",
+      ),
+    provider: z
+      .enum(VALID_MEMORY_EMBEDDING_PROVIDERS, {
+        error: `memory.embeddings.provider must be one of: ${VALID_MEMORY_EMBEDDING_PROVIDERS.join(
+          ", ",
+        )}`,
+      })
+      .default("auto")
+      .describe(
+        "Embedding provider — 'auto' selects the best available provider",
+      ),
+    localModel: z
+      .string({ error: "memory.embeddings.localModel must be a string" })
+      .default("Xenova/bge-small-en-v1.5")
+      .describe("Model name for the local (in-process) embedding provider"),
+    openaiModel: z
+      .string({ error: "memory.embeddings.openaiModel must be a string" })
+      .default("text-embedding-3-small")
+      .describe("Model name for the OpenAI embedding provider"),
+    geminiModel: z
+      .string({ error: "memory.embeddings.geminiModel must be a string" })
+      .default("gemini-embedding-2-preview")
+      .describe("Model name for the Gemini embedding provider"),
+    geminiTaskType: z
+      .enum(
+        [
+          "SEMANTIC_SIMILARITY",
+          "CLASSIFICATION",
+          "CLUSTERING",
+          "RETRIEVAL_DOCUMENT",
+          "RETRIEVAL_QUERY",
+          "CODE_RETRIEVAL_QUERY",
+          "QUESTION_ANSWERING",
+          "FACT_VERIFICATION",
+        ],
+        { error: "memory.embeddings.geminiTaskType must be a valid task type" },
+      )
+      .optional()
+      .describe("Gemini-specific task type hint for embedding generation"),
+    geminiDimensions: z
+      .number({ error: "memory.embeddings.geminiDimensions must be a number" })
+      .int("memory.embeddings.geminiDimensions must be an integer")
+      .min(128, "memory.embeddings.geminiDimensions must be >= 128")
+      .max(3072, "memory.embeddings.geminiDimensions must be <= 3072")
+      .optional()
+      .describe("Output dimensionality for Gemini embeddings"),
+    ollamaModel: z
+      .string({ error: "memory.embeddings.ollamaModel must be a string" })
+      .default("nomic-embed-text")
+      .describe("Model name for the Ollama embedding provider"),
+  })
+  .describe("Embedding generation configuration for semantic memory search");
 
-export const QdrantConfigSchema = z.object({
-  url: z
-    .string({ error: "memory.qdrant.url must be a string" })
-    .default("http://127.0.0.1:6333"),
-  collection: z
-    .string({ error: "memory.qdrant.collection must be a string" })
-    .default("memory"),
-  vectorSize: z
-    .number({ error: "memory.qdrant.vectorSize must be a number" })
-    .int("memory.qdrant.vectorSize must be an integer")
-    .positive("memory.qdrant.vectorSize must be a positive integer")
-    .default(384),
-  onDisk: z
-    .boolean({ error: "memory.qdrant.onDisk must be a boolean" })
-    .default(true),
-  quantization: z
-    .enum(VALID_QDRANT_QUANTIZATION, {
-      error: `memory.qdrant.quantization must be one of: ${VALID_QDRANT_QUANTIZATION.join(
-        ", ",
-      )}`,
-    })
-    .default("scalar"),
-});
+export const QdrantConfigSchema = z
+  .object({
+    url: z
+      .string({ error: "memory.qdrant.url must be a string" })
+      .default("http://127.0.0.1:6333")
+      .describe("URL of the Qdrant vector database instance"),
+    collection: z
+      .string({ error: "memory.qdrant.collection must be a string" })
+      .default("memory")
+      .describe("Name of the Qdrant collection used for memory storage"),
+    vectorSize: z
+      .number({ error: "memory.qdrant.vectorSize must be a number" })
+      .int("memory.qdrant.vectorSize must be an integer")
+      .positive("memory.qdrant.vectorSize must be a positive integer")
+      .default(384)
+      .describe("Dimensionality of the embedding vectors stored in Qdrant"),
+    onDisk: z
+      .boolean({ error: "memory.qdrant.onDisk must be a boolean" })
+      .default(true)
+      .describe("Whether to store vector data on disk rather than in memory"),
+    quantization: z
+      .enum(VALID_QDRANT_QUANTIZATION, {
+        error: `memory.qdrant.quantization must be one of: ${VALID_QDRANT_QUANTIZATION.join(
+          ", ",
+        )}`,
+      })
+      .default("scalar")
+      .describe(
+        "Vector quantization method — 'scalar' reduces memory usage, 'none' keeps full precision",
+      ),
+  })
+  .describe("Qdrant vector database configuration for memory storage");
 
-export const MemorySegmentationConfigSchema = z.object({
-  targetTokens: z
-    .number({ error: "memory.segmentation.targetTokens must be a number" })
-    .int("memory.segmentation.targetTokens must be an integer")
-    .positive("memory.segmentation.targetTokens must be a positive integer")
-    .default(450),
-  overlapTokens: z
-    .number({ error: "memory.segmentation.overlapTokens must be a number" })
-    .int("memory.segmentation.overlapTokens must be an integer")
-    .nonnegative(
-      "memory.segmentation.overlapTokens must be a non-negative integer",
-    )
-    .default(60),
-});
+export const MemorySegmentationConfigSchema = z
+  .object({
+    targetTokens: z
+      .number({ error: "memory.segmentation.targetTokens must be a number" })
+      .int("memory.segmentation.targetTokens must be an integer")
+      .positive("memory.segmentation.targetTokens must be a positive integer")
+      .default(450)
+      .describe("Target number of tokens per memory segment"),
+    overlapTokens: z
+      .number({ error: "memory.segmentation.overlapTokens must be a number" })
+      .int("memory.segmentation.overlapTokens must be an integer")
+      .nonnegative(
+        "memory.segmentation.overlapTokens must be a non-negative integer",
+      )
+      .default(60)
+      .describe(
+        "Number of overlapping tokens between adjacent segments for context continuity",
+      ),
+  })
+  .describe(
+    "Controls how conversation text is split into segments for embedding and storage",
+  );
 
 export type MemoryEmbeddingsConfig = z.infer<
   typeof MemoryEmbeddingsConfigSchema

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -16,33 +16,38 @@ import {
   QdrantConfigSchema,
 } from "./memory-storage.js";
 
-export const MemoryConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "memory.enabled must be a boolean" })
-    .default(true),
-  embeddings: MemoryEmbeddingsConfigSchema.default(
-    MemoryEmbeddingsConfigSchema.parse({}),
-  ),
-  qdrant: QdrantConfigSchema.default(QdrantConfigSchema.parse({})),
-  retrieval: MemoryRetrievalConfigSchema.default(
-    MemoryRetrievalConfigSchema.parse({}),
-  ),
-  segmentation: MemorySegmentationConfigSchema.default(
-    MemorySegmentationConfigSchema.parse({}),
-  ),
-  jobs: MemoryJobsConfigSchema.default(MemoryJobsConfigSchema.parse({})),
-  retention: MemoryRetentionConfigSchema.default(
-    MemoryRetentionConfigSchema.parse({}),
-  ),
-  cleanup: MemoryCleanupConfigSchema.default(
-    MemoryCleanupConfigSchema.parse({}),
-  ),
-  extraction: MemoryExtractionConfigSchema.default(
-    MemoryExtractionConfigSchema.parse({}),
-  ),
-  summarization: MemorySummarizationConfigSchema.default(
-    MemorySummarizationConfigSchema.parse({}),
-  ),
-});
+export const MemoryConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether the long-term memory system is enabled"),
+    embeddings: MemoryEmbeddingsConfigSchema.default(
+      MemoryEmbeddingsConfigSchema.parse({}),
+    ),
+    qdrant: QdrantConfigSchema.default(QdrantConfigSchema.parse({})),
+    retrieval: MemoryRetrievalConfigSchema.default(
+      MemoryRetrievalConfigSchema.parse({}),
+    ),
+    segmentation: MemorySegmentationConfigSchema.default(
+      MemorySegmentationConfigSchema.parse({}),
+    ),
+    jobs: MemoryJobsConfigSchema.default(MemoryJobsConfigSchema.parse({})),
+    retention: MemoryRetentionConfigSchema.default(
+      MemoryRetentionConfigSchema.parse({}),
+    ),
+    cleanup: MemoryCleanupConfigSchema.default(
+      MemoryCleanupConfigSchema.parse({}),
+    ),
+    extraction: MemoryExtractionConfigSchema.default(
+      MemoryExtractionConfigSchema.parse({}),
+    ),
+    summarization: MemorySummarizationConfigSchema.default(
+      MemorySummarizationConfigSchema.parse({}),
+    ),
+  })
+  .describe(
+    "Long-term memory system — stores, retrieves, and manages persistent knowledge across conversations",
+  );
 
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;

--- a/assistant/src/config/schemas/notifications.ts
+++ b/assistant/src/config/schemas/notifications.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 
-export const NotificationsConfigSchema = z.object({
-  decisionModelIntent: z
-    .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-      error: "notifications.decisionModelIntent must be a valid model intent",
-    })
-    .default("latency-optimized"),
-});
+export const NotificationsConfigSchema = z
+  .object({
+    decisionModelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "notifications.decisionModelIntent must be a valid model intent",
+      })
+      .default("latency-optimized")
+      .describe(
+        "Model selection strategy for deciding whether to send a notification",
+      ),
+  })
+  .describe("Notification delivery configuration");
 
 export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -1,48 +1,71 @@
 import { z } from "zod";
 
-export const PlatformConfigSchema = z.object({
-  baseUrl: z
-    .string({ error: "platform.baseUrl must be a string" })
-    .refine(
-      (val) => val === "" || /^https?:\/\//i.test(val),
-      "platform.baseUrl must be an absolute URL starting with http:// or https://",
-    )
-    .default(""),
-});
+export const PlatformConfigSchema = z
+  .object({
+    baseUrl: z
+      .string({ error: "platform.baseUrl must be a string" })
+      .refine(
+        (val) => val === "" || /^https?:\/\//i.test(val),
+        "platform.baseUrl must be an absolute URL starting with http:// or https://",
+      )
+      .default("")
+      .describe("Base URL of the Vellum platform API"),
+  })
+  .describe("Vellum platform connection settings");
 
 export type PlatformConfig = z.infer<typeof PlatformConfigSchema>;
 
-export const DaemonConfigSchema = z.object({
-  startupSocketWaitMs: z
-    .number({ error: "daemon.startupSocketWaitMs must be a number" })
-    .int("daemon.startupSocketWaitMs must be an integer")
-    .positive("daemon.startupSocketWaitMs must be a positive integer")
-    .default(5000),
-  stopTimeoutMs: z
-    .number({ error: "daemon.stopTimeoutMs must be a number" })
-    .int("daemon.stopTimeoutMs must be an integer")
-    .positive("daemon.stopTimeoutMs must be a positive integer")
-    .default(5000),
-  sigkillGracePeriodMs: z
-    .number({ error: "daemon.sigkillGracePeriodMs must be a number" })
-    .int("daemon.sigkillGracePeriodMs must be an integer")
-    .positive("daemon.sigkillGracePeriodMs must be a positive integer")
-    .default(2000),
-  titleGenerationMaxTokens: z
-    .number({ error: "daemon.titleGenerationMaxTokens must be a number" })
-    .int("daemon.titleGenerationMaxTokens must be an integer")
-    .positive("daemon.titleGenerationMaxTokens must be a positive integer")
-    .default(30),
-  standaloneRecording: z
-    .boolean({ error: "daemon.standaloneRecording must be a boolean" })
-    .default(true),
-});
+export const DaemonConfigSchema = z
+  .object({
+    startupSocketWaitMs: z
+      .number({ error: "daemon.startupSocketWaitMs must be a number" })
+      .int("daemon.startupSocketWaitMs must be an integer")
+      .positive("daemon.startupSocketWaitMs must be a positive integer")
+      .default(5000)
+      .describe(
+        "How long to wait for the daemon socket to become available on startup (ms)",
+      ),
+    stopTimeoutMs: z
+      .number({ error: "daemon.stopTimeoutMs must be a number" })
+      .int("daemon.stopTimeoutMs must be an integer")
+      .positive("daemon.stopTimeoutMs must be a positive integer")
+      .default(5000)
+      .describe(
+        "How long to wait for the daemon to stop gracefully before force-killing (ms)",
+      ),
+    sigkillGracePeriodMs: z
+      .number({ error: "daemon.sigkillGracePeriodMs must be a number" })
+      .int("daemon.sigkillGracePeriodMs must be an integer")
+      .positive("daemon.sigkillGracePeriodMs must be a positive integer")
+      .default(2000)
+      .describe("Grace period after SIGTERM before sending SIGKILL (ms)"),
+    titleGenerationMaxTokens: z
+      .number({ error: "daemon.titleGenerationMaxTokens must be a number" })
+      .int("daemon.titleGenerationMaxTokens must be an integer")
+      .positive("daemon.titleGenerationMaxTokens must be a positive integer")
+      .default(30)
+      .describe(
+        "Maximum number of tokens for auto-generated conversation titles",
+      ),
+    standaloneRecording: z
+      .boolean({ error: "daemon.standaloneRecording must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the daemon records conversations even when no client is connected",
+      ),
+  })
+  .describe("Background daemon process configuration");
 
-export const UiConfigSchema = z.object({
-  userTimezone: z
-    .string({ error: "ui.userTimezone must be a string" })
-    .optional(),
-});
+export const UiConfigSchema = z
+  .object({
+    userTimezone: z
+      .string({ error: "ui.userTimezone must be a string" })
+      .optional()
+      .describe(
+        "IANA timezone identifier for displaying dates and times (e.g. 'America/New_York')",
+      ),
+  })
+  .describe("User interface display settings");
 
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 export type UiConfig = z.infer<typeof UiConfigSchema>;

--- a/assistant/src/config/schemas/sandbox.ts
+++ b/assistant/src/config/schemas/sandbox.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
 
-export const SandboxConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "sandbox.enabled must be a boolean" })
-    .default(true),
-});
+export const SandboxConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "sandbox.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to run tool executions in a sandboxed environment for safety",
+      ),
+  })
+  .describe("Sandbox configuration for isolating tool executions");
 
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -5,49 +5,80 @@ const VALID_PERMISSIONS_MODES = ["strict", "workspace"] as const;
 
 export { VALID_PERMISSIONS_MODES, VALID_SECRET_ACTIONS };
 
-const CustomSecretPatternSchema = z.object({
-  label: z.string({
-    error: "secretDetection.customPatterns[].label must be a string",
-  }),
-  pattern: z.string({
-    error: "secretDetection.customPatterns[].pattern must be a string",
-  }),
-});
+const CustomSecretPatternSchema = z
+  .object({
+    label: z
+      .string({
+        error: "secretDetection.customPatterns[].label must be a string",
+      })
+      .describe("Human-readable label for this secret pattern"),
+    pattern: z
+      .string({
+        error: "secretDetection.customPatterns[].pattern must be a string",
+      })
+      .describe("Regular expression pattern to match secrets"),
+  })
+  .describe("Custom pattern for detecting secrets in messages");
 
-export const SecretDetectionConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "secretDetection.enabled must be a boolean" })
-    .default(true),
-  action: z
-    .enum(VALID_SECRET_ACTIONS, {
-      error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(
-        ", ",
-      )}`,
-    })
-    .default("redact"),
-  entropyThreshold: z
-    .number({ error: "secretDetection.entropyThreshold must be a number" })
-    .finite("secretDetection.entropyThreshold must be finite")
-    .positive("secretDetection.entropyThreshold must be a positive number")
-    .default(4.0),
-  allowOneTimeSend: z
-    .boolean({ error: "secretDetection.allowOneTimeSend must be a boolean" })
-    .default(false),
-  blockIngress: z
-    .boolean({ error: "secretDetection.blockIngress must be a boolean" })
-    .default(true),
-  customPatterns: z.array(CustomSecretPatternSchema).optional(),
-});
+export const SecretDetectionConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "secretDetection.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether automatic secret detection is enabled"),
+    action: z
+      .enum(VALID_SECRET_ACTIONS, {
+        error: `secretDetection.action must be one of: ${VALID_SECRET_ACTIONS.join(
+          ", ",
+        )}`,
+      })
+      .default("redact")
+      .describe(
+        "Action to take when a secret is detected: redact (replace with placeholder), warn (log a warning), block (reject the message), or prompt (ask the user)",
+      ),
+    entropyThreshold: z
+      .number({ error: "secretDetection.entropyThreshold must be a number" })
+      .finite("secretDetection.entropyThreshold must be finite")
+      .positive("secretDetection.entropyThreshold must be a positive number")
+      .default(4.0)
+      .describe(
+        "Shannon entropy threshold for detecting high-entropy strings as potential secrets",
+      ),
+    allowOneTimeSend: z
+      .boolean({ error: "secretDetection.allowOneTimeSend must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether to allow sending a detected secret once (with user confirmation) before redacting future occurrences",
+      ),
+    blockIngress: z
+      .boolean({ error: "secretDetection.blockIngress must be a boolean" })
+      .default(true)
+      .describe("Whether to block secrets in incoming ingress messages"),
+    customPatterns: z
+      .array(CustomSecretPatternSchema)
+      .optional()
+      .describe(
+        "Additional regex patterns for detecting domain-specific secrets",
+      ),
+  })
+  .describe(
+    "Automatic secret detection and redaction to prevent leaking sensitive data",
+  );
 
-export const PermissionsConfigSchema = z.object({
-  mode: z
-    .enum(VALID_PERMISSIONS_MODES, {
-      error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(
-        ", ",
-      )}`,
-    })
-    .default("workspace"),
-});
+export const PermissionsConfigSchema = z
+  .object({
+    mode: z
+      .enum(VALID_PERMISSIONS_MODES, {
+        error: `permissions.mode must be one of: ${VALID_PERMISSIONS_MODES.join(
+          ", ",
+        )}`,
+      })
+      .default("workspace")
+      .describe(
+        "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
+      ),
+  })
+  .describe("Permission enforcement mode for tool operations");
 
 export type SecretDetectionConfig = z.infer<typeof SecretDetectionConfigSchema>;
 export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;

--- a/assistant/src/config/schemas/skills.ts
+++ b/assistant/src/config/schemas/skills.ts
@@ -1,59 +1,87 @@
 import { z } from "zod";
 
-export const SkillEntryConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "skills.entries[].enabled must be a boolean" })
-    .default(true),
-  apiKey: z
-    .string({ error: "skills.entries[].apiKey must be a string" })
-    .optional(),
-  env: z
-    .record(
-      z.string(),
-      z.string({ error: "skills.entries[].env values must be strings" }),
-    )
-    .optional(),
-  config: z.record(z.string(), z.unknown()).optional(),
-});
+export const SkillEntryConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "skills.entries[].enabled must be a boolean" })
+      .default(true)
+      .describe("Whether this skill is enabled"),
+    apiKey: z
+      .string({ error: "skills.entries[].apiKey must be a string" })
+      .optional()
+      .describe("API key for authenticated skill access"),
+    env: z
+      .record(
+        z.string(),
+        z.string({ error: "skills.entries[].env values must be strings" }),
+      )
+      .optional()
+      .describe("Environment variables passed to the skill"),
+    config: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe("Arbitrary key-value configuration passed to the skill"),
+  })
+  .describe("Configuration for an individual skill");
 
-export const SkillsLoadConfigSchema = z.object({
-  extraDirs: z
-    .array(z.string({ error: "skills.load.extraDirs values must be strings" }))
-    .default([]),
-  watch: z
-    .boolean({ error: "skills.load.watch must be a boolean" })
-    .default(true),
-  watchDebounceMs: z
-    .number({ error: "skills.load.watchDebounceMs must be a number" })
-    .int()
-    .positive()
-    .default(250),
-});
+export const SkillsLoadConfigSchema = z
+  .object({
+    extraDirs: z
+      .array(
+        z.string({ error: "skills.load.extraDirs values must be strings" }),
+      )
+      .default([])
+      .describe("Additional directories to search for skill definitions"),
+    watch: z
+      .boolean({ error: "skills.load.watch must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to watch skill directories for changes and auto-reload",
+      ),
+    watchDebounceMs: z
+      .number({ error: "skills.load.watchDebounceMs must be a number" })
+      .int()
+      .positive()
+      .default(250)
+      .describe(
+        "Debounce delay in milliseconds for skill file change detection",
+      ),
+  })
+  .describe("Controls how skills are discovered and loaded");
 
-export const SkillsInstallConfigSchema = z.object({
-  nodeManager: z
-    .enum(["npm", "pnpm", "yarn", "bun"], {
-      error: "skills.install.nodeManager must be one of: npm, pnpm, yarn, bun",
-    })
-    .default("npm"),
-});
+export const SkillsInstallConfigSchema = z
+  .object({
+    nodeManager: z
+      .enum(["npm", "pnpm", "yarn", "bun"], {
+        error:
+          "skills.install.nodeManager must be one of: npm, pnpm, yarn, bun",
+      })
+      .default("npm")
+      .describe("Node package manager used to install skill dependencies"),
+  })
+  .describe("Skill dependency installation settings");
 
-export const RemoteProviderConfigSchema = z.object({
-  enabled: z
-    .boolean({
-      error: "skills.remoteProviders.<provider>.enabled must be a boolean",
-    })
-    .default(true),
-});
+export const RemoteProviderConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "skills.remoteProviders.<provider>.enabled must be a boolean",
+      })
+      .default(true)
+      .describe("Whether this remote skill provider is enabled"),
+  })
+  .describe("Configuration for a remote skill provider");
 
-export const RemoteProvidersConfigSchema = z.object({
-  skillssh: RemoteProviderConfigSchema.default(
-    RemoteProviderConfigSchema.parse({}),
-  ),
-  clawhub: RemoteProviderConfigSchema.default(
-    RemoteProviderConfigSchema.parse({}),
-  ),
-});
+export const RemoteProvidersConfigSchema = z
+  .object({
+    skillssh: RemoteProviderConfigSchema.default(
+      RemoteProviderConfigSchema.parse({}),
+    ).describe("skills.sh remote skill provider"),
+    clawhub: RemoteProviderConfigSchema.default(
+      RemoteProviderConfigSchema.parse({}),
+    ).describe("ClawHub remote skill provider"),
+  })
+  .describe("Remote skill provider configurations");
 
 // 'unknown' is valid as a risk label on a skill but not as a threshold — setting the threshold
 // to 'unknown' would silently disable fail-closed behavior since nothing can exceed it.
@@ -65,38 +93,60 @@ const VALID_MAX_RISK_LEVELS = [
   "critical",
 ] as const;
 
-export const RemotePolicyConfigSchema = z.object({
-  blockSuspicious: z
-    .boolean({ error: "skills.remotePolicy.blockSuspicious must be a boolean" })
-    .default(true),
-  blockMalware: z
-    .boolean({ error: "skills.remotePolicy.blockMalware must be a boolean" })
-    .default(true),
-  maxSkillsShRisk: z
-    .enum(VALID_MAX_RISK_LEVELS, {
-      error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_MAX_RISK_LEVELS.join(
-        ", ",
-      )}`,
-    })
-    .default("medium"),
-});
+export const RemotePolicyConfigSchema = z
+  .object({
+    blockSuspicious: z
+      .boolean({
+        error: "skills.remotePolicy.blockSuspicious must be a boolean",
+      })
+      .default(true)
+      .describe("Whether to block skills flagged as suspicious"),
+    blockMalware: z
+      .boolean({ error: "skills.remotePolicy.blockMalware must be a boolean" })
+      .default(true)
+      .describe("Whether to block skills flagged as malware"),
+    maxSkillsShRisk: z
+      .enum(VALID_MAX_RISK_LEVELS, {
+        error: `skills.remotePolicy.maxSkillsShRisk must be one of: ${VALID_MAX_RISK_LEVELS.join(
+          ", ",
+        )}`,
+      })
+      .default("medium")
+      .describe(
+        "Maximum risk level accepted from skills.sh — skills above this level are blocked",
+      ),
+  })
+  .describe(
+    "Security policy for remote skills — controls what risk levels are allowed",
+  );
 
-export const SkillsConfigSchema = z.object({
-  entries: z
-    .record(z.string(), SkillEntryConfigSchema)
-    .default({} as Record<string, never>),
-  load: SkillsLoadConfigSchema.default(SkillsLoadConfigSchema.parse({})),
-  install: SkillsInstallConfigSchema.default(
-    SkillsInstallConfigSchema.parse({}),
-  ),
-  allowBundled: z.array(z.string()).nullable().default(null),
-  remoteProviders: RemoteProvidersConfigSchema.default(
-    RemoteProvidersConfigSchema.parse({}),
-  ),
-  remotePolicy: RemotePolicyConfigSchema.default(
-    RemotePolicyConfigSchema.parse({}),
-  ),
-});
+export const SkillsConfigSchema = z
+  .object({
+    entries: z
+      .record(z.string(), SkillEntryConfigSchema)
+      .default({} as Record<string, never>)
+      .describe("Map of skill names to their per-skill configuration"),
+    load: SkillsLoadConfigSchema.default(SkillsLoadConfigSchema.parse({})),
+    install: SkillsInstallConfigSchema.default(
+      SkillsInstallConfigSchema.parse({}),
+    ),
+    allowBundled: z
+      .array(z.string())
+      .nullable()
+      .default(null)
+      .describe(
+        "Allowlist of bundled skill names to load (null = load all bundled skills)",
+      ),
+    remoteProviders: RemoteProvidersConfigSchema.default(
+      RemoteProvidersConfigSchema.parse({}),
+    ),
+    remotePolicy: RemotePolicyConfigSchema.default(
+      RemotePolicyConfigSchema.parse({}),
+    ),
+  })
+  .describe(
+    "Skill system configuration — loading, installation, and remote providers",
+  );
 
 export type SkillEntryConfig = z.infer<typeof SkillEntryConfigSchema>;
 export type SkillsLoadConfig = z.infer<typeof SkillsLoadConfigSchema>;

--- a/assistant/src/config/schemas/swarm.ts
+++ b/assistant/src/config/schemas/swarm.ts
@@ -1,50 +1,82 @@
 import { z } from "zod";
 
-export const SwarmConfigSchema = z.object({
-  enabled: z
-    .boolean({ error: "swarm.enabled must be a boolean" })
-    .default(true),
-  maxWorkers: z
-    .number({ error: "swarm.maxWorkers must be a number" })
-    .int("swarm.maxWorkers must be an integer")
-    .positive("swarm.maxWorkers must be a positive integer")
-    .max(6, "swarm.maxWorkers must be at most 6")
-    .default(3),
-  maxTasks: z
-    .number({ error: "swarm.maxTasks must be a number" })
-    .int("swarm.maxTasks must be an integer")
-    .positive("swarm.maxTasks must be a positive integer")
-    .max(20, "swarm.maxTasks must be at most 20")
-    .default(8),
-  maxRetriesPerTask: z
-    .number({ error: "swarm.maxRetriesPerTask must be a number" })
-    .int("swarm.maxRetriesPerTask must be an integer")
-    .nonnegative("swarm.maxRetriesPerTask must be a non-negative integer")
-    .max(3, "swarm.maxRetriesPerTask must be at most 3")
-    .default(1),
-  workerTimeoutSec: z
-    .number({ error: "swarm.workerTimeoutSec must be a number" })
-    .int("swarm.workerTimeoutSec must be an integer")
-    .positive("swarm.workerTimeoutSec must be a positive integer")
-    .default(900),
-  roleTimeoutsSec: z
-    .object({
-      router: z.number().int().positive().optional(),
-      researcher: z.number().int().positive().optional(),
-      coder: z.number().int().positive().optional(),
-      reviewer: z.number().int().positive().optional(),
-    })
-    .default({}),
-  plannerModelIntent: z
-    .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-      error: "swarm.plannerModelIntent must be a valid model intent",
-    })
-    .default("latency-optimized"),
-  synthesizerModelIntent: z
-    .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-      error: "swarm.synthesizerModelIntent must be a valid model intent",
-    })
-    .default("quality-optimized"),
-});
+export const SwarmConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "swarm.enabled must be a boolean" })
+      .default(true)
+      .describe("Whether swarm (parallel multi-agent) execution is enabled"),
+    maxWorkers: z
+      .number({ error: "swarm.maxWorkers must be a number" })
+      .int("swarm.maxWorkers must be an integer")
+      .positive("swarm.maxWorkers must be a positive integer")
+      .max(6, "swarm.maxWorkers must be at most 6")
+      .default(3)
+      .describe("Maximum number of concurrent swarm workers"),
+    maxTasks: z
+      .number({ error: "swarm.maxTasks must be a number" })
+      .int("swarm.maxTasks must be an integer")
+      .positive("swarm.maxTasks must be a positive integer")
+      .max(20, "swarm.maxTasks must be at most 20")
+      .default(8)
+      .describe("Maximum number of tasks a single swarm can execute"),
+    maxRetriesPerTask: z
+      .number({ error: "swarm.maxRetriesPerTask must be a number" })
+      .int("swarm.maxRetriesPerTask must be an integer")
+      .nonnegative("swarm.maxRetriesPerTask must be a non-negative integer")
+      .max(3, "swarm.maxRetriesPerTask must be at most 3")
+      .default(1)
+      .describe("Maximum number of retries for a failed swarm task"),
+    workerTimeoutSec: z
+      .number({ error: "swarm.workerTimeoutSec must be a number" })
+      .int("swarm.workerTimeoutSec must be an integer")
+      .positive("swarm.workerTimeoutSec must be a positive integer")
+      .default(900)
+      .describe("Timeout for a single swarm worker in seconds"),
+    roleTimeoutsSec: z
+      .object({
+        router: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout override for router workers (seconds)"),
+        researcher: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout override for researcher workers (seconds)"),
+        coder: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout override for coder workers (seconds)"),
+        reviewer: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Timeout override for reviewer workers (seconds)"),
+      })
+      .default({})
+      .describe("Per-role timeout overrides for swarm workers"),
+    plannerModelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "swarm.plannerModelIntent must be a valid model intent",
+      })
+      .default("latency-optimized")
+      .describe("Model selection strategy for the swarm planning phase"),
+    synthesizerModelIntent: z
+      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
+        error: "swarm.synthesizerModelIntent must be a valid model intent",
+      })
+      .default("quality-optimized")
+      .describe(
+        "Model selection strategy for the swarm synthesis (result-combining) phase",
+      ),
+  })
+  .describe("Swarm configuration — parallel multi-agent task execution");
 
 export type SwarmConfig = z.infer<typeof SwarmConfigSchema>;

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -1,47 +1,70 @@
 import { z } from "zod";
 
-export const TimeoutConfigSchema = z.object({
-  shellMaxTimeoutSec: z
-    .number({ error: "timeouts.shellMaxTimeoutSec must be a number" })
-    .finite("timeouts.shellMaxTimeoutSec must be finite")
-    .positive("timeouts.shellMaxTimeoutSec must be a positive number")
-    .default(600),
-  shellDefaultTimeoutSec: z
-    .number({ error: "timeouts.shellDefaultTimeoutSec must be a number" })
-    .finite("timeouts.shellDefaultTimeoutSec must be finite")
-    .positive("timeouts.shellDefaultTimeoutSec must be a positive number")
-    .default(120),
-  permissionTimeoutSec: z
-    .number({ error: "timeouts.permissionTimeoutSec must be a number" })
-    .finite("timeouts.permissionTimeoutSec must be finite")
-    .positive("timeouts.permissionTimeoutSec must be a positive number")
-    .default(300),
-  toolExecutionTimeoutSec: z
-    .number({ error: "timeouts.toolExecutionTimeoutSec must be a number" })
-    .finite("timeouts.toolExecutionTimeoutSec must be finite")
-    .positive("timeouts.toolExecutionTimeoutSec must be a positive number")
-    .default(120),
-  providerStreamTimeoutSec: z
-    .number({ error: "timeouts.providerStreamTimeoutSec must be a number" })
-    .finite("timeouts.providerStreamTimeoutSec must be finite")
-    .positive("timeouts.providerStreamTimeoutSec must be a positive number")
-    .default(300),
-});
+export const TimeoutConfigSchema = z
+  .object({
+    shellMaxTimeoutSec: z
+      .number({ error: "timeouts.shellMaxTimeoutSec must be a number" })
+      .finite("timeouts.shellMaxTimeoutSec must be finite")
+      .positive("timeouts.shellMaxTimeoutSec must be a positive number")
+      .default(600)
+      .describe(
+        "Maximum allowed timeout for shell command execution in seconds",
+      ),
+    shellDefaultTimeoutSec: z
+      .number({ error: "timeouts.shellDefaultTimeoutSec must be a number" })
+      .finite("timeouts.shellDefaultTimeoutSec must be finite")
+      .positive("timeouts.shellDefaultTimeoutSec must be a positive number")
+      .default(120)
+      .describe(
+        "Default timeout for shell commands when no explicit timeout is specified (seconds)",
+      ),
+    permissionTimeoutSec: z
+      .number({ error: "timeouts.permissionTimeoutSec must be a number" })
+      .finite("timeouts.permissionTimeoutSec must be finite")
+      .positive("timeouts.permissionTimeoutSec must be a positive number")
+      .default(300)
+      .describe(
+        "How long to wait for user permission approval before timing out (seconds)",
+      ),
+    toolExecutionTimeoutSec: z
+      .number({ error: "timeouts.toolExecutionTimeoutSec must be a number" })
+      .finite("timeouts.toolExecutionTimeoutSec must be finite")
+      .positive("timeouts.toolExecutionTimeoutSec must be a positive number")
+      .default(120)
+      .describe("Default timeout for tool execution in seconds"),
+    providerStreamTimeoutSec: z
+      .number({ error: "timeouts.providerStreamTimeoutSec must be a number" })
+      .finite("timeouts.providerStreamTimeoutSec must be finite")
+      .positive("timeouts.providerStreamTimeoutSec must be a positive number")
+      .default(300)
+      .describe(
+        "Timeout for waiting on the LLM provider's streaming response (seconds)",
+      ),
+  })
+  .describe("Timeout configuration for various operations");
 
-export const RateLimitConfigSchema = z.object({
-  maxRequestsPerMinute: z
-    .number({ error: "rateLimit.maxRequestsPerMinute must be a number" })
-    .int("rateLimit.maxRequestsPerMinute must be an integer")
-    .nonnegative(
-      "rateLimit.maxRequestsPerMinute must be a non-negative integer",
-    )
-    .default(0),
-  maxTokensPerSession: z
-    .number({ error: "rateLimit.maxTokensPerSession must be a number" })
-    .int("rateLimit.maxTokensPerSession must be an integer")
-    .nonnegative("rateLimit.maxTokensPerSession must be a non-negative integer")
-    .default(0),
-});
+export const RateLimitConfigSchema = z
+  .object({
+    maxRequestsPerMinute: z
+      .number({ error: "rateLimit.maxRequestsPerMinute must be a number" })
+      .int("rateLimit.maxRequestsPerMinute must be an integer")
+      .nonnegative(
+        "rateLimit.maxRequestsPerMinute must be a non-negative integer",
+      )
+      .default(0)
+      .describe("Maximum number of LLM requests per minute (0 = unlimited)"),
+    maxTokensPerSession: z
+      .number({ error: "rateLimit.maxTokensPerSession must be a number" })
+      .int("rateLimit.maxTokensPerSession must be an integer")
+      .nonnegative(
+        "rateLimit.maxTokensPerSession must be a non-negative integer",
+      )
+      .default(0)
+      .describe(
+        "Maximum total tokens (input + output) per conversation session (0 = unlimited)",
+      ),
+  })
+  .describe("Rate limiting for LLM provider requests");
 
 export type TimeoutConfig = z.infer<typeof TimeoutConfigSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;

--- a/assistant/src/config/schemas/workspace-git.ts
+++ b/assistant/src/config/schemas/workspace-git.ts
@@ -1,169 +1,226 @@
 import { z } from "zod";
 
-export const WorkspaceGitConfigSchema = z.object({
-  turnCommitMaxWaitMs: z
-    .number({ error: "workspaceGit.turnCommitMaxWaitMs must be a number" })
-    .int("workspaceGit.turnCommitMaxWaitMs must be an integer")
-    .positive("workspaceGit.turnCommitMaxWaitMs must be a positive integer")
-    .default(4000),
-  failureBackoffBaseMs: z
-    .number({ error: "workspaceGit.failureBackoffBaseMs must be a number" })
-    .int("workspaceGit.failureBackoffBaseMs must be an integer")
-    .positive("workspaceGit.failureBackoffBaseMs must be a positive integer")
-    .default(2000),
-  failureBackoffMaxMs: z
-    .number({ error: "workspaceGit.failureBackoffMaxMs must be a number" })
-    .int("workspaceGit.failureBackoffMaxMs must be an integer")
-    .positive("workspaceGit.failureBackoffMaxMs must be a positive integer")
-    .default(60000),
-  interactiveGitTimeoutMs: z
-    .number({ error: "workspaceGit.interactiveGitTimeoutMs must be a number" })
-    .int("workspaceGit.interactiveGitTimeoutMs must be an integer")
-    .positive("workspaceGit.interactiveGitTimeoutMs must be a positive integer")
-    .default(10000),
-  enrichmentQueueSize: z
-    .number({ error: "workspaceGit.enrichmentQueueSize must be a number" })
-    .int("workspaceGit.enrichmentQueueSize must be an integer")
-    .positive("workspaceGit.enrichmentQueueSize must be a positive integer")
-    .default(50),
-  enrichmentConcurrency: z
-    .number({ error: "workspaceGit.enrichmentConcurrency must be a number" })
-    .int("workspaceGit.enrichmentConcurrency must be an integer")
-    .positive("workspaceGit.enrichmentConcurrency must be a positive integer")
-    .default(1),
-  enrichmentJobTimeoutMs: z
-    .number({ error: "workspaceGit.enrichmentJobTimeoutMs must be a number" })
-    .int("workspaceGit.enrichmentJobTimeoutMs must be an integer")
-    .positive("workspaceGit.enrichmentJobTimeoutMs must be a positive integer")
-    .default(30000),
-  enrichmentMaxRetries: z
-    .number({ error: "workspaceGit.enrichmentMaxRetries must be a number" })
-    .int("workspaceGit.enrichmentMaxRetries must be an integer")
-    .nonnegative("workspaceGit.enrichmentMaxRetries must be non-negative")
-    .default(2),
-  commitMessageLLM: z
-    .object({
-      enabled: z
-        .boolean({
-          error: "workspaceGit.commitMessageLLM.enabled must be a boolean",
-        })
-        .default(false),
-      useConfiguredProvider: z
-        .boolean({
-          error:
-            "workspaceGit.commitMessageLLM.useConfiguredProvider must be a boolean",
-        })
-        .default(true),
-      providerFastModelOverrides: z
-        .record(z.string(), z.string())
-        .default({} as Record<string, string>),
-      timeoutMs: z
-        .number({
-          error: "workspaceGit.commitMessageLLM.timeoutMs must be a number",
-        })
-        .int("workspaceGit.commitMessageLLM.timeoutMs must be an integer")
-        .positive(
-          "workspaceGit.commitMessageLLM.timeoutMs must be a positive integer",
-        )
-        .default(600),
-      maxTokens: z
-        .number({
-          error: "workspaceGit.commitMessageLLM.maxTokens must be a number",
-        })
-        .int("workspaceGit.commitMessageLLM.maxTokens must be an integer")
-        .positive(
-          "workspaceGit.commitMessageLLM.maxTokens must be a positive integer",
-        )
-        .default(120),
-      temperature: z
-        .number({
-          error: "workspaceGit.commitMessageLLM.temperature must be a number",
-        })
-        .min(0, "workspaceGit.commitMessageLLM.temperature must be >= 0")
-        .max(2, "workspaceGit.commitMessageLLM.temperature must be <= 2")
-        .default(0.2),
-      maxFilesInPrompt: z
-        .number({
-          error:
-            "workspaceGit.commitMessageLLM.maxFilesInPrompt must be a number",
-        })
-        .int(
-          "workspaceGit.commitMessageLLM.maxFilesInPrompt must be an integer",
-        )
-        .positive(
-          "workspaceGit.commitMessageLLM.maxFilesInPrompt must be a positive integer",
-        )
-        .default(30),
-      maxDiffBytes: z
-        .number({
-          error: "workspaceGit.commitMessageLLM.maxDiffBytes must be a number",
-        })
-        .int("workspaceGit.commitMessageLLM.maxDiffBytes must be an integer")
-        .positive(
-          "workspaceGit.commitMessageLLM.maxDiffBytes must be a positive integer",
-        )
-        .default(12000),
-      minRemainingTurnBudgetMs: z
-        .number({
-          error:
-            "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be a number",
-        })
-        .int(
-          "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be an integer",
-        )
-        .nonnegative(
-          "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be non-negative",
-        )
-        .default(1000),
-      breaker: z
-        .object({
-          openAfterFailures: z
-            .number({
-              error:
-                "workspaceGit.commitMessageLLM.breaker.openAfterFailures must be a number",
-            })
-            .int()
-            .positive()
-            .default(3),
-          backoffBaseMs: z
-            .number({
-              error:
-                "workspaceGit.commitMessageLLM.breaker.backoffBaseMs must be a number",
-            })
-            .int()
-            .positive()
-            .default(2000),
-          backoffMaxMs: z
-            .number({
-              error:
-                "workspaceGit.commitMessageLLM.breaker.backoffMaxMs must be a number",
-            })
-            .int()
-            .positive()
-            .default(60000),
-        })
-        .default({
+export const WorkspaceGitConfigSchema = z
+  .object({
+    turnCommitMaxWaitMs: z
+      .number({ error: "workspaceGit.turnCommitMaxWaitMs must be a number" })
+      .int("workspaceGit.turnCommitMaxWaitMs must be an integer")
+      .positive("workspaceGit.turnCommitMaxWaitMs must be a positive integer")
+      .default(4000)
+      .describe(
+        "Maximum time to wait for a turn-based auto-commit to complete (ms)",
+      ),
+    failureBackoffBaseMs: z
+      .number({ error: "workspaceGit.failureBackoffBaseMs must be a number" })
+      .int("workspaceGit.failureBackoffBaseMs must be an integer")
+      .positive("workspaceGit.failureBackoffBaseMs must be a positive integer")
+      .default(2000)
+      .describe(
+        "Base delay for exponential backoff after a git operation failure (ms)",
+      ),
+    failureBackoffMaxMs: z
+      .number({ error: "workspaceGit.failureBackoffMaxMs must be a number" })
+      .int("workspaceGit.failureBackoffMaxMs must be an integer")
+      .positive("workspaceGit.failureBackoffMaxMs must be a positive integer")
+      .default(60000)
+      .describe(
+        "Maximum delay for exponential backoff after a git operation failure (ms)",
+      ),
+    interactiveGitTimeoutMs: z
+      .number({
+        error: "workspaceGit.interactiveGitTimeoutMs must be a number",
+      })
+      .int("workspaceGit.interactiveGitTimeoutMs must be an integer")
+      .positive(
+        "workspaceGit.interactiveGitTimeoutMs must be a positive integer",
+      )
+      .default(10000)
+      .describe(
+        "Timeout for interactive git operations like status and diff (ms)",
+      ),
+    enrichmentQueueSize: z
+      .number({ error: "workspaceGit.enrichmentQueueSize must be a number" })
+      .int("workspaceGit.enrichmentQueueSize must be an integer")
+      .positive("workspaceGit.enrichmentQueueSize must be a positive integer")
+      .default(50)
+      .describe(
+        "Maximum number of pending commit enrichment jobs in the queue",
+      ),
+    enrichmentConcurrency: z
+      .number({ error: "workspaceGit.enrichmentConcurrency must be a number" })
+      .int("workspaceGit.enrichmentConcurrency must be an integer")
+      .positive("workspaceGit.enrichmentConcurrency must be a positive integer")
+      .default(1)
+      .describe("Number of concurrent commit enrichment workers"),
+    enrichmentJobTimeoutMs: z
+      .number({ error: "workspaceGit.enrichmentJobTimeoutMs must be a number" })
+      .int("workspaceGit.enrichmentJobTimeoutMs must be an integer")
+      .positive(
+        "workspaceGit.enrichmentJobTimeoutMs must be a positive integer",
+      )
+      .default(30000)
+      .describe("Timeout for a single commit enrichment job (ms)"),
+    enrichmentMaxRetries: z
+      .number({ error: "workspaceGit.enrichmentMaxRetries must be a number" })
+      .int("workspaceGit.enrichmentMaxRetries must be an integer")
+      .nonnegative("workspaceGit.enrichmentMaxRetries must be non-negative")
+      .default(2)
+      .describe("Maximum retries for a failed commit enrichment job"),
+    commitMessageLLM: z
+      .object({
+        enabled: z
+          .boolean({
+            error: "workspaceGit.commitMessageLLM.enabled must be a boolean",
+          })
+          .default(false)
+          .describe("Whether to use an LLM to generate commit messages"),
+        useConfiguredProvider: z
+          .boolean({
+            error:
+              "workspaceGit.commitMessageLLM.useConfiguredProvider must be a boolean",
+          })
+          .default(true)
+          .describe(
+            "Whether to use the globally configured LLM provider for commit messages",
+          ),
+        providerFastModelOverrides: z
+          .record(z.string(), z.string())
+          .default({} as Record<string, string>)
+          .describe(
+            "Map of provider names to fast model overrides for commit message generation",
+          ),
+        timeoutMs: z
+          .number({
+            error: "workspaceGit.commitMessageLLM.timeoutMs must be a number",
+          })
+          .int("workspaceGit.commitMessageLLM.timeoutMs must be an integer")
+          .positive(
+            "workspaceGit.commitMessageLLM.timeoutMs must be a positive integer",
+          )
+          .default(600)
+          .describe("Timeout for LLM commit message generation (ms)"),
+        maxTokens: z
+          .number({
+            error: "workspaceGit.commitMessageLLM.maxTokens must be a number",
+          })
+          .int("workspaceGit.commitMessageLLM.maxTokens must be an integer")
+          .positive(
+            "workspaceGit.commitMessageLLM.maxTokens must be a positive integer",
+          )
+          .default(120)
+          .describe("Maximum number of tokens in the generated commit message"),
+        temperature: z
+          .number({
+            error: "workspaceGit.commitMessageLLM.temperature must be a number",
+          })
+          .min(0, "workspaceGit.commitMessageLLM.temperature must be >= 0")
+          .max(2, "workspaceGit.commitMessageLLM.temperature must be <= 2")
+          .default(0.2)
+          .describe(
+            "LLM sampling temperature for commit message generation (lower = more deterministic)",
+          ),
+        maxFilesInPrompt: z
+          .number({
+            error:
+              "workspaceGit.commitMessageLLM.maxFilesInPrompt must be a number",
+          })
+          .int(
+            "workspaceGit.commitMessageLLM.maxFilesInPrompt must be an integer",
+          )
+          .positive(
+            "workspaceGit.commitMessageLLM.maxFilesInPrompt must be a positive integer",
+          )
+          .default(30)
+          .describe(
+            "Maximum number of changed files to include in the LLM prompt",
+          ),
+        maxDiffBytes: z
+          .number({
+            error:
+              "workspaceGit.commitMessageLLM.maxDiffBytes must be a number",
+          })
+          .int("workspaceGit.commitMessageLLM.maxDiffBytes must be an integer")
+          .positive(
+            "workspaceGit.commitMessageLLM.maxDiffBytes must be a positive integer",
+          )
+          .default(12000)
+          .describe("Maximum diff size in bytes to include in the LLM prompt"),
+        minRemainingTurnBudgetMs: z
+          .number({
+            error:
+              "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be a number",
+          })
+          .int(
+            "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be an integer",
+          )
+          .nonnegative(
+            "workspaceGit.commitMessageLLM.minRemainingTurnBudgetMs must be non-negative",
+          )
+          .default(1000)
+          .describe(
+            "Minimum remaining turn budget required before attempting LLM commit message generation (ms)",
+          ),
+        breaker: z
+          .object({
+            openAfterFailures: z
+              .number({
+                error:
+                  "workspaceGit.commitMessageLLM.breaker.openAfterFailures must be a number",
+              })
+              .int()
+              .positive()
+              .default(3)
+              .describe(
+                "Number of consecutive failures before the circuit breaker opens",
+              ),
+            backoffBaseMs: z
+              .number({
+                error:
+                  "workspaceGit.commitMessageLLM.breaker.backoffBaseMs must be a number",
+              })
+              .int()
+              .positive()
+              .default(2000)
+              .describe("Base delay for circuit breaker backoff (ms)"),
+            backoffMaxMs: z
+              .number({
+                error:
+                  "workspaceGit.commitMessageLLM.breaker.backoffMaxMs must be a number",
+              })
+              .int()
+              .positive()
+              .default(60000)
+              .describe("Maximum delay for circuit breaker backoff (ms)"),
+          })
+          .default({
+            openAfterFailures: 3,
+            backoffBaseMs: 2000,
+            backoffMaxMs: 60000,
+          })
+          .describe(
+            "Circuit breaker settings to temporarily disable LLM commit messages after repeated failures",
+          ),
+      })
+      .default({
+        enabled: false,
+        useConfiguredProvider: true,
+        providerFastModelOverrides: {},
+        timeoutMs: 600,
+        maxTokens: 120,
+        temperature: 0.2,
+        maxFilesInPrompt: 30,
+        maxDiffBytes: 12000,
+        minRemainingTurnBudgetMs: 1000,
+        breaker: {
           openAfterFailures: 3,
           backoffBaseMs: 2000,
           backoffMaxMs: 60000,
-        }),
-    })
-    .default({
-      enabled: false,
-      useConfiguredProvider: true,
-      providerFastModelOverrides: {},
-      timeoutMs: 600,
-      maxTokens: 120,
-      temperature: 0.2,
-      maxFilesInPrompt: 30,
-      maxDiffBytes: 12000,
-      minRemainingTurnBudgetMs: 1000,
-      breaker: {
-        openAfterFailures: 3,
-        backoffBaseMs: 2000,
-        backoffMaxMs: 60000,
-      },
-    }),
-});
+        },
+      })
+      .describe("LLM-powered commit message generation settings"),
+  })
+  .describe(
+    "Workspace git integration — auto-commits, enrichment, and LLM-generated commit messages",
+  );
 
 export type WorkspaceGitConfig = z.infer<typeof WorkspaceGitConfigSchema>;


### PR DESCRIPTION
## Summary
- Added `.describe()` calls to every field and object schema across all 23 config schema files
- Descriptions propagate to JSON Schema output via `z.toJSONSchema()`, making the `assistant config schema` CLI command return human-readable documentation for every config option
- Covers all sub-schemas: calls, channels, ElevenLabs, heartbeat, inference, ingress, logging, MCP, memory (lifecycle, processing, retrieval, storage), notifications, platform, sandbox, security, skills, swarm, timeouts, workspace-git, and the top-level schema

## Original prompt
yes add descriptions to the config schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
