### PR TITLE
fix: remove duplicate appearance settings from Account tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// General settings tab — account/platform sign-in card followed by appearance settings.
+/// General settings tab — account/platform sign-in card.
 @MainActor
 struct SettingsGeneralTab: View {
     @ObservedObject var store: SettingsStore
@@ -18,7 +18,6 @@ struct SettingsGeneralTab: View {
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
                 mobilePairingCard
             }
-            SettingsAppearanceTab(store: store)
         }
         .onAppear {
             Task { await authManager.checkSession() }


### PR DESCRIPTION
## Summary
Fixes gap: SettingsAppearanceTab was rendered in both Account and Appearance tabs.
Removed the embed from SettingsGeneralTab so it only appears in the dedicated Appearance tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
