### PR TITLE
M3: Integrate ComposerTextEditor into ComposerView and slim bridge (#17974)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -19,17 +19,11 @@ extension EnvironmentValues {
 
 // MARK: - Composer Focus Bridge
 
-/// Minimal NSViewRepresentable that provides AppKit integration for the
-/// SwiftUI TextField composer:
+/// Minimal NSViewRepresentable that provides AppKit integration for the composer:
 /// - Registers a typing-redirect handler with TitleBarZoomableWindow so
 ///   keystrokes auto-focus the composer when nothing else is focused.
 /// - Registers the composer container view for click-away-to-blur detection.
-/// - Intercepts Cmd+V when the pasteboard contains image content.
-/// - Intercepts Cmd+Return when `cmdEnterToSend` is enabled to trigger send
-///   before SwiftUI's `.onSubmit` fires.
-/// - Intercepts Shift+Return in default send mode to insert a newline, and
-///   routes default-mode Option+Return through the same bridge send path used
-///   by Cmd+Return, before SwiftUI's `.onSubmit` fires.
+/// - Passes through zoom shortcuts (Cmd+/-/0) so they are not consumed.
 struct ComposerFocusBridge: NSViewRepresentable {
     let isFocused: Bool
     let cmdEnterToSend: Bool
@@ -72,22 +66,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
             candidate = view.superview
         }
         window.composerContainerView = container
-
-        // Prevent the internal NSTextView from intercepting file drops.
-        // SwiftUI's TextField wraps an NSTextView that registers for file URL
-        // drag types by default, causing it to insert file paths as text.
-        // Re-register with only text types so file drops fall through to the
-        // SwiftUI .onDrop handler on the parent ScrollView.
-        Self.unregisterFileDragTypes(in: container)
-    }
-
-    private static func unregisterFileDragTypes(in view: NSView) {
-        if view is NSTextView {
-            view.registerForDraggedTypes([.string, .rtf, .rtfd])
-        }
-        for subview in view.subviews {
-            unregisterFileDragTypes(in: subview)
-        }
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
@@ -111,42 +89,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
                 let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
 
-                // Cmd+V with image content -> intercept paste
-                if modifiers == [.command],
-                   event.charactersIgnoringModifiers?.lowercased() == "v",
-                   Self.pasteboardHasImageContent() {
-                    self.parent.onImagePaste()
-                    return nil
-                }
-
-                // Return-key routing. The bridge handles modifier-specific
-                // interception for its dedicated paths: Shift+Enter newline in
-                // default mode, Option+Enter send in default mode, and
-                // Cmd+Enter send when the preference is enabled.
-                // Plain Enter flows through to SwiftUI's .onSubmit which
-                // calls performSendAction() — the canonical send path that
-                // handles slash-menu, ghost-text, and pending-confirmation.
-                let isReturn = event.keyCode == 36 || event.keyCode == 76
-                if isReturn {
-                    let action = ComposerReturnKeyRouting.resolve(
-                        cmdEnterToSend: self.parent.cmdEnterToSend,
-                        modifiers: modifiers
-                    )
-                    let textView = (event.window?.firstResponder as? NSTextView)
-                        ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
-
-                    // Still consume newline routes when the field editor is
-                    // missing so SwiftUI cannot accidentally treat them as send.
-                    if ComposerReturnKeyRouting.performBridgeAction(
-                        action,
-                        textView: textView,
-                        onSend: self.parent.onSend
-                    ) {
-                        return nil
-                    }
-                    return event
-                }
-
                 // Let zoom shortcuts propagate instead of being consumed
                 if modifiers == [.command] || modifiers == [.command, .option] {
                     let key = event.charactersIgnoringModifiers ?? ""
@@ -164,18 +106,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 eventMonitor = nil
             }
-        }
-
-        static func pasteboardHasImageContent() -> Bool {
-            let pasteboard = NSPasteboard.general
-            let hasImageFile = (pasteboard.readObjects(forClasses: [NSURL.self], options: [
-                .urlReadingFileURLsOnly: true,
-            ]) as? [URL])?.contains { url in
-                let ext = url.pathExtension.lowercased()
-                return ["png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"].contains(ext)
-            } ?? false
-            let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
-            return hasImageFile || hasImageData
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -23,12 +23,8 @@ extension EnvironmentValues {
 /// - Registers a typing-redirect handler with TitleBarZoomableWindow so
 ///   keystrokes auto-focus the composer when nothing else is focused.
 /// - Registers the composer container view for click-away-to-blur detection.
-/// - Passes through zoom shortcuts (Cmd+/-/0) so they are not consumed.
 struct ComposerFocusBridge: NSViewRepresentable {
     let isFocused: Bool
-    let cmdEnterToSend: Bool
-    let onImagePaste: () -> Void
-    let onSend: () -> Void
     let onRedirectKeystroke: (String) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -37,7 +33,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        context.coordinator.setupEventMonitor()
         return view
     }
 
@@ -69,7 +64,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.removeEventMonitor()
         if let window = nsView.window as? TitleBarZoomableWindow {
             window.composerRedirectHandler = nil
         }
@@ -77,35 +71,9 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
     final class Coordinator {
         var parent: ComposerFocusBridge
-        var eventMonitor: Any?
 
         init(parent: ComposerFocusBridge) {
             self.parent = parent
-        }
-
-        func setupEventMonitor() {
-            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                guard let self, self.parent.isFocused else { return event }
-
-                let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
-
-                // Let zoom shortcuts propagate instead of being consumed
-                if modifiers == [.command] || modifiers == [.command, .option] {
-                    let key = event.charactersIgnoringModifiers ?? ""
-                    if key == "=" || key == "+" || key == "-" || key == "0" {
-                        return event
-                    }
-                }
-
-                return event
-            }
-        }
-
-        func removeEventMonitor() {
-            if let monitor = eventMonitor {
-                NSEvent.removeMonitor(monitor)
-                eventMonitor = nil
-            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -224,9 +224,6 @@ struct ComposerView: View {
         .background(
             ComposerFocusBridge(
                 isFocused: composerFocus,
-                cmdEnterToSend: cmdEnterToSend,
-                onImagePaste: onPaste,
-                onSend: { performSendAction() },
                 onRedirectKeystroke: { chars in
                     inputText += chars
                     composerFocus = true
@@ -377,14 +374,6 @@ struct ComposerView: View {
                     && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             onAllowPendingConfirmation?()
         }
-    }
-
-    private func handleComposerSubmit() {
-        // On macOS, the bridge consumes all Return variants that should insert
-        // a newline (cmd-enter mode) or trigger a bridge-level send. The only
-        // Return events that reach `.onSubmit` are plain Return in default mode,
-        // which always means "send".
-        performSendAction()
     }
 
     // MARK: - Text Entry Mode

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -70,6 +70,9 @@ struct ComposerView: View {
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
 
+    @State private var measuredTextHeight: CGFloat = 32
+    @State private var textViewIsFocused: Bool = false
+
     @State var showSlashMenu = false
     @State var slashFilter = ""
     @State var slashSelectedIndex = 0
@@ -173,72 +176,49 @@ struct ComposerView: View {
         }
     }
 
-    /// The native TextField with keyboard handlers. Extracted so the compiler
-    /// can type-check each builder method independently.
-    @ViewBuilder
-    private func composerInputField(font: Font, hasSlashHighlight: Bool) -> some View {
-        TextField(
-            ghostSuffix == nil ? placeholderText : "",
-            text: $inputText,
-            axis: .vertical
-        )
-        .lineLimit(1...)
-        .textFieldStyle(.plain)
-        .font(font)
-        .lineSpacing(4)
-        .foregroundColor(hasSlashHighlight ? .clear : VColor.contentDefault)
-        .tint(VColor.primaryBase)
-        .focused($composerFocus)
-        .disabled(!hasAPIKey)
-        .onSubmit { handleComposerSubmit() }
-        .onKeyPress(.tab, phases: .down) { press in
-            if !press.modifiers.contains(.shift), showSlashMenu {
-                handleSlashNavigation(.tab)
-                return .handled
-            }
-            if !press.modifiers.contains(.shift), ghostSuffix != nil {
-                onAcceptSuggestion()
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.upArrow) {
-            if showSlashMenu {
-                handleSlashNavigation(.up)
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.downArrow) {
-            if showSlashMenu {
-                handleSlashNavigation(.down)
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.escape) {
-            if showSlashMenu {
-                handleSlashNavigation(.dismiss)
-                return .handled
-            }
-            return .ignored
-        }
-    }
-
     private var composerTextField: some View {
         let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
         let hasSlashHighlight = slashCommandRange != nil
+        let nsFont = NSFont(name: "Inter", size: 13 * zoomScale) ?? .systemFont(ofSize: 13)
 
-        return ScrollView(.vertical, showsIndicators: false) {
-            ZStack(alignment: .leading) {
-                composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-                composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-            }
-            .frame(maxWidth: .infinity, minHeight: composerActionButtonSize, alignment: .leading)
+        return ZStack(alignment: .leading) {
+            composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+            ComposerTextEditor(
+                text: $inputText,
+                measuredHeight: $measuredTextHeight,
+                isFocused: $textViewIsFocused,
+                font: nsFont,
+                lineSpacing: 4,
+                insertionPointColor: NSColor(VColor.primaryBase),
+                minHeight: composerActionButtonSize,
+                maxHeight: composerMaxHeight,
+                placeholder: ghostSuffix == nil ? placeholderText : "",
+                isEditable: hasAPIKey,
+                cmdEnterToSend: cmdEnterToSend,
+                textColorOverride: hasSlashHighlight
+                    ? NSColor(VColor.contentDefault).withAlphaComponent(0) : nil,
+                onSubmit: { performSendAction() },
+                onTab: {
+                    if showSlashMenu { handleSlashNavigation(.tab); return true }
+                    if ghostSuffix != nil { onAcceptSuggestion(); return true }
+                    return false
+                },
+                onUpArrow: {
+                    if showSlashMenu { handleSlashNavigation(.up); return true }
+                    return false
+                },
+                onDownArrow: {
+                    if showSlashMenu { handleSlashNavigation(.down); return true }
+                    return false
+                },
+                onEscape: {
+                    if showSlashMenu { handleSlashNavigation(.dismiss); return true }
+                    return false
+                },
+                onPasteImage: onPaste
+            )
         }
-        .scrollBounceBehavior(.basedOnSize)
-        .defaultScrollAnchor(.bottom)
-        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty ? composerActionButtonSize : composerMaxHeight)
+        .frame(maxWidth: .infinity, height: measuredTextHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)
         .background(
@@ -246,15 +226,25 @@ struct ComposerView: View {
                 isFocused: composerFocus,
                 cmdEnterToSend: cmdEnterToSend,
                 onImagePaste: onPaste,
-                onSend: {
-                    performSendAction()
-                },
+                onSend: { performSendAction() },
                 onRedirectKeystroke: { chars in
                     inputText += chars
                     composerFocus = true
                 }
             )
         )
+        // Focus: SwiftUI → AppKit (one-directional)
+        .onChange(of: composerFocus) {
+            if textViewIsFocused != composerFocus {
+                textViewIsFocused = composerFocus
+            }
+        }
+        // Focus: AppKit → SwiftUI (from delegate)
+        .onChange(of: textViewIsFocused) {
+            if composerFocus != textViewIsFocused {
+                composerFocus = textViewIsFocused
+            }
+        }
         .onChange(of: composerFocus) {
             isComposerFocused = composerFocus
             if composerFocus {


### PR DESCRIPTION
## Summary
- Replace `TextField(axis: .vertical)` with `ComposerTextEditor` (NSViewRepresentable backed by NSTextView) in the composer, fixing the 1-to-2 line wrap clipping bug by measuring height synchronously from NSTextView's layout manager.
- Remove the ScrollView wrapper and `composerInputField` function; the new `ComposerTextEditor` handles scrolling, key routing, placeholder, and focus internally.
- Slim `ComposerFocusBridge`: remove Return key routing, Cmd+V paste interception, and `unregisterFileDragTypes` (all now handled by `ComposerTextView`); keep keystroke redirect registration and composer container detection.

## Test plan
- [ ] Verify single-line and multi-line text input works correctly
- [ ] Verify text wraps and composer grows/shrinks without clipping
- [ ] Verify Return/Cmd+Enter/Shift+Return behavior matches send-mode preference
- [ ] Verify Cmd+V with image content triggers image paste
- [ ] Verify slash command menu appears, navigates (up/down/tab), and selects
- [ ] Verify ghost text (autocomplete suggestion) appears and Tab accepts it
- [ ] Verify file drag-and-drop onto composer still works
- [ ] Verify zoom (Cmd+/-/0) still works
- [ ] Verify focus auto-redirects keystrokes to composer when nothing else is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
