### PR TITLE
refactor: extract shared FileContentView from WorkspacePanel and AgentPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -490,45 +490,13 @@ struct AgentPanelContent: View {
 
     @ViewBuilder
     private func skillFileContentPane(file: SkillFileEntry, content: String) -> some View {
-        let modes = availableViewModes(for: file.path, mimeType: file.mimeType)
-        let effectiveMode = modes.contains(skillFileViewMode) ? skillFileViewMode : (modes.first ?? .source)
-
-        VStack(alignment: .leading, spacing: 0) {
-            // File header
-            FileContentHeaderBar(
-                icon: fileIcon(for: file.mimeType),
-                fileName: file.path,
-                fileSize: formatFileSize(file.size)
-            ) {
-                if modes.count > 1 {
-                    VSegmentedControl(
-                        items: modes.map { (label: viewModeLabel($0), tag: $0) },
-                        selection: $skillFileViewMode,
-                        style: .pill
-                    )
-                    .fixedSize()
-                }
-            }
-
-            Divider().background(VColor.borderBase)
-
-            // File content
-            switch effectiveMode {
-            case .source:
-                HighlightedTextView(
-                    text: .constant(content),
-                    language: SyntaxLanguage.detect(fileName: file.path, mimeType: file.mimeType),
-                    isEditable: false
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .preview:
-                MarkdownPreviewView(content: content)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            case .tree:
-                JSONTreeView(content: content)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
-        }
+        FileContentView(
+            fileName: file.path,
+            mimeType: file.mimeType,
+            fileSize: formatFileSize(file.size),
+            content: .constant(content),
+            viewMode: $skillFileViewMode
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
@@ -598,14 +566,6 @@ struct AgentPanelContent: View {
             .background(VColor.surfaceBase)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         }
-    }
-
-    private func fileIcon(for mimeType: String) -> VIcon {
-        if mimeType.hasPrefix("image/") { return .image }
-        if mimeType.hasPrefix("video/") { return .video }
-        if mimeType.hasPrefix("text/") { return .fileText }
-        if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
-        return .file
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -29,6 +29,78 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
     }
 }
 
+// MARK: - File Icon
+
+func fileIcon(for mimeType: String) -> VIcon {
+    if mimeType.hasPrefix("image/") { return .image }
+    if mimeType.hasPrefix("video/") { return .video }
+    if mimeType.hasPrefix("text/") { return .fileText }
+    if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+    return .file
+}
+
+// MARK: - File Content View
+
+struct FileContentView: View {
+    let fileName: String
+    let mimeType: String
+    let fileSize: String
+    @Binding var content: String
+    @Binding var viewMode: FileViewMode
+    var isEditable: Bool = false
+    var showReadOnlyBadge: Bool = false
+    var onTextChange: ((String) -> Void)? = nil
+
+    var body: some View {
+        let modes = availableViewModes(for: fileName, mimeType: mimeType)
+        let effectiveMode = modes.contains(viewMode) ? viewMode : (modes.first ?? .source)
+
+        VStack(alignment: .leading, spacing: 0) {
+            FileContentHeaderBar(
+                icon: fileIcon(for: mimeType),
+                fileName: fileName,
+                fileSize: fileSize
+            ) {
+                if modes.count > 1 {
+                    VSegmentedControl(
+                        items: modes.map { (label: viewModeLabel($0), tag: $0) },
+                        selection: $viewMode,
+                        style: .pill
+                    )
+                    .fixedSize()
+                }
+
+                if showReadOnlyBadge {
+                    Text("Read-only")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+            }
+
+            Divider().background(VColor.borderBase)
+
+            switch effectiveMode {
+            case .source:
+                HighlightedTextView(
+                    text: isEditable ? $content : .constant(content),
+                    language: SyntaxLanguage.detect(fileName: fileName, mimeType: mimeType),
+                    isEditable: isEditable,
+                    onTextChange: onTextChange
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .preview:
+                MarkdownPreviewView(content: content)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            case .tree:
+                JSONTreeView(content: content)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+        }
+    }
+}
+
+// MARK: - File Content Header Bar
+
 /// Header bar showing file icon, name, and size for file content viewers.
 struct FileContentHeaderBar<Trailing: View>: View {
     let icon: VIcon

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -713,41 +713,36 @@ private struct WorkspaceFileViewer: View {
         let readOnly = isText && isHiddenPath(detail.path)
 
         VStack(spacing: 0) {
-            FileContentHeaderBar(
-                icon: fileIcon(for: mime),
-                fileName: detail.name,
-                fileSize: formatFileSize(detail.size)
-            ) {
-                if isText {
-                    let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
-                    if modes.count > 1 {
-                        VSegmentedControl(
-                            items: modes.map { (label: viewModeLabel($0), tag: $0) },
-                            selection: $state.viewMode,
-                            style: .pill
-                        )
-                        .fixedSize()
-                    }
-                }
-
-                if isText && readOnly {
-                    Text("Read-only")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-            }
-            Divider().background(VColor.borderBase)
-
             if isText {
-                textViewer(detail, readOnly: readOnly)
-            } else if mime.hasPrefix("image/") {
-                imageViewer(detail)
-            } else if mime.hasPrefix("video/") {
-                videoViewer(detail)
-            } else if !detail.isBinary, detail.content == nil {
-                fileTooLarge(detail)
+                FileContentView(
+                    fileName: detail.name,
+                    mimeType: detail.mimeType,
+                    fileSize: formatFileSize(detail.size),
+                    content: $state.editableContent,
+                    viewMode: $state.viewMode,
+                    isEditable: !readOnly,
+                    showReadOnlyBadge: readOnly,
+                    onTextChange: { newValue in
+                        state.isDirty = newValue != state.originalContent
+                    }
+                )
             } else {
-                binaryFallback(detail)
+                FileContentHeaderBar(
+                    icon: fileIcon(for: mime),
+                    fileName: detail.name,
+                    fileSize: formatFileSize(detail.size)
+                )
+                Divider().background(VColor.borderBase)
+
+                if mime.hasPrefix("image/") {
+                    imageViewer(detail)
+                } else if mime.hasPrefix("video/") {
+                    videoViewer(detail)
+                } else if !detail.isBinary, detail.content == nil {
+                    fileTooLarge(detail)
+                } else {
+                    binaryFallback(detail)
+                }
             }
 
             if isText && !readOnly && state.isDirty {
@@ -774,64 +769,6 @@ private struct WorkspaceFileViewer: View {
                 .background(VColor.surfaceOverlay)
             }
         }
-    }
-
-    private func fileIcon(for mimeType: String) -> VIcon {
-        if mimeType.hasPrefix("image/") { return .image }
-        if mimeType.hasPrefix("video/") { return .video }
-        if mimeType.hasPrefix("text/") { return .fileText }
-        if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
-        return .file
-    }
-
-    @ViewBuilder
-    private func textViewer(_ detail: WorkspaceFileResponse, readOnly: Bool) -> some View {
-        let modes = availableViewModes(for: detail.name, mimeType: detail.mimeType)
-        let effectiveMode = modes.contains(state.viewMode) ? state.viewMode : (modes.first ?? .source)
-
-        switch effectiveMode {
-        case .source:
-            sourceView(detail)
-        case .preview:
-            previewView(detail)
-        case .tree:
-            treeView(detail)
-        }
-    }
-
-    private func sourceView(_ detail: WorkspaceFileResponse) -> some View {
-        let readOnly = isHiddenPath(detail.path)
-        let language = SyntaxLanguage.detect(fileName: detail.name, mimeType: detail.mimeType)
-        return Group {
-            if readOnly {
-                HighlightedTextView(
-                    text: .constant(detail.content ?? ""),
-                    language: language,
-                    isEditable: false
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                HighlightedTextView(
-                    text: $state.editableContent,
-                    language: language,
-                    isEditable: true,
-                    onTextChange: { newValue in
-                        state.isDirty = newValue != state.originalContent
-                    }
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        }
-    }
-
-    private func previewView(_ detail: WorkspaceFileResponse) -> some View {
-        MarkdownPreviewView(content: state.editableContent)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private func treeView(_ detail: WorkspaceFileResponse) -> some View {
-        JSONTreeView(content: state.editableContent)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private func saveFile(path: String) async {


### PR DESCRIPTION
## Summary
- Extract shared FileContentView component into SharedFileViewerComponents.swift that encapsulates header bar, view mode toggle, and source/preview/tree content switching
- Both WorkspacePanel and AgentPanel now use FileContentView, eliminating duplicated rendering logic
- Move duplicated fileIcon(for:) helper into SharedFileViewerComponents.swift

Part of plan: unify-file-viewer-source-highlight.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
