### PR TITLE
fix: add account parameter to google_contacts tool for multi-account support

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -150,6 +150,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["action"]

--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -36,6 +36,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const action = input.action as string;
 
   if (!action) {
@@ -43,7 +44,10 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google");
+    const connection = await resolveOAuthConnection(
+      "integration:google",
+      account,
+    );
     switch (action) {
       case "list": {
         const pageSize = (input.page_size as number) ?? 50;


### PR DESCRIPTION
## Summary
- Add optional account parameter to google_contacts tool schema
- Pass account info through to resolveOAuthConnection for proper multi-account credential resolution

Addresses feedback on #16199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
