### PR TITLE
fix: sync canonical guardian request on auto-deny

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -16,7 +16,10 @@ mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 import { createGuardianBinding } from "../contacts/contacts-write.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import { createCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import {
+  createCanonicalGuardianRequest,
+  getCanonicalGuardianRequest,
+} from "../memory/canonical-guardian-store.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 
 const testDir = realpathSync(
@@ -880,6 +883,62 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       }),
     });
     expect(res.status).toBe(400);
+
+    await stopServer();
+  });
+
+  test("auto-deny resolves canonical guardian request so stale records do not cause pending_interaction_not_found", async () => {
+    const conversationKey = "conv-auto-deny-canonical";
+    const { conversationId } = getOrCreateConversation(conversationKey);
+    const requestId = "req-auto-deny-canonical";
+
+    // Step 1: Create a pending approval conversation with a canonical request.
+    const { conversation, denyAllPendingConfirmationsMock } =
+      makePendingApprovalConversation(requestId, false);
+
+    pendingInteractions.register(requestId, {
+      conversation,
+      conversationId,
+      kind: "confirmation",
+    });
+    createCanonicalGuardianRequest({
+      id: requestId,
+      kind: "tool_approval",
+      sourceType: "desktop",
+      sourceChannel: "vellum",
+      conversationId,
+      toolName: "bash",
+      guardianPrincipalId: "test-principal-id",
+      status: "pending",
+      requestCode: "STALE1",
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    });
+
+    await startServer(() => conversation);
+
+    // Step 2: Send a non-approval message to trigger auto-deny of the
+    // pending confirmation. "do something else" is not an approval phrase,
+    // so tryConsumeCanonicalGuardianReply won't consume it, and the
+    // auto-deny path will fire.
+    const res = await fetch(messagesUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey,
+        content: "do something else instead",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+    expect(res.status).toBe(202);
+    expect(denyAllPendingConfirmationsMock).toHaveBeenCalledTimes(1);
+
+    // Step 3: Verify the canonical guardian request was resolved to "denied".
+    // Without the fix, this would remain "pending", causing
+    // pending_interaction_not_found errors on subsequent "yes" messages.
+    const canonicalRequest = getCanonicalGuardianRequest(requestId);
+    expect(canonicalRequest).toBeDefined();
+    expect(canonicalRequest!.status).toBe("denied");
 
     await stopServer();
   });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -35,6 +35,7 @@ import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
   listPendingRequestsByConversationScope,
+  resolveCanonicalGuardianRequest,
 } from "../../memory/canonical-guardian-store.js";
 import {
   addMessage,
@@ -811,6 +812,11 @@ export async function handleSendMessage(
             state: "denied" as const,
             source: "auto_deny" as const,
           });
+          // Sync canonical guardian request status so stale "pending" DB
+          // records don't get matched by later guardian reply routing.
+          resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
+            status: "denied",
+          });
         }
       }
       conversation.denyAllPendingConfirmations();
@@ -841,6 +847,11 @@ export async function handleSendMessage(
           requestId: interaction.requestId,
           state: "denied" as const,
           source: "auto_deny" as const,
+        });
+        // Sync canonical guardian request status so stale "pending" DB
+        // records don't get matched by later guardian reply routing.
+        resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
+          status: "denied",
         });
       }
     }


### PR DESCRIPTION
## Summary
- When a new user message auto-denies pending confirmations, the in-memory pending interaction was cleared but the canonical guardian request in the DB stayed `"pending"`. Later, if the user sent "yes" to an unrelated conversational question, the guardian reply router would find the orphaned canonical request, apply the CAS successfully, but fail to find the pending interaction — producing the error: "Decision recorded but could not be completed: pending_interaction_not_found".
- Fix: call `resolveCanonicalGuardianRequest()` to mark the canonical request as `"denied"` in both auto-deny paths (busy-session queuing and idle-session new-turn).
- Added a regression test that verifies canonical request status is synced to `"denied"` after auto-deny.

## Test plan
- [x] Existing `send-endpoint-busy.test.ts` tests pass (13/13)
- [x] New test: `auto-deny resolves canonical guardian request so stale records do not cause pending_interaction_not_found`
- [ ] Manual: trigger a tool approval prompt in the desktop app, send a non-approval message to auto-deny it, then send "yes" — should no longer show the `pending_interaction_not_found` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
