### PR TITLE
fix: fail explicitly when AppDelegate launcher is unavailable in HatchingStepView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -256,8 +256,14 @@ struct HatchingStepView: View {
         // AppDelegate.applicationWillTerminate and cleaned up on app exit.
         // Creating a local instance here would leave an orphaned VM running
         // after the user quits.
-        let launcher = AppDelegate.shared?.appleContainersLauncher
         hatchTask = Task {
+            guard let launcher = AppDelegate.shared?.appleContainersLauncher else {
+                log.error("Apple Containers hatch failed: AppDelegate.shared or appleContainersLauncher is unavailable")
+                failureReason = "Container launcher is unavailable \u{2014} please restart the app and try again"
+                state.hatchFailed = true
+                return
+            }
+
             do {
                 state.hatchLogLines.append("Preparing kernel images\u{2026}")
                 guard !Task.isCancelled else { return }
@@ -265,7 +271,7 @@ struct HatchingStepView: View {
                 // AppleContainersLauncher writes its own lockfile entry and manages
                 // the full pod lifecycle; we just need to wait for it to finish.
                 state.hatchLogLines.append("Starting pod\u{2026}")
-                try await launcher?.launch(name: nil, daemonOnly: false, restart: false)
+                try await launcher.launch(name: nil, daemonOnly: false, restart: false)
                 guard !Task.isCancelled else { return }
 
                 state.hatchLogLines.append("Waiting for gateway\u{2026}")


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for apple-containers-hatch.md.

**Gap:** Silent false-success hatch when AppDelegate.shared is nil
**What was expected:** Explicit failure with clear error message when launcher is unavailable
**What was found:** Optional chaining on launcher?.launch() silently returns nil (no throw) causing handleHatchSuccess() to be called with no container running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
