### PR TITLE
fix(gateway): keep credential reloads alive across atomic rewrites

### DIFF
--- a/gateway/src/__tests__/credential-watcher.test.ts
+++ b/gateway/src/__tests__/credential-watcher.test.ts
@@ -14,7 +14,7 @@ import {
   pbkdf2Sync,
   randomBytes as cryptoRandomBytes,
 } from "node:crypto";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, renameSync, writeFileSync, rmSync } from "node:fs";
 import { hostname, tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -114,39 +114,47 @@ function writeEncryptedStore(botToken: string, webhookSecret: string): void {
   writeFileSync(storePath, JSON.stringify(store));
 }
 
+function metadataRecord(
+  credentialId: string,
+  service: string,
+  field: string,
+): Record<string, unknown> {
+  return {
+    credentialId,
+    service,
+    field,
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
 /**
- * Write credential metadata so readTelegramCredentials() knows to look
- * for bot_token and webhook_secret.
+ * Write credential metadata using the same atomic rename pattern as the
+ * production metadata store.
  */
-function writeCredentialMetadata(): void {
+function writeCredentialMetadata(
+  credentials: Record<string, unknown>[] = [
+    metadataRecord("test-bt", "telegram", "bot_token"),
+    metadataRecord("test-ws", "telegram", "webhook_secret"),
+  ],
+): void {
   const dir = join(testDir, ".vellum", "workspace", "data", "credentials");
   mkdirSync(dir, { recursive: true });
+  const metadataPath = join(dir, "metadata.json");
+  const tmpPath = join(
+    dir,
+    `.tmp-${cryptoRandomBytes(4).toString("hex")}-metadata.json`,
+  );
   writeFileSync(
-    join(dir, "metadata.json"),
+    tmpPath,
     JSON.stringify({
       version: 2,
-      credentials: [
-        {
-          credentialId: "test-bt",
-          service: "telegram",
-          field: "bot_token",
-          allowedTools: [],
-          allowedDomains: [],
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        },
-        {
-          credentialId: "test-ws",
-          service: "telegram",
-          field: "webhook_secret",
-          allowedTools: [],
-          allowedDomains: [],
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        },
-      ],
+      credentials,
     }),
   );
+  renameSync(tmpPath, metadataPath);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,11 +165,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const gatewayRoot = join(__dirname, "..", "..");
 const gatewayEntry = join(gatewayRoot, "src", "index.ts");
 
-const port = 49152 + Math.floor(Math.random() * 16383);
-
 let gatewayProc: ChildProcess | null = null;
+let port = 0;
 
 async function startGateway(): Promise<void> {
+  port = 49152 + Math.floor(Math.random() * 16383);
   gatewayProc = spawn("bun", ["run", gatewayEntry], {
     env: {
       ...process.env,
@@ -233,6 +241,49 @@ describe("gateway telegram hot-reload (e2e)", () => {
     // We expect 401 (webhook secret verification failed) rather than 503
     // (not configured). Getting past the 503 gate proves the gateway
     // hot-reloaded the credentials from the credential store.
+    const after = await fetch(`${base}/webhooks/telegram`, {
+      method: "POST",
+    });
+    expect(after.status).toBe(401);
+  }, 15_000);
+
+  test("gateway keeps reloading credentials after multiple atomic metadata rewrites when metadata.json already existed at startup", async () => {
+    mkdirSync(testDir, { recursive: true });
+
+    // Start in file-watch mode by creating metadata.json before boot, but
+    // omit Telegram entries so the integration is initially unconfigured.
+    writeCredentialMetadata([metadataRecord("baseline", "github", "token")]);
+    writeEncryptedStore("fake-bot-token:ABC123", "fake-webhook-secret");
+
+    await startGateway();
+
+    const base = `http://localhost:${port}`;
+
+    const before = await fetch(`${base}/webhooks/telegram`, {
+      method: "POST",
+    });
+    expect(before.status).toBe(503);
+
+    // First rewrite after startup stales a file-scoped fs.watch() subscription
+    // on macOS when metadata.json is atomically replaced.
+    writeCredentialMetadata([
+      metadataRecord("baseline", "github", "token"),
+      metadataRecord("other", "openai", "api_key"),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Second rewrite adds Telegram credentials. The gateway must still see
+    // this update without requiring a restart.
+    writeCredentialMetadata([
+      metadataRecord("baseline", "github", "token"),
+      metadataRecord("other", "openai", "api_key"),
+      metadataRecord("test-bt", "telegram", "bot_token"),
+      metadataRecord("test-ws", "telegram", "webhook_secret"),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
     const after = await fetch(`${base}/webhooks/telegram`, {
       method: "POST",
     });

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -3,11 +3,13 @@
  * triggers a callback when Telegram or Twilio credentials are added,
  * updated, or removed.
  *
- * Uses fs.watch() on the metadata file with debouncing to avoid
- * rapid re-reads from atomic rename writes.
+ * Watches the parent directory rather than the file itself because
+ * metadata.json is rewritten via atomic rename. File-scoped fs.watch()
+ * subscriptions can stay attached to the old inode after the first write,
+ * causing later credential changes to be missed until restart.
  */
 
-import { existsSync, mkdirSync, watch, type FSWatcher } from "node:fs";
+import { mkdirSync, watch, type FSWatcher } from "node:fs";
 import { dirname } from "node:path";
 import { getLogger } from "./logger.js";
 import {
@@ -41,7 +43,6 @@ export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
 
 export class CredentialWatcher {
   private watcher: FSWatcher | null = null;
-  private watchingDirectory = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSerialized: Map<string, string> = new Map();
   private polling = false;
@@ -57,23 +58,18 @@ export class CredentialWatcher {
   async start(): Promise<void> {
     await this.pollOnce();
 
-    this.watchingDirectory = !existsSync(this.metadataPath);
-    const watchTarget = this.watchingDirectory
-      ? dirname(this.metadataPath)
-      : this.metadataPath;
+    const watchTarget = dirname(this.metadataPath);
 
     // Ensure the directory exists so fs.watch() doesn't throw ENOENT
     // on a fresh hatch where no credentials have been written yet.
-    if (this.watchingDirectory) {
-      mkdirSync(watchTarget, { recursive: true });
-    }
+    mkdirSync(watchTarget, { recursive: true });
 
     try {
       this.watcher = watch(
         watchTarget,
         { persistent: false },
         (_event, filename) => {
-          if (this.watchingDirectory && filename !== "metadata.json") {
+          if (filename && filename !== "metadata.json") {
             return;
           }
           this.scheduleCheck();
@@ -108,30 +104,7 @@ export class CredentialWatcher {
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
       void this.pollOnce();
-
-      if (this.watchingDirectory && existsSync(this.metadataPath)) {
-        this.upgradeWatcher();
-      }
     }, DEBOUNCE_MS);
-  }
-
-  private upgradeWatcher(): void {
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
-    }
-
-    if (!existsSync(this.metadataPath)) return;
-
-    try {
-      this.watcher = watch(this.metadataPath, { persistent: false }, () => {
-        this.scheduleCheck();
-      });
-      this.watchingDirectory = false;
-      log.debug("Upgraded watcher to metadata file");
-    } catch (err) {
-      log.warn({ err }, "Failed to upgrade credential file watcher");
-    }
   }
 
   private async pollOnce(): Promise<void> {


### PR DESCRIPTION
## Summary
- watch the credentials directory instead of `metadata.json` directly so atomic rename writes do not stale the gateway credential watcher
- keep debounced reload behavior scoped to `metadata.json` events
- add an e2e regression test for repeated metadata rewrites after startup when the metadata file already exists

## Root cause
The gateway watcher attached `fs.watch()` to `metadata.json` when that file already existed at startup. Credential metadata writes replace the file via atomic rename, so after the first rewrite the watcher could stay attached to the old inode and miss later credential updates. That left Slack socket mode waiting for a full assistant restart, which reran the startup credential poll.

## Testing
- `bun test gateway/src/__tests__/credential-watcher.test.ts`
- `cd gateway && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
