### PR TITLE
fix: SQL injection and total count in capability cards endpoint

### DIFF
--- a/assistant/src/runtime/routes/thread-starter-routes.ts
+++ b/assistant/src/runtime/routes/thread-starter-routes.ts
@@ -153,7 +153,14 @@ function handleListCapabilityCards(url: URL): Response {
   // Build per-category status map
   const categoryStatuses = buildCategoryStatuses(scopeId);
 
-  const total = transformedCards.length;
+  // Proper COUNT query — transformedCards.length would be LIMIT-capped
+  const countCondition = categoryFilter ? `AND category = ?` : ``;
+  const countParams = categoryFilter ? [scopeId, categoryFilter] : [scopeId];
+  const countRow = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM thread_starters WHERE scope_id = ? AND card_type = 'card' ${countCondition}`,
+    ...countParams,
+  );
+  const total = countRow?.c ?? 0;
 
   // If we have cards, return them
   if (total > 0) {
@@ -229,7 +236,8 @@ function buildCategoryStatuses(
     `SELECT payload FROM memory_jobs
      WHERE type = 'generate_capability_cards'
        AND status IN ('pending', 'running')
-       AND payload LIKE '%"scopeId":"${scopeId}"%'`,
+       AND payload LIKE ?`,
+    `%"scopeId":"${scopeId}"%`,
   );
 
   for (const job of pendingJobs) {


### PR DESCRIPTION
## Summary
- Parameterize scopeId in raw SQL query in buildCategoryStatuses to prevent SQL injection
- Replace LIMIT-capped array length with proper SELECT COUNT(*) for the total field in capability cards response

Addresses feedback on #18039

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
