### PR TITLE
fix: bridge/runtime core bugs in Apple Containers

### DIFF
--- a/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersPodRuntime.swift
+++ b/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersPodRuntime.swift
@@ -52,6 +52,8 @@ public enum AppleContainersPodRuntimeError: LocalizedError {
     /// The assistant process did not emit the readiness sentinel within the
     /// allowed timeout.
     case readinessTimeout(seconds: Int)
+    /// The assistant container exited before emitting the readiness sentinel.
+    case containerExitedBeforeReady
 
     public var errorDescription: String? {
         switch self {
@@ -67,6 +69,8 @@ public enum AppleContainersPodRuntimeError: LocalizedError {
             return "Pod failed to start: \(err.localizedDescription)"
         case .readinessTimeout(let seconds):
             return "Assistant did not become ready within \(seconds) seconds."
+        case .containerExitedBeforeReady:
+            return "Assistant container exited before emitting the readiness sentinel."
         }
     }
 }
@@ -131,9 +135,11 @@ public final class AppleContainersPodRuntime: @unchecked Sendable {
     ///
     /// - Throws: `AppleContainersPodRuntimeError` on any failure.
     public func hatch() async throws {
-        guard kernelStore.isCached else {
-            throw AppleContainersPodRuntimeError.kernelImagesNotReady
-        }
+        // Ensure kernel and init images are available before doing anything
+        // else.  ensureImagesReady() is idempotent — it returns immediately
+        // when the images are already cached, so calling it here adds no
+        // overhead on subsequent hatches.
+        try await kernelStore.ensureImagesReady()
 
         runtimeLog.info(
             "Hatching pod for '\(self.definition.instanceName, privacy: .private)' " +
@@ -285,10 +291,21 @@ public final class AppleContainersPodRuntime: @unchecked Sendable {
             podConfig.memoryInBytes = 2048 * 1024 * 1024  // 2 GiB for three services
         }
 
-        // Shared virtiofs mounts available to all containers.
+        // Virtiofs mounts shared across the assistant and gateway containers.
+        // Both services need read-write access to /data.
         let sharedMounts: [Mount] = [
             .share(source: def.hostDataDirectory.path,
                    destination: VellumPodMount.dataDirectory),
+            .share(source: def.hostCesBootstrapDirectory.path,
+                   destination: VellumPodMount.cesBootstrapDirectory),
+        ]
+
+        // The credential-executor container mounts /data read-only to match
+        // the Docker topology (docker.ts mounts the data volume `:ro` for CES).
+        let cesMounts: [Mount] = [
+            .share(source: def.hostDataDirectory.path,
+                   destination: VellumPodMount.dataDirectory,
+                   options: ["ro"]),
             .share(source: def.hostCesBootstrapDirectory.path,
                    destination: VellumPodMount.cesBootstrapDirectory),
         ]
@@ -320,11 +337,12 @@ public final class AppleContainersPodRuntime: @unchecked Sendable {
         }
 
         // Register the credential-executor container.
+        // /data is mounted read-only to match the Docker topology.
         try await pod.addContainer(
             "\(def.instanceName)-credential-executor",
             rootfs: rootfsMounts[.credentialExecutor]!
         ) { containerConfig in
-            containerConfig.mounts = sharedMounts + LinuxContainer.defaultMounts()
+            containerConfig.mounts = cesMounts + LinuxContainer.defaultMounts()
             containerConfig.process.environmentVariables = buildEnv(def.cesEnvironment())
         }
 
@@ -372,6 +390,8 @@ public final class AppleContainersPodRuntime: @unchecked Sendable {
             }
 
             // Log-watch task — reads lines until the sentinel appears.
+            // If the stream ends (container exited) before the sentinel is
+            // found, throw so hatch() fails rather than silently succeeding.
             group.addTask {
                 for await line in reader {
                     runtimeLog.debug(
@@ -382,6 +402,9 @@ public final class AppleContainersPodRuntime: @unchecked Sendable {
                         return
                     }
                 }
+                // Stream ended without the sentinel — the container exited.
+                runtimeLog.error("Assistant container exited before emitting readiness sentinel.")
+                throw AppleContainersPodRuntimeError.containerExitedBeforeReady
             }
 
             // The first task to finish (readiness or timeout) cancels the other.

--- a/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntime.swift
+++ b/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntime.swift
@@ -18,7 +18,7 @@ public struct AppleContainersRuntime: Sendable {
     /// The version of the Apple Containerization dependency this runtime was
     /// compiled against.  Exposed so the availability helper can surface it in
     /// diagnostic output without importing this module directly.
-    public static let containerizationVersion = "0.1.1"
+    public static let containerizationVersion = "0.12.1"
 
     public init() {}
 

--- a/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntimeBridge.swift
+++ b/clients/macos/apple-containers-runtime/Sources/AppleContainersRuntime/AppleContainersRuntimeBridge.swift
@@ -24,15 +24,16 @@ import Foundation
 public func vellumRegisterPodRuntimeFactory() {
     let provider = AppleContainersPodRuntimeFactoryProvider()
 
-    // Post on main queue so the observer in AppleContainersLauncher (which is
-    // @MainActor-isolated) receives the notification on the right thread.
-    DispatchQueue.main.async {
-        NotificationCenter.default.post(
-            name: Notification.Name("com.vellum.AppleContainersRuntimeDidLoad"),
-            object: provider,
-            userInfo: nil
-        )
-    }
+    // Post synchronously so that makePodRuntimeHandle() in
+    // AppleContainersLauncher can read factoryProvider immediately after
+    // vellum_register_pod_runtime_factory() returns.  An async dispatch would
+    // let makePodRuntimeHandle() run before the notification fires, leaving
+    // factoryProvider nil on the first launch.
+    NotificationCenter.default.post(
+        name: Notification.Name("com.vellum.AppleContainersRuntimeDidLoad"),
+        object: provider,
+        userInfo: nil
+    )
 }
 
 // MARK: - Factory provider
@@ -141,7 +142,7 @@ public final class AppleContainersPodRuntimeAdapter: NSObject {
 
     /// Starts the pod.  Calls `completionHandler(nil)` on success or
     /// `completionHandler(error)` on failure.
-    @objc
+    @objc(hatchAsync:)
     public func hatchAsync(completionHandler: @escaping (Error?) -> Void) {
         Task {
             do {
@@ -155,7 +156,7 @@ public final class AppleContainersPodRuntimeAdapter: NSObject {
 
     /// Stops the pod.  Calls `completionHandler(nil)` on success or
     /// `completionHandler(error)` on failure.
-    @objc
+    @objc(retireAsync:)
     public func retireAsync(completionHandler: @escaping (Error?) -> Void) {
         Task {
             do {

--- a/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
+++ b/clients/macos/vellum-assistant/App/AppleContainersLauncher.swift
@@ -317,6 +317,9 @@ final class AppleContainersLauncher: LocalAssistantLauncher {
         //
         // We use a `CheckedContinuation` so the main actor is suspended (not
         // blocked) while waiting for the reply, avoiding a deadlock.
+        // How long to wait for the factory provider to reply before giving up.
+        let makeRuntimeTimeoutSeconds: UInt64 = 5
+
         let adapter: NSObject = try await withCheckedThrowingContinuation { continuation in
             let replyName = Notification.Name("com.vellum.AppleContainersMakeRuntime")
             // Wrap the observer token in an @unchecked Sendable box so we can
@@ -337,6 +340,18 @@ final class AppleContainersLauncher: LocalAssistantLauncher {
                 } else {
                     continuation.resume(throwing: AppleContainersLauncherError.runtimeUnavailable)
                 }
+            }
+
+            // Timeout task: if handleRuntimeRequest() fails a guard and never
+            // posts the reply notification the continuation would leak and
+            // hatch() would hang forever.  This task resumes the continuation
+            // with an error after a short deadline so the hang is bounded.
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: makeRuntimeTimeoutSeconds * 1_000_000_000)
+                guard once.trySet() else { return }
+                if let obs = tokenBox.value { NotificationCenter.default.removeObserver(obs) }
+                log.error("AppleContainersLauncher: makePodRuntimeHandle timed out waiting for MakeRuntime reply")
+                continuation.resume(throwing: AppleContainersLauncherError.runtimeUnavailable)
             }
 
             let userInfo: [AnyHashable: Any] = [


### PR DESCRIPTION
## Summary

Fixes gaps identified during plan review for apple-containers-hatch.md.

- G1: Fix wrong ObjC selectors (`hatchAsync:`/`retireAsync:`) so pod runtime methods are actually invoked
- G2: Fix async dispatch in `vellumRegisterPodRuntimeFactory` causing nil `factoryProvider` on first launch
- G3: Call `ensureImagesReady()` before hatch so `kernelImagesNotReady` is not thrown on every invocation
- G5: Throw error when readiness stream ends without sentinel (container exit before ready)
- G6: Add timeout to `CheckedContinuation` in `makePodRuntimeHandle` to prevent permanent hangs
- G17: Mark CES data mount read-only to match Docker topology
- G18: Fix `containerizationVersion` constant from `0.1.1` to `0.12.1`

## Test plan

- [ ] Verify `responds(to:)` check for `hatchAsync:` and `retireAsync:` returns `true` at runtime
- [ ] Verify `factoryProvider` is non-nil synchronously after `vellum_register_pod_runtime_factory()` returns
- [ ] Verify hatch no longer throws `kernelImagesNotReady` on first invocation
- [ ] Verify hatch fails with `containerExitedBeforeReady` when assistant container crashes before emitting sentinel
- [ ] Verify `makePodRuntimeHandle` fails within 5 seconds if factory provider doesn't reply
- [ ] Verify CES container's `/data` mount is read-only in pod configuration
- [ ] Verify `AppleContainersRuntime.containerizationVersion` matches Package.swift dependency version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
