### PR TITLE
feat: capability cards backend — per-category parallel generation with relevance scoring

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -41,6 +41,7 @@ import {
   migrateCallSessionMode,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
+  migrateCapabilityCardColumns,
   migrateChannelInboundDeliveredSegments,
   migrateChannelInteractionColumns,
   migrateContactChannelsAccessFields,
@@ -427,6 +428,9 @@ export function initializeDb(): void {
 
   // 73. Create thread_starters table for personalized empty-thread suggestions
   migrateCreateThreadStartersTable(database);
+
+  // 74. Add capability card columns to thread_starters + category relevance table
+  migrateCapabilityCardColumns(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/job-handlers/capability-cards.ts
+++ b/assistant/src/memory/job-handlers/capability-cards.ts
@@ -1,0 +1,420 @@
+/**
+ * Job handler for generating capability cards.
+ *
+ * Each job generates cards for a single capability category, running in
+ * parallel with jobs for other categories. Cards are personalized to the
+ * user's memory items and available skills.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import {
+  createTimeout,
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { getLogger } from "../../util/logger.js";
+import { truncate } from "../../util/truncate.js";
+import { getDb } from "../db.js";
+import { asString } from "../job-utils.js";
+import type { MemoryJob } from "../jobs-store.js";
+import {
+  capabilityCardCategories,
+  memoryCheckpoints,
+  threadStarters,
+} from "../schema.js";
+import { buildMemoryRollup, buildSkillsSummary } from "./thread-starters.js";
+
+const log = getLogger("capability-cards-gen");
+
+/** Capability categories for the feed (knowledge dropped — not actionable). */
+export const CAPABILITY_CARD_CATEGORIES = [
+  "communication",
+  "productivity",
+  "development",
+  "media",
+  "automation",
+  "web_social",
+  "integration",
+] as const;
+
+export type CapabilityCardCategory =
+  (typeof CAPABILITY_CARD_CATEGORIES)[number];
+
+/** Human-readable descriptions for each category, used in the LLM prompt. */
+const CATEGORY_DESCRIPTIONS: Record<CapabilityCardCategory, string> = {
+  communication: "Email, Slack, messaging, drafting messages, replying",
+  productivity:
+    "Calendar, tasks, planning, scheduling, meeting prep, time management",
+  development:
+    "Code, debugging, architecture, PR reviews, build systems, documentation",
+  media: "Images, video, audio, 3D, creative assets, media editing",
+  automation:
+    "Workflows, scheduling, scripts, recurring tasks, integrations orchestration",
+  web_social:
+    "Web browsing, social media, research, competitive analysis, news",
+  integration:
+    "Third-party services, APIs, syncing data across tools, connecting services",
+};
+
+/**
+ * Curated subset of VIcon names the LLM can choose from, organized by
+ * category relevance. Kept small (~30) to avoid bloating the prompt.
+ */
+const ICON_PALETTE: Record<string, string[]> = {
+  communication: [
+    "lucide-mail",
+    "lucide-message-circle",
+    "lucide-message-square",
+    "lucide-phone",
+    "lucide-send",
+  ],
+  productivity: [
+    "lucide-calendar",
+    "lucide-clock",
+    "lucide-clipboard-list",
+    "lucide-list-checks",
+    "lucide-flag",
+  ],
+  development: [
+    "lucide-terminal",
+    "lucide-git-branch",
+    "lucide-file-code",
+    "lucide-bug",
+    "lucide-cpu",
+  ],
+  media: [
+    "lucide-image",
+    "lucide-video",
+    "lucide-music-2",
+    "lucide-camera",
+    "lucide-palette",
+  ],
+  automation: [
+    "lucide-zap",
+    "lucide-refresh-cw",
+    "lucide-settings",
+    "lucide-layers",
+    "lucide-rocket",
+  ],
+  web_social: [
+    "lucide-globe",
+    "lucide-search",
+    "lucide-trending-up",
+    "lucide-chart-bar",
+    "lucide-binoculars",
+  ],
+  integration: [
+    "lucide-puzzle",
+    "lucide-link",
+    "lucide-network",
+    "lucide-package",
+    "lucide-share-2",
+  ],
+};
+
+const CK_BATCH = "capability_cards:generation_batch";
+
+function checkpointKey(base: string, scopeId: string): string {
+  return `${base}:${scopeId}`;
+}
+
+interface GeneratedCard {
+  icon: string;
+  title: string;
+  description: string;
+  prompt: string;
+  tags: string[];
+}
+
+interface GenerationResult {
+  relevance: number;
+  cards: GeneratedCard[];
+}
+
+async function generateCardsForCategory(
+  scopeId: string,
+  category: CapabilityCardCategory,
+): Promise<GenerationResult> {
+  const provider = await getConfiguredProvider();
+  if (!provider) {
+    log.info("No configured provider for capability card generation");
+    return { relevance: 0, cards: [] };
+  }
+
+  const rollup = buildMemoryRollup(scopeId);
+  if (!rollup) {
+    log.info("No memory items to generate capability cards from");
+    return { relevance: 0, cards: [] };
+  }
+
+  const skills = buildSkillsSummary();
+  const icons = ICON_PALETTE[category] ?? [];
+  const allIcons = [
+    ...icons,
+    // A few general-purpose icons always available
+    "lucide-sparkles",
+    "lucide-wand",
+    "lucide-lightbulb",
+    "lucide-star",
+    "lucide-briefcase",
+  ];
+
+  const systemPrompt = `You are generating capability cards for a personal AI assistant's new thread page. These cards showcase what the assistant can do, personalized to the user's context.
+
+You are generating cards for the "${category}" category: ${CATEGORY_DESCRIPTIONS[category]}.
+
+Given the user's memories below, do two things:
+1. Assess how relevant this category is to this user (0.0–1.0). A score of 0.7+ means the user has clear context that makes this category actionable. Score lower if the user's memories have little relation to this category.
+2. If relevant (0.7+), generate 2–3 capability cards that cross the user's context with what the assistant can do in this area.
+
+For each card, provide:
+- icon: One of these Lucide icon names: ${allIcons.join(", ")}
+- title: Action-oriented, verb-first, max 50 chars (e.g., "Triage your inbox", "Debug the auth middleware")
+- description: One line explaining the outcome, personalized to the user's context, max 120 chars
+- prompt: The full message that will be sent when clicked (1-2 natural sentences, as if the user typed it)
+- tags: 1-3 short labels for integrations/tools involved (e.g., "Gmail", "Calendar", "Linear")
+
+Rules:
+- Be specific to THIS user — generic suggestions are not useful.
+- Titles should be concise and scannable, starting with a verb.
+- Prompts should be natural, as if the user typed them.
+- Tags should reference actual tools/services relevant to the suggestion.
+- If relevance is below 0.7, you may return an empty cards array.
+
+${rollup}
+${skills}`;
+
+  const { signal, cleanup } = createTimeout(25000);
+  try {
+    const response = await provider.sendMessage(
+      [
+        userMessage(
+          `Generate capability cards for the "${category}" category based on my context.`,
+        ),
+      ],
+      [
+        {
+          name: "store_capability_cards",
+          description:
+            "Store the relevance assessment and generated capability cards",
+          input_schema: {
+            type: "object" as const,
+            properties: {
+              relevance: {
+                type: "number",
+                description:
+                  "How relevant this category is to the user (0.0–1.0)",
+              },
+              cards: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    icon: {
+                      type: "string",
+                      description: "Lucide icon name from the provided list",
+                    },
+                    title: {
+                      type: "string",
+                      description:
+                        "Action-oriented title, verb-first, max 50 chars",
+                    },
+                    description: {
+                      type: "string",
+                      description:
+                        "One-line outcome description, max 120 chars",
+                    },
+                    prompt: {
+                      type: "string",
+                      description: "Full message sent on click (1-2 sentences)",
+                    },
+                    tags: {
+                      type: "array",
+                      items: { type: "string" },
+                      description: "1-3 integration/tool tags",
+                    },
+                  },
+                  required: ["icon", "title", "description", "prompt", "tags"],
+                },
+              },
+            },
+            required: ["relevance", "cards"],
+          },
+        },
+      ],
+      systemPrompt,
+      {
+        config: {
+          modelIntent: "quality-optimized",
+          max_tokens: 1024,
+          tool_choice: {
+            type: "tool" as const,
+            name: "store_capability_cards",
+          },
+        },
+        signal,
+      },
+    );
+    cleanup();
+
+    const toolBlock = extractToolUse(response);
+    if (!toolBlock) {
+      log.warn("No tool_use block in capability card generation response");
+      return { relevance: 0, cards: [] };
+    }
+
+    const input = toolBlock.input as {
+      relevance?: number;
+      cards?: GeneratedCard[];
+    };
+
+    const relevance =
+      typeof input.relevance === "number"
+        ? Math.max(0, Math.min(1, input.relevance))
+        : 0;
+
+    if (!Array.isArray(input.cards)) {
+      return { relevance, cards: [] };
+    }
+
+    const cards = input.cards
+      .filter(
+        (c) =>
+          typeof c.title === "string" &&
+          c.title.length > 0 &&
+          typeof c.prompt === "string" &&
+          c.prompt.length > 0,
+      )
+      .map((c) => ({
+        icon:
+          typeof c.icon === "string" && c.icon.length > 0
+            ? c.icon
+            : "lucide-sparkles",
+        title: truncate(c.title, 50, ""),
+        description: truncate(c.description ?? "", 120, ""),
+        prompt: truncate(c.prompt, 500, ""),
+        tags: Array.isArray(c.tags)
+          ? c.tags.filter((t): t is string => typeof t === "string").slice(0, 3)
+          : [],
+      }));
+
+    return { relevance, cards };
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+}
+
+// ── Job handler ───────────────────────────────────────────────────
+
+export async function generateCapabilityCardsJob(
+  job: MemoryJob,
+): Promise<void> {
+  const scopeId = asString(job.payload.scopeId) ?? "default";
+  const category = asString(job.payload.category) as
+    | CapabilityCardCategory
+    | undefined;
+
+  if (
+    !category ||
+    !(CAPABILITY_CARD_CATEGORIES as readonly string[]).includes(category)
+  ) {
+    log.warn({ category }, "Invalid or missing category for capability cards");
+    return;
+  }
+
+  const result = await generateCardsForCategory(scopeId, category);
+
+  const db = getDb();
+  const now = Date.now();
+
+  // Determine next batch number
+  const batchCheckpoint = db
+    .select({ value: memoryCheckpoints.value })
+    .from(memoryCheckpoints)
+    .where(eq(memoryCheckpoints.key, checkpointKey(CK_BATCH, scopeId)))
+    .get();
+  const nextBatch = batchCheckpoint
+    ? parseInt(batchCheckpoint.value, 10) + 1
+    : 1;
+
+  // Upsert category relevance
+  db.insert(capabilityCardCategories)
+    .values({
+      scopeId,
+      category,
+      relevance: result.relevance,
+      generationBatch: nextBatch,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        capabilityCardCategories.scopeId,
+        capabilityCardCategories.category,
+      ],
+      set: {
+        relevance: result.relevance,
+        generationBatch: nextBatch,
+        createdAt: now,
+      },
+    })
+    .run();
+
+  // Delete old cards for this category+scope, then insert new ones
+  db.delete(threadStarters)
+    .where(
+      and(
+        eq(threadStarters.scopeId, scopeId),
+        eq(threadStarters.category, category),
+        eq(threadStarters.cardType, "card"),
+      ),
+    )
+    .run();
+
+  // Insert new cards
+  for (const card of result.cards) {
+    db.insert(threadStarters)
+      .values({
+        id: uuid(),
+        label: card.title,
+        prompt: card.prompt,
+        icon: card.icon,
+        description: card.description,
+        tags: card.tags.join(","),
+        category,
+        cardType: "card",
+        generationBatch: nextBatch,
+        scopeId,
+        sourceMemoryKinds: null,
+        createdAt: now,
+      })
+      .run();
+  }
+
+  // Update batch checkpoint
+  db.insert(memoryCheckpoints)
+    .values({
+      key: checkpointKey(CK_BATCH, scopeId),
+      value: String(nextBatch),
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: memoryCheckpoints.key,
+      set: { value: String(nextBatch), updatedAt: now },
+    })
+    .run();
+
+  log.info(
+    {
+      scopeId,
+      category,
+      relevance: result.relevance,
+      cardCount: result.cards.length,
+      batch: nextBatch,
+    },
+    "Generated capability cards",
+  );
+}

