### PR TITLE
fix: resolve Swift 6 actor isolation warning for fallbackLogSizeLimit

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -437,7 +437,7 @@ enum LogExporter {
     // MARK: - Daemon Log Fallback
 
     /// Maximum total bytes to read when collecting fallback daemon logs.
-    private static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
+    private nonisolated(unsafe) static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
 
     /// When the daemon is unreachable, reads log files directly from the
     /// filesystem and copies them into `directory/daemon-logs-fallback/`.


### PR DESCRIPTION
## Summary
- Mark `fallbackLogSizeLimit` as `nonisolated(unsafe)` to fix Swift 6 warning about accessing a `@MainActor`-isolated static property from nonisolated context
- The property is an immutable `let` with a literal integer value, so cross-isolation access is safe

## Original prompt
Fix: main actor-isolated static property 'fallbackLogSizeLimit' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
