### PR TITLE
fix: rename `source_session_id` column to `source_context_id` in notification_events

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -92,6 +92,7 @@ import {
   migrateRenameNotificationThreadColumns,
   migrateRenameSequenceEnrollmentsThreadIdColumn,
   migrateRenameSequenceStepsReplyKey,
+  migrateRenameSourceSessionIdColumn,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
@@ -435,6 +436,9 @@ export function initializeDb(): void {
 
   // 75. Rename created_by_session_id → source_conversation_id in verification sessions and invites
   migrateRenameCreatedBySessionIdColumns(database);
+
+  // 76. Rename source_session_id → source_context_id in notification_events
+  migrateRenameSourceSessionIdColumn(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/173-rename-source-session-id.ts
+++ b/assistant/src/memory/migrations/173-rename-source-session-id.ts
@@ -1,0 +1,16 @@
+import { type DrizzleDb } from "../db-connection.js";
+
+/**
+ * Rename `source_session_id` to `source_context_id` in the `notification_events`
+ * table, aligning with the field's actual polymorphic usage (it holds conversation
+ * IDs, call session IDs, schedule IDs, etc.).
+ */
+export function migrateRenameSourceSessionIdColumn(database: DrizzleDb): void {
+  try {
+    database.run(
+      `ALTER TABLE notification_events RENAME COLUMN source_session_id TO source_context_id`,
+    );
+  } catch {
+    /* already renamed */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -114,6 +114,7 @@ export { migrateRenameGmailProviderKeyToGoogle } from "./169-rename-gmail-provid
 export { migrateCreateThreadStartersTable } from "./170-thread-starters-table.js";
 export { migrateCapabilityCardColumns } from "./171-capability-card-columns.js";
 export { migrateRenameCreatedBySessionIdColumns } from "./172-rename-created-by-session-id.js";
+export { migrateRenameSourceSessionIdColumn } from "./173-rename-source-session-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/notifications.ts
+++ b/assistant/src/memory/schema/notifications.ts
@@ -13,7 +13,7 @@ export const notificationEvents = sqliteTable("notification_events", {
   id: text("id").primaryKey(),
   sourceEventName: text("source_event_name").notNull(),
   sourceChannel: text("source_channel").notNull(),
-  sourceSessionId: text("source_session_id").notNull(),
+  sourceSessionId: text("source_context_id").notNull(),
   attentionHintsJson: text("attention_hints_json").notNull().default("{}"),
   payloadJson: text("payload_json").notNull().default("{}"),
   dedupeKey: text("dedupe_key"),


### PR DESCRIPTION
## Summary
- Adds migration 173 to rename `source_session_id` → `source_context_id` in the `notification_events` table
- Updates Drizzle schema column mapping to `source_context_id` while keeping TS field name unchanged
- Migration is idempotent via try/catch

Part of plan: rename-source-session-id.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
