### PR TITLE
fix: correct misleading comment on thread_starters migration in db-init.ts

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -429,7 +429,7 @@ export function initializeDb(): void {
   // 72. Rename integration:gmail → integration:google across OAuth tables
   migrateRenameGmailProviderKeyToGoogle(database);
 
-  // 73. Create conversation_starters table for personalized empty-conversation suggestions
+  // 73. Create thread_starters table for personalized empty-thread suggestions (renamed in migration 77)
   migrateCreateThreadStartersTable(database);
 
   // 74. Add capability card columns to thread_starters + category relevance table


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rename-remaining-thread-session.md.

**Gap:** Misleading comment in db-init.ts for migration 73
**What was expected:** Comment should accurately describe what migration 73 does (creates thread_starters)
**What was found:** Comment says 'Create conversation_starters table' but migration 73 creates thread_starters (renamed in migration 77)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
