### PR TITLE
fix: sort MCP server names for deterministic prompt caching

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -934,7 +934,7 @@ function getMcpSetupDescription(): string {
     return "Add, authenticate, list, and remove MCP (Model Context Protocol) servers";
   }
 
-  const serverNames = Object.keys(servers);
+  const serverNames = Object.keys(servers).sort();
   return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load this skill to check status, authenticate, or add/remove servers.`;
 }
 


### PR DESCRIPTION
## Summary
- Sort `Object.keys(servers)` in `getMcpSetupDescription()` so the MCP server names in the skills catalog are always in alphabetical order
- Prevents prompt cache invalidation when config file key ordering changes (e.g. after manual edits)

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
