### PR TITLE
fix: reset draftMode to your-own on logout in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -77,6 +77,11 @@ struct InferenceServiceCard: View {
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
         }
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            if !isAuthenticated && draftMode == "managed" {
+                draftMode = "your-own"
+            }
+        }
     }
 
     // MARK: - Header


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-mode-ui.md.

**Gap:** Missing validation for unauthorized managed mode persistence
**What was expected:** draftMode should reset to your-own when user logs out
**What was found:** draftMode retained managed after logout, causing save to persist managed mode while unauthenticated

Adds onChange handler for authManager.isAuthenticated to reset draftMode.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
