### PR TITLE
feat(macos): add backend-aware local launcher abstraction and lockfile metadata

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -319,6 +319,13 @@ async function retireInner(): Promise<void> {
   const source = parseSource();
   const cloud = resolveCloud(entry);
 
+  if (entry.runtimeBackend === "apple-containers") {
+    console.error(
+      `Error: '${name}' uses the apple-containers runtime. Its lifecycle is managed by the macOS app — use the app to retire it.`,
+    );
+    process.exit(1);
+  }
+
   if (cloud === "gcp") {
     const project = entry.project;
     const zone = entry.zone;

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -71,6 +71,13 @@ export async function sleep(): Promise<void> {
     process.exit(1);
   }
 
+  if (entry.runtimeBackend === "apple-containers") {
+    console.error(
+      `Error: '${entry.assistantId}' uses the apple-containers runtime. Its lifecycle is managed by the macOS app — use the app to stop it.`,
+    );
+    process.exit(1);
+  }
+
   if (!entry.resources) {
     console.error(
       `Error: Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -45,6 +45,13 @@ export async function wake(): Promise<void> {
     process.exit(1);
   }
 
+  if (entry.runtimeBackend === "apple-containers") {
+    console.error(
+      `Error: '${entry.assistantId}' uses the apple-containers runtime. Its lifecycle is managed by the macOS app — use the app to start it.`,
+    );
+    process.exit(1);
+  }
+
   if (!entry.resources) {
     console.error(
       `Error: Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -34,6 +34,16 @@ export interface LocalInstanceResources {
   [key: string]: unknown;
 }
 
+/**
+ * Which local launcher owns this assistant entry.
+ *
+ * - `"process"` (default) — standard `vellum-cli hatch` / PID-file lifecycle.
+ * - `"apple-containers"` — reserved for the Apple Containers path; lifecycle
+ *   is managed by the macOS app via `LinuxPod` and must not be touched by the
+ *   CLI's PID-based helpers.
+ */
+export type LocalRuntimeBackend = "process" | "apple-containers";
+
 export interface AssistantEntry {
   assistantId: string;
   runtimeUrl: string;
@@ -54,6 +64,13 @@ export interface AssistantEntry {
   volume?: string;
   /** Per-instance resource config. Present for local entries in multi-instance setups. */
   resources?: LocalInstanceResources;
+  /**
+   * Which local launcher owns this assistant.
+   * Defaults to `"process"` when absent (existing entries, normal hatch path).
+   * `"apple-containers"` is reserved for the Apple Containers runtime — the CLI
+   * must not attempt PID-based lifecycle operations on such entries.
+   */
+  runtimeBackend?: LocalRuntimeBackend;
   [key: string]: unknown;
 }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -125,6 +125,24 @@ extension AppDelegate {
         log.info("Configured HTTP transport for remote assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
     }
 
+    // MARK: - Backend Dispatch
+
+    /// Return the `LocalAssistantLauncher` appropriate for `assistant`'s `runtimeBackend`.
+    ///
+    /// - `process` (or absent): delegates to the bundled `AssistantCli` hatch path.
+    /// - `appleContainers`: reserved — falls back to `AssistantCli` today so existing
+    ///   behavior is preserved until PR 5 wires the real Apple Containers runtime.
+    ///   A log warning is emitted so the absence of a dedicated launcher is visible.
+    func localLauncher(for assistant: LockfileAssistant?) -> LocalAssistantLauncher {
+        guard let assistant, assistant.runtimeBackend == .appleContainers else {
+            return assistantCli
+        }
+        // Apple Containers runtime is not yet wired (see PR 5). Fall back to the
+        // CLI launcher and warn so the gap is visible during development.
+        log.warning("localLauncher: apple-containers backend not yet implemented — falling back to CLI hatch for '\(assistant.assistantId, privacy: .public)'")
+        return assistantCli
+    }
+
     // MARK: - Daemon Client Setup
 
     func setupDaemonClient(isFirstLaunch: Bool = false) {
@@ -384,8 +402,13 @@ extension AppDelegate {
                     // Pass the selected assistant ID so the gateway starts
                     // with the correct default assistant (not a random name).
                     let assistantName = assistant?.assistantId
+
+                    // Dispatch to the launcher registered for this assistant's backend.
+                    // apple-containers entries are owned by the macOS app and must not
+                    // go through the CLI hatch path.
+                    let launcher: LocalAssistantLauncher = localLauncher(for: assistant)
                     do {
-                        try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
+                        try await launcher.launch(name: assistantName, daemonOnly: daemonOnly, restart: false)
                     } catch let error as AssistantCli.CLIError {
                         switch error {
                         case .daemonStartupFailed(let startupError):
@@ -398,7 +421,7 @@ extension AppDelegate {
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
                             do {
-                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                try await assistantCli.launch(name: assistantName, daemonOnly: true, restart: false)
                                 self.daemonStartupError = nil
                             } catch {
                                 log.error("Fallback daemon-only hatch also failed: \(error)")
@@ -409,7 +432,7 @@ extension AppDelegate {
                         if needsLockfileEntry {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
                             do {
-                                try await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                                try await assistantCli.launch(name: assistantName, daemonOnly: true, restart: false)
                                 self.daemonStartupError = nil
                             } catch {
                                 log.error("Fallback daemon-only hatch also failed: \(error)")

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -51,6 +51,26 @@ struct DaemonStartupError {
     let detail: String?
 }
 
+// MARK: - LocalAssistantLauncher
+
+/// A launcher that knows how to start a local assistant instance.
+///
+/// Adopt this protocol to add a new backend (e.g. Apple Containers) without
+/// changing the startup logic in `AppDelegate+DaemonSetup`. The app reads
+/// `LockfileAssistant.runtimeBackend` and dispatches to the appropriate launcher.
+@MainActor
+protocol LocalAssistantLauncher: AnyObject {
+    /// Start (or re-start) the local assistant.
+    ///
+    /// - Parameters:
+    ///   - name: The assistant ID to hatch. Pass `nil` to let the launcher
+    ///     choose the name (e.g. first-launch scenario).
+    ///   - daemonOnly: When `true`, skip any lockfile-entry creation step and
+    ///     only ensure the daemon process is running.
+    ///   - restart: When `true`, stop any running instance before starting.
+    func launch(name: String?, daemonOnly: Bool, restart: Bool) async throws
+}
+
 /// Manages all daemon lifecycle operations through the bundled CLI binary.
 ///
 /// This is the single entry point for hatching, stopping, and retiring the
@@ -102,6 +122,13 @@ final class AssistantCli {
     }
 
     // MARK: - Public API
+
+    // MARK: - LocalAssistantLauncher conformance
+
+    /// `LocalAssistantLauncher` entry point — delegates to `hatch(name:daemonOnly:restart:)`.
+    func launch(name: String?, daemonOnly: Bool, restart: Bool) async throws {
+        try await hatch(name: name, daemonOnly: daemonOnly, restart: restart)
+    }
 
     /// Hatch a new assistant via the CLI. The CLI spawns the daemon binary,
     /// waits for the socket, and registers the assistant entry.

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -1,6 +1,18 @@
 #if os(macOS)
 import Foundation
 
+/// Which local launcher owns a `LockfileAssistant` entry.
+///
+/// - `process`: Standard `vellum-cli hatch` / PID-file lifecycle (default for
+///   all existing and new process-backed local assistants).
+/// - `appleContainers`: Reserved for the Apple Containers runtime path.
+///   Lifecycle is managed by the macOS app via `LinuxPod`; the CLI must not
+///   attempt PID-based operations on such entries.
+public enum LocalRuntimeBackend: String {
+    case process = "process"
+    case appleContainers = "apple-containers"
+}
+
 public struct LockfileAssistant {
     public let assistantId: String
     public let runtimeUrl: String?
@@ -15,6 +27,9 @@ public struct LockfileAssistant {
     public let daemonPort: Int?
     public let gatewayPort: Int?
     public let instanceDir: String?
+    /// Which local launcher owns this assistant.
+    /// Defaults to `.process` when the field is absent in the lockfile.
+    public let runtimeBackend: LocalRuntimeBackend
 
     public init(
         assistantId: String,
@@ -29,7 +44,8 @@ public struct LockfileAssistant {
         baseDataDir: String?,
         daemonPort: Int?,
         gatewayPort: Int?,
-        instanceDir: String?
+        instanceDir: String?,
+        runtimeBackend: LocalRuntimeBackend = .process
     ) {
         self.assistantId = assistantId
         self.runtimeUrl = runtimeUrl
@@ -44,6 +60,7 @@ public struct LockfileAssistant {
         self.daemonPort = daemonPort
         self.gatewayPort = gatewayPort
         self.instanceDir = instanceDir
+        self.runtimeBackend = runtimeBackend
     }
 
     /// Whether this assistant is running remotely (not on the local machine).
@@ -107,6 +124,15 @@ public struct LockfileAssistant {
         return sorted.compactMap { entry -> LockfileAssistant? in
             guard let assistantId = entry["assistantId"] as? String else { return nil }
             let resources = entry["resources"] as? [String: Any]
+            // Parse runtimeBackend — unknown values fall back to .process so a
+            // future or mistyped value never misclassifies an entry as process-backed.
+            let runtimeBackend: LocalRuntimeBackend
+            if let raw = entry["runtimeBackend"] as? String,
+               let parsed = LocalRuntimeBackend(rawValue: raw) {
+                runtimeBackend = parsed
+            } else {
+                runtimeBackend = .process
+            }
             return LockfileAssistant(
                 assistantId: assistantId,
                 runtimeUrl: entry["runtimeUrl"] as? String,
@@ -120,7 +146,8 @@ public struct LockfileAssistant {
                 baseDataDir: entry["baseDataDir"] as? String,
                 daemonPort: resources?["daemonPort"] as? Int,
                 gatewayPort: resources?["gatewayPort"] as? Int,
-                instanceDir: resources?["instanceDir"] as? String
+                instanceDir: resources?["instanceDir"] as? String,
+                runtimeBackend: runtimeBackend
             )
         }
     }


### PR DESCRIPTION
## Summary
- Add runtimeBackend field to lockfile with 'process' default and 'apple-containers' reserved value
- Introduce LocalAssistantLauncher protocol so the app dispatches to the right launcher from the lockfile entry
- Update Swift and TypeScript lockfile readers to round-trip runtimeBackend cleanly; CLI fails clearly for apple-containers entries

Part of plan: apple-containers-hatch.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
