### PR TITLE
fix: filter current-conversation segments from memory context

### DIFF
--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -318,9 +318,48 @@ describe("Memory Retriever Pipeline", () => {
     expect(result.tier1Count).toBeDefined();
     expect(result.tier2Count).toBeDefined();
     expect(result.hybridSearchMs).toBeDefined();
-    // Recency search finds candidates even though they don't pass tier classification
+    // Recency search finds raw candidates from this conversation…
     expect(result.recencyHits).toBeGreaterThan(0);
-    expect(result.mergedCount).toBeGreaterThan(0);
+    // …but they are filtered out because they belong to the active
+    // conversation and are already present in the conversation history.
+    expect(result.mergedCount).toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Current-conversation segment filtering
+  // -----------------------------------------------------------------------
+
+  test("current-conversation segments are filtered from recency results", async () => {
+    const db = getDb();
+    const now = Date.now();
+    const activeConv = "conv-active";
+    const otherConv = "conv-other";
+
+    insertConversation(db, activeConv, now - 60_000);
+    insertConversation(db, otherConv, now - 120_000);
+
+    // Messages and segments in the active conversation (should be filtered)
+    insertMessage(db, "msg-a1", activeConv, "user", "hello world", now - 50_000);
+    insertSegment(db, "seg-a1", "msg-a1", activeConv, "user", "hello world", now - 50_000);
+
+    // Messages and segments in a different conversation (should be kept)
+    insertMessage(db, "msg-o1", otherConv, "user", "hello world from other", now - 100_000);
+    insertSegment(db, "seg-o1", "msg-o1", otherConv, "user", "hello world from other", now - 100_000);
+
+    // Query from the active conversation
+    const result = await buildMemoryRecall(
+      "hello world",
+      activeConv,
+      TEST_CONFIG,
+    );
+
+    expect(result.enabled).toBe(true);
+    // Recency search finds segments from the active conversation
+    expect(result.recencyHits).toBeGreaterThan(0);
+    // But they are filtered out of merged results; only other-conversation
+    // segments would survive (none in this case since recency is scoped to
+    // the active conversation).
+    expect(result.mergedCount).toBe(0);
   });
 
   // -----------------------------------------------------------------------
@@ -527,10 +566,10 @@ describe("Memory Retriever Pipeline", () => {
     expect(result.enabled).toBe(true);
     // Semantic/hybrid search should be skipped
     expect(result.semanticHits).toBe(0);
-    // Recency search finds candidates (but they may not pass tier thresholds
-    // since recency-only candidates have no semantic score component)
+    // Recency search finds raw candidates…
     expect(result.recencyHits).toBeGreaterThan(0);
-    expect(result.mergedCount).toBeGreaterThan(0);
+    // …but current-conversation segments are filtered out
+    expect(result.mergedCount).toBe(0);
   });
 
   // -----------------------------------------------------------------------
@@ -728,7 +767,9 @@ describe("Memory Retriever Pipeline", () => {
     // pipeline proceeds non-degraded end-to-end.
     expect(result.enabled).toBe(true);
     expect(result.degraded).toBe(false);
-    // Recency search finds candidates; hybrid search returns empty from mock
+    // Recency search finds raw candidates; hybrid search returns empty from mock
     expect(result.recencyHits).toBeGreaterThan(0);
+    // Current-conversation segments are filtered out of merged results
+    expect(result.mergedCount).toBe(0);
   });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -356,6 +356,19 @@ export async function buildMemoryRecall(
     }
   }
 
+  // ── Step 5b: Filter out current-conversation segments ───────────
+  // Segments from the active conversation are already present in the
+  // conversation history, so including them in memory_context wastes
+  // tokens and causes the block to change between turns (hurting prompt
+  // caching). Items are cross-conversation and are kept.
+  if (conversationId) {
+    for (const [key, c] of candidateMap) {
+      if (c.type === "segment" && c.conversationId === conversationId) {
+        candidateMap.delete(key);
+      }
+    }
+  }
+
   // Compute RRF-style final scores for the merged candidates
   const allCandidates = [...candidateMap.values()];
   for (const c of allCandidates) {

--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -36,6 +36,7 @@ export function recencySearch(
     source: "recency",
     text: row.text,
     kind: "segment",
+    conversationId: row.conversationId,
     confidence: 0.55,
     importance: 0.5,
     createdAt: row.createdAt,

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -245,6 +245,7 @@ export async function semanticSearch(
         source: "semantic",
         text: payload.text,
         kind: "segment",
+        conversationId: payload.conversation_id,
         confidence: 0.55,
         importance: 0.5,
         createdAt,

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -11,6 +11,8 @@ export interface Candidate {
   text: string;
   kind: string;
   modality?: "text" | "image" | "audio" | "video";
+  /** The conversation this candidate originated from (segments only). */
+  conversationId?: string;
   confidence: number;
   importance: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
- Filter out segments belonging to the active conversation from memory retrieval results, since they are already present in the conversation history
- Add `conversationId` to `Candidate` type and populate it from both semantic (Qdrant payload) and recency (DB) search paths
- Filtering happens after merge/deduplicate (Step 5b) but before tier classification, so current-conversation segments never waste token budget or cause prompt cache misses

## Test plan
- [x] Updated existing tests that asserted `mergedCount > 0` for same-conversation queries (now correctly `0`)
- [x] Added new test: `current-conversation segments are filtered from recency results`
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 15 retriever tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
