### PR TITLE
fix: add services config to test mocks for CI

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -46,6 +46,19 @@ mock.module("../config/loader.js", () => ({
     secretDetection: { enabled: false },
     sandbox: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -30,6 +30,19 @@ const TEST_DIR = join(
 
 let currentConfig: Record<string, unknown> = {
   sandbox: { enabled: false, backend: "native" },
+  services: {
+    inference: {
+      mode: "your-own",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    },
+    "image-generation": {
+      mode: "your-own",
+      provider: "gemini",
+      model: "gemini-2.5-flash-image",
+    },
+    "web-search": { mode: "your-own", provider: "anthropic-native" },
+  },
 };
 
 const DECLARED_FLAG_ID = "contacts";
@@ -120,6 +133,19 @@ beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
   currentConfig = {
     sandbox: { enabled: false, backend: "native" },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   };
 });
 
@@ -180,6 +206,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         [DECLARED_FLAG_KEY]: false,
         "feature_flags.browser.enabled": true,
       },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -205,6 +244,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -234,6 +286,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         [DECLARED_FLAG_KEY]: false,
         "feature_flags.email-channel.enabled": false,
       },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -253,6 +318,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -271,6 +349,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
       assistantFeatureFlagValues: { "feature_flags.browser.enabled": false },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -290,6 +381,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();
@@ -303,6 +407,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
     };
 
     const result = buildSystemPrompt();

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -28,6 +28,19 @@ const geminiGenerateContentFn = mock(async () => geminiGenerateContentResult);
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     imageGenModel: "gemini-2.5-flash-image",
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -29,6 +29,19 @@ mock.module("../util/logger.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -65,6 +65,31 @@ mock.module("../util/platform.js", () => ({
   isWindows: () => false,
 }));
 
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
 import { Command } from "commander";
 import { z } from "zod";
 

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -55,6 +55,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -53,6 +53,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -46,6 +46,19 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -81,6 +81,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -32,6 +32,19 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -60,6 +60,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -60,6 +60,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -64,6 +64,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -62,6 +62,19 @@ mock.module("../config/loader.js", () => ({
       titleGenerationMaxTokens: 30,
       standaloneRecording: true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -249,6 +249,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "memory/embedding-backend.ts", // embedding backend API key lookup
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
+      "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -57,6 +57,19 @@ mock.module("../config/loader.js", () => ({
     assistantFeatureFlagValues: {
       "feature_flags.browser.enabled": true,
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -421,7 +421,9 @@ describe("executeBrowserClose", () => {
   test("closes session page", async () => {
     const result = await executeBrowserClose({}, ctx);
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Browser page closed for this session");
+    expect(result.content).toContain(
+      "Browser page closed for this conversation",
+    );
   });
 
   test("closes all pages when close_all_pages=true", async () => {

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -177,7 +177,9 @@ describe("executeBrowserClose", () => {
   test("closes session page by default", async () => {
     const result = await executeBrowserClose({}, ctx);
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Browser page closed for this session.");
+    expect(result.content).toContain(
+      "Browser page closed for this conversation.",
+    );
     expect(closeSessionPageMock).toHaveBeenCalledWith("test-conversation");
     expect(closeAllPagesMock).not.toHaveBeenCalled();
   });

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -133,6 +133,19 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -56,6 +56,19 @@ mock.module("../config/loader.js", () => ({
 
     sandbox: { enabled: false, backend: "local" },
     assistantFeatureFlagValues: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -24,6 +24,19 @@ const mockConfig = {
     entropyThreshold: 4.0,
   },
   auditLog: { retentionDays: 0 },
+  services: {
+    inference: {
+      mode: "your-own",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    },
+    "image-generation": {
+      mode: "your-own",
+      provider: "gemini",
+      model: "gemini-2.5-flash-image",
+    },
+    "web-search": { mode: "your-own", provider: "anthropic-native" },
+  },
 };
 
 mock.module("../util/platform.js", () => ({

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -22,6 +22,19 @@ let lastGenerateCredentials: unknown = null;
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -52,6 +52,19 @@ mock.module("../config/loader.js", () => ({
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/swarm-conversation-integration.test.ts
+++ b/assistant/src/__tests__/swarm-conversation-integration.test.ts
@@ -35,6 +35,19 @@ mock.module("../config/loader.js", () => ({
       plannerModelIntent: "latency-optimized",
       synthesizerModelIntent: "quality-optimized",
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -47,6 +47,19 @@ mock.module("../config/loader.js", () => ({
       plannerModelIntent: "latency-optimized",
       synthesizerModelIntent: "quality-optimized",
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -27,6 +27,19 @@ mock.module("../config/loader.js", () => ({
       plannerModelIntent: "latency-optimized",
       synthesizerModelIntent: "quality-optimized",
     },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   getSwarmDisabledConfig: () => ({
     provider: "anthropic",

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -63,6 +63,19 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     sandbox: { enabled: true },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-2.5-flash-image",
+      },
+      "web-search": { mode: "your-own", provider: "anthropic-native" },
+    },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({}),


### PR DESCRIPTION
## Summary
- Added `services` config field (inference, image-generation, web-search) to 24 test files that mock `getConfig` without the `services` object introduced by PR #17927
- Fixed 2 browser test assertions that still expected "session" instead of "conversation" after the session→conversation rename
- Added `workspace/migrations/006-services-config.ts` to the credential-security-invariants allowlist since it legitimately imports secure-keys for API key migration

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23169309691/job/67317220992

🤖 Generated with [Claude Code](https://claude.com/claude-code)