### PR TITLE
fix: reset draftMode on appear when managed unavailable in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -71,6 +71,9 @@ struct InferenceServiceCard: View {
         .vCard(background: VColor.surfaceOverlay)
         .onAppear {
             draftMode = store.inferenceMode
+            if draftMode == "managed" && !authManager.isAuthenticated {
+                draftMode = "your-own"
+            }
             initialModel = store.selectedModel
         }
         .onChange(of: store.inferenceMode) { _, newValue in


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-mode-ui.md.

**Gap:** Managed content shown when not logged in on first render
**What was expected:** Card should fall back to Your Own content when user is logged out
**What was found:** onAppear set draftMode to managed unconditionally; onChange for isAuthenticated didn't fire (already false)

Adds guard in onAppear to reset draftMode to your-own when not authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
