### PR TITLE
feat: gate thread starters UI behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -691,8 +691,8 @@ struct ActiveChatViewWrapper: View {
             conversationId: conversationId,
             daemonGreeting: viewModel.emptyStateGreeting,
             onRequestGreeting: { [weak viewModel] in viewModel?.generateGreeting() },
-            threadStarters: viewModel.threadStarters,
-            threadStartersLoading: viewModel.threadStartersLoading,
+            threadStarters: MacOSClientFeatureFlagManager.shared.isEnabled("thread_starters_enabled") ? viewModel.threadStarters : [],
+            threadStartersLoading: MacOSClientFeatureFlagManager.shared.isEnabled("thread_starters_enabled") && viewModel.threadStartersLoading,
             onSelectStarter: { [weak viewModel] starter in
                 viewModel?.inputText = starter.prompt
             },

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -224,6 +224,14 @@
       "label": "Figma Integration",
       "description": "Enable the Figma OAuth setup skill for connecting to Figma",
       "defaultEnabled": false
+    },
+    {
+      "id": "thread-starters",
+      "scope": "macos",
+      "key": "thread_starters_enabled",
+      "label": "Thread Starters",
+      "description": "Show personalized thread starter suggestions on the empty conversation page",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new `thread_starters_enabled` macOS feature flag (default off) to the registry
- Hides thread starter chips and loading state on the empty conversation page when the flag is disabled
- Backend fetching continues regardless so starters are pre-cached when the flag is enabled

## Test plan
- [ ] Verify thread starters don't appear on the empty conversation page by default
- [ ] Enable `thread_starters_enabled` in Settings > Developer > Feature Flags and verify chips appear
- [ ] Verify toggling the flag off hides the chips again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
