### PR TITLE
refactor: rename sessionId and createdBySessionId in verification, invite, and contacts stores

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -145,7 +145,7 @@ export function upsertContactChannel(params: {
   policy?: string;
   status?: string;
   inviteId?: string;
-  createdBySessionId?: string;
+  createdByConversationId?: string;
   verifiedAt?: number;
   verifiedVia?: string;
   role?: ContactRole;

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -78,7 +78,7 @@ export function getReadinessService(): ChannelReadinessService {
 export function createInboundChallenge(
   channel?: ChannelId,
   rebind?: boolean,
-  sessionId?: string,
+  conversationId?: string,
 ): ChannelVerificationSessionResult {
   const resolvedAssistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
@@ -97,7 +97,10 @@ export function createInboundChallenge(
     };
   }
 
-  const result = createInboundVerificationSession(resolvedChannel, sessionId);
+  const result = createInboundVerificationSession(
+    resolvedChannel,
+    conversationId,
+  );
 
   return {
     success: true,

--- a/assistant/src/memory/channel-verification-sessions.ts
+++ b/assistant/src/memory/channel-verification-sessions.ts
@@ -59,7 +59,7 @@ export interface VerificationSession {
   challengeHash: string;
   expiresAt: number;
   status: SessionStatus;
-  createdBySessionId: string | null;
+  createdByConversationId: string | null;
   consumedByExternalUserId: string | null;
   consumedByChatId: string | null;
   // Outbound session: expected-identity binding
@@ -96,7 +96,7 @@ function rowToSession(
     challengeHash: row.challengeHash,
     expiresAt: row.expiresAt,
     status: row.status as SessionStatus,
-    createdBySessionId: row.createdBySessionId,
+    createdByConversationId: row.createdByConversationId,
     consumedByExternalUserId: row.consumedByExternalUserId,
     consumedByChatId: row.consumedByChatId,
     expectedExternalUserId: row.expectedExternalUserId ?? null,
@@ -127,7 +127,7 @@ export function createInboundSession(params: {
   channel: string;
   challengeHash: string;
   expiresAt: number;
-  createdBySessionId?: string;
+  createdByConversationId?: string;
 }): VerificationSession {
   const db = getDb();
   const now = Date.now();
@@ -150,7 +150,7 @@ export function createInboundSession(params: {
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
     status: "pending" as const,
-    createdBySessionId: params.createdBySessionId ?? null,
+    createdByConversationId: params.createdByConversationId ?? null,
     consumedByExternalUserId: null,
     consumedByChatId: null,
     expectedExternalUserId: null,
@@ -278,7 +278,7 @@ export function createVerificationSession(params: {
   challengeHash: string;
   expiresAt: number;
   status: SessionStatus;
-  createdBySessionId?: string;
+  createdByConversationId?: string;
   expectedExternalUserId?: string | null;
   expectedChatId?: string | null;
   expectedPhoneE164?: string | null;
@@ -313,7 +313,7 @@ export function createVerificationSession(params: {
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
     status: params.status as string,
-    createdBySessionId: params.createdBySessionId ?? null,
+    createdByConversationId: params.createdByConversationId ?? null,
     consumedByExternalUserId: null,
     consumedByChatId: null,
     expectedExternalUserId: params.expectedExternalUserId ?? null,

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -23,7 +23,7 @@ export interface IngressInvite {
   id: string;
   sourceChannel: string;
   tokenHash: string;
-  createdBySessionId: string | null;
+  createdByConversationId: string | null;
   note: string | null;
   maxUses: number;
   useCount: number;
@@ -73,7 +73,7 @@ function rowToInvite(
     id: row.id,
     sourceChannel: row.sourceChannel,
     tokenHash: row.tokenHash,
-    createdBySessionId: row.createdBySessionId,
+    createdByConversationId: row.createdByConversationId,
     note: row.note,
     maxUses: row.maxUses,
     useCount: row.useCount,
@@ -101,7 +101,7 @@ function rowToInvite(
 export function createInvite(params: {
   sourceChannel: string;
   contactId: string;
-  createdBySessionId?: string;
+  createdByConversationId?: string;
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
@@ -124,7 +124,7 @@ export function createInvite(params: {
     id,
     sourceChannel: params.sourceChannel,
     tokenHash: tokenH,
-    createdBySessionId: params.createdBySessionId ?? null,
+    createdByConversationId: params.createdByConversationId ?? null,
     note: params.note ?? null,
     maxUses: params.maxUses ?? 1,
     useCount: 0,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -95,7 +95,7 @@ export const channelVerificationSessions = sqliteTable(
     challengeHash: text("challenge_hash").notNull(),
     expiresAt: integer("expires_at").notNull(),
     status: text("status").notNull().default("pending"),
-    createdBySessionId: text("created_by_session_id"),
+    createdByConversationId: text("created_by_session_id"),
     consumedByExternalUserId: text("consumed_by_external_user_id"),
     consumedByChatId: text("consumed_by_chat_id"),
     // Outbound session: expected-identity binding

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -69,7 +69,7 @@ export const assistantIngressInvites = sqliteTable(
     id: text("id").primaryKey(),
     sourceChannel: text("source_channel").notNull(),
     tokenHash: text("token_hash").notNull(),
-    createdBySessionId: text("created_by_session_id"),
+    createdByConversationId: text("created_by_session_id"),
     note: text("note"),
     maxUses: integer("max_uses").notNull().default(1),
     useCount: integer("use_count").notNull().default(0),

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -114,7 +114,7 @@ function generateNumericSecret(digits: number = 6): string {
  */
 export function createInboundVerificationSession(
   channel: string,
-  sessionId?: string,
+  conversationId?: string,
 ): CreateVerificationSessionResult {
   // High-entropy hex for unbound inbound challenges — 6-digit numeric
   // codes are only safe when identity binding provides a second factor.
@@ -128,7 +128,7 @@ export function createInboundVerificationSession(
     channel,
     challengeHash,
     expiresAt,
-    createdBySessionId: sessionId,
+    createdByConversationId: conversationId,
   });
 
   const ttlSeconds = CHALLENGE_TTL_MS / 1000;


### PR DESCRIPTION
## Summary
- Renamed `sessionId` param to `conversationId` in config-channels and channel-verification-service
- Renamed `createdBySessionId` to `createdByConversationId` across all verification, invite, and contact stores
- Preserved DB column names (`created_by_session_id`)

Part of plan: conv-rename-ts-swift-notif.md (PR 8 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
