### PR TITLE
fix: remove dead onChange for apple-containers availability in APIKeyStepView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -62,12 +62,10 @@ struct APIKeyStepView: View {
             // If apple-containers is no longer available (e.g. flag toggled off
             // after a previous session persisted it), reset to the process backend
             // so the user is not silently routed through a broken path.
+            // Note: this reset is onAppear-only and is NOT reactive to in-session
+            // availability changes. AppleContainersAvailabilityChecker is not
+            // @Observable, so onChange(of:) would never fire for it.
             if !appleContainersAvailability.isAvailable {
-                state.selectedRuntimeBackend = .process
-            }
-        }
-        .onChange(of: appleContainersAvailability.isAvailable) { _, isAvailable in
-            if !isAvailable {
                 state.selectedRuntimeBackend = .process
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for apple-containers-hatch.md.

**Gap:** Dead onChange(of: appleContainersAvailability.isAvailable) in APIKeyStepView never fires
**What was expected:** Reset of selectedRuntimeBackend is functional when availability changes
**What was found:** AppleContainersAvailabilityChecker is not @Observable so onChange never triggers; onAppear already handles the at-launch reset case correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
