### PR TITLE
fix: update stale test assertions after services config migration

### DIFF
--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -43,6 +43,14 @@ mock.module("../config/loader.js", () => ({
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },
   }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  syncConfigToLockfile: () => {},
 }));
 
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -88,6 +88,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+  syncConfigToLockfile: () => {},
 }));
 
 import { Command } from "commander";
@@ -102,12 +103,12 @@ import { getSchemaAtPath } from "../config/schema-utils.js";
 // ---------------------------------------------------------------------------
 
 describe("getSchemaAtPath", () => {
-  test("returns full schema for a top-level key (provider → enum schema)", () => {
-    const result = getSchemaAtPath(AssistantConfigSchema, "provider");
+  test("returns full schema for a top-level key (maxTokens → number schema)", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "maxTokens");
     expect(result).not.toBeNull();
-    // provider is an enum with a default, so it should be parseable
+    // maxTokens has a default, so it should be parseable
     const parsed = (result as z.ZodType).parse(undefined);
-    expect(parsed).toBe("anthropic");
+    expect(parsed).toBe(16000);
   });
 
   test("navigates nested paths (memory.segmentation → object schema)", () => {
@@ -155,8 +156,8 @@ describe("getSchemaAtPath", () => {
   });
 
   test("returns null for path traversal through a leaf type", () => {
-    // provider is an enum, not an object — can't traverse further
-    const result = getSchemaAtPath(AssistantConfigSchema, "provider.foo");
+    // maxTokens is a number, not an object — can't traverse further
+    const result = getSchemaAtPath(AssistantConfigSchema, "maxTokens.foo");
     expect(result).toBeNull();
   });
 });
@@ -174,8 +175,8 @@ describe("z.toJSONSchema integration", () => {
     const properties = jsonSchema.properties as Record<string, unknown>;
     expect(properties).toBeDefined();
     // Check that top-level keys are present
-    expect(properties.provider).toBeDefined();
-    expect(properties.model).toBeDefined();
+    expect(properties.services).toBeDefined();
+    expect(properties.providerOrder).toBeDefined();
     expect(properties.maxTokens).toBeDefined();
     expect(properties.calls).toBeDefined();
     expect(properties.memory).toBeDefined();

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -107,7 +107,7 @@ export const claudeCodeTool: Tool = {
           working_dir: {
             type: "string",
             description:
-              "Working directory for Claude Code (defaults to session working directory)",
+              "Working directory for Claude Code (defaults to conversation working directory)",
           },
           resume: {
             type: "string",


### PR DESCRIPTION
## Summary
- Fix `working_dir` description in `claude-code.ts` from "session working directory" to "conversation working directory" to match the static TOOLS.json manifest
- Update `config-schema-cmd.test.ts` to replace stale top-level `provider`/`model` key references with `services`/`providerOrder` (these were moved to `services.inference.*` in the services config PR #17927)
- Add `syncConfigToLockfile` and other missing loader exports to test mocks in both test files to prevent cross-file module cache contamination in Bun workers

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23171001356/job/67322617321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
