### PR TITLE
refactor: unify auth copy to "Log in / Log out" consistently

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -249,7 +249,7 @@ extension AppDelegate {
 
                 AvatarAppearanceManager.shared.reloadAvatar()
                 mainWindow?.windowState.showToast(
-                    message: "Signed out. You can sign in again from Settings.",
+                    message: "Logged out. You can log in again from Settings.",
                     style: .success
                 )
             } else {
@@ -392,7 +392,7 @@ extension AppDelegate {
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
                 self.mainWindow?.windowState.showToast(
-                    message: "Failed to set up Vellum credentials. You may need to sign out and sign in again.",
+                    message: "Failed to set up Vellum credentials. You may need to log out and log in again.",
                     style: .error
                 )
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -73,7 +73,7 @@ struct DrawerMenuView: View {
                 if authManager.isAuthenticated {
                     SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
                 } else {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Sign In"), action: onSignIn)
+                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -39,7 +39,7 @@ struct ReauthView: View {
                 .foregroundColor(VColor.contentDefault)
                 .padding(.bottom, VSpacing.xs)
 
-            Text("Sign in to continue.")
+            Text("Log in to continue.")
                 .font(.system(size: 16))
                 .foregroundColor(VColor.contentSecondary)
                 .padding(.bottom, VSpacing.xxl)
@@ -60,18 +60,18 @@ struct ReauthView: View {
                         ProgressView()
                             .controlSize(.small)
                             .progressViewStyle(.circular)
-                        Text("Signing in...")
+                        Text("Logging in...")
                             .font(VFont.monoMedium)
                             .foregroundColor(VColor.contentSecondary)
                     }
                     .frame(height: 36)
                 } else {
-                    OnboardingButton(title: "Sign In", style: .primary) {
+                    OnboardingButton(title: "Log In", style: .primary) {
                         Task {
                             await authManager.startWorkOSLogin()
                         }
                     }
-                    .accessibilityLabel("Sign In")
+                    .accessibilityLabel("Log In")
                 }
 
                 if let error = authManager.errorMessage {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -71,7 +71,7 @@ struct WakeUpStepView: View {
                     ProgressView()
                         .controlSize(.small)
                         .progressViewStyle(.circular)
-                    Text("Signing in...")
+                    Text("Logging in...")
                         .font(VFont.monoMedium)
                         .foregroundColor(VColor.contentSecondary)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// General settings tab — account/platform sign-in card followed by appearance settings.
+/// General settings tab — account/platform login card followed by appearance settings.
 @MainActor
 struct SettingsGeneralTab: View {
     @ObservedObject var store: SettingsStore
@@ -77,7 +77,7 @@ struct SettingsGeneralTab: View {
     // MARK: - Account Section
 
     private var accountSection: some View {
-        SettingsCard(title: "Account", subtitle: "Sign in to Your Account") {
+        SettingsCard(title: "Account", subtitle: "Log in to your account") {
             if authManager.isLoading {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
@@ -92,7 +92,7 @@ struct SettingsGeneralTab: View {
                 }
             } else {
                 VButton(
-                    label: authManager.isSubmitting ? "Signing in..." : "Sign In",
+                    label: authManager.isSubmitting ? "Logging in..." : "Log In",
                     style: .primary,
                     isDisabled: authManager.isSubmitting
                 ) {


### PR DESCRIPTION
## Summary
- Standardize all user-facing authentication copy to use "Log in / Log out" instead of a mix of "Sign in / Sign out" and "Log in / Log out"
- Updates 5 files across settings, onboarding, sidebar menu, and toast messages
- Changes: "Sign In" → "Log In", "Signing in..." → "Logging in...", "Sign in to continue" → "Log in to continue", "Signed out" → "Logged out", "sign out and sign in" → "log out and log in"

## Original prompt
We have a mix of user-facing copy between log in, log out, sign in, sign out. Can you help me decide which to unify around and then do so

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
