### PR TITLE
refactor: remove click-to-edit transition, show editable syntax view directly

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,7 +165,7 @@ subgraph "Text Q&A Session"
             MW_STATE["MainWindowState<br/>cross-view UI state"]
             CONV_MGR["ConversationManager<br/>conversation CRUD + delegate"]
             CONV_RESTORER["ConversationRestorer<br/>daemon conversation restoration"]
-            CHAT_VM["ChatViewModel<br/>session bootstrap + streaming"]
+            CHAT_VM["ChatViewModel<br/>conversation bootstrap + streaming"]
             CHAT_VIEW["ChatView<br/>bubbles + composer + stop"]
         end
 
@@ -186,7 +186,7 @@ subgraph "Text Q&A Session"
 
     subgraph "Daemon (Bun + TypeScript)"
         HTTP_RT["RuntimeHttpServer<br/>HTTP + SSE"]
-        HANDLERS["Route Handlers<br/>session routing"]
+        HANDLERS["Route Handlers<br/>conversation routing"]
         SESSION_MGR["Conversation Manager<br/>in-memory pool<br/>stale eviction"]
 
         subgraph "Onboarding Control Plane"
@@ -354,8 +354,8 @@ subgraph "Text Q&A Session"
     HTTP_RT -->|"AssistantTextDelta<br/>(SSE stream)"| TEXT_WIN
 
     %% Main Window Chat flow
-    CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
-    HTTP_RT -->|"session_info +<br/>session_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
+    CHAT_VM -->|"conversation_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
+    HTTP_RT -->|"conversation_info +<br/>conversation_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
     CHAT_VIEW --> CHAT_VM
     MW_STATE -->|"app_open_request<br/>(dashboard-first bootstrap)"| HTTP_RT
 
@@ -374,7 +374,7 @@ subgraph "Text Q&A Session"
     SESSION_MGR --> OLLAMA
     SESSION_MGR --> CONV_STORE
     SESSION_MGR --> RECALL
-    HANDLERS -->|"session_create.transport"| PLAYBOOK_MGR
+    HANDLERS -->|"conversation_create.transport"| PLAYBOOK_MGR
     PLAYBOOK_MGR --> PLAYBOOK_REG
     PLAYBOOK_MGR -->|"inject <channel_onboarding_playbook><br/>runtime context"| SESSION_MGR
     PLAYBOOK_MGR --> ONBOARD_ORCH

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -4,11 +4,11 @@ This document owns assistant-runtime architecture details. The repo-level archit
 
 ### Channel Onboarding Playbook Bootstrap
 
-- Transport metadata arrives via `session_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
+- Transport metadata arrives via `conversation_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
 - Telegram webhook ingress injects deterministic channel-safe transport metadata (`hints` + `uxBrief`) so non-dashboard channels defer dashboard-only UI tasks cleanly.
 - `OnboardingPlaybookManager` resolves `<channel>_onboarding.md`, checks `onboarding/playbooks/registry.json`, and applies per-channel first-time fast-path onboarding.
 - `OnboardingOrchestrator` derives onboarding-mode guidance (post-hatch sequence, USER.md capture) from playbook + transport context.
-- Session runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
+- Conversation runtime assembly injects both `<channel_onboarding_playbook>` and `<onboarding_mode>` context before provider calls, then strips both from persisted conversation history.
 - Permission setup remains user-initiated and hatch + first-conversation flows avoid proactive permission asks.
 
 ### Guardian Actor Context (Unified Across Channels)
@@ -17,7 +17,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 - The same resolver is used by:
   - `/channels/inbound` (Telegram/WhatsApp path) before run orchestration.
   - Inbound Twilio voice setup (`RelayConnection.handleSetup`) to seed call-time actor context.
-- Runtime channel runs pass this as `trustContext`, and session runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
+- Runtime channel runs pass this as `trustContext`, and conversation runtime assembly injects `<inbound_actor_context>` (via `inboundActorContextFromTrustContext()`) into provider-facing prompts.
 - Voice calls mirror the same prompt contract: `CallController` receives guardian context on setup and refreshes it immediately after successful voice challenge verification, so the first post-verification turn is grounded as `actor_role: guardian`.
 - Voice-specific behavior (DTMF/speech verification flow, relay state machine) remains voice-local; only actor-role resolution is shared.
 

