### PR TITLE
Move Save button from file header to sticky footer bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -733,7 +733,26 @@ private struct WorkspaceFileViewer: View {
                     Text("Read-only")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
-                } else if isText && state.isDirty {
+                }
+            }
+            Divider().background(VColor.borderBase)
+
+            if isText {
+                textViewer(detail, readOnly: readOnly)
+            } else if mime.hasPrefix("image/") {
+                imageViewer(detail)
+            } else if mime.hasPrefix("video/") {
+                videoViewer(detail)
+            } else if !detail.isBinary, detail.content == nil {
+                fileTooLarge(detail)
+            } else {
+                binaryFallback(detail)
+            }
+
+            if isText && !readOnly && state.isDirty {
+                Divider().background(VColor.borderBase)
+                HStack {
+                    Spacer()
                     HStack(spacing: VSpacing.xs) {
                         if state.isSaving {
                             VBusyIndicator(size: 8)
@@ -749,19 +768,9 @@ private struct WorkspaceFileViewer: View {
                         .keyboardShortcut("s", modifiers: .command)
                     }
                 }
-            }
-            Divider().background(VColor.borderBase)
-
-            if isText {
-                textViewer(detail, readOnly: readOnly)
-            } else if mime.hasPrefix("image/") {
-                imageViewer(detail)
-            } else if mime.hasPrefix("video/") {
-                videoViewer(detail)
-            } else if !detail.isBinary, detail.content == nil {
-                fileTooLarge(detail)
-            } else {
-                binaryFallback(detail)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.surfaceOverlay)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove Save button from the file header trailing content
- Add a sticky footer bar at the bottom of the file content area that appears when the file has unsaved changes
- Footer is right-aligned with a busy indicator during save operations
- Cmd+S keyboard shortcut preserved

Part of plan: file-viewer-ux-polish.md (PR 4 of 5)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
