### PR TITLE
fix: restore Voice tab in settings nav

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -18,7 +18,7 @@ enum SettingsTab: String {
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
     static func primaryTabs(contactsEnabled: Bool = false, billingEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [.account, .channels, .modelsAndServices, .automation]
+        var tabs: [SettingsTab] = [.account, .channels, .modelsAndServices, .voice, .automation]
         if contactsEnabled {
             tabs.append(.contacts)
         }


### PR DESCRIPTION
## Summary
Fixes gap: Voice tab was removed from primaryTabs() making voice settings unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
