### PR TITLE
fix: rename `daemon.session.created` event to `daemon.conversation.created`

### DIFF
--- a/assistant/src/__tests__/event-bus.test.ts
+++ b/assistant/src/__tests__/event-bus.test.ts
@@ -33,18 +33,18 @@ describe("EventBus", () => {
 
     bus.onAny((event) => {
       seenType = event.type;
-      if (event.type === "daemon.session.created") {
+      if (event.type === "daemon.conversation.created") {
         seenConversationId = event.payload.conversationId;
       }
       expect(typeof event.emittedAtMs).toBe("number");
     });
 
-    await bus.emit("daemon.session.created", {
+    await bus.emit("daemon.conversation.created", {
       conversationId: "conv-2",
       createdAtMs: Date.now(),
     });
 
-    expect(seenType).toBe("daemon.session.created");
+    expect(seenType).toBe("daemon.conversation.created");
     expect(seenConversationId).toBe("conv-2");
   });
 

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -70,7 +70,7 @@ export interface DaemonDomainEvents {
   "daemon.lifecycle.stopped": {
     stoppedAtMs: number;
   };
-  "daemon.session.created": {
+  "daemon.conversation.created": {
     conversationId: string;
     createdAtMs: number;
   };


### PR DESCRIPTION
## Summary
- Renames `daemon.session.created` event key to `daemon.conversation.created` in domain-events.ts
- Updates all 3 references in event-bus.test.ts
- Now consistent with sibling `daemon.conversation.evicted` event

Part of plan: rename-remaining-thread-session.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
