### PR TITLE
docs: fix stale `sessionId` references in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ GET /v1/events?conversationKey=<key>
 ```
 event: assistant_event
 id: <uuid>
-data: {"id":"...","assistantId":"self","sessionId":"conv_xxx","emittedAt":"2026-02-21T12:00:00.000Z","message":{...}}
+data: {"id":"...","assistantId":"self","conversationId":"conv_xxx","emittedAt":"2026-02-21T12:00:00.000Z","message":{...}}
 
 ```
 
@@ -491,11 +491,11 @@ Each `data` field is a JSON-serialized `AssistantEvent`:
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "assistantId": "self",
-  "sessionId": "conv_abc123",
+  "conversationId": "conv_abc123",
   "emittedAt": "2026-02-21T12:00:00.000Z",
   "message": {
     "type": "assistant_text_delta",
-    "sessionId": "conv_abc123",
+    "conversationId": "conv_abc123",
     "text": "Working on it..."
   }
 }

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -77,17 +77,17 @@ bun run src/index.ts                # interactive CLI session
 
 ### CLI commands
 
-| Command                                       | Description                                      |
-| --------------------------------------------- | ------------------------------------------------ |
-| `vellum wake`                                 | Start assistant + gateway from current checkout  |
-| `vellum sleep`                                | Stop assistant + gateway processes               |
-| `vellum ps`                                   | List assistants and per-assistant process status |
-| `assistant`                                   | Launch interactive CLI session                   |
-| `assistant sessions list\|new\|export\|clear` | Manage conversation sessions                     |
-| `assistant config set\|get\|list`             | Manage configuration                             |
-| `assistant keys set\|list\|delete`            | Manage API keys in secure storage                |
-| `assistant trust list\|remove\|clear`         | Manage trust rules                               |
-| `assistant doctor`                            | Run diagnostic checks                            |
+| Command                                            | Description                                      |
+| -------------------------------------------------- | ------------------------------------------------ |
+| `vellum wake`                                      | Start assistant + gateway from current checkout  |
+| `vellum sleep`                                     | Stop assistant + gateway processes               |
+| `vellum ps`                                        | List assistants and per-assistant process status |
+| `assistant`                                        | Launch interactive CLI session                   |
+| `assistant conversations list\|new\|export\|clear` | Manage conversations                             |
+| `assistant config set\|get\|list`                  | Manage configuration                             |
+| `assistant keys set\|list\|delete`                 | Manage API keys in secure storage                |
+| `assistant trust list\|remove\|clear`              | Manage trust rules                               |
+| `assistant doctor`                                 | Run diagnostic checks                            |
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Updates 3 SSE event payload examples in root README from `sessionId` to `conversationId`
- Fixes CLI command reference in assistant/README.md from `sessions` to `conversations`
- Aligns documentation with the actual codebase after the thread→conversation rename

Part of plan: rename-remaining-thread-session.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
