### PR TITLE
feat: show Sign In instead of Log Out in preferences menu for unauthenticated users

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -577,6 +577,12 @@ struct MainWindowView: View {
                                 sidebar.showPreferencesDrawer = false
                                 AppDelegate.shared?.performLogout()
                             },
+                            onSignIn: {
+                                sidebar.showPreferencesDrawer = false
+                                Task {
+                                    await authManager.startWorkOSLogin()
+                                }
+                            },
                             onOpenBilling: {
                                 sidebar.showPreferencesDrawer = false
                                 settingsStore.pendingSettingsTab = .billing

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -7,6 +7,7 @@ struct DrawerMenuView: View {
     let onUsage: () -> Void
     let onDebug: () -> Void
     let onLogOut: () -> Void
+    let onSignIn: () -> Void
     let onOpenBilling: () -> Void
 
     @State private var effectiveBalance: String?
@@ -69,7 +70,11 @@ struct DrawerMenuView: View {
 
                 SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
-                SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
+                if authManager.isAuthenticated {
+                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
+                } else {
+                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Sign In"), action: onSignIn)
+                }
             }
         }
         .padding(VSpacing.sm)


### PR DESCRIPTION
## Summary
- Show "Sign In" button in the preferences drawer menu when the user is not authenticated, instead of "Log Out"
- When clicked, triggers WorkOS login flow via `authManager.startWorkOSLogin()`
- When authenticated, shows the existing "Log Out" button as before

## Original prompt
When user isn't signed in, in Preferences menu add sign in button instead of Log out

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
