### PR TITLE
Default file viewer to Preview mode for markdown and JSON files

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -45,7 +45,14 @@ final class WorkspaceBrowserState {
 
     func loadFile(path targetPath: String, using workspaceClient: any WorkspaceClientProtocol) async {
         selectedFilePath = targetPath
-        viewMode = .source
+        let ext = (targetPath as NSString).pathExtension.lowercased()
+        if ext == "md" || ext == "markdown" {
+            viewMode = .preview
+        } else if ext == "json" {
+            viewMode = .tree
+        } else {
+            viewMode = .source
+        }
         isLoadingFile = true
         selectedFileDetail = nil
         isDirty = false
@@ -60,12 +67,6 @@ final class WorkspaceBrowserState {
             isDirty = false
             isSaving = false
             isLoadingFile = false
-
-            // Default read-only markdown files to preview mode
-            let ext = (targetPath as NSString).pathExtension.lowercased()
-            if (ext == "md" || ext == "markdown") && isHiddenPath(targetPath) {
-                viewMode = .preview
-            }
         }
         fileLoadTask = task
     }


### PR DESCRIPTION
## Summary
- Default markdown files to Preview mode (MarkdownPreviewView) instead of Source
- Default JSON files to Tree/Preview mode (JSONTreeView) instead of Source
- Remove old hidden-path-only auto-preview logic in favor of universal default

Part of plan: file-viewer-ux-polish.md (PR 2 of 5)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
