### PR TITLE
fix: rename created_by_session_id to source_conversation_id and align TS field names

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -145,7 +145,7 @@ export function upsertContactChannel(params: {
   policy?: string;
   status?: string;
   inviteId?: string;
-  createdByConversationId?: string;
+  sourceConversationId?: string;
   verifiedAt?: number;
   verifiedVia?: string;
   role?: ContactRole;

--- a/assistant/src/memory/channel-verification-sessions.ts
+++ b/assistant/src/memory/channel-verification-sessions.ts
@@ -59,7 +59,7 @@ export interface VerificationSession {
   challengeHash: string;
   expiresAt: number;
   status: SessionStatus;
-  createdByConversationId: string | null;
+  sourceConversationId: string | null;
   consumedByExternalUserId: string | null;
   consumedByChatId: string | null;
   // Outbound session: expected-identity binding
@@ -96,7 +96,7 @@ function rowToSession(
     challengeHash: row.challengeHash,
     expiresAt: row.expiresAt,
     status: row.status as SessionStatus,
-    createdByConversationId: row.createdByConversationId,
+    sourceConversationId: row.sourceConversationId,
     consumedByExternalUserId: row.consumedByExternalUserId,
     consumedByChatId: row.consumedByChatId,
     expectedExternalUserId: row.expectedExternalUserId ?? null,
@@ -127,7 +127,7 @@ export function createInboundSession(params: {
   channel: string;
   challengeHash: string;
   expiresAt: number;
-  createdByConversationId?: string;
+  sourceConversationId?: string;
 }): VerificationSession {
   const db = getDb();
   const now = Date.now();
@@ -150,7 +150,7 @@ export function createInboundSession(params: {
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
     status: "pending" as const,
-    createdByConversationId: params.createdByConversationId ?? null,
+    sourceConversationId: params.sourceConversationId ?? null,
     consumedByExternalUserId: null,
     consumedByChatId: null,
     expectedExternalUserId: null,
@@ -278,7 +278,7 @@ export function createVerificationSession(params: {
   challengeHash: string;
   expiresAt: number;
   status: SessionStatus;
-  createdByConversationId?: string;
+  sourceConversationId?: string;
   expectedExternalUserId?: string | null;
   expectedChatId?: string | null;
   expectedPhoneE164?: string | null;
@@ -313,7 +313,7 @@ export function createVerificationSession(params: {
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
     status: params.status as string,
-    createdByConversationId: params.createdByConversationId ?? null,
+    sourceConversationId: params.sourceConversationId ?? null,
     consumedByExternalUserId: null,
     consumedByChatId: null,
     expectedExternalUserId: params.expectedExternalUserId ?? null,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -84,6 +84,7 @@ import {
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
+  migrateRenameCreatedBySessionIdColumns,
   migrateRenameFollowupsThreadIdColumn,
   migrateRenameGmailProviderKeyToGoogle,
   migrateRenameGuardianVerificationValues,
@@ -431,6 +432,9 @@ export function initializeDb(): void {
 
   // 74. Add capability card columns to thread_starters + category relevance table
   migrateCapabilityCardColumns(database);
+
+  // 75. Rename created_by_session_id → source_conversation_id in verification sessions and invites
+  migrateRenameCreatedBySessionIdColumns(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -23,7 +23,7 @@ export interface IngressInvite {
   id: string;
   sourceChannel: string;
   tokenHash: string;
-  createdByConversationId: string | null;
+  sourceConversationId: string | null;
   note: string | null;
   maxUses: number;
   useCount: number;
@@ -73,7 +73,7 @@ function rowToInvite(
     id: row.id,
     sourceChannel: row.sourceChannel,
     tokenHash: row.tokenHash,
-    createdByConversationId: row.createdByConversationId,
+    sourceConversationId: row.sourceConversationId,
     note: row.note,
     maxUses: row.maxUses,
     useCount: row.useCount,
@@ -101,7 +101,7 @@ function rowToInvite(
 export function createInvite(params: {
   sourceChannel: string;
   contactId: string;
-  createdByConversationId?: string;
+  sourceConversationId?: string;
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
@@ -124,7 +124,7 @@ export function createInvite(params: {
     id,
     sourceChannel: params.sourceChannel,
     tokenHash: tokenH,
-    createdByConversationId: params.createdByConversationId ?? null,
+    sourceConversationId: params.sourceConversationId ?? null,
     note: params.note ?? null,
     maxUses: params.maxUses ?? 1,
     useCount: 0,

--- a/assistant/src/memory/migrations/172-rename-created-by-session-id.ts
+++ b/assistant/src/memory/migrations/172-rename-created-by-session-id.ts
@@ -1,0 +1,27 @@
+import { type DrizzleDb } from "../db-connection.js";
+
+/**
+ * Rename `created_by_session_id` to `source_conversation_id` in two tables,
+ * aligning with the broader session → conversation terminology unification.
+ *
+ * Each rename is wrapped in try/catch so re-running the migration is
+ * idempotent (SQLite throws if the source column does not exist).
+ */
+export function migrateRenameCreatedBySessionIdColumns(
+  database: DrizzleDb,
+): void {
+  try {
+    database.run(
+      `ALTER TABLE channel_verification_sessions RENAME COLUMN created_by_session_id TO source_conversation_id`,
+    );
+  } catch {
+    /* already renamed */
+  }
+  try {
+    database.run(
+      `ALTER TABLE assistant_ingress_invites RENAME COLUMN created_by_session_id TO source_conversation_id`,
+    );
+  } catch {
+    /* already renamed */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -113,6 +113,7 @@ export { migrateRenameSequenceStepsReplyKey } from "./168-rename-sequence-steps-
 export { migrateRenameGmailProviderKeyToGoogle } from "./169-rename-gmail-provider-key-to-google.js";
 export { migrateCreateThreadStartersTable } from "./170-thread-starters-table.js";
 export { migrateCapabilityCardColumns } from "./171-capability-card-columns.js";
+export { migrateRenameCreatedBySessionIdColumns } from "./172-rename-created-by-session-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -95,7 +95,7 @@ export const channelVerificationSessions = sqliteTable(
     challengeHash: text("challenge_hash").notNull(),
     expiresAt: integer("expires_at").notNull(),
     status: text("status").notNull().default("pending"),
-    createdByConversationId: text("created_by_session_id"),
+    sourceConversationId: text("source_conversation_id"),
     consumedByExternalUserId: text("consumed_by_external_user_id"),
     consumedByChatId: text("consumed_by_chat_id"),
     // Outbound session: expected-identity binding

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -69,7 +69,7 @@ export const assistantIngressInvites = sqliteTable(
     id: text("id").primaryKey(),
     sourceChannel: text("source_channel").notNull(),
     tokenHash: text("token_hash").notNull(),
-    createdByConversationId: text("created_by_session_id"),
+    sourceConversationId: text("source_conversation_id"),
     note: text("note"),
     maxUses: integer("max_uses").notNull().default(1),
     useCount: integer("use_count").notNull().default(0),

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -128,7 +128,7 @@ export function createInboundVerificationSession(
     channel,
     challengeHash,
     expiresAt,
-    createdByConversationId: conversationId,
+    sourceConversationId: conversationId,
   });
 
   const ttlSeconds = CHALLENGE_TTL_MS / 1000;


### PR DESCRIPTION
## Summary
- Adds migration 172 to rename `created_by_session_id` → `source_conversation_id` in `channel_verification_sessions` and `assistant_ingress_invites` tables
- Updates Drizzle schema mappings in `calls.ts` and `contacts.ts` to use `sourceConversationId` field name
- Renames all TypeScript references from `createdByConversationId` to `sourceConversationId` across 6 files

Part of plan: rename-created-by-session-col.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
