### PR TITLE
feat: capabilities feed UI — card views, masonry grid with skeleton loading, scroll CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/CapabilitiesFeedView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilitiesFeedView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Masonry-style grid of capability cards grouped by category.
+/// Shows skeleton placeholders for categories still generating.
+struct CapabilitiesFeedView: View {
+    let cards: [CapabilityCard]
+    let categoryStatuses: [String: CategoryStatus]
+    let loading: Bool
+    let onCardTap: (CapabilityCard) -> Void
+
+    /// Categories in display order.
+    private static let categoryOrder = [
+        "communication",
+        "productivity",
+        "development",
+        "automation",
+        "web_social",
+        "integration",
+        "media",
+    ]
+
+    /// Human-readable category labels.
+    private static let categoryLabels: [String: String] = [
+        "communication": "Communication",
+        "productivity": "Productivity",
+        "development": "Development",
+        "media": "Media",
+        "automation": "Automation",
+        "web_social": "Web & Social",
+        "integration": "Integration",
+    ]
+
+    private let columns = [
+        GridItem(.flexible(), spacing: VSpacing.md),
+        GridItem(.flexible(), spacing: VSpacing.md),
+        GridItem(.flexible(), spacing: VSpacing.md),
+    ]
+
+    /// Cards grouped by category in display order, filtered to relevant categories.
+    private var groupedCards: [(category: String, label: String, cards: [CapabilityCard])] {
+        let byCategory = Dictionary(grouping: cards, by: { $0.category ?? "other" })
+        return Self.categoryOrder.compactMap { cat in
+            guard let items = byCategory[cat], !items.isEmpty else { return nil }
+            let label = Self.categoryLabels[cat] ?? cat.capitalized
+            return (category: cat, label: label, cards: items)
+        }
+    }
+
+    /// Categories that are still generating (no cards yet, status is "generating").
+    private var generatingCategories: [String] {
+        Self.categoryOrder.filter { cat in
+            let status = categoryStatuses[cat]
+            let hasCards = cards.contains { $0.category == cat }
+            return !hasCards && status?.status == "generating"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxl) {
+            // Section header
+            VStack(alignment: .center, spacing: VSpacing.xs) {
+                Text("Everything I can do for you")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.contentDefault)
+
+                Text("Personalized for you \u{00B7} Tap any card to start")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, VSpacing.md)
+
+            // Cards grouped by category
+            ForEach(groupedCards, id: \.category) { group in
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text(group.label)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.contentTertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+
+                    LazyVGrid(columns: columns, spacing: VSpacing.md) {
+                        ForEach(group.cards) { card in
+                            CapabilityCardView(card: card) {
+                                onCardTap(card)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Skeleton placeholders for categories still generating
+            ForEach(generatingCategories, id: \.self) { cat in
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text(Self.categoryLabels[cat] ?? cat.capitalized)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.contentTertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+
+                    LazyVGrid(columns: columns, spacing: VSpacing.md) {
+                        ForEach(0..<2, id: \.self) { _ in
+                            CapabilityCardSkeleton()
+                        }
+                    }
+                }
+            }
+
+            // Loading state when no cards or generating categories exist yet
+            if cards.isEmpty && generatingCategories.isEmpty && loading {
+                LazyVGrid(columns: columns, spacing: VSpacing.md) {
+                    ForEach(0..<6, id: \.self) { _ in
+                        CapabilityCardSkeleton()
+                    }
+                }
+            }
+
+            // Soft closer
+            if !cards.isEmpty {
+                Text("And anything else you can dream up.")
+                    .font(.custom("Fraunces", size: 16).italic())
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, VSpacing.lg)
+                    .padding(.bottom, VSpacing.xxxl)
+            }
+        }
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth + 200) // Wider than hero for 3-col grid
+        .padding(.horizontal, VSpacing.xl)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/CapabilityCardView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilityCardView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A single capability card in the feed, showing an icon, title, description, and tag pills.
+struct CapabilityCardView: View {
+    let card: CapabilityCard
+    let onTap: () -> Void
+
+    @State private var isHovered = false
+
+    private var resolvedIcon: VIcon {
+        VIcon.resolve(card.icon ?? "lucide-sparkles")
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.sm) {
+                    resolvedIcon.image
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .foregroundColor(VColor.contentSecondary)
+
+                    Text(card.label)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+
+                if let desc = card.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
+
+                if !card.tags.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        ForEach(card.tags, id: \.self) { tag in
+                            Text(tag)
+                                .font(VFont.small)
+                                .foregroundColor(VColor.contentSecondary)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xxs)
+                                .background(
+                                    RoundedRectangle(cornerRadius: VRadius.sm)
+                                        .fill(VColor.surfaceOverlay)
+                                )
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(VSpacing.lg)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(isHovered ? VColor.surfaceOverlay : VColor.surfaceActive)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.borderBase, lineWidth: 0.5)
+            )
+            .offset(y: isHovered ? -2 : 0)
+            .shadow(
+                color: isHovered ? VColor.borderBase.opacity(0.15) : .clear,
+                radius: isHovered ? 8 : 0,
+                y: isHovered ? 4 : 0
+            )
+            .animation(VAnimation.fast, value: isHovered)
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+/// Skeleton placeholder for a card that is still being generated.
+struct CapabilityCardSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VSkeletonBone()
+                    .frame(width: 16, height: 16)
+
+                VSkeletonBone()
+                    .frame(width: 120, height: 14)
+            }
+
+            VSkeletonBone()
+                .frame(height: 12)
+
+            VSkeletonBone()
+                .frame(width: 80, height: 12)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceActive)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.borderBase.opacity(0.3), lineWidth: 0.5)
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -33,6 +33,12 @@ struct ChatEmptyStateView: View {
     var threadStartersLoading: Bool = false
     var onSelectStarter: ((ThreadStarter) -> Void)? = nil
     var onFetchThreadStarters: (() -> Void)? = nil
+    var capabilityCards: [CapabilityCard] = []
+    var capabilityCardsLoading: Bool = false
+    var cardCategoryStatuses: [String: CategoryStatus] = [:]
+    var onSelectCard: ((CapabilityCard) -> Void)? = nil
+    var onFetchCapabilityCards: (() -> Void)? = nil
+    var showCapabilityFeed: Bool = false
 
     @State private var visible = false
     @State private var placeholder: String = placeholderTexts.randomElement()!
@@ -60,119 +66,208 @@ struct ChatEmptyStateView: View {
         "Type or hold Fn to talk...",
     ]
 
+    @State private var scrolledPastHero = false
+
     // MARK: - Body
 
     var body: some View {
+        if showCapabilityFeed {
+            scrollableBody
+        } else {
+            staticBody
+        }
+    }
+
+    // MARK: - Static Body (original layout, no feed)
+
+    private var staticBody: some View {
         VStack(spacing: 0) {
             Spacer()
             Spacer()
 
-            HStack(spacing: VSpacing.md) {
-                Group {
-                    if let body = appearance.characterBodyShape,
-                       let eyes = appearance.characterEyeStyle,
-                       let color = appearance.characterColor {
-                        AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 32)
-                            .frame(width: 32, height: 32)
-                    } else {
-                        VAvatarImage(image: appearance.chatAvatarImage, size: 32)
-                    }
-                }
+            heroSection
 
-                if let greeting = effectiveGreeting {
-                    Text(greeting)
-                        .font(.custom("Fraunces", size: 28).weight(.regular))
-                        .foregroundColor(VColor.contentSecondary)
-                        .multilineTextAlignment(.leading)
-                        .transition(.opacity)
-                }
-            }
-            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
-            .animation(.easeOut(duration: 0.4), value: effectiveGreeting != nil)
-            .opacity(visible ? 1 : 0)
-            .scaleEffect(visible ? 1 : 0.8)
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.bottom, VSpacing.xl)
+            composerSection
 
-            ComposerView(
-                inputText: $inputText,
-                hasAPIKey: hasAPIKey,
-                isSending: isSending,
-                hasPendingConfirmation: false,
-                isRecording: isRecording,
-                suggestion: suggestion,
-                pendingAttachments: pendingAttachments,
-                isLoadingAttachment: isLoadingAttachment,
-                onSend: onSend,
-                onStop: onStop,
-                onAcceptSuggestion: onAcceptSuggestion,
-                onAttach: onAttach,
-                onRemoveAttachment: onRemoveAttachment,
-                onPaste: onPaste,
-                onFileDrop: onFileDrop,
-                onDropImageData: onDropImageData,
-                onMicrophoneToggle: onMicrophoneToggle,
-                recordingAmplitude: recordingAmplitude,
-                onDictateToggle: onDictateToggle,
-                onVoiceModeToggle: onVoiceModeToggle,
-                placeholderText: placeholder,
-                conversationId: conversationId
-            )
-            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
-            .opacity(visible ? 1 : 0)
-            .offset(y: visible ? 0 : 10)
-
-            if !threadStarters.isEmpty {
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.sm) {
-                    ForEach(threadStarters.prefix(4)) { starter in
-                        ThreadStarterChip(label: starter.label, fullPrompt: starter.prompt) {
-                            onSelectStarter?(starter)
-                        }
-                    }
-                }
-                .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
-                .padding(.top, VSpacing.xxxl)
-                .opacity(visible ? 1 : 0)
-                .offset(y: visible ? 0 : 10)
-            } else if threadStartersLoading {
-                HStack(spacing: VSpacing.sm) {
-                    Group {
-                        if let body = appearance.characterBodyShape,
-                           let eyes = appearance.characterEyeStyle,
-                           let color = appearance.characterColor {
-                            AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 16)
-                                .frame(width: 16, height: 16)
-                        } else {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                    }
-                    Text("Getting some ideas\u{2026}")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-                .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
-                .padding(.top, VSpacing.xxxl)
-                .opacity(visible ? 1 : 0)
-                .offset(y: visible ? 0 : 10)
-            }
+            threadStartersSection
 
             Spacer()
             Spacer()
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            if soulGreeting == nil {
-                onRequestGreeting?()
-            }
-            onFetchThreadStarters?()
-            withAnimation(.easeOut(duration: 0.5)) {
-                visible = true
+        .onAppear(perform: handleAppear)
+        .onDisappear { visible = false }
+    }
+
+    // MARK: - Scrollable Body (hero + capability feed)
+
+    private var scrollableBody: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 0) {
+                    // Zone 1: Hero
+                    VStack(spacing: 0) {
+                        Spacer()
+                            .frame(height: 80)
+
+                        heroSection
+
+                        composerSection
+
+                        threadStartersSection
+
+                        // Scroll CTA
+                        if !capabilityCards.isEmpty || capabilityCardsLoading {
+                            ScrollCTAView {
+                                withAnimation(.easeInOut(duration: 0.4)) {
+                                    proxy.scrollTo("feed-top", anchor: .top)
+                                }
+                            }
+                        }
+
+                        Spacer()
+                            .frame(height: VSpacing.xxl)
+                    }
+                    .frame(minHeight: 400)
+
+                    // Zone 2: Capabilities Feed
+                    if !capabilityCards.isEmpty || capabilityCardsLoading {
+                        Divider()
+                            .padding(.horizontal, VSpacing.xl)
+                            .id("feed-top")
+
+                        CapabilitiesFeedView(
+                            cards: capabilityCards,
+                            categoryStatuses: cardCategoryStatuses,
+                            loading: capabilityCardsLoading,
+                            onCardTap: { card in
+                                onSelectCard?(card)
+                                withAnimation(.easeInOut(duration: 0.3)) {
+                                    proxy.scrollTo("hero-top", anchor: .top)
+                                }
+                            }
+                        )
+                        .padding(.top, VSpacing.xxxl)
+                    }
+                }
+                .id("hero-top")
             }
         }
