### PR TITLE
Switch view mode toggle to underline style and fix file size visibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -504,9 +504,8 @@ struct AgentPanelContent: View {
                     VSegmentedControl(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
                         selection: $skillFileViewMode,
-                        style: .pill
+                        style: .underline
                     )
-                    .frame(width: CGFloat(modes.count) * 60)
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -56,6 +56,7 @@ struct FileContentHeaderBar<Trailing: View>: View {
             Text(fileSize)
                 .font(VFont.small)
                 .foregroundColor(VColor.contentTertiary)
+                .fixedSize()
             trailing
         }
         .padding(.horizontal, VSpacing.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -724,9 +724,8 @@ private struct WorkspaceFileViewer: View {
                         VSegmentedControl(
                             items: modes.map { (label: viewModeLabel($0), tag: $0) },
                             selection: $state.viewMode,
-                            style: .pill
+                            style: .underline
                         )
-                        .frame(width: CGFloat(modes.count) * 60)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Add .fixedSize() to file size text in FileContentHeaderBar to prevent compression
- Switch VSegmentedControl from .pill to .underline style in both WorkspacePanel and AgentPanel
- Remove fixed width frame from toggle — underline style auto-sizes to content

Part of plan: viewer-fixes.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
