### PR TITLE
fix: prevent JSON tree centering in file viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -165,16 +165,19 @@ struct JSONTreeView: View {
     private func treeContent(_ node: JSONNode) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             toolbar(node)
-            ScrollView([.vertical, .horizontal]) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    JSONNodeRow(
-                        node: node,
-                        key: nil,
-                        depth: 0,
-                        expandedPaths: $expandedPaths
-                    )
+            GeometryReader { proxy in
+                ScrollView([.vertical, .horizontal]) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        JSONNodeRow(
+                            node: node,
+                            key: nil,
+                            depth: 0,
+                            expandedPaths: $expandedPaths
+                        )
+                    }
+                    .padding(VSpacing.md)
+                    .frame(minWidth: proxy.size.width, minHeight: proxy.size.height, alignment: .topLeading)
                 }
-                .padding(VSpacing.md)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)


### PR DESCRIPTION
## Summary
- Wrap the ScrollView in a GeometryReader and set `minWidth`/`minHeight` on the content to prevent macOS NSScrollView from centering content when it's smaller than the visible area
- Tree content now always anchors to the top-left corner while preserving horizontal/vertical scrolling for larger content

## Original prompt
Fix JSON tree centering in JSONTreeView.swift. The issue is that macOS's NSScrollView (backing SwiftUI's ScrollView) centers content when it's smaller than the visible area. The fix is to wrap the ScrollView in a GeometryReader and set `minWidth`/`minHeight` on the content inside the ScrollView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
