### PR TITLE
fix: diagnostics export captures full conversation instead of single exchange

### DIFF
--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -18,7 +18,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 import archiver from "archiver";
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte } from "drizzle-orm";
 
 import {
   type ProfileResolution,
@@ -230,32 +230,26 @@ async function handleDiagnosticsExport(body: {
     }
 
     // 2. Compute the export time range.
-    // When an anchor message exists, scope to the preceding user message
-    // through the anchor. When no messages exist at all (empty conversation
-    // or race condition), use the current timestamp so the export still
-    // captures any in-flight usage/tool data.
+    // When an anchor message exists, scope from the earliest message in the
+    // conversation through the anchor so the full conversation context is
+    // captured. When no messages exist at all (empty conversation or race
+    // condition), use the current timestamp so the export still captures any
+    // in-flight usage/tool data.
     const now = Date.now();
     let rangeEnd: number;
     let rangeStart: number;
     let usageRangeEnd: number;
 
     if (anchorMessage) {
-      const precedingUserMessage = db
+      const earliestMessage = db
         .select()
         .from(messages)
-        .where(
-          and(
-            eq(messages.conversationId, conversationId),
-            eq(messages.role, "user"),
-            lte(messages.createdAt, anchorMessage.createdAt),
-          ),
-        )
-        .orderBy(desc(messages.createdAt))
+        .where(eq(messages.conversationId, conversationId))
+        .orderBy(asc(messages.createdAt))
         .limit(1)
         .get();
 
-      rangeStart =
-        precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
+      rangeStart = earliestMessage?.createdAt ?? anchorMessage.createdAt - 2000;
 
       // When the anchor was selected via the fallback "any message" path
       // (because the assistant reply hasn't been persisted yet), extend the


### PR DESCRIPTION
## Summary

- Changed the diagnostics export time range to start from the earliest message in the conversation instead of the preceding user message, so all LLM calls/messages/tool invocations in the conversation are captured
- Previously clicking the export button on an assistant message would only export that single exchange (1 LLM call); now it exports everything from the start of the conversation up to the clicked message

## Original prompt

Change the diagnostics export time range to capture everything from the start of the conversation up to the anchor message, instead of only from the preceding user message to the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
