### PR TITLE
fix: add syntax highlighting to editable source view for JSON and other languages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -14,6 +14,7 @@ struct HighlightedTextView: View {
     @State private var isSearchVisible = false
     @State private var searchQuery = ""
     @State private var currentMatchIndex = 0
+    @State private var isActivelyEditing = false
 
     private static let editorBackground = VColor.surfaceOverlay
     private static let gutterBackground = VColor.surfaceBase
@@ -26,10 +27,23 @@ struct HighlightedTextView: View {
     }
 
     var body: some View {
-        if isEditable {
-            editableView
-        } else {
-            readOnlyView
+        Group {
+            if isEditable {
+                if isActivelyEditing {
+                    editableView
+                } else {
+                    readOnlyView
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            isActivelyEditing = true
+                        }
+                }
+            } else {
+                readOnlyView
+            }
+        }
+        .onChange(of: language) { _, _ in
+            isActivelyEditing = false
         }
     }
 
@@ -62,9 +76,15 @@ struct HighlightedTextView: View {
             return .handled
         }
         .onKeyPress(.escape) {
-            guard isSearchVisible else { return .ignored }
-            dismissSearch()
-            return .handled
+            if isSearchVisible {
+                dismissSearch()
+                return .handled
+            }
+            if isActivelyEditing {
+                isActivelyEditing = false
+                return .handled
+            }
+            return .ignored
         }
         .onChange(of: text) { _, _ in
             let count = searchMatchCount


### PR DESCRIPTION
## Summary
- Show syntax-highlighted read-only view by default for editable files instead of plain TextEditor
- Click to enter editing mode (switches to TextEditor), press Escape to return to highlighted view
- Switching files automatically resets back to syntax-highlighted view

Part of plan: unify-file-viewer-source-highlight.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
