### PR TITLE
fix: show clean sign-in screen instead of onboarding for returning managed users

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -46,19 +46,34 @@ extension AppDelegate {
             return
         }
 
-        OnboardingState.clearPersistedState()
-        let state = OnboardingState()
-        state.shouldPersist = false
-        let authView = OnboardingFlowView(
-            state: state,
-            daemonClient: daemonClient,
-            authManager: authManager,
-            managedBootstrapEnabled: true,
-            onComplete: { [weak self] in
-                self?.proceedToApp()
-            },
-            onOpenSettings: {}
-        )
+        let hasAssistants = lockfileHasAssistants()
+        let authView: AnyView
+
+        if hasAssistants {
+            // Returning user with existing assistant — show clean sign-in, not full onboarding
+            authView = AnyView(ReauthView(
+                authManager: authManager,
+                onComplete: { [weak self] in
+                    self?.proceedToApp()
+                }
+            ))
+        } else {
+            // No assistants — show full onboarding (shouldn't normally happen via this path,
+            // but included as a safety net)
+            OnboardingState.clearPersistedState()
+            let state = OnboardingState()
+            state.shouldPersist = false
+            authView = AnyView(OnboardingFlowView(
+                state: state,
+                daemonClient: daemonClient,
+                authManager: authManager,
+                managedBootstrapEnabled: true,
+                onComplete: { [weak self] in
+                    self?.proceedToApp()
+                },
+                onOpenSettings: {}
+            ))
+        }
 
         let hostingController = NSHostingController(rootView: authView)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ReauthView")
+
+@MainActor
+struct ReauthView: View {
+    @Bindable var authManager: AuthManager
+    var onComplete: () -> Void
+
+    @State private var showContent = false
+
+    private static let appIcon: NSImage? = {
+        guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
+        return NSImage(contentsOfFile: path)
+    }()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            if let nsImage = Self.appIcon {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 96, height: 96)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                    .padding(.bottom, VSpacing.xl)
+            }
+
+            Text("Welcome Back")
+                .font(.system(size: 32, weight: .regular, design: .serif))
+                .foregroundColor(VColor.contentDefault)
+                .padding(.bottom, VSpacing.xs)
+
+            Text("Sign in to continue.")
+                .font(.system(size: 16))
+                .foregroundColor(VColor.contentSecondary)
+                .padding(.bottom, VSpacing.xxl)
+
+            VStack(spacing: VSpacing.sm) {
+                if authManager.isLoading {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.small)
+                            .progressViewStyle(.circular)
+                        Text("Checking...")
+                            .font(VFont.monoMedium)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                    .frame(height: 36)
+                } else if authManager.isSubmitting {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView()
+                            .controlSize(.small)
+                            .progressViewStyle(.circular)
+                        Text("Signing in...")
+                            .font(VFont.monoMedium)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                    .frame(height: 36)
+                } else {
+                    OnboardingButton(title: "Sign In", style: .primary) {
+                        Task {
+                            await authManager.startWorkOSLogin()
+                        }
+                    }
+                    .accessibilityLabel("Sign In")
+                }
+
+                if let error = authManager.errorMessage {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: 280)
+
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RadialGradient(
+                colors: [VColor.surfaceBase, VColor.surfaceOverlay],
+                center: .center,
+                startRadius: 0,
+                endRadius: 500
+            )
+            .ignoresSafeArea()
+        )
+        .opacity(showContent ? 1 : 0)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.4)) {
+                showContent = true
+            }
+        }
+        .task {
+            if !authManager.isAuthenticated {
+                await authManager.checkSession()
+            }
+            if authManager.isAuthenticated {
+                onComplete()
+            }
+        }
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                log.info("User re-authenticated — proceeding to app")
+                onComplete()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create ReauthView.swift — a minimal 'Welcome Back' sign-in screen for returning managed users
- When the lockfile has assistants, show ReauthView instead of the full OnboardingFlowView in the auth window
- Handles loading, submitting, and error states; auto-detects existing valid sessions
- First-time users (no lockfile) still see the full onboarding flow

Part of plan: logout-reopen-fix.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
