### PR TITLE
fix: remove nonactivatingPanel from secure credential panel to restore keyboard input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -99,7 +99,7 @@ final class SecretPromptManager {
 
         panels[message.requestId] = panel
         panelPresenter(panel)
-        panel.makeKeyAndOrderFront(nil)
+        panel.makeKey()
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -56,7 +56,7 @@ final class SecretPromptManager {
 
         let panel = KeyablePanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: 300),
-            styleMask: [.borderless, .nonactivatingPanel],
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
@@ -99,7 +99,7 @@ final class SecretPromptManager {
 
         panels[message.requestId] = panel
         panelPresenter(panel)
-        panel.makeKey()
+        panel.makeKeyAndOrderFront(nil)
 
         log.info("Showing secret prompt: requestId=\(message.requestId), service=\(message.service), field=\(message.field)")
     }


### PR DESCRIPTION
## Summary
- Removed `.nonactivatingPanel` from the secure credential panel's style mask, which was preventing the panel from activating and receiving keyboard events
- Changed `makeKey()` to `makeKeyAndOrderFront(nil)` for proper window activation

## Test plan
- [x] Existing `SecretPromptManagerTests` pass
- [ ] Trigger a secure credential prompt (e.g. Slack Bot OAuth Token) and verify you can click, type, and paste into the SecureField

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
