### PR TITLE
fix: address PR review — migration mode, managed default, setServiceField robustness

### DIFF
--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -13,9 +13,17 @@ export function setServiceField(
   field: string,
   value: unknown,
 ): void {
-  const services =
-    (raw.services as Record<string, Record<string, unknown>>) ?? {};
-  const svc = services[service] ?? {};
+  const services: Record<string, Record<string, unknown>> = raw.services !=
+    null &&
+  typeof raw.services === "object" &&
+  !Array.isArray(raw.services)
+    ? (raw.services as Record<string, Record<string, unknown>>)
+    : {};
+  const existing = services[service];
+  const svc: Record<string, unknown> =
+    existing != null && typeof existing === "object" && !Array.isArray(existing)
+      ? existing
+      : {};
   svc[field] = value;
   services[service] = svc;
   raw.services = services;

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { credentialKey } from "../../security/credential-key.js";
-import { getProviderKeyAsync, getSecureKeyAsync } from "../../security/secure-keys.js";
+import {
+  getProviderKeyAsync,
+  getSecureKeyAsync,
+} from "../../security/secure-keys.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const servicesConfigMigration: WorkspaceMigration = {
@@ -28,8 +31,23 @@ export const servicesConfigMigration: WorkspaceMigration = {
     // Determine inference mode
     let inferenceMode: "managed" | "your-own" = "your-own";
     try {
-      const userAnthropicKey = await getProviderKeyAsync("anthropic");
-      if (!userAnthropicKey) {
+      // Check if the user has ANY inference provider key configured.
+      // If so, keep "your-own" regardless of managed credentials.
+      const inferenceProviders = [
+        "anthropic",
+        "openai",
+        "gemini",
+        "fireworks",
+        "openrouter",
+      ];
+      let hasAnyUserKey = false;
+      for (const p of inferenceProviders) {
+        if (await getProviderKeyAsync(p)) {
+          hasAnyUserKey = true;
+          break;
+        }
+      }
+      if (!hasAnyUserKey) {
         const apiKey = await getSecureKeyAsync(
           credentialKey("vellum", "assistant_api_key"),
         );

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -317,19 +317,16 @@ extension AppDelegate {
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
 
-                // Set default inference mode to "managed" if not already configured
+                // After successful managed-proxy bootstrap, set inference mode to "managed".
+                // This overwrites the schema default ("your-own") that the daemon materializes
+                // on first load. If the user later switches mode in settings, setInferenceMode()
+                // will overwrite this value.
                 let existingConfig = WorkspaceConfigIO.read()
-                if let services = existingConfig["services"] as? [String: Any],
-                   let inference = services["inference"] as? [String: Any],
-                   inference["mode"] != nil {
-                    // Already configured — don't overwrite explicit user choice
-                } else {
-                    var services = existingConfig["services"] as? [String: Any] ?? [:]
-                    var inference = services["inference"] as? [String: Any] ?? [:]
-                    inference["mode"] = "managed"
-                    services["inference"] = inference
-                    try? WorkspaceConfigIO.merge(["services": services])
-                }
+                var services = existingConfig["services"] as? [String: Any] ?? [:]
+                var inference = services["inference"] as? [String: Any] ?? [:]
+                inference["mode"] = "managed"
+                services["inference"] = inference
+                try? WorkspaceConfigIO.merge(["services": services])
 
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -142,19 +142,16 @@ struct APIKeyEntryStepView: View {
         APIKeyManager.setKey(trimmed, for: "anthropic")
         APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
-        // Set default inference mode to "your-own" if not already configured
+        // After BYOK onboarding, set inference mode to "your-own".
+        // This overwrites the schema default that the daemon materializes on
+        // first load. If the user later switches mode in settings, setInferenceMode()
+        // will overwrite this value.
         let existingConfig = WorkspaceConfigIO.read()
-        if let services = existingConfig["services"] as? [String: Any],
-           let inference = services["inference"] as? [String: Any],
-           inference["mode"] != nil {
-            // Already configured
-        } else {
-            var services = existingConfig["services"] as? [String: Any] ?? [:]
-            var inference = services["inference"] as? [String: Any] ?? [:]
-            inference["mode"] = "your-own"
-            services["inference"] = inference
-            try? WorkspaceConfigIO.merge(["services": services])
-        }
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["mode"] = "your-own"
+        services["inference"] = inference
+        try? WorkspaceConfigIO.merge(["services": services])
 
         saveModelToConfig("claude-opus-4-6")
         state.isHatching = true


### PR DESCRIPTION
## Summary
Addresses three issues from PR #17927 review feedback:

1. **[P1] Migration mode inference**: Check ALL inference provider keys (not just Anthropic) before deciding managed mode. Users with OpenAI/Gemini/etc keys are no longer silently flipped to managed.

2. **[P1] Managed default persistence**: Make the managed-mode write unconditional after successful bootstrap. The previous conditional guard (`if mode != nil`) was always true because the daemon materializes schema defaults (including `mode: "your-own"`) before the Swift client runs, causing the managed write to no-op.

3. **[P2] setServiceField robustness**: Guard against malformed `raw.services` (e.g., user-edited bad JSON where `services` is a string instead of an object). Now replaces non-object values with `{}` instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