--- a/assistant/src/memory/job-handlers/thread-starters.ts
+++ b/assistant/src/memory/job-handlers/thread-starters.ts
@@ -35,7 +35,7 @@ const CK_LAST_GEN_AT = "thread_starters:last_gen_at";
 
 // ── Rollup construction ───────────────────────────────────────────
 
-function buildMemoryRollup(scopeId: string): string {
+export function buildMemoryRollup(scopeId: string): string {
   const db = getDb();
   const items = db
     .select({
@@ -102,7 +102,7 @@ function buildNewItemsDiff(scopeId: string): string {
   );
 }
 
-function buildSkillsSummary(): string {
+export function buildSkillsSummary(): string {
   try {
     const catalog = loadSkillCatalog();
     if (catalog.length === 0) return "";

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -26,7 +26,8 @@ export type MemoryJobType =
   | "media_processing"
   | "embed_media"
   | "embed_attachment"
-  | "generate_thread_starters";
+  | "generate_thread_starters"
+  | "generate_capability_cards";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -3,6 +3,7 @@ import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { rawRun } from "./db.js";
 import { backfillJob } from "./job-handlers/backfill.js";
+import { generateCapabilityCardsJob } from "./job-handlers/capability-cards.js";
 import {
   cleanupStaleSupersededItemsJob,
   pruneOldConversationsJob,
@@ -309,6 +310,9 @@ async function processJob(
       return;
     case "generate_thread_starters":
       await generateThreadStartersJob(job);
+      return;
+    case "generate_capability_cards":
+      await generateCapabilityCardsJob(job);
       return;
     default:
       throw new Error(

--- a/assistant/src/memory/migrations/171-capability-card-columns.ts
+++ b/assistant/src/memory/migrations/171-capability-card-columns.ts
@@ -1,0 +1,43 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateCapabilityCardColumns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Add new columns to thread_starters for capability cards
+  const newColumns = [
+    /*sql*/ `ALTER TABLE thread_starters ADD COLUMN icon TEXT`,
+    /*sql*/ `ALTER TABLE thread_starters ADD COLUMN description TEXT`,
+    /*sql*/ `ALTER TABLE thread_starters ADD COLUMN tags TEXT`,
+    /*sql*/ `ALTER TABLE thread_starters ADD COLUMN card_type TEXT NOT NULL DEFAULT 'chip'`,
+  ];
+
+  for (const sql of newColumns) {
+    try {
+      raw.exec(sql);
+    } catch {
+      // Column already exists
+    }
+  }
+
+  // Create capability_card_categories table for per-category relevance tracking
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS capability_card_categories (
+      scope_id TEXT NOT NULL,
+      category TEXT NOT NULL,
+      relevance REAL NOT NULL,
+      generation_batch INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (scope_id, category)
+    )
+  `);
+
+  // Index for card_type filtering
+  try {
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_thread_starters_card_type ON thread_starters (card_type, scope_id)`,
+    );
+  } catch {
+    // Index already exists
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -112,6 +112,7 @@ export { migrateRenameSequenceEnrollmentsThreadIdColumn } from "./167-rename-seq
 export { migrateRenameSequenceStepsReplyKey } from "./168-rename-sequence-steps-reply-key.js";
 export { migrateRenameGmailProviderKeyToGoogle } from "./169-rename-gmail-provider-key-to-google.js";
 export { migrateCreateThreadStartersTable } from "./170-thread-starters-table.js";
+export { migrateCapabilityCardColumns } from "./171-capability-card-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -2,6 +2,7 @@ import {
   blob,
   index,
   integer,
+  primaryKey,
   real,
   sqliteTable,
   text,
@@ -159,6 +160,10 @@ export const threadStarters = sqliteTable(
     scopeId: text("scope_id").notNull().default("default"),
     sourceMemoryKinds: text("source_memory_kinds"),
     category: text("category"),
+    icon: text("icon"),
+    description: text("description"),
+    tags: text("tags"),
+    cardType: text("card_type").notNull().default("chip"),
     createdAt: integer("created_at").notNull(),
   },
   (table) => [
@@ -166,5 +171,18 @@ export const threadStarters = sqliteTable(
       table.generationBatch,
       table.createdAt,
     ),
+    index("idx_thread_starters_card_type").on(table.cardType, table.scopeId),
   ],
+);
+
+export const capabilityCardCategories = sqliteTable(
+  "capability_card_categories",
+  {
+    scopeId: text("scope_id").notNull(),
+    category: text("category").notNull(),
+    relevance: real("relevance").notNull(),
+    generationBatch: integer("generation_batch").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.scopeId, table.category] })],
 );

--- a/assistant/src/memory/thread-starters-cadence.ts
+++ b/assistant/src/memory/thread-starters-cadence.ts
@@ -1,7 +1,7 @@
 /**
- * Cadence logic for thread starters generation.
+ * Cadence logic for thread starters and capability cards generation.
  *
- * Decides whether a new generation job should be enqueued based on how many
+ * Decides whether new generation jobs should be enqueued based on how many
  * active memory items have accumulated since the last generation.
  */
 
@@ -9,6 +9,7 @@ import { and, eq, inArray, like } from "drizzle-orm";
 
 import { getLogger } from "../util/logger.js";
 import { getDb } from "./db.js";
+import { CAPABILITY_CARD_CATEGORIES } from "./job-handlers/capability-cards.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
 import { rawGet } from "./raw-query.js";
 import { memoryCheckpoints, memoryJobs } from "./schema.js";
@@ -17,7 +18,7 @@ const log = getLogger("thread-starters-cadence");
 
 /**
  * Check whether enough new memory items have accumulated to justify
- * generating a fresh batch of thread starters.
+ * generating a fresh batch of thread starters and capability cards.
  */
 export function maybeEnqueueThreadStartersJob(scopeId: string): void {
   const db = getDb();
@@ -71,4 +72,36 @@ export function maybeEnqueueThreadStartersJob(scopeId: string): void {
     { totalActive, lastCount, delta, threshold, scopeId },
     "Enqueued thread starters generation job",
   );
+
+  // Also enqueue capability card regeneration for all categories
+  maybeEnqueueCapabilityCardJobs(scopeId);
+}
+
+/**
+ * Enqueue capability card generation jobs for all categories.
+ * Skips categories that already have pending/running jobs.
+ */
+function maybeEnqueueCapabilityCardJobs(scopeId: string): void {
+  const db = getDb();
+
+  for (const category of CAPABILITY_CARD_CATEGORIES) {
+    const existing = db
+      .select({ id: memoryJobs.id })
+      .from(memoryJobs)
+      .where(
+        and(
+          eq(memoryJobs.type, "generate_capability_cards"),
+          inArray(memoryJobs.status, ["pending", "running"]),
+          like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
+          like(memoryJobs.payload, `%"category":"${category}"%`),
+        ),
+      )
+      .get();
+
+    if (!existing) {
+      enqueueMemoryJob("generate_capability_cards", { scopeId, category });
+    }
+  }
+
+  log.info({ scopeId }, "Enqueued capability card generation jobs");
 }

--- a/assistant/src/runtime/routes/thread-starter-routes.ts
+++ b/assistant/src/runtime/routes/thread-starter-routes.ts
@@ -1,22 +1,33 @@
 /**
  * Route handlers for thread starter endpoints.
  *
- * GET /v1/thread-starters — list thread starters for empty conversation chips
+ * GET /v1/thread-starters — list thread starters (chips) or capability cards
  */
 
 import { and, desc, eq, inArray, like } from "drizzle-orm";
 
 import { getDb } from "../../memory/db.js";
+import { CAPABILITY_CARD_CATEGORIES } from "../../memory/job-handlers/capability-cards.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
-import { rawGet } from "../../memory/raw-query.js";
-import { memoryJobs, threadStarters } from "../../memory/schema.js";
+import { rawAll, rawGet } from "../../memory/raw-query.js";
+import {
+  capabilityCardCategories,
+  memoryJobs,
+  threadStarters,
+} from "../../memory/schema.js";
 import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
-// GET /v1/thread-starters
+// GET /v1/thread-starters?card_type=chip (default, backwards-compat)
 // ---------------------------------------------------------------------------
 
 function handleListThreadStarters(url: URL): Response {
+  const cardType = url.searchParams.get("card_type") ?? "chip";
+
+  if (cardType === "card") {
+    return handleListCapabilityCards(url);
+  }
+
   const limitParam = Math.min(
     Math.max(1, Number(url.searchParams.get("limit") ?? 4)),
     20,
@@ -35,7 +46,12 @@ function handleListThreadStarters(url: URL): Response {
       batch: threadStarters.generationBatch,
     })
     .from(threadStarters)
-    .where(eq(threadStarters.scopeId, scopeId))
+    .where(
+      and(
+        eq(threadStarters.scopeId, scopeId),
+        eq(threadStarters.cardType, "chip"),
+      ),
+    )
     .orderBy(
       desc(threadStarters.generationBatch),
       desc(threadStarters.createdAt),
@@ -45,7 +61,7 @@ function handleListThreadStarters(url: URL): Response {
     .all();
 
   const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM thread_starters WHERE scope_id = ?`,
+    `SELECT COUNT(*) AS c FROM thread_starters WHERE scope_id = ? AND card_type = 'chip'`,
     scopeId,
   );
   const total = countRow?.c ?? 0;
@@ -83,6 +99,176 @@ function handleListThreadStarters(url: URL): Response {
   }
 
   return Response.json({ starters: [], total: 0, status: "generating" });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/thread-starters?card_type=card — capability cards feed
+// ---------------------------------------------------------------------------
+
+function handleListCapabilityCards(url: URL): Response {
+  const limitParam = Math.min(
+    Math.max(1, Number(url.searchParams.get("limit") ?? 24)),
+    50,
+  );
+  const scopeId = url.searchParams.get("scope_id") ?? "default";
+  const categoryFilter = url.searchParams.get("category");
+
+  const db = getDb();
+
+  // Build WHERE conditions for cards
+  const conditions = [
+    eq(threadStarters.scopeId, scopeId),
+    eq(threadStarters.cardType, "card"),
+  ];
+  if (categoryFilter) {
+    conditions.push(eq(threadStarters.category, categoryFilter));
+  }
+
+  const cards = db
+    .select({
+      id: threadStarters.id,
+      icon: threadStarters.icon,
+      label: threadStarters.label,
+      description: threadStarters.description,
+      prompt: threadStarters.prompt,
+      category: threadStarters.category,
+      tags: threadStarters.tags,
+      batch: threadStarters.generationBatch,
+    })
+    .from(threadStarters)
+    .where(and(...conditions))
+    .orderBy(
+      desc(threadStarters.generationBatch),
+      desc(threadStarters.createdAt),
+    )
+    .limit(limitParam)
+    .all();
+
+  // Transform tags from comma-separated string to array
+  const transformedCards = cards.map((c) => ({
+    ...c,
+    tags: c.tags ? c.tags.split(",").filter(Boolean) : [],
+  }));
+
+  // Build per-category status map
+  const categoryStatuses = buildCategoryStatuses(scopeId);
+
+  const total = transformedCards.length;
+
+  // If we have cards, return them
+  if (total > 0) {
+    const overallStatus = Object.values(categoryStatuses).some(
+      (s) => s.status === "generating",
+    )
+      ? "generating"
+      : "ready";
+
+    return Response.json({
+      cards: transformedCards,
+      total,
+      status: overallStatus,
+      categories: categoryStatuses,
+    });
+  }
+
+  // No cards — check whether we have memory items to generate from
+  const memoryCount = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM memory_items WHERE status = 'active' AND scope_id = ?`,
+    scopeId,
+  );
+
+  if (!memoryCount || memoryCount.c === 0) {
+    return Response.json({
+      cards: [],
+      total: 0,
+      status: "empty",
+      categories: {},
+    });
+  }
+
+  // Memory items exist but no cards — enqueue generation for all categories
+  enqueueCapabilityCardJobs(scopeId);
+
+  return Response.json({
+    cards: [],
+    total: 0,
+    status: "generating",
+    categories: Object.fromEntries(
+      CAPABILITY_CARD_CATEGORIES.map((cat) => [
+        cat,
+        { status: "generating" as const },
+      ]),
+    ),
+  });
+}
+
+/** Build a status map for each category: ready (with relevance) or generating. */
+function buildCategoryStatuses(
+  scopeId: string,
+): Record<string, { status: string; relevance?: number }> {
+  const db = getDb();
+  const statuses: Record<string, { status: string; relevance?: number }> = {};
+
+  // Get completed categories with relevance scores
+  const completed = db
+    .select({
+      category: capabilityCardCategories.category,
+      relevance: capabilityCardCategories.relevance,
+    })
+    .from(capabilityCardCategories)
+    .where(eq(capabilityCardCategories.scopeId, scopeId))
+    .all();
+
+  const completedSet = new Set(completed.map((c) => c.category));
+  for (const row of completed) {
+    statuses[row.category] = { status: "ready", relevance: row.relevance };
+  }
+
+  // Check for in-flight generation jobs
+  const pendingJobs = rawAll<{ payload: string }>(
+    `SELECT payload FROM memory_jobs
+     WHERE type = 'generate_capability_cards'
+       AND status IN ('pending', 'running')
+       AND payload LIKE '%"scopeId":"${scopeId}"%'`,
+  );
+
+  for (const job of pendingJobs) {
+    try {
+      const parsed = JSON.parse(job.payload) as { category?: string };
+      if (parsed.category && !completedSet.has(parsed.category)) {
+        statuses[parsed.category] = { status: "generating" };
+      }
+    } catch {
+      // Skip malformed payloads
+    }
+  }
+
+  return statuses;
+}
+
+/** Enqueue one generation job per category, skipping those already in-flight. */
+function enqueueCapabilityCardJobs(scopeId: string): void {
+  const db = getDb();
+
+  for (const category of CAPABILITY_CARD_CATEGORIES) {
+    // Check if already pending/running for this scope+category
+    const existing = db
+      .select({ id: memoryJobs.id })
+      .from(memoryJobs)
+      .where(
+        and(
+          eq(memoryJobs.type, "generate_capability_cards"),
+          inArray(memoryJobs.status, ["pending", "running"]),
+          like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
+          like(memoryJobs.payload, `%"category":"${category}"%`),
+        ),
+      )
+      .get();
+
+    if (!existing) {
+      enqueueMemoryJob("generate_capability_cards", { scopeId, category });
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migration: adds `icon`, `description`, `tags`, `card_type` columns to `thread_starters` + new `capability_card_categories` table for per-category relevance tracking
- New `generate_capability_cards` job handler: generates 2-3 personalized cards per capability category using memory rollup + skill catalog, with LLM-assessed relevance scoring (0.0-1.0)
- Extended `GET /v1/thread-starters` endpoint: `?card_type=card` returns capability cards with per-category status/relevance; `?card_type=chip` (default) preserves existing behavior
- Cadence: capability card regeneration piggybacks on the existing thread starters delta-threshold logic

<details>
<summary>Plan: capability-discovery-v2-plan.md</summary>

PR 1 of 4: DB schema + per-category generation backend

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
