### PR TITLE
Fix JSON tree content vertically centered instead of top-aligned

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -120,7 +120,7 @@ struct JSONTreeView: View {
     @State private var expandedPaths: Set<String> = []
 
     var body: some View {
-        Group {
+        VStack(alignment: .leading, spacing: 0) {
             if let root = root {
                 switch root {
                 case .failure(let error):
@@ -133,6 +133,7 @@ struct JSONTreeView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: content) {
             let result = parseJSON(content)
             root = result


### PR DESCRIPTION
## Summary
- Change JSONTreeView container from Group to VStack with topLeading alignment
- Add frame with topLeading alignment to ensure content fills container from top-left
- Fixes vertical centering of JSON tree in both workspace and skill detail panels

Part of plan: viewer-fixes.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
