### PR TITLE
fix: remove unnecessary nonisolated(unsafe) from LogExporter constant

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -437,7 +437,7 @@ enum LogExporter {
     // MARK: - Daemon Log Fallback
 
     /// Maximum total bytes to read when collecting fallback daemon logs.
-    private nonisolated(unsafe) static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
+    private static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
 
     /// When the daemon is unreachable, reads log files directly from the
     /// filesystem and copies them into `directory/daemon-logs-fallback/`.


### PR DESCRIPTION
## Summary
- Removed unnecessary `nonisolated(unsafe)` annotation from `fallbackLogSizeLimit` in `LogExporter.swift`
- The annotation is not needed for constants with `Sendable` types like `Int`, and was producing a compiler warning

## Original prompt
Fix: /Users/runner/work/vellum-assistant/vellum-assistant/clients/macos/vellum-assistant/Logging/LogExporter.swift:440:13: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'Int', consider removing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
