### PR TITLE
fix: bypass auth gate on app launch for local assistants with existing lockfile

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -21,8 +21,20 @@ extension AppDelegate {
                 log.info("[authFlow] → proceedToApp()")
                 proceedToApp()
             } else {
-                log.info("[authFlow] → showAuthWindow()")
-                showAuthWindow()
+                // Check if the lockfile has a non-managed assistant we can connect to
+                // without authentication. Local/remote assistants run independently
+                // of the platform auth session, so the app can open in a logged-out
+                // state and the user can sign in from Settings > General.
+                let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+                let assistant = storedId.flatMap { LockfileAssistant.loadByName($0) }
+                    ?? LockfileAssistant.loadLatest()
+                if let assistant, !assistant.isManaged {
+                    log.info("[authFlow] Lockfile has non-managed assistant \(assistant.assistantId) — proceeding to app without auth")
+                    proceedToApp()
+                } else {
+                    log.info("[authFlow] → showAuthWindow()")
+                    showAuthWindow()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- When a user logs out and reopens the app with a local assistant in the lockfile, bypass the auth gate and proceed directly to the main app window
- Local/remote assistants run independently of the platform auth session, so the user can sign in later from Settings > General
- Managed assistant users still see the auth window (addressed in PR 2)

Part of plan: logout-reopen-fix.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
