### PR TITLE
refactor: rename thread starters to conversation starters in backend internals

### DIFF
--- a/assistant/src/memory/conversation-starters-cadence.ts
+++ b/assistant/src/memory/conversation-starters-cadence.ts
@@ -1,5 +1,5 @@
 /**
- * Cadence logic for thread starters and capability cards generation.
+ * Cadence logic for conversation starters and capability cards generation.
  *
  * Decides whether new generation jobs should be enqueued based on how many
  * active memory items have accumulated since the last generation.
@@ -14,13 +14,13 @@ import { enqueueMemoryJob } from "./jobs-store.js";
 import { rawGet } from "./raw-query.js";
 import { memoryCheckpoints, memoryJobs } from "./schema.js";
 
-const log = getLogger("thread-starters-cadence");
+const log = getLogger("conversation-starters-cadence");
 
 /**
  * Check whether enough new memory items have accumulated to justify
- * generating a fresh batch of thread starters and capability cards.
+ * generating a fresh batch of conversation starters and capability cards.
  */
-export function maybeEnqueueThreadStartersJob(scopeId: string): void {
+export function maybeEnqueueConversationStartersJob(scopeId: string): void {
   const db = getDb();
 
   // Count total active memory items
@@ -32,7 +32,7 @@ export function maybeEnqueueThreadStartersJob(scopeId: string): void {
   if (totalActive === 0) return;
 
   // Read checkpoint: item count at last generation (scoped so each scope tracks independently)
-  const checkpointKey = `thread_starters:item_count_at_last_gen:${scopeId}`;
+  const checkpointKey = `conversation_starters:item_count_at_last_gen:${scopeId}`;
   const checkpoint = db
     .select({ value: memoryCheckpoints.value })
     .from(memoryCheckpoints)
@@ -59,7 +59,7 @@ export function maybeEnqueueThreadStartersJob(scopeId: string): void {
     .from(memoryJobs)
     .where(
       and(
-        eq(memoryJobs.type, "generate_thread_starters"),
+        eq(memoryJobs.type, "generate_conversation_starters"),
         inArray(memoryJobs.status, ["pending", "running"]),
         like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
       ),
@@ -67,10 +67,10 @@ export function maybeEnqueueThreadStartersJob(scopeId: string): void {
     .get();
   if (existing) return;
 
-  enqueueMemoryJob("generate_thread_starters", { scopeId });
+  enqueueMemoryJob("generate_conversation_starters", { scopeId });
   log.info(
     { totalActive, lastCount, delta, threshold, scopeId },
-    "Enqueued thread starters generation job",
+    "Enqueued conversation starters generation job",
   );
 
   // Also enqueue capability card regeneration for all categories

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -429,7 +429,7 @@ export function initializeDb(): void {
   // 72. Rename integration:gmail → integration:google across OAuth tables
   migrateRenameGmailProviderKeyToGoogle(database);
 
-  // 73. Create thread_starters table for personalized empty-thread suggestions
+  // 73. Create conversation_starters table for personalized empty-conversation suggestions
   migrateCreateThreadStartersTable(database);
 
   // 74. Add capability card columns to thread_starters + category relevance table

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -12,6 +12,7 @@ import {
 } from "../providers/provider-send-message.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
+import { maybeEnqueueConversationStartersJob } from "./conversation-starters-cadence.js";
 import { getDb } from "./db.js";
 import { computeMemoryFingerprint } from "./fingerprint.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
@@ -20,7 +21,6 @@ import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
 import { getQdrantClient } from "./qdrant-client.js";
 import { memoryItems, memoryItemSources, messages } from "./schema.js";
 import { isConversationFailed } from "./task-memory-cleanup.js";
-import { maybeEnqueueThreadStartersJob } from "./thread-starters-cadence.js";
 import { clampUnitInterval } from "./validation.js";
 
 const log = getLogger("memory-items-extractor");
@@ -715,14 +715,14 @@ export async function extractAndUpsertMemoryItemsForMessage(
     "Extracted memory items from message",
   );
 
-  // Trigger thread starters generation when new items are upserted
+  // Trigger conversation starters generation when new items are upserted
   if (upserted > 0) {
     try {
-      maybeEnqueueThreadStartersJob(effectiveScopeId);
+      maybeEnqueueConversationStartersJob(effectiveScopeId);
     } catch (err) {
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
-        "Failed to check thread starters cadence",
+        "Failed to check conversation starters cadence",
       );
     }
   }

--- a/assistant/src/memory/job-handlers/capability-cards.ts
+++ b/assistant/src/memory/job-handlers/capability-cards.ts
@@ -22,10 +22,13 @@ import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
 import {
   capabilityCardCategories,
+  conversationStarters,
   memoryCheckpoints,
-  threadStarters,
 } from "../schema.js";
-import { buildMemoryRollup, buildSkillsSummary } from "./thread-starters.js";
+import {
+  buildMemoryRollup,
+  buildSkillsSummary,
+} from "./conversation-starters.js";
 
 const log = getLogger("capability-cards-gen");
 
@@ -162,7 +165,7 @@ async function generateCardsForCategory(
     "lucide-briefcase",
   ];
 
-  const systemPrompt = `You are generating capability cards for a personal AI assistant's new thread page. These cards showcase what the assistant can do, personalized to the user's context.
+  const systemPrompt = `You are generating capability cards for a personal AI assistant's new conversation page. These cards showcase what the assistant can do, personalized to the user's context.
 
 You are generating cards for the "${category}" category: ${CATEGORY_DESCRIPTIONS[category]}.
 
@@ -364,19 +367,19 @@ export async function generateCapabilityCardsJob(
     .run();
 
   // Delete old cards for this category+scope, then insert new ones
-  db.delete(threadStarters)
+  db.delete(conversationStarters)
     .where(
       and(
-        eq(threadStarters.scopeId, scopeId),
-        eq(threadStarters.category, category),
-        eq(threadStarters.cardType, "card"),
+        eq(conversationStarters.scopeId, scopeId),
+        eq(conversationStarters.category, category),
+        eq(conversationStarters.cardType, "card"),
       ),
     )
     .run();
 
   // Insert new cards
   for (const card of result.cards) {
-    db.insert(threadStarters)
+    db.insert(conversationStarters)
       .values({
         id: uuid(),
         label: card.title,

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -1,8 +1,8 @@
 /**
- * Job handler for generating thread starters.
+ * Job handler for generating conversation starters.
  *
  * Crosses user memory items with the skill catalog to produce personalized
- * suggestion chips shown on the empty thread page.
+ * suggestion chips shown on the empty conversation page.
  */
 
 import { and, desc, eq } from "drizzle-orm";
@@ -21,17 +21,17 @@ import { getDb } from "../db.js";
 import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
 import { rawAll, rawGet } from "../raw-query.js";
-import { memoryCheckpoints, memoryItems, threadStarters } from "../schema.js";
+import { conversationStarters, memoryCheckpoints, memoryItems } from "../schema.js";
 
-const log = getLogger("thread-starters-gen");
+const log = getLogger("conversation-starters-gen");
 
 function checkpointKey(base: string, scopeId: string): string {
   return `${base}:${scopeId}`;
 }
 
-const CK_ITEM_COUNT = "thread_starters:item_count_at_last_gen";
-const CK_BATCH = "thread_starters:generation_batch";
-const CK_LAST_GEN_AT = "thread_starters:last_gen_at";
+const CK_ITEM_COUNT = "conversation_starters:item_count_at_last_gen";
+const CK_BATCH = "conversation_starters:generation_batch";
+const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
 
 // ── Rollup construction ───────────────────────────────────────────
 
@@ -126,7 +126,7 @@ export function buildSkillsSummary(): string {
 // ── LLM generation ────────────────────────────────────────────────
 
 /** Capability categories matching the Intelligence page taxonomy. */
-export const THREAD_STARTER_CATEGORIES = [
+export const CONVERSATION_STARTER_CATEGORIES = [
   "communication",
   "productivity",
   "development",
@@ -137,7 +137,7 @@ export const THREAD_STARTER_CATEGORIES = [
   "integration",
 ] as const;
 
-export type ThreadStarterCategory = (typeof THREAD_STARTER_CATEGORIES)[number];
+export type ConversationStarterCategory = (typeof CONVERSATION_STARTER_CATEGORIES)[number];
 
 interface GeneratedStarter {
   label: string;
@@ -148,24 +148,24 @@ interface GeneratedStarter {
 async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   const provider = await getConfiguredProvider();
   if (!provider) {
-    log.info("No configured provider for thread starters generation");
+    log.info("No configured provider for conversation starters generation");
     return [];
   }
 
   const rollup = buildMemoryRollup(scopeId);
   if (!rollup) {
-    log.info("No memory items to generate thread starters from");
+    log.info("No memory items to generate conversation starters from");
     return [];
   }
   const diff = buildNewItemsDiff(scopeId);
   const skills = buildSkillsSummary();
 
-  const systemPrompt = `You are generating thread starter suggestions for a personal AI assistant's empty conversation page. These are clickable chips that help the user discover what the assistant can do, personalized to their context.
+  const systemPrompt = `You are generating conversation starter suggestions for a personal AI assistant's empty conversation page. These are clickable chips that help the user discover what the assistant can do, personalized to their context.
 
-Given the user's accumulated memories and the assistant's available skills, generate 4-6 thread starters. Each starter has:
+Given the user's accumulated memories and the assistant's available skills, generate 4-6 conversation starters. Each starter has:
 - label: Short chip text (max 50 chars). Start with a verb. Be specific and actionable.
 - prompt: The full message that will be sent when clicked (1-2 natural sentences).
-- category: One of: ${THREAD_STARTER_CATEGORIES.join(", ")}. Pick the best-fit capability category.
+- category: One of: ${CONVERSATION_STARTER_CATEGORIES.join(", ")}. Pick the best-fit capability category.
 
 Rules:
 - Cross user context (who they are, what they work on) with assistant capabilities (skills).
@@ -183,13 +183,13 @@ ${skills}`;
     const response = await provider.sendMessage(
       [
         userMessage(
-          "Generate personalized thread starters based on my context.",
+          "Generate personalized conversation starters based on my context.",
         ),
       ],
       [
         {
-          name: "store_thread_starters",
-          description: "Store generated thread starter suggestions",
+          name: "store_conversation_starters",
+          description: "Store generated conversation starter suggestions",
           input_schema: {
             type: "object" as const,
             properties: {
@@ -209,7 +209,7 @@ ${skills}`;
                     },
                     category: {
                       type: "string",
-                      enum: [...THREAD_STARTER_CATEGORIES],
+                      enum: [...CONVERSATION_STARTER_CATEGORIES],
                       description: "Capability category for grouping",
                     },
                   },
@@ -226,7 +226,7 @@ ${skills}`;
         config: {
           modelIntent: "quality-optimized",
           max_tokens: 1024,
-          tool_choice: { type: "tool" as const, name: "store_thread_starters" },
+          tool_choice: { type: "tool" as const, name: "store_conversation_starters" },
         },
         signal,
       },
@@ -235,7 +235,7 @@ ${skills}`;
 
     const toolBlock = extractToolUse(response);
     if (!toolBlock) {
-      log.warn("No tool_use block in thread starters generation response");
+      log.warn("No tool_use block in conversation starters generation response");
       return [];
     }
 
@@ -258,7 +258,7 @@ ${skills}`;
         prompt: truncate(s.prompt, 500, ""),
         category:
           typeof s.category === "string" &&
-          (THREAD_STARTER_CATEGORIES as readonly string[]).includes(s.category)
+          (CONVERSATION_STARTER_CATEGORIES as readonly string[]).includes(s.category)
             ? s.category
             : "productivity",
       }));
@@ -270,12 +270,12 @@ ${skills}`;
 
 // ── Job handler ───────────────────────────────────────────────────
 
-export async function generateThreadStartersJob(job: MemoryJob): Promise<void> {
+export async function generateConversationStartersJob(job: MemoryJob): Promise<void> {
   const scopeId = asString(job.payload.scopeId) ?? "default";
 
   const starters = await generateStarters(scopeId);
   if (starters.length === 0) {
-    log.info({ scopeId }, "No thread starters generated");
+    log.info({ scopeId }, "No conversation starters generated");
     return;
   }
 
@@ -305,7 +305,7 @@ export async function generateThreadStartersJob(job: MemoryJob): Promise<void> {
 
   // Insert starters
   for (const starter of starters) {
-    db.insert(threadStarters)
+    db.insert(conversationStarters)
       .values({
         id: uuid(),
         label: starter.label,
@@ -343,6 +343,6 @@ export async function generateThreadStartersJob(job: MemoryJob): Promise<void> {
 
   log.info(
     { scopeId, batch: nextBatch, count: starters.length },
-    "Generated thread starters",
+    "Generated conversation starters",
   );
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -26,7 +26,7 @@ export type MemoryJobType =
   | "media_processing"
   | "embed_media"
   | "embed_attachment"
-  | "generate_thread_starters"
+  | "generate_conversation_starters"
   | "generate_capability_cards";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -8,6 +8,7 @@ import {
   cleanupStaleSupersededItemsJob,
   pruneOldConversationsJob,
 } from "./job-handlers/cleanup.js";
+import { generateConversationStartersJob } from "./job-handlers/conversation-starters.js";
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
   embedAttachmentJob,
@@ -23,7 +24,6 @@ import {
 } from "./job-handlers/index-maintenance.js";
 import { mediaProcessingJob } from "./job-handlers/media-processing.js";
 import { buildConversationSummaryJob } from "./job-handlers/summarization.js";
-import { generateThreadStartersJob } from "./job-handlers/thread-starters.js";
 import {
   BackendUnavailableError,
   classifyError,
@@ -308,8 +308,8 @@ async function processJob(
     case "embed_attachment":
       await embedAttachmentJob(job, config);
       return;
-    case "generate_thread_starters":
-      await generateThreadStartersJob(job);
+    case "generate_conversation_starters":
+      await generateConversationStartersJob(job);
       return;
     case "generate_capability_cards":
       await generateCapabilityCardsJob(job);

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -150,7 +150,7 @@ export const memoryCheckpoints = sqliteTable("memory_checkpoints", {
   updatedAt: integer("updated_at").notNull(),
 });
 
-export const threadStarters = sqliteTable(
+export const conversationStarters = sqliteTable(
   "conversation_starters",
   {
     id: text("id").primaryKey(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -125,6 +125,7 @@ import { conversationAttentionRouteDefinitions } from "./routes/conversation-att
 import { conversationManagementRouteDefinitions } from "./routes/conversation-management-routes.js";
 import { conversationQueryRouteDefinitions } from "./routes/conversation-query-routes.js";
 import { conversationRouteDefinitions } from "./routes/conversation-routes.js";
+import { conversationStarterRouteDefinitions } from "./routes/conversation-starter-routes.js";
 import { debugRouteDefinitions } from "./routes/debug-routes.js";
 import { diagnosticsRouteDefinitions } from "./routes/diagnostics-routes.js";
 import { documentRouteDefinitions } from "./routes/documents-routes.js";
@@ -160,7 +161,6 @@ import { skillRouteDefinitions } from "./routes/skills-routes.js";
 import { subagentRouteDefinitions } from "./routes/subagents-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
-import { threadStarterRouteDefinitions } from "./routes/thread-starter-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
@@ -741,7 +741,7 @@ export class RuntimeHttpServer {
       ...usageRouteDefinitions(),
       ...workspaceRouteDefinitions(),
       ...memoryItemRouteDefinitions(),
-      ...threadStarterRouteDefinitions(),
+      ...conversationStarterRouteDefinitions(),
       ...settingsRouteDefinitions(),
       ...avatarRouteDefinitions(),
       ...scheduleRouteDefinitions({

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -1,7 +1,7 @@
 /**
- * Route handlers for thread starter endpoints.
+ * Route handlers for conversation starter endpoints.
  *
- * GET /v1/thread-starters — list thread starters (chips) or capability cards
+ * GET /v1/thread-starters — list conversation starters (chips) or capability cards
  */
 
 import { and, desc, eq, inArray, like } from "drizzle-orm";
@@ -12,8 +12,8 @@ import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { rawAll, rawGet } from "../../memory/raw-query.js";
 import {
   capabilityCardCategories,
+  conversationStarters,
   memoryJobs,
-  threadStarters,
 } from "../../memory/schema.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -21,7 +21,7 @@ import type { RouteDefinition } from "../http-router.js";
 // GET /v1/thread-starters?card_type=chip (default, backwards-compat)
 // ---------------------------------------------------------------------------
 
-function handleListThreadStarters(url: URL): Response {
+function handleListConversationStarters(url: URL): Response {
   const cardType = url.searchParams.get("card_type") ?? "chip";
 
   if (cardType === "card") {
@@ -39,29 +39,29 @@ function handleListThreadStarters(url: URL): Response {
 
   const items = db
     .select({
-      id: threadStarters.id,
-      label: threadStarters.label,
-      prompt: threadStarters.prompt,
-      category: threadStarters.category,
-      batch: threadStarters.generationBatch,
+      id: conversationStarters.id,
+      label: conversationStarters.label,
+      prompt: conversationStarters.prompt,
+      category: conversationStarters.category,
+      batch: conversationStarters.generationBatch,
     })
-    .from(threadStarters)
+    .from(conversationStarters)
     .where(
       and(
-        eq(threadStarters.scopeId, scopeId),
-        eq(threadStarters.cardType, "chip"),
+        eq(conversationStarters.scopeId, scopeId),
+        eq(conversationStarters.cardType, "chip"),
       ),
     )
     .orderBy(
-      desc(threadStarters.generationBatch),
-      desc(threadStarters.createdAt),
+      desc(conversationStarters.generationBatch),
+      desc(conversationStarters.createdAt),
     )
     .limit(limitParam)
     .offset(offsetParam)
     .all();
 
   const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM thread_starters WHERE scope_id = ? AND card_type = 'chip'`,
+    `SELECT COUNT(*) AS c FROM conversation_starters WHERE scope_id = ? AND card_type = 'chip'`,
     scopeId,
   );
   const total = countRow?.c ?? 0;
@@ -87,7 +87,7 @@ function handleListThreadStarters(url: URL): Response {
     .from(memoryJobs)
     .where(
       and(
-        eq(memoryJobs.type, "generate_thread_starters"),
+        eq(memoryJobs.type, "generate_conversation_starters"),
         inArray(memoryJobs.status, ["pending", "running"]),
         like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
       ),
@@ -95,7 +95,7 @@ function handleListThreadStarters(url: URL): Response {
     .get();
 
   if (!existing) {
-    enqueueMemoryJob("generate_thread_starters", { scopeId });
+    enqueueMemoryJob("generate_conversation_starters", { scopeId });
   }
 
   return Response.json({ starters: [], total: 0, status: "generating" });
@@ -117,29 +117,29 @@ function handleListCapabilityCards(url: URL): Response {
 
   // Build WHERE conditions for cards
   const conditions = [
-    eq(threadStarters.scopeId, scopeId),
-    eq(threadStarters.cardType, "card"),
+    eq(conversationStarters.scopeId, scopeId),
+    eq(conversationStarters.cardType, "card"),
   ];
   if (categoryFilter) {
-    conditions.push(eq(threadStarters.category, categoryFilter));
+    conditions.push(eq(conversationStarters.category, categoryFilter));
   }
 
   const cards = db
     .select({
-      id: threadStarters.id,
-      icon: threadStarters.icon,
-      label: threadStarters.label,
-      description: threadStarters.description,
-      prompt: threadStarters.prompt,
-      category: threadStarters.category,
-      tags: threadStarters.tags,
-      batch: threadStarters.generationBatch,
+      id: conversationStarters.id,
+      icon: conversationStarters.icon,
+      label: conversationStarters.label,
+      description: conversationStarters.description,
+      prompt: conversationStarters.prompt,
+      category: conversationStarters.category,
+      tags: conversationStarters.tags,
+      batch: conversationStarters.generationBatch,
     })
-    .from(threadStarters)
+    .from(conversationStarters)
     .where(and(...conditions))
     .orderBy(
-      desc(threadStarters.generationBatch),
-      desc(threadStarters.createdAt),
+      desc(conversationStarters.generationBatch),
+      desc(conversationStarters.createdAt),
     )
     .limit(limitParam)
     .all();
@@ -157,7 +157,7 @@ function handleListCapabilityCards(url: URL): Response {
   const countCondition = categoryFilter ? `AND category = ?` : ``;
   const countParams = categoryFilter ? [scopeId, categoryFilter] : [scopeId];
   const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM thread_starters WHERE scope_id = ? AND card_type = 'card' ${countCondition}`,
+    `SELECT COUNT(*) AS c FROM conversation_starters WHERE scope_id = ? AND card_type = 'card' ${countCondition}`,
     ...countParams,
   );
   const total = countRow?.c ?? 0;
@@ -283,12 +283,12 @@ function enqueueCapabilityCardJobs(scopeId: string): void {
 // Route definitions
 // ---------------------------------------------------------------------------
 
-export function threadStarterRouteDefinitions(): RouteDefinition[] {
+export function conversationStarterRouteDefinitions(): RouteDefinition[] {
   return [
     {
       endpoint: "thread-starters",
       method: "GET",
-      handler: (ctx) => handleListThreadStarters(ctx.url),
+      handler: (ctx) => handleListConversationStarters(ctx.url),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Renames 3 TS files: thread-starters → conversation-starters (job handler, cadence, routes)
- Updates schema export, job type, checkpoint keys, logger modules, and all imports
- API endpoint path intentionally kept as `thread-starters` (changed atomically with Swift client in PR 5)

Part of plan: rename-remaining-thread-session.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
