### PR TITLE
perf: split system prompt into static + dynamic cache blocks

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -88,12 +88,25 @@ const {
   ensurePromptFiles,
   stripCommentLines,
   buildExternalCommsIdentitySection,
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
 } = await import("../prompts/system-prompt.js");
 
-/** Strip the Configuration, Skills, and hardcoded preamble sections so base-prompt tests stay focused. */
+/**
+ * Extract just the workspace-file content (IDENTITY.md, SOUL.md, USER.md,
+ * BOOTSTRAP.md) from the full system prompt, stripping all static
+ * instruction sections, configuration, and skills catalog.
+ *
+ * After the cache-boundary refactor, workspace content lives in the
+ * dynamic block (after SYSTEM_PROMPT_CACHE_BOUNDARY).
+ */
 function basePrompt(result: string): string {
-  let s = result;
-  // Strip the hardcoded em-dash instruction preamble
+  // The workspace files are in the dynamic block after the cache boundary.
+  const boundaryIdx = result.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+  let s =
+    boundaryIdx >= 0
+      ? result.slice(boundaryIdx + SYSTEM_PROMPT_CACHE_BOUNDARY.length)
+      : result;
+  // Strip the hardcoded em-dash instruction preamble (in case boundary is absent)
   const emDashLine =
     "IMPORTANT: Never use em dashes (\u2014) in your messages. Use commas, periods, or just start a new sentence instead.";
   if (s.startsWith(emDashLine)) {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -115,12 +115,57 @@ export interface BuildSystemPromptOptions {
   excludeBootstrap?: boolean;
 }
 
+/**
+ * Sentinel that separates the static instruction prefix (stable across turns)
+ * from the dynamic workspace suffix (changes when workspace files are edited).
+ *
+ * The Anthropic provider splits on this marker to create two system-prompt
+ * cache blocks so that static instructions stay cached even when workspace
+ * files change between turns.
+ */
+export const SYSTEM_PROMPT_CACHE_BOUNDARY =
+  "\n<!-- SYSTEM_PROMPT_CACHE_BOUNDARY -->\n";
+
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
+  const hasNoClient = options?.hasNoClient ?? false;
+
+  // ── Static instruction sections (stable across turns) ──
+  // These sections are deterministic within a process lifetime.  They form
+  // the first cache block so they remain cached even when workspace files
+  // (IDENTITY.md, SOUL.md, USER.md, etc.) are edited between turns.
+  const staticParts: string[] = [];
+  staticParts.push(
+    "IMPORTANT: Never use em dashes (—) in your messages. Use commas, periods, or just start a new sentence instead.",
+  );
+  if (getIsContainerized()) staticParts.push(buildContainerizedSection());
+  staticParts.push(buildCliReferenceSection());
+  staticParts.push(buildPostToolResponseSection());
+  staticParts.push(buildChannelAwarenessSection());
+  if (!hasNoClient) staticParts.push(buildToolPermissionSection());
+  staticParts.push(buildTaskScheduleReminderRoutingSection());
+  staticParts.push(buildAttachmentSection());
+  staticParts.push(buildInChatConfigurationSection());
+  if (!isOnboardingComplete()) {
+    staticParts.push(buildStarterTaskPlaybookSection());
+  }
+  if (!hasNoClient) staticParts.push(buildSystemPermissionSection());
+  staticParts.push(buildSwarmGuidanceSection());
+  staticParts.push(buildAccessPreferenceSection(hasNoClient));
+  staticParts.push(buildMemoryPersistenceSection());
+  staticParts.push(buildMemoryRecallSection());
+  staticParts.push(buildWorkspaceReflectionSection());
+  staticParts.push(buildLearningMemorySection());
+
+  // ── Dynamic sections (may change between turns) ──
+  // Workspace files, config, external comms identity, connected services,
+  // and skills catalog are all re-read from disk/DB each turn.  They form
+  // the second cache block.
+  const dynamicParts: string[] = [];
+
   const soulPath = getWorkspacePromptPath("SOUL.md");
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   const userPath = getWorkspacePromptPath("USER.md");
   const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
-
   const updatesPath = getWorkspacePromptPath("UPDATES.md");
 
   const soul = readPromptFile(soulPath);
@@ -129,23 +174,18 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const bootstrap = readPromptFile(bootstrapPath);
   const updates = readPromptFile(updatesPath);
 
-  // ── Core sections ──
-  const parts: string[] = [];
-  parts.push(
-    "IMPORTANT: Never use em dashes (—) in your messages. Use commas, periods, or just start a new sentence instead.",
-  );
-  if (identity) parts.push(identity);
-  if (soul) parts.push(soul);
-  if (user) parts.push(user);
+  if (identity) dynamicParts.push(identity);
+  if (soul) dynamicParts.push(soul);
+  if (user) dynamicParts.push(user);
   if (bootstrap && !options?.excludeBootstrap) {
-    parts.push(
+    dynamicParts.push(
       "# First-Run Ritual\n\n" +
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
   }
   if (updates) {
-    parts.push(
+    dynamicParts.push(
       [
         "## Recent Updates",
         "",
@@ -161,30 +201,15 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       ].join("\n"),
     );
   }
-  if (getIsContainerized()) parts.push(buildContainerizedSection());
-  const hasNoClient = options?.hasNoClient ?? false;
-  parts.push(buildConfigSection(hasNoClient));
-  parts.push(buildCliReferenceSection());
-  parts.push(buildPostToolResponseSection());
-  parts.push(buildExternalCommsIdentitySection());
-  parts.push(buildChannelAwarenessSection());
-  if (!hasNoClient) parts.push(buildToolPermissionSection());
-  parts.push(buildTaskScheduleReminderRoutingSection());
-  parts.push(buildAttachmentSection());
-  parts.push(buildInChatConfigurationSection());
-  if (!isOnboardingComplete()) {
-    parts.push(buildStarterTaskPlaybookSection());
-  }
-  if (!hasNoClient) parts.push(buildSystemPermissionSection());
-  parts.push(buildSwarmGuidanceSection());
-  parts.push(buildAccessPreferenceSection(hasNoClient));
-  parts.push(buildIntegrationSection());
-  parts.push(buildMemoryPersistenceSection());
-  parts.push(buildMemoryRecallSection());
-  parts.push(buildWorkspaceReflectionSection());
-  parts.push(buildLearningMemorySection());
+  dynamicParts.push(buildConfigSection(hasNoClient));
+  dynamicParts.push(buildExternalCommsIdentitySection());
+  dynamicParts.push(buildIntegrationSection());
 
-  return appendSkillsCatalog(parts.join("\n\n"));
+  const dynamicWithSkills = appendSkillsCatalog(dynamicParts.join("\n\n"));
+
+  return (
+    staticParts.join("\n\n") + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamicWithSkills
+  );
 }
 
 function buildTaskScheduleReminderRoutingSection(): string {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
@@ -648,13 +649,37 @@ export class AnthropicProvider implements Provider {
       };
 
       if (systemPrompt) {
-        params.system = [
-          {
-            type: "text" as const,
-            text: systemPrompt,
-            cache_control: { type: "ephemeral" as const },
-          },
-        ];
+        const boundaryIdx = systemPrompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+        if (boundaryIdx >= 0) {
+          // Split into two cache blocks: static instructions (stable across
+          // turns) and dynamic workspace content (changes when files are
+          // edited).  The static prefix stays cached even when workspace
+          // files change, saving ~8-10K tokens of cache creation per turn.
+          const staticBlock = systemPrompt.slice(0, boundaryIdx);
+          const dynamicBlock = systemPrompt.slice(
+            boundaryIdx + SYSTEM_PROMPT_CACHE_BOUNDARY.length,
+          );
+          params.system = [
+            {
+              type: "text" as const,
+              text: staticBlock,
+              cache_control: { type: "ephemeral" as const },
+            },
+            {
+              type: "text" as const,
+              text: dynamicBlock,
+              cache_control: { type: "ephemeral" as const },
+            },
+          ];
+        } else {
+          params.system = [
+            {
+              type: "text" as const,
+              text: systemPrompt,
+              cache_control: { type: "ephemeral" as const },
+            },
+          ];
+        }
       }
 
       if (tools && tools.length > 0) {


### PR DESCRIPTION
## Summary
- Reorder `buildSystemPrompt()` to emit static instruction sections first, then a `SYSTEM_PROMPT_CACHE_BOUNDARY` sentinel, then dynamic workspace content (files, config, skills, integrations)
- Update the Anthropic client to split on the boundary and create two system text blocks with independent `cache_control: ephemeral` breakpoints
- When workspace files are edited mid-conversation, only the dynamic block (~3-4K tokens) is invalidated; the static prefix (~8-9K tokens) stays cached

## Original prompt
Split the system prompt into static + dynamic blocks to prevent workspace file edits from busting the entire system prompt cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
