### PR TITLE
refactor: rename sessionId→conversationId in CES approval bridge options

### DIFF
--- a/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
+++ b/assistant/src/__tests__/credential-execution-approval-bridge.test.ts
@@ -176,7 +176,7 @@ describe("CES approval bridge", () => {
 
       const result = await bridgeCesApproval(approval, prompter, cesClient, {
         isInteractive: true,
-        sessionId: "session-1",
+        conversationId: "session-1",
       });
 
       expect(result.outcome).toBe("approved");
@@ -203,7 +203,7 @@ describe("CES approval bridge", () => {
 
       await bridgeCesApproval(approval, prompter, cesClient, {
         isInteractive: true,
-        sessionId: "session-1",
+        conversationId: "session-1",
       });
 
       expect(prompter.promptCalls.length).toBe(1);

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -167,8 +167,8 @@ export async function bridgeCesApproval(
   options?: {
     /** Whether an interactive client is connected. When false, auto-deny. */
     isInteractive?: boolean;
-    /** Session ID for the confirmation prompt. */
-    sessionId?: string;
+    /** Conversation ID for the confirmation prompt. */
+    conversationId?: string;
     /** Abort signal for cooperative cancellation. */
     signal?: AbortSignal;
   },
@@ -221,7 +221,7 @@ export async function bridgeCesApproval(
     [], // No scope options — CES manages scope internally
     undefined, // No file diff
     undefined, // Not sandboxed
-    options?.sessionId,
+    options?.conversationId,
     "host", // CES operations target the host
     false, // Persistent decisions are managed by CES, not trust.json
     options?.signal,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -259,7 +259,7 @@ export class ToolExecutor {
           context.cesClient,
           {
             isInteractive: context.isInteractive,
-            sessionId: context.conversationId,
+            conversationId: context.conversationId,
             signal: context.signal,
           },
         );


### PR DESCRIPTION
## Summary
- Rename options.sessionId to options.conversationId in bridgeCesApproval function
- Update caller in executor.ts to pass conversationId instead of sessionId
- Update test file to use the renamed option
- CES transport sessionId (approval.sessionId) intentionally left unchanged

Part of plan: conv-rename-final.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
