### PR TITLE
refactor: inline memory context as user block for prefix caching

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -273,7 +273,7 @@ The recall pipeline runs on every turn that passes the `needsMemory` gate (skips
 
    Empty sections are omitted. Each section has a per-item token budget (150 tokens for tier 1, 100 for tier 2). Tier 1 sections consume budget first; tier 2 uses the remainder.
 
-10. **Injection strategy**: The rendered `<memory_context>` block is injected as a separate user + assistant acknowledgment message pair before the last user message (`injectMemoryRecallAsSeparateMessage`). This separates memory context from the user's actual query.
+10. **Injection strategy**: The rendered `<memory_context>` block is prepended as a text content block to the last user message (`injectMemoryRecallAsUserBlock`), following the same pattern as workspace, temporal, and other runtime injections. Stripping is handled by the generic `stripUserTextBlocksByPrefix` mechanism matching the `<memory_context>` prefix. This avoids synthetic message pairs and preserves prompt prefix caching between turns.
 
 ### Internal-Only Trust Gating
 

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -166,7 +166,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -133,7 +133,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -171,7 +171,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../memory/app-store.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -154,7 +154,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../memory/app-store.js", () => ({

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -158,7 +158,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -123,7 +123,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 // Mock AgentLoop to capture the messages it receives

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -185,7 +185,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 let maybeCompactCalls: Array<{ force: boolean }> = [];

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -178,7 +178,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -134,7 +134,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -141,7 +141,7 @@ mock.module("../memory/retriever.js", () => ({
     injectedTokens: 0,
     latencyMs: 0,
   }),
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../context/window-manager.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -105,8 +105,7 @@ mock.module("../memory/attachments-store.js", () => ({
 
 mock.module("../memory/retriever.js", () => ({
   buildMemoryRecall: async () => null,
-  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 
 mock.module("../memory/query-builder.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -154,8 +154,7 @@ mock.module("../memory/retriever.js", () => ({
     latencyMs: 0,
     topCandidates: [],
   }),
-  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -152,8 +152,7 @@ mock.module("../memory/retriever.js", () => ({
     latencyMs: 0,
     topCandidates: [],
   }),
-  injectMemoryRecallAsSeparateMessage: (msgs: Message[]) => msgs,
-  stripMemoryRecallMessages: (msgs: Message[]) => msgs,
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
 }));
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -82,6 +82,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
+import { stripUserTextBlocksByPrefix } from "../daemon/conversation-runtime-assembly.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
   resetCleanupScheduleThrottle,
@@ -89,8 +90,7 @@ import {
 } from "../memory/jobs-worker.js";
 import {
   buildMemoryRecall,
-  injectMemoryRecallAsSeparateMessage,
-  stripMemoryRecallMessages,
+  injectMemoryRecallAsUserBlock,
 } from "../memory/retriever.js";
 import {
   conversations,
@@ -98,6 +98,7 @@ import {
   memoryItemSources,
   messages,
 } from "../memory/schema.js";
+import type { Message } from "../providers/types.js";
 
 describe("Memory lifecycle E2E regression", () => {
   beforeAll(() => {
@@ -369,30 +370,35 @@ describe("Memory lifecycle E2E regression", () => {
     expect(recall.injectedText).toContain("</memory_context>");
   });
 
-  test("stripping removes <memory_context> tags from injected recall", () => {
+  test("stripping removes <memory_context> block from injected recall", () => {
     const memoryRecallText =
       "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
-    const originalMessages = [
+    const originalMessages: Message[] = [
       {
-        role: "user" as const,
-        content: [{ type: "text", text: "Actual user request" }],
+        role: "user",
+        content: [{ type: "text" as const, text: "Actual user request" }],
       },
     ];
-    const injected = injectMemoryRecallAsSeparateMessage(
+    const injected = injectMemoryRecallAsUserBlock(
       originalMessages,
       memoryRecallText,
     );
 
-    expect(injected).toHaveLength(3);
+    // Memory context prepended to the last user message as a content block
+    expect(injected).toHaveLength(1);
     expect(injected[0].role).toBe("user");
-    expect(injected[0].content[0].text).toBe(memoryRecallText);
-    expect(injected[1].role as string).toBe("assistant");
-    expect(injected[2].role).toBe("user");
-    expect(injected[2].content[0].text).toBe("Actual user request");
+    expect(injected[0].content).toHaveLength(2);
+    const b0 = injected[0].content[0];
+    const b1 = injected[0].content[1];
+    expect(b0.type === "text" && b0.text).toBe(memoryRecallText);
+    expect(b1.type === "text" && b1.text).toBe("Actual user request");
 
-    const cleaned = stripMemoryRecallMessages(injected, memoryRecallText);
+    // Stripped by prefix-based stripping (same mechanism as workspace/temporal)
+    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context>"]);
     expect(cleaned).toHaveLength(1);
-    expect(cleaned[0].content[0].text).toBe("Actual user request");
+    expect(cleaned[0].content).toHaveLength(1);
+    const cb0 = cleaned[0].content[0];
+    expect(cb0.type === "text" && cb0.text).toBe("Actual user request");
   });
 
   test("empty retrieval returns no injection", async () => {

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -86,6 +86,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 import { estimateTextTokens } from "../context/token-estimator.js";
+import { stripUserTextBlocksByPrefix } from "../daemon/conversation-runtime-assembly.js";
 import {
   getMemorySystemStatus,
   requestMemoryBackfill,
@@ -120,8 +121,7 @@ import {
   escapeXmlTags,
   formatAbsoluteTime,
   formatRelativeTime,
-  injectMemoryRecallAsSeparateMessage,
-  stripMemoryRecallMessages,
+  injectMemoryRecallAsUserBlock,
 } from "../memory/retriever.js";
 import {
   conversations,
@@ -133,6 +133,7 @@ import {
   messages,
 } from "../memory/schema.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
+import type { Message } from "../providers/types.js";
 
 describe("Memory regressions", () => {
   beforeAll(() => {
@@ -308,133 +309,120 @@ describe("Memory regressions", () => {
     expect(recall.enabled).toBe(true);
   });
 
-  test("memory recall injection via separate message and stripped from runtime history", () => {
+  test("memory recall injection as user block and stripped from runtime history", () => {
     const memoryRecallText =
       "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
-    const originalMessages = [
+    const originalMessages: Message[] = [
       {
-        role: "user" as const,
-        content: [{ type: "text", text: "Actual user request" }],
+        role: "user",
+        content: [{ type: "text" as const, text: "Actual user request" }],
       },
     ];
-    const injected = injectMemoryRecallAsSeparateMessage(
+    const injected = injectMemoryRecallAsUserBlock(
       originalMessages,
       memoryRecallText,
     );
 
-    expect(injected).toHaveLength(3);
+    // Memory context prepended to last user message as content block
+    expect(injected).toHaveLength(1);
     expect(injected[0].role).toBe("user");
-    expect(injected[0].content[0].text).toBe(memoryRecallText);
-    expect(injected[1].role as string).toBe("assistant");
-    expect(injected[2].role).toBe("user");
-    expect(injected[2].content[0].text).toBe("Actual user request");
+    expect(injected[0].content).toHaveLength(2);
+    const b0 = injected[0].content[0];
+    const b1 = injected[0].content[1];
+    expect(b0.type === "text" && b0.text).toBe(memoryRecallText);
+    expect(b1.type === "text" && b1.text).toBe("Actual user request");
 
-    const cleaned = stripMemoryRecallMessages(injected, memoryRecallText);
+    // Stripped by prefix-based stripping
+    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context>"]);
     expect(cleaned).toHaveLength(1);
-    expect(cleaned[0].content[0].text).toBe("Actual user request");
+    expect(cleaned[0].content).toHaveLength(1);
+    const cb0 = cleaned[0].content[0];
+    expect(cb0.type === "text" && cb0.text).toBe("Actual user request");
   });
 
-  test("recall stripping removes last matching block in merged content after deep-repair", () => {
+  test("prefix-based stripping removes all <memory_context> blocks from merged content", () => {
     const memoryRecallText =
-      "[Memory Recall v1]\n- [item:abc] user prefers concise answers";
-    // Simulate deep-repair merging two consecutive user messages where both
-    // contain the recall text. The injected (active) recall block is the last one.
-    const mergedUserMessage = {
-      role: "user" as const,
+      "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
+    // Simulate deep-repair merging where multiple memory context blocks exist.
+    // Prefix-based stripping removes all blocks starting with <memory_context>.
+    const mergedUserMessage: Message = {
+      role: "user",
       content: [
-        { type: "text", text: memoryRecallText },
-        { type: "text", text: "Earlier user request" },
-        { type: "text", text: memoryRecallText },
-        { type: "text", text: "Latest user request" },
+        { type: "text" as const, text: memoryRecallText },
+        { type: "text" as const, text: "Earlier user request" },
+        { type: "text" as const, text: memoryRecallText },
+        { type: "text" as const, text: "Latest user request" },
       ],
     };
 
-    const cleaned = stripMemoryRecallMessages(
+    const cleaned = stripUserTextBlocksByPrefix(
       [mergedUserMessage],
-      memoryRecallText,
+      ["<memory_context>"],
     );
     expect(cleaned).toHaveLength(1);
-    // The last (active) recall block should be stripped, the first (leaked) one preserved
     expect(cleaned[0].content).toEqual([
-      { type: "text", text: memoryRecallText },
       { type: "text", text: "Earlier user request" },
       { type: "text", text: "Latest user request" },
     ]);
   });
 
-  test("separate_context_message injects memory as user+assistant pair before last user message", () => {
-    const history = [
-      { role: "user" as const, content: [{ type: "text", text: "Hello" }] },
-      { role: "assistant" as const, content: [{ type: "text", text: "Hi!" }] },
+  test("injectMemoryRecallAsUserBlock prepends memory to last user message", () => {
+    const history: Message[] = [
+      { role: "user", content: [{ type: "text" as const, text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text" as const, text: "Hi!" }] },
       {
-        role: "user" as const,
-        content: [{ type: "text", text: "Tell me about X" }],
+        role: "user",
+        content: [{ type: "text" as const, text: "Tell me about X" }],
       },
     ];
-    const recallText = "<memory>Some recalled fact</memory>";
-    const result = injectMemoryRecallAsSeparateMessage(history, recallText);
-    // Should have 5 messages: original 2 + injected user + injected assistant ack + original last user
-    expect(result).toHaveLength(5);
+    const recallText =
+      "<memory_context>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
+    const result = injectMemoryRecallAsUserBlock(history, recallText);
+    // Same number of messages — no synthetic pair
+    expect(result).toHaveLength(3);
     expect(result[0]).toBe(history[0]);
     expect(result[1]).toBe(history[1]);
-    // Injected context message
-    expect(result[2].role).toBe("user");
-    expect(result[2].content).toEqual([{ type: "text", text: recallText }]);
-    // Assistant acknowledgment
-    expect(result[3].role).toBe("assistant");
-    expect(result[3].content).toEqual([
-      { type: "text", text: "[Memory context loaded.]" },
-    ]);
-    // Original user message preserved unchanged
-    expect(result[4]).toBe(history[2]);
+    // Last user message has memory prepended
+    const r0 = result[2].content[0];
+    const r1 = result[2].content[1];
+    expect(r0.type === "text" && r0.text).toBe(recallText);
+    expect(r1.type === "text" && r1.text).toBe("Tell me about X");
   });
 
-  test("separate_context_message with empty text is a no-op", () => {
-    const history = [
-      { role: "user" as const, content: [{ type: "text", text: "Hello" }] },
+  test("injectMemoryRecallAsUserBlock with empty text is a no-op", () => {
+    const history: Message[] = [
+      { role: "user", content: [{ type: "text" as const, text: "Hello" }] },
     ];
-    const result = injectMemoryRecallAsSeparateMessage(history, "  ");
+    const result = injectMemoryRecallAsUserBlock(history, "  ");
     expect(result).toBe(history);
   });
 
-  test("stripMemoryRecallMessages removes separate_context_message pair", () => {
-    const recallText = "<memory>Some recalled fact</memory>";
-    const messages = [
-      { role: "user" as const, content: [{ type: "text", text: "Hello" }] },
-      { role: "assistant" as const, content: [{ type: "text", text: "Hi!" }] },
-      // Injected context message pair
-      { role: "user" as const, content: [{ type: "text", text: recallText }] },
+  test("stripUserTextBlocksByPrefix removes memory_context block from user message", () => {
+    const recallText =
+      "<memory_context>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
+    const msgs: Message[] = [
+      { role: "user", content: [{ type: "text" as const, text: "Hello" }] },
       {
-        role: "assistant" as const,
-        content: [{ type: "text", text: "[Memory context loaded.]" }],
+        role: "assistant",
+        content: [{ type: "text" as const, text: "Hi!" }],
       },
-      // Real user message
       {
-        role: "user" as const,
-        content: [{ type: "text", text: "Tell me about X" }],
-      },
-    ];
-    const cleaned = stripMemoryRecallMessages(messages, recallText);
-    expect(cleaned).toHaveLength(3);
-    expect(cleaned[0].content[0].text).toBe("Hello");
-    expect(cleaned[1].content[0].text).toBe("Hi!");
-    expect(cleaned[2].content[0].text).toBe("Tell me about X");
-  });
-
-  test("stripMemoryRecallMessages falls back to prepend_user_block when no separate pair found", () => {
-    const recallText = "<memory>Fact</memory>";
-    const messages = [
-      {
-        role: "user" as const,
+        role: "user",
         content: [
-          { type: "text", text: recallText },
-          { type: "text", text: "User query" },
+          { type: "text" as const, text: recallText },
+          { type: "text" as const, text: "Tell me about X" },
         ],
       },
     ];
-    const cleaned = stripMemoryRecallMessages(messages, recallText);
-    expect(cleaned).toHaveLength(1);
-    expect(cleaned[0].content).toEqual([{ type: "text", text: "User query" }]);
+    const cleaned = stripUserTextBlocksByPrefix(msgs, ["<memory_context>"]);
+    expect(cleaned).toHaveLength(3);
+    const c0 = cleaned[0].content[0];
+    const c1 = cleaned[1].content[0];
+    const c2 = cleaned[2].content[0];
+    expect(c0.type === "text" && c0.text).toBe("Hello");
+    expect(c1.type === "text" && c1.text).toBe("Hi!");
+    expect(cleaned[2].content).toHaveLength(1);
+    expect(c2.type === "text" && c2.text).toBe("Tell me about X");
   });
 
   test("aborting memory recall embedding returns a non-degraded aborted recall result", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -49,7 +49,6 @@ import {
   queueRegenerateConversationTitle,
   UNTITLED_FALLBACK,
 } from "../memory/conversation-title-service.js";
-import { stripMemoryRecallMessages } from "../memory/retriever.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
@@ -915,14 +914,7 @@ export async function runAgentLoopImpl(
 
       // Strip injected context from updated history before compacting,
       // so we compact the "raw" persistent messages.
-      const rawHistory = stripInjectedContext(updatedHistory, {
-        stripRecall: (msgs) =>
-          stripMemoryRecallMessages(
-            msgs,
-            recall.injectedText,
-            "separate_context_message",
-          ),
-      });
+      const rawHistory = stripInjectedContext(updatedHistory);
       ctx.messages = rawHistory;
 
       ctx.emitActivityState(
@@ -1055,14 +1047,7 @@ export async function runAgentLoopImpl(
     // convergence loop operates on the full (larger) history.
     if (state.contextTooLargeDetected) {
       if (updatedHistory.length > preRunHistoryLength) {
-        ctx.messages = stripInjectedContext(updatedHistory, {
-          stripRecall: (msgs) =>
-            stripMemoryRecallMessages(
-              msgs,
-              recall.injectedText,
-              "separate_context_message",
-            ),
-        });
+        ctx.messages = stripInjectedContext(updatedHistory);
         preRepairMessages = updatedHistory;
         preRunHistoryLength = updatedHistory.length;
       }
@@ -1517,14 +1502,7 @@ export async function runAgentLoopImpl(
     }
 
     const restoredHistory = [...preRepairMessages, ...newMessages];
-    ctx.messages = stripInjectedContext(restoredHistory, {
-      stripRecall: (msgs) =>
-        stripMemoryRecallMessages(
-          msgs,
-          recall.injectedText,
-          "separate_context_message",
-        ),
-    });
+    ctx.messages = stripInjectedContext(restoredHistory);
 
     emitUsage(
       ctx,

--- a/assistant/src/daemon/conversation-memory.ts
+++ b/assistant/src/daemon/conversation-memory.ts
@@ -4,7 +4,7 @@ import { buildMemoryQuery } from "../memory/query-builder.js";
 import { computeRecallBudget } from "../memory/retrieval-budget.js";
 import {
   buildMemoryRecall,
-  injectMemoryRecallAsSeparateMessage,
+  injectMemoryRecallAsUserBlock,
 } from "../memory/retriever.js";
 import type { ScopePolicyOverride } from "../memory/search/types.js";
 import type { Message } from "../providers/types.js";
@@ -68,9 +68,10 @@ export function needsMemory(messages: Message[], content: string): boolean {
  * pipeline. Returns the augmented run messages and metadata for
  * downstream event emission.
  *
- * The V2 pipeline always uses `separate_context_message` injection
- * strategy (user + assistant ack pair). When injection text is empty,
- * no synthetic messages are added.
+ * Memory context is injected as a text content block prepended to the
+ * last user message (same pattern as workspace/temporal injections).
+ * Stripping is handled by `stripUserTextBlocksByPrefix` matching the
+ * `<memory_context>` prefix in `RUNTIME_INJECTION_PREFIXES`.
  */
 export async function prepareMemoryContext(
   ctx: MemoryPrepareContext,
@@ -165,13 +166,13 @@ export async function prepareMemoryContext(
     model: recall.model,
   });
 
-  // Inject recall into messages using separate_context_message strategy.
-  // When injection text is empty, skip injection entirely (no synthetic messages).
+  // Inject recall as a text block prepended to the last user message.
+  // When injection text is empty, skip injection entirely.
   let runMessages = ctx.messages;
   if (recall.injectedText.length > 0) {
     const userTail = ctx.messages[ctx.messages.length - 1];
     if (userTail && userTail.role === "user") {
-      runMessages = injectMemoryRecallAsSeparateMessage(
+      runMessages = injectMemoryRecallAsUserBlock(
         ctx.messages,
         recall.injectedText,
       );

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1075,6 +1075,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<guardian_context>",
   "<inbound_actor_context>",
   "<interface_turn_context>",
+  "<memory_context>",
   "<voice_call_control>",
   "<workspace_top_level>",
   TEMPORAL_INJECTED_PREFIX,
@@ -1086,19 +1087,13 @@ const RUNTIME_INJECTION_PREFIXES = [
 /**
  * Strip all runtime-injected context from message history in a single pass.
  *
- * Composes:
- * 1. `stripMemoryRecallMessages` (caller-supplied, handles its own logic)
- * 2. Prefix-based stripping for channel capabilities, workspace top-level,
- *    temporal context, and active surface context (single pass).
+ * All injections (memory context, channel capabilities, workspace top-level,
+ * temporal context, active surface context, etc.) are text blocks prepended
+ * to user messages with known XML tag prefixes. A single prefix-based pass
+ * removes them all.
  */
-export function stripInjectedContext(
-  messages: Message[],
-  options: {
-    stripRecall: (msgs: Message[]) => Message[];
-  },
-): Message[] {
-  const afterRecall = options.stripRecall(messages);
-  return stripUserTextBlocksByPrefix(afterRecall, RUNTIME_INJECTION_PREFIXES);
+export function stripInjectedContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, RUNTIME_INJECTION_PREFIXES);
 }
 
 /**

--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -95,8 +95,7 @@ import {
 } from "../memory/qdrant-circuit-breaker.js";
 import {
   buildMemoryRecall,
-  injectMemoryRecallAsSeparateMessage,
-  stripMemoryRecallMessages,
+  injectMemoryRecallAsUserBlock,
 } from "../memory/retriever.js";
 import {
   conversations,
@@ -104,10 +103,17 @@ import {
   memoryItemSources,
   messages,
 } from "../memory/schema.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Extract text from a content block, asserting it is a text block. */
+function textOf(block: ContentBlock): string {
+  if (block.type !== "text") throw new Error(`Expected text block, got ${block.type}`);
+  return block.text;
+}
 
 function insertConversation(
   db: ReturnType<typeof getDb>,
@@ -627,81 +633,11 @@ describe("Memory Retriever Pipeline", () => {
   });
 
   // -----------------------------------------------------------------------
-  // stripMemoryRecallMessages with <memory_context> format
+  // injectMemoryRecallAsUserBlock
   // -----------------------------------------------------------------------
 
-  test("stripMemoryRecallMessages: strips <memory_context> XML format", () => {
-    type Msg = {
-      role: "user" | "assistant";
-      content: Array<{ type: string; text?: string }>;
-    };
-    const recallText =
-      "<memory_context>\n\n<relevant_context>\nsome context\n</relevant_context>\n\n</memory_context>";
-
-    const msgs: Msg[] = [
-      {
-        role: "user",
-        content: [{ type: "text", text: recallText }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "[Memory context loaded.]" }],
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "Hello, what do you know about me?" }],
-      },
-    ];
-
-    const cleaned = stripMemoryRecallMessages(msgs, recallText);
-    expect(cleaned).toHaveLength(1);
-    expect(cleaned[0].role).toBe("user");
-    expect(cleaned[0].content[0].text).toBe(
-      "Hello, what do you know about me?",
-    );
-  });
-
-  test("stripMemoryRecallMessages: handles <memory_context> with slightly different content", () => {
-    type Msg = {
-      role: "user" | "assistant";
-      content: Array<{ type: string; text?: string }>;
-    };
-    const originalRecall =
-      "<memory_context>\n\n<relevant_context>\noriginal\n</relevant_context>\n\n</memory_context>";
-    const actualRecall =
-      "<memory_context>\n\n<relevant_context>\nslightly different\n</relevant_context>\n\n</memory_context>";
-
-    const msgs: Msg[] = [
-      {
-        role: "user",
-        content: [{ type: "text", text: actualRecall }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "[Memory context loaded.]" }],
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "follow-up question" }],
-      },
-    ];
-
-    // The <memory_context> tag-based matching should work even when exact text differs
-    const cleaned = stripMemoryRecallMessages(msgs, originalRecall);
-    expect(cleaned).toHaveLength(1);
-    expect(cleaned[0].content[0].text).toBe("follow-up question");
-  });
-
-  // -----------------------------------------------------------------------
-  // injectMemoryRecallAsSeparateMessage
-  // -----------------------------------------------------------------------
-
-  test("injectMemoryRecallAsSeparateMessage: injects context + ack before last user message", () => {
-    type Msg = {
-      role: "user" | "assistant";
-      content: Array<{ type: string; text?: string }>;
-    };
-    const msgs: Msg[] = [
+  test("injectMemoryRecallAsUserBlock: prepends memory context to last user message", () => {
+    const msgs: Message[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hello" }],
@@ -710,32 +646,49 @@ describe("Memory Retriever Pipeline", () => {
 
     const recallText =
       "<memory_context>\n\n<relevant_context>\ntest\n</relevant_context>\n\n</memory_context>";
-    const result = injectMemoryRecallAsSeparateMessage(msgs, recallText);
+    const result = injectMemoryRecallAsUserBlock(msgs, recallText);
 
-    expect(result).toHaveLength(3);
+    // Same number of messages — no synthetic pair added
+    expect(result).toHaveLength(1);
     expect(result[0].role).toBe("user");
-    expect(result[0].content[0].text).toBe(recallText);
-    expect(result[1].role).toBe("assistant");
-    expect(result[1].content[0].text).toBe("[Memory context loaded.]");
-    expect(result[2].role).toBe("user");
-    expect(result[2].content[0].text).toBe("Hello");
+    // Memory context prepended as first content block
+    expect(result[0].content).toHaveLength(2);
+    expect(textOf(result[0].content[0])).toBe(recallText);
+    // Original user text preserved as second block
+    expect(textOf(result[0].content[1])).toBe("Hello");
   });
 
-  test("injectMemoryRecallAsSeparateMessage: no-op for empty text", () => {
-    type Msg = {
-      role: "user" | "assistant";
-      content: Array<{ type: string; text?: string }>;
-    };
-    const msgs: Msg[] = [
+  test("injectMemoryRecallAsUserBlock: no-op for empty text", () => {
+    const msgs: Message[] = [
       {
         role: "user",
         content: [{ type: "text", text: "Hello" }],
       },
     ];
 
-    const result = injectMemoryRecallAsSeparateMessage(msgs, "");
+    const result = injectMemoryRecallAsUserBlock(msgs, "");
     expect(result).toHaveLength(1);
-    expect(result[0].content[0].text).toBe("Hello");
+    expect(textOf(result[0].content[0])).toBe("Hello");
+  });
+
+  test("injectMemoryRecallAsUserBlock: preserves history before last user message", () => {
+    const msgs: Message[] = [
+      { role: "user", content: [{ type: "text", text: "First" }] },
+      { role: "assistant", content: [{ type: "text", text: "Response" }] },
+      { role: "user", content: [{ type: "text", text: "Second" }] },
+    ];
+
+    const recallText =
+      "<memory_context>\n\n<relevant_context>\nfact\n</relevant_context>\n\n</memory_context>";
+    const result = injectMemoryRecallAsUserBlock(msgs, recallText);
+
+    expect(result).toHaveLength(3);
+    // Earlier messages unchanged
+    expect(result[0]).toBe(msgs[0]);
+    expect(result[1]).toBe(msgs[1]);
+    // Last user message has memory prepended
+    expect(textOf(result[2].content[0])).toBe(recallText);
+    expect(textOf(result[2].content[1])).toBe("Second");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -2,6 +2,7 @@ import { inArray, sql } from "drizzle-orm";
 
 import type { AssistantConfig } from "../config/types.js";
 import { estimateTextTokens } from "../context/token-estimator.js";
+import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   abortableSleep,
@@ -25,7 +26,6 @@ import {
 import {
   buildTwoLayerInjection,
   IDENTITY_KINDS,
-  MEMORY_CONTEXT_ACK,
   PREFERENCE_KINDS,
 } from "./search/formatting.js";
 import { recencySearch } from "./search/lexical.js";
@@ -684,146 +684,32 @@ function enrichSourceLabels(candidates: TieredCandidate[]): void {
 }
 
 /**
- * Strip memory recall messages from the conversation history.
+ * Inject memory recall as a text content block prepended to the last user
+ * message. This follows the same pattern as workspace, temporal, and other
+ * runtime injections — the memory context is a text block in the user
+ * message rather than a separate synthetic message pair.
  *
- * Handles both exact text matching and `<memory_context>` XML wrapper
- * detection: when the recall text starts with `<memory_context>`, we
- * also match user messages whose sole text block starts with the same
- * tag (covering cases where the exact text differs slightly due to
- * dynamic content).
+ * Stripping is handled by `stripUserTextBlocksByPrefix` matching the
+ * `<memory_context>` prefix in `RUNTIME_INJECTION_PREFIXES`, so no
+ * dedicated strip function is needed.
  */
-export function stripMemoryRecallMessages<
-  T extends {
-    role: "user" | "assistant";
-    content: Array<{ type: string; text?: string }>;
-  },
->(
-  messages: T[],
-  memoryRecallText?: string,
-  injectionStrategy?: "prepend_user_block" | "separate_context_message",
-): T[] {
-  const recallText = memoryRecallText ?? "";
-  if (recallText.trim().length === 0) return messages;
-
-  const isAck = (msg: T) =>
-    msg.role === "assistant" &&
-    msg.content.length === 1 &&
-    msg.content[0].type === "text" &&
-    msg.content[0].text === MEMORY_CONTEXT_ACK;
-
-  // Check if the recall text uses the <memory_context> XML format
-  const isMemoryContextFormat = recallText
-    .trimStart()
-    .startsWith("<memory_context>");
-
-  // Helper: does a text block match the recall text?
-  const textMatches = (text: string | undefined): boolean => {
-    if (!text) return false;
-    if (text === recallText) return true;
-    // For <memory_context> format, match any block that starts with the tag
-    if (
-      isMemoryContextFormat &&
-      text.trimStart().startsWith("<memory_context>")
-    ) {
-      return true;
-    }
-    return false;
-  };
-
-  // Prefer the canonical separate_context_message pair: a user message whose
-  // sole text block is the recall text, followed by an assistant ack. This
-  // must be checked first so that a real user message that happens to contain
-  // the same text is not incorrectly removed instead of the synthetic one.
-  if (injectionStrategy !== "prepend_user_block") {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role !== "user") continue;
-      if (msg.content.length !== 1) continue;
-      const block = msg.content[0];
-      if (block.type !== "text" || !textMatches(block.text)) continue;
-      const next = messages[i + 1];
-      if (next && isAck(next)) {
-        return [...messages.slice(0, i), ...messages.slice(i + 2)];
-      }
-    }
-  }
-
-  // Fall back to generic text-match removal: find the last user message
-  // containing the recall text block.
-  let targetIndex = -1;
-  let blockIndex = -1;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== "user" || msg.content.length === 0) continue;
-    for (let bi = msg.content.length - 1; bi >= 0; bi--) {
-      const block = msg.content[bi];
-      if (block.type === "text" && textMatches(block.text)) {
-        targetIndex = i;
-        blockIndex = bi;
-        break;
-      }
-    }
-    if (targetIndex !== -1) break;
-  }
-  if (targetIndex === -1) return messages;
-
-  // Strip the adjacent assistant ack when the injection strategy used a
-  // separate context message (or is unknown). This mirrors the canonical
-  // pair removal above but covers repair-merged cases where the user
-  // message has multiple content blocks.
-  const ackIndex =
-    injectionStrategy !== "prepend_user_block" &&
-    targetIndex + 1 < messages.length &&
-    isAck(messages[targetIndex + 1])
-      ? targetIndex + 1
-      : -1;
-
-  const cleaned: T[] = [];
-  for (let i = 0; i < messages.length; i++) {
-    if (i === ackIndex) continue;
-    if (i !== targetIndex) {
-      cleaned.push(messages[i]);
-      continue;
-    }
-    const filteredContent = [
-      ...messages[i].content.slice(0, blockIndex),
-      ...messages[i].content.slice(blockIndex + 1),
-    ];
-    if (filteredContent.length === 0) continue;
-    cleaned.push({ ...messages[i], content: filteredContent } as T);
-  }
-  return cleaned;
-}
-
-/**
- * Inject memory recall as a separate user+assistant message pair before the
- * last user message. This separates memory context from the user's actual
- * query, making it clearer to the model that the memory is background context.
- */
-export function injectMemoryRecallAsSeparateMessage<
-  T extends {
-    role: "user" | "assistant";
-    content: Array<{ type: string; text?: string }>;
-  },
->(messages: T[], memoryRecallText: string): T[] {
+export function injectMemoryRecallAsUserBlock(
+  messages: Message[],
+  memoryRecallText: string,
+): Message[] {
   if (memoryRecallText.trim().length === 0) return messages;
   if (messages.length === 0) return messages;
-  // These synthetic messages satisfy the structural constraint T extends { role; content }
-  // but may lack extra fields present on T. In practice T is always Message which has
-  // only role and content, so the cast is safe.
-  const contextMessage = {
-    role: "user" as const,
-    content: [{ type: "text" as const, text: memoryRecallText }],
-  } as T;
-  const ackMessage = {
-    role: "assistant" as const,
-    content: [{ type: "text" as const, text: MEMORY_CONTEXT_ACK }],
-  } as T;
+  const userTail = messages[messages.length - 1];
+  if (!userTail || userTail.role !== "user") return messages;
   return [
     ...messages.slice(0, -1),
-    contextMessage,
-    ackMessage,
-    messages[messages.length - 1],
+    {
+      ...userTail,
+      content: [
+        { type: "text" as const, text: memoryRecallText },
+        ...userTail.content,
+      ],
+    },
   ];
 }
 

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -1,9 +1,6 @@
 import { estimateTextTokens } from "../../context/token-estimator.js";
 import type { TieredCandidate } from "./tier-classifier.js";
 
-/** Marker text used in the assistant acknowledgment of a separate context message. */
-export const MEMORY_CONTEXT_ACK = "[Memory context loaded.]";
-
 /**
  * Escape XML-like tag sequences in recalled text to prevent delimiter injection.
  * Recalled content is interpolated verbatim inside `<memory>` wrapper tags,


### PR DESCRIPTION
## Summary
- Changed memory context injection from a separate user+assistant message pair (`injectMemoryRecallAsSeparateMessage`) to a text content block prepended to the last user message (`injectMemoryRecallAsUserBlock`), matching the pattern used by workspace/temporal injections
- Added `<memory_context>` to `RUNTIME_INJECTION_PREFIXES` so stripping is handled by the generic `stripUserTextBlocksByPrefix` mechanism, removing the need for the `stripRecall` callback in `stripInjectedContext`
- Removed `injectMemoryRecallAsSeparateMessage`, `stripMemoryRecallMessages`, and `MEMORY_CONTEXT_ACK` as dead code

## Test plan
- [x] `bun test src/memory/retriever.test.ts` — all 14 tests pass
- [x] `bun test src/__tests__/memory-regressions.test.ts` — 69 pass, 3 pre-existing failures (same on main)
- [x] `bun test src/__tests__/memory-lifecycle-e2e.test.ts` — 4 pass, 1 pre-existing failure (same on main)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
