### PR TITLE
fix: rename remaining stale session/thread references to conversation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,7 +165,7 @@ subgraph "Text Q&A Session"
             MW_STATE["MainWindowState<br/>cross-view UI state"]
             CONV_MGR["ConversationManager<br/>conversation CRUD + delegate"]
             CONV_RESTORER["ConversationRestorer<br/>daemon conversation restoration"]
-            CHAT_VM["ChatViewModel<br/>session bootstrap + streaming"]
+            CHAT_VM["ChatViewModel<br/>conversation bootstrap + streaming"]
             CHAT_VIEW["ChatView<br/>bubbles + composer + stop"]
         end
 
@@ -186,7 +186,7 @@ subgraph "Text Q&A Session"
 
     subgraph "Daemon (Bun + TypeScript)"
         HTTP_RT["RuntimeHttpServer<br/>HTTP + SSE"]
-        HANDLERS["Route Handlers<br/>session routing"]
+        HANDLERS["Route Handlers<br/>conversation routing"]
         SESSION_MGR["Conversation Manager<br/>in-memory pool<br/>stale eviction"]
 
         subgraph "Onboarding Control Plane"
@@ -354,8 +354,8 @@ subgraph "Text Q&A Session"
     HTTP_RT -->|"AssistantTextDelta<br/>(SSE stream)"| TEXT_WIN
 
     %% Main Window Chat flow
-    CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
-    HTTP_RT -->|"session_info +<br/>session_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
+    CHAT_VM -->|"conversation_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
+    HTTP_RT -->|"conversation_info +<br/>conversation_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
     CHAT_VIEW --> CHAT_VM
     MW_STATE -->|"app_open_request<br/>(dashboard-first bootstrap)"| HTTP_RT
 
@@ -374,7 +374,7 @@ subgraph "Text Q&A Session"
     SESSION_MGR --> OLLAMA
     SESSION_MGR --> CONV_STORE
     SESSION_MGR --> RECALL
-    HANDLERS -->|"session_create.transport"| PLAYBOOK_MGR
+    HANDLERS -->|"conversation_create.transport"| PLAYBOOK_MGR
     PLAYBOOK_MGR --> PLAYBOOK_REG
     PLAYBOOK_MGR -->|"inject <channel_onboarding_playbook><br/>runtime context"| SESSION_MGR
     PLAYBOOK_MGR --> ONBOARD_ORCH

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -4,11 +4,11 @@ This document owns assistant-runtime architecture details. The repo-level archit
 
 ### Channel Onboarding Playbook Bootstrap
 
-- Transport metadata arrives via `session_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
+- Transport metadata arrives via `conversation_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
 - Telegram webhook ingress injects deterministic channel-safe transport metadata (`hints` + `uxBrief`) so non-dashboard channels defer dashboard-only UI tasks cleanly.
 - `OnboardingPlaybookManager` resolves `<channel>_onboarding.md`, checks `onboarding/playbooks/registry.json`, and applies per-channel first-time fast-path onboarding.
 - `OnboardingOrchestrator` derives onboarding-mode guidance (post-hatch sequence, USER.md capture) from playbook + transport context.
-- Session runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
+- Conversation runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
 - Permission setup remains user-initiated and hatch + first-conversation flows avoid proactive permission asks.
 
 ### Guardian Actor Context (Unified Across Channels)
@@ -17,7 +17,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/WhatsApp path) before run orchestration.
   - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
