### PR TITLE
fix: preserve compacted segments in memory recall filter

### DIFF
--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -113,6 +113,7 @@ function insertConversation(
   db: ReturnType<typeof getDb>,
   id: string,
   createdAt: number,
+  opts?: { contextCompactedMessageCount?: number },
 ) {
   db.insert(conversations)
     .values({
@@ -124,7 +125,7 @@ function insertConversation(
       totalOutputTokens: 0,
       totalEstimatedCost: 0,
       contextSummary: null,
-      contextCompactedMessageCount: 0,
+      contextCompactedMessageCount: opts?.contextCompactedMessageCount ?? 0,
       contextCompactedAt: null,
     })
     .run();
@@ -360,6 +361,47 @@ describe("Memory Retriever Pipeline", () => {
     // segments would survive (none in this case since recency is scoped to
     // the active conversation).
     expect(result.mergedCount).toBe(0);
+  });
+
+  test("compacted segments from current conversation are preserved in memory", async () => {
+    const db = getDb();
+    const now = Date.now();
+    const convId = "conv-compacted";
+
+    // Create a conversation where 2 messages have been compacted away
+    insertConversation(db, convId, now - 120_000, {
+      contextCompactedMessageCount: 2,
+    });
+
+    // Older messages (compacted out of context window) — their segments
+    // should NOT be filtered because the model can no longer see them
+    insertMessage(db, "msg-old-1", convId, "user", "old discussion topic", now - 100_000);
+    insertMessage(db, "msg-old-2", convId, "assistant", "old response", now - 90_000);
+
+    // Newer messages (still in context window) — their segments should
+    // be filtered since the model can still see them
+    insertMessage(db, "msg-new-1", convId, "user", "recent discussion", now - 50_000);
+    insertMessage(db, "msg-new-2", convId, "assistant", "recent response", now - 40_000);
+
+    // Segments from compacted messages (should survive filtering)
+    insertSegment(db, "seg-old-1", "msg-old-1", convId, "user", "old discussion topic details", now - 100_000);
+    insertSegment(db, "seg-old-2", "msg-old-2", convId, "assistant", "old response details", now - 90_000);
+
+    // Segments from in-context messages (should be filtered)
+    insertSegment(db, "seg-new-1", "msg-new-1", convId, "user", "recent discussion details", now - 50_000);
+    insertSegment(db, "seg-new-2", "msg-new-2", convId, "assistant", "recent response details", now - 40_000);
+
+    const result = await buildMemoryRecall(
+      "discussion topic",
+      convId,
+      TEST_CONFIG,
+    );
+
+    expect(result.enabled).toBe(true);
+    // Recency search finds segments from this conversation
+    expect(result.recencyHits).toBeGreaterThan(0);
+    // Compacted segments survive filtering — they are no longer in context
+    expect(result.mergedCount).toBeGreaterThan(0);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,4 +1,4 @@
-import { inArray, sql } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 
 import type { AssistantConfig } from "../config/types.js";
 import { estimateTextTokens } from "../context/token-estimator.js";
@@ -356,15 +356,23 @@ export async function buildMemoryRecall(
     }
   }
 
-  // ── Step 5b: Filter out current-conversation segments ───────────
-  // Segments from the active conversation are already present in the
-  // conversation history, so including them in memory_context wastes
-  // tokens and causes the block to change between turns (hurting prompt
-  // caching). Items are cross-conversation and are kept.
+  // ── Step 5b: Filter out current-conversation segments still in context ──
+  // Segments whose source message is still in the conversation's context
+  // window are redundant (already visible to the model). However, segments
+  // from messages that were removed by context compaction should be kept —
+  // those messages are no longer in the conversation history and memory is
+  // the only way they can influence the response.
   if (conversationId) {
-    for (const [key, c] of candidateMap) {
-      if (c.type === "segment" && c.conversationId === conversationId) {
-        candidateMap.delete(key);
+    const inContextMessageIds = getInContextMessageIds(conversationId);
+    if (inContextMessageIds) {
+      for (const [key, c] of candidateMap) {
+        if (
+          c.type === "segment" &&
+          c.messageId &&
+          inContextMessageIds.has(c.messageId)
+        ) {
+          candidateMap.delete(key);
+        }
       }
     }
   }
@@ -539,6 +547,52 @@ export async function buildMemoryRecall(
   };
 
   return result;
+}
+
+/**
+ * Get the set of message IDs that are still in the conversation's context
+ * window (i.e., not compacted away). Uses `contextCompactedMessageCount` to
+ * determine the offset: messages ordered by createdAt after that count are
+ * still visible to the model.
+ *
+ * Returns `null` if the conversation is not found (deleted, or no DB row).
+ */
+function getInContextMessageIds(conversationId: string): Set<string> | null {
+  try {
+    const db = getDb();
+
+    // Look up the conversation's compacted message count
+    const conv = db
+      .select({
+        contextCompactedMessageCount:
+          conversations.contextCompactedMessageCount,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .get();
+
+    if (!conv) return null;
+
+    const offset = conv.contextCompactedMessageCount;
+
+    // Fetch message IDs ordered by creation time, skipping compacted ones
+    const rows = db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.conversationId, conversationId))
+      .orderBy(asc(messages.createdAt))
+      .all();
+
+    // Messages up to `offset` have been compacted out of context
+    const inContextRows = rows.slice(offset);
+    return new Set(inContextRows.map((r) => r.id));
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to fetch in-context message IDs; skipping segment filter",
+    );
+    return null;
+  }
 }
 
 /**

--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -37,6 +37,7 @@ export function recencySearch(
     text: row.text,
     kind: "segment",
     conversationId: row.conversationId,
+    messageId: row.messageId,
     confidence: 0.55,
     importance: 0.5,
     createdAt: row.createdAt,

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -246,6 +246,7 @@ export async function semanticSearch(
         text: payload.text,
         kind: "segment",
         conversationId: payload.conversation_id,
+        messageId: payload.message_id,
         confidence: 0.55,
         importance: 0.5,
         createdAt,

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -13,6 +13,8 @@ export interface Candidate {
   modality?: "text" | "image" | "audio" | "video";
   /** The conversation this candidate originated from (segments only). */
   conversationId?: string;
+  /** The source message ID this candidate was extracted from (segments only). */
+  messageId?: string;
   confidence: number;
   importance: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
- Fixed overly aggressive segment filtering in Step 5b of the memory recall pipeline that removed ALL segments from the current conversation, even those from compacted messages no longer in the context window.
- Added `messageId` field to `Candidate` interface, populated from both Qdrant payloads and DB rows for segment candidates.
- Changed filter to check each segment's source message against the set of messages still in context (determined via `contextCompactedMessageCount` from the conversations table), preserving segments from compacted messages so they can still influence responses through memory.

## Test plan
- [x] Existing retriever tests pass (16/16)
- [x] New test verifies compacted segments survive the filter
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
