### PR TITLE
refactor: rename --session-id to --conversation-id in channel-verification-sessions CLI

### DIFF
--- a/assistant/src/cli/commands/channel-verification-sessions.ts
+++ b/assistant/src/cli/commands/channel-verification-sessions.ts
@@ -112,7 +112,10 @@ Examples:
       "Destination address for outbound verification (handle, phone number, or user ID)",
     )
     .option("--rebind", "Replace existing guardian binding")
-    .option("--session-id <sessionId>", "Session ID for inbound challenges")
+    .option(
+      "--conversation-id <conversationId>",
+      "Conversation ID for inbound challenges",
+    )
     .option(
       "--origin-conversation-id <id>",
       "Origin conversation ID for routing",
@@ -147,7 +150,7 @@ Examples:
   $ assistant channel-verification-sessions create --purpose trusted_contact --contact-channel-id abc-123
   $ assistant channel-verification-sessions create --channel telegram --destination "@guardian_handle"
   $ assistant channel-verification-sessions create --channel phone --destination "+15551234567" --rebind
-  $ assistant channel-verification-sessions create --channel telegram --session-id sess-123`,
+  $ assistant channel-verification-sessions create --channel telegram --conversation-id conv-123`,
     )
     .action(
       async (
@@ -155,7 +158,7 @@ Examples:
           channel?: string;
           destination?: string;
           rebind?: boolean;
-          sessionId?: string;
+          conversationId?: string;
           originConversationId?: string;
           purpose?: string;
           contactChannelId?: string;
@@ -249,7 +252,7 @@ Examples:
           const result = createInboundChallenge(
             channel,
             opts.rebind,
-            opts.sessionId,
+            opts.conversationId,
           );
           writeOutput(cmd, result);
           if (!result.success) {


### PR DESCRIPTION
## Summary
- Renamed CLI flag from `--session-id` to `--conversation-id` in the channel-verification-sessions command
- Updated TypeScript type and usage to match (`sessionId` -> `conversationId`)
- Updated help text example to use new flag name

Part of plan: conv-rename-ts-swift-notif.md (PR 10 of 12)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
