### PR TITLE
Reduce view mode toggle width from 80pt to 60pt per segment

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -725,7 +725,7 @@ private struct WorkspaceFileViewer: View {
                             selection: $state.viewMode,
                             style: .pill
                         )
-                        .frame(width: CGFloat(modes.count) * 80)
+                        .frame(width: CGFloat(modes.count) * 60)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Shrink VSegmentedControl toggle width from 80pt to 60pt per segment for a more proportional appearance

Part of plan: file-viewer-ux-polish.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
