### PR TITLE
fix: reset editing state when switching between same-language files

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -87,6 +87,7 @@ struct FileContentView: View {
                     isEditable: isEditable,
                     onTextChange: onTextChange
                 )
+                .id(fileName)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .preview:
                 MarkdownPreviewView(content: content)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewer-source-highlight.md.

**Gap:** isActivelyEditing state persists when switching between files of the same language
**What was expected:** Switching files resets back to syntax-highlighted view
**What was found:** HighlightedTextView only resets isActivelyEditing on onChange(of: language), so switching between two .json files keeps the plain TextEditor

**Fix:** Added `.id(fileName)` modifier to `HighlightedTextView` in `FileContentView` so SwiftUI recreates the view instance when the file changes, resetting all `@State` properties including `isActivelyEditing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