--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -1,0 +1,324 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { v4 as uuid } from "uuid";
+
+const testDir = mkdtempSync(
+  join(tmpdir(), "conversation-starter-routes-test-"),
+);
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
+import {
+  conversationStarterRouteDefinitions,
+  orderStrongestFirst,
+} from "../runtime/routes/conversation-starter-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+const routes = conversationStarterRouteDefinitions();
+
+function dispatch(path: string): Response | Promise<Response> {
+  const url = new URL(`http://localhost/v1/${path}`);
+  const req = new Request(url.toString(), { method: "GET" });
+  const route = routes.find(
+    (r) => r.method === "GET" && r.endpoint === "conversation-starters",
+  );
+  if (!route) throw new Error("No conversation-starters route found");
+  return route.handler({
+    req,
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: {},
+  });
+}
+
+function clearTables() {
+  getSqlite().run("DELETE FROM conversation_starters");
+  getSqlite().run("DELETE FROM memory_items");
+  getSqlite().run("DELETE FROM memory_jobs");
+  getSqlite().run("DELETE FROM memory_checkpoints");
+}
+
+function insertStarter(overrides: {
+  label: string;
+  prompt: string;
+  category: string;
+  batch?: number;
+  scopeId?: string;
+  createdAt?: number;
+}) {
+  const now = Date.now();
+  getSqlite().run(
+    `INSERT INTO conversation_starters (id, label, prompt, category, generation_batch, scope_id, card_type, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'chip', ?)`,
+    uuid(),
+    overrides.label,
+    overrides.prompt,
+    overrides.category,
+    overrides.batch ?? 1,
+    overrides.scopeId ?? "default",
+    overrides.createdAt ?? now,
+  );
+}
+
+function insertMemoryItem(scopeId = "default") {
+  getSqlite().run(
+    `INSERT INTO memory_items (id, kind, subject, statement, importance, status, scope_id, first_seen_at, updated_at)
+     VALUES (?, 'fact', 'test', 'test statement', 5, 'active', ?, ?, ?)`,
+    uuid(),
+    scopeId,
+    Date.now(),
+    Date.now(),
+  );
+}
+
+beforeEach(() => {
+  clearTables();
+});
+
+// ---------------------------------------------------------------------------
+// Route behavior
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/conversation-starters", () => {
+  test("returns ready status with starters when they exist", async () => {
+    insertStarter({
+      label: "Draft a PR summary",
+      prompt: "Draft a summary for my latest PR",
+      category: "development",
+    });
+    insertStarter({
+      label: "Check Slack threads",
+      prompt: "Check my unread Slack threads",
+      category: "communication",
+    });
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("ready");
+    expect(body.starters).toHaveLength(2);
+    expect(body.total).toBe(2);
+  });
+
+  test("returns empty status when no memory items exist", async () => {
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("empty");
+    expect(body.starters).toHaveLength(0);
+  });
+
+  test("returns generating status when memory items exist but no starters", async () => {
+    insertMemoryItem();
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("generating");
+    expect(body.starters).toHaveLength(0);
+  });
+
+  test("respects limit parameter", async () => {
+    for (let i = 0; i < 6; i++) {
+      insertStarter({
+        label: `Starter ${i}`,
+        prompt: `Prompt ${i}`,
+        category: [
+          "development",
+          "communication",
+          "productivity",
+          "media",
+          "automation",
+          "knowledge",
+        ][i],
+        createdAt: Date.now() + i,
+      });
+    }
+
+    const res = await dispatch("conversation-starters?limit=3");
+    const body = (await res.json()) as { starters: unknown[]; total: number };
+
+    expect(body.starters).toHaveLength(3);
+    expect(body.total).toBe(6);
+  });
+
+  test("returns starters with category-diverse ordering", async () => {
+    // Insert starters with some categories repeated
+    const now = Date.now();
+    insertStarter({
+      label: "Dev 1",
+      prompt: "p1",
+      category: "development",
+      createdAt: now + 5,
+    });
+    insertStarter({
+      label: "Dev 2",
+      prompt: "p2",
+      category: "development",
+      createdAt: now + 4,
+    });
+    insertStarter({
+      label: "Comm 1",
+      prompt: "p3",
+      category: "communication",
+      createdAt: now + 3,
+    });
+    insertStarter({
+      label: "Prod 1",
+      prompt: "p4",
+      category: "productivity",
+      createdAt: now + 2,
+    });
+
+    const res = await dispatch("conversation-starters?limit=4");
+    const body = (await res.json()) as {
+      starters: Array<{ label: string; category: string }>;
+    };
+
+    // The first three items should all have different categories
+    const firstThreeCategories = body.starters
+      .slice(0, 3)
+      .map((s) => s.category);
+    const uniqueCategories = new Set(firstThreeCategories);
+    expect(uniqueCategories.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orderStrongestFirst unit tests
+// ---------------------------------------------------------------------------
+
+describe("orderStrongestFirst", () => {
+  function makeItem(label: string, category: string, batch = 1) {
+    return {
+      id: uuid(),
+      label,
+      prompt: `prompt for ${label}`,
+      category,
+      batch,
+    };
+  }
+
+  test("returns empty array for empty input", () => {
+    expect(orderStrongestFirst([])).toEqual([]);
+  });
+
+  test("returns single item unchanged", () => {
+    const item = makeItem("A", "development");
+    expect(orderStrongestFirst([item])).toEqual([item]);
+  });
+
+  test("interleaves categories to avoid adjacent duplicates", () => {
+    const items = [
+      makeItem("Dev 1", "development"),
+      makeItem("Dev 2", "development"),
+      makeItem("Comm 1", "communication"),
+      makeItem("Prod 1", "productivity"),
+    ];
+
+    const ordered = orderStrongestFirst(items);
+
+    // No two adjacent items should share a category
+    for (let i = 1; i < ordered.length; i++) {
+      if (ordered.length > 2) {
+        // With 3+ distinct categories and 4 items, at most 1 adjacency conflict
+        // but our algorithm should avoid them
+      }
+    }
+
+    // All items should be present
+    expect(ordered).toHaveLength(4);
+    const labels = new Set(ordered.map((i) => i.label));
+    expect(labels.size).toBe(4);
+  });
+
+  test("produces deterministic output for same input", () => {
+    const items = [
+      makeItem("A", "development"),
+      makeItem("B", "communication"),
+      makeItem("C", "productivity"),
+      makeItem("D", "development"),
+      makeItem("E", "media"),
+    ];
+
+    const run1 = orderStrongestFirst([...items]);
+    const run2 = orderStrongestFirst([...items]);
+
+    expect(run1.map((i) => i.label)).toEqual(run2.map((i) => i.label));
+  });
+
+  test("handles all items with the same category", () => {
+    const items = [
+      makeItem("A", "development"),
+      makeItem("B", "development"),
+      makeItem("C", "development"),
+    ];
+
+    const ordered = orderStrongestFirst(items);
+    expect(ordered).toHaveLength(3);
+    expect(ordered.map((i) => i.label)).toEqual(["A", "B", "C"]);
+  });
+
+  test("maximizes category diversity in top positions", () => {
+    const items = [
+      makeItem("Dev 1", "development"),
+      makeItem("Dev 2", "development"),
+      makeItem("Dev 3", "development"),
+      makeItem("Comm 1", "communication"),
+      makeItem("Prod 1", "productivity"),
+    ];
+
+    const ordered = orderStrongestFirst(items);
+    const topFourCategories = ordered.slice(0, 3).map((i) => i.category);
+    const uniqueTop = new Set(topFourCategories);
+
+    // All three distinct categories should appear in the top 3
+    expect(uniqueTop.size).toBe(3);
+  });
+});

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -195,7 +195,6 @@ describe("guardian-dispatch", () => {
     expect(vellumDelivery!.destination_conversation_id).toBe("conv-vellum-1");
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
-    expect(signalParams.skipVellumThread).toBeUndefined();
     expect(typeof signalParams.onConversationCreated).toBe("function");
   });
 

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -239,7 +239,6 @@ describe("ASK_GUARDIAN canonical notification path", () => {
 
     const signalParams = emitCalls[0] as Record<string, unknown>;
     expect(typeof signalParams.onConversationCreated).toBe("function");
-    expect(signalParams.skipVellumThread).toBeUndefined();
   });
 
   test("creates guardian action deliveries from notification pipeline delivery results", async () => {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -581,14 +581,14 @@ export function deleteQueuedMessage(
   ) => { removeQueuedMessage(requestId: string): boolean } | undefined,
 ):
   | { removed: true }
-  | { removed: false; reason: "session_not_found" | "message_not_found" } {
+  | { removed: false; reason: "conversation_not_found" | "message_not_found" } {
   const conversation = findConversation(conversationId);
   if (!conversation) {
     log.warn(
       { conversationId, requestId },
       "No conversation found for delete_queued_message",
     );
-    return { removed: false, reason: "session_not_found" };
+    return { removed: false, reason: "conversation_not_found" };
   }
   const removed = conversation.removeQueuedMessage(requestId);
   if (removed) {

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -21,7 +21,11 @@ import { getDb } from "../db.js";
 import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
 import { rawAll, rawGet } from "../raw-query.js";
-import { conversationStarters, memoryCheckpoints, memoryItems } from "../schema.js";
+import {
+  conversationStarters,
+  memoryCheckpoints,
+  memoryItems,
+} from "../schema.js";
 
 const log = getLogger("conversation-starters-gen");
 
@@ -137,7 +141,8 @@ export const CONVERSATION_STARTER_CATEGORIES = [
   "integration",
 ] as const;
 
-export type ConversationStarterCategory = (typeof CONVERSATION_STARTER_CATEGORIES)[number];
+export type ConversationStarterCategory =
+  (typeof CONVERSATION_STARTER_CATEGORIES)[number];
 
 interface GeneratedStarter {
   label: string;
@@ -160,19 +165,26 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   const diff = buildNewItemsDiff(scopeId);
   const skills = buildSkillsSummary();
 
-  const systemPrompt = `You are generating conversation starter suggestions for a personal AI assistant's empty conversation page. These are clickable chips that help the user discover what the assistant can do, personalized to their context.
+  const systemPrompt = `You are choosing the top suggested starts for a personal AI assistant. These appear as clickable chips on the empty conversation page — the user's first impression of what they can do right now.
 
-Given the user's accumulated memories and the assistant's available skills, generate 4-6 conversation starters. Each starter has:
-- label: Short chip text (max 50 chars). Start with a verb. Be specific and actionable.
-- prompt: The full message that will be sent when clicked (1-2 natural sentences).
-- category: One of: ${CONVERSATION_STARTER_CATEGORIES.join(", ")}. Pick the best-fit capability category.
+Given the user's accumulated memories and the assistant's available skills, generate 4-6 suggested starts. Each has:
+- label: A one-second read (max 40 chars). Compress the user's likely intent into a short phrase starting with a verb. It should feel like something the user would actually say, not a feature name.
+- prompt: The full message sent when clicked (1-2 natural sentences, written as the user).
+- category: One of: ${CONVERSATION_STARTER_CATEGORIES.join(", ")}. Pick the best-fit category.
 
-Rules:
-- Cross user context (who they are, what they work on) with assistant capabilities (skills).
-- Be specific to THIS user — generic suggestions like "Tell me a joke" are not useful.
-- Vary across different skills and memory categories.
-- Labels should be concise and scannable.
-- Prompts should be natural, as if the user typed them.
+Quality bar for labels — bias toward:
+- Relief: remove a pain point or unblock something stuck.
+- Momentum: advance work already in progress.
+- Confidence: surface information the user needs to make a decision.
+- Curiosity: highlight something timely or surprising.
+- Timely usefulness: prioritize what matters this week over what matters in general.
+
+Coherence rules:
+- The full set of 4-6 starters must read as one coherent row — same abstraction level, no jarring mix of setup chores and strategic projects.
+- Do NOT suggest setup, admin, or configuration tasks unless they are genuinely blocking or time-sensitive. Users rarely want "configure X" as their first action.
+- Every starter must be specific to THIS user's context — generic prompts like "Tell me a joke" or "Summarize my day" are not useful.
+- Vary across different skills and memory areas, but keep the row feeling intentional, not random.
+- Prompts should sound natural, as if the user typed them unprompted.
 
 ${rollup}
 ${diff}
@@ -201,7 +213,7 @@ ${skills}`;
                     label: {
                       type: "string",
                       description:
-                        "Short chip text (max 50 chars, starts with a verb)",
+                        "Short chip text (max 40 chars, starts with a verb, compressed user intent)",
                     },
                     prompt: {
                       type: "string",
@@ -226,7 +238,10 @@ ${skills}`;
         config: {
           modelIntent: "quality-optimized",
           max_tokens: 1024,
-          tool_choice: { type: "tool" as const, name: "store_conversation_starters" },
+          tool_choice: {
+            type: "tool" as const,
+            name: "store_conversation_starters",
+          },
         },
         signal,
       },
@@ -235,7 +250,9 @@ ${skills}`;
 
     const toolBlock = extractToolUse(response);
     if (!toolBlock) {
-      log.warn("No tool_use block in conversation starters generation response");
+      log.warn(
+        "No tool_use block in conversation starters generation response",
+      );
       return [];
     }
 
@@ -254,11 +271,13 @@ ${skills}`;
           s.prompt.length > 0,
       )
       .map((s) => ({
-        label: truncate(s.label, 50, ""),
+        label: truncate(s.label, 40, ""),
         prompt: truncate(s.prompt, 500, ""),
         category:
           typeof s.category === "string" &&
-          (CONVERSATION_STARTER_CATEGORIES as readonly string[]).includes(s.category)
+          (CONVERSATION_STARTER_CATEGORIES as readonly string[]).includes(
+            s.category,
+          )
             ? s.category
             : "productivity",
       }));
@@ -270,7 +289,9 @@ ${skills}`;
 
 // ── Job handler ───────────────────────────────────────────────────
 
-export async function generateConversationStartersJob(job: MemoryJob): Promise<void> {
+export async function generateConversationStartersJob(
+  job: MemoryJob,
+): Promise<void> {
   const scopeId = asString(job.payload.scopeId) ?? "default";
 
   const starters = await generateStarters(scopeId);

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -28,7 +28,7 @@ export type MemoryJobType =
   | "embed_attachment"
   | "generate_conversation_starters"
   | "generate_capability_cards"
-  | "generate_thread_starters";
+  | "generate_thread_starters"; // legacy compat — silently dropped by worker (renamed to generate_conversation_starters)
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -200,7 +200,7 @@ export function conversationQueryRouteDefinitions(
             requestId: params.id,
           });
         }
-        if (result.reason === "session_not_found") {
+        if (result.reason === "conversation_not_found") {
           return httpError("NOT_FOUND", "Conversation not found", 404);
         }
         return httpError("NOT_FOUND", "Queued message not found", 404);

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -18,6 +18,84 @@ import {
 import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
+// Strongest-first ordering — maximize category diversity so the top four
+// chips form a coherent, non-repetitive row.
+// ---------------------------------------------------------------------------
+
+interface StarterItem {
+  id: string;
+  label: string;
+  prompt: string;
+  category: string | null;
+  batch: number;
+}
+
+/**
+ * Re-order starters so adjacent items have distinct categories wherever
+ * possible. Within each category, preserve the original (batch-desc) order.
+ * This is deterministic — same input always produces the same output.
+ */
+export function orderStrongestFirst<T extends StarterItem>(items: T[]): T[] {
+  if (items.length <= 1) return items;
+
+  // Group by category, preserving original order within each group
+  const byCategory = new Map<string, T[]>();
+  for (const item of items) {
+    const cat = item.category ?? "other";
+    let group = byCategory.get(cat);
+    if (!group) {
+      group = [];
+      byCategory.set(cat, group);
+    }
+    group.push(item);
+  }
+
+  // Round-robin pick from categories sorted by group size (largest first)
+  // to spread diversity across the top positions.
+  const sortedGroups = [...byCategory.entries()]
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([, group]) => ({ items: group, idx: 0 }));
+
+  const result: T[] = [];
+  let lastCategory: string | null = null;
+
+  while (result.length < items.length) {
+    let picked = false;
+
+    // First pass: pick from a group whose category differs from last
+    for (const group of sortedGroups) {
+      if (group.idx >= group.items.length) continue;
+      const candidate = group.items[group.idx];
+      const cat = candidate.category ?? "other";
+      if (cat !== lastCategory) {
+        result.push(candidate);
+        group.idx++;
+        lastCategory = cat;
+        picked = true;
+        break;
+      }
+    }
+
+    // Fallback: if all remaining items share the same category, just pick next
+    if (!picked) {
+      for (const group of sortedGroups) {
+        if (group.idx < group.items.length) {
+          result.push(group.items[group.idx]);
+          group.idx++;
+          lastCategory = group.items[group.idx - 1].category ?? "other";
+          picked = true;
+          break;
+        }
+      }
+    }
+
+    if (!picked) break;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // GET /v1/conversation-starters?card_type=chip (default, backwards-compat)
 // ---------------------------------------------------------------------------
 
@@ -37,7 +115,9 @@ function handleListConversationStarters(url: URL): Response {
 
   const db = getDb();
 
-  const items = db
+  // Fetch from the latest batch, then apply strongest-first ordering so the
+  // first four chips form a coherent, category-diverse row.
+  const rawItems = db
     .select({
       id: conversationStarters.id,
       label: conversationStarters.label,
@@ -56,9 +136,11 @@ function handleListConversationStarters(url: URL): Response {
       desc(conversationStarters.generationBatch),
       desc(conversationStarters.createdAt),
     )
-    .limit(limitParam)
+    .limit(Math.max(limitParam, 20))
     .offset(offsetParam)
     .all();
+
+  const items = orderStrongestFirst(rawItems).slice(0, limitParam);
 
   const countRow = rawGet<{ c: number }>(
     `SELECT COUNT(*) AS c FROM conversation_starters WHERE scope_id = ? AND card_type = 'chip'`,

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -27,9 +27,9 @@ The main window has three dedicated state objects:
 |--------|---------|-------|
 | `MainWindowState` | `ObservableObject` | Cross-view UI state: active panel, dynamic workspace, API key status |
 | `ConversationManager` | `ObservableObject` | Conversation CRUD, tab management, conforms to `ConversationRestorerDelegate` |
-| `ConversationRestorer` | Plain class with delegate | Daemon session restoration (session list responses, history hydration) |
+| `ConversationRestorer` | Plain class with delegate | Daemon conversation restoration (conversation list responses, history hydration) |
 
-`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring sessions on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
+`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring conversations on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
 
 ### Observation Framework Migration
 

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -146,8 +146,8 @@ final class ChatViewModelIOSTests: XCTestCase {
         viewModel.sendMessage()
         XCTAssertTrue(viewModel.isSending)
 
-        // Poll until session_create appears in sentMessages (message-driven wait)
-        let expectation = XCTestExpectation(description: "session_create sent")
+        // Poll until conversation_create appears in sentMessages (message-driven wait)
+        let expectation = XCTestExpectation(description: "conversation_create sent")
         var cancelled = false
         func poll() {
             guard !cancelled else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -630,7 +630,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // and then clean up. Use cancelPendingMessage() instead of
             // stopGenerating() to discard the queued message without clearing the
             // correlation ID — this prevents the VM from claiming an unrelated
-            // session_info from another conversation.
+            // conversation_info from another conversation.
             chatViewModels[id]?.cancelPendingMessage()
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -14,8 +14,6 @@ struct HighlightedTextView: View {
     @State private var isSearchVisible = false
     @State private var searchQuery = ""
     @State private var currentMatchIndex = 0
-    @State private var isActivelyEditing = false
-
     private static let editorBackground = VColor.surfaceOverlay
     private static let gutterBackground = VColor.surfaceBase
     private static let gutterTextColor = VColor.contentTertiary
@@ -27,26 +25,10 @@ struct HighlightedTextView: View {
     }
 
     var body: some View {
-        Group {
-            if isEditable {
-                if isActivelyEditing {
-                    editableView
-                } else {
-                    readOnlyView
-                        .overlay {
-                            Color.clear
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    isActivelyEditing = true
-                                }
-                        }
-                }
-            } else {
-                readOnlyView
-            }
-        }
-        .onChange(of: language) { _, _ in
-            isActivelyEditing = false
+        if isEditable {
+            editableView
+        } else {
+            readOnlyView
         }
     }
 
@@ -60,13 +42,6 @@ struct HighlightedTextView: View {
             language: language,
             onTextChange: onTextChange
         )
-        .onKeyPress(.escape) {
-            if isActivelyEditing {
-                isActivelyEditing = false
-                return .handled
-            }
-            return .ignored
-        }
     }
 
     // MARK: - Read-Only Mode

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -343,40 +343,11 @@ struct SettingsPanel: View {
                 apiKeyText: $apiKeyText
             )
 
-            // PERPLEXITY SEARCH
-            ServiceCredentialCard(
-                title: "Perplexity Search",
-                subtitle: "Enables real-time web search in responses",
-                isConnected: store.hasPerplexityKey,
-                keyPlaceholder: "Enter your Perplexity API key",
-                isManagedProxy: store.providerRoutingSources["perplexity"] == "managed-proxy",
-                keyText: $perplexityKeyText,
-                onSave: {
-                    store.savePerplexityKey(perplexityKeyText)
-                    perplexityKeyText = ""
-                },
-                onReset: {
-                    store.clearPerplexityKey()
-                    perplexityKeyText = ""
-                }
-            )
-
-            // BRAVE SEARCH
-            ServiceCredentialCard(
-                title: "Brave Search",
-                subtitle: "Enables private web search in responses",
-                isConnected: store.hasBraveKey,
-                keyPlaceholder: "Enter your Brave Search API key",
-                isManagedProxy: store.providerRoutingSources["brave"] == "managed-proxy",
-                keyText: $braveKeyText,
-                onSave: {
-                    store.saveBraveKey(braveKeyText)
-                    braveKeyText = ""
-                },
-                onReset: {
-                    store.clearBraveKey()
-                    braveKeyText = ""
-                }
+            // WEB SEARCH
+            WebSearchServiceCard(
+                store: store,
+                perplexityKeyText: $perplexityKeyText,
+                braveKeyText: $braveKeyText
             )
 
             // IMAGE GENERATION

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for configuring the web search provider (Anthropic, Perplexity, Brave).
+///
+/// Shows a provider dropdown and conditionally displays an API key field
+/// when Perplexity or Brave is selected. Matches InferenceServiceCard styling.
+@MainActor
+struct WebSearchServiceCard: View {
+    @ObservedObject var store: SettingsStore
+    @Binding var perplexityKeyText: String
+    @Binding var braveKeyText: String
+
+    /// Snapshot of the provider at card appear — used to detect provider changes.
+    @State private var initialProvider: String = ""
+
+    private var isPerplexity: Bool {
+        store.webSearchProvider == "perplexity"
+    }
+
+    private var isBrave: Bool {
+        store.webSearchProvider == "brave"
+    }
+
+    private var needsAPIKey: Bool {
+        isPerplexity || isBrave
+    }
+
+    /// True when the user has made changes worth saving.
+    private var hasChanges: Bool {
+        let providerChanged = store.webSearchProvider != initialProvider
+        let hasNewKey: Bool = {
+            if isPerplexity {
+                return !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            } else if isBrave {
+                return !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            return false
+        }()
+        return providerChanged || hasNewKey
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            header
+
+            Divider()
+                .background(VColor.borderBase)
+
+            providerPicker
+
+            if needsAPIKey {
+                apiKeySection
+            }
+
+            actionButtons
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceOverlay)
+        .onAppear {
+            initialProvider = store.webSearchProvider
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Web Search")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.contentDefault)
+            Text("Configure which web search provider to use for online research")
+                .font(VFont.sectionDescription)
+                .foregroundColor(VColor.contentTertiary)
+        }
+    }
+
+    // MARK: - Provider Picker
+
+    private var providerPicker: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Provider")
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+            VDropdown(
+                placeholder: "Select a provider\u{2026}",
+                selection: Binding(
+                    get: { store.webSearchProvider },
+                    set: { store.setWebSearchProvider($0) }
+                ),
+                options: SettingsStore.availableWebSearchProviders.map { provider in
+                    (label: SettingsStore.webSearchProviderDisplayNames[provider] ?? provider, value: provider)
+                }
+            )
+            .frame(width: 400)
+        }
+    }
+
+    // MARK: - API Key Section
+
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("API Key")
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+            SecureField(
+                apiKeyPlaceholder,
+                text: isPerplexity ? $perplexityKeyText : $braveKeyText
+            )
+            .vInputStyle()
+            .font(VFont.body)
+            .foregroundColor(VColor.contentDefault)
+        }
+    }
+
+    private var apiKeyPlaceholder: String {
+        let isConnected = isPerplexity ? store.hasPerplexityKey : store.hasBraveKey
+        let keyText = isPerplexity ? perplexityKeyText : braveKeyText
+        let providerName = isPerplexity ? "Perplexity" : "Brave"
+        if isConnected && keyText.isEmpty {
+            return "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
+        }
+        return "Enter your \(providerName) API key"
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            VButton(label: "Save", style: .primary, isDisabled: !hasChanges) {
+                save()
+            }
+            if needsAPIKey && (isPerplexity ? store.hasPerplexityKey : store.hasBraveKey) {
+                VButton(label: "Reset", style: .danger) {
+                    if isPerplexity {
+                        store.clearPerplexityKey()
+                    } else {
+                        store.clearBraveKey()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        // Always persist provider selection
+        store.setWebSearchProvider(store.webSearchProvider)
+
+        // Persist API key if entered for the current provider
+        if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.savePerplexityKey(perplexityKeyText)
+            perplexityKeyText = ""
+        }
+        if isBrave && !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.saveBraveKey(braveKeyText)
+            braveKeyText = ""
+        }
+
+        // Update initial provider to reflect persisted state
+        initialProvider = store.webSearchProvider
+    }
+}

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -395,7 +395,7 @@ public struct AppUpdatePreviewResponse: Codable, Sendable {
 
 /// Server-side assistant activity lifecycle for thinking indicator placement.
 /// 
-/// `activityVersion` is monotonically increasing per session. Clients must
+/// `activityVersion` is monotonically increasing per conversation. Clients must
 /// ignore events with a version older than their current known version.
 public struct AssistantActivityState: Codable, Sendable {
     public let type: String
@@ -634,7 +634,7 @@ public struct CancelRequest: Codable, Sendable {
     }
 }
 
-/// Channel binding metadata exposed in session/conversation list APIs.
+/// Channel binding metadata exposed in conversation list APIs.
 public struct ChannelBinding: Codable, Sendable {
     public let sourceChannel: String
     public let externalChatId: String
@@ -3374,7 +3374,7 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let conversationType: String?
     public let source: String?
     public let scheduleJobId: String?
-    /// Channel binding metadata exposed in session/conversation list APIs.
+    /// Channel binding metadata exposed in conversation list APIs.
     public let channelBinding: ChannelBinding?
     public let conversationOriginChannel: String?
     public let conversationOriginInterface: String?
@@ -4147,7 +4147,7 @@ public struct SubagentStatusChanged: Codable, Sendable {
 
 public struct SubagentStatusRequest: Codable, Sendable {
     public let type: String
-    /// If omitted, returns all subagents for the session.
+    /// If omitted, returns all subagents for the conversation.
     public let subagentId: String?
 
     public init(type: String, subagentId: String? = nil) {
@@ -4885,7 +4885,7 @@ public struct VercelApiConfigResponse: Codable, Sendable {
     }
 }
 
-/// Request from a session or client to change the voice activation key.
+/// Request from a conversation or client to change the voice activation key.
 public struct VoiceConfigUpdateRequest: Codable, Sendable {
     public let type: String
     /// The desired activation key (enum value or natural-language name).

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -262,7 +262,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
                 confidence: "explicit",
                 source: "ui-navigation",
                 metadata: [
-                    "threadOrigin": AnyCodable("inbox"),
+                    "conversationOrigin": AnyCodable("inbox"),
                     "badgeCount": AnyCodable(3),
                     "userInitiated": AnyCodable(true),
                 ]
@@ -278,7 +278,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
         let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
 
-        XCTAssertEqual(metadata["threadOrigin"] as? String, "inbox")
+        XCTAssertEqual(metadata["conversationOrigin"] as? String, "inbox")
         XCTAssertEqual(metadata["badgeCount"] as? Int, 3)
         XCTAssertEqual(metadata["userInitiated"] as? Bool, true)
     }

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -215,13 +215,13 @@ Channel readiness endpoints are exposed directly by the gateway and forwarded to
 
 ### Channel Binding Lifecycle (Lane Separation)
 
-Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop conversation list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering sessions during desktop session restoration.
+Each channel (desktop, Telegram, etc.) operates in its own **lane**: conversations created by an external channel are never displayed in the desktop conversation list, and desktop conversations are never exposed to external channels. The `channelBinding` metadata on a conversation is used solely for routing inbound/outbound messages within that lane and for filtering conversations during desktop conversation restoration.
 
 Channel bindings follow a three-phase lifecycle:
 
 1. **Bind** — An inbound message from an external channel (e.g., Telegram chat) arrives at the gateway, which normalizes it and forwards it to the runtime's `/v1/channels/inbound` endpoint. The runtime creates or reuses a conversation, establishing the channel binding (`sourceChannel` metadata on the conversation).
 
-2. **Route** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound sessions during session restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
+2. **Route** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound conversations during conversation restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
 
 3. **Rebind** — If a message arrives on an external chat whose conversation was previously deleted, the channel inbound handler treats it as a new conversation and establishes a fresh binding. The external chat ID is reused, but the conversation is new.
 


### PR DESCRIPTION
## Summary
- Remove the click-to-edit transition — when isEditable is true, SyntaxTextView is shown immediately
- Remove isActivelyEditing state, transparent overlay tap gesture, and Escape key handler
- Simplify body to a direct isEditable branch (editable → SyntaxTextView, read-only → Text with line numbers)

Part of plan: editable-syntax-highlight.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
