### PR TITLE
feat: add NSFont and NSColor bridging for syntax theme tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxTheme.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 import VellumAssistantShared
 
 /// Maps syntax token types to SwiftUI colors and builds syntax-highlighted `AttributedString` values.
@@ -63,4 +66,62 @@ struct SyntaxTheme {
 
         return attributedString
     }
+
+    // MARK: - AppKit Bridging
+
+    #if os(macOS)
+    /// Returns the `NSColor` for the given syntax token type (for NSTextStorage use).
+    static func nsColor(for tokenType: SyntaxTokenType) -> NSColor {
+        NSColor(color(for: tokenType))
+    }
+
+    /// The monospaced `NSFont` matching `VFont.mono` for NSTextView use.
+    static var nsMonoFont: NSFont {
+        let baseName = "DMMono-Regular"
+        let size: CGFloat = 13
+        guard let base = NSFont(name: baseName, size: size) else {
+            return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+        }
+        // Apply ss05 stylistic set (conventional "f" glyph), same as VFont.dmMono()
+        let descriptor = base.fontDescriptor.addingAttributes([
+            .featureSettings: [[
+                NSFontDescriptor.FeatureKey.typeIdentifier: kStylisticAlternativesType,
+                NSFontDescriptor.FeatureKey.selectorIdentifier: kStylisticAltFiveOnSelector,
+            ]]
+        ])
+        return NSFont(descriptor: descriptor, size: size) ?? base
+    }
+
+    /// Applies syntax highlighting to an `NSMutableAttributedString` in-place.
+    /// Sets the base font and foreground color, then overlays token colors.
+    static func applyHighlighting(to storage: NSMutableAttributedString, language: SyntaxLanguage) {
+        let fullRange = NSRange(location: 0, length: storage.length)
+        let text = storage.string
+
+        // Set base attributes
+        storage.addAttribute(.font, value: nsMonoFont, range: fullRange)
+        storage.addAttribute(.foregroundColor, value: NSColor(VColor.contentDefault), range: fullRange)
+
+        guard language != .plain else { return }
+
+        let tokens = SyntaxTokenizer.tokenize(text, language: language)
+        for token in tokens {
+            guard token.range.location + token.range.length <= storage.length else { continue }
+            storage.addAttribute(.foregroundColor, value: nsColor(for: token.type), range: token.range)
+
+            switch token.type {
+            case .heading, .bold:
+                if let boldFont = NSFontManager.shared.convert(nsMonoFont, toHaveTrait: .boldFontMask) as NSFont? {
+                    storage.addAttribute(.font, value: boldFont, range: token.range)
+                }
+            case .italic:
+                if let italicFont = NSFontManager.shared.convert(nsMonoFont, toHaveTrait: .italicFontMask) as NSFont? {
+                    storage.addAttribute(.font, value: italicFont, range: token.range)
+                }
+            default:
+                break
+            }
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
- Add `nsColor(for:)` method that bridges SwiftUI syntax colors to NSColor for NSTextStorage use
- Add `nsMonoFont` property that provides the DMMono-Regular 13pt font with ss05 stylistic set as NSFont
- Add `applyHighlighting(to:language:)` method that applies syntax token colors and font variants to NSMutableAttributedString in-place

Part of plan: editable-syntax-highlight.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
