### PR TITLE
Replace composer TextField(axis: .vertical) with NSTextView-backed input (LUM-233)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -19,22 +19,12 @@ extension EnvironmentValues {
 
 // MARK: - Composer Focus Bridge
 
-/// Minimal NSViewRepresentable that provides AppKit integration for the
-/// SwiftUI TextField composer:
+/// Minimal NSViewRepresentable that provides AppKit integration for the composer:
 /// - Registers a typing-redirect handler with TitleBarZoomableWindow so
 ///   keystrokes auto-focus the composer when nothing else is focused.
 /// - Registers the composer container view for click-away-to-blur detection.
-/// - Intercepts Cmd+V when the pasteboard contains image content.
-/// - Intercepts Cmd+Return when `cmdEnterToSend` is enabled to trigger send
-///   before SwiftUI's `.onSubmit` fires.
-/// - Intercepts Shift+Return in default send mode to insert a newline, and
-///   routes default-mode Option+Return through the same bridge send path used
-///   by Cmd+Return, before SwiftUI's `.onSubmit` fires.
 struct ComposerFocusBridge: NSViewRepresentable {
     let isFocused: Bool
-    let cmdEnterToSend: Bool
-    let onImagePaste: () -> Void
-    let onSend: () -> Void
     let onRedirectKeystroke: (String) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -43,7 +33,6 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
-        context.coordinator.setupEventMonitor()
         return view
     }
 
@@ -72,26 +61,9 @@ struct ComposerFocusBridge: NSViewRepresentable {
             candidate = view.superview
         }
         window.composerContainerView = container
-
-        // Prevent the internal NSTextView from intercepting file drops.
-        // SwiftUI's TextField wraps an NSTextView that registers for file URL
-        // drag types by default, causing it to insert file paths as text.
-        // Re-register with only text types so file drops fall through to the
-        // SwiftUI .onDrop handler on the parent ScrollView.
-        Self.unregisterFileDragTypes(in: container)
-    }
-
-    private static func unregisterFileDragTypes(in view: NSView) {
-        if view is NSTextView {
-            view.registerForDraggedTypes([.string, .rtf, .rtfd])
-        }
-        for subview in view.subviews {
-            unregisterFileDragTypes(in: subview)
-        }
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.removeEventMonitor()
         if let window = nsView.window as? TitleBarZoomableWindow {
             window.composerRedirectHandler = nil
         }
@@ -99,83 +71,9 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
     final class Coordinator {
         var parent: ComposerFocusBridge
-        var eventMonitor: Any?
 
         init(parent: ComposerFocusBridge) {
             self.parent = parent
-        }
-
-        func setupEventMonitor() {
-            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                guard let self, self.parent.isFocused else { return event }
-
-                let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
-
-                // Cmd+V with image content -> intercept paste
-                if modifiers == [.command],
-                   event.charactersIgnoringModifiers?.lowercased() == "v",
-                   Self.pasteboardHasImageContent() {
-                    self.parent.onImagePaste()
-                    return nil
-                }
-
-                // Return-key routing. The bridge handles modifier-specific
-                // interception for its dedicated paths: Shift+Enter newline in
-                // default mode, Option+Enter send in default mode, and
-                // Cmd+Enter send when the preference is enabled.
-                // Plain Enter flows through to SwiftUI's .onSubmit which
-                // calls performSendAction() — the canonical send path that
-                // handles slash-menu, ghost-text, and pending-confirmation.
-                let isReturn = event.keyCode == 36 || event.keyCode == 76
-                if isReturn {
-                    let action = ComposerReturnKeyRouting.resolve(
-                        cmdEnterToSend: self.parent.cmdEnterToSend,
-                        modifiers: modifiers
-                    )
-                    let textView = (event.window?.firstResponder as? NSTextView)
-                        ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
-
-                    // Still consume newline routes when the field editor is
-                    // missing so SwiftUI cannot accidentally treat them as send.
-                    if ComposerReturnKeyRouting.performBridgeAction(
-                        action,
-                        textView: textView,
-                        onSend: self.parent.onSend
-                    ) {
-                        return nil
-                    }
-                    return event
-                }
-
-                // Let zoom shortcuts propagate instead of being consumed
-                if modifiers == [.command] || modifiers == [.command, .option] {
-                    let key = event.charactersIgnoringModifiers ?? ""
-                    if key == "=" || key == "+" || key == "-" || key == "0" {
-                        return event
-                    }
-                }
-
-                return event
-            }
-        }
-
-        func removeEventMonitor() {
-            if let monitor = eventMonitor {
-                NSEvent.removeMonitor(monitor)
-                eventMonitor = nil
-            }
-        }
-
-        static func pasteboardHasImageContent() -> Bool {
-            let pasteboard = NSPasteboard.general
-            let hasImageFile = (pasteboard.readObjects(forClasses: [NSURL.self], options: [
-                .urlReadingFileURLsOnly: true,
-            ]) as? [URL])?.contains { url in
-                let ext = url.pathExtension.lowercased()
-                return ["png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"].contains(ext)
-            } ?? false
-            let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
-            return hasImageFile || hasImageData
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -51,7 +51,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(width: 0, height: .greatestFiniteMagnitude)
+        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
         textView.textContainer?.lineFragmentPadding = 5
         textView.textContainerInset = NSSize(width: 0, height: 6)
         textView.isVerticallyResizable = true

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -1,0 +1,212 @@
+// This component replaces SwiftUI's TextField(axis: .vertical) which does not
+// reliably report its intrinsic height on macOS when text wraps to a new line.
+// Verified across 10+ approaches (ScrollView, fixedSize, lineLimit, GeometryReader,
+// PreferenceKey, NSText notifications, keyDown scroll reset).
+// See LUM-233 and the git history of ComposerView.swift for full context.
+// Ref: clients/AGENTS.md line 88 — justified exception to SwiftUI preference.
+
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+struct ComposerTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var measuredHeight: CGFloat
+    @Binding var isFocused: Bool
+
+    let font: NSFont
+    let lineSpacing: CGFloat
+    let insertionPointColor: NSColor
+    let minHeight: CGFloat
+    let maxHeight: CGFloat
+    let placeholder: String
+    let isEditable: Bool
+    let cmdEnterToSend: Bool
+    var textColorOverride: NSColor? = nil
+    var onSubmit: (() -> Void)? = nil
+    var onTab: (() -> Bool)? = nil
+    var onUpArrow: (() -> Bool)? = nil
+    var onDownArrow: (() -> Bool)? = nil
+    var onEscape: (() -> Bool)? = nil
+    var onPasteImage: (() -> Void)? = nil
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+
+        let textView = ComposerTextView()
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: 0, height: .greatestFiniteMagnitude)
+        textView.textContainer?.lineFragmentPadding = 5
+        textView.textContainerInset = NSSize(width: 0, height: 6)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.font = font
+        textView.insertionPointColor = insertionPointColor
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineSpacing
+        textView.defaultParagraphStyle = paragraphStyle
+        textView.typingAttributes = [
+            .font: font,
+            .paragraphStyle: paragraphStyle,
+        ]
+
+        textView.registerForDraggedTypes([.string, .rtf, .rtfd])
+        textView.postsFrameChangedNotifications = true
+
+        scrollView.documentView = textView
+        textView.delegate = context.coordinator
+
+        let coordinator = context.coordinator
+
+        coordinator.frameObserver = NotificationCenter.default.addObserver(
+            forName: NSView.frameDidChangeNotification,
+            object: textView,
+            queue: .main
+        ) { [weak coordinator] _ in
+            coordinator?.measureHeight(textView)
+        }
+
+        scrollView.contentView.postsBoundsChangedNotifications = true
+
+        coordinator.boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak coordinator] _ in
+            coordinator?.measureHeight(textView)
+        }
+
+        DispatchQueue.main.async {
+            coordinator.measureHeight(textView)
+        }
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        // Refresh the coordinator's parent so delegate callbacks use current bindings/values.
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? ComposerTextView else { return }
+
+        // Sync text
+        if textView.string != text {
+            textView.string = text
+            textView.scrollRangeToVisible(textView.selectedRange())
+        }
+
+        // Sync isEditable
+        textView.isEditable = isEditable
+
+        // Sync font and paragraph style
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineSpacing
+        textView.font = font
+        textView.defaultParagraphStyle = paragraphStyle
+        textView.typingAttributes = [
+            .font: font,
+            .paragraphStyle: paragraphStyle,
+        ]
+
+        // Sync placeholder
+        textView.placeholderString = placeholder
+
+        // Sync textColorOverride
+        if let override = textColorOverride {
+            textView.textColor = override
+        } else {
+            textView.textColor = .labelColor
+        }
+
+        // Sync callbacks
+        textView.cmdEnterToSend = cmdEnterToSend
+        textView.onSubmit = onSubmit
+        textView.onTab = onTab
+        textView.onUpArrow = onUpArrow
+        textView.onDownArrow = onDownArrow
+        textView.onEscape = onEscape
+        textView.onPasteImage = onPasteImage
+
+        // Focus sync (one-directional SwiftUI → AppKit)
+        if let window = textView.window {
+            if isFocused, textView != window.firstResponder {
+                window.makeFirstResponder(textView)
+            } else if !isFocused, textView == window.firstResponder {
+                window.makeFirstResponder(nil)
+            }
+        }
+
+        context.coordinator.measureHeight(textView)
+    }
+
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        if let frameObserver = coordinator.frameObserver {
+            NotificationCenter.default.removeObserver(frameObserver)
+            coordinator.frameObserver = nil
+        }
+        if let boundsObserver = coordinator.boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+            coordinator.boundsObserver = nil
+        }
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ComposerTextEditor
+        var frameObserver: NSObjectProtocol?
+        var boundsObserver: NSObjectProtocol?
+
+        init(parent: ComposerTextEditor) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            let newText = textView.string
+            if parent.text != newText {
+                parent.text = newText
+            }
+            measureHeight(textView)
+        }
+
+        func textDidBeginEditing(_ notification: Notification) {
+            if !parent.isFocused {
+                parent.isFocused = true
+            }
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            if parent.isFocused {
+                parent.isFocused = false
+            }
+        }
+
+        func measureHeight(_ textView: NSTextView) {
+            guard let lm = textView.layoutManager, let tc = textView.textContainer else { return }
+            lm.ensureLayout(for: tc)
+            let contentHeight = ceil(lm.usedRect(for: tc).height + textView.textContainerInset.height * 2)
+            let clamped = max(parent.minHeight, min(contentHeight, parent.maxHeight))
+            if abs(parent.measuredHeight - clamped) > 0.5 {
+                parent.measuredHeight = clamped
+            }
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -1,0 +1,141 @@
+#if os(macOS)
+import AppKit
+
+final class ComposerTextView: NSTextView {
+
+    // MARK: - Properties
+
+    var placeholderString: String = ""
+    var cmdEnterToSend: Bool = false
+    var onSubmit: (() -> Void)?
+    var onTab: (() -> Bool)?        // return true = handled
+    var onUpArrow: (() -> Bool)?
+    var onDownArrow: (() -> Bool)?
+    var onEscape: (() -> Bool)?
+    var onPasteImage: (() -> Void)?
+
+    // MARK: - Placeholder Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        // Draw placeholder when string is empty and placeholder is set
+        guard string.isEmpty, !placeholderString.isEmpty else { return }
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font ?? NSFont.systemFont(ofSize: 13),
+            .foregroundColor: NSColor.placeholderTextColor,
+        ]
+        let inset = textContainerInset
+        let padding = textContainer?.lineFragmentPadding ?? 5
+        let rect = NSRect(
+            x: inset.width + padding,
+            y: inset.height,
+            width: bounds.width - inset.width * 2 - padding * 2,
+            height: bounds.height - inset.height * 2
+        )
+        placeholderString.draw(in: rect, withAttributes: attrs)
+    }
+
+    override var string: String {
+        didSet { needsDisplay = true }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        needsDisplay = true
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        needsDisplay = true
+        return result
+    }
+
+    // MARK: - Key Routing
+
+    override func keyDown(with event: NSEvent) {
+        // [IME guard] Skip all custom handling during composition
+        if hasMarkedText() {
+            super.keyDown(with: event)
+            return
+        }
+
+        let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
+        let isReturn = event.keyCode == 36 || event.keyCode == 76
+
+        if isReturn {
+            let action = ComposerReturnKeyRouting.resolve(
+                cmdEnterToSend: cmdEnterToSend,
+                modifiers: modifiers
+            )
+            switch action {
+            case .bridgeSend:
+                onSubmit?()
+                return
+            case .bridgeInsertNewline:
+                insertText("\n", replacementRange: selectedRange())
+                return
+            case .deferToSubmit:
+                // Only send for plain Return (no modifiers).
+                // Cmd+Return in default mode falls through to super.
+                if modifiers.isEmpty {
+                    onSubmit?()
+                    return
+                }
+                super.keyDown(with: event)
+                return
+            }
+        }
+
+        // Tab (no shift): ghost text accept or slash menu, else insert tab
+        if event.keyCode == 48, !modifiers.contains(.shift) {
+            if onTab?() == true { return }
+            // Fall through to super which inserts a tab character
+        }
+
+        // Up arrow: slash menu navigation
+        if event.keyCode == 126 {
+            if onUpArrow?() == true { return }
+        }
+
+        // Down arrow: slash menu navigation
+        if event.keyCode == 125 {
+            if onDownArrow?() == true { return }
+        }
+
+        // Escape: slash menu dismiss
+        if event.keyCode == 53 {
+            if onEscape?() == true { return }
+        }
+
+        super.keyDown(with: event)
+    }
+
+    // MARK: - Cmd+V Image Paste
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection([.shift, .command, .control, .option])
+        if modifiers == [.command],
+           event.charactersIgnoringModifiers?.lowercased() == "v",
+           Self.pasteboardHasImageContent(),
+           let onPasteImage {
+            onPasteImage()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    /// Check if the pasteboard contains image content (file URLs with image extensions or raw image data).
+    static func pasteboardHasImageContent() -> Bool {
+        let pasteboard = NSPasteboard.general
+        let hasImageFile = (pasteboard.readObjects(forClasses: [NSURL.self], options: [
+            .urlReadingFileURLsOnly: true,
+        ]) as? [URL])?.contains { url in
+            let ext = url.pathExtension.lowercased()
+            return ["png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"].contains(ext)
+        } ?? false
+        let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
+        return hasImageFile || hasImageData
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -70,6 +70,9 @@ struct ComposerView: View {
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
 
+    @State private var measuredTextHeight: CGFloat = 32
+    @State private var textViewIsFocused: Bool = false
+
     @State var showSlashMenu = false
     @State var slashFilter = ""
     @State var slashSelectedIndex = 0
@@ -173,88 +176,72 @@ struct ComposerView: View {
         }
     }
 
-    /// The native TextField with keyboard handlers. Extracted so the compiler
-    /// can type-check each builder method independently.
-    @ViewBuilder
-    private func composerInputField(font: Font, hasSlashHighlight: Bool) -> some View {
-        TextField(
-            ghostSuffix == nil ? placeholderText : "",
-            text: $inputText,
-            axis: .vertical
-        )
-        .lineLimit(1...)
-        .textFieldStyle(.plain)
-        .font(font)
-        .lineSpacing(4)
-        .foregroundColor(hasSlashHighlight ? .clear : VColor.contentDefault)
-        .tint(VColor.primaryBase)
-        .focused($composerFocus)
-        .disabled(!hasAPIKey)
-        .onSubmit { handleComposerSubmit() }
-        .onKeyPress(.tab, phases: .down) { press in
-            if !press.modifiers.contains(.shift), showSlashMenu {
-                handleSlashNavigation(.tab)
-                return .handled
-            }
-            if !press.modifiers.contains(.shift), ghostSuffix != nil {
-                onAcceptSuggestion()
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.upArrow) {
-            if showSlashMenu {
-                handleSlashNavigation(.up)
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.downArrow) {
-            if showSlashMenu {
-                handleSlashNavigation(.down)
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress(.escape) {
-            if showSlashMenu {
-                handleSlashNavigation(.dismiss)
-                return .handled
-            }
-            return .ignored
-        }
-    }
-
     private var composerTextField: some View {
         let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
         let hasSlashHighlight = slashCommandRange != nil
+        let nsFont = NSFont(name: "Inter", size: 13 * zoomScale) ?? .systemFont(ofSize: 13)
 
-        return ScrollView(.vertical, showsIndicators: false) {
-            ZStack(alignment: .leading) {
-                composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-                composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-            }
-            .frame(maxWidth: .infinity, minHeight: composerActionButtonSize, alignment: .leading)
+        return ZStack(alignment: .leading) {
+            composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+            ComposerTextEditor(
+                text: $inputText,
+                measuredHeight: $measuredTextHeight,
+                isFocused: $textViewIsFocused,
+                font: nsFont,
+                lineSpacing: 4,
+                insertionPointColor: NSColor(VColor.primaryBase),
+                minHeight: composerActionButtonSize,
+                maxHeight: composerMaxHeight,
+                placeholder: ghostSuffix == nil ? placeholderText : "",
+                isEditable: hasAPIKey,
+                cmdEnterToSend: cmdEnterToSend,
+                textColorOverride: hasSlashHighlight
+                    ? NSColor(VColor.contentDefault).withAlphaComponent(0) : nil,
+                onSubmit: { performSendAction() },
+                onTab: {
+                    if showSlashMenu { handleSlashNavigation(.tab); return true }
+                    if ghostSuffix != nil { onAcceptSuggestion(); return true }
+                    return false
+                },
+                onUpArrow: {
+                    if showSlashMenu { handleSlashNavigation(.up); return true }
+                    return false
+                },
+                onDownArrow: {
+                    if showSlashMenu { handleSlashNavigation(.down); return true }
+                    return false
+                },
+                onEscape: {
+                    if showSlashMenu { handleSlashNavigation(.dismiss); return true }
+                    return false
+                },
+                onPasteImage: onPaste
+            )
         }
-        .scrollBounceBehavior(.basedOnSize)
-        .defaultScrollAnchor(.bottom)
-        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty ? composerActionButtonSize : composerMaxHeight)
+        .frame(maxWidth: .infinity, height: measuredTextHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)
         .background(
             ComposerFocusBridge(
                 isFocused: composerFocus,
-                cmdEnterToSend: cmdEnterToSend,
-                onImagePaste: onPaste,
-                onSend: {
-                    performSendAction()
-                },
                 onRedirectKeystroke: { chars in
                     inputText += chars
                     composerFocus = true
                 }
             )
         )
+        // Focus: SwiftUI → AppKit (one-directional)
+        .onChange(of: composerFocus) {
+            if textViewIsFocused != composerFocus {
+                textViewIsFocused = composerFocus
+            }
+        }
+        // Focus: AppKit → SwiftUI (from delegate)
+        .onChange(of: textViewIsFocused) {
+            if composerFocus != textViewIsFocused {
+                composerFocus = textViewIsFocused
+            }
+        }
         .onChange(of: composerFocus) {
             isComposerFocused = composerFocus
             if composerFocus {
@@ -387,14 +374,6 @@ struct ComposerView: View {
                     && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             onAllowPendingConfirmation?()
         }
-    }
-
-    private func handleComposerSubmit() {
-        // On macOS, the bridge consumes all Return variants that should insert
-        // a newline (cmd-enter mode) or trigger a bridge-level send. The only
-        // Return events that reach `.onSubmit` are plain Return in default mode,
-        // which always means "send".
-        performSendAction()
     }
 
     // MARK: - Text Entry Mode

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -218,7 +218,7 @@ struct ComposerView: View {
                 onPasteImage: onPaste
             )
         }
-        .frame(maxWidth: .infinity, height: measuredTextHeight)
+        .frame(height: measuredTextHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)
         .background(

--- a/clients/macos/vellum-assistantTests/ComposerTextViewTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerTextViewTests.swift
@@ -1,0 +1,244 @@
+#if os(macOS)
+import AppKit
+import XCTest
+@testable import VellumAssistantLib
+
+final class ComposerTextViewTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTextView() -> ComposerTextView {
+        let textView = ComposerTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 100))
+        // Ensure the text container and layout manager are wired up for text insertion.
+        if textView.textContainer == nil {
+            let container = NSTextContainer(containerSize: NSSize(width: 400, height: CGFloat.greatestFiniteMagnitude))
+            let layoutManager = NSLayoutManager()
+            layoutManager.addTextContainer(container)
+            textView.textStorage?.addLayoutManager(layoutManager)
+        }
+        return textView
+    }
+
+    private func makeKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags = []) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+    }
+
+    // Key codes
+    private let returnKey: UInt16 = 36
+    private let numpadEnter: UInt16 = 76
+    private let tabKey: UInt16 = 48
+    private let upArrow: UInt16 = 126
+    private let downArrow: UInt16 = 125
+    private let escapeKey: UInt16 = 53
+
+    // MARK: - Return key routing (default mode, cmdEnterToSend = false)
+
+    func testPlainReturnCallsOnSubmit() {
+        let textView = makeTextView()
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = false
+
+        let event = makeKeyDown(keyCode: returnKey)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnSubmit, "Plain Return should call onSubmit in default mode")
+    }
+
+    func testShiftReturnInsertsNewline() {
+        let textView = makeTextView()
+        textView.string = "hello"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = false
+
+        let event = makeKeyDown(keyCode: returnKey, modifiers: [.shift])
+        textView.keyDown(with: event)
+
+        XCTAssertFalse(didCallOnSubmit, "Shift+Return should NOT call onSubmit")
+        XCTAssertTrue(textView.string.contains("\n"), "Shift+Return should insert a newline character")
+    }
+
+    func testOptionReturnCallsOnSubmit() {
+        let textView = makeTextView()
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = false
+
+        let event = makeKeyDown(keyCode: returnKey, modifiers: [.option])
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnSubmit, "Option+Return should call onSubmit (bridgeSend) in default mode")
+    }
+
+    func testCmdReturnDefaultModeDoesNotSend() {
+        let textView = makeTextView()
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = false
+
+        let event = makeKeyDown(keyCode: returnKey, modifiers: [.command])
+        textView.keyDown(with: event)
+
+        XCTAssertFalse(didCallOnSubmit, "Cmd+Return in default mode should NOT call onSubmit (falls through to super)")
+    }
+
+    // MARK: - Return key routing (cmdEnterToSend mode)
+
+    func testCmdReturnSendsInCmdEnterMode() {
+        let textView = makeTextView()
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = true
+
+        let event = makeKeyDown(keyCode: returnKey, modifiers: [.command])
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnSubmit, "Cmd+Return should call onSubmit in cmdEnterToSend mode")
+    }
+
+    func testPlainReturnInsertsNewlineInCmdEnterMode() {
+        let textView = makeTextView()
+        textView.string = "hello"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        var didCallOnSubmit = false
+        textView.onSubmit = { didCallOnSubmit = true }
+        textView.cmdEnterToSend = true
+
+        let event = makeKeyDown(keyCode: returnKey)
+        textView.keyDown(with: event)
+
+        XCTAssertFalse(didCallOnSubmit, "Plain Return should NOT call onSubmit in cmdEnterToSend mode")
+        XCTAssertTrue(textView.string.contains("\n"), "Plain Return should insert a newline in cmdEnterToSend mode")
+    }
+
+    // MARK: - Tab routing
+
+    func testTabCallsOnTab() {
+        let textView = makeTextView()
+        var didCallOnTab = false
+        textView.onTab = {
+            didCallOnTab = true
+            return true
+        }
+
+        let event = makeKeyDown(keyCode: tabKey)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnTab, "Tab should call onTab callback")
+    }
+
+    func testTabFallsThroughWhenOnTabReturnsFalse() {
+        let textView = makeTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        var didCallOnTab = false
+        textView.onTab = {
+            didCallOnTab = true
+            return false
+        }
+
+        let event = makeKeyDown(keyCode: tabKey)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnTab, "Tab should call onTab even when it returns false")
+        // When onTab returns false, Tab falls through to super which inserts a tab character.
+        // The text view should have received the event (we verified onTab was called).
+    }
+
+    // MARK: - Arrow key routing
+
+    func testUpArrowCallsOnUpArrow() {
+        let textView = makeTextView()
+        var didCallOnUpArrow = false
+        textView.onUpArrow = {
+            didCallOnUpArrow = true
+            return true
+        }
+
+        let event = makeKeyDown(keyCode: upArrow)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnUpArrow, "Up arrow should call onUpArrow callback")
+    }
+
+    func testDownArrowCallsOnDownArrow() {
+        let textView = makeTextView()
+        var didCallOnDownArrow = false
+        textView.onDownArrow = {
+            didCallOnDownArrow = true
+            return true
+        }
+
+        let event = makeKeyDown(keyCode: downArrow)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnDownArrow, "Down arrow should call onDownArrow callback")
+    }
+
+    // MARK: - Escape routing
+
+    func testEscapeCallsOnEscape() {
+        let textView = makeTextView()
+        var didCallOnEscape = false
+        textView.onEscape = {
+            didCallOnEscape = true
+            return true
+        }
+
+        let event = makeKeyDown(keyCode: escapeKey)
+        textView.keyDown(with: event)
+
+        XCTAssertTrue(didCallOnEscape, "Escape should call onEscape callback")
+    }
+
+    // MARK: - IME guard
+
+    // Skipped: testMarkedTextSkipsCustomHandling
+    // Testing marked text (IME composition) requires an active input context and window
+    // to set the marked text state on the NSTextView. Without a real window and input
+    // source, hasMarkedText() always returns false, making it impossible to reliably
+    // simulate IME composition in a headless test environment.
+
+    // MARK: - Cmd+V paste routing
+
+    func testPerformKeyEquivalentCmdVWithoutImagePassesThrough() {
+        let textView = makeTextView()
+        var didCallOnPasteImage = false
+        textView.onPasteImage = { didCallOnPasteImage = true }
+
+        // Clear the pasteboard to ensure no image content is present
+        NSPasteboard.general.clearContents()
+
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "v",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9  // 'v' key code
+        )!
+
+        let result = textView.performKeyEquivalent(with: event)
+
+        XCTAssertFalse(didCallOnPasteImage, "Cmd+V without image on pasteboard should NOT call onPasteImage")
+        XCTAssertFalse(result, "Cmd+V without image on pasteboard should return false (pass through to super)")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
Replace SwiftUI's TextField(axis: .vertical) in the macOS composer with a custom NSViewRepresentable backed by NSTextView. TextField(axis: .vertical) does not reliably update its intrinsic height on macOS when text wraps, causing transient top-line clipping. The new component measures height synchronously from NSTextView's layout manager, fixing the bug.

