### PR TITLE
fix: re-bootstrap actor credentials on sign-in from Settings after soft logout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -305,6 +305,14 @@ struct SettingsPanel: View {
         switch selectedTab {
         case .general:
             SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, onSignIn: {
+                // Re-bootstrap actor credentials first so the actor token is
+                // available when ensureLocalAssistantApiKey() waits for it.
+                // This mirrors the pattern in proceedToApp() and
+                // performSwitchAssistant(). Managed assistants derive identity
+                // from the platform session, so skip for them.
+                if !(AppDelegate.shared?.isCurrentAssistantManaged ?? false) {
+                    AppDelegate.shared?.ensureActorCredentials()
+                }
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
             })
         case .modelsAndServices:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for self-hosted-logout-flow.md.

**Gap:** Missing `ensureActorCredentials()` call on re-login from Settings after non-managed logout
**What was expected:** Actor credentials should be re-bootstrapped on re-login so managed-proxy features work
**What was found:** `onSignIn` only called `ensureLocalAssistantApiKey()`, which waits for an actor token that nobody produces

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
