### PR TITLE
fix: use VColor.auxWhite in checkbox to pass design token guard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -171,7 +171,7 @@ private struct VCheckbox: View {
                         .fill(VColor.primaryBase)
 
                     VIconView(.check, size: 12)
-                        .foregroundColor(.white)
+                        .foregroundColor(VColor.auxWhite)
                 } else {
                     RoundedRectangle(cornerRadius: cornerRadius)
                         .fill(Color.clear)


### PR DESCRIPTION
## Summary
- Replaced `.foregroundColor(.white)` with `.foregroundColor(VColor.auxWhite)` in the VCheckbox checkmark icon to satisfy the design token strict mode guard

## Original prompt
fix what's failing https://github.com/vellum-ai/vellum-assistant/actions/runs/23172067061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
