### PR TITLE
perf: separate SPM cache keys for debug and release builds

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -91,10 +91,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
+          key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-week${{ steps.week.outputs.num }}-
-            macos-spm-
+            macos-spm-debug-week${{ steps.week.outputs.num }}-
+            macos-spm-debug-
 
       - name: Design token guard
         run: bash clients/scripts/check-design-tokens.sh --mode=strict
@@ -165,10 +165,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
+          key: macos-spm-release-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-week${{ steps.week.outputs.num }}-
-            macos-spm-
+            macos-spm-release-week${{ steps.week.outputs.num }}-
+            macos-spm-release-
 
       - name: Configure GitHub auth for SPM binary downloads
         env:

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
+          key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-week${{ steps.week.outputs.num }}-
-            macos-spm-
+            macos-spm-debug-week${{ steps.week.outputs.num }}-
+            macos-spm-debug-
 
       - name: Download previous baseline artifact
         env:

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -41,10 +41,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
+          key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-week${{ steps.week.outputs.num }}-
-            macos-spm-
+            macos-spm-debug-week${{ steps.week.outputs.num }}-
+            macos-spm-debug-
 
       - name: Lint unused code
         run: bash scripts/periphery-scan.sh --ci
@@ -117,10 +117,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: clients/.build
-          key: macos-spm-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
+          key: macos-spm-release-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: |
-            macos-spm-week${{ steps.week.outputs.num }}-
-            macos-spm-
+            macos-spm-release-week${{ steps.week.outputs.num }}-
+            macos-spm-release-
 
       - name: Cache Bun dependencies (assistant)
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Split shared SPM cache key into `macos-spm-debug-*` and `macos-spm-release-*` across all three macOS workflows (`ci-main-macos`, `pr-macos`, `ci-perf-macos`)
- Debug jobs (`test`, `lint-unused`, `perf-baselines`) and release jobs (`build-app`, `build-check`) were competing for the same cache entry, causing the last writer to overwrite the other config's artifacts
- Each build config now maintains its own cache, eliminating cross-config pollution and reducing unnecessary recompilation

## Test plan
- [ ] Verify next CI run creates separate `macos-spm-debug-*` and `macos-spm-release-*` cache entries
- [ ] Confirm debug and release jobs no longer overwrite each other's cached artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
