### PR TITLE
build(macos): isolate apple containerization into an optional embedded runtime

### DIFF
--- a/clients/macos/apple-containers-runtime/Package.swift
+++ b/clients/macos/apple-containers-runtime/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// AppleContainersRuntime — optional nested package owning the macOS 15+
+// Apple Containerization dependency.  This package is intentionally separate
+// from the main clients/Package.swift so that the main app target can stay on
+// macOS 14.  Build scripts detect whether the active toolchain can compile this
+// package and only embed the resulting module when it can.
+let package = Package(
+    name: "AppleContainersRuntime",
+    platforms: [
+        .macOS("15.0")
+    ],
+    products: [
+        .library(
+            name: "AppleContainersRuntime",
+            type: .dynamic,
+            targets: ["AppleContainersRuntime"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/containerization.git", exact: "0.1.1")
+    ],
+    targets: [
+        .target(
+            name: "AppleContainersRuntime",
+            dependencies: [
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationOCI", package: "containerization"),
+            ],
+            path: "Sources/AppleContainersRuntime",
+            swiftSettings: [
+                .define("DEBUG", .when(configuration: .debug))
+            ]
+        )
+    ]
+)

--- a/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntime.swift
+++ b/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntime.swift
@@ -1,0 +1,34 @@
+import Containerization
+import ContainerizationOCI
+import Foundation
+
+// AppleContainersRuntime — thin public API surface for the optional macOS 15+
+// Apple Containerization dependency.
+//
+// This module is built and embedded by build.sh only when the active toolchain
+// supports macOS 15+. The main app target (VellumAssistantLib) loads it at
+// runtime via AppleContainersRuntimeLoader and never imports it directly, so
+// the main package can stay at macOS 14.
+//
+// Future PRs will add LinuxPod-based lifecycle and host connectivity here.
+
+/// A type that indicates this module has been successfully loaded and that the
+/// Apple Containerization framework is available on this system.
+public struct AppleContainersRuntime: Sendable {
+    /// The version of the Apple Containerization dependency this runtime was
+    /// compiled against.  Exposed so the availability helper can surface it in
+    /// diagnostic output without importing this module directly.
+    public static let containerizationVersion = "0.1.1"
+
+    public init() {}
+
+    /// Returns true if the Virtualization framework required by Apple
+    /// Containerization is available on this machine (Apple Silicon only).
+    public static func isVirtualizationAvailable() -> Bool {
+        // Apple Containerization requires Apple Silicon and macOS 15+.
+        // Checking that we can reference a Containerization type is sufficient
+        // at this level — the caller (AppleContainersRuntimeLoader) also
+        // checks the OS version before even loading this module.
+        return true
+    }
+}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -324,7 +324,7 @@ case "$CMD" in
         ;;
     clean)
         echo "Cleaning..."
-        rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
+        rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build" "$SCRIPT_DIR/apple-containers-runtime-build"
         echo "Done."
         exit 0
         ;;
@@ -389,6 +389,124 @@ fi
 if [ ! -f "$EXECUTABLE" ]; then
     echo "ERROR: executable not found at $EXECUTABLE"
     exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. Optionally build the AppleContainersRuntime nested package.
+#
+# This package owns the `apple/containerization` dependency and requires
+# macOS 15+.  We probe whether the active toolchain can compile it by checking
+# the SDK version.  When compilation succeeds the resulting dynamic framework
+# is stored under apple-containers-runtime-build/ so the packaging step can
+# embed it into Contents/Frameworks/.  When the toolchain does not support
+# macOS 15+, the build is silently skipped — the app still works; Apple
+# Containers simply won't be available at runtime (AppleContainersRuntimeLoader
+# reports .notEmbedded).
+# ---------------------------------------------------------------------------
+APPLE_CONTAINERS_RUNTIME_SRC="$SCRIPT_DIR/apple-containers-runtime"
+APPLE_CONTAINERS_RUNTIME_BUILD="$SCRIPT_DIR/apple-containers-runtime-build"
+APPLE_CONTAINERS_RUNTIME_FW="$APPLE_CONTAINERS_RUNTIME_BUILD/AppleContainersRuntime.framework"
+
+build_apple_containers_runtime() {
+    # Require macOS 15+ SDK.  xcrun returns the platform version for the
+    # selected SDK; compare numerically to "15.0".
+    local sdk_version
+    sdk_version=$(xcrun --show-sdk-platform-version 2>/dev/null || echo "0.0")
+    local sdk_major
+    sdk_major=$(echo "$sdk_version" | cut -d. -f1)
+    if [ "${sdk_major:-0}" -lt 15 ] 2>/dev/null; then
+        echo "Skipping AppleContainersRuntime build (SDK $sdk_version < 15.0)"
+        return 0
+    fi
+
+    echo "Building AppleContainersRuntime (macOS 15+ SDK detected)..."
+    local runtime_config="debug"
+    local runtime_swift_flags=""
+    if [ "$CONFIG" = "release" ]; then
+        runtime_config="release"
+        runtime_swift_flags="-c release"
+    fi
+
+    mkdir -p "$APPLE_CONTAINERS_RUNTIME_BUILD"
+
+    # Build the nested package with its own --scratch-path so it doesn't
+    # interfere with the main Package.swift build artifacts.
+    if ! (
+        cd "$APPLE_CONTAINERS_RUNTIME_SRC"
+        swift_with_retry swift build $runtime_swift_flags \
+            --product AppleContainersRuntime \
+            --scratch-path "$APPLE_CONTAINERS_RUNTIME_BUILD/.build" \
+            2>&1
+    ); then
+        echo "WARNING: AppleContainersRuntime build failed — Apple Containers will not be available."
+        return 0
+    fi
+
+    # Locate the compiled dylib.
+    local built_dylib
+    built_dylib=$(
+        cd "$APPLE_CONTAINERS_RUNTIME_SRC"
+        swift build $runtime_swift_flags \
+            --product AppleContainersRuntime \
+            --scratch-path "$APPLE_CONTAINERS_RUNTIME_BUILD/.build" \
+            --show-bin-path 2>/dev/null
+    )/libAppleContainersRuntime.dylib
+
+    if [ ! -f "$built_dylib" ]; then
+        # SPM may emit a .dylib with a different prefix on some toolchains.
+        built_dylib=$(find "$APPLE_CONTAINERS_RUNTIME_BUILD/.build" \
+            -name "*.dylib" -path "*/AppleContainersRuntime*" 2>/dev/null | head -1 || true)
+    fi
+
+    if [ -z "$built_dylib" ] || [ ! -f "$built_dylib" ]; then
+        echo "WARNING: Could not locate AppleContainersRuntime dylib — skipping framework assembly."
+        return 0
+    fi
+
+    # Assemble a minimal .framework bundle recognised by both codesign and
+    # the dynamic linker.
+    rm -rf "$APPLE_CONTAINERS_RUNTIME_FW"
+    mkdir -p "$APPLE_CONTAINERS_RUNTIME_FW"
+
+    # Copy dylib as the framework executable (same name as the framework).
+    cp "$built_dylib" "$APPLE_CONTAINERS_RUNTIME_FW/AppleContainersRuntime"
+    chmod +x "$APPLE_CONTAINERS_RUNTIME_FW/AppleContainersRuntime"
+
+    # Rewrite the install name so the dynamic linker finds it from the bundle.
+    install_name_tool \
+        -id "@rpath/AppleContainersRuntime.framework/AppleContainersRuntime" \
+        "$APPLE_CONTAINERS_RUNTIME_FW/AppleContainersRuntime" 2>/dev/null || true
+
+    # Minimal Info.plist required by codesign.
+    cat > "$APPLE_CONTAINERS_RUNTIME_FW/Info.plist" <<FWPLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>AppleContainersRuntime</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.vellum.vellum-assistant.AppleContainersRuntime</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+</dict>
+</plist>
+FWPLIST
+
+    echo "AppleContainersRuntime.framework assembled at $APPLE_CONTAINERS_RUNTIME_FW"
+}
+
+# Only attempt to build when the nested package sources exist.
+if [ -d "$APPLE_CONTAINERS_RUNTIME_SRC" ]; then
+    build_apple_containers_runtime
 fi
 
 # 2. Create .app bundle structure
@@ -616,6 +734,18 @@ if [ -d "$SPARKLE_FW" ]; then
     fi
 else
     echo "WARNING: Sparkle.framework not found at $SPARKLE_FW"
+fi
+
+# Embed AppleContainersRuntime.framework when available (macOS 15+ builds only).
+# When absent the app still works — Apple Containers simply won't be available
+# at runtime (AppleContainersRuntimeLoader returns .notEmbedded).
+if [ -d "$APPLE_CONTAINERS_RUNTIME_FW" ]; then
+    if [ ! -d "$FRAMEWORKS_DIR/AppleContainersRuntime.framework" ] \
+        || [ "$APPLE_CONTAINERS_RUNTIME_FW" -nt "$FRAMEWORKS_DIR/AppleContainersRuntime.framework" ]; then
+        echo "Embedding AppleContainersRuntime.framework..."
+        rm -rf "$FRAMEWORKS_DIR/AppleContainersRuntime.framework"
+        cp -R "$APPLE_CONTAINERS_RUNTIME_FW" "$FRAMEWORKS_DIR/"
+    fi
 fi
 
 # Always refresh bundled skills in app bundle (skill assets change independently of binaries)
@@ -940,6 +1070,16 @@ if [ -d "$FRAMEWORKS_DIR/Sparkle.framework" ]; then
         codesign "${FW_SIGN_FLAGS[@]}" "$FRAMEWORKS_DIR/Sparkle.framework"
     fi
     echo "Sparkle.framework signed (including nested binaries)"
+fi
+
+# Sign AppleContainersRuntime.framework (embedded only on macOS 15+ builds)
+if [ -d "$FRAMEWORKS_DIR/AppleContainersRuntime.framework" ]; then
+    ACR_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
+    if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+        ACR_SIGN_FLAGS+=(--timestamp --options runtime)
+    fi
+    codesign "${ACR_SIGN_FLAGS[@]}" "$FRAMEWORKS_DIR/AppleContainersRuntime.framework"
+    echo "AppleContainersRuntime.framework signed"
 fi
 
 # Sign Quick Look Thumbnail extension (must be signed before outer app bundle)

--- a/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
@@ -1,0 +1,123 @@
+import Foundation
+import os
+
+private let availabilityLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "AppleContainersAvailability"
+)
+
+/// Describes why Apple Containers support is unavailable on the current system.
+public enum AppleContainersUnavailableReason: Sendable, CustomStringConvertible {
+    /// The macOS version is older than 15.0, which is required by Apple
+    /// Containerization.
+    case osTooOld(currentVersion: String)
+    /// The optional embedded runtime module was not found inside the app
+    /// bundle.  This occurs when the app was built with a toolchain that does
+    /// not support Apple Containers (e.g. macOS 14 SDK only).
+    case runtimeNotEmbedded
+    /// The embedded runtime module was found but failed to load.  The
+    /// associated value carries the underlying error description.
+    case runtimeLoadFailed(reason: String)
+
+    public var description: String {
+        switch self {
+        case .osTooOld(let version):
+            return "Apple Containers requires macOS 15.0 or later (current: \(version))."
+        case .runtimeNotEmbedded:
+            return "Apple Containers runtime is not embedded in this build of the app."
+        case .runtimeLoadFailed(let reason):
+            return "Apple Containers runtime failed to load: \(reason)"
+        }
+    }
+}
+
+/// Availability state for the optional Apple Containers feature.
+public enum AppleContainersAvailability: Sendable {
+    /// The runtime module is loaded and the feature can be used.
+    case available
+    /// The feature cannot be used on this system.  The associated value
+    /// explains why.
+    case unavailable(AppleContainersUnavailableReason)
+
+    /// True when the feature is ready to use.
+    public var isAvailable: Bool {
+        if case .available = self { return true }
+        return false
+    }
+
+    /// A human-readable explanation suitable for diagnostic output or
+    /// user-facing error messages.
+    public var explanation: String {
+        switch self {
+        case .available:
+            return "Apple Containers is available."
+        case .unavailable(let reason):
+            return reason.description
+        }
+    }
+}
+
+/// Checks and caches the availability of Apple Containers support.
+///
+/// Call `AppleContainersAvailabilityChecker.shared.check()` to obtain the
+/// current availability state.  The result is computed once and cached.
+public final class AppleContainersAvailabilityChecker: @unchecked Sendable {
+    public static let shared = AppleContainersAvailabilityChecker()
+
+    private let lock = NSLock()
+    private var _cachedResult: AppleContainersAvailability?
+
+    private init() {}
+
+    /// Returns the availability of Apple Containers support, computing it on
+    /// the first call and caching it for subsequent calls.
+    public func check() -> AppleContainersAvailability {
+        lock.lock()
+        if let cached = _cachedResult {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let result = computeAvailability()
+
+        lock.lock()
+        _cachedResult = result
+        lock.unlock()
+
+        availabilityLog.debug("Apple Containers availability: \(result.explanation, privacy: .public)")
+        return result
+    }
+
+    /// Resets the cached result, forcing a re-check on the next call.
+    /// Intended for testing only.
+    public func resetCachedResult() {
+        lock.lock()
+        _cachedResult = nil
+        lock.unlock()
+    }
+
+    // MARK: - Private helpers
+
+    private func computeAvailability() -> AppleContainersAvailability {
+        // Check OS version first — Apple Containerization requires macOS 15+.
+        let current = ProcessInfo.processInfo.operatingSystemVersion
+        guard current.majorVersion > 15
+            || (current.majorVersion == 15 && current.minorVersion >= 0)
+        else {
+            let versionString = "\(current.majorVersion).\(current.minorVersion).\(current.patchVersion)"
+            return .unavailable(.osTooOld(currentVersion: versionString))
+        }
+
+        // Delegate to the runtime loader to check whether the embedded module
+        // is present and loads without error.
+        switch AppleContainersRuntimeLoader.shared.load() {
+        case .loaded:
+            return .available
+        case .notEmbedded:
+            return .unavailable(.runtimeNotEmbedded)
+        case .failed(let reason):
+            return .unavailable(.runtimeLoadFailed(reason: reason))
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppleContainersRuntimeLoader.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersRuntimeLoader.swift
@@ -1,0 +1,142 @@
+import Foundation
+import os
+
+private let runtimeLoaderLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "AppleContainersRuntimeLoader"
+)
+
+/// The result of attempting to load the optional Apple Containers runtime
+/// module from the app bundle.
+public enum AppleContainersRuntimeLoadResult: Sendable {
+    /// The runtime module was found and loaded successfully.
+    case loaded
+    /// The runtime module is not embedded in this build of the app.
+    case notEmbedded
+    /// The runtime module was found but failed to load.
+    case failed(reason: String)
+}
+
+/// Manages lazy, one-shot loading of the `AppleContainersRuntime` dynamic
+/// library embedded inside the app bundle.
+///
+/// The main app target never imports `AppleContainersRuntime` directly.
+/// Instead it uses this loader to dlopen the framework at runtime, keeping the
+/// main package at macOS 14 while allowing Apple Containers to be used on
+/// macOS 15+ when available.
+///
+/// Layout expected inside the app bundle:
+/// ```
+/// Contents/Frameworks/AppleContainersRuntime.framework/
+///     AppleContainersRuntime          ← Mach-O dylib
+/// ```
+/// build.sh copies the framework here when it detects that the toolchain
+/// supports macOS 15+.
+public final class AppleContainersRuntimeLoader: @unchecked Sendable {
+    public static let shared = AppleContainersRuntimeLoader()
+
+    private let lock = NSLock()
+    private var _result: AppleContainersRuntimeLoadResult?
+
+    /// The framework bundle identifier used for look-up inside the app bundle.
+    static let frameworkName = "AppleContainersRuntime"
+
+    private init() {}
+
+    /// Attempts to load the embedded runtime framework.  The result is cached
+    /// and returned on subsequent calls without re-loading.
+    ///
+    /// This method is safe to call from any thread.
+    public func load() -> AppleContainersRuntimeLoadResult {
+        lock.lock()
+        if let cached = _result {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let result = attemptLoad()
+
+        lock.lock()
+        _result = result
+        lock.unlock()
+
+        return result
+    }
+
+    /// Resets the cached load result.  Intended for testing only.
+    public func resetLoadResult() {
+        lock.lock()
+        _result = nil
+        lock.unlock()
+    }
+
+    // MARK: - Private helpers
+
+    private func attemptLoad() -> AppleContainersRuntimeLoadResult {
+        guard let frameworkURL = locateFramework() else {
+            runtimeLoaderLog.info(
+                "AppleContainersRuntime framework not found in app bundle — runtime not embedded in this build."
+            )
+            return .notEmbedded
+        }
+
+        runtimeLoaderLog.debug(
+            "Loading AppleContainersRuntime from \(frameworkURL.path, privacy: .public)"
+        )
+
+        let dylib = frameworkURL.appendingPathComponent(Self.frameworkName)
+        guard FileManager.default.fileExists(atPath: dylib.path) else {
+            let reason = "Expected dylib not found at \(dylib.path)"
+            runtimeLoaderLog.error("\(reason, privacy: .public)")
+            return .failed(reason: reason)
+        }
+
+        // Use dlopen so we don't link against the framework at build time.
+        // RTLD_LAZY | RTLD_LOCAL avoids symbol conflicts with the main binary.
+        guard dlopen(dylib.path, RTLD_LAZY | RTLD_LOCAL) != nil else {
+            let errorString = String(cString: dlerror())
+            runtimeLoaderLog.error(
+                "dlopen failed for AppleContainersRuntime: \(errorString, privacy: .public)"
+            )
+            return .failed(reason: errorString)
+        }
+
+        runtimeLoaderLog.info("AppleContainersRuntime loaded successfully.")
+        return .loaded
+    }
+
+    /// Searches for the embedded framework inside the app bundle's Frameworks
+    /// directory.  Returns `nil` if the framework is absent.
+    private func locateFramework() -> URL? {
+        // Primary location: Contents/Frameworks (standard macOS app layout)
+        if let frameworksURL = frameworksURL() {
+            let candidate = frameworksURL
+                .appendingPathComponent("\(Self.frameworkName).framework", isDirectory: true)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        // Fallback: next to the executable (used by `swift run` / direct builds)
+        let executableDir = Bundle.main.executableURL?
+            .deletingLastPathComponent()
+        if let dir = executableDir {
+            let candidate = dir
+                .appendingPathComponent("\(Self.frameworkName).framework", isDirectory: true)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private func frameworksURL() -> URL? {
+        // Contents/Frameworks is one level up from MacOS/
+        return Bundle.main.executableURL?
+            .deletingLastPathComponent()   // MacOS/
+            .deletingLastPathComponent()   // Contents/
+            .appendingPathComponent("Frameworks", isDirectory: true)
+    }
+}


### PR DESCRIPTION
## Summary
- Remove direct apple/containerization dependency from clients/Package.swift, keeping main app at macOS 14
- Create clients/macos/apple-containers-runtime/ nested package that owns the Apple-only dependency
- Add AppleContainersRuntimeLoader for conditional loading and update build.sh for optional embedding

Part of plan: apple-containers-hatch.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
