### PR TITLE
refactor: replace user-facing 'daemon' references with 'assistant'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For low-level development (e.g., working on the assistant runtime itself):
 ```bash
 cd assistant
 bun install
-bun run src/index.ts daemon start
+bun run src/index.ts assistant start
 ```
 
 > **Note:** Some dependencies (`agentmail`, `@pydantic/logfire-node`) are optional at runtime but required for full `tsc --noEmit` type-checking to pass. They are installed automatically by `bun install`.

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1943,7 +1943,7 @@ function ChatApp({
             .update(hostname() + userInfo().username)
             .digest("hex");
           const payload = JSON.stringify({
-            type: "vellum-daemon",
+            type: "vellum-assistant",
             v: 4,
             id: hostId,
             g: gatewayUrl,

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -254,7 +254,7 @@ struct QRPairingSheet: View {
             return
         }
 
-        guard json["type"] as? String == "vellum-daemon" else {
+        guard json["type"] as? String == "vellum-assistant" || json["type"] as? String == "vellum-daemon" else {
             errorMessage = "This QR code isn't from Vellum."
             phase = .error
             return

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -25,7 +25,7 @@ enum VideoPlaybackFailure: Equatable {
     var userMessage: String {
         switch self {
         case .port_missing:
-            return "Reconnecting to daemon..."
+            return "Reconnecting to assistant..."
         case .fetch_failed(let detail):
             return detail.isEmpty ? "Could not fetch video" : detail
         case .invalid_media:

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 /// Displays a QR code containing the v4 connection payload for iOS pairing.
 ///
 /// v4 payload:
-/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","<redacted>":"<redacted>"}`
+/// `{"type":"vellum-assistant","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","<redacted>":"<redacted>"}`
 ///
 /// Key differences from v3:
 /// - No bearer token in QR code (secured by pairing secret + Mac approval)
@@ -58,7 +58,7 @@ struct PairingQRCodeSheet: View {
             }
 
             if daemonClient == nil {
-                errorContent("Cannot generate QR code \u{2014} daemon not connected. Please wait for the daemon to start and try again.")
+                errorContent("Cannot generate QR code \u{2014} assistant not connected. Please wait for the assistant to start and try again.")
             } else {
                 switch registrationState {
                 case .idle, .registering:
@@ -86,7 +86,7 @@ struct PairingQRCodeSheet: View {
                     }
 
                 case .failed:
-                    errorContent(registrationError ?? "Could not register pairing request. Ensure the daemon is running.")
+                    errorContent(registrationError ?? "Could not register pairing request. Ensure the assistant is running.")
                 }
 
                 // State indicator
@@ -271,7 +271,7 @@ struct PairingQRCodeSheet: View {
                 return .failure(RegistrationRequestError(message: "Registration failed (HTTP \(statusCode))."))
             }
         } catch {
-            return .failure(RegistrationRequestError(message: "Could not reach daemon: \(error.localizedDescription)"))
+            return .failure(RegistrationRequestError(message: "Could not reach assistant: \(error.localizedDescription)"))
         }
     }
 
@@ -297,7 +297,7 @@ struct PairingQRCodeSheet: View {
         guard canGenerateQR else { return nil }
 
         var payload: [String: Any] = [
-            "type": "vellum-daemon",
+            "type": "vellum-assistant",
             "v": 4,
             "id": hostId,
             "g": effectiveGatewayUrl,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -160,7 +160,7 @@ struct SettingsDeveloperTab: View {
             if lockfileAssistants.count > 1 {
                 Text("This will stop the current assistant and switch to another. The retired assistant's lockfile entry will be removed.")
             } else {
-                Text("This will stop the assistant daemon, remove local data, and return to initial setup. This action cannot be undone.")
+                Text("This will stop the assistant, remove local data, and return to initial setup. This action cannot be undone.")
             }
         }
         .alert("Upgrade Assistant", isPresented: $showingInlineUpgradeConfirmation) {
@@ -207,7 +207,7 @@ struct SettingsDeveloperTab: View {
                 Text("Retiring assistant...")
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.contentDefault)
-                Text("Stopping the daemon and removing local data.")
+                Text("Stopping the assistant and removing local data.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
             }
@@ -710,7 +710,7 @@ struct SettingsDeveloperTab: View {
             title: "Retire Assistant",
             subtitle: lockfileAssistants.count > 1
                 ? "Stops the current assistant and switches to another."
-                : "Stops the daemon, removes local data, and returns to initial setup."
+                : "Stops the assistant, removes local data, and returns to initial setup."
         ) {
             VButton(label: "Retire", style: .danger) {
                 showingRetireConfirmation = true
@@ -896,7 +896,7 @@ struct SettingsDeveloperTab: View {
     @ViewBuilder
     private var environmentVariablesSection: some View {
         if daemonClient != nil {
-            SettingsCard(title: "Environment Variables", subtitle: "View env vars for both the app and daemon processes") {
+            SettingsCard(title: "Environment Variables", subtitle: "View env vars for both the app and assistant processes") {
                 VButton(label: "View", style: .outlined) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
@@ -1047,7 +1047,7 @@ private struct DeveloperDaemonStatusRows: View {
 
     var body: some View {
         statusRow(
-            label: "Daemon",
+            label: "Assistant",
             isHealthy: daemonClient.isConnected,
             detail: daemonClient.isConnected
                 ? "Connected" + (daemonClient.daemonVersion.map { " (v\($0))" } ?? "")

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -377,7 +377,7 @@ final class ToolPermissionTesterModel: ObservableObject {
     /// may have edited in the form since then.
     func alwaysAllow(pattern: String, scope: String) {
         guard let dc = daemonClient as? DaemonClient else {
-            lastError = "Cannot add trust rule: daemon client unavailable"
+            lastError = "Cannot add trust rule: assistant not connected"
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -35,7 +35,7 @@ struct ToolPermissionTesterView: View {
             // Working directory
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 fieldLabel("Working Directory")
-                TextField("Leave empty for daemon default", text: $model.workingDir)
+                TextField("Leave empty for assistant default", text: $model.workingDir)
                     .vInputStyle()
                     .font(VFont.mono)
             }

--- a/clients/macos/vellum-assistant/Logging/PortDiagnostics.swift
+++ b/clients/macos/vellum-assistant/Logging/PortDiagnostics.swift
@@ -99,7 +99,7 @@ enum PortDiagnostics {
     /// lockfile-specific ports that differ from the defaults.
     private static func collectPorts() -> [(label: String, port: Int)] {
         var ports: [(label: String, port: Int)] = [
-            ("daemon (default)", defaultDaemonPort),
+            ("assistant (default)", defaultDaemonPort),
             ("gateway (default)", defaultGatewayPort),
             ("qdrant (default)", defaultQdrantPort),
         ]
@@ -109,7 +109,7 @@ enum PortDiagnostics {
         let assistants = LockfileAssistant.loadAll()
         for assistant in assistants {
             if let dp = assistant.daemonPort, !seen.contains(dp) {
-                ports.append(("daemon (\(assistant.assistantId))", dp))
+                ports.append(("assistant (\(assistant.assistantId))", dp))
             }
             if let gp = assistant.gatewayPort, !seen.contains(gp) {
                 ports.append(("gateway (\(assistant.assistantId))", gp))

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -100,7 +100,7 @@ private struct VDropdownPreviewWrapper: View {
                     emptyValue: ""
                 )
 
-                TextField("Leave empty for daemon default", text: .constant(""))
+                TextField("Leave empty for assistant default", text: .constant(""))
                     .vInputStyle()
                     .font(VFont.body)
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2296,7 +2296,7 @@ public final class ChatViewModel: ObservableObject {
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String, decision: String = "always_allow") {
         guard daemonClient.isConnected else {
             log.warning("Cannot persist always-allow: daemon not connected")
-            errorText = "Cannot send confirmation — daemon is not connected."
+            errorText = "Cannot send confirmation — assistant is not connected."
             return
         }
         do {

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,11 +26,11 @@ bun run dev
 
 ## Configuration
 
-| Variable                  | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                                        |
-| ------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TELEGRAM_BOT_TOKEN`      | No       | —       | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store: keychain broker first (UDS to the assistant daemon), then the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (daemon not running or non-macOS), the encrypted store is used directly. |
-| `TELEGRAM_WEBHOOK_SECRET` | No       | —       | Secret for verifying webhook requests (Telegram disabled when unset). Same credential reader fallback behavior as `TELEGRAM_BOT_TOKEN`.                                                                                                                                                                                                                                            |
-| `GATEWAY_PORT`            | No       | `7830`  | Port for the gateway HTTP server                                                                                                                                                                                                                                                                                                                                                   |
+| Variable                  | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TELEGRAM_BOT_TOKEN`      | No       | —       | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store: keychain broker first (UDS to the assistant process), then the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (assistant not running or non-macOS), the encrypted store is used directly. |
+| `TELEGRAM_WEBHOOK_SECRET` | No       | —       | Secret for verifying webhook requests (Telegram disabled when unset). Same credential reader fallback behavior as `TELEGRAM_BOT_TOKEN`.                                                                                                                                                                                                                                                |
+| `GATEWAY_PORT`            | No       | `7830`  | Port for the gateway HTTP server                                                                                                                                                                                                                                                                                                                                                       |
 
 Most gateway behavior is now configured via hardcoded defaults or workspace config (`~/.vellum/workspace/config.json`) rather than environment variables. Channel operational settings (Telegram API base URL, timeouts, deliver auth bypass flags, runtime base URL, routing, proxy settings, attachment limits, shutdown drain) are managed via `workspace/config.json` through `ConfigFileCache`. See the channel-specific sections in `ARCHITECTURE.md` for details.
 
@@ -185,7 +185,7 @@ Use this flow when you are changing files under `gateway/` and need to validate 
 ```bash
 # Terminal 1: restart assistant runtime HTTP server
 cd assistant
-bun run daemon:restart:http
+bun run assistant:restart:http
 
 # Terminal 2: run gateway from local source with runtime proxy enabled
 cd gateway


### PR DESCRIPTION
## Summary
- Replace all user-facing mentions of "daemon" with "assistant" across UI strings, error messages, documentation, and QR pairing protocol identifiers
- Update QR pairing type from `vellum-daemon` to `vellum-assistant` (iOS scanner accepts both for backward compatibility)
- Leaves internal code identifiers (variable names, JWT audiences, process management) unchanged

## Original prompt
Replace all user-facing mentions of "daemon" with "assistant"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
