### PR TITLE
fix: guard API key persistence to your-own mode in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -251,9 +251,9 @@ struct InferenceServiceCard: View {
             store.setInferenceMode(draftMode)
         }
 
-        // Persist API key if entered (only relevant for your-own mode)
+        // Persist API key if entered and in your-own mode
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedKey.isEmpty {
+        if draftMode == "your-own" && !trimmedKey.isEmpty {
             store.saveAPIKey(trimmedKey)
             apiKeyText = ""
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-mode-ui.md.

**Gap:** save() persists API key even when switching to managed mode
**What was expected:** API key should only be saved in your-own mode
**What was found:** saveAPIKey called unconditionally when apiKeyText is non-empty

Guards saveAPIKey with draftMode == "your-own" check.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
