### PR TITLE
fix: cache second-to-last user turn instead of last

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -714,17 +714,25 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Place a cache breakpoint on the last user turn so the conversation
-      // prefix is cached between agent-loop iterations.
+      // Place a cache breakpoint on the second-to-last user turn so the
+      // conversation prefix is cached between agent-loop iterations.
       //
-      // NOTE: We use only 1 user-turn breakpoint (not 2) to stay within
-      // the Anthropic API limit of 4 cache_control blocks total:
-      //   system-static (1) + system-dynamic (2) + last-tool (3) + last-user (4)
+      // Why second-to-last, not last?  The last user message is always new
+      // (either the initial message with fresh temporal context, or a tool
+      // result appended by the agent loop) so its breakpoint never produces
+      // a cache hit.  The second-to-last user turn is stable between
+      // iterations and caching up to it saves re-processing the full
+      // conversation prefix.
+      //
+      // We use only 1 user-turn breakpoint to stay within the Anthropic
+      // API limit of 4 cache_control blocks total:
+      //   system-static (1) + system-dynamic (2) + last-tool (3) + user (4)
       const userIndices: number[] = [];
       for (let i = 0; i < params.messages.length; i++) {
         if (params.messages[i].role === "user") userIndices.push(i);
       }
-      for (const idx of userIndices.slice(-1)) {
+      // slice(-2, -1) gives the second-to-last; empty array if < 2 user turns.
+      for (const idx of userIndices.slice(-2, -1)) {
         const content = params.messages[idx].content;
         if (Array.isArray(content) && content.length > 0) {
           (


### PR DESCRIPTION
## Summary
- Switch user-message cache breakpoint from `slice(-1)` (last) to `slice(-2, -1)` (second-to-last)
- The last user message is always new (fresh temporal context or new tool result), so its breakpoint never hits. The second-to-last is stable between agent-loop iterations and actually produces cache hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
