### PR TITLE
ci: remove informational periphery lint from main CI

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -8,9 +8,6 @@ on:
       - 'clients/macos/**'
       - 'clients/shared/**'
       - 'clients/Package.swift'
-      - 'clients/.periphery.yml'
-      - 'clients/.periphery_baseline.json'
-      - 'clients/scripts/periphery-scan.sh'
       - 'assistant/**'
       - 'cli/**'
       - 'gateway/**'
@@ -106,21 +103,6 @@ jobs:
         working-directory: clients/macos
         run: ./build.sh test
 
-      - name: Lint unused code (informational)
-        if: always()
-        continue-on-error: true
-        working-directory: clients
-        run: bash scripts/periphery-scan.sh
-
-      - name: Upload baseline artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: periphery-baseline
-          path: clients/.periphery_baseline.json
-          if-no-files-found: ignore
-          retention-days: 7
-          include-hidden-files: true
 
   build-app:
     name: Build macOS App


### PR DESCRIPTION
## Summary
- Removed the informational-only "Lint unused code" periphery scan step and its "Upload baseline artifact" step from `ci-main-macos.yaml` (~36s savings per run)
- Removed periphery-specific path triggers (`clients/.periphery.yml`, `clients/.periphery_baseline.json`, `clients/scripts/periphery-scan.sh`) from the workflow's push trigger since no steps use them
- The enforcing periphery scan in `pr-macos.yaml` (with `--ci` flag) is unaffected

## Original prompt
Remove the periphery lint step from ci-main-macos.yaml. It runs with continue-on-error: true (purely informational) and adds ~36s to every CI run. Remove the "Lint unused code (informational)" step and the "Upload baseline artifact" step that follows it (which uploads the periphery baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
