### PR TITLE
fix: check all lockfile assistants for Skip button visibility on ReauthView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -13,10 +13,7 @@ struct ReauthView: View {
     @State private var didComplete = false
 
     private var hasNonManagedAssistant: Bool {
-        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        let assistant = storedId.flatMap { LockfileAssistant.loadByName($0) }
-            ?? LockfileAssistant.loadLatest()
-        return assistant != nil && !assistant!.isManaged
+        LockfileAssistant.loadAll().contains { !$0.isManaged }
     }
 
     private static let appIcon: NSImage? = {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for self-hosted-logout-flow.md.

**Gap:** `hasNonManagedAssistant` only checks the connected/latest assistant
**What was expected:** Skip button should appear when ANY non-managed assistant exists in the lockfile
**What was found:** Only checked a single assistant, hiding the button when a managed assistant is latest but a local one also exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
