### PR TITLE
fix: resolve Swift compiler warnings in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -734,8 +734,8 @@ extension AppDelegate {
         } catch {
             return false
         }
-        guard let data = try? pipe.fileHandleForReading.readDataToEndOfFile(),
-              let command = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let command = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
               !command.isEmpty else {
             return false
         }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -437,7 +437,7 @@ enum LogExporter {
     // MARK: - Daemon Log Fallback
 
     /// Maximum total bytes to read when collecting fallback daemon logs.
-    private static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
+    private nonisolated(unsafe) static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
 
     /// When the daemon is unreachable, reads log files directly from the
     /// filesystem and copies them into `directory/daemon-logs-fallback/`.


### PR DESCRIPTION
## Summary
- Remove unnecessary `try?` on non-throwing `readDataToEndOfFile()` call in `AppDelegate+AuthLifecycle.swift`
- Mark `fallbackLogSizeLimit` as `nonisolated(unsafe)` in `LogExporter.swift` since it's a compile-time constant accessed from a `nonisolated static` method

## Original prompt
Fix Swift compiler warnings: unnecessary `try?` expression and main-actor-isolated static property referenced from nonisolated context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
