### PR TITLE
fix: treat provider-only credential match as ambiguous with multiple active connections

### DIFF
--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -31,6 +31,7 @@ import {
   getApp,
   getConnectionByProvider,
   getConnectionByProviderAndAccount,
+  listActiveConnectionsByProvider,
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
@@ -141,9 +142,19 @@ export async function storeOAuth2Tokens(
   //    same account, or create a new one for a different account.
   //    First try to match by account info (email); fall back to provider-only
   //    lookup so that re-auth without userinfo still updates the right row.
-  const existingConn = resolvedAccountInfo
-    ? getConnectionByProviderAndAccount(service, resolvedAccountInfo)
-    : getConnectionByProvider(service);
+  //    However, treat provider-only matches as ambiguous when multiple active
+  //    connections exist to avoid overwriting the wrong account's tokens.
+  let existingConn: ReturnType<typeof getConnectionByProvider>;
+  if (resolvedAccountInfo) {
+    existingConn = getConnectionByProviderAndAccount(
+      service,
+      resolvedAccountInfo,
+    );
+  } else {
+    const activeConns = listActiveConnectionsByProvider(service);
+    // Only reuse the provider-only match when it's unambiguous (single connection).
+    existingConn = activeConns.length === 1 ? activeConns[0] : undefined;
+  }
   let connId: string;
 
   const hasRefreshToken = !!tokens.refreshToken;


### PR DESCRIPTION
## Summary
- When resolvedAccountInfo is absent and multiple active OAuth connections exist for a provider, skip the token update instead of blindly overwriting the most recent connection
- Prevents cross-account credential corruption during identity-resolution failures

Addresses feedback on #16195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
