### PR TITLE
feat: replace usage panel tabs with dropdowns and bar chart

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -119,34 +119,36 @@ struct UsageDashboardPanel: View {
         let sorted = buckets.sorted { $0.totalEstimatedCostUsd > $1.totalEstimatedCostUsd }
         let maxCost = sorted.first?.totalEstimatedCostUsd ?? 1.0
 
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            // Bar chart — left-aligned
-            HStack(alignment: .bottom, spacing: VSpacing.xs) {
-                ForEach(sorted, id: \.date) { bucket in
-                    let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
-                    VStack(spacing: VSpacing.xxs) {
-                        Spacer(minLength: 0)
-                        RoundedRectangle(cornerRadius: VRadius.xs)
-                            .fill(VColor.systemPositiveStrong)
-                            .frame(width: maxBarWidth, height: max(2, barChartHeight * fraction))
+        ScrollView(.horizontal, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                // Bar chart — left-aligned
+                HStack(alignment: .bottom, spacing: VSpacing.xs) {
+                    ForEach(sorted, id: \.date) { bucket in
+                        let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
+                        VStack(spacing: VSpacing.xxs) {
+                            Spacer(minLength: 0)
+                            RoundedRectangle(cornerRadius: VRadius.xs)
+                                .fill(VColor.systemPositiveStrong)
+                                .frame(width: maxBarWidth, height: max(2, barChartHeight * fraction))
+                        }
                     }
                 }
-            }
-            .frame(height: barChartHeight)
+                .frame(height: barChartHeight)
 
-            // Cost + date labels — left-aligned
-            HStack(alignment: .top, spacing: VSpacing.xs) {
-                ForEach(sorted, id: \.date) { bucket in
-                    VStack(spacing: VSpacing.xxs) {
-                        Text(formatCost(bucket.totalEstimatedCostUsd))
-                            .font(VFont.small)
-                            .foregroundColor(VColor.contentSecondary)
-                        Text(formatShortDate(bucket.date))
-                            .font(VFont.small)
-                            .foregroundColor(VColor.contentTertiary)
+                // Cost + date labels — left-aligned
+                HStack(alignment: .top, spacing: VSpacing.xs) {
+                    ForEach(sorted, id: \.date) { bucket in
+                        VStack(spacing: VSpacing.xxs) {
+                            Text(formatCost(bucket.totalEstimatedCostUsd))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.contentSecondary)
+                            Text(formatShortDate(bucket.date))
+                                .font(VFont.small)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                        .frame(width: maxBarWidth)
+                        .lineLimit(1)
                     }
-                    .frame(width: maxBarWidth)
-                    .lineLimit(1)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -154,6 +154,7 @@ struct UsageDashboardPanel: View {
     private static let shortDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d"
+        f.timeZone = .current
         return f
     }()
 
@@ -161,10 +162,12 @@ struct UsageDashboardPanel: View {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
         f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")!
         return f
     }()
 
-    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15").
+    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15")
+    /// using the computer's local timezone.
     private func formatShortDate(_ dateString: String) -> String {
         guard let date = Self.isoParser.date(from: dateString) else { return dateString }
         return Self.shortDateFormatter.string(from: date)
@@ -216,28 +219,38 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func breakdownTable(_ entries: [UsageGroupBreakdownEntry]) -> some View {
-        VStack(spacing: VSpacing.sm) {
+        VStack(spacing: 0) {
             // Header row
-            HStack(alignment: .top, spacing: VSpacing.sm) {
+            HStack(alignment: .center, spacing: VSpacing.sm) {
                 Text("Group")
-                    .font(VFont.small)
+                    .font(VFont.captionMedium)
                     .foregroundColor(VColor.contentTertiary)
                     .frame(width: 130, alignment: .leading)
                 Text("Tokens")
-                    .font(VFont.small)
+                    .font(VFont.captionMedium)
                     .foregroundColor(VColor.contentTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text("Cost")
-                    .font(VFont.small)
+                    .font(VFont.captionMedium)
                     .foregroundColor(VColor.contentTertiary)
-                    .frame(width: 60, alignment: .trailing)
+                    .frame(width: 70, alignment: .trailing)
             }
-            .padding(.bottom, VSpacing.xxs)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.borderBase.opacity(0.15))
 
-            ForEach(entries, id: \.group) { entry in
+            ForEach(Array(entries.enumerated()), id: \.element.group) { index, entry in
+                if index > 0 {
+                    Divider().background(VColor.borderBase)
+                }
                 breakdownRow(entry)
             }
         }
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .frame(maxWidth: breakdownTableWidth, alignment: .leading)
     }
 
@@ -245,21 +258,23 @@ struct UsageDashboardPanel: View {
     func breakdownRow(_ entry: UsageGroupBreakdownEntry) -> some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             Text(entry.group)
-                .font(VFont.captionMedium)
+                .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
                 .frame(width: 130, alignment: .leading)
                 .lineLimit(1)
             Text(UsageFormatting.formatBreakdownSummary(entry))
-                .font(VFont.small)
+                .font(VFont.caption)
                 .foregroundColor(VColor.contentSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .lineLimit(2)
                 .multilineTextAlignment(.leading)
             Text(formatCost(entry.totalEstimatedCostUsd))
-                .font(VFont.small)
-                .foregroundColor(VColor.contentSecondary)
-                .frame(width: 60, alignment: .trailing)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .frame(width: 70, alignment: .trailing)
         }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Shared Components
@@ -268,10 +283,10 @@ struct UsageDashboardPanel: View {
     private func statCard(label: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
             Text(value)
-                .font(VFont.captionMedium)
+                .font(VFont.bodyBold)
                 .foregroundColor(VColor.contentDefault)
             Text(label)
-                .font(VFont.small)
+                .font(VFont.caption)
                 .foregroundColor(VColor.contentTertiary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -11,7 +11,6 @@ struct UsageDashboardPanel: View {
     var body: some View {
         VSidePanel(title: "Usage", onClose: onClose, pinnedContent: {
             timeRangeStrip(store: store)
-            Divider().background(VColor.borderBase)
         }) {
             contentView(store: store)
         }
@@ -60,7 +59,9 @@ struct UsageDashboardPanel: View {
     func contentView(store: UsageDashboardStore) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
             totalsSection(store: store)
+            Divider().background(VColor.borderBase)
             dailySection(store: store)
+            Divider().background(VColor.borderBase)
             breakdownSection(store: store)
         }
     }
@@ -69,22 +70,24 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func totalsSection(store: UsageDashboardStore) -> some View {
-        sectionHeader("Totals", icon: "chart.bar.fill")
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            sectionTitle("Totals")
 
-        switch store.totalsState {
-        case .idle, .loading:
-            loadingRow()
-        case .loaded(let totals):
-            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
-                statCard(label: "Estimated Cost", value: formatCost(totals.totalEstimatedCostUsd))
-                statCard(label: "LLM Calls", value: formatCount(totals.eventCount))
-                statCard(label: UsageFormatting.directInputTokensLabel, value: formatTokenCount(totals.totalInputTokens))
-                statCard(label: "Output Tokens", value: formatTokenCount(totals.totalOutputTokens))
-                statCard(label: "Cache Created", value: formatTokenCount(totals.totalCacheCreationTokens))
-                statCard(label: "Cache Read", value: formatTokenCount(totals.totalCacheReadTokens))
+            switch store.totalsState {
+            case .idle, .loading:
+                loadingRow()
+            case .loaded(let totals):
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
+                    statCard(label: "Estimated Cost", value: formatCost(totals.totalEstimatedCostUsd))
+                    statCard(label: "LLM Calls", value: formatCount(totals.eventCount))
+                    statCard(label: UsageFormatting.directInputTokensLabel, value: formatTokenCount(totals.totalInputTokens))
+                    statCard(label: "Output Tokens", value: formatTokenCount(totals.totalOutputTokens))
+                    statCard(label: "Cache Created", value: formatTokenCount(totals.totalCacheCreationTokens))
+                    statCard(label: "Cache Read", value: formatTokenCount(totals.totalCacheReadTokens))
+                }
+            case .failed(let message):
+                errorRow(message)
             }
-        case .failed(let message):
-            errorRow(message)
         }
     }
 
@@ -92,58 +95,62 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func dailySection(store: UsageDashboardStore) -> some View {
-        sectionHeader("Daily Trend", icon: "chart.line.uptrend.xyaxis")
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            sectionTitle("Daily Trend")
 
-        switch store.dailyState {
-        case .idle, .loading:
-            loadingRow()
-        case .loaded(let daily):
-            if daily.buckets.isEmpty {
-                VEmptyState(
-                    title: "No daily data",
-                    subtitle: "No usage recorded in this time range",
-                    icon: "calendar"
-                )
-            } else {
-                dailyTrendList(daily.buckets)
+            switch store.dailyState {
+            case .idle, .loading:
+                loadingRow()
+            case .loaded(let daily):
+                if daily.buckets.isEmpty {
+                    VEmptyState(
+                        title: "No daily data",
+                        subtitle: "No usage recorded in this time range",
+                        icon: "calendar"
+                    )
+                } else {
+                    dailyBarChart(daily.buckets)
+                }
+            case .failed(let message):
+                errorRow(message)
             }
-        case .failed(let message):
-            errorRow(message)
         }
     }
 
     private let barChartHeight: CGFloat = 140
+    private let maxBarWidth: CGFloat = 32
 
     @ViewBuilder
-    private func dailyTrendList(_ buckets: [UsageDayBucket]) -> some View {
+    private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
 
         VStack(spacing: VSpacing.xs) {
             // Bar chart
-            HStack(alignment: .bottom, spacing: 2) {
+            HStack(alignment: .bottom, spacing: VSpacing.xs) {
                 ForEach(buckets, id: \.date) { bucket in
                     let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
                     VStack(spacing: VSpacing.xxs) {
                         Spacer(minLength: 0)
                         RoundedRectangle(cornerRadius: VRadius.xs)
                             .fill(VColor.systemPositiveStrong)
-                            .frame(height: max(2, barChartHeight * fraction))
+                            .frame(width: maxBarWidth, height: max(2, barChartHeight * fraction))
                     }
-                    .frame(maxWidth: .infinity)
                 }
             }
             .frame(height: barChartHeight)
+            .frame(maxWidth: .infinity)
 
             // Date labels
-            HStack(spacing: 2) {
+            HStack(spacing: VSpacing.xs) {
                 ForEach(buckets, id: \.date) { bucket in
                     Text(formatShortDate(bucket.date))
                         .font(VFont.small)
                         .foregroundColor(VColor.contentTertiary)
-                        .frame(maxWidth: .infinity)
+                        .frame(width: maxBarWidth)
                         .lineLimit(1)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -158,27 +165,27 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func breakdownSection(store: UsageDashboardStore) -> some View {
-        HStack {
-            sectionHeader("Breakdown", icon: "rectangle.3.group")
-            Spacer()
-            groupByPicker(store: store)
-        }
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            sectionTitle("Breakdown")
 
-        switch store.breakdownState {
-        case .idle, .loading:
-            loadingRow()
-        case .loaded(let breakdown):
-            if breakdown.breakdown.isEmpty {
-                VEmptyState(
-                    title: "No breakdown data",
-                    subtitle: "No usage recorded for this grouping",
-                    icon: "rectangle.3.group"
-                )
-            } else {
-                breakdownList(breakdown.breakdown)
+            groupByPicker(store: store)
+
+            switch store.breakdownState {
+            case .idle, .loading:
+                loadingRow()
+            case .loaded(let breakdown):
+                if breakdown.breakdown.isEmpty {
+                    VEmptyState(
+                        title: "No breakdown data",
+                        subtitle: "No usage recorded for this grouping",
+                        icon: "rectangle.3.group"
+                    )
+                } else {
+                    breakdownTable(breakdown.breakdown)
+                }
+            case .failed(let message):
+                errorRow(message)
             }
-        case .failed(let message):
-            errorRow(message)
         }
     }
 
@@ -195,11 +202,13 @@ struct UsageDashboardPanel: View {
             ),
             options: UsageGroupByDimension.allCases.map { ($0.rawValue.capitalized, $0) }
         )
-        .frame(width: 120)
+        .frame(width: 140)
     }
 
+    private let breakdownTableWidth: CGFloat = 500
+
     @ViewBuilder
-    private func breakdownList(_ entries: [UsageGroupBreakdownEntry]) -> some View {
+    private func breakdownTable(_ entries: [UsageGroupBreakdownEntry]) -> some View {
         VStack(spacing: VSpacing.sm) {
             // Header row
             HStack(alignment: .top, spacing: VSpacing.sm) {
@@ -222,6 +231,7 @@ struct UsageDashboardPanel: View {
                 breakdownRow(entry)
             }
         }
+        .frame(maxWidth: breakdownTableWidth, alignment: .leading)
     }
 
     @ViewBuilder
@@ -248,14 +258,10 @@ struct UsageDashboardPanel: View {
     // MARK: - Shared Components
 
     @ViewBuilder
-    private func sectionHeader(_ title: String, icon: String) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            VIconView(SFSymbolMapping.icon(forSFSymbol: icon, fallback: .puzzle), size: 12)
-                .foregroundColor(VColor.systemPositiveStrong)
-            Text(title)
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.contentDefault)
-        }
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(VFont.headline)
+            .foregroundColor(VColor.contentDefault)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -34,32 +34,24 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func timeRangeStrip(store: UsageDashboardStore) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: VSpacing.sm) {
-                ForEach(UsageTimeRange.allCases, id: \.rawValue) { range in
-                    Button {
+        HStack {
+            VDropdown(
+                placeholder: "Time range",
+                selection: Binding(
+                    get: { store.selectedRange },
+                    set: { newRange in
                         refreshTask?.cancel()
                         breakdownTask?.cancel()
-                        refreshTask = Task { await store.selectRange(range) }
-                    } label: {
-                        Text(range.rawValue)
-                            .font(VFont.captionMedium)
-                            .foregroundColor(store.selectedRange == range ? VColor.contentDefault : VColor.contentTertiary)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xs)
-                            .background(
-                                store.selectedRange == range
-                                    ? VColor.borderBase.opacity(0.5)
-                                    : Color.clear
-                            )
-                            .cornerRadius(6)
+                        refreshTask = Task { await store.selectRange(newRange) }
                     }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
+                ),
+                options: UsageTimeRange.allCases.map { ($0.rawValue, $0) }
+            )
+            .frame(width: 160)
+            Spacer()
         }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Content
@@ -120,33 +112,46 @@ struct UsageDashboardPanel: View {
         }
     }
 
+    private let barChartHeight: CGFloat = 140
+
     @ViewBuilder
     private func dailyTrendList(_ buckets: [UsageDayBucket]) -> some View {
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
 
         VStack(spacing: VSpacing.xs) {
-            ForEach(buckets, id: \.date) { bucket in
-                HStack(spacing: VSpacing.sm) {
-                    Text(bucket.date)
+            // Bar chart
+            HStack(alignment: .bottom, spacing: 2) {
+                ForEach(buckets, id: \.date) { bucket in
+                    let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
+                    VStack(spacing: VSpacing.xxs) {
+                        Spacer(minLength: 0)
+                        RoundedRectangle(cornerRadius: VRadius.xs)
+                            .fill(VColor.systemPositiveStrong)
+                            .frame(height: max(2, barChartHeight * fraction))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .frame(height: barChartHeight)
+
+            // Date labels
+            HStack(spacing: 2) {
+                ForEach(buckets, id: \.date) { bucket in
+                    Text(formatShortDate(bucket.date))
                         .font(VFont.small)
                         .foregroundColor(VColor.contentTertiary)
-                        .frame(width: 80, alignment: .leading)
-
-                    GeometryReader { geo in
-                        let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(VColor.systemPositiveStrong)
-                            .frame(width: max(2, geo.size.width * fraction))
-                    }
-                    .frame(height: 12)
-
-                    Text(formatCost(bucket.totalEstimatedCostUsd))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.contentSecondary)
-                        .frame(width: 60, alignment: .trailing)
+                        .frame(maxWidth: .infinity)
+                        .lineLimit(1)
                 }
             }
         }
+    }
+
+    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "15").
+    private func formatShortDate(_ dateString: String) -> String {
+        let parts = dateString.split(separator: "-")
+        guard parts.count == 3 else { return dateString }
+        return String(parts[2]).replacingOccurrences(of: "^0", with: "", options: .regularExpression)
     }
 
     // MARK: - Breakdown Section
@@ -179,27 +184,18 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func groupByPicker(store: UsageDashboardStore) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            ForEach(UsageGroupByDimension.allCases, id: \.rawValue) { dimension in
-                Button {
+        VDropdown(
+            placeholder: "Group by",
+            selection: Binding(
+                get: { store.selectedGroupBy },
+                set: { newDimension in
                     breakdownTask?.cancel()
-                    breakdownTask = Task { await store.selectGroupBy(dimension) }
-                } label: {
-                    Text(dimension.rawValue.capitalized)
-                        .font(VFont.small)
-                        .foregroundColor(store.selectedGroupBy == dimension ? VColor.contentDefault : VColor.contentTertiary)
-                        .padding(.horizontal, VSpacing.xs)
-                        .padding(.vertical, 2)
-                        .background(
-                            store.selectedGroupBy == dimension
-                                ? VColor.borderBase.opacity(0.5)
-                                : Color.clear
-                        )
-                        .cornerRadius(4)
+                    breakdownTask = Task { await store.selectGroupBy(newDimension) }
                 }
-                .buttonStyle(.plain)
-            }
-        }
+            ),
+            options: UsageGroupByDimension.allCases.map { ($0.rawValue.capitalized, $0) }
+        )
+        .frame(width: 120)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -155,7 +155,9 @@ struct UsageDashboardPanel: View {
     private static let shortDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d"
-        f.timeZone = .current
+        // Use UTC for both parse and display since these are calendar dates,
+        // not timestamps — "2026-03-15" should always show as "Mar 15".
+        f.timeZone = TimeZone(identifier: "UTC")!
         return f
     }()
 
@@ -167,8 +169,7 @@ struct UsageDashboardPanel: View {
         return f
     }()
 
-    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15")
-    /// using the computer's local timezone.
+    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15").
     private func formatShortDate(_ dateString: String) -> String {
         guard let date = Self.isoParser.date(from: dateString) else { return dateString }
         return Self.shortDateFormatter.string(from: date)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -112,7 +112,7 @@ struct UsageDashboardPanel: View {
     }
 
     private let barChartHeight: CGFloat = 140
-    private let maxBarWidth: CGFloat = 32
+    private let maxBarWidth: CGFloat = 40
 
     @ViewBuilder
     private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
@@ -151,11 +151,23 @@ struct UsageDashboardPanel: View {
         }
     }
 
-    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "15").
+    private static let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private static let isoParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15").
     private func formatShortDate(_ dateString: String) -> String {
-        let parts = dateString.split(separator: "-")
-        guard parts.count == 3 else { return dateString }
-        return String(parts[2]).replacingOccurrences(of: "^0", with: "", options: .regularExpression)
+        guard let date = Self.isoParser.date(from: dateString) else { return dateString }
+        return Self.shortDateFormatter.string(from: date)
     }
 
     // MARK: - Breakdown Section

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -57,11 +57,9 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     func contentView(store: UsageDashboardStore) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             totalsSection(store: store)
-            Divider().background(VColor.borderBase)
             dailySection(store: store)
-            Divider().background(VColor.borderBase)
             breakdownSection(store: store)
         }
     }
@@ -70,9 +68,7 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func totalsSection(store: UsageDashboardStore) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            sectionTitle("Totals")
-
+        SettingsCard(title: "Totals") {
             switch store.totalsState {
             case .idle, .loading:
                 loadingRow()
@@ -95,9 +91,7 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func dailySection(store: UsageDashboardStore) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            sectionTitle("Daily Trend")
-
+        SettingsCard(title: "Daily Trend") {
             switch store.dailyState {
             case .idle, .loading:
                 loadingRow()
@@ -124,8 +118,8 @@ struct UsageDashboardPanel: View {
     private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
 
-        VStack(spacing: VSpacing.xs) {
-            // Bar chart
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            // Bar chart — left-aligned
             HStack(alignment: .bottom, spacing: VSpacing.xs) {
                 ForEach(buckets, id: \.date) { bucket in
                     let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
@@ -138,19 +132,22 @@ struct UsageDashboardPanel: View {
                 }
             }
             .frame(height: barChartHeight)
-            .frame(maxWidth: .infinity)
 
-            // Date labels
-            HStack(spacing: VSpacing.xs) {
+            // Cost + date labels — left-aligned
+            HStack(alignment: .top, spacing: VSpacing.xs) {
                 ForEach(buckets, id: \.date) { bucket in
-                    Text(formatShortDate(bucket.date))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.contentTertiary)
-                        .frame(width: maxBarWidth)
-                        .lineLimit(1)
+                    VStack(spacing: VSpacing.xxs) {
+                        Text(formatCost(bucket.totalEstimatedCostUsd))
+                            .font(VFont.small)
+                            .foregroundColor(VColor.contentSecondary)
+                        Text(formatShortDate(bucket.date))
+                            .font(VFont.small)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+                    .frame(width: maxBarWidth)
+                    .lineLimit(1)
                 }
             }
-            .frame(maxWidth: .infinity)
         }
     }
 
@@ -165,9 +162,7 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func breakdownSection(store: UsageDashboardStore) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            sectionTitle("Breakdown")
-
+        SettingsCard(title: "Breakdown") {
             groupByPicker(store: store)
 
             switch store.breakdownState {
@@ -256,13 +251,6 @@ struct UsageDashboardPanel: View {
     }
 
     // MARK: - Shared Components
-
-    @ViewBuilder
-    private func sectionTitle(_ title: String) -> some View {
-        Text(title)
-            .font(VFont.headline)
-            .foregroundColor(VColor.contentDefault)
-    }
 
     @ViewBuilder
     private func statCard(label: String, value: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -116,12 +116,13 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
-        let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
+        let sorted = buckets.sorted { $0.totalEstimatedCostUsd > $1.totalEstimatedCostUsd }
+        let maxCost = sorted.first?.totalEstimatedCostUsd ?? 1.0
 
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             // Bar chart — left-aligned
             HStack(alignment: .bottom, spacing: VSpacing.xs) {
-                ForEach(buckets, id: \.date) { bucket in
+                ForEach(sorted, id: \.date) { bucket in
                     let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
                     VStack(spacing: VSpacing.xxs) {
                         Spacer(minLength: 0)
@@ -135,7 +136,7 @@ struct UsageDashboardPanel: View {
 
             // Cost + date labels — left-aligned
             HStack(alignment: .top, spacing: VSpacing.xs) {
-                ForEach(buckets, id: \.date) { bucket in
+                ForEach(sorted, id: \.date) { bucket in
                     VStack(spacing: VSpacing.xxs) {
                         Text(formatCost(bucket.totalEstimatedCostUsd))
                             .font(VFont.small)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -116,8 +116,8 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
-        let sorted = buckets.sorted { $0.totalEstimatedCostUsd > $1.totalEstimatedCostUsd }
-        let maxCost = sorted.first?.totalEstimatedCostUsd ?? 1.0
+        let sorted = buckets.sorted { $0.date > $1.date }
+        let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
 
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -237,20 +237,12 @@ struct UsageDashboardPanel: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(VColor.borderBase.opacity(0.15))
 
             ForEach(Array(entries.enumerated()), id: \.element.group) { index, entry in
-                if index > 0 {
-                    Divider().background(VColor.borderBase)
-                }
+                Divider().background(VColor.borderBase)
                 breakdownRow(entry)
             }
         }
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .frame(maxWidth: breakdownTableWidth, alignment: .leading)
     }
 


### PR DESCRIPTION
## Summary
- Replaced time range tab strip with `VDropdown` for cleaner selection UI
- Replaced breakdown group-by picker tabs with `VDropdown`
- Converted daily trend from horizontal bar rows to a vertical bar chart with date labels underneath

## Original prompt
In usage, replace tabs for time to be VDropdown, tabs for breakdown to be VDropdown, daily trend chart make it as a bar chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
