### PR TITLE
refactor: fix session→conversation in TS comments, JSDoc, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ All three tools require explicit user approval before execution (Risk Level = Hi
 
 - Snippets must export a `default` or `run` function with signature `(input: unknown) => unknown | Promise<unknown>`.
 - If evaluation fails after 3 attempts, the assistant asks for user guidance instead of retrying.
-- After a skill is written or deleted, the file watcher triggers session eviction. The next turn runs in a fresh session.
+- After a skill is written or deleted, the file watcher triggers conversation eviction. The next turn runs in a fresh conversation.
 - Managed skills appear in the macOS Settings UI with Inspect and Delete controls.
 
 ### Child Skill Includes

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1094,7 +1094,7 @@ graph TB
 - `evaluate_typescript_code` always forces `sandbox.enabled = true` regardless of global config.
 - Snippet contract: must export `default` or `run` with signature `(input: unknown) => unknown | Promise<unknown>`.
 - Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` or `SKILLS.md` files.
-- After persist or delete, the file watcher triggers session eviction; the next turn runs in a fresh session. The model's system prompt instructs it to continue normally.
+- After persist or delete, the file watcher triggers conversation eviction; the next turn runs in a fresh conversation. The model's system prompt instructs it to continue normally.
 - macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
 - `skill_load` validates the recursive include graph (via `include-graph.ts`) before emitting output. Missing children and cycles produce `isError: true` with no `<loaded_skill>` marker. Valid includes produce an "Included Skills (immediate)" metadata section showing child ID, name, description, and path.
 

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -6,7 +6,7 @@
 
 The single HTTP send endpoint is `POST /v1/messages`. Key behaviors:
 
-- **Queue if busy**: When the session is processing, messages are queued and processed when the current agent turn completes. No 409 rejections.
+- **Queue if busy**: When the conversation is processing, messages are queued and processed when the current agent turn completes. No 409 rejections.
 - **Fire-and-forget**: Returns `202 { accepted: true }` immediately. The client observes progress via SSE (`GET /v1/events`).
 - **Hub publishing**: All agent events are published to `assistantEventHub`, making them observable via SSE.
 
@@ -21,7 +21,7 @@ Approvals are **orthogonal to message sending**. The assistant asks for approval
   - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_conversation"`, `"deny"`, `"always_allow"`, `"always_deny"`, `"always_allow_high_risk"`. For persistent decisions (`always_allow`, `always_deny`, `always_allow_high_risk`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
   - `POST /v1/secret` — `{ requestId, value, delivery }`
   - `POST /v1/trust-rules` — `{ requestId, pattern, scope, decision, allowHighRisk? }`. Validates pattern/scope against server-provided options. Does not resolve the confirmation itself.
-- **Tracking**: The `pending-interactions` tracker (`assistant/src/runtime/pending-interactions.ts`) maps `requestId → session`. Use `register()` to track, `resolve()` to consume, `getByConversation()` to query.
+- **Tracking**: The `pending-interactions` tracker (`assistant/src/runtime/pending-interactions.ts`) maps `requestId → conversation`. Use `register()` to track, `resolve()` to consume, `getByConversation()` to query.
 
 Do NOT couple approval handling to message sending. Do NOT add run/status tracking to the send path.
 

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -13,7 +13,7 @@ import type { AssistantEvent } from "./assistant-event.js";
 export type AssistantEventFilter = {
   /** Only deliver events for this assistant. */
   assistantId: string;
-  /** When set, further restrict to this session. */
+  /** When set, further restrict to this conversation. */
   conversationId?: string;
 };
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -145,7 +145,7 @@ export type MessageProcessor = (
 /**
  * Dependencies for the POST /v1/messages handler.
  *
- * The handler needs direct access to the session so it can check busy state,
+ * The handler needs direct access to the conversation so it can check busy state,
  * persist user messages, fire the agent loop, or queue messages when busy.
  * Hub publishing wires outbound events to the SSE stream.
  */
@@ -219,7 +219,7 @@ export interface RuntimeHttpServerOptions {
     | undefined;
   /** Dependencies for conversation management HTTP routes (switch, rename, clear, cancel, undo, regenerate). */
   conversationManagementDeps?: ConversationManagementDeps;
-  /** Lazy factory for model config set context (session eviction, config reload suppression). */
+  /** Lazy factory for model config set context (conversation eviction, config reload suppression). */
   getModelSetContext?: () => import("../daemon/handlers/config-model.js").ModelSetContext;
   /** Provider for watch observation dependencies (watch routes). */
   getWatchDeps?: () => import("./routes/watch-routes.js").WatchDeps;

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -2,7 +2,7 @@
  * HTTP route definitions for model configuration, conversation search,
  * message content, and queued message deletion.
  *
- * These routes expose session query functionality over the HTTP API.
+ * These routes expose conversation query functionality over the HTTP API.
  *
  * GET    /v1/model                   — current model info
  * PUT    /v1/model                   — set model
@@ -31,9 +31,9 @@ import type { RouteDefinition } from "../http-router.js";
 // ---------------------------------------------------------------------------
 
 export interface ConversationQueryRouteDeps {
-  /** Lazy factory for model set context (config reload suppression, session eviction). */
+  /** Lazy factory for model set context (config reload suppression, conversation eviction). */
   getModelSetContext?: () => ModelSetContext;
-  /** Lookup an active session by ID for queued message deletion. */
+  /** Lookup an active conversation by ID for queued message deletion. */
   findConversationForQueue?: (
     id: string,
   ) => { removeQueuedMessage(requestId: string): boolean } | undefined;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -398,7 +398,7 @@ export function handleListMessages(
  *
  * Also registers pending interactions when confirmation_request,
  * secret_request, host_bash_request, or host_file_request events flow
- * through, so standalone approval/result endpoints can look up the session
+ * through, so standalone approval/result endpoints can look up the conversation
  * by requestId.
  */
 function makeHubPublisher(
@@ -447,7 +447,7 @@ function makeHubPublisher(
           expiresAt: Date.now() + 5 * 60 * 1000,
         });
 
-        // For trusted-contact sessions, bridge to guardian.question so the
+        // For trusted-contact conversations, bridge to guardian.question so the
         // guardian gets notified and can approve via callback/request-code.
         if (trustContext) {
           bridgeConfirmationRequestToGuardian({
@@ -666,7 +666,7 @@ export async function handleSendMessage(
   );
   const isInteractive = isInteractiveInterface(sourceInterface);
   // Only create the host bash proxy for desktop client interfaces that can
-  // execute commands on the user's machine. Non-desktop sessions (CLI,
+  // execute commands on the user's machine. Non-desktop conversations (CLI,
   // channels, headless) fall back to local execution.
   // Set the proxy BEFORE updateClient so updateClient's call to
   // hostBashProxy.updateSender targets the correct (new) proxy.
@@ -823,9 +823,9 @@ export async function handleSendMessage(
     );
   }
 
-  // Auto-deny pending confirmations for idle sessions. The legacy
+  // Auto-deny pending confirmations for idle conversations. The legacy
   // handleUserMessage called autoDenyPendingConfirmations unconditionally
-  // before dispatching, so an idle session with lingering confirmations
+  // before dispatching, so an idle conversation with lingering confirmations
   // (e.g. the user never responded to a tool-approval prompt) must deny
   // them before starting the new turn.
   if (conversation.hasAnyPendingConfirmation()) {

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -153,7 +153,7 @@ export class CredentialBroker {
     return existed;
   }
 
-  /** Revoke all tokens (e.g. on session teardown). */
+  /** Revoke all tokens (e.g. on conversation teardown). */
   revokeAll(): void {
     const count = this.tokens.size;
     this.tokens.clear();

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -104,13 +104,13 @@ export interface ToolContext {
   assistantId?: string;
   /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
-  /** Per-message request ID for log correlation across session/connection boundaries. */
+  /** Per-message request ID for log correlation across conversation/connection boundaries. */
   requestId?: string;
   /** Optional callback for streaming incremental output to the client. */
   onOutput?: (chunk: string) => void;
   /** Abort signal for cooperative cancellation. Tools should check this periodically. */
   signal?: AbortSignal;
-  /** Per-session sandbox override. When set, takes precedence over the global config. */
+  /** Per-conversation sandbox override. When set, takes precedence over the global config. */
   sandboxOverride?: boolean;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error/secret_detected). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
@@ -141,7 +141,7 @@ export interface ToolContext {
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
   /** True when an interactive client is connected (not just a no-op callback). */
   isInteractive?: boolean;
-  /** Memory scope ID from the session's memory policy, so memory tools can target the correct scope. */
+  /** Memory scope ID from the conversation's memory policy, so memory tools can target the correct scope. */
   memoryScopeId?: string;
   /** When true, tools with private side-effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;

--- a/assistant/src/workspace/turn-commit.ts
+++ b/assistant/src/workspace/turn-commit.ts
@@ -28,7 +28,7 @@ const log = getLogger("turn-commit");
 export interface TurnCommitMetadata {
   /** Conversation/conversation identifier */
   conversationId: string;
-  /** 1-based turn number within the session */
+  /** 1-based turn number within the conversation */
   turnNumber: number;
   /** ISO 8601 timestamp of when the turn completed */
   timestamp: string;
@@ -43,11 +43,11 @@ export interface TurnCommitMetadata {
  * creates a single commit with structured metadata.
  *
  * This function should be awaited so it completes before the next turn
- * starts. All errors are caught and logged to avoid disrupting the session.
+ * starts. All errors are caught and logged to avoid disrupting the conversation.
  *
  * @param workspaceDir - Absolute path to the workspace directory
  * @param conversationId - Conversation/conversation identifier
- * @param turnNumber - 1-based turn number within the session
+ * @param turnNumber - 1-based turn number within the conversation
  * @param provider - Optional commit message provider (defaults to deterministic)
  * @param deadlineMs - Optional absolute deadline (Date.now()) after which the commit should be skipped
  */


### PR DESCRIPTION
## Summary
- Updated comments and JSDoc in tools/types.ts, turn-commit.ts, routes, event-hub, broker
- Updated documentation in AGENTS.md, ARCHITECTURE.md, README.md
- Preserved wire protocol strings

Part of plan: conv-rename-ts-swift-notif.md (PR 3 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
