### PR TITLE
fix: pre-select non-managed assistant when skipping ReauthView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -83,6 +83,11 @@ struct ReauthView: View {
 
                 if hasNonManagedAssistant {
                     Button {
+                        // Pre-select a non-managed assistant so proceedToApp() doesn't
+                        // fall back to a managed assistant whose session was invalidated.
+                        if let nonManaged = LockfileAssistant.loadAll().first(where: { !$0.isManaged }) {
+                            UserDefaults.standard.set(nonManaged.assistantId, forKey: "connectedAssistantId")
+                        }
                         onComplete()
                     } label: {
                         Text("Skip")


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for self-hosted-logout-flow.md.

**Gap:** ReauthView Skip can select a logged-out managed assistant
**What was expected:** Skip should connect to a non-managed assistant, not a managed one with invalidated credentials
**What was found:** `proceedToApp()` fell back to `loadLatest()` which could return a managed assistant

**Fix:** Before calling `onComplete()` in the Skip button action, pre-select a non-managed assistant by finding one in the lockfile and setting `connectedAssistantId` in UserDefaults. This ensures `proceedToApp()` uses the non-managed assistant rather than falling back to `LockfileAssistant.loadLatest()` which could return a managed assistant with invalidated credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
