### PR TITLE
fix: unreachable .tall card size and missing poll task cancellation

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -63,8 +63,8 @@ public struct CapabilityCard: Identifiable, Codable, Sendable {
     /// Card size computed from content characteristics.
     public var computedSize: CardSize {
         let desc = description ?? ""
-        if tags.count >= 3 || desc.count > 80 { return .wide }
         if desc.count > 120 { return .tall }
+        if tags.count >= 3 || desc.count > 80 { return .wide }
         return .normal
     }
 
@@ -3023,6 +3023,7 @@ public final class ChatViewModel: ObservableObject {
         // @MainActor computed properties (forwarded from ChatMessageManager), which
         // cannot be referenced from nonisolated deinit. Both tasks use [weak self],
         // so they will exit naturally when self is deallocated.
+        capabilityCardPollTask?.cancel()
         reconnectLatchTimeoutTask?.cancel()
         reconnectDebounceTask?.cancel()
         btwTask?.cancel()


### PR DESCRIPTION
## Summary
- Reorder computedSize checks: check desc > 120 (tall) before desc > 80 (wide) so .tall is reachable
- Cancel capabilityCardPollTask in deinit to prevent retain cycles during polling

Addresses feedback on #18042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
