### PR TITLE
fix: use getProviderKeyAsync consistently and update config CLI help text

### DIFF
--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -51,9 +51,9 @@ and "assistant keys set <provider> <key>" to view and manage API keys.
 
 Examples:
   $ assistant config list
-  $ assistant config get provider
-  $ assistant config schema provider
-  $ assistant config set provider anthropic
+  $ assistant config get services.inference.provider
+  $ assistant config schema services
+  $ assistant config set services.inference.provider anthropic
   $ assistant config set calls.enabled true`,
   );
 
@@ -66,8 +66,9 @@ Examples:
       "after",
       `
 Arguments:
-  key     Dotted path to the config key (e.g. provider, calls.enabled,
-          twilio.accountSid). Intermediate objects are created automatically.
+  key     Dotted path to the config key (e.g. services.inference.provider,
+          calls.enabled, twilio.accountSid). Intermediate objects are created
+          automatically.
   value   The value to store. Parsed as JSON first (so "true" becomes boolean
           true, "42" becomes number 42). Falls back to plain string if JSON
           parsing fails.
@@ -78,7 +79,7 @@ to reflect the updated configuration.
 To manage API keys, use "assistant keys set <provider> <key>" instead.
 
 Examples:
-  $ assistant config set provider anthropic
+  $ assistant config set services.inference.provider anthropic
   $ assistant config set calls.enabled true`,
     )
     .action((key: string, value: string) => {
@@ -103,7 +104,8 @@ Examples:
       "after",
       `
 Arguments:
-  key   Dotted path to the config key (e.g. provider, calls.enabled)
+  key   Dotted path to the config key (e.g. services.inference.provider,
+        calls.enabled)
 
 Prints the value at the given key path. If the key is not set, prints
 "(not set)". Object values are pretty-printed as indented JSON.
@@ -111,7 +113,7 @@ Prints the value at the given key path. If the key is not set, prints
 To view API keys, use "assistant keys list" instead.
 
 Examples:
-  $ assistant config get provider
+  $ assistant config get services.inference.provider
   $ assistant config get calls.enabled`,
     )
     .action((key: string) => {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -18,7 +18,7 @@ import {
   resolveManagedProxyContext,
 } from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
 import type {
   ToolContext,
@@ -55,8 +55,7 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const apiKey =
-    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
+  const apiKey = await getProviderKeyAsync("gemini");
 
   // Resolve credentials: prefer direct API key, fall back to managed proxy
   let credentials: ImageGenCredentials | undefined;

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { getMediaAssetById } from "../../../../memory/media-store.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -29,8 +29,7 @@ export async function mapSegmentsForAsset(
   options: MapSegmentsOptions,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
-  const apiKey =
-    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
+  const apiKey = await getProviderKeyAsync("gemini");
 
   if (!apiKey) {
     throw new Error(
@@ -122,8 +121,7 @@ export async function run(
     let output: MapOutput;
 
     if (mode === "direct_video") {
-      const apiKey =
-        (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
+      const apiKey = await getProviderKeyAsync("gemini");
       if (!apiKey) {
         return {
           content:

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -14,7 +14,7 @@ import {
   getAttachmentsByIds,
   getFilePathForAttachment,
 } from "../../../../memory/attachments-store.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -449,8 +449,7 @@ export async function run(
   // Validate API key for api mode
   let openaiKey: string | undefined;
   if (mode === "api") {
-    openaiKey =
-      (await getSecureKeyAsync("openai")) ?? process.env.OPENAI_API_KEY;
+    openaiKey = await getProviderKeyAsync("openai");
     if (!openaiKey) {
       return {
         content:

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -15,7 +15,7 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../providers/managed-proxy/context.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import {
   generateImage,
@@ -37,8 +37,7 @@ export async function generateAppIcon(
   appDescription?: string,
 ): Promise<void> {
   const config = getConfig();
-  const apiKey =
-    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
+  const apiKey = await getProviderKeyAsync("gemini");
 
   let credentials: ImageGenCredentials | undefined;
   if (apiKey) {

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -3,7 +3,7 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../providers/managed-proxy/context.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 import {
   generateImage,
@@ -14,8 +14,7 @@ export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
-  const geminiKey =
-    (await getSecureKeyAsync("gemini")) ?? process.env.GEMINI_API_KEY;
+  const geminiKey = await getProviderKeyAsync("gemini");
 
   let credentials: ImageGenCredentials | undefined;
   if (geminiKey) {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -1,7 +1,7 @@
 import { getConfig } from "../../config/loader.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import {
   DEFAULT_BASE_DELAY_MS,
@@ -54,11 +54,11 @@ async function getApiKey(
   provider: WebSearchProvider,
 ): Promise<string | undefined> {
   if (provider === "brave") {
-    return (await getSecureKeyAsync("brave")) ?? undefined;
+    return (await getProviderKeyAsync("brave")) ?? undefined;
   }
 
   // Perplexity
-  return (await getSecureKeyAsync("perplexity")) ?? undefined;
+  return (await getProviderKeyAsync("perplexity")) ?? undefined;
 }
 
 function formatBraveResults(


### PR DESCRIPTION
## Summary
- Replace `getSecureKeyAsync` with `getProviderKeyAsync` in `web-search.ts` for brave/perplexity key lookups (env var support)
- Replace `getSecureKeyAsync(...) ?? process.env.X` patterns with `getProviderKeyAsync(...)` in media/image tool files
- Update `config` CLI help text to reference `services.inference.provider` instead of stale top-level `provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
