### PR TITLE
refactor: rename sessionId→conversationId in auth context across assistant and gateway

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -430,9 +430,9 @@ describe("resolveLocalAuthContext", () => {
     expect(ctx.actorPrincipalId).toMatch(/^vellum-principal-/);
   });
 
-  test("sessionId matches the provided argument", () => {
+  test("conversationId matches the provided argument", () => {
     const ctx = resolveLocalAuthContext("my-session");
-    expect(ctx.sessionId).toBe("my-session");
+    expect(ctx.conversationId).toBe("my-session");
   });
 });
 

--- a/assistant/src/runtime/auth/__tests__/context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/context.test.ts
@@ -27,7 +27,7 @@ describe("buildAuthContext", () => {
       expect(result.context.principalType).toBe("actor");
       expect(result.context.assistantId).toBe("self");
       expect(result.context.actorPrincipalId).toBe("principal-abc");
-      expect(result.context.sessionId).toBeUndefined();
+      expect(result.context.conversationId).toBeUndefined();
       expect(result.context.scopeProfile).toBe("actor_client_v1");
       expect(result.context.policyEpoch).toBe(1);
       expect(result.context.scopes.has("chat.read")).toBe(true);
@@ -61,7 +61,7 @@ describe("buildAuthContext", () => {
     if (result.ok) {
       expect(result.context.principalType).toBe("local");
       expect(result.context.assistantId).toBe("self");
-      expect(result.context.sessionId).toBe("session-123");
+      expect(result.context.conversationId).toBe("session-123");
       expect(result.context.scopes.has("local.all")).toBe(true);
     }
   });

--- a/assistant/src/runtime/auth/__tests__/local-auth-context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/local-auth-context.test.ts
@@ -22,9 +22,9 @@ describe("buildLocalAuthContext", () => {
     expect(ctx.assistantId).toBe("self");
   });
 
-  test("includes sessionId from argument", () => {
+  test("includes conversationId from argument", () => {
     const ctx = buildLocalAuthContext("my-session-123");
-    expect(ctx.sessionId).toBe("my-session-123");
+    expect(ctx.conversationId).toBe("my-session-123");
   });
 
   test("uses local_v1 scope profile", () => {
@@ -62,10 +62,10 @@ describe("buildLocalAuthContext", () => {
     expect(typeof ctx.scopes.has).toBe("function");
   });
 
-  test("different session IDs produce different subjects", () => {
+  test("different conversation IDs produce different subjects", () => {
     const ctx1 = buildLocalAuthContext("session-1");
     const ctx2 = buildLocalAuthContext("session-2");
     expect(ctx1.subject).not.toBe(ctx2.subject);
-    expect(ctx1.sessionId).not.toBe(ctx2.sessionId);
+    expect(ctx1.conversationId).not.toBe(ctx2.conversationId);
   });
 });

--- a/assistant/src/runtime/auth/context.ts
+++ b/assistant/src/runtime/auth/context.ts
@@ -53,7 +53,7 @@ export function buildAuthContext(claims: TokenClaims): BuildAuthContextResult {
     principalType: subResult.principalType,
     assistantId,
     actorPrincipalId: subResult.actorPrincipalId,
-    sessionId: subResult.conversationId,
+    conversationId: subResult.conversationId,
     scopeProfile: claims.scope_profile,
     scopes,
     policyEpoch: claims.policy_epoch,

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -73,7 +73,7 @@ export interface AuthContext {
   principalType: PrincipalType;
   assistantId: string;
   actorPrincipalId?: string;
-  sessionId?: string;
+  conversationId?: string;
   scopeProfile: ScopeProfile;
   scopes: ReadonlySet<Scope>;
   policyEpoch: number;

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -32,12 +32,12 @@ const log = getLogger("local-actor-identity");
  * routes receive from JWT verification, keeping downstream code
  * transport-agnostic.
  */
-export function buildLocalAuthContext(sessionId: string): AuthContext {
+export function buildLocalAuthContext(conversationId: string): AuthContext {
   return {
-    subject: `local:self:${sessionId}`,
+    subject: `local:self:${conversationId}`,
     principalType: "local",
     assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-    sessionId,
+    conversationId,
     scopeProfile: "local_v1",
     scopes: resolveScopeProfile("local_v1"),
     policyEpoch: CURRENT_POLICY_EPOCH,
@@ -112,8 +112,8 @@ export function resolveLocalTrustContext(
  * downstream code to resolve guardian context using the same
  * `authContext.actorPrincipalId` path as HTTP sessions.
  */
-export function resolveLocalAuthContext(sessionId: string): AuthContext {
-  const authContext = buildLocalAuthContext(sessionId);
+export function resolveLocalAuthContext(conversationId: string): AuthContext {
+  const authContext = buildLocalAuthContext(conversationId);
 
   // Enrich with the guardian principal ID from contacts-first path
   const guardianResult = findGuardianForChannel("vellum");

--- a/gateway/src/auth/subject.ts
+++ b/gateway/src/auth/subject.ts
@@ -17,7 +17,7 @@ export type ParseSubResult =
       principalType: PrincipalType;
       assistantId: string;
       actorPrincipalId?: string;
-      sessionId?: string;
+      conversationId?: string;
     }
   | { ok: false; reason: string };
 
@@ -32,7 +32,7 @@ export type ParseSubResult =
  *   actor:<assistantId>:<actorPrincipalId>
  *   svc:gateway:<assistantId>
  *   svc:daemon:<identifier>
- *   local:<assistantId>:<sessionId>
+ *   local:<assistantId>:<conversationId>
  */
 export function parseSub(sub: string): ParseSubResult {
   if (!sub || typeof sub !== "string") {
@@ -69,14 +69,14 @@ export function parseSub(sub: string): ParseSubResult {
   }
 
   if (parts[0] === "local" && parts.length === 3) {
-    const [, assistantId, sessionId] = parts;
-    if (!assistantId || !sessionId) {
+    const [, assistantId, conversationId] = parts;
+    if (!assistantId || !conversationId) {
       return {
         ok: false,
-        reason: "local sub has empty assistantId or sessionId",
+        reason: "local sub has empty assistantId or conversationId",
       };
     }
-    return { ok: true, principalType: "local", assistantId, sessionId };
+    return { ok: true, principalType: "local", assistantId, conversationId };
   }
 
   return { ok: false, reason: `unrecognized sub pattern: ${sub}` };

--- a/gateway/src/auth/token-exchange.ts
+++ b/gateway/src/auth/token-exchange.ts
@@ -78,7 +78,7 @@ export function mintExchangeToken(
         exchangeSub = "svc:gateway:self";
         break;
       case "local":
-        exchangeSub = `local:self:${parsed.sessionId}`;
+        exchangeSub = `local:self:${parsed.conversationId}`;
         break;
       default:
         exchangeSub = "svc:gateway:self";

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -73,7 +73,7 @@ export interface AuthContext {
   principalType: PrincipalType;
   assistantId: string;
   actorPrincipalId?: string;
-  sessionId?: string;
+  conversationId?: string;
   scopeProfile: ScopeProfile;
   scopes: ReadonlySet<Scope>;
   policyEpoch: number;


### PR DESCRIPTION
## Summary
- Rename `AuthContext.sessionId` → `AuthContext.conversationId` in both assistant and gateway auth types
- Rename `ParseSubResult.sessionId` → `ParseSubResult.conversationId` in gateway subject parser
- Rename `buildLocalAuthContext` parameter from `sessionId` to `conversationId`
- Update all consumers: token exchange, context builder, tests

Part of plan: conv-rename-remaining.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
