### PR TITLE
fix: reconnect Slack/Telegram channels after laptop sleep/wake

### DIFF
--- a/gateway/src/__tests__/sleep-wake-detector.test.ts
+++ b/gateway/src/__tests__/sleep-wake-detector.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { SleepWakeDetector } from "../sleep-wake-detector.js";
+
+// Suppress logger output during tests
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  initLogger: () => {},
+}));
+
+describe("SleepWakeDetector", () => {
+  let detector: SleepWakeDetector;
+  let onWake: ReturnType<typeof mock>;
+  let originalDateNow: () => number;
+  let fakeNow: number;
+
+  beforeEach(() => {
+    onWake = mock(() => {});
+    originalDateNow = Date.now;
+    fakeNow = 1000000;
+    Date.now = () => fakeNow;
+  });
+
+  afterEach(() => {
+    detector?.stop();
+    Date.now = originalDateNow;
+  });
+
+  test("does not fire callback on normal ticks", async () => {
+    detector = new SleepWakeDetector(onWake, 50, 2);
+    detector.start();
+
+    // Advance time normally (within threshold)
+    fakeNow += 55;
+    await new Promise((r) => setTimeout(r, 70));
+
+    expect(onWake).not.toHaveBeenCalled();
+  });
+
+  test("fires callback when elapsed time exceeds threshold", async () => {
+    detector = new SleepWakeDetector(onWake, 50, 2);
+    detector.start();
+
+    // Wait for first tick at normal time
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Simulate a sleep gap: jump time forward well past the threshold
+    fakeNow += 200; // 4x the interval
+
+    // Wait for next tick
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(onWake).toHaveBeenCalledTimes(1);
+  });
+
+  test("stop prevents further callbacks", async () => {
+    detector = new SleepWakeDetector(onWake, 50, 2);
+    detector.start();
+    detector.stop();
+
+    fakeNow += 500;
+    await new Promise((r) => setTimeout(r, 70));
+
+    expect(onWake).not.toHaveBeenCalled();
+  });
+
+  test("start after stop resets cleanly", async () => {
+    detector = new SleepWakeDetector(onWake, 50, 2);
+    detector.start();
+    detector.stop();
+    detector.start();
+
+    // Normal tick — should not fire
+    fakeNow += 55;
+    await new Promise((r) => setTimeout(r, 70));
+
+    expect(onWake).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -67,6 +67,7 @@ import {
   type RouteDefinition,
   type GetClientIp,
 } from "./http/router.js";
+import { SleepWakeDetector } from "./sleep-wake-detector.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 
@@ -983,11 +984,34 @@ async function main() {
 
   configFileWatcher.start();
 
+  // ── Sleep/wake detection ──
+  // Detect system sleep/wake transitions and force-reconnect channels
+  // that may have stale connections after the OS suspended the process.
+  const sleepWakeDetector = new SleepWakeDetector(() => {
+    log.info("System wake detected — reconnecting channels");
+
+    // Force-reconnect Slack WebSocket (may be half-open after sleep)
+    slackSocketClient?.forceReconnect();
+
+    // Invalidate caches so next read picks up any config changes (e.g. new ngrok URL)
+    configFileCache.invalidate();
+    credentialCache.invalidate();
+
+    // Re-register Telegram webhook with current ingress URL
+    if (telegramReady) {
+      reconcileTelegramWebhook(telegramCaches).catch((err) => {
+        log.error({ err }, "Failed to reconcile Telegram webhook after wake");
+      });
+    }
+  });
+  sleepWakeDetector.start();
+
   const drainMs = config.shutdownDrainMs;
 
   process.on("SIGTERM", () => {
     log.info("SIGTERM received, starting graceful shutdown");
     draining = true;
+    sleepWakeDetector.stop();
     credentialWatcher.stop();
     configFileWatcher.stop();
     telegramDedupCache.stopCleanup();

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -149,6 +149,36 @@ export class SlackSocketModeClient {
   }
 
   /**
+   * Force-close the current WebSocket and reconnect immediately.
+   * Used by the sleep/wake detector to recover from half-open connections
+   * that survive system sleep.
+   */
+  forceReconnect(): void {
+    if (!this.running) return;
+
+    log.info("Force-reconnecting Slack Socket Mode (sleep/wake recovery)");
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.ws) {
+      try {
+        this.ws.close(1000, "force reconnect");
+      } catch {
+        // ignore close errors
+      }
+      this.ws = null;
+    }
+
+    this.reconnectAttempt = 0;
+    this.connect().catch((err) => {
+      log.error({ err }, "Force reconnect failed");
+    });
+  }
+
+  /**
    * Register a thread as active so future replies (without @mention) are forwarded.
    */
   trackThread(threadTs: string): void {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -154,6 +154,10 @@ export class SlackSocketModeClient {
    * Force-close the current WebSocket and reconnect immediately.
    * Used by the sleep/wake detector to recover from half-open connections
    * that survive system sleep.
+   *
+   * Waits for the old socket to fully close before connecting a new one
+   * to prevent overlapping connections where stale message events could
+   * be ACKed on the wrong socket.
    */
   forceReconnect(): void {
     if (!this.running) return;
@@ -167,19 +171,50 @@ export class SlackSocketModeClient {
       this.reconnectTimer = null;
     }
 
-    if (this.ws) {
-      try {
-        this.ws.close(1000, "force reconnect");
-      } catch {
-        // ignore close errors
-      }
-      this.ws = null;
+    this.reconnectAttempt = 0;
+
+    const oldWs = this.ws;
+    this.ws = null;
+
+    if (!oldWs || oldWs.readyState === WebSocket.CLOSED) {
+      this.connect().catch((err) => {
+        log.error({ err }, "Force reconnect failed");
+      });
+      return;
     }
 
-    this.reconnectAttempt = 0;
-    this.connect().catch((err) => {
-      log.error({ err }, "Force reconnect failed");
-    });
+    // Wait for the old socket to fully close before opening a new one.
+    // Use a timeout to avoid blocking indefinitely on half-open sockets
+    // that may never emit a close event (the exact scenario that triggers
+    // a force reconnect after sleep).
+    const CLOSE_TIMEOUT_MS = 5_000;
+    let settled = false;
+
+    const proceed = () => {
+      if (settled) return;
+      settled = true;
+      this.connect().catch((err) => {
+        log.error({ err }, "Force reconnect failed");
+      });
+    };
+
+    oldWs.addEventListener("close", proceed, { once: true });
+
+    setTimeout(() => {
+      if (!settled) {
+        log.warn(
+          "Old Slack socket did not close within timeout, proceeding with reconnect",
+        );
+        proceed();
+      }
+    }, CLOSE_TIMEOUT_MS);
+
+    try {
+      oldWs.close(1000, "force reconnect");
+    } catch {
+      // Socket may already be in a broken state — proceed immediately
+      proceed();
+    }
   }
 
   /**
@@ -217,7 +252,7 @@ export class SlackSocketModeClient {
       });
 
       ws.addEventListener("message", (messageEvent) => {
-        this.handleMessage(messageEvent.data as string);
+        this.handleMessage(messageEvent.data as string, ws);
       });
 
       ws.addEventListener("close", (closeEvent) => {
@@ -286,7 +321,7 @@ export class SlackSocketModeClient {
     };
   }
 
-  private handleMessage(raw: string): void {
+  private handleMessage(raw: string, originWs: WebSocket): void {
     let envelope: {
       envelope_id?: string;
       type?: string;
@@ -316,32 +351,31 @@ export class SlackSocketModeClient {
       return;
     }
 
-    // ACK every envelope immediately
-    if (
-      envelope.envelope_id &&
-      this.ws &&
-      this.ws.readyState === WebSocket.OPEN
-    ) {
-      this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+    // ACK every envelope on the socket that received it — never cross-ACK
+    // onto a different connection (e.g. after forceReconnect replaces this.ws).
+    if (envelope.envelope_id && originWs.readyState === WebSocket.OPEN) {
+      originWs.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
     }
 
-    // Handle disconnect type: Slack asks us to reconnect
+    // Handle disconnect type: Slack asks us to reconnect.
+    // Only act if the requesting socket is still the active one —
+    // a stale socket's disconnect should not tear down a new connection.
     if (envelope.type === "disconnect") {
       log.info(
         { reason: envelope.reason },
         "Slack requested disconnect, reconnecting",
       );
-      if (this.ws) {
+      if (this.ws === originWs) {
         try {
           this.ws.close(1000, "server requested disconnect");
         } catch {
           // ignore
         }
         this.ws = null;
+        // Reconnect immediately (attempt 0 = minimal backoff)
+        this.reconnectAttempt = 0;
+        this.scheduleReconnect();
       }
-      // Reconnect immediately (attempt 0 = minimal backoff)
-      this.reconnectAttempt = 0;
-      this.scheduleReconnect();
       return;
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -51,6 +51,7 @@ export class SlackSocketModeClient {
   private config: SlackSocketModeConfig;
   private onEvent: (event: NormalizedSlackEvent) => void;
   private ws: WebSocket | null = null;
+  private connecting = false;
   private running = false;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -133,6 +134,7 @@ export class SlackSocketModeClient {
 
   stop(): void {
     this.running = false;
+    this.connecting = false;
     this.stopDedupCleanup();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -157,6 +159,8 @@ export class SlackSocketModeClient {
     if (!this.running) return;
 
     log.info("Force-reconnecting Slack Socket Mode (sleep/wake recovery)");
+
+    this.connecting = false;
 
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -187,12 +191,15 @@ export class SlackSocketModeClient {
 
   private async connect(): Promise<void> {
     if (!this.running) return;
+    if (this.connecting) return;
+    this.connecting = true;
 
     let wsUrl: string;
     try {
       wsUrl = await this.getWebSocketUrl();
     } catch (err) {
       log.error({ err }, "Failed to obtain Socket Mode WebSocket URL");
+      this.connecting = false;
       this.scheduleReconnect();
       return;
     }
@@ -202,6 +209,7 @@ export class SlackSocketModeClient {
     try {
       const ws = new WebSocket(wsUrl);
       this.ws = ws;
+      this.connecting = false;
 
       ws.addEventListener("open", () => {
         log.info("Slack Socket Mode connected");
@@ -235,6 +243,7 @@ export class SlackSocketModeClient {
     } catch (err) {
       log.error({ err }, "Failed to create WebSocket connection");
       this.ws = null;
+      this.connecting = false;
       this.scheduleReconnect();
     }
   }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -217,8 +217,13 @@ export class SlackSocketModeClient {
           { code: closeEvent.code, reason: closeEvent.reason },
           "Slack Socket Mode disconnected",
         );
-        this.ws = null;
-        this.scheduleReconnect();
+        // Only reconnect if this socket is still the active one.
+        // forceReconnect nulls this.ws before initiating a new connection,
+        // so a stale close event should be ignored.
+        if (this.ws === ws) {
+          this.ws = null;
+          this.scheduleReconnect();
+        }
       });
 
       ws.addEventListener("error", (errorEvent) => {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -164,8 +164,6 @@ export class SlackSocketModeClient {
 
     log.info("Force-reconnecting Slack Socket Mode (sleep/wake recovery)");
 
-    this.connecting = false;
-
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -175,6 +173,24 @@ export class SlackSocketModeClient {
 
     const oldWs = this.ws;
     this.ws = null;
+
+    // If a connect() call is already in-flight (awaiting getWebSocketUrl),
+    // don't start another one — the in-flight attempt will complete and
+    // establish a fresh connection. We still tear down the old socket and
+    // cancel the reconnect timer above so there's no stale state.
+    if (this.connecting) {
+      log.info(
+        "Connect already in-flight, skipping duplicate — tearing down old socket only",
+      );
+      if (oldWs) {
+        try {
+          oldWs.close(1000, "force reconnect");
+        } catch {
+          // ignore
+        }
+      }
+      return;
+    }
 
     if (!oldWs || oldWs.readyState === WebSocket.CLOSED) {
       this.connect().catch((err) => {

--- a/gateway/src/sleep-wake-detector.ts
+++ b/gateway/src/sleep-wake-detector.ts
@@ -1,0 +1,44 @@
+import { getLogger } from "./logger.js";
+
+const log = getLogger("sleep-wake-detector");
+
+/**
+ * Detects system sleep/wake transitions using the epoch-gap technique:
+ * a periodic timer checks if the elapsed time between ticks far exceeds
+ * the expected interval, which indicates the process was suspended.
+ */
+export class SleepWakeDetector {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastTick: number = 0;
+
+  constructor(
+    private onWake: () => void,
+    private intervalMs: number = 10_000,
+    private thresholdMultiplier: number = 2,
+  ) {}
+
+  start(): void {
+    this.stop();
+    this.lastTick = Date.now();
+    this.timer = setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - this.lastTick;
+      this.lastTick = now;
+
+      if (elapsed > this.intervalMs * this.thresholdMultiplier) {
+        log.info(
+          { elapsedMs: elapsed, expectedMs: this.intervalMs },
+          "System wake detected (epoch gap)",
+        );
+        this.onWake();
+      }
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `SleepWakeDetector` utility that detects system sleep/wake transitions using the epoch-gap technique (periodic timer that fires when elapsed time between ticks exceeds 2x the expected interval)
- Adds `forceReconnect()` to `SlackSocketModeClient` to tear down stale half-open WebSocket connections and immediately reconnect
- Wires up the detector in the gateway: on wake, force-reconnects Slack WebSocket, invalidates config/credential caches, and re-registers the Telegram webhook with the current ingress URL

## Test plan
- [x] `bun test src/__tests__/sleep-wake-detector.test.ts` — 4 tests pass
- [x] `bunx tsc --noEmit` — type-checks clean
- [ ] Manual: close laptop lid, reopen, verify gateway logs show "System wake detected" and subsequent Slack reconnect / Telegram webhook reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
