### PR TITLE
refactor: fix session/thread→conversation in Swift gallery, debug, and developer settings

### DIFF
--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Full-screen debug panel for iOS, showing trace logs and session metrics.
+/// Full-screen debug panel for iOS, showing trace logs and conversation metrics.
 ///
 /// Mirrors the macOS DebugPanel. Presented as a sheet from the chat view when
 /// the developer toggle is enabled. Gated behind `UserDefaultsKeys.developerModeEnabled`.
@@ -22,7 +22,7 @@ struct DebugPanelView: View {
                     if events.isEmpty {
                         emptyState(
                             title: "No trace events yet",
-                            subtitle: "Events will appear as the session runs",
+                            subtitle: "Events will appear as the conversation runs",
                             icon: .audioWaveform
                         )
                     } else {
@@ -30,7 +30,7 @@ struct DebugPanelView: View {
                     }
                 } else {
                     emptyState(
-                        title: "No session selected",
+                        title: "No conversation selected",
                         subtitle: "Start a conversation to see trace events",
                         icon: .bug
                     )

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -51,7 +51,7 @@ private struct DeveloperSettingsSectionContent: View {
     var body: some View {
         Form {
             Section("Trace Store") {
-                LabeledContent("Sessions with events", value: "\(conversationCount)")
+                LabeledContent("Conversations with events", value: "\(conversationCount)")
                 LabeledContent("Total events", value: "\(totalEventCount)")
 
                 Button("Clear All Trace Events", role: .destructive) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -23,7 +23,7 @@ enum SidebarLayoutMetrics {
 
     // MARK: - Section Title
 
-    /// Gap above a section title (e.g. "Threads", "Scheduled") — tighter than divider bottom.
+    /// Gap above a section title (e.g. "Conversations", "Scheduled") — tighter than divider bottom.
     static let sectionTitleTopGap: CGFloat = VSpacing.xxs  // 2pt
 
     /// Gap below a section title before the first row.

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -9,7 +9,7 @@ struct ChatGallerySection: View {
             // MARK: - Error Banners
             GallerySectionHeader(
                 title: "Error Banners",
-                description: "ChatErrorBanner — dismissible banner for non-retryable session errors."
+                description: "ChatErrorBanner — dismissible banner for non-retryable conversation errors."
             )
 
             VCard {

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -181,7 +181,7 @@ struct FeedbackGallerySection: View {
                     onDismiss: {}
                 )
                 VToast(
-                    message: "Session was interrupted.",
+                    message: "Conversation was interrupted.",
                     style: .warning,
                     onDismiss: {}
                 )

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -9,7 +9,7 @@ struct NavigationGallerySection: View {
     private let segmentItems = ["All", "Active", "Archived", "Drafts"]
     private let tabs = [
         (label: "Dashboard", icon: VIcon.house.rawValue),
-        (label: "Sessions", icon: VIcon.list.rawValue),
+        (label: "Conversations", icon: VIcon.list.rawValue),
         (label: "Settings", icon: VIcon.settings.rawValue),
         (label: "Logs", icon: VIcon.fileText.rawValue),
     ]

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -779,7 +779,7 @@ public struct ConfirmationRequest: Codable, Sendable {
     public let conversationId: String?
     /// When false, the client should hide "always allow" / trust-rule persistence affordances.
     public let persistentDecisionsAllowed: Bool?
-    /// Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread").
+    /// Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this conversation").
     public let temporaryOptionsAvailable: [String]?
     /// The tool_use block ID for client-side correlation with specific tool calls.
     public let toolUseId: String?


### PR DESCRIPTION
## Summary
- Updated gallery demo text, debug panel strings, and developer settings label
- Updated doc comment in GeneratedAPITypes.swift (thread → conversation)
- Preserved auth session reference in ChatGallerySection

Part of plan: conv-rename-ts-swift-notif.md (PR 12 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
