### PR TITLE
ci: replace custom cancel-if-superseded with native concurrency group

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -14,6 +14,10 @@ on:
       - 'packages/**'
       - '.github/workflows/ci-main-macos.yaml'
 
+concurrency:
+  group: ci-main-macos
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Detect Path Changes
@@ -48,35 +52,6 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - name: Cancel if superseded by a newer run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = context.ref.replace('refs/heads/', '');
-            for (const status of ['queued', 'waiting', 'in_progress']) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci-main-macos.yaml',
-                branch,
-                status,
-                per_page: 10,
-              });
-              const newer = data.workflow_runs.filter(r => r.run_number > context.runNumber);
-              if (newer.length > 0) {
-                core.info(`Superseded by newer ${status} run(s): ${newer.map(r => '#' + r.run_number).join(', ')}`);
-                await github.rest.actions.cancelWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: context.runId,
-                });
-                await new Promise(r => setTimeout(r, 5000));
-                core.setFailed('Superseded by a newer run');
-                return;
-              }
-            }
-            core.info('This is the newest run — proceeding.');
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -117,35 +92,6 @@ jobs:
     env:
       APP_DISPLAY_NAME: Vellum
     steps:
-      - name: Cancel if superseded by a newer run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = context.ref.replace('refs/heads/', '');
-            for (const status of ['queued', 'waiting', 'in_progress']) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci-main-macos.yaml',
-                branch,
-                status,
-                per_page: 10,
-              });
-              const newer = data.workflow_runs.filter(r => r.run_number > context.runNumber);
-              if (newer.length > 0) {
-                core.info(`Superseded by newer ${status} run(s): ${newer.map(r => '#' + r.run_number).join(', ')}`);
-                await github.rest.actions.cancelWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: context.runId,
-                });
-                await new Promise(r => setTimeout(r, 5000));
-                core.setFailed('Superseded by a newer run');
-                return;
-              }
-            }
-            core.info('This is the newest run — proceeding.');
-
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Replace the custom `actions/github-script` "Cancel if superseded" steps in both `test` and `build-app` jobs with GitHub's native `concurrency` key at the workflow level
- The custom script was causing over half of main CI runs to show as cancelled (with red X marks), wasting macOS runner time on the cancellation check itself, and triggering Node.js 20 deprecation warnings from `actions/github-script@v7`
- The native `concurrency` group cancels superseded runs before runners are claimed, which is cleaner and more efficient

## Original prompt
fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/23168077915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
