### PR TITLE
fix: guard ReauthView onComplete to prevent double invocation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -10,6 +10,7 @@ struct ReauthView: View {
     var onComplete: () -> Void
 
     @State private var showContent = false
+    @State private var didComplete = false
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -101,12 +102,14 @@ struct ReauthView: View {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()
             }
-            if authManager.isAuthenticated {
+            if authManager.isAuthenticated && !didComplete {
+                didComplete = true
                 onComplete()
             }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            if isAuthenticated {
+            if isAuthenticated && !didComplete {
+                didComplete = true
                 log.info("User re-authenticated — proceeding to app")
                 onComplete()
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for logout-reopen-fix.md.

**Gap:** Double invocation of onComplete() in ReauthView when session is still valid
**What was expected:** onComplete() should fire exactly once when authentication succeeds
**What was found:** Both the .task and .onChange modifiers call onComplete() when checkSession() finds a valid session, resulting in proceedToApp() being called twice

## Fix
Added a `@State private var didComplete = false` flag to ReauthView. Both the `.task` and `.onChange(of: authManager.isAuthenticated)` call sites now check `!didComplete` before invoking `onComplete()`, and set the flag to `true` before calling. Whichever path fires first claims the flag, preventing the second path from triggering a redundant call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
