### PR TITLE
fix: migrate checkpoint keys from thread_starters to conversation_starters prefix

### DIFF
--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -40,6 +40,13 @@ export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
       raw.exec(
         /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
       );
+
+      // Migrate checkpoint keys from old thread_starters: prefix to
+      // conversation_starters: so existing checkpoint data is found by
+      // the renamed code paths and unnecessary re-generation is avoided.
+      raw.exec(
+        /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
+      );
     },
   );
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rename-remaining-thread-session.md.

**Gap:** Checkpoint key migration missing from migration 174
**What was expected:** Migration 174 should update checkpoint keys in memory_checkpoints from thread_starters: to conversation_starters: prefix
**What was found:** Code reads conversation_starters:* keys but DB still has thread_starters:* rows, causing unnecessary re-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
