### PR TITLE
refactor: fix session→conversation in browser tool log and result strings

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -148,7 +148,7 @@ export async function executeBrowserNavigate(
   let routeHandler: RouteHandler | null = null;
   let blockedUrl: string | null = null;
 
-  // Start screencast if a sender is registered for this session
+  // Start screencast if a sender is registered for this conversation
   const sender = getSender(context.conversationId);
   if (sender) {
     await ensureScreencast(context.conversationId);
@@ -621,7 +621,10 @@ export async function executeBrowserClose(
       };
     }
     await browserManager.closeSessionPage(context.conversationId);
-    return { content: "Browser page closed for this session.", isError: false };
+    return {
+      content: "Browser page closed for this conversation.",
+      isError: false,
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Close failed");

--- a/assistant/src/tools/browser/browser-handoff.ts
+++ b/assistant/src/tools/browser/browser-handoff.ts
@@ -35,7 +35,7 @@ export async function startHandoff(
   }
 
   if (!isScreencastActive(conversationId)) {
-    log.warn({ conversationId }, "No active browser session for handoff");
+    log.warn({ conversationId }, "No active browser page for handoff");
     return;
   }
 

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -418,7 +418,7 @@ class BrowserManager {
       await this.positionWindowSidebar();
     }
 
-    log.debug({ conversationId }, "Session page created");
+    log.debug({ conversationId }, "Conversation page created");
     return page;
   }
 
@@ -442,10 +442,11 @@ class BrowserManager {
     // Reject any pending download waiters
     const pending = this.pendingDownloads.get(conversationId);
     if (pending) {
-      for (const waiter of pending) waiter.reject(new Error("Session closed"));
+      for (const waiter of pending)
+        waiter.reject(new Error("Browser page closed"));
       this.pendingDownloads.delete(conversationId);
     }
-    log.debug({ conversationId }, "Session page closed");
+    log.debug({ conversationId }, "Conversation page closed");
   }
 
   async closeAllPages(): Promise<void> {


### PR DESCRIPTION
## Summary
- Updated user-facing browser close result string
- Updated browser log strings to disambiguate page vs CDP session vs conversation
- Preserved CDP session references

Part of plan: conv-rename-ts-swift-notif.md (PR 5 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
