### PR TITLE
refactor: fix session→conversation in Swift client comments and slash command help

### DIFF
--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -377,7 +377,7 @@ export async function resolveSlash(
       "/pair — Generate pairing info for connecting a mobile device",
     ];
     if (context) {
-      lines.push("/status — Show session status and context usage");
+      lines.push("/status — Show conversation status and context usage");
     }
     return {
       kind: "unknown",

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -25,7 +25,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         self.settingsStore = settingsStore
     }
 
-    /// Sends a notification when a session completes.
+    /// Sends a notification when a conversation completes.
     /// - Only sends if notifications are enabled in settings
     /// - Only sends if app is in background
     /// - Only sends if notification permissions are granted
@@ -35,7 +35,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         toolCalls: [ToolCallData],
         conversationId: String
     ) async {
-        log.info("notifyConversationComplete called for session \(conversationId, privacy: .public)")
+        log.info("notifyConversationComplete called for conversation \(conversationId, privacy: .public)")
 
         // Check if notifications enabled in settings
         guard settingsStore.activityNotificationsEnabled else {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -232,7 +232,7 @@ extension ConversationCreateRequest {
     }
 }
 
-/// Sent to add a user message to an existing Q&A session.
+/// Sent to add a user message to an existing conversation.
 /// Backed by generated `UserMessage`.
 public typealias UserMessageMessage = UserMessage
 
@@ -459,7 +459,7 @@ extension RegenerateRequest {
     }
 }
 
-/// Sent to request message history for a specific session.
+/// Sent to request message history for a specific conversation.
 /// Backed by generated `HistoryRequest`.
 public typealias HistoryRequestMessage = HistoryRequest
 
@@ -825,7 +825,7 @@ public typealias DocumentListResponseMessage = DocumentListResponse
 public typealias UndoCompleteMessage = UndoComplete
 
 /// Confirms generation was cancelled.
-/// Kept hand-maintained — the Swift type includes `conversationId` for session
+/// Kept hand-maintained — the Swift type includes `conversationId` for conversation
 /// filtering, which the TS contract does not define for this message type.
 public struct GenerationCancelledMessage: Decodable, Sendable {
     public let conversationId: String?
@@ -1537,7 +1537,7 @@ public struct HostCuResultPayload: Codable, Sendable {
 public typealias AssistantActivityStateMessage = AssistantActivityState
 
 
-/// Request a follow-up suggestion for the current session.
+/// Request a follow-up suggestion for the current conversation.
 /// Backed by generated `SuggestionRequest`.
 public typealias SuggestionRequestMessage = SuggestionRequest
 
@@ -2061,7 +2061,7 @@ public struct SubagentAbortMessage: Encodable, Sendable {
     }
 }
 
-/// Wraps any ServerMessage emitted by a subagent session for routing to the client.
+/// Wraps any ServerMessage emitted by a subagent conversation for routing to the client.
 /// Hand-maintained because `event` is a recursive `ServerMessage` reference (codegen skips ServerMessage).
 /// Wire type: `"subagent_event"`
 public struct SubagentEventMessage: Decodable, Sendable {


### PR DESCRIPTION
## Summary
- Update Swift doc comments in MessageTypes.swift from session to conversation terminology
- Fix log string in ActivityNotificationService.swift
- Update /status slash command help text in conversation-slash.ts

Part of plan: conv-rename-final.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
