### PR TITLE
fix: show static name fallback on Identity panel when daemon intro unavailable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -48,16 +48,14 @@ struct IdentityPanel: View {
                 if !isFullscreen {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
-                            // Daemon-generated intro heading (nil = loading, shows nothing)
-                            if let introText {
-                                Text(introText)
-                                    .font(.system(size: 22, weight: .regular, design: .rounded))
-                                    .foregroundColor(VColor.contentDefault)
-                                    .multilineTextAlignment(.center)
-                                    .frame(maxWidth: .infinity, alignment: .center)
-                                    .padding(.top, VSpacing.xxl)
-                                    .padding(.horizontal, VSpacing.lg)
-                            }
+                            // Intro heading — show daemon-generated text, fall back to static name
+                            Text(introText ?? "I'm \(assistantDisplayName)!")
+                                .font(.system(size: 22, weight: .regular, design: .rounded))
+                                .foregroundColor(VColor.contentDefault)
+                                .multilineTextAlignment(.center)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, VSpacing.xxl)
+                                .padding(.horizontal, VSpacing.lg)
 
                             Spacer()
 


### PR DESCRIPTION
## Summary
- The Identity panel's name display was conditional on a successful daemon LLM call (`sendBtwMessage`), which can fail or be delayed if the daemon isn't connected yet when the panel renders
- Changed from `if let introText { Text(introText) }` to `Text(introText ?? "I'm \(assistantDisplayName)!")` so the name always renders immediately
- The daemon-generated intro still takes over once available, but the user sees the assistant's name right away instead of a blank space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
