### PR TITLE
fix: skip migrateLegacyEntry for apple-containers lockfile entries

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -361,7 +361,13 @@ async function listAllAssistants(): Promise<void> {
       // network health check to avoid a misleading "unreachable" status.
       let health: { status: string; detail: string | null };
       const resources = a.resources;
-      if (a.cloud === "local" && resources) {
+      if (a.runtimeBackend === "apple-containers") {
+        // Apple-containers assistants are managed by the macOS app via LinuxPod.
+        // PID-based lifecycle checks don't apply; use the gateway health endpoint
+        // directly so the assistant shows as running (or unreachable) rather than
+        // the misleading "sleeping" status that would result from a missing pidFile.
+        health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
+      } else if (a.cloud === "local" && resources) {
         const pid = readPidFile(resources.pidFile);
         const alive = pid !== null && isProcessAlive(pid);
         if (!alive) {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -146,6 +146,13 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     return false;
   }
 
+  // Apple-containers entries are managed by the macOS app via LinuxPod.
+  // They do not use process-daemon resources (instanceDir, daemonPort,
+  // pidFile, qdrantPort), so we must not backfill those fields.
+  if (raw.runtimeBackend === "apple-containers") {
+    return false;
+  }
+
   let mutated = false;
 
   // Migrate top-level `baseDataDir` → `resources.instanceDir`


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for apple-containers-hatch.md.

**Gap:** migrateLegacyEntry corrupts apple-containers lockfile entries
**What was expected:** CLI migration skips apple-containers entries that don't use process-daemon resources
**What was found:** migrateLegacyEntry backfills instanceDir/daemonPort/pidFile/qdrantPort for apple-containers entries, persisting garbage fields to lockfile on every CLI invocation; vellum ps shows misleading 'sleeping' status

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
