### PR TITLE
fix: repair orphaned server_tool_use blocks to prevent 400 errors

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -670,9 +670,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   // ensureToolPairing — server_tool_use / web_search_tool_result pairing
   // -----------------------------------------------------------------------
 
-  test("server_tool_use without web_search_tool_result passes through as-is (no synthetic injection)", async () => {
-    // Server-side tools are self-paired within the assistant message.
-    // ensureToolPairing should NOT inject synthetic results for them.
+  test("orphaned server_tool_use gets synthetic web_search_tool_result injected", async () => {
+    // When stream is interrupted, server_tool_use may be stored without its
+    // paired web_search_tool_result. repairOrphanedServerToolUse should inject
+    // a synthetic empty-content web_search_tool_result after the orphan.
     const messages: Message[] = [
       userMsg("Search for something"),
       {
@@ -699,17 +700,20 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       }>;
     }>;
 
-    // server_tool_use stays in the assistant message, no synthetic result injected
+    // server_tool_use stays in the assistant message with synthetic result appended
     expect(sent).toHaveLength(3);
     expect(sent[1].role).toBe("assistant");
     expect(sent[1].content[0].type).toBe("server_tool_use");
+    expect(sent[1].content[1].type).toBe("web_search_tool_result");
+    expect(sent[1].content[1].tool_use_id).toBe("srvtoolu_abc123");
+    expect(sent[1].content[1].content).toEqual([]);
     expect(sent[2].role).toBe("user");
-    expect(sent[2].content[0].type).toBe("text"); // original user text, not a synthetic result
+    expect(sent[2].content[0].type).toBe("text");
   });
 
-  test("server_tool_use at end of messages is not modified (no synthetic append)", async () => {
-    // Server-side tools don't need cross-message pairing, so no synthetic
-    // user message should be appended.
+  test("orphaned server_tool_use at end of messages gets synthetic result (no synthetic user append)", async () => {
+    // Orphaned server_tool_use at the end should get a synthetic
+    // web_search_tool_result but no synthetic user message.
     const messages: Message[] = [
       userMsg("Search something"),
       {
@@ -731,10 +735,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       content: Array<{ type: string; tool_use_id?: string }>;
     }>;
 
-    // No synthetic user message appended — just the original 2 messages
+    // Original 2 messages, with synthetic result injected in assistant message
     expect(sent).toHaveLength(2);
     expect(sent[1].role).toBe("assistant");
     expect(sent[1].content[0].type).toBe("server_tool_use");
+    expect(sent[1].content[1].type).toBe("web_search_tool_result");
+    expect(sent[1].content[1].tool_use_id).toBe("srvtoolu_end");
   });
 
   test("server_tool_use with matching web_search_tool_result passes through unchanged", async () => {
@@ -907,10 +913,127 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       tool_use_id: "tu_a",
     });
 
-    // server_tool_use preserved in a carryover assistant message
+    // server_tool_use preserved in a carryover assistant message with synthetic result
     const carryoverAssistant = sent[3];
     expect(carryoverAssistant.role).toBe("assistant");
     expect(carryoverAssistant.content[0].type).toBe("server_tool_use");
+    expect(carryoverAssistant.content[1].type).toBe("web_search_tool_result");
+    expect(carryoverAssistant.content[1].tool_use_id).toBe("srvtoolu_b");
+  });
+
+  test("orphaned server_tool_use from interrupted stream gets repaired in multi-turn conversation", async () => {
+    // Reproduces the real bug: web_search stream interrupted, server_tool_use
+    // stored without web_search_tool_result, next user message triggers replay
+    // which would cause a 400 error without the repair.
+    const messages: Message[] = [
+      userMsg("fetch this page and search the web"),
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll do both." },
+          {
+            type: "tool_use",
+            id: "tu_fetch",
+            name: "web_fetch",
+            input: { url: "https://example.com" },
+          },
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_interrupted",
+            name: "web_search",
+            input: { query: "test" },
+          },
+          // NOTE: no web_search_tool_result — stream was interrupted
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_fetch",
+            content: "page content here",
+            is_error: false,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "The fetch worked but search failed." },
+        ],
+      },
+      userMsg("try again"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        id?: string;
+        tool_use_id?: string;
+        content?: unknown;
+      }>;
+    }>;
+
+    // The orphaned server_tool_use should have a synthetic web_search_tool_result
+    // injected in the assistant message, preventing the 400 error.
+    const allBlocks = sent.flatMap((m) => m.content);
+    const syntheticResults = allBlocks.filter(
+      (b) =>
+        b.type === "web_search_tool_result" &&
+        b.tool_use_id === "srvtoolu_interrupted",
+    );
+    expect(syntheticResults).toHaveLength(1);
+    expect(syntheticResults[0].content).toEqual([]);
+  });
+
+  test("paired server_tool_use is not modified by repair", async () => {
+    // When server_tool_use has its matching web_search_tool_result,
+    // repairOrphanedServerToolUse should not inject anything.
+    const messages: Message[] = [
+      userMsg("search"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_paired",
+            name: "web_search",
+            input: { query: "test" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_paired",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "Example",
+                encrypted_content: "enc",
+              },
+            ],
+          },
+          { type: "text", text: "Found results." },
+        ],
+      },
+      userMsg("thanks"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // Only 1 web_search_tool_result — the original, no synthetic one added
+    const allBlocks = sent.flatMap((m) => m.content);
+    const wsResults = allBlocks.filter(
+      (b) => b.type === "web_search_tool_result",
+    );
+    expect(wsResults).toHaveLength(1);
+    expect(wsResults[0].tool_use_id).toBe("srvtoolu_paired");
   });
 
   test("assistant message with only unknown blocks gets placeholder text", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -234,6 +234,87 @@ function normalizeFollowingUserContent(
   };
 }
 
