### PR TITLE
fix: restore connectedAssistantId after soft logout for self-hosted users

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -234,6 +234,14 @@ extension AppDelegate {
             if !wasManaged {
                 // Self-hosted (local or remote): clear auth state but keep the
                 // app running. The user can sign in again from Settings > General.
+
+                // Restore connectedAssistantId — authManager.logout() clears it
+                // from UserDefaults, but the app stays running in this path and
+                // subsystems (avatar, gateway resolution, API key sync) need it.
+                if let connectedAssistantId {
+                    UserDefaults.standard.set(connectedAssistantId, forKey: "connectedAssistantId")
+                }
+
                 actorTokenBootstrapTask?.cancel()
                 actorTokenBootstrapTask = nil
                 ActorTokenManager.deleteToken()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for self-hosted-logout-flow.md.

**Gap:** `authManager.logout()` clears `connectedAssistantId` but the app stays running in the non-managed path
**What was expected:** `connectedAssistantId` should remain set so subsystems continue functioning during soft logout
**What was found:** `authManager.logout()` unconditionally removes it, causing cascading degradation (avatar, gateway, API key sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
