### PR TITLE
refactor: rename sessionId→conversationId in watch tool and shotgun signal

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -273,8 +273,8 @@ mock.module("../calls/call-store.js", () => ({
 }));
 
 mock.module("../daemon/watch-handler.js", () => ({
-  lastCommentaryBySession: new Map(),
-  lastSummaryBySession: new Map(),
+  lastCommentaryByConversation: new Map(),
+  lastSummaryByConversation: new Map(),
 }));
 
 mock.module("../tools/browser/browser-screencast.js", () => ({

--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -36,8 +36,8 @@ import {
 import type { TrustContext } from "./conversation-runtime-assembly.js";
 import type { ServerMessage } from "./message-protocol.js";
 import {
-  lastCommentaryBySession,
-  lastSummaryBySession,
+  lastCommentaryByConversation,
+  lastSummaryByConversation,
 } from "./watch-handler.js";
 
 /**
@@ -70,9 +70,9 @@ export function registerConversationNotifiers(
   });
 
   registerWatchCommentaryNotifier(conversationId, (_session: WatchSession) => {
-    const commentary = lastCommentaryBySession.get(conversationId);
+    const commentary = lastCommentaryByConversation.get(conversationId);
     if (commentary) {
-      lastCommentaryBySession.delete(conversationId);
+      lastCommentaryByConversation.delete(conversationId);
       ctx.sendToClient({
         type: "assistant_text_delta",
         text: commentary,
@@ -86,9 +86,9 @@ export function registerConversationNotifiers(
   });
 
   registerWatchCompletionNotifier(conversationId, (_session: WatchSession) => {
-    const summary = lastSummaryBySession.get(conversationId);
+    const summary = lastSummaryByConversation.get(conversationId);
     if (summary) {
-      lastSummaryBySession.delete(conversationId);
+      lastSummaryByConversation.delete(conversationId);
       ctx.sendToClient({
         type: "assistant_text_delta",
         text: summary,

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -21,10 +21,10 @@ const log = getLogger("watch-handler");
 
 /**
  * Module-level maps to store commentary/summary text so that session
- * notifier callbacks can retrieve it from the WatchSession's sessionId.
+ * notifier callbacks can retrieve it from the WatchSession's conversationId.
  */
-export const lastCommentaryBySession = new Map<string, string>();
-export const lastSummaryBySession = new Map<string, string>();
+export const lastCommentaryByConversation = new Map<string, string>();
+export const lastSummaryByConversation = new Map<string, string>();
 
 export async function handleWatchObservation(
   msg: WatchObservation,
@@ -76,7 +76,7 @@ export async function handleWatchObservation(
         totalObservations: session.observations.length,
         status: session.status,
       },
-      "Observation added to session",
+      "Observation added to watch session",
     );
 
     // 4. Every 3 observations: call the LLM for live commentary
@@ -92,7 +92,7 @@ export async function handleWatchObservation(
     if (session.status === "completing") {
       log.debug(
         { watchId: msg.watchId },
-        "Session is completing — generating summary from observation handler",
+        "Watch session completing — generating summary from observation handler",
       );
       session.status = "completed";
       await generateSummary(session);
@@ -116,7 +116,9 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       return;
     }
     const lastThree = session.observations.slice(-3);
-    const previousCommentary = lastCommentaryBySession.get(session.sessionId);
+    const previousCommentary = lastCommentaryByConversation.get(
+      session.conversationId,
+    );
 
     const userContent = [
       `Focus area: ${session.focusArea}`,
@@ -165,8 +167,8 @@ async function generateCommentary(session: WatchSession): Promise<void> {
     const commentaryText = extractText(response);
 
     if (commentaryText && commentaryText !== "SKIP") {
-      lastCommentaryBySession.set(session.sessionId, commentaryText);
-      fireWatchCommentaryNotifier(session.sessionId, session);
+      lastCommentaryByConversation.set(session.conversationId, commentaryText);
+      fireWatchCommentaryNotifier(session.conversationId, session);
       session.commentaryCount++;
     }
   } catch (err) {
@@ -192,7 +194,7 @@ export async function generateSummary(session: WatchSession): Promise<void> {
     log.debug(
       {
         watchId: session.watchId,
-        sessionId: session.sessionId,
+        conversationId: session.conversationId,
         observationCount: session.observations.length,
         commentaryCount: session.commentaryCount,
       },
@@ -204,11 +206,11 @@ export async function generateSummary(session: WatchSession): Promise<void> {
         { watchId: session.watchId },
         "Configured provider unavailable for summary generation",
       );
-      lastSummaryBySession.set(
-        session.sessionId,
+      lastSummaryByConversation.set(
+        session.conversationId,
         "[error] Configured provider unavailable. Check your settings.",
       );
-      fireWatchCompletionNotifier(session.sessionId, session);
+      fireWatchCompletionNotifier(session.conversationId, session);
       return;
     }
 
@@ -321,22 +323,22 @@ export async function generateSummary(session: WatchSession): Promise<void> {
     );
 
     if (summaryText) {
-      lastSummaryBySession.set(session.sessionId, summaryText);
+      lastSummaryByConversation.set(session.conversationId, summaryText);
       log.debug(
-        { watchId: session.watchId, sessionId: session.sessionId },
+        { watchId: session.watchId, conversationId: session.conversationId },
         "Firing completion notifier with summary",
       );
-      fireWatchCompletionNotifier(session.sessionId, session);
+      fireWatchCompletionNotifier(session.conversationId, session);
     } else {
       log.warn(
         { watchId: session.watchId },
         "Summary was empty from API response",
       );
-      lastSummaryBySession.set(
-        session.sessionId,
+      lastSummaryByConversation.set(
+        session.conversationId,
         "[error] The API returned an empty summary. This may indicate a service issue.",
       );
-      fireWatchCompletionNotifier(session.sessionId, session);
+      fireWatchCompletionNotifier(session.conversationId, session);
     }
   } catch (err) {
     log.error(
@@ -344,10 +346,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       "Error generating watch summary — LLM API call failed",
     );
     const message = err instanceof Error ? err.message : String(err);
-    lastSummaryBySession.set(
-      session.sessionId,
+    lastSummaryByConversation.set(
+      session.conversationId,
       `[error] Summary generation failed: ${message}`,
     );
-    fireWatchCompletionNotifier(session.sessionId, session);
+    fireWatchCompletionNotifier(session.conversationId, session);
   }
 }

--- a/assistant/src/signals/shotgun.ts
+++ b/assistant/src/signals/shotgun.ts
@@ -7,7 +7,7 @@
  * the result to `signals/shotgun.<requestId>.result` for the CLI to pick up.
  *
  * Supports two actions:
- * - `start`: Create a new watch session and return the watchId/sessionId.
+ * - `start`: Create a new watch session and return the watchId/conversationId.
  * - `status`: Query the status of an existing watch session by watchId.
  */
 
@@ -33,7 +33,7 @@ interface ShotgunResult {
   ok: boolean;
   error?: string;
   watchId?: string;
-  sessionId?: string;
+  conversationId?: string;
   status?: string;
 }
 
@@ -128,12 +128,12 @@ function handleStart(
       : "general observation";
 
   const watchId = crypto.randomUUID().slice(0, SHORT_HASH_LENGTH);
-  const sessionId = `shotgun-${watchId}`;
+  const conversationId = `shotgun-${watchId}`;
   const now = Date.now();
 
   const session: WatchSession = {
     watchId,
-    sessionId,
+    conversationId,
     focusArea,
     durationSeconds,
     intervalSeconds,
@@ -144,7 +144,7 @@ function handleStart(
   };
 
   watchSessions.set(watchId, session);
-  fireWatchStartNotifier(sessionId, session);
+  fireWatchStartNotifier(conversationId, session);
 
   session.timeoutHandle = setTimeout(() => {
     session.status = "completing";
@@ -153,11 +153,11 @@ function handleStart(
       { watchId, focusArea },
       "Shotgun session duration expired, marking as completing",
     );
-    fireWatchCompletionNotifier(sessionId, session);
+    fireWatchCompletionNotifier(conversationId, session);
   }, durationSeconds * 1000);
 
   log.info(
-    { watchId, sessionId, focusArea, durationSeconds, intervalSeconds },
+    { watchId, conversationId, focusArea, durationSeconds, intervalSeconds },
     "Shotgun watch session started via signal",
   );
 
@@ -165,7 +165,7 @@ function handleStart(
     requestId,
     ok: true,
     watchId,
-    sessionId,
+    conversationId,
   });
 }
 
@@ -194,7 +194,7 @@ function handleStatus(requestId: string, payload: { watchId?: string }): void {
     requestId,
     ok: true,
     watchId,
-    sessionId: session.sessionId,
+    conversationId: session.conversationId,
     status: session.status,
   });
 }

--- a/assistant/src/tools/watch/screen-watch.ts
+++ b/assistant/src/tools/watch/screen-watch.ts
@@ -52,7 +52,7 @@ class ScreenWatchTool implements Tool {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const { conversationId: sessionId } = context;
+    const { conversationId } = context;
 
     // Validate focus_area
     const focusArea =
@@ -78,7 +78,7 @@ class ScreenWatchTool implements Tool {
     intervalSeconds = Math.max(5, Math.min(30, intervalSeconds));
 
     // Check for existing active session
-    const existing = getActiveWatchSession(sessionId);
+    const existing = getActiveWatchSession(conversationId);
     if (existing) {
       return {
         content: `Error: An active watch session already exists for this conversation (watchId: ${existing.watchId}, focus: "${existing.focusArea}"). Cancel or wait for it to complete before starting a new one.`,
@@ -94,7 +94,7 @@ class ScreenWatchTool implements Tool {
     // Create session
     const session: WatchSession = {
       watchId,
-      sessionId,
+      conversationId,
       focusArea,
       durationSeconds,
       intervalSeconds,
@@ -108,7 +108,7 @@ class ScreenWatchTool implements Tool {
     watchSessions.set(watchId, session);
 
     // Fire start notifier
-    fireWatchStartNotifier(sessionId, session);
+    fireWatchStartNotifier(conversationId, session);
 
     // Set timeout for duration expiry
     session.timeoutHandle = setTimeout(() => {
@@ -118,11 +118,11 @@ class ScreenWatchTool implements Tool {
         { watchId, focusArea },
         "Watch session duration expired, marking as completing",
       );
-      fireWatchCompletionNotifier(sessionId, session);
+      fireWatchCompletionNotifier(conversationId, session);
     }, durationSeconds * 1000);
 
     log.info(
-      { watchId, sessionId, focusArea, durationMinutes, intervalSeconds },
+      { watchId, conversationId, focusArea, durationMinutes, intervalSeconds },
       "Screen watch session started",
     );
 

--- a/assistant/src/tools/watch/watch-state.ts
+++ b/assistant/src/tools/watch/watch-state.ts
@@ -13,7 +13,7 @@ export interface WatchObservationEntry {
 
 export interface WatchSession {
   watchId: string;
-  sessionId: string;
+  conversationId: string;
   focusArea: string;
   durationSeconds: number;
   intervalSeconds: number;
@@ -33,73 +33,80 @@ export const watchSessions = new Map<string, WatchSession>();
 const startNotifiers = new Map<string, (session: WatchSession) => void>();
 
 export function registerWatchStartNotifier(
-  sessionId: string,
+  conversationId: string,
   callback: (session: WatchSession) => void,
 ): void {
-  startNotifiers.set(sessionId, callback);
+  startNotifiers.set(conversationId, callback);
 }
 
-export function unregisterWatchStartNotifier(sessionId: string): void {
-  startNotifiers.delete(sessionId);
+export function unregisterWatchStartNotifier(conversationId: string): void {
+  startNotifiers.delete(conversationId);
 }
 
 export function fireWatchStartNotifier(
-  sessionId: string,
+  conversationId: string,
   session: WatchSession,
 ): void {
-  startNotifiers.get(sessionId)?.(session);
+  startNotifiers.get(conversationId)?.(session);
 }
 
 // ── Commentary notifiers ────────────────────────────────────────────
 const commentaryNotifiers = new Map<string, (session: WatchSession) => void>();
 
 export function registerWatchCommentaryNotifier(
-  sessionId: string,
+  conversationId: string,
   callback: (session: WatchSession) => void,
 ): void {
-  commentaryNotifiers.set(sessionId, callback);
+  commentaryNotifiers.set(conversationId, callback);
 }
 
-export function unregisterWatchCommentaryNotifier(sessionId: string): void {
-  commentaryNotifiers.delete(sessionId);
+export function unregisterWatchCommentaryNotifier(
+  conversationId: string,
+): void {
+  commentaryNotifiers.delete(conversationId);
 }
 
 export function fireWatchCommentaryNotifier(
-  sessionId: string,
+  conversationId: string,
   session: WatchSession,
 ): void {
-  commentaryNotifiers.get(sessionId)?.(session);
+  commentaryNotifiers.get(conversationId)?.(session);
 }
 
 // ── Completion notifiers ────────────────────────────────────────────
 const completionNotifiers = new Map<string, (session: WatchSession) => void>();
 
 export function registerWatchCompletionNotifier(
-  sessionId: string,
+  conversationId: string,
   callback: (session: WatchSession) => void,
 ): void {
-  completionNotifiers.set(sessionId, callback);
+  completionNotifiers.set(conversationId, callback);
 }
 
-export function unregisterWatchCompletionNotifier(sessionId: string): void {
-  completionNotifiers.delete(sessionId);
+export function unregisterWatchCompletionNotifier(
+  conversationId: string,
+): void {
+  completionNotifiers.delete(conversationId);
 }
 
 export function fireWatchCompletionNotifier(
-  sessionId: string,
+  conversationId: string,
   session: WatchSession,
 ): void {
-  completionNotifiers.get(sessionId)?.(session);
+  completionNotifiers.get(conversationId)?.(session);
 }
 
-// ── Session helpers ─────────────────────────────────────────────────
+// ── Conversation helpers ─────────────────────────────────────────────────
 
-/** Find the first active watch session for a given sessionId. */
+/** Find the first active watch session for a given conversationId. */
 export function getActiveWatchSession(
-  sessionId: string,
+  conversationId: string,
 ): WatchSession | undefined {
   for (const session of watchSessions.values()) {
-    if (session.sessionId === sessionId && session.status === "active") {
+    if (
+      session.conversationId === conversationId &&
+      session.status === "active"
+    ) {
       return session;
     }
   }
@@ -123,10 +130,10 @@ export function addObservation(
   );
 }
 
-/** Remove completed/cancelled sessions for a given sessionId. */
-export function pruneWatchSessions(sessionId: string): void {
+/** Remove completed/cancelled sessions for a given conversationId. */
+export function pruneWatchSessions(conversationId: string): void {
   for (const [watchId, session] of watchSessions) {
-    if (session.sessionId !== sessionId) continue;
+    if (session.conversationId !== conversationId) continue;
     if (session.status === "completed" || session.status === "cancelled") {
       if (session.timeoutHandle) clearTimeout(session.timeoutHandle);
       watchSessions.delete(watchId);


### PR DESCRIPTION
## Summary
- Rename WatchSession.sessionId to conversationId and update all notifier function parameters
- Rename lastCommentaryBySession/lastSummaryBySession maps to lastCommentaryByConversation/lastSummaryByConversation
- Rename ShotgunResult.sessionId to conversationId and update all local variables
- Update conversation-notifiers.ts and benchmark test to use renamed exports

Part of plan: conv-rename-final.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
