### PR TITLE
feat: replace Perplexity/Brave cards with unified Web Search card

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -343,40 +343,11 @@ struct SettingsPanel: View {
                 apiKeyText: $apiKeyText
             )
 
-            // PERPLEXITY SEARCH
-            ServiceCredentialCard(
-                title: "Perplexity Search",
-                subtitle: "Enables real-time web search in responses",
-                isConnected: store.hasPerplexityKey,
-                keyPlaceholder: "Enter your Perplexity API key",
-                isManagedProxy: store.providerRoutingSources["perplexity"] == "managed-proxy",
-                keyText: $perplexityKeyText,
-                onSave: {
-                    store.savePerplexityKey(perplexityKeyText)
-                    perplexityKeyText = ""
-                },
-                onReset: {
-                    store.clearPerplexityKey()
-                    perplexityKeyText = ""
-                }
-            )
-
-            // BRAVE SEARCH
-            ServiceCredentialCard(
-                title: "Brave Search",
-                subtitle: "Enables private web search in responses",
-                isConnected: store.hasBraveKey,
-                keyPlaceholder: "Enter your Brave Search API key",
-                isManagedProxy: store.providerRoutingSources["brave"] == "managed-proxy",
-                keyText: $braveKeyText,
-                onSave: {
-                    store.saveBraveKey(braveKeyText)
-                    braveKeyText = ""
-                },
-                onReset: {
-                    store.clearBraveKey()
-                    braveKeyText = ""
-                }
+            // WEB SEARCH
+            WebSearchServiceCard(
+                store: store,
+                perplexityKeyText: $perplexityKeyText,
+                braveKeyText: $braveKeyText
             )
 
             // IMAGE GENERATION


### PR DESCRIPTION
## Summary
- Remove separate Perplexity Search and Brave Search ServiceCredentialCard instances from Models & Services tab
- Replace with single WebSearchServiceCard that has provider dropdown and conditional API key field
- Existing key text state variables preserved and passed through to new card

Part of plan: unified-web-search-card.md (PR 3 of 4)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
