### PR TITLE
refactor: fix remaining session/thread terminology in comments and docs

### DIFF
--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -63,7 +63,7 @@ export interface ChannelDestination {
 export interface DestinationBindingContext {
   /** The channel this binding belongs to (e.g. "telegram", "slack"). */
   sourceChannel: NotificationChannel;
-  /** The channel-specific chat/thread identifier (e.g. Telegram chat ID, phone number). */
+  /** The channel-specific chat/conversation identifier (e.g. Telegram chat ID, phone number). */
   externalChatId: string;
   /** Optional external user identifier within the chat. */
   externalUserId?: string;

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -22,7 +22,7 @@ export interface AssistantEvent {
   id: string;
   /** The assistant this event belongs to. */
   assistantId: string;
-  /** Resolved conversation/session id when available. */
+  /** Resolved conversation id when available. */
   conversationId?: string;
   /** ISO-8601 timestamp of when the event was emitted. */
   emittedAt: string;
@@ -37,7 +37,7 @@ export interface AssistantEvent {
  *
  * @param assistantId  The logical assistant identifier (e.g. from the daemon or HTTP route).
  * @param message      The outbound server message payload.
- * @param conversationId    Optional conversation/session id — pass when known.
+ * @param conversationId    Optional conversation id — pass when known.
  */
 export function buildAssistantEvent(
   assistantId: string,

--- a/assistant/src/signals/cancel.ts
+++ b/assistant/src/signals/cancel.ts
@@ -4,9 +4,9 @@
  * The built-in CLI writes JSON to `signals/cancel` instead of making an
  * HTTP POST to `/v1/conversations/:id/cancel`. The daemon's ConfigWatcher
  * detects the file change and invokes {@link handleCancelSignal}, which
- * reads the payload and aborts the target session.
+ * reads the payload and aborts the target conversation.
  *
- * Because the signal handler needs access to the daemon's session map, the
+ * Because the signal handler needs access to the daemon's conversation map, the
  * daemon registers a callback at startup via {@link registerCancelCallback}.
  */
 
@@ -26,7 +26,7 @@ let _cancelGeneration: CancelCallback | null = null;
 
 /**
  * Register the cancel-generation callback. Called once by the daemon
- * server at startup so the signal handler can reach the session map.
+ * server at startup so the signal handler can reach the conversation map.
  */
 export function registerCancelCallback(cb: CancelCallback): void {
   _cancelGeneration = cb;
@@ -35,7 +35,7 @@ export function registerCancelCallback(cb: CancelCallback): void {
 // ── Signal handler ───────────────────────────────────────────────────
 
 /**
- * Read the `signals/cancel` file and abort the target session.
+ * Read the `signals/cancel` file and abort the target conversation.
  * Called by ConfigWatcher when the signal file is written or modified.
  */
 export function handleCancelSignal(): void {

--- a/assistant/src/signals/conversation-undo.ts
+++ b/assistant/src/signals/conversation-undo.ts
@@ -8,7 +8,7 @@
  * the undo, and writes `signals/conversation-undo.result` so the CLI
  * receives feedback.
  *
- * Because the signal handler needs access to the daemon's session map, the
+ * Because the signal handler needs access to the daemon's conversation map, the
  * daemon registers a callback at startup via
  * {@link registerConversationUndoCallback}.
  */
@@ -31,7 +31,7 @@ let _undoLastMessage: UndoCallback | null = null;
 
 /**
  * Register the undo callback. Called once by the daemon server at startup
- * so the signal handler can reach the session map.
+ * so the signal handler can reach the conversation map.
  */
 export function registerConversationUndoCallback(cb: UndoCallback): void {
   _undoLastMessage = cb;
@@ -41,7 +41,7 @@ export function registerConversationUndoCallback(cb: UndoCallback): void {
 
 /**
  * Read the `signals/conversation-undo` file and undo the last message in
- * the session. Writes `signals/conversation-undo.result` with the outcome
+ * the conversation. Writes `signals/conversation-undo.result` with the outcome
  * so the CLI can display feedback. Called by ConfigWatcher when the signal
  * file is written.
  */

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -10,7 +10,7 @@
  * Per-request filenames avoid dropped messages when overlapping invocations
  * race on the same signal file.
  *
- * Because the signal handler needs access to the daemon's session map and
+ * Because the signal handler needs access to the daemon's conversation map and
  * event hub, the daemon registers a callback at startup via
  * {@link registerUserMessageCallback}.
  */
@@ -36,7 +36,7 @@ let _sendUserMessage: UserMessageCallback | null = null;
 
 /**
  * Register the user-message callback. Called once by the daemon server at
- * startup so the signal handler can reach the session map and event hub.
+ * startup so the signal handler can reach the conversation map and event hub.
  */
 export function registerUserMessageCallback(cb: UserMessageCallback): void {
   _sendUserMessage = cb;

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -35,7 +35,7 @@ All assistant API requests from clients, CLI, skills, and user-facing tooling **
 
 Gateway inbound events use a channel-discriminated union model (`GatewayInboundEvent`) with explicit identity fields:
 
-- **`conversationExternalId`**: Delivery/thread address (e.g., Telegram chat ID, phone number). Used for conversation binding and message routing. **Not** used for trust classification.
+- **`conversationExternalId`**: Delivery/conversation address (e.g., Telegram chat ID, phone number). Used for conversation binding and message routing. **Not** used for trust classification.
 - **`actorExternalId`**: Sender identity (e.g., Telegram user ID, WhatsApp phone number). Used for trust classification, guardian binding, and ACL enforcement. **Required** for all public channel ingress.
 - **"conversation"** is canonical vocabulary for delivery addresses. "thread" is reserved for provider-specific fields (Slack `thread_ts`, email thread IDs).
 - **"actor"** is canonical vocabulary for sender identity.

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -4,7 +4,7 @@ import type { ChannelId } from "./types.js";
  * Channel-discriminated inbound event model.
  *
  * Every normalized inbound event carries explicit `conversationExternalId`
- * (delivery/thread address) and `actorExternalId` (sender identity) fields.
+ * (delivery/conversation address) and `actorExternalId` (sender identity) fields.
  * The discriminated union is keyed by `sourceChannel`.
  */
 

--- a/packages/ces-contracts/src/grants.ts
+++ b/packages/ces-contracts/src/grants.ts
@@ -91,7 +91,7 @@ export const TemporaryGrantDecisionSchema = z.object({
    * The type of grant to create. Determines persistence behaviour:
    * - `allow_once`: Temporary single-use grant (consumed after one use)
    * - `allow_10m`: Temporary timed grant (10-minute TTL)
-   * - `allow_conversation`: Temporary conversation-scoped grant (lives for session)
+   * - `allow_conversation`: Temporary conversation-scoped grant (lives for conversation)
    * - `always_allow`: Persistent grant (survives restart)
    *
    * When omitted, defaults to `always_allow` for backwards compatibility.
@@ -118,14 +118,14 @@ export type GrantStatus = (typeof GrantStatus)[keyof typeof GrantStatus];
 /**
  * A persistent grant record stored by CES.
  *
- * Grants authorize a specific agent session to use a credential for a
+ * Grants authorize a specific agent connection to use a credential for a
  * constrained purpose. They are never sent to the assistant with secret
  * values — only metadata.
  */
 export const PersistentGrantRecordSchema = z.object({
   /** Unique grant identifier. */
   grantId: z.string(),
-  /** The agent session that holds this grant. */
+  /** The CES connection that created this grant. */
   sessionId: z.string(),
   /** The credential handle this grant authorizes. */
   credentialHandle: z.string(),
@@ -172,7 +172,7 @@ export const AuditRecordSummarySchema = z.object({
   toolName: z.string(),
   /** Target of the operation (URL for HTTP, command summary for commands). */
   target: z.string(),
-  /** The agent session that triggered materialization. */
+  /** The CES connection that triggered materialization. */
   sessionId: z.string(),
   /** Whether the execution succeeded. */
   success: z.boolean(),

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -292,9 +292,9 @@ export const ApprovalRequiredSchema = z.object({
   proposalHash: z.string(),
   /** Human-readable rendering of the proposal. */
   renderedProposal: z.string(),
-  /** The agent session requesting approval. */
+  /** The CES connection requesting approval. */
   sessionId: z.string(),
-  /** The conversation/thread ID for thread-scoped grants. */
+  /** The conversation ID for conversation-scoped grants. */
   conversationId: z.string().optional(),
 });
 export type ApprovalRequired = z.infer<typeof ApprovalRequiredSchema>;
@@ -314,9 +314,9 @@ export type ApprovalRequiredResponse = z.infer<
 export const RecordGrantSchema = z.object({
   /** The grant decision from the guardian. */
   decision: TemporaryGrantDecisionSchema,
-  /** The agent session this grant applies to. */
+  /** The CES connection this grant applies to. */
   sessionId: z.string(),
-  /** The conversation/thread ID for thread-scoped grants. */
+  /** The conversation ID for conversation-scoped grants. */
   conversationId: z.string().optional(),
 });
 export type RecordGrant = z.infer<typeof RecordGrantSchema>;
@@ -336,7 +336,7 @@ export type RecordGrantResponse = z.infer<typeof RecordGrantResponseSchema>;
 // ---------------------------------------------------------------------------
 
 export const ListGrantsSchema = z.object({
-  /** Filter by session ID. */
+  /** Filter by CES connection ID. */
   sessionId: z.string().optional(),
   /** Filter by credential handle. */
   credentialHandle: z.string().optional(),
@@ -378,7 +378,7 @@ export type RevokeGrantResponse = z.infer<typeof RevokeGrantResponseSchema>;
 // ---------------------------------------------------------------------------
 
 export const ListAuditRecordsSchema = z.object({
-  /** Filter by session ID. */
+  /** Filter by CES connection ID. */
   sessionId: z.string().optional(),
   /** Filter by credential handle. */
   credentialHandle: z.string().optional(),


### PR DESCRIPTION
## Summary
- Update remaining "session" references in signals, runtime, and CES contract comments to use "conversation" or "CES connection" as appropriate
- Fix "thread" references in gateway docs and notification types to use "conversation"
- All changes are comments/documentation only — no functional code changes

Part of plan: conv-rename-remaining.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
