### PR TITLE
fix: track model selection changes in InferenceServiceCard hasChanges

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -15,6 +15,8 @@ struct InferenceServiceCard: View {
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
+    /// Snapshot of the model at card appear — used to detect model-only changes.
+    @State private var initialModel: String = ""
     /// Whether the Managed segment is being hovered (for tooltip).
     @State private var isManagedHovered: Bool = false
 
@@ -39,7 +41,8 @@ struct InferenceServiceCard: View {
     private var hasChanges: Bool {
         let modeChanged = draftMode != store.inferenceMode
         let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        return modeChanged || hasNewKey
+        let modelChanged = store.selectedModel != initialModel
+        return modeChanged || hasNewKey || modelChanged
     }
 
     var body: some View {
@@ -68,6 +71,7 @@ struct InferenceServiceCard: View {
         .vCard(background: VColor.surfaceOverlay)
         .onAppear {
             draftMode = store.inferenceMode
+            initialModel = store.selectedModel
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
@@ -256,5 +260,6 @@ struct InferenceServiceCard: View {
 
         // Persist model selection
         store.setModel(store.selectedModel)
+        initialModel = store.selectedModel
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-mode-ui.md.

**Gap:** Model-only changes cannot be saved
**What was expected:** Save button should enable when model selection changes
**What was found:** hasChanges only checked mode and API key, not model selection

Adds @State initialModel tracking so model-only changes enable the Save button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
