### PR TITLE
perf: improve SPM cache hit rate with weekly-rotating cache keys

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -83,13 +83,17 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Compute cache week
+        id: week
+        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-week${{ steps.week.outputs.num }}-
             macos-spm-
 
       - name: Design token guard
@@ -153,13 +157,17 @@ jobs:
         with:
           bun-version: '1.3.9'
 
+      - name: Compute cache week
+        id: week
+        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-week${{ steps.week.outputs.num }}-
             macos-spm-
 
       - name: Configure GitHub auth for SPM binary downloads

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -20,13 +20,17 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Compute cache week
+        id: week
+        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-week${{ steps.week.outputs.num }}-
             macos-spm-
 
       - name: Download previous baseline artifact

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -33,13 +33,17 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Compute cache week
+        id: week
+        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-week${{ steps.week.outputs.num }}-
             macos-spm-
 
       - name: Lint unused code
@@ -105,13 +109,17 @@ jobs:
           security find-identity -v -p codesigning | grep -q "Developer ID Application" \
             || { echo "::error::Developer ID Application identity not found in keychain. Check the DEVID_CERTIFICATE_P12 secret."; exit 1; }
 
+      - name: Compute cache week
+        id: week
+        run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/**/*.swift') }}
+          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-${{ hashFiles('clients/Package.resolved') }}-
+            macos-spm-week${{ steps.week.outputs.num }}-
             macos-spm-
 
       - name: Cache Bun dependencies (assistant)


### PR DESCRIPTION
## Summary
- Remove `clients/**/*.swift` hash from SPM cache key across all macOS workflows (`ci-main-macos`, `pr-macos`, `ci-perf-macos`) — any Swift source change was busting the cache, forcing full rebuilds. SPM's incremental compilation handles source changes correctly from a stale cache.
- Add ISO-week rotation (`week<num>`) to the cache key so orphaned `.o` files from deleted/renamed sources are naturally cleaned up weekly, preventing unbounded cache growth.

## Test plan
- [ ] Verify CI runs after merge use the new cache key format (`macos-spm-week<N>-<Package.resolved hash>`)
- [ ] Confirm cache hit on consecutive main pushes that only change Swift files (no `Package.resolved` change)
- [ ] Confirm cache busts at the weekly boundary

## Original prompt
Improve SPM cache key to increase cache hit rates and prevent unbounded cache growth. Key only on `Package.resolved` (dependency lock) with a weekly rotation, removing the `clients/**/*.swift` hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
