### PR TITLE
fix: deterministic ordering for OAuth connections query

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -567,9 +567,14 @@ export function listConnections(
       .select()
       .from(oauthConnections)
       .where(eq(oauthConnections.providerKey, providerKey))
+      .orderBy(oauthConnections.providerKey, oauthConnections.id)
       .all();
   } else {
-    rows = db.select().from(oauthConnections).all();
+    rows = db
+      .select()
+      .from(oauthConnections)
+      .orderBy(oauthConnections.providerKey, oauthConnections.id)
+      .all();
   }
 
   if (clientId) {


### PR DESCRIPTION
## Summary
- Add `orderBy(providerKey, id)` to both query paths in `listConnections()` so the "Connected Services" section in the system prompt is stable across turns
- Prevents unnecessary LLM prompt cache busts when connections are deleted/re-created (rowid changes no longer affect ordering)

## Original prompt
Fix #2: Add ORDER BY to the `listConnections()` query in `assistant/src/oauth/oauth-store.ts` to ensure deterministic ordering of OAuth connections. The query at line 572 (`db.select().from(oauthConnections).all()`) and the filtered query at line 566-570 have no ORDER BY clause. Add `.orderBy(oauthConnections.providerKey, oauthConnections.id)` to both query paths so the "Connected Services" section in the system prompt is stable across turns, preventing unnecessary cache busts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
