### PR TITLE
fix: attach app icon to all macOS notification types

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -254,6 +254,7 @@ extension AppDelegate {
             }
         }
         content.userInfo = userInfo
+        content.attachAppIcon()
 
         let notificationId = "notification-intent-\(UUID().uuidString)"
         let request = UNNotificationRequest(

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -67,6 +67,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         content.categoryIdentifier = "ACTIVITY_COMPLETE"
         content.sound = .default
         content.userInfo = ["conversationId": conversationId, "type": "activity_complete"]
+        content.attachAppIcon()
 
         log.info("Sending notification: \(content.title, privacy: .public)")
 
@@ -104,6 +105,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         content.body = truncated.isEmpty ? "Response complete" : truncated
         content.sound = .default
         content.userInfo = ["type": "quick_input_complete"]
+        content.attachAppIcon()
 
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -24,10 +24,7 @@ public final class ToolConfirmationNotificationService {
             "type": "tool_confirmation"
         ]
 
-        // Attach app icon
-        if let attachment = createAppIconAttachment() {
-            content.attachments = [attachment]
-        }
+        content.attachAppIcon()
 
         let request = UNNotificationRequest(
             identifier: "tool-confirm-\(message.requestId)",
@@ -129,16 +126,4 @@ public final class ToolConfirmationNotificationService {
         }
     }
 
-    private func createAppIconAttachment() -> UNNotificationAttachment? {
-        // Find the app icon in the bundle resources
-        guard let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns") else {
-            // Try to find in the resource bundle
-            let resourceBundle = Bundle(identifier: "com.vellum.vellum-assistant")
-            guard let bundleIconURL = resourceBundle?.url(forResource: "AppIcon", withExtension: "icns") else {
-                return nil
-            }
-            return try? UNNotificationAttachment(identifier: "app-icon", url: bundleIconURL, options: nil)
-        }
-        return try? UNNotificationAttachment(identifier: "app-icon", url: iconURL, options: nil)
-    }
 }

--- a/clients/macos/vellum-assistant/Services/UNMutableNotificationContent+AppIcon.swift
+++ b/clients/macos/vellum-assistant/Services/UNMutableNotificationContent+AppIcon.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UserNotifications
+
+extension UNMutableNotificationContent {
+    /// Attaches the app icon to the notification content so macOS displays it
+    /// in banners and Notification Center (important for LSUIElement apps
+    /// that have no dock icon).
+    func attachAppIcon() {
+        guard let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns")
+                ?? Bundle(identifier: "com.vellum.vellum-assistant")?.url(forResource: "AppIcon", withExtension: "icns"),
+              let attachment = try? UNNotificationAttachment(identifier: "app-icon", url: iconURL, options: nil)
+        else { return }
+        attachments = [attachment]
+    }
+}


### PR DESCRIPTION
## Summary
- Only `ToolConfirmationNotificationService` was attaching the app icon to notifications — `ActivityNotificationService` and `postNotificationIntent()` were missing it
- Since the app runs as `LSUIElement` (no dock icon), macOS shows a generic default icon when no attachment is set
- Extract icon-attachment logic into a shared `UNMutableNotificationContent.attachAppIcon()` extension and apply it to all notification paths

## Original prompt
put this all on a git worktree feature branch and ship it from there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/17999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
