### PR TITLE
ci: cancel stale PR CI runs on close/merge

### DIFF
--- a/.github/workflows/pr-cancel-on-close.yaml
+++ b/.github/workflows/pr-cancel-on-close.yaml
@@ -1,0 +1,26 @@
+name: Cancel stale PR runs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-progress workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for status in queued in_progress; do
+            gh run list \
+              --repo "${{ github.repository }}" \
+              --branch "${{ github.head_ref }}" \
+              --status "$status" \
+              --json databaseId \
+              --jq '.[].databaseId' | \
+            while read -r run_id; do
+              echo "Cancelling run $run_id (was $status)"
+              gh run cancel "$run_id" --repo "${{ github.repository }}" || true
+            done
+          done


### PR DESCRIPTION
## Summary
- Adds a lightweight workflow (`pr-cancel-on-close.yaml`) triggered on `pull_request: closed`
- Lists all `queued` and `in_progress` runs for the PR's head branch and cancels them via `gh run cancel`
- Saves CI runner minutes by stopping orphaned PR runs after merge or close

## Original prompt
Ship the pr-cancel-on-close.yaml workflow that cancels in-flight PR CI runs when a PR is closed or merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
