### PR TITLE
fix: handle legacy generate_thread_starters jobs gracefully

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -27,7 +27,8 @@ export type MemoryJobType =
   | "embed_media"
   | "embed_attachment"
   | "generate_conversation_starters"
-  | "generate_capability_cards";
+  | "generate_capability_cards"
+  | "generate_thread_starters";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -314,6 +314,9 @@ async function processJob(
     case "generate_capability_cards":
       await generateCapabilityCardsJob(job);
       return;
+    case "generate_thread_starters":
+      // Thread starters renamed to conversation starters — silently drop legacy jobs
+      return;
     default:
       throw new Error(
         `Unknown memory job type: ${(job as { type: string }).type}`,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rename-remaining-thread-session.md.

**Gap:** Stale generate_thread_starters jobs throw unhandled-type error
**What was expected:** Legacy jobs should be handled gracefully, not throw errors
**What was found:** Pending generate_thread_starters jobs hit the default throw case in processJob

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
