### PR TITLE
feat: add web search provider selection to SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -188,6 +188,18 @@ public final class SettingsStore: ObservableObject {
     /// Values: `"managed"` or `"your-own"`.
     @Published var inferenceMode: String = "your-own"
 
+    /// The selected web search provider, persisted in workspace config under
+    /// `services.web-search.provider`.
+    @Published var webSearchProvider: String = "anthropic-native"
+
+    static let availableWebSearchProviders = ["anthropic-native", "perplexity", "brave"]
+
+    static let webSearchProviderDisplayNames: [String: String] = [
+        "anthropic-native": "Anthropic",
+        "perplexity": "Perplexity",
+        "brave": "Brave",
+    ]
+
     // MARK: - Platform Config State
 
     @Published var platformBaseUrl: String = ""
@@ -356,6 +368,14 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(from: configPath)
+
+        // Load web search provider from workspace config
+        let config = WorkspaceConfigIO.read(from: configPath)
+        if let services = config["services"] as? [String: Any],
+           let webSearch = services["web-search"] as? [String: Any],
+           let provider = webSearch["provider"] as? String {
+            self.webSearchProvider = provider
+        }
 
         // When enabledSince was defaulted to "now" (no value on disk),
         // persist it immediately so subsequent loads produce the same
@@ -1855,6 +1875,22 @@ public final class SettingsStore: ObservableObject {
             try WorkspaceConfigIO.merge(["services": services], into: configPath)
         } catch {
             log.error("Failed to merge workspace config for inference mode: \(error)")
+        }
+        scheduleRoutingSourceRefresh()
+    }
+
+    func setWebSearchProvider(_ provider: String) {
+        webSearchProvider = provider
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var webSearch = services["web-search"] as? [String: Any] ?? [:]
+        webSearch["provider"] = provider
+        services["web-search"] = webSearch
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for web search provider: \(error)")
         }
         scheduleRoutingSourceRefresh()
     }


### PR DESCRIPTION
## Summary
- Add @Published webSearchProvider property initialized from workspace config
- Add setWebSearchProvider() method that persists to config.json and triggers routing source refresh
- Add static display names and available providers arrays for the upcoming Web Search card UI

Part of plan: unified-web-search-card.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
