### PR TITLE
style: remove file size from header bar and tighten padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -493,7 +493,6 @@ struct AgentPanelContent: View {
         FileContentView(
             fileName: file.path,
             mimeType: file.mimeType,
-            fileSize: formatFileSize(file.size),
             content: .constant(content),
             viewMode: $skillFileViewMode
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -41,7 +41,6 @@ func fileIcon(for mimeType: String) -> VIcon {
 struct FileContentView: View {
     let fileName: String
     let mimeType: String
-    let fileSize: String
     @Binding var content: String
     @Binding var viewMode: FileViewMode
     var isEditable: Bool = false
@@ -55,8 +54,7 @@ struct FileContentView: View {
         VStack(alignment: .leading, spacing: 0) {
             FileContentHeaderBar(
                 icon: fileIcon(for: mimeType),
-                fileName: fileName,
-                fileSize: fileSize
+                fileName: fileName
             ) {
                 if modes.count > 1 {
                     VSegmentedControl(
@@ -100,17 +98,15 @@ struct FileContentView: View {
 
 // MARK: - File Content Header Bar
 
-/// Header bar showing file icon, name, and size for file content viewers.
+/// Header bar showing file icon and name for file content viewers.
 struct FileContentHeaderBar<Trailing: View>: View {
     let icon: VIcon
     let fileName: String
-    let fileSize: String
     let trailing: Trailing
 
-    init(icon: VIcon, fileName: String, fileSize: String, @ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
+    init(icon: VIcon, fileName: String, @ViewBuilder trailing: () -> Trailing = { EmptyView() }) {
         self.icon = icon
         self.fileName = fileName
-        self.fileSize = fileSize
         self.trailing = trailing()
     }
 
@@ -124,13 +120,9 @@ struct FileContentHeaderBar<Trailing: View>: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
             Spacer()
-            Text(fileSize)
-                .font(VFont.small)
-                .foregroundColor(VColor.contentTertiary)
-                .fixedSize()
             trailing
         }
-        .padding(.horizontal, VSpacing.md)
+        .padding(.horizontal, VSpacing.sm)
         .frame(height: 36)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -715,7 +715,6 @@ private struct WorkspaceFileViewer: View {
                 FileContentView(
                     fileName: detail.name,
                     mimeType: detail.mimeType,
-                    fileSize: formatFileSize(detail.size),
                     content: $state.editableContent,
                     viewMode: $state.viewMode,
                     isEditable: !readOnly,
@@ -727,8 +726,7 @@ private struct WorkspaceFileViewer: View {
             } else {
                 FileContentHeaderBar(
                     icon: fileIcon(for: mime),
-                    fileName: detail.name,
-                    fileSize: formatFileSize(detail.size)
+                    fileName: detail.name
                 )
                 Divider().background(VColor.borderBase)
 


### PR DESCRIPTION
## Summary
- Remove file size display from the file content header bar in both WorkspacePanel and AgentPanel
- Reduce horizontal padding from `VSpacing.md` (12pt) to `VSpacing.sm` (8pt) for better visual balance with surrounding spacing

## Original prompt
Two improvements to the file viewer header bar:
1. Remove file size from the header bar entirely
2. Reduce right padding to be more equal to the padding above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
