### PR TITLE
fix: enable click-to-edit in workspace source view and add Discard button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -33,9 +33,12 @@ struct HighlightedTextView: View {
                     editableView
                 } else {
                     readOnlyView
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            isActivelyEditing = true
+                        .overlay {
+                            Color.clear
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    isActivelyEditing = true
+                                }
                         }
                 }
             } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -746,6 +746,15 @@ private struct WorkspaceFileViewer: View {
                 HStack {
                     Spacer()
                     HStack(spacing: VSpacing.xs) {
+                        VButton(
+                            label: "Discard",
+                            style: .ghost,
+                            size: .compact,
+                            isDisabled: state.isSaving
+                        ) {
+                            state.editableContent = state.originalContent
+                            state.isDirty = false
+                        }
                         if state.isSaving {
                             VBusyIndicator(size: 8)
                         }


### PR DESCRIPTION
## Summary
- Fix click-to-edit not working in workspace source view — `.textSelection(.enabled)` on the syntax-highlighted text was swallowing tap events before the `.onTapGesture` handler could fire; replaced with a transparent overlay that captures taps above the text selection layer
- Add a "Discard" ghost button to the left of Save in the sticky footer that resets content to original and clears the dirty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
