### PR TITLE
feat: make /update skill branch-aware for local development

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,14 +1,23 @@
 ---
 name: update
 description: >
-  Pull latest from main (or a specified branch), use vellum ps/sleep/wake to manage assistant and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
+  Restart Vellum services and rebuild the macOS app. Smart branch handling: pulls from main by default, restarts in-place on feature branches, or switches to a specified branch. Pass --pull to force-pull on the current branch.
 ---
 
-# Update — Pull Latest and Restart Vellum
+# Update — Restart Vellum (with Smart Branch Handling)
 
-Pull the latest changes from main (or a specified branch), use `vellum` lifecycle CLI to stop and restart processes, rebuild/launch the macOS app.
+Restart Vellum services and rebuild the macOS app with branch-aware git behavior.
 
-The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-setup`). If provided, check out and pull that branch instead of `main`. If not provided, default to `main`.
+## Arguments
+
+The user may pass `$ARGUMENTS` to control branch behavior:
+
+| Invocation | Behavior |
+|---|---|
+| `/update` (no args, on `main`) | Pull latest from `origin/main` (default) |
+| `/update` (no args, on a feature branch) | Skip git ops — restart with the current checkout |
+| `/update <branch>` | Check out that branch, pull if it has a remote |
+| `/update --pull` | Force pull on whatever branch you're currently on |
 
 ## Steps
 
@@ -47,19 +56,55 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
    ```
    After fallback cleanup, run `vellum ps` again to confirm all processes are stopped.
 
-5. Determine the target branch and switch to it:
+5. Smart branch handling — determine what git operations (if any) to perform:
 
    ```bash
-   BRANCH="${ARGUMENTS:-main}"
-   git fetch origin "$BRANCH"
-   git checkout "$BRANCH"
-   git pull origin "$BRANCH"
+   CURRENT=$(git branch --show-current)
+   GIT_OPS_RAN=false
    ```
 
-6. Install any new dependencies:
+   **Case A — `--pull` flag:** Force pull on the current branch.
    ```bash
-   cd assistant && bun install && cd ..
-   cd gateway && bun install && cd ..
+   if [[ "$ARGUMENTS" == "--pull" ]]; then
+     git pull
+     GIT_OPS_RAN=true
+   fi
+   ```
+
+   **Case B — Explicit branch name provided:** Check out the requested branch, pulling if possible. Before checking out, verify the working tree is clean — if there are uncommitted changes, **stop and warn the user** rather than silently losing work. Do NOT stash automatically.
+   ```bash
+   if [[ -n "$ARGUMENTS" && "$ARGUMENTS" != "--pull" ]]; then
+     if ! git diff --quiet || ! git diff --cached --quiet; then
+       echo "ERROR: Uncommitted changes detected. Commit or stash them before switching branches."
+       # Stop and report the error to the user. Do not proceed.
+     fi
+     git checkout "$ARGUMENTS"
+     git pull origin "$ARGUMENTS" 2>/dev/null || true
+     GIT_OPS_RAN=true
+   fi
+   ```
+
+   **Case C — No args, on `main`:** Pull latest from origin (preserves current default behavior).
+   ```bash
+   if [[ -z "$ARGUMENTS" && "$CURRENT" == "main" ]]; then
+     git pull origin main
+     GIT_OPS_RAN=true
+   fi
+   ```
+
+   **Case D — No args, on a feature branch:** Skip git ops entirely — just restart with the current checkout.
+   ```bash
+   if [[ -z "$ARGUMENTS" && "$CURRENT" != "main" ]]; then
+     echo "On branch '$CURRENT' — skipping git pull, restarting with current checkout"
+   fi
+   ```
+
+6. Install dependencies — only if git operations ran (dependencies are unlikely to have changed for a local-only restart):
+   ```bash
+   if [[ "$GIT_OPS_RAN" == "true" ]]; then
+     cd assistant && bun install && cd ..
+     cd gateway && bun install && cd ..
+   fi
    ```
 
 7. Restart with `vellum wake` — start assistant and gateway from the current checkout. `vellum wake` must be run from the checkout directory that should supply the new assistant code:
@@ -88,9 +133,11 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
    echo "======================="
    ```
 
-Report:
+## Report
 
-1. What was pulled (new commits).
-2. The startup summary block output (assistant health, gateway health).
-3. Whether the macOS app build succeeded or failed (and the error if it failed).
-4. Note: the macOS app manages its own assistant and gateway. On first launch, the app will hatch and start them automatically.
+Tailor the report to what actually happened:
+
+- **If git pulled (Cases A, B, C):** Report what was pulled (new commits), the branch, and whether dependencies were updated.
+- **If restarted in-place (Case D):** Report that services were restarted on the current branch with no git changes.
+- **Always include:** The startup summary block output (assistant health, gateway health), whether the macOS app build succeeded or failed (and the error if it failed).
+- Note: the macOS app manages its own assistant and gateway. On first launch, the app will hatch and start them automatically.


### PR DESCRIPTION
## Summary
- Make the `/update` skill branch-aware: when on `main` with no args it pulls from origin (preserving current behavior), but when on a feature branch it skips git ops and just restarts services with the current checkout
- Add `--pull` flag to force-pull on whatever branch you're on, and a dirty working tree guard that warns before switching branches with uncommitted changes
- Make `bun install` conditional — only runs when git operations actually pulled new code, skipping it for local-only restarts

## Original prompt
Improve the `/update` skill to be more compatible with testing local branches

## Test plan
- [ ] Run `/update` on `main` — should pull from origin and restart (existing behavior preserved)
- [ ] Run `/update` on a feature branch — should skip git ops and restart in-place
- [ ] Run `/update some-branch` — should checkout and pull that branch
- [ ] Run `/update --pull` on a feature branch — should force pull on current branch
- [ ] Run `/update some-branch` with uncommitted changes — should warn and stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
