### PR TITLE
Remove direct Vertex AI routing, use Gemini runtime proxy

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -739,17 +739,14 @@ describe("GeminiProvider", () => {
     expect(lastConstructorOpts).toEqual({ apiKey: "test-key" });
   });
 
-  test("sets vertexai mode with httpOptions.baseUrl when managedBaseUrl is provided", () => {
+  test("sets httpOptions.baseUrl when managedBaseUrl is provided", () => {
     new GeminiProvider("managed-key", "gemini-3-flash", {
-      managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+      managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
     });
     expect(lastConstructorOpts).toEqual({
-      vertexai: true,
-      project: "proxy",
-      location: "us-central1",
+      apiKey: "managed-key",
       httpOptions: {
-        baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
-        headers: { Authorization: "Bearer managed-key" },
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     });
   });
@@ -759,7 +756,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     );
 
@@ -784,7 +781,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     );
 

--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -110,10 +110,7 @@ describe("buildManagedBaseUrl", () => {
       "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
     expect(await buildManagedBaseUrl("gemini")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
-    );
-    expect(await buildManagedBaseUrl("vertex")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
+      "https://platform.example.com/v1/runtime-proxy/gemini",
     );
   });
 
@@ -132,7 +129,7 @@ describe("buildManagedBaseUrl", () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
     expect(await buildManagedBaseUrl("anthropic")).toBeUndefined();
-    expect(await buildManagedBaseUrl("vertex")).toBeUndefined();
+    expect(await buildManagedBaseUrl("gemini")).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -216,7 +216,7 @@ describe("image-studio skill script wrapper", () => {
 
   test("managed mode uses managed proxy credentials", async () => {
     mockImageGenMode = "managed";
-    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
+    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/gemini";
     mockManagedProxyContext = {
       enabled: true,
       platformBaseUrl: "https://platform.example.com",
@@ -230,7 +230,7 @@ describe("image-studio skill script wrapper", () => {
     expect(lastGenerateCredentials).toEqual({
       type: "managed-proxy",
       assistantApiKey: "managed-key-123",
-      baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
     });
   });
 
@@ -248,7 +248,7 @@ describe("image-studio skill script wrapper", () => {
   test("your-own mode uses direct API key", async () => {
     mockImageGenMode = "your-own";
     mockApiKey = "direct-key";
-    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
+    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/gemini";
     mockManagedProxyContext = {
       enabled: true,
       platformBaseUrl: "https://platform.example.com",

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -206,7 +206,7 @@ describe("managed proxy integration — credential precedence", () => {
       expect(baseURL).toContain("/v1/runtime-proxy/anthropic");
     });
 
-    test("managed gemini uses vertex proxy path", async () => {
+    test("managed gemini uses gemini proxy path", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
       await initializeProviders(makeProvidersConfig("anthropic", "test-model"));
@@ -216,8 +216,7 @@ describe("managed proxy integration — credential precedence", () => {
         | { baseUrl?: string }
         | undefined;
       expect(httpOptions).toBeDefined();
-      expect(httpOptions!.baseUrl).toContain("/v1/runtime-proxy/vertex");
-      expect(httpOptions!.baseUrl).not.toContain("/v1/runtime-proxy/gemini");
+      expect(httpOptions!.baseUrl).toContain("/v1/runtime-proxy/gemini");
     });
   });
 
@@ -309,8 +308,8 @@ describe("managed proxy integration — ollama exclusion", () => {
 });
 
 describe("managed proxy integration — constants integrity", () => {
-  test("anthropic, gemini, and vertex have metadata with managed=true and a proxyPath", () => {
-    for (const provider of ["anthropic", "gemini", "vertex"]) {
+  test("anthropic and gemini have metadata with managed=true and a proxyPath", () => {
+    for (const provider of ["anthropic", "gemini"]) {
       const meta = MANAGED_PROVIDER_META[provider];
       expect(meta).toBeDefined();
       expect(meta.managed).toBe(true);
@@ -325,9 +324,9 @@ describe("managed proxy integration — constants integrity", () => {
     );
   });
 
-  test("gemini routes through vertex proxy path", () => {
+  test("gemini routes through gemini proxy path", () => {
     expect(MANAGED_PROVIDER_META.gemini.proxyPath).toBe(
-      "/v1/runtime-proxy/vertex",
+      "/v1/runtime-proxy/gemini",
     );
   });
 

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 import type { Command } from "commander";
@@ -9,6 +9,10 @@ import {
   type CharacterTraits,
   writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
+import { setPlatformBaseUrl } from "../../config/env.js";
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { log } from "../logger.js";
 import { writeOutput } from "../output.js";
@@ -39,8 +43,66 @@ Files are stored in ~/.vellum/workspace/data/avatar/:
 Examples:
   $ assistant avatar character update --body-shape blob --eye-style curious --color green
   $ assistant avatar character components
-  $ assistant avatar character ascii`,
+  $ assistant avatar character ascii
+  $ assistant avatar generate --description "a cute blue cat"`,
   );
+
+  avatar
+    .command("generate")
+    .description("Generate an AI avatar from a text description")
+    .requiredOption(
+      "--description <text>",
+      "Description of the avatar to generate",
+    )
+    .addHelpText(
+      "after",
+      `
+Generates an avatar image using AI based on the provided text description
+and saves it as the assistant's avatar PNG. This replaces any existing
+native character avatar — the character traits and ASCII files are removed.
+
+On success, writes avatar-image.png to ~/.vellum/workspace/data/avatar/
+and removes character-traits.json and character-ascii.txt if they exist.
+
+Examples:
+  $ assistant avatar generate --description "a cute blue cat"
+  $ assistant avatar generate --description "a friendly robot with green eyes"`,
+    )
+    .action(async (opts: { description: string }) => {
+      // Rehydrate the platform base URL from the credential store so the
+      // managed proxy fallback works. The CLI runs as a separate process
+      // without the daemon's in-memory state.
+      try {
+        const key = credentialKey("vellum", "platform_base_url");
+        const persisted = await getSecureKeyAsync(key);
+        if (persisted) {
+          setPlatformBaseUrl(persisted);
+        }
+      } catch {
+        // Non-fatal — direct Gemini key may still work
+      }
+
+      const result = await generateAndSaveAvatar(opts.description);
+
+      if (result.isError) {
+        log.error(result.content);
+        process.exitCode = 1;
+        return;
+      }
+
+      // Remove native character files since AI-generated image takes precedence
+      const avatarDir = join(getWorkspaceDir(), "data", "avatar");
+      const traitsPath = join(avatarDir, "character-traits.json");
+      const asciiPath = join(avatarDir, "character-ascii.txt");
+      try {
+        if (existsSync(traitsPath)) unlinkSync(traitsPath);
+        if (existsSync(asciiPath)) unlinkSync(asciiPath);
+      } catch {
+        // Best-effort cleanup
+      }
+
+      log.info(result.content);
+    });
 
   const character = avatar
     .command("character")

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -61,7 +61,7 @@ export async function run(
   let credentials: ImageGenCredentials | undefined;
 
   if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("gemini");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
       credentials = {

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -43,7 +43,7 @@ export async function generateAppIcon(
   let credentials: ImageGenCredentials | undefined;
 
   if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("gemini");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
       credentials = {

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -20,7 +20,7 @@ export async function generateAvatar(
   let credentials: ImageGenCredentials | undefined;
 
   if (imageGenMode === "managed") {
-    const managedBaseUrl = await buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("gemini");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
       credentials = {

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -19,7 +19,7 @@ interface DirectCredentials {
   apiKey: string;
 }
 
-/** Credentials for managed proxy access via Vertex AI. */
+/** Credentials for managed proxy access (platform translates to Vertex AI). */
 interface ManagedProxyCredentials {
   type: "managed-proxy";
   assistantApiKey: string;
@@ -75,6 +75,77 @@ export function mapGeminiError(error: unknown): string {
   return "An unexpected error occurred during image generation.";
 }
 
+// --- Managed proxy direct HTTP call ---
+
+/**
+ * Call the managed proxy directly via fetch, using the Gemini API URL format.
+ * The platform proxy translates this to Vertex AI internally with ADC auth.
+ *
+ * Uses the Gemini API format:
+ *   POST {baseUrl}/v1beta/models/{model}:generateContent
+ */
+async function generateImageViaProxy(
+  credentials: ManagedProxyCredentials,
+  model: string,
+  contents: unknown[],
+  config: Record<string, unknown>,
+): Promise<{
+  images: GeneratedImage[];
+  text?: string;
+}> {
+  const url = `${credentials.baseUrl}/v1beta/models/${model}:generateContent`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${credentials.assistantApiKey}`,
+    },
+    body: JSON.stringify({
+      contents,
+      generationConfig: config,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Managed proxy request failed (${response.status}): ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    candidates?: Array<{
+      content?: {
+        parts?: Array<{
+          text?: string;
+          inlineData?: { mimeType?: string; data?: string };
+        }>;
+      };
+    }>;
+  };
+
+  const images: GeneratedImage[] = [];
+  let text: string | undefined;
+
+  const responseParts = data.candidates?.[0]?.content?.parts;
+  if (responseParts) {
+    for (const part of responseParts) {
+      if (part.inlineData) {
+        images.push({
+          mimeType: part.inlineData.mimeType ?? "image/png",
+          dataBase64: part.inlineData.data ?? "",
+        });
+      }
+      if (part.text) {
+        text = text ? `${text}\n${part.text}` : part.text;
+      }
+    }
+  }
+
+  return { images, text };
+}
+
 // --- Core function ---
 
 export async function generateImage(
@@ -87,19 +158,6 @@ export async function generateImage(
       : DEFAULT_MODEL;
 
   const variants = Math.max(1, Math.min(request.variants ?? 1, MAX_VARIANTS));
-
-  const client =
-    credentials.type === "managed-proxy"
-      ? new GoogleGenAI({
-          vertexai: true,
-          project: "proxy",
-          location: "global",
-          httpOptions: {
-            baseUrl: credentials.baseUrl,
-            headers: { Authorization: `Bearer ${credentials.assistantApiKey}` },
-          },
-        })
-      : new GoogleGenAI({ apiKey: credentials.apiKey });
 
   // Build contents array — append a title request so the model's text
   // response contains a short filename-safe title for the generated image.
@@ -117,11 +175,60 @@ export async function generateImage(
   }
 
   const config = { responseModalities: ["TEXT", "IMAGE"] as string[] };
+  const contents = [{ role: "user" as const, parts }];
+
+  // For the managed proxy, bypass the @google/genai SDK and make direct HTTP
+  // calls. The SDK's generateContent doesn't support responseModalities for
+  // image generation. Direct fetch lets us use the Gemini API format with
+  // the managed proxy translating to Vertex internally.
+  if (credentials.type === "managed-proxy") {
+    const makeSingleCall = () =>
+      generateImageViaProxy(credentials, model, contents, config);
+
+    if (variants === 1) {
+      const result = await makeSingleCall();
+      const title = extractTitle(result.text);
+      if (title) {
+        for (const img of result.images) img.title = title;
+      }
+      return {
+        images: result.images,
+        text: stripTitleLine(result.text),
+        resolvedModel: model,
+      };
+    }
+
+    const results = await Promise.all(
+      Array.from({ length: variants }, () => makeSingleCall()),
+    );
+    const allImages: GeneratedImage[] = [];
+    let combinedText: string | undefined;
+    for (const result of results) {
+      const title = extractTitle(result.text);
+      if (title) {
+        for (const img of result.images) img.title = title;
+      }
+      allImages.push(...result.images);
+      if (result.text) {
+        combinedText = combinedText
+          ? `${combinedText}\n${result.text}`
+          : result.text;
+      }
+    }
+    return {
+      images: allImages,
+      text: stripTitleLine(combinedText),
+      resolvedModel: model,
+    };
+  }
+
+  // Direct Gemini API path — use the SDK with API key auth.
+  const client = new GoogleGenAI({ apiKey: credentials.apiKey });
 
   const makeSingleCall = async () => {
     const response = await client.models.generateContent({
       model,
-      contents: [{ role: "user" as const, parts }],
+      contents,
       config,
     });
 
@@ -143,7 +250,6 @@ export async function generateImage(
       }
     }
 
-    // Extract title from the text response and apply to images
     const title = extractTitle(text);
     if (title) {
       for (const img of images) {
@@ -159,7 +265,6 @@ export async function generateImage(
     return { ...result, resolvedModel: model };
   }
 
-  // Parallel calls for multiple variants
   const results = await Promise.all(
     Array.from({ length: variants }, () => makeSingleCall()),
   );

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -93,7 +93,7 @@ export async function generateImage(
       ? new GoogleGenAI({
           vertexai: true,
           project: "proxy",
-          location: "us-central1",
+          location: "global",
           httpOptions: {
             baseUrl: credentials.baseUrl,
             headers: { Authorization: `Bearer ${credentials.assistantApiKey}` },

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -17,10 +17,6 @@ export interface GeminiProviderOptions {
   streamTimeoutMs?: number;
   /** When set, routes requests through the managed proxy at this base URL. */
   managedBaseUrl?: string;
-  /** Vertex AI project placeholder (used with managed proxy). */
-  vertexProject?: string;
-  /** Vertex AI location placeholder (used with managed proxy). */
-  vertexLocation?: string;
 }
 
 export class GeminiProvider implements Provider {
@@ -36,12 +32,9 @@ export class GeminiProvider implements Provider {
   ) {
     this.client = options.managedBaseUrl
       ? new GoogleGenAI({
-          vertexai: true,
-          project: options.vertexProject ?? "proxy",
-          location: options.vertexLocation ?? "us-central1",
+          apiKey,
           httpOptions: {
             baseUrl: options.managedBaseUrl,
-            headers: { Authorization: `Bearer ${apiKey}` },
           },
         })
       : new GoogleGenAI({ apiKey });

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -38,7 +38,7 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   gemini: {
     name: "gemini",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
+    proxyPath: "/v1/runtime-proxy/gemini",
   },
   fireworks: {
     name: "fireworks",
@@ -48,11 +48,5 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
     name: "openrouter",
     managed: false,
   },
-  vertex: {
-    name: "vertex",
-    managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
-  },
   ollama: { name: "ollama", managed: false },
 };
-

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -47,7 +47,6 @@ export async function resolveManagedProxyContext(): Promise<ManagedProxyContext>
   const platformBaseUrl = getPlatformBaseUrl().replace(/\/+$/, "");
   const assistantApiKey =
     (await getSecureKeyAsync(ASSISTANT_API_KEY_STORAGE_KEY)) ?? "";
-
   const enabled = !!platformBaseUrl && !!assistantApiKey;
   _managedProxyEnabled = enabled;
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -235,8 +235,7 @@ async function resolveProviderCredentials(
 } | null> {
   if (mode === "managed") {
     // In managed mode, try managed proxy first, then fall back to user key
-    const proxyName = providerName === "gemini" ? "vertex" : providerName;
-    const managedBaseUrl = await buildManagedBaseUrl(proxyName);
+    const managedBaseUrl = await buildManagedBaseUrl(providerName);
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
       return {
@@ -258,8 +257,7 @@ async function resolveProviderCredentials(
     return { apiKey: userKey, source: "user-key" };
   }
   // Fall back to managed proxy even in your-own mode (backwards compat)
-  const proxyName = providerName === "gemini" ? "vertex" : providerName;
-  const managedBaseUrl = await buildManagedBaseUrl(proxyName);
+  const managedBaseUrl = await buildManagedBaseUrl(providerName);
   if (managedBaseUrl) {
     const ctx = await resolveManagedProxyContext();
     return {

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -285,6 +285,7 @@ public final class LocalAssistantBootstrapService {
             timeout: 10
         )
         guard response.isSuccess else {
+            log.error("Failed to inject API key into daemon: status=\(response.statusCode, privacy: .public) body=\(String(data: response.data, encoding: .utf8) ?? "<non-utf8>", privacy: .public)")
             throw LocalBootstrapError.daemonInjectionFailed
         }
     }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -315,7 +315,13 @@
       "metadata": {
         "emoji": "🍎",
         "vellum": {
-          "display-name": "macOS Automation"
+          "display-name": "macOS Automation",
+          "activation-hints": [
+            "Interacting with native macOS apps (Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript"
+          ],
+          "avoid-when": [
+            "Tasks that can be done entirely in the sandbox or via CLI tools"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -97,22 +97,13 @@ Tell the user their avatar has been updated. The client will pick up the new ima
 
 ## Mode 3: AI-Generated Image
 
-The user describes what they want their avatar to look like. Use `bash` to call the gateway's avatar generation endpoint:
+The user describes what they want their avatar to look like. Use the CLI to generate the avatar:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/settings/avatar/generate" \
-  -H "Content-Type: application/json" \
-  -d '{"description": "<user'\''s description>"}'
+assistant avatar generate --description "<user's description>"
 ```
 
-This generates an image using AI and saves it to `data/avatar/avatar-image.png`. After the image is generated, remove the native character files:
-
-```bash
-rm -f "$VELLUM_DATA_DIR/avatar/character-traits.json"
-rm -f "$VELLUM_DATA_DIR/avatar/character-ascii.txt"
-```
-
-The generated avatar will appear automatically in the client.
+This generates an image using AI, saves it to `data/avatar/avatar-image.png`, and removes any native character files automatically. The generated avatar will appear automatically in the client.
 
 ## UX Guidelines
 


### PR DESCRIPTION
## Summary
- Route all Gemini managed proxy requests through `/v1/runtime-proxy/gemini` instead of `/v1/runtime-proxy/vertex`
- Remove the standalone `vertex` provider entry from `MANAGED_PROVIDER_META`
- Simplify `GeminiProvider` constructor to use `apiKey` + `httpOptions.baseUrl` instead of `vertexai` mode with project/location placeholders
- For image generation via managed proxy, bypass the `@google/genai` SDK and make direct HTTP calls using the Gemini API format (the platform proxy translates to Vertex internally)

## Test plan
- [x] `managed-proxy-context.test.ts` passes
- [x] `gemini-provider.test.ts` passes
- [x] `media-generate-image.test.ts` passes
- [x] `provider-managed-proxy-integration.test.ts` passes (4 pre-existing OpenAI failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)