### PR TITLE
refactor: rename thread-starters API endpoint, feature flag, and Swift client types to conversation-starters

### DIFF
--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route handlers for conversation starter endpoints.
  *
- * GET /v1/thread-starters — list conversation starters (chips) or capability cards
+ * GET /v1/conversation-starters — list conversation starters (chips) or capability cards
  */
 
 import { and, desc, eq, inArray, like } from "drizzle-orm";
@@ -18,7 +18,7 @@ import {
 import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
-// GET /v1/thread-starters?card_type=chip (default, backwards-compat)
+// GET /v1/conversation-starters?card_type=chip (default, backwards-compat)
 // ---------------------------------------------------------------------------
 
 function handleListConversationStarters(url: URL): Response {
@@ -102,7 +102,7 @@ function handleListConversationStarters(url: URL): Response {
 }
 
 // ---------------------------------------------------------------------------
-// GET /v1/thread-starters?card_type=card — capability cards feed
+// GET /v1/conversation-starters?card_type=card — capability cards feed
 // ---------------------------------------------------------------------------
 
 function handleListCapabilityCards(url: URL): Response {
@@ -286,7 +286,7 @@ function enqueueCapabilityCardJobs(scopeId: string): void {
 export function conversationStarterRouteDefinitions(): RouteDefinition[] {
   return [
     {
-      endpoint: "thread-starters",
+      endpoint: "conversation-starters",
       method: "GET",
       handler: (ctx) => handleListConversationStarters(ctx.url),
     },

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -29,10 +29,10 @@ struct ChatEmptyStateView: View {
     var conversationId: UUID?
     var daemonGreeting: String? = nil
     var onRequestGreeting: (() -> Void)? = nil
-    var threadStarters: [ThreadStarter] = []
-    var threadStartersLoading: Bool = false
-    var onSelectStarter: ((ThreadStarter) -> Void)? = nil
-    var onFetchThreadStarters: (() -> Void)? = nil
+    var conversationStarters: [ConversationStarter] = []
+    var conversationStartersLoading: Bool = false
+    var onSelectStarter: ((ConversationStarter) -> Void)? = nil
+    var onFetchConversationStarters: (() -> Void)? = nil
     var capabilityCards: [CapabilityCard] = []
     var capabilityCardsLoading: Bool = false
     var cardCategoryStatuses: [String: CategoryStatus] = [:]
@@ -89,7 +89,7 @@ struct ChatEmptyStateView: View {
 
             composerSection
 
-            threadStartersSection
+            conversationStartersSection
 
             Spacer()
             Spacer()
@@ -116,7 +116,7 @@ struct ChatEmptyStateView: View {
 
                         composerSection
 
-                        threadStartersSection
+                        conversationStartersSection
 
                         // Scroll CTA
                         if !capabilityCards.isEmpty || capabilityCardsLoading {
@@ -245,11 +245,11 @@ struct ChatEmptyStateView: View {
     }
 
     @ViewBuilder
-    private var threadStartersSection: some View {
-        if !threadStarters.isEmpty {
+    private var conversationStartersSection: some View {
+        if !conversationStarters.isEmpty {
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.sm) {
-                ForEach(threadStarters.prefix(4)) { starter in
-                    ThreadStarterChip(label: starter.label, fullPrompt: starter.prompt) {
+                ForEach(conversationStarters.prefix(4)) { starter in
+                    ConversationStarterChip(label: starter.label, fullPrompt: starter.prompt) {
                         onSelectStarter?(starter)
                     }
                 }
@@ -258,7 +258,7 @@ struct ChatEmptyStateView: View {
             .padding(.top, VSpacing.xxxl)
             .opacity(visible ? 1 : 0)
             .offset(y: visible ? 0 : 10)
-        } else if threadStartersLoading {
+        } else if conversationStartersLoading {
             HStack(spacing: VSpacing.sm) {
                 Group {
                     if let body = appearance.characterBodyShape,
@@ -286,7 +286,7 @@ struct ChatEmptyStateView: View {
         if soulGreeting == nil {
             onRequestGreeting?()
         }
-        onFetchThreadStarters?()
+        onFetchConversationStarters?()
         if showCapabilityFeed {
             onFetchCapabilityCards?()
         }
@@ -297,9 +297,9 @@ struct ChatEmptyStateView: View {
 
 }
 
-// MARK: - Thread Starter Chip
+// MARK: - Conversation Starter Chip
 
-struct ThreadStarterChip: View {
+struct ConversationStarterChip: View {
     let label: String
     let fullPrompt: String
     let action: () -> Void

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -66,10 +66,10 @@ struct ChatView: View {
     var conversationId: UUID?
     var daemonGreeting: String? = nil
     var onRequestGreeting: (() -> Void)? = nil
-    var threadStarters: [ThreadStarter] = []
-    var threadStartersLoading: Bool = false
-    var onSelectStarter: ((ThreadStarter) -> Void)? = nil
-    var onFetchThreadStarters: (() -> Void)? = nil
+    var conversationStarters: [ConversationStarter] = []
+    var conversationStartersLoading: Bool = false
+    var onSelectStarter: ((ConversationStarter) -> Void)? = nil
+    var onFetchConversationStarters: (() -> Void)? = nil
     var capabilityCards: [CapabilityCard] = []
     var capabilityCardsLoading: Bool = false
     var cardCategoryStatuses: [String: CategoryStatus] = [:]
@@ -207,10 +207,10 @@ struct ChatView: View {
                             conversationId: conversationId,
                             daemonGreeting: daemonGreeting,
                             onRequestGreeting: onRequestGreeting,
-                            threadStarters: threadStarters,
-                            threadStartersLoading: threadStartersLoading,
+                            conversationStarters: conversationStarters,
+                            conversationStartersLoading: conversationStartersLoading,
                             onSelectStarter: onSelectStarter,
-                            onFetchThreadStarters: onFetchThreadStarters,
+                            onFetchConversationStarters: onFetchConversationStarters,
                             capabilityCards: capabilityCards,
                             capabilityCardsLoading: capabilityCardsLoading,
                             cardCategoryStatuses: cardCategoryStatuses,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -691,12 +691,12 @@ struct ActiveChatViewWrapper: View {
             conversationId: conversationId,
             daemonGreeting: viewModel.emptyStateGreeting,
             onRequestGreeting: { [weak viewModel] in viewModel?.generateGreeting() },
-            threadStarters: MacOSClientFeatureFlagManager.shared.isEnabled("thread_starters_enabled") ? viewModel.threadStarters : [],
-            threadStartersLoading: MacOSClientFeatureFlagManager.shared.isEnabled("thread_starters_enabled") && viewModel.threadStartersLoading,
+            conversationStarters: MacOSClientFeatureFlagManager.shared.isEnabled("conversation_starters_enabled") ? viewModel.conversationStarters : [],
+            conversationStartersLoading: MacOSClientFeatureFlagManager.shared.isEnabled("conversation_starters_enabled") && viewModel.conversationStartersLoading,
             onSelectStarter: { [weak viewModel] starter in
                 viewModel?.inputText = starter.prompt
             },
-            onFetchThreadStarters: { [weak viewModel] in viewModel?.fetchThreadStarters() },
+            onFetchConversationStarters: { [weak viewModel] in viewModel?.fetchConversationStarters() },
             capabilityCards: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") ? viewModel.capabilityCards : [],
             capabilityCardsLoading: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") && viewModel.capabilityCardsLoading,
             cardCategoryStatuses: MacOSClientFeatureFlagManager.shared.isEnabled("capability_feed_enabled") ? viewModel.cardCategoryStatuses : [:],

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -14,9 +14,9 @@ import UIKit
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel")
 
-// MARK: - Thread Starter Types
+// MARK: - Conversation Starter Types
 
-public struct ThreadStarter: Identifiable, Codable {
+public struct ConversationStarter: Identifiable, Codable {
     public let id: String
     public let label: String
     public let prompt: String
@@ -24,27 +24,27 @@ public struct ThreadStarter: Identifiable, Codable {
     public let batch: Int
 }
 
-struct ThreadStartersResponse: Codable {
-    let starters: [ThreadStarter]
+struct ConversationStartersResponse: Codable {
+    let starters: [ConversationStarter]
     let total: Int
     let status: String  // "ready", "generating", "empty"
 }
 
 @MainActor
-protocol ThreadStarterClientProtocol {
-    func fetchThreadStarters(limit: Int) async -> ThreadStartersResponse?
+protocol ConversationStarterClientProtocol {
+    func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse?
 }
 
 @MainActor
-struct ThreadStarterClient: ThreadStarterClientProtocol {
+struct ConversationStarterClient: ConversationStarterClientProtocol {
     nonisolated init() {}
 
-    func fetchThreadStarters(limit: Int) async -> ThreadStartersResponse? {
+    func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse? {
         guard let response = try? await GatewayHTTPClient.get(
-            path: "thread-starters",
+            path: "conversation-starters",
             params: ["limit": String(limit)]
         ), response.isSuccess else { return nil }
-        return try? JSONDecoder().decode(ThreadStartersResponse.self, from: response.data)
+        return try? JSONDecoder().decode(ConversationStartersResponse.self, from: response.data)
     }
 }
 
@@ -96,7 +96,7 @@ struct CapabilityCardClient: CapabilityCardClientProtocol {
 
     func fetchCapabilityCards(limit: Int) async -> CapabilityCardsResponse? {
         guard let response = try? await GatewayHTTPClient.get(
-            path: "thread-starters",
+            path: "conversation-starters",
             params: ["card_type": "card", "limit": String(limit)]
         ), response.isSuccess else { return nil }
         return try? JSONDecoder().decode(CapabilityCardsResponse.self, from: response.data)
@@ -406,7 +406,7 @@ public final class ChatViewModel: ObservableObject {
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol
     private let surfaceClient: any SurfaceClientProtocol = SurfaceClient()
-    private let threadStarterClient: any ThreadStarterClientProtocol = ThreadStarterClient()
+    private let conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient()
     private let capabilityCardClient: any CapabilityCardClientProtocol = CapabilityCardClient()
     /// Tracks the action submitted for each guardian decision requestId so the
     /// response handler can display the correct resolved state (the server does
@@ -686,11 +686,11 @@ public final class ChatViewModel: ObservableObject {
     /// The in-flight greeting streaming task, stored for cancellation.
     private var greetingTask: Task<Void, Never>?
 
-    // MARK: - Thread Starters
+    // MARK: - Conversation Starters
 
     /// Personalized suggestion chips shown on the empty conversation page.
-    @Published public var threadStarters: [ThreadStarter] = []
-    @Published public var threadStartersLoading: Bool = false
+    @Published public var conversationStarters: [ConversationStarter] = []
+    @Published public var conversationStartersLoading: Bool = false
 
     // MARK: - Capability Cards
 
@@ -1391,42 +1391,42 @@ public final class ChatViewModel: ObservableObject {
         isGeneratingGreeting = false
     }
 
-    private var threadStarterPollTask: Task<Void, Never>?
+    private var conversationStarterPollTask: Task<Void, Never>?
 
-    /// Fetch personalized thread starters from the daemon for the empty conversation state.
-    public func fetchThreadStarters() {
-        threadStarterPollTask?.cancel()
-        threadStarterPollTask = Task { @MainActor [weak self] in
+    /// Fetch personalized conversation starters from the daemon for the empty conversation state.
+    public func fetchConversationStarters() {
+        conversationStarterPollTask?.cancel()
+        conversationStarterPollTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            let response = await self.threadStarterClient.fetchThreadStarters(limit: 4)
+            let response = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
             guard !Task.isCancelled else { return }
 
             if let response, !response.starters.isEmpty {
-                self.threadStarters = response.starters
-                self.threadStartersLoading = false
+                self.conversationStarters = response.starters
+                self.conversationStartersLoading = false
                 return
             }
 
             if response?.status == "generating" {
-                self.threadStartersLoading = true
+                self.conversationStartersLoading = true
                 // Poll every 3 seconds until ready
                 while !Task.isCancelled {
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
                     guard !Task.isCancelled else { return }
-                    let poll = await self.threadStarterClient.fetchThreadStarters(limit: 4)
+                    let poll = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
                     guard !Task.isCancelled else { return }
                     if let poll, !poll.starters.isEmpty {
-                        self.threadStarters = poll.starters
-                        self.threadStartersLoading = false
+                        self.conversationStarters = poll.starters
+                        self.conversationStartersLoading = false
                         return
                     }
                     if poll?.status != "generating" {
-                        self.threadStartersLoading = false
+                        self.conversationStartersLoading = false
                         return
                     }
                 }
             } else {
-                self.threadStartersLoading = false
+                self.conversationStartersLoading = false
             }
         }
     }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -226,11 +226,11 @@
       "defaultEnabled": false
     },
     {
-      "id": "thread-starters",
+      "id": "conversation-starters",
       "scope": "macos",
-      "key": "thread_starters_enabled",
-      "label": "Thread Starters",
-      "description": "Show personalized thread starter suggestions on the empty conversation page",
+      "key": "conversation_starters_enabled",
+      "label": "Conversation Starters",
+      "description": "Show personalized conversation starter suggestions on the empty conversation page",
       "defaultEnabled": false
     },
     {
@@ -238,7 +238,7 @@
       "scope": "macos",
       "key": "capability_feed_enabled",
       "label": "Capability Feed",
-      "description": "Show the scrollable capability cards feed below the hero on the new thread page",
+      "description": "Show the scrollable capability cards feed below the hero on the new conversation page",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Renames server endpoint from `/v1/thread-starters` to `/v1/conversation-starters`
- Updates feature flag id/key/label/description from thread-starters to conversation-starters
- Renames all Swift types: `ThreadStarter` → `ConversationStarter`, `ThreadStarterClient` → `ConversationStarterClient`, etc.
- All changes are atomic — server endpoint, feature flag, and client URL change together

Part of plan: rename-remaining-thread-session.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
