### PR TITLE
feat(macos): expose Apple Containers as a real local install option

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -64,6 +64,10 @@ struct APIKeyStepView: View {
 
     // MARK: - Hosting Cards
 
+    private var appleContainersAvailability: AppleContainersAvailability {
+        AppleContainersAvailabilityChecker.shared.check()
+    }
+
     private var hostingCards: some View {
         VStack(spacing: VSpacing.sm) {
             if !state.skippedAuth {
@@ -84,7 +88,66 @@ struct APIKeyStepView: View {
                 comingSoon: false
             )
 
+            // Apple Containers option — only shown when the feature flag is on
+            // and the current machine passes all availability checks.
+            if appleContainersAvailability.isAvailable {
+                appleContainersCard
+            }
         }
+    }
+
+    private var appleContainersCard: some View {
+        let isSelected = state.selectedHostingMode == .local
+            && state.selectedRuntimeBackend == .appleContainers
+
+        return Button(action: {
+            state.selectedHostingMode = .local
+            state.selectedRuntimeBackend = .appleContainers
+        }) {
+            HStack(spacing: VSpacing.md) {
+                VIconView(.package, size: 18)
+                    .foregroundColor(isSelected ? VColor.primaryBase : VColor.contentSecondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Apple Containers")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Run in an isolated container on your Mac")
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.contentSecondary)
+                }
+
+                Spacer()
+
+                Circle()
+                    .fill(isSelected ? VColor.primaryBase : Color.clear)
+                    .overlay(
+                        Circle().stroke(isSelected ? VColor.primaryBase : VColor.borderBase, lineWidth: 1.5)
+                    )
+                    .overlay(
+                        isSelected
+                            ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
+                            : nil
+                    )
+                    .frame(width: 18, height: 18)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isSelected ? VColor.primaryBase.opacity(0.1) : Color.clear)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(
+                                isSelected ? VColor.primaryBase.opacity(0.5) : VColor.borderBase,
+                                lineWidth: 1
+                            )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
     }
 
     private func hostingCard(
@@ -94,11 +157,20 @@ struct APIKeyStepView: View {
         mode: OnboardingState.HostingMode,
         comingSoon: Bool
     ) -> some View {
-        let isSelected = state.selectedHostingMode == mode && !comingSoon
+        // A card is selected when it matches the hosting mode AND we are using
+        // the process backend (i.e. the card represents the standard local path,
+        // not the Apple Containers path which has its own card above).
+        let isSelected = state.selectedHostingMode == mode
+            && state.selectedRuntimeBackend == .process
+            && !comingSoon
 
         return Button(action: {
             guard !comingSoon else { return }
             state.selectedHostingMode = mode
+            // Selecting the standard card always resets to process backend.
+            if mode == .local {
+                state.selectedRuntimeBackend = .process
+            }
         }) {
             HStack(spacing: VSpacing.md) {
                 VIconView(icon, size: 18)
@@ -165,6 +237,10 @@ struct APIKeyStepView: View {
         state.selectedHostingMode == .local
     }
 
+    private var isAppleContainersSelected: Bool {
+        state.selectedHostingMode == .local && state.selectedRuntimeBackend == .appleContainers
+    }
+
     private var continueButtonTitle: String {
         if isAuthenticated {
             return "Hatch"
@@ -176,13 +252,19 @@ struct APIKeyStepView: View {
         guard canContinue else { return }
 
         state.cloudProvider = state.selectedHostingMode.rawValue
+        // selectedRuntimeBackend is already kept in sync by the card tap actions;
+        // no additional assignment needed here.
 
         if isAuthenticated {
-            // Authenticated user selecting Local: skip API key, go straight to hatching
+            // Authenticated user selecting Local: skip API key, go straight to hatching.
+            // For the Apple Containers path the API key is resolved from the keychain
+            // or env at launch time by AppleContainersLauncher, so we don't need to
+            // prompt for it here either.
             saveModelToConfig("claude-opus-4-6")
             state.isHatching = true
         } else {
-            // Skipped auth: advance to API key entry (step 2)
+            // Skipped auth: advance to API key entry (step 2).
+            // Apple Containers still needs an Anthropic API key for the assistant.
             state.advance()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -9,6 +9,7 @@ struct HatchingStepView: View {
     @Bindable var state: OnboardingState
 
     @State private var cliLauncher = AssistantCli()
+    @State private var appleContainersLauncher = AppleContainersLauncher()
     @State private var showContent = false
     @State private var characterAwake = false
     @State private var pulseScale: CGFloat = 0.9
@@ -102,6 +103,10 @@ struct HatchingStepView: View {
         state.cloudProvider == "customHardware"
     }
 
+    private var isAppleContainersHatch: Bool {
+        state.selectedRuntimeBackend == .appleContainers
+    }
+
     private var statusText: some View {
         VStack(spacing: VSpacing.sm) {
             if state.hatchFailed {
@@ -130,6 +135,24 @@ struct HatchingStepView: View {
                 Text("Pairing\u{2026}")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.contentDefault)
+            } else if isAppleContainersHatch {
+                Text("Starting container\u{2026}")
+                    .font(.system(size: 24, weight: .regular, design: .serif))
+                    .foregroundColor(VColor.contentDefault)
+                Text("Setting up your assistant in an Apple Container\u{2026}")
+                    .font(.system(size: 14))
+                    .foregroundColor(VColor.contentSecondary)
+                // Surface the most recent pod runtime progress line if any.
+                if let latestLine = state.hatchLogLines.last {
+                    Text(latestLine)
+                        .font(.system(size: 12))
+                        .foregroundColor(VColor.contentTertiary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                }
+                Text("This may take a few minutes while images are pulled.")
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.contentTertiary)
             } else {
                 Text("Waking up...")
                     .font(.system(size: 24, weight: .regular, design: .serif))
@@ -220,8 +243,25 @@ struct HatchingStepView: View {
         if state.isManagedHatch { return }
         if isCustomHardware {
             startPairing()
+        } else if isAppleContainersHatch {
+            startAppleContainersHatch()
         } else {
             startRemoteHatch()
+        }
+    }
+
+    private func startAppleContainersHatch() {
+        Task {
+            do {
+                // AppleContainersLauncher writes its own lockfile entry and manages
+                // the full pod lifecycle; we just need to wait for it to finish.
+                try await appleContainersLauncher.launch(name: nil, daemonOnly: false, restart: false)
+                handleHatchSuccess()
+            } catch {
+                log.error("Apple Containers hatch failed: \(String(describing: error), privacy: .public)")
+                failureReason = friendlyErrorMessage(from: error)
+                state.hatchFailed = true
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -47,6 +47,18 @@ final class OnboardingState {
         case vellumCloud = "vellum-cloud"
         case local = "local"
     }
+
+    /// The local runtime backend selected during onboarding or hatch-new flows.
+    /// Persisted so subsequent launches continue using the same launcher.
+    var selectedRuntimeBackend: LocalRuntimeBackend = .process
+
+    /// UserDefaults key written by the developer settings tab before opening a
+    /// new-hatch onboarding window. `OnboardingState.init()` consumes this key
+    /// so the window's state reflects the chosen backend from the start.
+    /// This key is intentionally NOT cleared by `clearPersistedState()` so that
+    /// it survives the state reset triggered by `hatchNewAssistant()`.
+    static let pendingHatchBackendKey = "onboarding.pendingRuntimeBackend"
+
     var hasHatched: Bool = false
     var interviewCompleted: Bool = false
     var cloudProvider: String = "local"
@@ -130,6 +142,10 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
+            if let rawBackend = UserDefaults.standard.string(forKey: "onboarding.runtimeBackend"),
+               let backend = LocalRuntimeBackend(rawValue: rawBackend) {
+                selectedRuntimeBackend = backend
+            }
         }
         if let rawVariant = UserDefaults.standard.string(forKey: "onboarding.variant"),
            let variant = OnboardingVariant(rawValue: rawVariant) {
@@ -160,6 +176,15 @@ final class OnboardingState {
         if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil {
             UserDefaults.standard.set(true, forKey: "sendDiagnostics")
         }
+
+        // Consume the one-shot pending backend selection written by the settings
+        // tab before opening a new-hatch window. Clear it immediately so it does
+        // not affect subsequent launches.
+        if let rawPending = UserDefaults.standard.string(forKey: Self.pendingHatchBackendKey),
+           let pending = LocalRuntimeBackend(rawValue: rawPending) {
+            selectedRuntimeBackend = pending
+            UserDefaults.standard.removeObject(forKey: Self.pendingHatchBackendKey)
+        }
     }
 
     func advance(by steps: Int = 1) {
@@ -177,6 +202,7 @@ final class OnboardingState {
         UserDefaults.standard.set(hasHatched, forKey: "onboarding.hatched")
         UserDefaults.standard.set(interviewCompleted, forKey: "onboarding.interviewCompleted")
         UserDefaults.standard.set(cloudProvider, forKey: "onboarding.cloudProvider")
+        UserDefaults.standard.set(selectedRuntimeBackend.rawValue, forKey: "onboarding.runtimeBackend")
         UserDefaults.standard.set(onboardingVariant.rawValue, forKey: "onboarding.variant")
         UserDefaults.standard.set(Double(firstMeetingCrackProgress), forKey: "onboarding.firstMeetingCrackProgress")
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
@@ -200,6 +226,7 @@ final class OnboardingState {
 
         // Reset cloud credentials (in-memory only; not persisted)
         cloudProvider = "local"
+        selectedRuntimeBackend = .process
         gcpProjectId = ""
         gcpZone = "us-central1-a"
         gcpServiceAccountKey = ""
@@ -215,7 +242,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.runtimeBackend"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -49,6 +49,9 @@ struct SettingsDeveloperTab: View {
     @State private var inlineUpgradeError: String?
     @State private var inlineUpgradeSuccess: String?
 
+    // -- Hatch backend selection --
+    @State private var hatchRuntimeBackend: LocalRuntimeBackend = .process
+
     // -- Sentry testing state --
     @State private var lastSentryStatus: String?
     @State private var sentryDismissTask: Task<Void, Never>?
@@ -720,21 +723,106 @@ struct SettingsDeveloperTab: View {
 
     // MARK: - Hatch New Assistant
 
+    private var appleContainersAvailability: AppleContainersAvailability {
+        AppleContainersAvailabilityChecker.shared.check()
+    }
+
     private var hatchNewAssistantSection: some View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
+            // Backend picker — always show the process option; show the Apple
+            // Containers option based on availability, with disabled copy when the
+            // flag is off but developer surfaces are visible.
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text("Backend")
+                    .font(VFont.inputLabel)
+                    .foregroundColor(VColor.contentSecondary)
+
+                hatchBackendRow(
+                    title: "Local (process)",
+                    subtitle: "Standard vellum-cli hatch path",
+                    backend: .process,
+                    disabledReason: nil
+                )
+
+                let availability = appleContainersAvailability
+                let acDisabledReason: String? = availability.isAvailable ? nil : availability.explanation
+                hatchBackendRow(
+                    title: "Apple Containers",
+                    subtitle: "Run the assistant in an Apple Container",
+                    backend: .appleContainers,
+                    disabledReason: acDisabledReason
+                )
+
+                SettingsDivider()
+            }
+
             VButton(label: "Hatch...", style: .primary) {
                 showingHatchConfirmation = true
             }
             .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
                 Button("Cancel", role: .cancel) {}
                 Button("Continue") {
+                    // Write the pending backend selection so the new OnboardingState
+                    // init() picks it up after clearPersistedState() runs.
+                    UserDefaults.standard.set(
+                        hatchRuntimeBackend.rawValue,
+                        forKey: OnboardingState.pendingHatchBackendKey
+                    )
                     AppDelegate.shared?.hatchNewAssistant()
                     onClose()
                 }
             } message: {
-                Text("This will create a brand new assistant. Your existing assistant(s) will continue to exist and you can switch back to using them.")
+                Text("This will create a brand new assistant using the \(hatchRuntimeBackend == .appleContainers ? "Apple Containers" : "local process") backend. Your existing assistant(s) will continue to exist and you can switch back to using them.")
             }
         }
+    }
+
+    private func hatchBackendRow(
+        title: String,
+        subtitle: String,
+        backend: LocalRuntimeBackend,
+        disabledReason: String?
+    ) -> some View {
+        let isDisabled = disabledReason != nil
+        let isSelected = hatchRuntimeBackend == backend && !isDisabled
+
+        return Button(action: {
+            guard !isDisabled else { return }
+            hatchRuntimeBackend = backend
+        }) {
+            HStack(spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(title)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentDefault)
+                    Text(disabledReason ?? subtitle)
+                        .font(VFont.caption)
+                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentTertiary)
+                }
+
+                Spacer()
+
+                Circle()
+                    .fill(isSelected ? VColor.primaryBase : Color.clear)
+                    .overlay(
+                        Circle().stroke(
+                            isSelected ? VColor.primaryBase : (isDisabled ? VColor.borderDisabled : VColor.borderBase),
+                            lineWidth: 1.5
+                        )
+                    )
+                    .overlay(
+                        isSelected
+                            ? Circle().fill(VColor.auxWhite).frame(width: 6, height: 6)
+                            : nil
+                    )
+                    .frame(width: 16, height: 16)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.6 : 1.0)
+        .pointerCursor()
     }
 
     // MARK: - Assistant Feature Flags


### PR DESCRIPTION
## Summary
- Add Apple Containers install card to onboarding (visible only when availability check passes)
- Persist selected runtimeBackend through onboarding state into the hatched lockfile entry
- Update HatchingStepView to render Apple Containers-specific pod runtime progress
- Add backend choice to developer/settings surfaces with explicit disabled copy when flag is off

Part of plan: apple-containers-hatch.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
