### PR TITLE
feat: add ChatViewModel.prepareForNotificationCatchUp() to enable history merge

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1018,6 +1018,21 @@ public final class ChatViewModel: ObservableObject {
         self.memoryPressureSource = source
     }
 
+    // MARK: - Notification Catch-Up
+
+    /// Prepare the view model for a notification catch-up history fetch.
+    ///
+    /// Sets `needsReconnectCatchUp` so the next `populateFromHistory` call uses
+    /// the smart merge path (server-authoritative list + preserved unsent locals)
+    /// instead of the prepend-older-only path which would drop the new message.
+    ///
+    /// Called by ConversationManager when a `notification_intent` arrives for a
+    /// conversation that already has an active ViewModel. Must be followed by a
+    /// `requestReconnectHistory()` call on the ConversationRestorer.
+    public func prepareForNotificationCatchUp() {
+        needsReconnectCatchUp = true
+    }
+
     // MARK: - Deep Link
 
     /// Check for a buffered deep-link message and apply it to `inputText`.


### PR DESCRIPTION
## Summary
- Add `prepareForNotificationCatchUp()` public method to ChatViewModel that sets the `needsReconnectCatchUp` flag
- This enables the reconnect-style smart merge path in `populateFromHistory` for notification-seeded messages
- Required by ConversationManager (PR 2) to trigger history catch-up when a `notification_intent` arrives for a reused conversation

Part of plan: notif-intent-unread-badge.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
