### PR TITLE
fix: remove unenforced account parameter from messaging_draft schema

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -276,10 +276,6 @@
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Required for create/list."
           },
-          "account": {
-            "type": "string",
-            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
-          },
           "conversation_id": {
             "type": "string",
             "description": "Target conversation/channel ID (for create)"


### PR DESCRIPTION
## Summary
- Remove the account parameter from messaging_draft tool schema since the implementation and draft store don't use it
- Prevents LLM from believing it's routing drafts to specific accounts when the parameter is silently dropped
- Other messaging tools that properly wire account through are unchanged

Addresses feedback on #16383

## Test plan
- [x] Verified messaging_draft tool no longer has `account` in schema
- [x] Verified all other messaging tools still have their `account` parameter
- [x] Pre-commit checks pass (formatting, secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
