### PR TITLE
fix: mark fallbackLogSizeLimit as nonisolated in LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -437,7 +437,7 @@ enum LogExporter {
     // MARK: - Daemon Log Fallback
 
     /// Maximum total bytes to read when collecting fallback daemon logs.
-    private static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
+    private nonisolated static let fallbackLogSizeLimit = 10 * 1024 * 1024 // 10 MB
 
     /// When the daemon is unreachable, reads log files directly from the
     /// filesystem and copies them into `directory/daemon-logs-fallback/`.


### PR DESCRIPTION
## Summary
- `fallbackLogSizeLimit` is accessed inside a `nonisolated static func` but was declared without `nonisolated`, causing a Swift 6 actor-isolation warning (error in Swift 6 mode)
- Added `nonisolated` to the static `let` declaration to match the isolation of the function that reads it

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run warnings about main actor-isolated static property 'fallbackLogSizeLimit' can not be referenced from a nonisolated context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
