### PR TITLE
fix: guard onChange for inferenceMode against unauthenticated managed mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -79,6 +79,9 @@ struct InferenceServiceCard: View {
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
+            if draftMode == "managed" && !authManager.isAuthenticated {
+                draftMode = "your-own"
+            }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if !isAuthenticated && draftMode == "managed" {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for anthropic-card-mode-ui.md.

**Gap:** onChange for store.inferenceMode missing auth guard
**What was expected:** Guard against managed mode when not authenticated (matching onAppear pattern)
**What was found:** onChange unconditionally accepted managed mode from daemon even when logged out

Adds auth guard to onChange handler, mirroring the onAppear guard from PR #17998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