## Changes
- New `ComposerTextView` (NSTextView subclass): placeholder drawing, Return/Tab/arrow/Escape key routing via existing ComposerReturnKeyRouting policy, Cmd+V image paste interception, IME marked-text guard
- New `ComposerTextEditor` (NSViewRepresentable): wraps NSScrollView + ComposerTextView, synchronous height measurement via layoutManager.usedRect, stable scroller width (overlay style), frameDidChange + boundsDidChange observers, one-directional focus sync
- Updated `ComposerView`: replaced TextField + ScrollView with ComposerTextEditor in ZStack, ghost text and slash highlighting overlays unchanged
- Slimmed `ComposerFocusBridge`: removed Return routing, Cmd+V interception, event monitor, drag type unregistration (all moved to ComposerTextView/ComposerTextEditor). Bridge now only owns keystroke redirect and container detection.
- 12 integration tests for ComposerTextView key routing covering all Return modifier combinations, Tab/arrow/Escape callbacks, and Cmd+V passthrough

## Milestone PRs (merged into feature branch)
- #17977: M1 — ComposerTextView NSTextView subclass
- #17983: M2 — ComposerTextEditor NSViewRepresentable
- #17990: M3 — Integration into ComposerView + bridge slimming
- #18003: M4 — Integration tests

## Project issue
Closes #17971

## Test plan
- [ ] Composer grows immediately at 1→2 line wrap — no top-line clipping
- [ ] Composer scrolls internally when content exceeds 200pt
- [ ] Height updates on window resize and zoom change
- [ ] All Return key combinations work in default and cmdEnterToSend modes
- [ ] Tab accepts ghost text / selects slash command
- [ ] Placeholder visible when empty, centered
- [ ] Ghost text and slash highlighting work
- [ ] Cmd+V pastes image as attachment
- [ ] Focus restores on app activation, thread switch
- [ ] Dictation mode works
- [ ] File drop works
- [ ] CJK/IME input works
- [ ] All 12 ComposerTextViewTests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
