### PR TITLE
fix: rename `thread_starters` table to `conversation_starters`

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -93,6 +93,7 @@ import {
   migrateRenameSequenceEnrollmentsThreadIdColumn,
   migrateRenameSequenceStepsReplyKey,
   migrateRenameSourceSessionIdColumn,
+  migrateRenameThreadStartersTable,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
@@ -439,6 +440,9 @@ export function initializeDb(): void {
 
   // 76. Rename source_session_id → source_context_id in notification_events
   migrateRenameSourceSessionIdColumn(database);
+
+  // 77. Rename thread_starters → conversation_starters table and indexes
+  migrateRenameThreadStartersTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -1,0 +1,45 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Rename `thread_starters` table to `conversation_starters` and recreate
+ * indexes with new names, aligning with the thread → conversation
+ * terminology unification.
+ */
+export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_thread_starters_table_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      // Check the old table exists before attempting anything
+      const oldTableExists = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'thread_starters'`,
+        )
+        .get();
+      if (!oldTableExists) return;
+
+      // Rename the physical table
+      raw.exec(
+        /*sql*/ `ALTER TABLE thread_starters RENAME TO conversation_starters`,
+      );
+
+      // Drop old indexes and recreate with new names.
+      // SQLite automatically updates index table references on RENAME, but the
+      // index names still reference the old naming convention — drop and recreate
+      // with consistent names pointing at the new table.
+
+      raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_thread_starters_batch`);
+      raw.exec(
+        /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_batch ON conversation_starters(generation_batch, created_at)`,
+      );
+
+      raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_thread_starters_card_type`);
+      raw.exec(
+        /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
+      );
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -115,6 +115,7 @@ export { migrateCreateThreadStartersTable } from "./170-thread-starters-table.js
 export { migrateCapabilityCardColumns } from "./171-capability-card-columns.js";
 export { migrateRenameCreatedBySessionIdColumns } from "./172-rename-created-by-session-id.js";
 export { migrateRenameSourceSessionIdColumn } from "./173-rename-source-session-id.js";
+export { migrateRenameThreadStartersTable } from "./174-rename-thread-starters-table.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -215,6 +215,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections",
   },
+  {
+    key: "migration_rename_thread_starters_table_v1",
+    version: 32,
+    description:
+      "Rename thread_starters table to conversation_starters and recreate indexes with new names",
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -151,7 +151,7 @@ export const memoryCheckpoints = sqliteTable("memory_checkpoints", {
 });
 
 export const threadStarters = sqliteTable(
-  "thread_starters",
+  "conversation_starters",
   {
     id: text("id").primaryKey(),
     label: text("label").notNull(),
@@ -167,11 +167,14 @@ export const threadStarters = sqliteTable(
     createdAt: integer("created_at").notNull(),
   },
   (table) => [
-    index("idx_thread_starters_batch").on(
+    index("idx_conversation_starters_batch").on(
       table.generationBatch,
       table.createdAt,
     ),
-    index("idx_thread_starters_card_type").on(table.cardType, table.scopeId),
+    index("idx_conversation_starters_card_type").on(
+      table.cardType,
+      table.scopeId,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Adds migration 174 to rename `thread_starters` table to `conversation_starters` with index recreation
- Updates Drizzle schema table/index strings to match the new names
- TS export name `threadStarters` is unchanged (renamed in a later PR)

Part of plan: rename-remaining-thread-session.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
