### PR TITLE
fix: lifecycle and onboarding UX gaps in Apple Containers

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -457,6 +457,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         keychainBroker?.stop()
         #endif
         assistantCli.stop()
+        // Stop any active Apple Containers pod so the VM does not continue
+        // running after the app exits.  Fired-and-forgotten because
+        // applicationWillTerminate cannot suspend the termination sequence;
+        // the launcher's retire() is best-effort on shutdown.
+        Task { await appleContainersLauncher.stop() }
     }
 
     // MARK: - Public Actions (for SwiftUI .commands menu items)

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -218,6 +218,12 @@ final class AppleContainersLauncher: LocalAssistantLauncher {
 
     // MARK: - LocalAssistantLauncher conformance
 
+    /// Stops the active pod, if any.  Called by `AppDelegate.applicationWillTerminate`
+    /// so the VM does not continue running after the app exits.
+    func stop() async {
+        await retireActivePod()
+    }
+
     /// Launch (or re-launch) an apple-containers assistant.
     ///
     /// - Parameters:

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -59,6 +59,17 @@ struct APIKeyStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
+            // If apple-containers is no longer available (e.g. flag toggled off
+            // after a previous session persisted it), reset to the process backend
+            // so the user is not silently routed through a broken path.
+            if !appleContainersAvailability.isAvailable {
+                state.selectedRuntimeBackend = .process
+            }
+        }
+        .onChange(of: appleContainersAvailability.isAvailable) { _, isAvailable in
+            if !isAvailable {
+                state.selectedRuntimeBackend = .process
+            }
         }
     }
 
@@ -66,6 +77,14 @@ struct APIKeyStepView: View {
 
     private var appleContainersAvailability: AppleContainersAvailability {
         AppleContainersAvailabilityChecker.shared.check()
+    }
+
+    /// True when the apple_containers_enabled flag is on, regardless of whether
+    /// OS/runtime checks pass.  Used to decide whether to show the card at all
+    /// (available: interactive card; flag-on-but-unavailable: disabled card with
+    /// explanation; flag-off: card is hidden entirely).
+    private var appleContainersFlagEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("apple_containers_enabled")
     }
 
     private var hostingCards: some View {
@@ -88,12 +107,58 @@ struct APIKeyStepView: View {
                 comingSoon: false
             )
 
-            // Apple Containers option — only shown when the feature flag is on
-            // and the current machine passes all availability checks.
+            // Apple Containers option — shown when the feature flag is on.
+            // When available: interactive card.
+            // When flag is on but machine does not qualify: disabled card with reason.
+            // When flag is off: hidden entirely.
             if appleContainersAvailability.isAvailable {
                 appleContainersCard
+            } else if appleContainersFlagEnabled {
+                // Flag is on but OS or runtime check failed — show a disabled card
+                // so users with partially-supported machines get a concrete reason
+                // rather than a silently missing option.
+                appleContainersDisabledCard(reason: appleContainersAvailability.explanation)
             }
         }
+    }
+
+    /// A non-interactive Apple Containers card shown when the feature flag is on
+    /// but the current machine does not meet availability requirements.
+    /// Displays the availability failure reason so users know what to address.
+    private func appleContainersDisabledCard(reason: String) -> some View {
+        HStack(spacing: VSpacing.md) {
+            VIconView(.package, size: 18)
+                .foregroundColor(VColor.contentDisabled)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Apple Containers")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(VColor.contentDisabled)
+                Text(reason)
+                    .font(.system(size: 12))
+                    .foregroundColor(VColor.contentDisabled)
+            }
+
+            Spacer()
+
+            Circle()
+                .fill(Color.clear)
+                .overlay(
+                    Circle().stroke(VColor.borderDisabled, lineWidth: 1.5)
+                )
+                .frame(width: 18, height: 18)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.lg)
+                        .stroke(VColor.borderDisabled, lineWidth: 1)
+                )
+        )
+        .opacity(0.7)
     }
 
     private var appleContainersCard: some View {
@@ -235,10 +300,6 @@ struct APIKeyStepView: View {
 
     private var canContinue: Bool {
         state.selectedHostingMode == .local
-    }
-
-    private var isAppleContainersSelected: Bool {
-        state.selectedHostingMode == .local && state.selectedRuntimeBackend == .appleContainers
     }
 
     private var continueButtonTitle: String {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -9,7 +9,6 @@ struct HatchingStepView: View {
     @Bindable var state: OnboardingState
 
     @State private var cliLauncher = AssistantCli()
-    @State private var appleContainersLauncher = AppleContainersLauncher()
     @State private var showContent = false
     @State private var characterAwake = false
     @State private var pulseScale: CGFloat = 0.9
@@ -20,6 +19,7 @@ struct HatchingStepView: View {
     @State private var hatchEyes = AvatarEyeStyle.allCases.randomElement()!
     @State private var hatchColor = AvatarColor.allCases.randomElement()! // color-literal-ok
     @State private var completionTask: Task<Void, Never>?
+    @State private var hatchTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -50,6 +50,7 @@ struct HatchingStepView: View {
         }
         .onDisappear {
             completionTask?.cancel()
+            hatchTask?.cancel()
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
@@ -251,13 +252,26 @@ struct HatchingStepView: View {
     }
 
     private func startAppleContainersHatch() {
-        Task {
+        // Use the AppDelegate-owned launcher so the active pod is tracked by
+        // AppDelegate.applicationWillTerminate and cleaned up on app exit.
+        // Creating a local instance here would leave an orphaned VM running
+        // after the user quits.
+        let launcher = AppDelegate.shared?.appleContainersLauncher
+        hatchTask = Task {
             do {
+                state.hatchLogLines.append("Preparing kernel images\u{2026}")
+                guard !Task.isCancelled else { return }
+
                 // AppleContainersLauncher writes its own lockfile entry and manages
                 // the full pod lifecycle; we just need to wait for it to finish.
-                try await appleContainersLauncher.launch(name: nil, daemonOnly: false, restart: false)
+                state.hatchLogLines.append("Starting pod\u{2026}")
+                try await launcher?.launch(name: nil, daemonOnly: false, restart: false)
+                guard !Task.isCancelled else { return }
+
+                state.hatchLogLines.append("Waiting for gateway\u{2026}")
                 handleHatchSuccess()
             } catch {
+                guard !Task.isCancelled else { return }
                 log.error("Apple Containers hatch failed: \(String(describing: error), privacy: .public)")
                 failureReason = friendlyErrorMessage(from: error)
                 state.hatchFailed = true


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for apple-containers-hatch.md.

- G8: Use AppDelegate-owned launcher in HatchingStepView to prevent VM leak; add retire() on app termination
- G10: Store and cancel hatch Task on view disappear to prevent orphaned container launches
- G11: Add staged progress messages to hatchLogLines during apple-containers hatch
- G12: Reset selectedRuntimeBackend to .process when apple-containers becomes unavailable
- G13: Show disabled Apple Containers card with explanation in onboarding for partially-supported users
- G16: Remove unused isAppleContainersSelected dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
