### PR TITLE
fix: use checkbox instead of toggle for ToS consent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -74,6 +74,7 @@ struct ImproveExperienceStepView: View {
                     VCheckbox(isOn: $tosAccepted)
                     tosConsentText
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.lg)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -70,12 +70,10 @@ struct ImproveExperienceStepView: View {
                 )
 
                 // ToS consent checkbox
-                HStack(alignment: .top, spacing: VSpacing.md) {
-                    Toggle("Agree to Terms of Service and Privacy Policy", isOn: $tosAccepted)
-                        .toggleStyle(.checkbox)
-                        .labelsHidden()
-                        .padding(.top, VSpacing.xxs)
+                HStack {
                     tosConsentText
+                    Spacer()
+                    VCheckbox(isOn: $tosAccepted)
                 }
                 .padding(VSpacing.lg)
                 .overlay(
@@ -150,5 +148,42 @@ struct ImproveExperienceStepView: View {
             // Users who skipped step 2 (API key) go back to step 1
             state.currentStep -= skippedAPIKeyEntry ? 2 : 1
         }
+    }
+}
+
+// MARK: - Checkbox
+
+/// A styled checkbox matching the V* component aesthetic: primary-filled with
+/// white checkmark when checked, outlined rounded square when unchecked.
+private struct VCheckbox: View {
+    @Binding var isOn: Bool
+
+    private let size: CGFloat = 20
+    private let cornerRadius: CGFloat = VRadius.sm
+
+    var body: some View {
+        Button {
+            isOn.toggle()
+        } label: {
+            ZStack {
+                if isOn {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .fill(VColor.primaryBase)
+                        .frame(width: size, height: size)
+
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(.white)
+                } else {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .stroke(VColor.borderBase, lineWidth: 1.5)
+                        .frame(width: size, height: size)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .animation(VAnimation.fast, value: isOn)
+        .accessibilityLabel("Agree to Terms of Service and Privacy Policy")
+        .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -187,6 +187,7 @@ private struct VCheckbox: View {
         .buttonStyle(.plain)
         .animation(VAnimation.fast, value: isOn)
         .accessibilityLabel("Agree to Terms of Service and Privacy Policy")
+        .accessibilityValue(isOn ? "Checked" : "Unchecked")
         .accessibilityAddTraits(.isToggle)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -70,10 +70,9 @@ struct ImproveExperienceStepView: View {
                 )
 
                 // ToS consent checkbox
-                HStack {
-                    tosConsentText
-                    Spacer()
+                HStack(spacing: VSpacing.md) {
                     VCheckbox(isOn: $tosAccepted)
+                    tosConsentText
                 }
                 .padding(VSpacing.lg)
                 .overlay(
@@ -117,7 +116,7 @@ struct ImproveExperienceStepView: View {
     private var tosConsentText: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text(.init("I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"))
-                .font(VFont.body)
+                .font(VFont.bodyBold)
                 .foregroundColor(VColor.contentSecondary)
                 .tint(VColor.primaryBase)
                 .environment(\.openURL, OpenURLAction { url in

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -71,10 +71,10 @@ struct ImproveExperienceStepView: View {
 
                 // ToS consent checkbox
                 HStack(alignment: .top, spacing: VSpacing.md) {
-                    Toggle("", isOn: $tosAccepted)
+                    Toggle("Agree to Terms of Service and Privacy Policy", isOn: $tosAccepted)
                         .toggleStyle(.checkbox)
                         .labelsHidden()
-                        .padding(.top, 2)
+                        .padding(.top, VSpacing.xxs)
                     tosConsentText
                 }
                 .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -169,17 +169,21 @@ private struct VCheckbox: View {
                 if isOn {
                     RoundedRectangle(cornerRadius: cornerRadius)
                         .fill(VColor.primaryBase)
-                        .frame(width: size, height: size)
 
                     Image(systemName: "checkmark")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(.white)
                 } else {
                     RoundedRectangle(cornerRadius: cornerRadius)
-                        .stroke(VColor.borderBase, lineWidth: 1.5)
-                        .frame(width: size, height: size)
+                        .fill(Color.clear)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .stroke(VColor.borderBase, lineWidth: 1.5)
+                        )
                 }
             }
+            .frame(width: size, height: size)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .animation(VAnimation.fast, value: isOn)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -170,8 +170,7 @@ private struct VCheckbox: View {
                     RoundedRectangle(cornerRadius: cornerRadius)
                         .fill(VColor.primaryBase)
 
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 12, weight: .bold))
+                    VIconView(.check, size: 12)
                         .foregroundColor(.white)
                 } else {
                     RoundedRectangle(cornerRadius: cornerRadius)
@@ -188,6 +187,6 @@ private struct VCheckbox: View {
         .buttonStyle(.plain)
         .animation(VAnimation.fast, value: isOn)
         .accessibilityLabel("Agree to Terms of Service and Privacy Policy")
-        .accessibilityAddTraits(isOn ? .isSelected : [])
+        .accessibilityAddTraits(.isToggle)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -69,11 +69,13 @@ struct ImproveExperienceStepView: View {
                         .stroke(VColor.borderBase, lineWidth: 1)
                 )
 
-                // ToS consent toggle
-                HStack {
+                // ToS consent checkbox
+                HStack(alignment: .top, spacing: VSpacing.md) {
+                    Toggle("", isOn: $tosAccepted)
+                        .toggleStyle(.checkbox)
+                        .labelsHidden()
+                        .padding(.top, 2)
                     tosConsentText
-                    Spacer()
-                    VToggle(isOn: $tosAccepted)
                 }
                 .padding(VSpacing.lg)
                 .overlay(

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -117,7 +117,7 @@ struct ImproveExperienceStepView: View {
     private var tosConsentText: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text(.init("I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"))
-                .font(VFont.bodyBold)
+                .font(VFont.body)
                 .foregroundColor(VColor.contentSecondary)
                 .tint(VColor.primaryBase)
                 .environment(\.openURL, OpenURLAction { url in


### PR DESCRIPTION
## Summary
- Replaced `VToggle` with native macOS checkbox (`Toggle` with `.toggleStyle(.checkbox)`) for the Terms of Service consent in the onboarding flow
- Moved the checkbox to the leading side of the consent text, which is the standard pattern for consent checkboxes

## Original prompt
instead of VToggle for Terms of Service and Privacy Policy let's use our component library checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