-- Runtime channel runs pass this as `trustContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
+- Runtime channel runs pass this as `trustContext`, and conversation runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -195,7 +195,6 @@ describe("guardian-dispatch", () => {
     expect(vellumDelivery!.destination_conversation_id).toBe("conv-vellum-1");
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
-    expect(signalParams.skipVellumThread).toBeUndefined();
     expect(typeof signalParams.onConversationCreated).toBe("function");
   });
 

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -239,7 +239,6 @@ describe("ASK_GUARDIAN canonical notification path", () => {
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
     expect(typeof signalParams.onConversationCreated).toBe("function");
-    expect(signalParams.skipVellumThread).toBeUndefined();
   });
 
   test("creates guardian action deliveries from notification pipeline delivery results", async () => {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -581,14 +581,14 @@ export function deleteQueuedMessage(
   ) => { removeQueuedMessage(requestId: string): boolean } | undefined,
 ):
   | { removed: true }
-  | { removed: false; reason: "session_not_found" | "message_not_found" } {
+  | { removed: false; reason: "conversation_not_found" | "message_not_found" } {
   const conversation = findConversation(conversationId);
   if (!conversation) {
     log.warn(
       { conversationId, requestId },
       "No conversation found for delete_queued_message",
     );
-    return { removed: false, reason: "session_not_found" };
+    return { removed: false, reason: "conversation_not_found" };
   }
   const removed = conversation.removeQueuedMessage(requestId);
   if (removed) {

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -28,7 +28,7 @@ export type MemoryJobType =
   | "embed_attachment"
   | "generate_conversation_starters"
   | "generate_capability_cards"
-  | "generate_thread_starters";
+  | "generate_thread_starters"; // legacy compat — silently dropped by worker (renamed to generate_conversation_starters)
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -200,7 +200,7 @@ export function conversationQueryRouteDefinitions(
             requestId: params.id,
           });
         }
-        if (result.reason === "session_not_found") {
+        if (result.reason === "conversation_not_found") {
           return httpError("NOT_FOUND", "Conversation not found", 404);
         }
         return httpError("NOT_FOUND", "Queued message not found", 404);

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -27,9 +27,9 @@ The main window has three dedicated state objects:
 |--------|---------|-------|
 | `MainWindowState` | `ObservableObject` | Cross-view UI state: active panel, dynamic workspace, API key status |
 | `ConversationManager` | `ObservableObject` | Conversation CRUD, tab management, conforms to `ConversationRestorerDelegate` |
-| `ConversationRestorer` | Plain class with delegate | Daemon session restoration (session list responses, history hydration) |
+| `ConversationRestorer` | Plain class with delegate | Daemon conversation restoration (conversation list responses, history hydration) |
 
-`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring sessions on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
+`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring conversations on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
 
 ### Observation Framework Migration
 

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -146,8 +146,8 @@ final class ChatViewModelIOSTests: XCTestCase {
         viewModel.sendMessage()
         XCTAssertTrue(viewModel.isSending)
 
-        // Poll until session_create appears in sentMessages (message-driven wait)
-        let expectation = XCTestExpectation(description: "session_create sent")
+        // Poll until conversation_create appears in sentMessages (message-driven wait)
+        let expectation = XCTestExpectation(description: "conversation_create sent")
         var cancelled = false
         func poll() {
             guard !cancelled else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -630,7 +630,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // and then clean up. Use cancelPendingMessage() instead of
             // stopGenerating() to discard the queued message without clearing the
             // correlation ID — this prevents the VM from claiming an unrelated
-            // session_info from another conversation.
+            // conversation_info from another conversation.
             chatViewModels[id]?.cancelPendingMessage()
         }
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -395,7 +395,7 @@ public struct AppUpdatePreviewResponse: Codable, Sendable {
 
 /// Server-side assistant activity lifecycle for thinking indicator placement.
 /// 
-/// `activityVersion` is monotonically increasing per session. Clients must
+/// `activityVersion` is monotonically increasing per conversation. Clients must
 /// ignore events with a version older than their current known version.
 public struct AssistantActivityState: Codable, Sendable {
     public let type: String
@@ -634,7 +634,7 @@ public struct CancelRequest: Codable, Sendable {
     }
 }
 
-/// Channel binding metadata exposed in session/conversation list APIs.
+/// Channel binding metadata exposed in conversation list APIs.
 public struct ChannelBinding: Codable, Sendable {
     public let sourceChannel: String
     public let externalChatId: String
@@ -3374,7 +3374,7 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let conversationType: String?
     public let source: String?
     public let scheduleJobId: String?
-    /// Channel binding metadata exposed in session/conversation list APIs.
+    /// Channel binding metadata exposed in conversation list APIs.
     public let channelBinding: ChannelBinding?
     public let conversationOriginChannel: String?
     public let conversationOriginInterface: String?
@@ -4147,7 +4147,7 @@ public struct SubagentStatusChanged: Codable, Sendable {
 
 public struct SubagentStatusRequest: Codable, Sendable {
     public let type: String
-    /// If omitted, returns all subagents for the session.
+    /// If omitted, returns all subagents for the conversation.
     public let subagentId: String?
 
     public init(type: String, subagentId: String? = nil) {
@@ -4885,7 +4885,7 @@ public struct VercelApiConfigResponse: Codable, Sendable {
     }
 }
 
-/// Request from a session or client to change the voice activation key.
+/// Request from a conversation or client to change the voice activation key.
 public struct VoiceConfigUpdateRequest: Codable, Sendable {
     public let type: String
     /// The desired activation key (enum value or natural-language name).

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -262,7 +262,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
                 confidence: "explicit",
                 source: "ui-navigation",
                 metadata: [
-                    "threadOrigin": AnyCodable("inbox"),
+                    "conversationOrigin": AnyCodable("inbox"),
                     "badgeCount": AnyCodable(3),
                     "userInitiated": AnyCodable(true),
                 ]
@@ -278,7 +278,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
         let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
 
-        XCTAssertEqual(metadata["threadOrigin"] as? String, "inbox")
+        XCTAssertEqual(metadata["conversationOrigin"] as? String, "inbox")
         XCTAssertEqual(metadata["badgeCount"] as? Int, 3)
         XCTAssertEqual(metadata["userInitiated"] as? Bool, true)
     }

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -215,13 +215,13 @@ Channel readiness endpoints are exposed directly by the gateway and forwarded to
 
 ### Channel Binding Lifecycle (Lane Separation)
 
-Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop conversation list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering sessions during desktop session restoration.
+Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop conversation list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering conversations during desktop conversation restoration.
 
 Channel bindings follow a three-phase lifecycle:
 
 1. **Bind** — An inbound message from an external channel (e.g., Telegram chat) arrives at the gateway, which normalizes it and forwards it to the runtime's `/v1/channels/inbound` endpoint. The runtime creates or reuses a conversation, establishing the channel binding (`sourceChannel` metadata on the conversation).
 
-2. **Route** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound sessions during session restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
+2. **Route** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound conversations during conversation restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
 
 3. **Rebind** — If a message arrives on an external chat whose conversation was previously deleted, the channel inbound handler treats it as a new conversation and establishes a fresh binding. The external chat ID is reused, but the conversation is new.
 


### PR DESCRIPTION
## Summary
- Renames `session_not_found` error reason to `conversation_not_found` across 2 TS files
- Fixes stale wire protocol names (`session_create`, `session_info`, etc.) in 4 ARCHITECTURE.md files and 2 Swift files
- Removes vestigial `skipVellumThread` test assertions and renames `threadOrigin` test metadata key
- Syncs 5 stale comments in GeneratedAPITypes.swift with already-corrected TS source
- Adds explanatory comment to legacy `generate_thread_starters` job type in jobs-store.ts

Part of plan: fix-stale-session-thread-refs.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
