### PR TITLE
fix: remove duplicate fileIcon(for:) from SkillFileTreeView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -79,12 +79,4 @@ struct SkillFileTreeView: View {
         }
     }
 
-    private func fileIcon(for mimeType: String) -> VIcon {
-        if mimeType.hasPrefix("image/") { return .image }
-        if mimeType.hasPrefix("video/") { return .video }
-        if mimeType.hasPrefix("text/") { return .fileText }
-        if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
-        return .file
-    }
-
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-file-viewer-source-highlight.md.

**Gap:** fileIcon(for:) still duplicated in SkillFileTreeView.swift
**What was expected:** fileIcon(for:) exists once in SharedFileViewerComponents.swift
**What was found:** SkillFileTreeView.swift contains an identical private copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
