### PR TITLE
chore: update actions/cache v4 → v5

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -29,7 +29,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -65,7 +65,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -101,7 +101,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -118,7 +118,7 @@ jobs:
         run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
 
       - name: Restore test durations cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: assistant/.test-durations
           key: test-durations-unused
@@ -133,7 +133,7 @@ jobs:
 
       - name: Save test durations cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/xcodegen
@@ -43,7 +43,7 @@ jobs:
         run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Cache SPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ios-spm-${{ hashFiles('clients/Package.resolved') }}

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -95,7 +95,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -25,7 +25,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -34,7 +34,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -74,7 +74,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}
@@ -111,7 +111,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('assistant/bun.lock') }}

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/xcodegen

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -38,7 +38,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/.build
           key: macos-spm-debug-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -114,7 +114,7 @@ jobs:
         run: echo "num=$(date -u +%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: clients/.build
           key: macos-spm-release-week${{ steps.week.outputs.num }}-${{ hashFiles('clients/Package.resolved') }}
@@ -123,21 +123,21 @@ jobs:
             macos-spm-release-
 
       - name: Cache Bun dependencies (assistant)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: assistant/node_modules
           key: macos-bun-assistant-${{ hashFiles('assistant/bun.lock') }}
           restore-keys: macos-bun-assistant-
 
       - name: Cache Bun dependencies (cli)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cli/node_modules
           key: macos-bun-cli-${{ hashFiles('cli/bun.lock') }}
           restore-keys: macos-bun-cli-
 
       - name: Cache Bun dependencies (gateway)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: gateway/node_modules
           key: macos-bun-gateway-${{ hashFiles('gateway/bun.lock') }}
@@ -188,7 +188,7 @@ jobs:
 
       - name: Cache Homebrew create-dmg
         id: cache-create-dmg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/create-dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -946,7 +946,7 @@ jobs:
 
       - name: Cache Homebrew create-dmg
         id: cache-create-dmg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/create-dmg
@@ -1080,7 +1080,7 @@ jobs:
 
       - name: Cache Homebrew Sparkle
         id: cache-sparkle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Caskroom/sparkle
@@ -1333,7 +1333,7 @@ jobs:
 
       - name: Cache Homebrew create-dmg
         id: cache-create-dmg-x64
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/create-dmg
@@ -1799,7 +1799,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen-build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/xcodegen
@@ -1887,7 +1887,7 @@ jobs:
 
       - name: Cache Homebrew XcodeGen
         id: cache-xcodegen-release
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/Cellar/xcodegen


### PR DESCRIPTION
## Summary
- Update all `actions/cache@v4`, `actions/cache/restore@v4`, and `actions/cache/save@v4` references to `@v5` across all GitHub Actions workflow files
- Fixes the CI deprecation warning: "Node.js 20 actions are deprecated" for `actions/cache@v4`
- Affects 8 workflow files (24 total references)

## Original prompt
Fix this issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
