### PR TITLE
fix: add missing maxUses parameter to createInvite protocol call

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -1134,6 +1134,7 @@ struct ContactDetailView: View {
                 if let result = try await contactClient.createInvite(
                     sourceChannel: type,
                     note: "Invite for \(displayContact.displayName)",
+                    maxUses: nil,
                     contactName: displayContact.displayName,
                     contactId: displayContact.id,
                     expectedExternalUserId: phoneNumber,


### PR DESCRIPTION
## Summary
- Added missing `maxUses: nil` argument to `createInvite` call in `ContactDetailView.swift`
- The `ContactClientProtocol` protocol requires all parameters explicitly (protocol methods don't inherit default values from implementations), so the call through the protocol type was failing to compile

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23171443167/job/67323976324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