+/** Type-guard for server_tool_use blocks. */
+function isServerToolUseBlock(
+  block: unknown,
+): block is { type: "server_tool_use"; id: string; name: string } {
+  return (
+    typeof block === "object" &&
+    block != null &&
+    (block as { type: string }).type === "server_tool_use"
+  );
+}
+
+/** Type-guard for web_search_tool_result blocks. */
+function isWebSearchToolResultBlock(
+  block: unknown,
+): block is { type: "web_search_tool_result"; tool_use_id: string } {
+  return (
+    typeof block === "object" &&
+    block != null &&
+    (block as { type: string }).type === "web_search_tool_result"
+  );
+}
+
+/**
+ * Repair orphaned server_tool_use blocks within assistant messages.
+ * Server-side tools (e.g. web_search) are self-paired: the assistant message
+ * should contain both server_tool_use and its matching web_search_tool_result.
+ * When the stream is interrupted or the API returns a partial response, the
+ * web_search_tool_result may be missing. This function injects a synthetic
+ * error result for any orphaned server_tool_use block.
+ */
+function repairOrphanedServerToolUse(
+  messages: Anthropic.MessageParam[],
+): Anthropic.MessageParam[] {
+  return messages.map((msg) => {
+    if (msg.role !== "assistant") return msg;
+    const content = Array.isArray(msg.content) ? msg.content : [];
+
+    // Collect server_tool_use IDs and web_search_tool_result IDs in this message
+    const serverToolUseIds = new Set<string>();
+    const pairedResultIds = new Set<string>();
+    for (const block of content) {
+      if (isServerToolUseBlock(block)) {
+        serverToolUseIds.add(block.id);
+      }
+      if (isWebSearchToolResultBlock(block)) {
+        pairedResultIds.add(block.tool_use_id);
+      }
+    }
+
+    // Find orphaned server_tool_use blocks (no matching web_search_tool_result)
+    const orphanedIds: string[] = [];
+    for (const id of serverToolUseIds) {
+      if (!pairedResultIds.has(id)) {
+        orphanedIds.push(id);
+      }
+    }
+
+    if (orphanedIds.length === 0) return msg;
+
+    log.warn(
+      { orphanedIds, blockCount: content.length },
+      "Injecting synthetic web_search_tool_result for orphaned server_tool_use blocks",
+    );
+
+    // Insert a synthetic error web_search_tool_result after each orphaned server_tool_use
+    const repairedContent: Anthropic.ContentBlockParam[] = [];
+    for (const block of content) {
+      repairedContent.push(block);
+      if (isServerToolUseBlock(block) && orphanedIds.includes(block.id)) {
+        repairedContent.push({
+          type: "web_search_tool_result",
+          tool_use_id: block.id,
+          content: [],
+        } as unknown as Anthropic.ContentBlockParam);
+      }
+    }
+
+    return { role: msg.role, content: repairedContent };
+  });
+}
+
 /**
  * Last-line-of-defense fix that ensures every assistant message with tool_use
  * blocks has matching tool_result blocks in the immediately following user
@@ -538,7 +619,7 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      sentMessages = ensureToolPairing(formatted);
+      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
       const { effort, output_config, ...restConfig } = (config ?? {}) as Record<
         string,
         unknown

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -54,7 +54,7 @@ final class SecretPromptManager {
         let hostingController = NSHostingController(rootView: view)
         hostingController.sizingOptions = .preferredContentSize
 
-        let panel = NSPanel(
+        let panel = KeyablePanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 300),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -99,6 +99,7 @@ final class SecretPromptManager {
 
         panels[message.requestId] = panel
         panelPresenter(panel)
+        panel.makeKey()
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
     }
@@ -317,4 +318,12 @@ struct SecretPromptView: View {
                 .foregroundColor(VColor.contentTertiary)
         }
     }
+}
+
+// MARK: - KeyablePanel
+
+/// Borderless NSPanel subclass that accepts key window status,
+/// allowing SecureField (and other text inputs) to receive keyboard focus.
+private final class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
 }


### PR DESCRIPTION
## Summary
- When an Anthropic native web search stream is interrupted, the `server_tool_use` block gets stored without its paired `web_search_tool_result`. Replaying this orphaned block on the next turn causes a 400 error from the API.
- Adds `repairOrphanedServerToolUse()` which scans assistant messages for unpaired `server_tool_use` blocks and injects a synthetic empty `web_search_tool_result` before sending to the API.
- Called before `ensureToolPairing()` so both server-side and client-side tool pairing issues are fixed.

## Test plan
- [x] Updated existing `server_tool_use` tests to verify synthetic results are injected for orphaned blocks
- [x] Added test for multi-turn interrupted stream scenario (exact repro of the bug)
- [x] Added test verifying paired `server_tool_use` blocks are not modified
- [x] All 38 anthropic-provider tests pass
- [x] All 8 conversation-history-web-search tests pass
- [ ] Manual repro: ask Vellum to fetch a large page + web search in parallel, verify no 400 error on follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
