### PR TITLE
Reorder view modes (Preview first) and rename Tree to Preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -13,10 +13,10 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
     let ext = (fileName as NSString).pathExtension.lowercased()
     let mime = mimeType.lowercased()
     if ext == "md" || ext == "markdown" || mime == "text/markdown" {
-        return [.source, .preview]
+        return [.preview, .source]
     }
     if ext == "json" || mime == "application/json" {
-        return [.source, .tree]
+        return [.tree, .source]
     }
     return [.source]
 }
@@ -25,7 +25,7 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
     switch mode {
     case .source: return "Source"
     case .preview: return "Preview"
-    case .tree: return "Tree"
+    case .tree: return "Preview"
     }
 }
 


### PR DESCRIPTION
## Summary
- Reorder availableViewModes to return Preview/Tree before Source for markdown and JSON files
- Rename the Tree view mode label to Preview for consistent user-facing terminology

Part of plan: file-viewer-ux-polish.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
