### PR TITLE
refactor: rename stale sessionId→conversationId in DoorDash CLI response type

### DIFF
--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -1007,7 +1007,7 @@ async function startLearnSession(durationSeconds: number): Promise<void> {
   const startResult = JSON.parse(startStdout) as {
     ok: boolean;
     watchId?: string;
-    sessionId?: string;
+    conversationId?: string;
     error?: string;
   };
 


### PR DESCRIPTION
## Summary
- Renamed stale `sessionId` to `conversationId` in the DoorDash CLI response type to match the renamed ShotgunResult

Part of plan: conv-rename-ts-swift-notif.md (PR 11 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
