### PR TITLE
revert: remove non-functional processName dock tooltip approach

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -123,7 +123,6 @@ final class AvatarAppearanceManager {
         loadAvatarComponents()
         watchAvatarFile()
         watchTraitsFile()
-        updateDockName()
 
         // Fire-and-forget: fetch character component definitions from the
         // daemon and populate AvatarComponentStore.shared so downstream
@@ -152,7 +151,6 @@ final class AvatarAppearanceManager {
                 self.cachedFallbackName = nil
                 self.cachedFullFallbackAvatar = nil
                 self.cachedFullFallbackName = nil
-                self.updateDockName()
             }
         }
     }
@@ -250,8 +248,6 @@ final class AvatarAppearanceManager {
     /// bundle icon without deleting any files on disk.
     /// Called during logout, retire, and switch-assistant flows.
     func resetForDisconnect() {
-        assistantName = "V"
-        updateDockName()
         customAvatarImage = nil
         characterBodyShape = nil
         characterEyeStyle = nil
@@ -454,19 +450,7 @@ final class AvatarAppearanceManager {
         source.resume()
     }
 
-    // MARK: - Dock Name & Icon
-
-    /// Updates the process name so the dock tooltip shows the assistant's name
-    /// instead of the static "Vellum". Falls back to "Vellum" when no real
-    /// assistant name is available (placeholder, bootstrap sentinel, or initial).
-    private func updateDockName() {
-        let name = assistantName
-        if name == "V" || name == AssistantDisplayName.placeholder {
-            ProcessInfo.processInfo.processName = "Vellum"
-        } else {
-            ProcessInfo.processInfo.processName = name
-        }
-    }
+    // MARK: - Dock Icon
 
     /// Updates the application dock icon to match the current avatar.
     /// When a custom avatar exists, renders it inside a macOS-style squircle mask.


### PR DESCRIPTION
## Summary
- Reverts the `updateDockName()` / `ProcessInfo.processInfo.processName` approach from PR #17805
- `processName` does not control the macOS dock tooltip — the tooltip comes from `CFBundleDisplayName`/`CFBundleName` in the app bundle's Info.plist, which cannot be changed at runtime due to code signing
- Removes all dead code: the `updateDockName()` method and its three call sites (start, identityChanged observer, resetForDisconnect)

## Original prompt
Revert the non-functional `updateDockName()` / `ProcessInfo.processInfo.processName` approach from PR #17805, and replace it with a working alternative that actually updates the dock tooltip to show the assistant's name. Research confirmed there is no reliable public API to change the dock tooltip at runtime on macOS — the text comes from bundle metadata that is immutable after code signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
