### PR TITLE
style: use compact pill size for file viewer mode toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -62,7 +62,8 @@ struct FileContentView: View {
                     VSegmentedControl(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
                         selection: $viewMode,
-                        style: .pill
+                        style: .pill,
+                        size: .compact
                     )
                     .fixedSize()
                 }


### PR DESCRIPTION
## Summary
- Switch the file viewer's VSegmentedControl from regular (32pt) to compact (24pt) size for a more proportional look in the 36pt header bar
- Reduces visual weight so the toggle doesn't dominate the header

## Original prompt
Switch the file viewer's VSegmentedControl from `.pill` / `.regular` (default) to `.pill` / `.compact` for a more proportional look in the 36pt header bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
