### PR TITLE
fix: reduce cache_control blocks to stay within Anthropic 4-block limit

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -714,13 +714,17 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Place cache breakpoints on the last two user turns so the
-      // conversation prefix is cached between agent-loop iterations.
+      // Place a cache breakpoint on the last user turn so the conversation
+      // prefix is cached between agent-loop iterations.
+      //
+      // NOTE: We use only 1 user-turn breakpoint (not 2) to stay within
+      // the Anthropic API limit of 4 cache_control blocks total:
+      //   system-static (1) + system-dynamic (2) + last-tool (3) + last-user (4)
       const userIndices: number[] = [];
       for (let i = 0; i < params.messages.length; i++) {
         if (params.messages[i].role === "user") userIndices.push(i);
       }
-      for (const idx of userIndices.slice(-2)) {
+      for (const idx of userIndices.slice(-1)) {
         const content = params.messages[idx].content;
         if (Array.isArray(content) && content.length > 0) {
           (


### PR DESCRIPTION
## Summary
- Reduce user-message cache breakpoints from 2 (last two user turns) to 1 (last user turn) to stay within the Anthropic API limit of 4 `cache_control` blocks: system-static + system-dynamic + last-tool + last-user
- Fixes `invalid_request_error: A maximum of 4 blocks with cache_control may be provided. Found 5.` introduced by #18016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
