### PR TITLE
fix: AppDelegate transport routing and CLI ps crash for apple-containers entries

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -253,6 +253,16 @@ async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
 
   console.log(`Processes for ${entry.assistantId} (${cloud}):\n`);
 
+  // Apple-containers entries are fully managed by the macOS app via the Apple
+  // Containerization framework. They do not use a process-based daemon and have
+  // no instanceDir, so the standard PID/port detection would crash or mislead.
+  if (entry.runtimeBackend === "apple-containers") {
+    console.log(
+      `${entry.assistantId}: managed by Apple Containers (use the macOS app to manage)`,
+    );
+    return;
+  }
+
   if (cloud === "local") {
     const rows = await getLocalProcesses(entry);
     printTable(rows);

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -93,6 +93,21 @@ extension AppDelegate {
             return
         }
 
+        // Apple-containers assistants have cloud == "local" so isRemote is false,
+        // but their gateway runs on the port written to runtimeUrl by
+        // AppleContainersLauncher (e.g. http://localhost:7830). Treat them like
+        // a remote entry for transport purposes so the correct port is used.
+        if let assistant, assistant.runtimeBackend == .appleContainers, let runtimeUrl = assistant.runtimeUrl {
+            let config = DaemonConfig(transport: .http(
+                baseURL: runtimeUrl,
+                bearerToken: nil,
+                conversationKey: assistant.assistantId
+            ))
+            services.reconfigureDaemonClient(config: config)
+            log.info("Configured apple-containers HTTP transport for assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
+            return
+        }
+
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant — use HTTP transport to the local daemon.
             // Bearer token is nil; resolved lazily at connect time.
@@ -418,7 +433,12 @@ extension AppDelegate {
                         default:
                             log.error("Failed to hatch assistant during daemon setup: \(error)")
                         }
-                        if needsLockfileEntry {
+                        // Only fall back to the process-based CLI launcher for
+                        // process-backed local assistants. Apple-containers entries
+                        // must not start a process daemon — doing so creates a
+                        // mixed-backend state where the lockfile says apple-containers
+                        // but a process daemon is running.
+                        if needsLockfileEntry && assistant?.runtimeBackend != .appleContainers {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
                             do {
                                 try await assistantCli.launch(name: assistantName, daemonOnly: true, restart: false)
@@ -429,7 +449,12 @@ extension AppDelegate {
                         }
                     } catch {
                         log.error("Failed to hatch assistant during daemon setup: \(error)")
-                        if needsLockfileEntry {
+                        // Only fall back to the process-based CLI launcher for
+                        // process-backed local assistants. Apple-containers entries
+                        // must not start a process daemon — doing so creates a
+                        // mixed-backend state where the lockfile says apple-containers
+                        // but a process daemon is running.
+                        if needsLockfileEntry && assistant?.runtimeBackend != .appleContainers {
                             log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
                             do {
                                 try await assistantCli.launch(name: assistantName, daemonOnly: true, restart: false)


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for apple-containers-hatch.md.

- G4: Route apple-containers entries to port 7830 (from runtimeUrl) in configureDaemonTransport instead of hardcoded 7821
- G9: Skip process-based fallback hatch when AppleContainersLauncher fails to prevent mixed-backend state
- G7: Guard vellum ps against apple-containers entries to prevent TypeError crash on undefined instanceDir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
