### PR TITLE
fix: usage dashboard live-refreshes on new LLM calls

### DIFF
--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -15,8 +15,11 @@ struct UsageDashboardView: View {
                 .navigationTitle("Usage & Cost")
                 .navigationBarTitleDisplayMode(.inline)
                 .task {
+                    await store.refresh()
+                }
+                .onChange(of: store.needsRefresh) {
                     if store.needsRefresh {
-                        await store.refresh()
+                        Task { await store.refresh() }
                     }
                 }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -290,6 +290,11 @@ public final class MainWindow {
                 self?.traceStore.ingest(msg)
             }
         }
+        services.daemonClient.onUsageUpdate = { [weak self] _ in
+            Task { @MainActor in
+                self?.usageDashboardStore.reset()
+            }
+        }
         observeDaemonReconnects()
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -16,7 +16,13 @@ struct UsageDashboardPanel: View {
         }
         .onAppear {
             refreshTask = Task {
-                if store.needsRefresh {
+                await store.refresh()
+            }
+        }
+        .onChange(of: store.needsRefresh) {
+            if store.needsRefresh {
+                refreshTask?.cancel()
+                refreshTask = Task {
                     await store.refresh()
                 }
             }

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -392,6 +392,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `trace_event` message.
     public var onTraceEvent: ((TraceEventMessage) -> Void)?
 
+    /// Called when the daemon sends a `usage_update` message.
+    public var onUsageUpdate: ((UsageUpdate) -> Void)?
+
     /// Called when the daemon sends an `apps_list_response` message.
     public var onAppsListResponse: ((AppsListResponseMessage) -> Void)?
 

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -171,6 +171,8 @@ extension DaemonClient {
             latestMemoryStatus = msg
         case .traceEvent(let msg):
             onTraceEvent?(msg)
+        case .usageUpdate(let msg):
+            onUsageUpdate?(msg)
         case .error(let msg):
             onError?(msg)
         #if os(macOS)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2209,6 +2209,7 @@ public enum ServerMessage: Decodable, Sendable {
     case hostBashRequest(HostBashRequest)
     case hostFileRequest(HostFileRequest)
     case hostCuRequest(HostCuRequest)
+    case usageUpdate(UsageUpdate)
     case pong
     case unknown(String)
 
@@ -2632,6 +2633,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_cu_request":
             let message = try HostCuRequest(from: decoder)
             self = .hostCuRequest(message)
+        case "usage_update":
+            let message = try UsageUpdate(from: decoder)
+            self = .usageUpdate(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Wire up the `usage_update` SSE event that the daemon already emits but the client was silently dropping as `unknown`
- Reset the `UsageDashboardStore` on each `usage_update` so the panel re-fetches while visible
- Always refresh on panel appear instead of only when state is `.idle`/`.failed`

Previously the Usage Dashboard showed stale cost data ($0.13 from the first message) even after multiple subsequent messages drove the actual cost to $0.42+.

## Test plan
- [x] macOS build passes (`./build.sh`)
- [x] Existing tests pass (pre-existing `panelRendersWithEmptyLoadedData` failure confirmed unrelated)
- [ ] Open Usage Dashboard, send a message, verify cost updates without navigating away
- [ ] Close and reopen Usage Dashboard, verify it shows fresh data


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
