### PR TITLE
feat: mark existing conversations unseen and trigger catch-up on notification intent

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1393,6 +1393,37 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
+    /// Handle a `notification_intent` that targets a conversation the client already
+    /// knows about (reuse case). Two effects:
+    ///
+    /// 1. **Unseen badge** — marks the conversation as having unseen content (if it's
+    ///    not the active conversation). Does NOT send a signal to the daemon because
+    ///    the server already advanced the attention cursor via `projectAssistantMessage`.
+    ///
+    /// 2. **Message visibility** — triggers a reconnect-style history fetch so the
+    ///    notification seed message appears in the chat view. Only fires when a
+    ///    ViewModel exists and is idle (not mid-response), to avoid disrupting
+    ///    active streaming. For inactive conversations without a ViewModel, the
+    ///    message will load normally when the user opens the conversation.
+    func handleNotificationIntentForExistingConversation(daemonConversationId: String) {
+        guard let idx = conversations.firstIndex(where: { $0.conversationId == daemonConversationId }) else { return }
+        let localId = conversations[idx].id
+
+        if localId != activeConversationId {
+            // Background conversation: mark unseen. Message loads on activation.
+            conversations[idx].hasUnseenLatestAssistantMessage = true
+            conversations[idx].latestAssistantMessageAt = Date()
+        }
+
+        // Trigger history catch-up so the new message appears in the chat view.
+        // Guard: only when a ViewModel exists and is idle — triggering populateFromHistory
+        // mid-stream would discard the in-flight streaming buffer (line 2709 of ChatViewModel).
+        if let vm = chatViewModels[localId], !vm.isThinking, !vm.isSending {
+            vm.prepareForNotificationCatchUp()
+            conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
+        }
+    }
+
     /// Set a pending anchor message for scroll-to behavior on notification deep links.
     /// Only takes effect when the specified conversation is currently active.
     func setPendingAnchorMessage(conversationId: UUID, messageId: UUID) {

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -724,6 +724,124 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                        "Duplicate conversationId should not create a second conversation")
     }
 
+    func testNotificationIntentMarksInactiveConversationUnseen() {
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-reuse-1",
+            scheduleJobId: "sched-reuse-1",
+            title: "Reuse Target"
+        )
+
+        guard let idx = conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-reuse-1" }) else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        // Simulate previously seen state
+        conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = false
+
+        // Ensure the active conversation is a different one (the default from setUp)
+        XCTAssertNotEqual(conversationManager.conversations[idx].id, conversationManager.activeConversationId)
+
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-reuse-1")
+
+        XCTAssertTrue(conversationManager.conversations[idx].hasUnseenLatestAssistantMessage,
+                      "Inactive conversation should be marked unseen after notification intent")
+        XCTAssertNotNil(conversationManager.conversations[idx].latestAssistantMessageAt,
+                        "latestAssistantMessageAt should be set")
+        XCTAssertTrue(
+            abs(conversationManager.conversations[idx].latestAssistantMessageAt!.timeIntervalSinceNow) < 1.0,
+            "latestAssistantMessageAt should be recent (within last second)"
+        )
+    }
+
+    func testNotificationIntentSkipsUnseenBadgeForActiveConversation() {
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-active-1",
+            scheduleJobId: "sched-active-1",
+            title: "Active Target"
+        )
+
+        guard let conversation = conversationManager.conversations.first(where: { $0.conversationId == "notif-active-1" }) else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        conversationManager.selectConversation(id: conversation.id)
+
+        // Re-find index after selectConversation (may have shifted due to removeAbandonedEmptyConversation)
+        guard let idx = conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-active-1" }) else {
+            XCTFail("Expected conversation to still exist after selection")
+            return
+        }
+
+        conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = false
+
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-active-1")
+
+        XCTAssertFalse(conversationManager.conversations[idx].hasUnseenLatestAssistantMessage,
+                       "Active conversation should not be marked unseen — user is looking at it")
+    }
+
+    func testNotificationIntentNoopsForUnknownConversation() {
+        let countBefore = conversationManager.conversations.count
+
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "nonexistent")
+
+        XCTAssertEqual(conversationManager.conversations.count, countBefore,
+                       "Unknown conversation ID should not change conversation count")
+    }
+
+    func testNotificationIntentDoesNotSendDaemonSignal() {
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-no-signal",
+            scheduleJobId: "sched-no-signal",
+            title: "No Signal Target"
+        )
+
+        guard let idx = conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-no-signal" }) else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        // Mark as seen and switch away
+        conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = false
+
+        sentMessages.removeAll()
+
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-no-signal")
+
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
+
+        XCTAssertTrue(unreadSignals.isEmpty,
+                      "handleNotificationIntentForExistingConversation should not emit conversation_unread_signal")
+        XCTAssertTrue(seenSignals.isEmpty,
+                      "handleNotificationIntentForExistingConversation should not emit conversation_seen_signal")
+    }
+
+    func testNotificationIntentTriggersHistoryRequest() {
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-history-1",
+            scheduleJobId: "sched-history-1",
+            title: "History Target"
+        )
+
+        guard conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-history-1" }) != nil else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        sentMessages.removeAll()
+
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-history-1")
+
+        let historyRequests = sentMessages.compactMap { $0 as? HistoryRequestMessage }
+        XCTAssertFalse(historyRequests.isEmpty,
+                       "handleNotificationIntentForExistingConversation should trigger a history request")
+        XCTAssertEqual(historyRequests.first?.conversationId, "notif-history-1",
+                       "History request should target the correct conversation")
+    }
+
     private func waitForPropagation() {
         let exp = expectation(description: "combine propagation")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {


### PR DESCRIPTION
## Summary
- Add `handleNotificationIntentForExistingConversation(daemonConversationId:)` to ConversationManager
- Marks reused notification conversations as unseen (if not active) and triggers reconnect-style history catch-up so new messages appear in the chat view
- Does NOT send a daemon signal — the server already has the correct attention state
- Guards against disrupting active streaming with `isThinking`/`isSending` checks
- Adds 5 unit tests covering unseen badge, active conversation skip, unknown conversation noop, no daemon signal, and history request trigger

Part of plan: notif-intent-unread-badge.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