-        .onDisappear {
-            visible = false
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear(perform: handleAppear)
+        .onDisappear { visible = false }
+    }
+
+    // MARK: - Shared Sections
+
+    private var heroSection: some View {
+        HStack(spacing: VSpacing.md) {
+            Group {
+                if let body = appearance.characterBodyShape,
+                   let eyes = appearance.characterEyeStyle,
+                   let color = appearance.characterColor {
+                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 32)
+                        .frame(width: 32, height: 32)
+                } else {
+                    VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                }
+            }
+
+            if let greeting = effectiveGreeting {
+                Text(greeting)
+                    .font(.custom("Fraunces", size: 28).weight(.regular))
+                    .foregroundColor(VColor.contentSecondary)
+                    .multilineTextAlignment(.leading)
+                    .transition(.opacity)
+            }
+        }
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+        .animation(.easeOut(duration: 0.4), value: effectiveGreeting != nil)
+        .opacity(visible ? 1 : 0)
+        .scaleEffect(visible ? 1 : 0.8)
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.bottom, VSpacing.xl)
+    }
+
+    private var composerSection: some View {
+        ComposerView(
+            inputText: $inputText,
+            hasAPIKey: hasAPIKey,
+            isSending: isSending,
+            hasPendingConfirmation: false,
+            isRecording: isRecording,
+            suggestion: suggestion,
+            pendingAttachments: pendingAttachments,
+            isLoadingAttachment: isLoadingAttachment,
+            onSend: onSend,
+            onStop: onStop,
+            onAcceptSuggestion: onAcceptSuggestion,
+            onAttach: onAttach,
+            onRemoveAttachment: onRemoveAttachment,
+            onPaste: onPaste,
+            onFileDrop: onFileDrop,
+            onDropImageData: onDropImageData,
+            onMicrophoneToggle: onMicrophoneToggle,
+            recordingAmplitude: recordingAmplitude,
+            onDictateToggle: onDictateToggle,
+            onVoiceModeToggle: onVoiceModeToggle,
+            placeholderText: placeholder,
+            conversationId: conversationId
+        )
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+        .opacity(visible ? 1 : 0)
+        .offset(y: visible ? 0 : 10)
+    }
+
+    @ViewBuilder
+    private var threadStartersSection: some View {
+        if !threadStarters.isEmpty {
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.sm) {
+                ForEach(threadStarters.prefix(4)) { starter in
+                    ThreadStarterChip(label: starter.label, fullPrompt: starter.prompt) {
+                        onSelectStarter?(starter)
+                    }
+                }
+            }
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+            .padding(.top, VSpacing.xxxl)
+            .opacity(visible ? 1 : 0)
+            .offset(y: visible ? 0 : 10)
+        } else if threadStartersLoading {
+            HStack(spacing: VSpacing.sm) {
+                Group {
+                    if let body = appearance.characterBodyShape,
+                       let eyes = appearance.characterEyeStyle,
+                       let color = appearance.characterColor {
+                        AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 16)
+                            .frame(width: 16, height: 16)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                Text("Getting some ideas\u{2026}")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+            .padding(.top, VSpacing.xxxl)
+            .opacity(visible ? 1 : 0)
+            .offset(y: visible ? 0 : 10)
+        }
+    }
+
+    private func handleAppear() {
+        if soulGreeting == nil {
+            onRequestGreeting?()
+        }
+        onFetchThreadStarters?()
+        if showCapabilityFeed {
+            onFetchCapabilityCards?()
+        }
+        withAnimation(.easeOut(duration: 0.5)) {
+            visible = true
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -70,6 +70,12 @@ struct ChatView: View {
     var threadStartersLoading: Bool = false
     var onSelectStarter: ((ThreadStarter) -> Void)? = nil
     var onFetchThreadStarters: (() -> Void)? = nil
+    var capabilityCards: [CapabilityCard] = []
+    var capabilityCardsLoading: Bool = false
+    var cardCategoryStatuses: [String: CategoryStatus] = [:]
+    var onSelectCard: ((CapabilityCard) -> Void)? = nil
+    var onFetchCapabilityCards: (() -> Void)? = nil
+    var showCapabilityFeed: Bool = false
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
@@ -204,7 +210,13 @@ struct ChatView: View {
                             threadStarters: threadStarters,
                             threadStartersLoading: threadStartersLoading,
                             onSelectStarter: onSelectStarter,
-                            onFetchThreadStarters: onFetchThreadStarters
+                            onFetchThreadStarters: onFetchThreadStarters,
+                            capabilityCards: capabilityCards,
+                            capabilityCardsLoading: capabilityCardsLoading,
+                            cardCategoryStatuses: cardCategoryStatuses,
+                            onSelectCard: onSelectCard,
+                            onFetchCapabilityCards: onFetchCapabilityCards,
+                            showCapabilityFeed: showCapabilityFeed
                         )
                     }
                 } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// "There's a lot more I can do" scroll prompt with a bouncing chevron.
+/// Fades in ~1 second after appearing.
+struct ScrollCTAView: View {
+    let onTap: () -> Void
+
+    @State private var visible = false
+    @State private var bouncing = false
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: VSpacing.sm) {
+                Text("There\u{2019}s a lot more I can do")
+                    .font(.custom("Fraunces", size: 14).italic())
+                    .foregroundColor(VColor.contentTertiary)
+
+                VIcon.chevronDown.image
+                    .resizable()
+                    .frame(width: 14, height: 14)
+                    .foregroundColor(VColor.contentTertiary)
+                    .offset(y: bouncing ? 4 : 0)
+                    .animation(
+                        .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                        value: bouncing
+                    )
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .opacity(visible ? 1 : 0)
+        .padding(.vertical, VSpacing.xxl)
+        .onAppear {
+            // Delay fade-in so the hero section breathes
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    visible = true
+                }
+                bouncing = true
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -697,6 +697,14 @@ struct ActiveChatViewWrapper: View {
                 viewModel?.inputText = starter.prompt
             },
             onFetchThreadStarters: { [weak viewModel] in viewModel?.fetchThreadStarters() },
+            capabilityCards: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") ? viewModel.capabilityCards : [],
+            capabilityCardsLoading: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") && viewModel.capabilityCardsLoading,
+            cardCategoryStatuses: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") ? viewModel.cardCategoryStatuses : [:],
+            onSelectCard: { [weak viewModel] card in
+                viewModel?.inputText = card.prompt
+            },
+            onFetchCapabilityCards: { [weak viewModel] in viewModel?.fetchCapabilityCards() },
+            showCapabilityFeed: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled"),
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,


### PR DESCRIPTION
## Summary
- `CapabilityCardView` — individual card with Lucide icon, title, description, tag pills, hover lift effect
- `CapabilityCardSkeleton` — shimmer loading placeholder using `VSkeletonBone`
- `CapabilitiesFeedView` — 3-column LazyVGrid grouped by category, progressive skeleton loading per category, soft closer text
- `ScrollCTAView` — "There's a lot more I can do" with bouncing chevron, 1s delayed fade-in
- `ChatEmptyStateView` refactored into two modes: static (original) and scrollable (hero + feed), toggled by `showCapabilityFeed`
- Full prop wiring through `ChatView` → `PanelCoordinator`, gated by `capability_feed_enabled` feature flag

<details>
<summary>Plan: capability-discovery-v2-plan.md</summary>

PR 3 of 4: Capabilities feed UI

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)