### PR TITLE
fix: update remaining stale session/thread comments in auth, CES, and docs

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1719,13 +1719,13 @@ graph TB
 
 Every event published through the hub is wrapped in an `AssistantEvent` (defined in `runtime/assistant-event.ts`):
 
-| Field         | Type                | Description                                           |
-| ------------- | ------------------- | ----------------------------------------------------- |
-| `id`          | `string` (UUID)     | Globally unique event identifier                      |
-| `assistantId` | `string`            | Logical assistant identifier (`"self"` for HTTP runs) |
-| `sessionId`   | `string?`           | Resolved conversation ID when available               |
-| `emittedAt`   | `string` (ISO-8601) | Server-side timestamp                                 |
-| `message`     | `ServerMessage`     | The outbound message payload                          |
+| Field            | Type                | Description                                           |
+| ---------------- | ------------------- | ----------------------------------------------------- |
+| `id`             | `string` (UUID)     | Globally unique event identifier                      |
+| `assistantId`    | `string`            | Logical assistant identifier (`"self"` for HTTP runs) |
+| `conversationId` | `string?`           | Resolved conversation ID when available               |
+| `emittedAt`      | `string` (ISO-8601) | Server-side timestamp                                 |
+| `message`        | `ServerMessage`     | The outbound message payload                          |
 
 ### SSE Frame Format
 

--- a/assistant/src/runtime/auth/subject.ts
+++ b/assistant/src/runtime/auth/subject.ts
@@ -2,7 +2,7 @@
  * Sub (subject) pattern parser for JWT tokens.
  *
  * The sub claim encodes principal type, assistant scope, and optional
- * actor/session identifiers in a colon-delimited string.
+ * actor/conversation identifiers in a colon-delimited string.
  */
 
 import type { PrincipalType } from "./types.js";

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -107,7 +107,7 @@ export interface ExecuteCommandRequest {
   purpose: string;
   /** Explicit grant ID to consume, if the caller holds one. */
   grantId?: string;
-  /** Conversation ID for thread-scoped temporary grants. */
+  /** Conversation ID for conversation-scoped temporary grants. */
   conversationId?: string;
 }
 

--- a/credential-executor/src/http/policy.ts
+++ b/credential-executor/src/http/policy.ts
@@ -91,7 +91,7 @@ export interface HttpPolicyRequest {
   purpose: string;
   /** Explicit grant ID the caller claims to hold. */
   grantId?: string;
-  /** Conversation ID for thread-scoped temporary grants. */
+  /** Conversation ID for conversation-scoped temporary grants. */
   conversationId?: string;
 }
 

--- a/gateway/src/auth/subject.ts
+++ b/gateway/src/auth/subject.ts
@@ -2,7 +2,7 @@
  * Sub (subject) pattern parser for JWT tokens.
  *
  * The sub claim encodes principal type, assistant scope, and optional
- * actor/session identifiers in a colon-delimited string.
+ * actor/conversation identifiers in a colon-delimited string.
  */
 
 import type { PrincipalType } from "./types.js";

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -17,7 +17,7 @@
  * - `record_grant` — Record a grant decision after guardian approval
  *
  * **Grant management**
- * - `list_grants` — List grants for a session
+ * - `list_grants` — List grants for a CES connection
  * - `revoke_grant` — Revoke a specific grant
  *
  * **Audit**
@@ -75,7 +75,7 @@ export const MakeAuthenticatedRequestSchema = z.object({
   purpose: z.string(),
   /** Existing grant ID to consume, if the caller holds one. */
   grantId: z.string().optional(),
-  /** Conversation ID for thread-scoped temporary grants. */
+  /** Conversation ID for conversation-scoped temporary grants. */
   conversationId: z.string().optional(),
 });
 export type MakeAuthenticatedRequest = z.infer<
@@ -138,7 +138,7 @@ export const RunAuthenticatedCommandSchema = z.object({
   purpose: z.string(),
   /** Existing grant ID to consume, if the caller holds one. */
   grantId: z.string().optional(),
-  /** Conversation ID for thread-scoped temporary grants. */
+  /** Conversation ID for conversation-scoped temporary grants. */
   conversationId: z.string().optional(),
 });
 export type RunAuthenticatedCommand = z.infer<


### PR DESCRIPTION
## Summary
- Fix stale "actor/session identifiers" in subject.ts module docs (both assistant and gateway copies)
- Fix "thread-scoped" → "conversation-scoped" in CES contracts and credential-executor comments
- Fix "List grants for a session" → "List grants for a CES connection" in rpc.ts module docs
- Fix stale `sessionId` → `conversationId` in ARCHITECTURE.md AssistantEvent envelope table

Fixes gaps identified during plan review for conv-rename-remaining.md.

Generated with [Claude Code](https://claude.com/claude-code)