### PR TITLE
feat: improve Inference card — inline toggle, login prompt, simplify reset

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 ///
 /// Shows different content based on mode and auth state:
 /// - **Managed + logged in**: Model picker, Save button
-/// - **Managed + not logged in**: "Log in to select" tooltip on Managed segment, falls back to Your Own content
+/// - **Managed + not logged in**: Empty state prompting login
 /// - **Your Own**: API key field, model picker, Save + Reset buttons
 @MainActor
 struct InferenceServiceCard: View {
@@ -17,8 +17,6 @@ struct InferenceServiceCard: View {
     @State private var draftMode: String = "your-own"
     /// Snapshot of the model at card appear — used to detect model-only changes.
     @State private var initialModel: String = ""
-    /// Whether the Managed segment is being hovered (for tooltip).
-    @State private var isManagedHovered: Bool = false
 
     private var isConnected: Bool {
         store.hasKey
@@ -26,11 +24,6 @@ struct InferenceServiceCard: View {
 
     private var isLoggedIn: Bool {
         authManager.isAuthenticated
-    }
-
-    /// Whether managed mode is available to select (requires login).
-    private var isManagedAvailable: Bool {
-        isLoggedIn
     }
 
     /// True when the user has made changes worth saving.
@@ -43,11 +36,8 @@ struct InferenceServiceCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            // Header: title + subtitle
+            // Header: title + subtitle + mode toggle
             header
-
-            // Integration Mode segmented control
-            modeSelector
 
             Divider()
                 .background(VColor.borderBase)
@@ -67,22 +57,11 @@ struct InferenceServiceCard: View {
         .vCard(background: VColor.surfaceOverlay)
         .onAppear {
             draftMode = store.inferenceMode
-            if draftMode == "managed" && !authManager.isAuthenticated {
-                draftMode = "your-own"
-            }
             initialModel = store.selectedModel
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
-            if draftMode == "managed" && !authManager.isAuthenticated {
-                draftMode = "your-own"
-            }
-        }
-        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            if !isAuthenticated && draftMode == "managed" {
-                draftMode = "your-own"
-            }
         }
     }
 
@@ -90,25 +69,11 @@ struct InferenceServiceCard: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text("Inference")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.contentDefault)
-            Text("Configure which LLM provider and model to use to power your assistant")
-                .font(VFont.sectionDescription)
-                .foregroundColor(VColor.contentTertiary)
-        }
-    }
-
-    // MARK: - Mode Selector
-
-    private var modeSelector: some View {
-        HStack {
-            Text("Integration Mode")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentTertiary)
-            Spacer()
-
-            if isManagedAvailable {
+            HStack {
+                Text("Inference")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.contentDefault)
+                Spacer()
                 VSegmentedControl(
                     items: [
                         (label: "Managed", tag: "managed"),
@@ -118,40 +83,45 @@ struct InferenceServiceCard: View {
                     style: .pill
                 )
                 .frame(width: 220)
-            } else {
-                // Not logged in — show segmented control with Managed disabled + tooltip
-                ZStack(alignment: .leading) {
-                    VSegmentedControl(
-                        items: [
-                            (label: "Managed", tag: "managed"),
-                            (label: "Your Own", tag: "your-own"),
-                        ],
-                        selection: .constant("your-own"),
-                        style: .pill
-                    )
-
-                    // Invisible hover target over the "Managed" half
-                    Color.clear
-                        .frame(width: 110, height: 36)
-                        .contentShape(Rectangle())
-                        .onHover { isManagedHovered = $0 }
-                        .popover(isPresented: $isManagedHovered, arrowEdge: .top) {
-                            Text("Log in to select")
-                                .font(VFont.captionMedium)
-                                .foregroundColor(VColor.contentInset)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, VSpacing.xs)
-                        }
-                }
-                .frame(width: 220)
             }
+            Text("Configure which LLM provider and model to use to power your assistant")
+                .font(VFont.sectionDescription)
+                .foregroundColor(VColor.contentTertiary)
         }
     }
 
     // MARK: - Managed Content
 
     private var managedContent: some View {
-        modelPicker
+        Group {
+            if isLoggedIn {
+                modelPicker
+            } else {
+                managedLoginPrompt
+            }
+        }
+    }
+
+    // MARK: - Managed Login Prompt
+
+    private var managedLoginPrompt: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("In order to use the managed inference service, you must be logged in to Vellum.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
+            VButton(
+                label: authManager.isSubmitting ? "Logging in..." : "Log In",
+                style: .primary,
+                isDisabled: authManager.isSubmitting
+            ) {
+                Task {
+                    await authManager.startWorkOSLogin()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
     }
 
     // MARK: - Your Own Content
@@ -204,13 +174,17 @@ struct InferenceServiceCard: View {
 
     private var actionButtons: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: "Save", style: .primary, isDisabled: !hasChanges) {
-                save()
-            }
-            if draftMode == "your-own" && isConnected {
-                VButton(label: "Reset (disconnect)", style: .danger) {
-                    store.clearAPIKey()
-                    apiKeyText = ""
+            if draftMode == "managed" && !isLoggedIn {
+                EmptyView()
+            } else {
+                VButton(label: "Save", style: .primary, isDisabled: !hasChanges) {
+                    save()
+                }
+                if draftMode == "your-own" && isConnected {
+                    VButton(label: "Reset", style: .danger) {
+                        store.clearAPIKey()
+                        apiKeyText = ""
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Move the Managed/Your Own segmented control into the header row alongside the "Inference" title, removing the separate "Integration Mode" label
- Allow clicking "Managed" when not logged in — shows an empty state with "In order to use the managed inference service, you must be logged in to Vellum." and a green "Log In" button
- Change "Reset (disconnect)" button copy to just "Reset"

## Original prompt
1. Lets change the button copy from "Reset (disconnect)" to just "Reset"
2. When you are not logged in, you should still be able to click the "Managed" toggle. You should see an empty state that says "In order to used the managed inference service, you must be logged in to Vellum." and there should be a "Log In" green button that you can click on as a shortcut to log in
3. Lets remove "Integration Mode" and move the Managed/Your Own toggle into the same line/row as the "Inference" header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
