### PR TITLE
feat: add Skip button on welcome screen when self-hosted assistant exists

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -12,6 +12,13 @@ struct ReauthView: View {
     @State private var showContent = false
     @State private var didComplete = false
 
+    private var hasNonManagedAssistant: Bool {
+        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant = storedId.flatMap { LockfileAssistant.loadByName($0) }
+            ?? LockfileAssistant.loadLatest()
+        return assistant != nil && !assistant!.isManaged
+    }
+
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
         return NSImage(contentsOfFile: path)
@@ -75,6 +82,18 @@ struct ReauthView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemNegativeStrong)
                         .multilineTextAlignment(.center)
+                }
+
+                if hasNonManagedAssistant {
+                    Button {
+                        onComplete()
+                    } label: {
+                        Text("Skip")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Skip")
                 }
             }
             .frame(maxWidth: 280)


### PR DESCRIPTION
## Summary
- Adds a "Skip" button to the ReauthView (Welcome Back screen) that appears only when the lockfile contains a non-managed (self-hosted) assistant
- Clicking Skip proceeds to the app without authentication, matching the existing Skip button behavior on the WakeUpStepView
- No Skip button is shown when all assistants are platform-managed

Part of plan: self-hosted-logout-flow.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
