### PR TITLE
feat(macos): add apple containers rollout flag and centralized availability gating

### DIFF
--- a/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
@@ -1,0 +1,158 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "AppleContainers")
+
+/// The set of reasons Apple Containers may be unavailable on the current system.
+///
+/// The gate checks these in priority order: feature flag first, then runtime
+/// capability checks. Multiple reasons can coexist, but `featureFlagDisabled`
+/// always takes precedence and short-circuits further checks when the flag is
+/// off.
+public enum AppleContainersUnavailableReason: Equatable, CustomStringConvertible {
+    /// The `apple_containers_enabled` feature flag is off (the default).
+    case featureFlagDisabled
+    /// The host OS is below the minimum required for Apple Containerization.
+    /// Apple Containerization requires macOS 15 (Sequoia) or later.
+    case osVersionTooLow
+    /// The embedded apple-containers runtime bundle was not found inside the
+    /// main application bundle. This bundle is only embedded in builds that
+    /// explicitly include it.
+    case runtimeBundleNotFound
+    /// The runtime loader reported that the containerization toolchain is not
+    /// ready (e.g. missing helper binaries or entitlements not granted).
+    case runtimeLoaderNotReady
+
+    public var description: String {
+        switch self {
+        case .featureFlagDisabled:
+            return "Apple Containers feature flag is disabled"
+        case .osVersionTooLow:
+            return "Apple Containers requires macOS 15 or later"
+        case .runtimeBundleNotFound:
+            return "Apple Containers runtime bundle not found in app bundle"
+        case .runtimeLoaderNotReady:
+            return "Apple Containers runtime loader is not ready"
+        }
+    }
+}
+
+/// The resolved availability of Apple Containers for the current session.
+public enum AppleContainersAvailability: Equatable {
+    /// Apple Containers is fully available — the flag is on and all runtime
+    /// capability checks passed.
+    case available
+    /// Apple Containers is not available for one or more reasons.
+    case unavailable([AppleContainersUnavailableReason])
+
+    /// Whether Apple Containers is available and ready to use.
+    public var isAvailable: Bool {
+        if case .available = self { return true }
+        return false
+    }
+
+    /// The reasons Apple Containers is unavailable, or an empty array when
+    /// availability is `.available`.
+    public var unavailableReasons: [AppleContainersUnavailableReason] {
+        if case .unavailable(let reasons) = self { return reasons }
+        return []
+    }
+}
+
+/// Central gate for all Apple Containers entry points in the macOS app.
+///
+/// Resolution order:
+/// 1. Feature flag (`apple_containers_enabled`) — if off, returns
+///    `.unavailable([.featureFlagDisabled])` immediately without running
+///    capability checks.
+/// 2. OS version — Apple Containerization requires macOS 15 (Sequoia) or
+///    later.
+/// 3. Embedded runtime bundle — the `apple-containers-runtime` bundle must be
+///    present inside `Bundle.main`.
+/// 4. Runtime loader readiness — `AppleContainersRuntimeLoader.isReady` must
+///    return `true` (added in PR 2).
+///
+/// All Apple Containers-specific surfaces (onboarding, settings, launcher,
+/// restart) **must** consult this helper rather than performing ad hoc checks.
+public enum AppleContainersAvailabilityChecker {
+
+    // MARK: - Public API
+
+    /// Evaluate and return Apple Containers availability for the current
+    /// process, using the shared `MacOSClientFeatureFlagManager` and the live
+    /// system environment.
+    public static func evaluate() -> AppleContainersAvailability {
+        return evaluate(
+            flagManager: MacOSClientFeatureFlagManager.shared,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersion,
+            bundleChecker: defaultBundleChecker,
+            runtimeLoaderReady: defaultRuntimeLoaderReady
+        )
+    }
+
+    // MARK: - Testable core
+
+    /// Evaluate availability with injected dependencies.
+    ///
+    /// - Parameters:
+    ///   - flagManager: The feature flag manager to consult.
+    ///   - osVersion: The current operating system version.
+    ///   - bundleChecker: Returns `true` if the embedded runtime bundle exists.
+    ///   - runtimeLoaderReady: Returns `true` if the runtime loader reports
+    ///     readiness.
+    static func evaluate(
+        flagManager: MacOSClientFeatureFlagManager,
+        osVersion: OperatingSystemVersion,
+        bundleChecker: () -> Bool,
+        runtimeLoaderReady: () -> Bool
+    ) -> AppleContainersAvailability {
+        // 1. Feature flag gate — short-circuit if the flag is off.
+        guard flagManager.isEnabled("apple_containers_enabled") else {
+            log.debug("Apple Containers unavailable: feature flag disabled")
+            return .unavailable([.featureFlagDisabled])
+        }
+
+        var reasons: [AppleContainersUnavailableReason] = []
+
+        // 2. OS version check — requires macOS 15 (Sequoia) or later.
+        if osVersion.majorVersion < 15 {
+            log.debug("Apple Containers unavailable: OS version \(osVersion.majorVersion).\(osVersion.minorVersion) < 15.0")
+            reasons.append(.osVersionTooLow)
+        }
+
+        // 3. Embedded runtime bundle check.
+        if !bundleChecker() {
+            log.debug("Apple Containers unavailable: runtime bundle not found in app bundle")
+            reasons.append(.runtimeBundleNotFound)
+        }
+
+        // 4. Runtime loader readiness.
+        if !runtimeLoaderReady() {
+            log.debug("Apple Containers unavailable: runtime loader not ready")
+            reasons.append(.runtimeLoaderNotReady)
+        }
+
+        if reasons.isEmpty {
+            log.info("Apple Containers is available")
+            return .available
+        }
+
+        log.debug("Apple Containers unavailable: \(reasons.map(\.description).joined(separator: ", "))")
+        return .unavailable(reasons)
+    }
+
+    // MARK: - Default implementations
+
+    /// Default bundle checker: looks for `apple-containers-runtime` inside
+    /// `Bundle.main`. In PR 2, the runtime module is embedded here.
+    private static let defaultBundleChecker: () -> Bool = {
+        Bundle.main.url(forResource: "apple-containers-runtime", withExtension: "bundle") != nil
+    }
+
+    /// Default runtime loader readiness: always returns `false` until
+    /// `AppleContainersRuntimeLoader` is introduced in PR 2. At that point
+    /// this closure will be replaced with `AppleContainersRuntimeLoader.isReady`.
+    private static let defaultRuntimeLoaderReady: () -> Bool = {
+        false
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersAvailability.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "AppleContainers")
 

--- a/clients/macos/vellum-assistantTests/AppleContainersAvailabilityTests.swift
+++ b/clients/macos/vellum-assistantTests/AppleContainersAvailabilityTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class AppleContainersAvailabilityTests: XCTestCase {
+
+    // MARK: - Feature flag gate
+
+    /// The registry default is false, so with no env override the flag is off.
+    func testFeatureFlagOffByDefault() {
+        // GIVEN a flag manager with no overrides (empty environment)
+        let manager = MacOSClientFeatureFlagManager(environment: [:])
+
+        // WHEN we evaluate availability
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN the feature is unavailable with featureFlagDisabled as the only reason
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertEqual(availability.unavailableReasons, [.featureFlagDisabled])
+    }
+
+    /// Setting VELLUM_FLAG_APPLE_CONTAINERS_ENABLED=1 enables the flag.
+    func testEnvVarOverrideEnablesFlag() {
+        // GIVEN a flag manager with the Apple Containers env var set to "1"
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate on a capable system
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN the feature is available
+        XCTAssertTrue(availability.isAvailable)
+        XCTAssertEqual(availability.unavailableReasons, [])
+    }
+
+    /// VELLUM_FLAG_APPLE_CONTAINERS_ENABLED=true also enables the flag.
+    func testEnvVarTrueEnablesFlag() {
+        // GIVEN a flag manager with the Apple Containers env var set to "true"
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "true"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate on a capable system
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN the feature is available
+        XCTAssertTrue(availability.isAvailable)
+    }
+
+    // MARK: - Feature flag short-circuit
+
+    /// When the flag is off, capability checks are skipped entirely.
+    func testFeatureFlagOffShortCircuitsCapabilityChecks() {
+        // GIVEN a flag manager with the flag disabled
+        let manager = MacOSClientFeatureFlagManager(environment: [:])
+        var bundleCheckerCalled = false
+        var runtimeLoaderCalled = false
+
+        // WHEN we evaluate availability
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { bundleCheckerCalled = true; return false },
+            runtimeLoaderReady: { runtimeLoaderCalled = true; return false }
+        )
+
+        // THEN only featureFlagDisabled is reported and no capability checks ran
+        XCTAssertEqual(availability.unavailableReasons, [.featureFlagDisabled])
+        XCTAssertFalse(bundleCheckerCalled, "bundleChecker should not be called when feature flag is off")
+        XCTAssertFalse(runtimeLoaderCalled, "runtimeLoaderReady should not be called when feature flag is off")
+    }
+
+    // MARK: - OS version check
+
+    /// macOS 14 is too low — requires macOS 15+.
+    func testOSTooOldReturnsOSVersionTooLow() {
+        // GIVEN the flag is on but the OS is macOS 14
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate with macOS 14
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 14, minorVersion: 7, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN the feature is unavailable with osVersionTooLow
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertTrue(availability.unavailableReasons.contains(.osVersionTooLow))
+    }
+
+    /// macOS 15.0 is the minimum supported version.
+    func testMacOS15IsSupported() {
+        // GIVEN the flag is on and the OS is exactly macOS 15.0
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate with macOS 15.0
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN osVersionTooLow is not in the reasons
+        XCTAssertFalse(availability.unavailableReasons.contains(.osVersionTooLow))
+    }
+
+    // MARK: - Runtime bundle check
+
+    /// Missing runtime bundle is reported as runtimeBundleNotFound.
+    func testMissingRuntimeBundleReturnsRuntimeBundleNotFound() {
+        // GIVEN the flag is on, OS is fine, but the runtime bundle is absent
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate with a missing bundle
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { false },
+            runtimeLoaderReady: { true }
+        )
+
+        // THEN the feature is unavailable with runtimeBundleNotFound
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertTrue(availability.unavailableReasons.contains(.runtimeBundleNotFound))
+    }
+
+    // MARK: - Runtime loader check
+
+    /// A runtime loader that is not ready is reported as runtimeLoaderNotReady.
+    func testRuntimeLoaderNotReadyReturnsRuntimeLoaderNotReady() {
+        // GIVEN the flag is on, OS is fine, bundle is present, but loader is not ready
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate with a not-ready runtime loader
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 15, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { true },
+            runtimeLoaderReady: { false }
+        )
+
+        // THEN the feature is unavailable with runtimeLoaderNotReady
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertTrue(availability.unavailableReasons.contains(.runtimeLoaderNotReady))
+    }
+
+    // MARK: - Multiple reasons
+
+    /// All capability failure reasons are accumulated and returned together.
+    func testMultipleDisabledReasonsAreAccumulated() {
+        // GIVEN the flag is on but all capability checks fail
+        let env = ["VELLUM_FLAG_APPLE_CONTAINERS_ENABLED": "1"]
+        let manager = MacOSClientFeatureFlagManager(environment: env)
+
+        // WHEN we evaluate with every capability failing
+        let availability = AppleContainersAvailabilityChecker.evaluate(
+            flagManager: manager,
+            osVersion: .init(majorVersion: 14, minorVersion: 0, patchVersion: 0),
+            bundleChecker: { false },
+            runtimeLoaderReady: { false }
+        )
+
+        // THEN all three capability reasons are present
+        let reasons = availability.unavailableReasons
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertTrue(reasons.contains(.osVersionTooLow))
+        XCTAssertTrue(reasons.contains(.runtimeBundleNotFound))
+        XCTAssertTrue(reasons.contains(.runtimeLoaderNotReady))
+        XCTAssertEqual(reasons.count, 3)
+    }
+
+    // MARK: - Availability helpers
+
+    /// `.available` reports `isAvailable == true` and empty reasons.
+    func testAvailableStateHelpers() {
+        let availability = AppleContainersAvailability.available
+        XCTAssertTrue(availability.isAvailable)
+        XCTAssertEqual(availability.unavailableReasons, [])
+    }
+
+    /// `.unavailable` reports `isAvailable == false` and the correct reasons.
+    func testUnavailableStateHelpers() {
+        let reasons: [AppleContainersUnavailableReason] = [.featureFlagDisabled]
+        let availability = AppleContainersAvailability.unavailable(reasons)
+        XCTAssertFalse(availability.isAvailable)
+        XCTAssertEqual(availability.unavailableReasons, reasons)
+    }
+
+    // MARK: - UnavailableReason descriptions
+
+    /// Each reason has a non-empty human-readable description.
+    func testUnavailableReasonDescriptions() {
+        let reasons: [AppleContainersUnavailableReason] = [
+            .featureFlagDisabled,
+            .osVersionTooLow,
+            .runtimeBundleNotFound,
+            .runtimeLoaderNotReady
+        ]
+        for reason in reasons {
+            XCTAssertFalse(reason.description.isEmpty, "\(reason) should have a non-empty description")
+        }
+    }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -224,6 +224,14 @@
       "label": "Figma Integration",
       "description": "Enable the Figma OAuth setup skill for connecting to Figma",
       "defaultEnabled": false
+    },
+    {
+      "id": "apple-containers",
+      "scope": "macos",
+      "key": "apple_containers_enabled",
+      "label": "Apple Containers",
+      "description": "Enable Apple Containers as a local install option for running the assistant in a Linux container via the Apple Containerization framework",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add apple_containers_enabled feature flag (macOS scope, off by default) to the unified registry
- Add AppleContainersAvailability helper that gates all Apple Containers code paths via feature flag + runtime capability checks
- Add tests covering default, env override, and disabled reason scenarios

Part of plan: apple-containers-hatch.md (PR 1 of 7)

Apple refs checked (2026-03-16): ProcessInfo.operatingSystemVersion (stable since macOS 10.0), Bundle.main.url(forResource:withExtension:) (stable), OperatingSystemVersion struct (stable since macOS 10.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
