### PR TITLE
fix: suppress API key banner for platform-authenticated users

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -230,8 +230,8 @@ public final class MainWindowState: ObservableObject {
         showPanel(.intelligence)
     }
 
-    func refreshAPIKeyStatus(isConnected: Bool) {
-        hasAPIKey = APIKeyManager.hasAnyKey() || isConnected
+    func refreshAPIKeyStatus(isConnected: Bool, isAuthenticated: Bool) {
+        hasAPIKey = APIKeyManager.hasAnyKey() || isConnected || isAuthenticated
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -696,7 +696,7 @@ struct MainWindowView: View {
             // isAppChatOpen could remain persisted as true with no UI to
             // disable it, leaving panels stuck in split mode.
             isAppChatOpen = false
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
+            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
             selectedConversationId = conversationManager.activeConversationId
             // Initialize persistent conversation tracking on launch
             if let activeId = conversationManager.activeConversationId {
@@ -725,10 +725,10 @@ struct MainWindowView: View {
             daemonClient.stopSSE()
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
+            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
         }
         .onReceive(daemonClient.$isConnected) { connected in
-            windowState.refreshAPIKeyStatus(isConnected: connected)
+            windowState.refreshAPIKeyStatus(isConnected: connected, isAuthenticated: authManager.isAuthenticated)
 
             // Fallback for fresh users with 0 conversations: dismiss skeleton after a
             // short delay once the daemon is connected. Only applies during initial load.
@@ -739,6 +739,9 @@ struct MainWindowView: View {
                     showDaemonLoading = false
                 }
             }
+        }
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: isAuthenticated)
         }
         .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
             // Dismiss skeleton when conversations arrive from daemon


### PR DESCRIPTION
## Summary
- `refreshAPIKeyStatus` now accepts an `isAuthenticated` parameter so platform-authenticated users are treated as having valid credentials even without a local API key
- All three existing call sites in `MainWindowView` updated to pass `authManager.isAuthenticated`
- Added `.onChange(of: authManager.isAuthenticated)` observer to refresh API key status when auth state changes

## Original prompt
I shouldn't get this message if I'm signed in to the Vellum platform and using Vellum's API keys through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
