### PR TITLE
refactor: rename body.sessionId→conversationId in ACP spawn route

### DIFF
--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -26,13 +26,13 @@ export function acpRouteDefinitions(): RouteDefinition[] {
         const body = (await req.json()) as {
           agent?: string;
           task?: string;
-          sessionId?: string;
+          conversationId?: string;
           cwd?: string;
         };
-        if (!body.agent || !body.task || !body.sessionId) {
+        if (!body.agent || !body.task || !body.conversationId) {
           return httpError(
             "BAD_REQUEST",
-            "agent, task, and sessionId are required",
+            "agent, task, and conversationId are required",
             400,
           );
         }
@@ -53,7 +53,7 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           {
             agent: body.agent,
             task: body.task?.slice(0, 100),
-            sessionId: body.sessionId,
+            conversationId: body.conversationId,
           },
           "ACP spawn request received",
         );
@@ -65,7 +65,7 @@ export function acpRouteDefinitions(): RouteDefinition[] {
           agentConfig,
           body.task,
           body.cwd ?? process.cwd(),
-          body.sessionId,
+          body.conversationId,
           sendToVellum,
         );
         log.info(


### PR DESCRIPTION
## Summary
- Renamed `body.sessionId` to `body.conversationId` in the ACP spawn HTTP route
- Updated validation error message and log property

Part of plan: conv-rename-ts-swift-notif.md (PR 7 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
