### PR TITLE
refactor: fix session/thread→conversation in test strings, names, and variables

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -202,7 +202,7 @@ function makeConfirmationEmittingSession(opts?: {
         allowlistOptions: [
           { label: "Allow ls", description: "Allow ls command", pattern: "ls" },
         ],
-        scopeOptions: [{ label: "This session", scope: "session" }],
+        scopeOptions: [{ label: "This conversation", scope: "session" }],
         persistentDecisionsAllowed: true,
       });
       // Hang to simulate waiting for decision

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -298,7 +298,7 @@ describe("ConfigWatcher protected directory handlers", () => {
     protectedWatcher!.callback("change", "trust.json");
 
     await new Promise((r) => setTimeout(r, 300));
-    // trust.json should NOT trigger session eviction
+    // trust.json should NOT trigger conversation eviction
     expect(evictCallCount).toBe(0);
     // but clearCache should have been called
     expect(trustClearCacheCallCount).toBe(1);
@@ -311,7 +311,7 @@ describe("ConfigWatcher protected directory handlers", () => {
     protectedWatcher!.callback("change", "secret-allowlist.json");
 
     await new Promise((r) => setTimeout(r, 300));
-    // secret-allowlist.json should NOT trigger session eviction
+    // secret-allowlist.json should NOT trigger conversation eviction
     expect(evictCallCount).toBe(0);
     // but resetAllowlist should have been called
     expect(resetAllowlistCallCount).toBe(1);

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -374,7 +374,7 @@ async function waitForCondition(
 
 /**
  * Resolve the Nth pending AgentLoop.run() call. Fires the minimal events
- * that `runAgentLoop` expects (usage + message_complete) so the session
+ * that `runAgentLoop` expects (usage + message_complete) so the conversation
  * cleanly transitions out of its processing state.
  */
 function resolveRun(index: number) {
@@ -416,7 +416,7 @@ describe("Conversation message queue", () => {
     pendingRuns = [];
   });
 
-  test("second message is queued when session is busy (does not throw)", async () => {
+  test("second message is queued when conversation is busy (does not throw)", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -539,7 +539,7 @@ describe("Conversation message queue", () => {
       requestId: "req-2",
     });
 
-    // Complete second run so the session finishes cleanly
+    // Complete second run so the conversation finishes cleanly
     resolveRun(1);
     await new Promise((r) => setTimeout(r, 10));
   });
@@ -566,7 +566,7 @@ describe("Conversation message queue", () => {
     // Queue should be empty
     expect(conversation.getQueueDepth()).toBe(0);
 
-    // Both queued messages should receive session-scoped cancellation events.
+    // Both queued messages should receive conversation-scoped cancellation events.
     const cancel2 = events2.find((e) => e.type === "generation_cancelled");
     expect(cancel2).toEqual({
       type: "generation_cancelled",
@@ -585,11 +585,15 @@ describe("Conversation message queue", () => {
     const err3 = events3.find((e) => e.type === "error");
     expect(err3).toBeUndefined();
 
-    const sessionErr2 = events2.find((e) => e.type === "conversation_error");
-    expect(sessionErr2).toBeUndefined();
+    const conversationErr2 = events2.find(
+      (e) => e.type === "conversation_error",
+    );
+    expect(conversationErr2).toBeUndefined();
 
-    const sessionErr3 = events3.find((e) => e.type === "conversation_error");
-    expect(sessionErr3).toBeUndefined();
+    const conversationErr3 = events3.find(
+      (e) => e.type === "conversation_error",
+    );
+    expect(conversationErr3).toBeUndefined();
   });
 
   test("conversation-scoped errors emit both conversation_error and generic error", async () => {
@@ -613,8 +617,8 @@ describe("Conversation message queue", () => {
     await p1;
 
     // Should emit conversation_error (typed, structured)
-    const sessionErr = events.find((e) => e.type === "conversation_error");
-    expect(sessionErr).toBeDefined();
+    const conversationErr = events.find((e) => e.type === "conversation_error");
+    expect(conversationErr).toBeDefined();
 
     // Should also emit generic error (callers rely on error events to detect failures)
     const genericErr = events.find((e) => e.type === "error");
@@ -723,7 +727,7 @@ describe("Conversation queue policy helpers", () => {
     pendingRuns = [];
   });
 
-  test("hasQueuedMessages() returns false on a fresh session", async () => {
+  test("hasQueuedMessages() returns false on a fresh conversation", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
     expect(conversation.hasQueuedMessages()).toBe(false);
@@ -855,7 +859,7 @@ describe("Conversation checkpoint handoff", () => {
     // Because there is a queued message, the callback should return 'yield'
     expect(decision).toBe("yield");
 
-    // Complete the run so the session finishes cleanly
+    // Complete the run so the conversation finishes cleanly
     resolveRun(0);
     await p1;
 
@@ -1558,7 +1562,7 @@ describe("Conversation attachment event payloads", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression: cancel semantics + session/global error channel split
+// Regression: cancel semantics + conversation/global error channel split
 // ---------------------------------------------------------------------------
 
 describe("Regression: cancel semantics and error channel split", () => {
@@ -1594,8 +1598,10 @@ describe("Regression: cancel semantics and error channel split", () => {
     expect(cancelEvent).toBeDefined();
 
     // conversation_error must never appear on cancel
-    const sessionErr = msgEvents.find((e) => e.type === "conversation_error");
-    expect(sessionErr).toBeUndefined();
+    const conversationErr = msgEvents.find(
+      (e) => e.type === "conversation_error",
+    );
+    expect(conversationErr).toBeUndefined();
   });
 
   test("post-processing failure still attempts turn-boundary commit", async () => {
@@ -1667,8 +1673,10 @@ describe("Regression: cancel semantics and error channel split", () => {
     await p1;
 
     // Should get conversation_error (structured)
-    const sessionErr = allEvents.find((e) => e.type === "conversation_error");
-    expect(sessionErr).toBeDefined();
+    const conversationErr = allEvents.find(
+      (e) => e.type === "conversation_error",
+    );
+    expect(conversationErr).toBeDefined();
 
     // Should also get generic error
     const genericErr = allEvents.find((e) => e.type === "error");
@@ -1706,8 +1714,10 @@ describe("Regression: cancel semantics and error channel split", () => {
 
     // No queued message should have received conversation_error
     for (const events of eventsPerMsg) {
-      const sessionErr = events.find((e) => e.type === "conversation_error");
-      expect(sessionErr).toBeUndefined();
+      const conversationErr = events.find(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationErr).toBeUndefined();
     }
   });
 

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -107,7 +107,7 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("3 attempts");
   });
 
-  test("workflow section includes session eviction note", () => {
+  test("workflow section includes conversation eviction note", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
     expect(result).toContain("recreated session");

--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -78,7 +78,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-123",
+        conversation_id: "conv-123",
       },
       ctx,
     );
@@ -86,7 +86,7 @@ describe("followup_create tool", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Created follow-up");
     expect(result.content).toContain("email");
-    expect(result.content).toContain("thread-123");
+    expect(result.content).toContain("conv-123");
     expect(result.content).toContain("Status: pending");
   });
 
@@ -108,7 +108,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-456",
+        conversation_id: "conv-456",
         reminder_schedule_id: "sched-abc",
       },
       ctx,
@@ -121,7 +121,7 @@ describe("followup_create tool", () => {
   test("rejects missing channel", async () => {
     const result = await executeFollowupCreate(
       {
-        conversation_id: "thread-123",
+        conversation_id: "conv-123",
       },
       ctx,
     );
@@ -134,7 +134,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "   ",
-        conversation_id: "thread-123",
+        conversation_id: "conv-123",
       },
       ctx,
     );
@@ -159,7 +159,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-123",
+        conversation_id: "conv-123",
         expected_response_hours: -1,
       },
       ctx,
@@ -175,7 +175,7 @@ describe("followup_create tool", () => {
     const result = await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-123",
+        conversation_id: "conv-123",
         contact_id: "nonexistent-contact",
       },
       ctx,
@@ -200,11 +200,11 @@ describe("followup_list tool", () => {
 
   test("lists all follow-ups", async () => {
     await executeFollowupCreate(
-      { channel: "email", conversation_id: "thread-1" },
+      { channel: "email", conversation_id: "conv-1" },
       ctx,
     );
     await executeFollowupCreate(
-      { channel: "slack", conversation_id: "thread-2" },
+      { channel: "slack", conversation_id: "conv-2" },
       ctx,
     );
 
@@ -218,7 +218,7 @@ describe("followup_list tool", () => {
 
   test("filters by status", async () => {
     await executeFollowupCreate(
-      { channel: "email", conversation_id: "thread-1" },
+      { channel: "email", conversation_id: "conv-1" },
       ctx,
     );
 
@@ -230,11 +230,11 @@ describe("followup_list tool", () => {
 
   test("filters by channel", async () => {
     await executeFollowupCreate(
-      { channel: "email", conversation_id: "thread-1" },
+      { channel: "email", conversation_id: "conv-1" },
       ctx,
     );
     await executeFollowupCreate(
-      { channel: "slack", conversation_id: "thread-2" },
+      { channel: "slack", conversation_id: "conv-2" },
       ctx,
     );
 
@@ -262,7 +262,7 @@ describe("followup_resolve tool", () => {
     const createResult = await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-1",
+        conversation_id: "conv-1",
       },
       ctx,
     );
@@ -279,7 +279,7 @@ describe("followup_resolve tool", () => {
     await executeFollowupCreate(
       {
         channel: "email",
-        conversation_id: "thread-1",
+        conversation_id: "conv-1",
       },
       ctx,
     );
@@ -287,7 +287,7 @@ describe("followup_resolve tool", () => {
     const result = await executeFollowupResolve(
       {
         channel: "email",
-        conversation_id: "thread-1",
+        conversation_id: "conv-1",
       },
       ctx,
     );

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -186,7 +186,7 @@ describe("SSE assistant-events endpoint", () => {
   // ── Unfiltered subscription ──────────────────────────────────────────────
 
   test("streams all events when conversationKey is omitted", async () => {
-    // Subscribe without a conversationKey — should receive events from any session.
+    // Subscribe without a conversationKey — should receive events from any conversation.
     const ac = new AbortController();
     const req = new Request("http://localhost/v1/events", {
       signal: ac.signal,
@@ -212,9 +212,17 @@ describe("SSE assistant-events endpoint", () => {
     expect(heartbeat.done).toBe(false);
     expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
 
-    // Publish events with two different sessionIds.
-    const eventA = buildAssistantEvent("self", { type: "pong" }, "session-aaa");
-    const eventB = buildAssistantEvent("self", { type: "pong" }, "session-bbb");
+    // Publish events with two different conversationIds.
+    const eventA = buildAssistantEvent(
+      "self",
+      { type: "pong" },
+      "conversation-aaa",
+    );
+    const eventB = buildAssistantEvent(
+      "self",
+      { type: "pong" },
+      "conversation-bbb",
+    );
     await testHub.publish(eventA);
     await testHub.publish(eventB);
 
@@ -222,12 +230,12 @@ describe("SSE assistant-events endpoint", () => {
     const frameA = await reader.read();
     expect(frameA.done).toBe(false);
     const textA = new TextDecoder().decode(frameA.value);
-    expect(textA).toContain("session-aaa");
+    expect(textA).toContain("conversation-aaa");
 
     const frameB = await reader.read();
     expect(frameB.done).toBe(false);
     const textB = new TextDecoder().decode(frameB.value);
-    expect(textB).toContain("session-bbb");
+    expect(textB).toContain("conversation-bbb");
 
     ac.abort();
   });

--- a/assistant/src/__tests__/token-estimator-accuracy.benchmark.test.ts
+++ b/assistant/src/__tests__/token-estimator-accuracy.benchmark.test.ts
@@ -21,7 +21,7 @@ const MODEL = "claude-sonnet-4-20250514";
 const describeWithApi = API_KEY ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
-// Helpers to construct realistic payloads matching a desktop session
+// Helpers to construct realistic payloads matching a desktop conversation
 // ---------------------------------------------------------------------------
 
 /** Generates a system prompt similar to production (~35-40K chars) */
@@ -416,7 +416,7 @@ function makeRuntimeInjectedMessage(): Message {
   };
 }
 
-/** Generates tool definitions matching a realistic desktop session */
+/** Generates tool definitions matching a realistic desktop conversation */
 function makeToolDefinitions(): Array<{
   name: string;
   description: string;

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1535,9 +1535,9 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── USER.md security invariant (PR 31) ──────────
 
-  test("file_edit to USER.md forces prompt in private thread even with matching trust rule", async () => {
+  test("file_edit to USER.md forces prompt in private conversation even with matching trust rule", async () => {
     // This is a key security invariant: USER.md contains the user's persistent
-    // memory. In a private thread (forcePromptSideEffects=true), edits to it
+    // memory. In a private conversation (forcePromptSideEffects=true), edits to it
     // must always require explicit approval, even when a trust rule matches.
     checkResultOverride = {
       decision: "allow",
@@ -1560,7 +1560,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("host_file_edit to USER.md forces prompt in private thread", async () => {
+  test("host_file_edit to USER.md forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1580,7 +1580,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── Browser action tools as side-effect tools (PR fix2) ──────────
 
-  test("browser_click forces prompt in private thread", async () => {
+  test("browser_click forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1594,7 +1594,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("browser_type forces prompt in private thread", async () => {
+  test("browser_type forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1608,7 +1608,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("browser_snapshot does NOT force prompt in private thread", async () => {
+  test("browser_snapshot does NOT force prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1625,7 +1625,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── Always-mutating document tools (PR fix5) ──────────
 
-  test("document_create forces prompt in private thread", async () => {
+  test("document_create forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1639,7 +1639,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("document_update forces prompt in private thread", async () => {
+  test("document_update forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1655,7 +1655,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── Always-mutating schedule tools (PR fix7) ──────────
 
-  test("schedule_create forces prompt in private thread", async () => {
+  test("schedule_create forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1669,7 +1669,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("schedule_update forces prompt in private thread", async () => {
+  test("schedule_update forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1683,7 +1683,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("schedule_delete forces prompt in private thread", async () => {
+  test("schedule_delete forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1699,7 +1699,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── Credential store action-aware (PR fix9) ──────────
 
-  test("credential_store store forces prompt in private thread", async () => {
+  test("credential_store store forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1713,7 +1713,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("credential_store delete forces prompt in private thread", async () => {
+  test("credential_store delete forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1727,7 +1727,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("credential_store oauth2_connect forces prompt in private thread", async () => {
+  test("credential_store oauth2_connect forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1741,7 +1741,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("credential_store list does NOT force prompt in private thread", async () => {
+  test("credential_store list does NOT force prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1758,7 +1758,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 
   // ── Workspace mode + forcePromptSideEffects interaction ──────────
 
-  test("workspace mode allow → prompt promotion still works for side-effect tools in private threads", async () => {
+  test("workspace mode allow → prompt promotion still works for side-effect tools in private conversations", async () => {
     // Simulate workspace mode returning 'allow' for a workspace-scoped file_write
     checkResultOverride = {
       decision: "allow",
@@ -1778,7 +1778,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("schedule_create forces prompt in private thread", async () => {
+  test("schedule_create forces prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1796,7 +1796,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("schedule_list does NOT force prompt in private thread", async () => {
+  test("schedule_list does NOT force prompt in private conversation", async () => {
     checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
 
     const executor = new ToolExecutor(makeTrackingPrompter());
@@ -1967,7 +1967,7 @@ describe("ToolExecutor persistentDecisionsAllowed contract", () => {
         _scopeOptions: ScopeOption[],
         _diff: unknown,
         _sandboxed: unknown,
-        _sessionId: unknown,
+        _conversationId: unknown,
         _executionTarget: unknown,
         persistentDecisionsAllowed: boolean | undefined,
       ) => {


### PR DESCRIPTION
## Summary
- Updated ~18 test names from "private thread" to "private conversation" in tool-executor tests
- Renamed `_sessionId` parameter to `_conversationId` in tool-executor test
- Renamed `sessionErr` variables to `conversationErr` in conversation-queue tests
- Updated session→conversation in test names and comments across conversation-queue tests
- Updated fixture IDs from `session-aaa`/`session-bbb` to `conversation-aaa`/`conversation-bbb` in runtime-events-sse tests
- Updated fixture IDs from `thread-*` to `conv-*` in followup-tools tests (preserving `slack-thread-1`)
- Updated "session eviction" to "conversation eviction" in config-watcher and dynamic-skill-workflow-prompt tests
- Updated "desktop session" to "desktop conversation" in token-estimator-accuracy benchmark test
- Updated "This session" to "This conversation" in approval-routes-http test

Part of plan: conv-rename-ts-swift-notif.md (PR 9 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
