### PR TITLE
fix: strip effort parameter for Haiku models

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -627,9 +627,15 @@ export class AnthropicProvider implements Provider {
         effort?: Anthropic.OutputConfig["effort"];
         output_config?: Record<string, unknown>;
       };
+      // Haiku does not support the effort / output_config parameter.
+      // Determine the effective model (per-call override or provider default)
+      // and strip effort when the model doesn't support it.
+      const effectiveModel =
+        (restConfig as Record<string, unknown>).model?.toString() ?? this.model;
+      const supportsEffort = !effectiveModel.includes("haiku");
       const mergedOutputConfig = {
         ...(output_config ?? {}),
-        ...(effort ? { effort } : {}),
+        ...(effort && supportsEffort ? { effort } : {}),
       };
       const params: Anthropic.MessageStreamParams = {
         model: this.model,


### PR DESCRIPTION
## Summary
- Haiku 4.5 does not support the `effort` / `output_config` parameter, but the Anthropic provider was sending it unconditionally when configured
- Every agent loop turn fails with `400: This model does not support the effort parameter` when using Haiku with `effort: high`
- The fix checks the effective model (per-call override or provider default) and strips `effort` when the model is Haiku

## Original prompt
yes fix it now thank you

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
