### PR TITLE
refactor: remove JSON tree view in favor of syntax-highlighted source

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -15,9 +15,6 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
     if ext == "md" || ext == "markdown" || mime == "text/markdown" {
         return [.preview, .source]
     }
-    if ext == "json" || mime == "application/json" {
-        return [.tree, .source]
-    }
     return [.source]
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -48,8 +48,6 @@ final class WorkspaceBrowserState {
         let ext = (targetPath as NSString).pathExtension.lowercased()
         if ext == "md" || ext == "markdown" {
             viewMode = .preview
-        } else if ext == "json" {
-            viewMode = .tree
         } else {
             viewMode = .source
         }


### PR DESCRIPTION
## Summary
- Remove the Preview/Source toggle and JSON tree view for `.json` files
- JSON files now show only the syntax-highlighted source view with no toggle
- Simplifies `availableViewModes()` by removing the JSON branch and removes the `viewMode = .tree` auto-select in WorkspacePanel's `loadFile`

## Original prompt
Remove Preview/Source toggle and JSON tree view for .json files. JSON files should only show the syntax-highlighted source view with no toggle, no tree mode. Simplify the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
