### PR TITLE
Use regular pill toggle size and fix JSON tree top-alignment

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -504,8 +504,7 @@ struct AgentPanelContent: View {
                     VSegmentedControl(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
                         selection: $skillFileViewMode,
-                        style: .pill,
-                        size: .compact
+                        style: .pill
                     )
                     .fixedSize()
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -177,6 +177,7 @@ struct JSONTreeView: View {
                 .padding(VSpacing.md)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -724,8 +724,7 @@ private struct WorkspaceFileViewer: View {
                         VSegmentedControl(
                             items: modes.map { (label: viewModeLabel($0), tag: $0) },
                             selection: $state.viewMode,
-                            style: .pill,
-                            size: .compact
+                            style: .pill
                         )
                         .fixedSize()
                     }


### PR DESCRIPTION
## Summary
- Switch file viewer toggles from compact to regular pill size with `.fixedSize()` for proper proportions
- Add `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` to JSONTreeView treeContent to prevent vertical centering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
