### PR TITLE
fix: update unread badge and surface new messages when notification intent arrives for existing conversation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -353,6 +353,16 @@ extension AppDelegate {
             pendingFallbackNotifications.removeValue(forKey: conversationId)
         }
 
+        // When a notification intent targets a conversation the client already knows
+        // about (reuse case), mark it as unseen and trigger a history catch-up so the
+        // new message appears in the chat view. New conversations are handled by
+        // notification_conversation_created instead.
+        if let conversationId = conversationId(from: msg.deepLinkMetadata) {
+            mainWindow?.conversationManager.handleNotificationIntentForExistingConversation(
+                daemonConversationId: conversationId
+            )
+        }
+
         postNotificationIntent(
             sourceEventName: msg.sourceEventName,
             title: msg.title,


### PR DESCRIPTION
## Summary
- Wire `handleNotificationIntentForExistingConversation` into `deliverNotificationIntent` in AppDelegate
- When a `notification_intent` SSE arrives for a conversation the client already knows about, the sidebar unread badge now appears and the new message surfaces via history catch-up
- Fixes both symptoms of reused notification conversations: missing unread dot and invisible messages

Part of plan: notif-intent-unread-badge.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
