### PR TITLE
Add a macOS presentation model for concierge-style capability feeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/CapabilityFeedPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilityFeedPresentation.swift
@@ -1,0 +1,103 @@
+import Foundation
+import VellumAssistantShared
+
+// MARK: - Feed Presentation Model
+
+/// Pure presentation model that partitions an already-ordered `[CapabilityCard]` array
+/// into hero, supporting, and overflow buckets for the concierge-style capability feed.
+///
+/// This builder is deterministic, isolated from SwiftUI, and does not invent new backend
+/// ranking heuristics — it relies entirely on the server-provided ordering.
+struct CapabilityFeedPresentation {
+
+    /// The single headline card shown with prominence.
+    let hero: CapabilityCard?
+
+    /// A small set of secondary cards shown beneath the hero (up to `maxSupportingCount`).
+    let supporting: [CapabilityCard]
+
+    /// Remaining cards available via an expandable overflow section.
+    let overflow: [CapabilityCard]
+
+    /// Maximum number of cards in the supporting bucket.
+    static let maxSupportingCount = 4
+
+    /// Index at which overflow begins (hero + supporting).
+    static let overflowStartIndex = 1 + maxSupportingCount // 5
+
+    /// Whether any cards are still being generated.
+    let isGenerating: Bool
+
+    /// Builds a presentation from the server-ordered card array and category statuses.
+    ///
+    /// - Parameters:
+    ///   - cards: Cards in the order the backend determined (highest priority first).
+    ///   - categoryStatuses: Per-category generation status from the backend.
+    init(cards: [CapabilityCard], categoryStatuses: [String: CategoryStatus] = [:]) {
+        self.hero = cards.first
+
+        let supportingEnd = min(Self.overflowStartIndex, cards.count)
+        self.supporting = cards.count > 1
+            ? Array(cards[1..<supportingEnd])
+            : []
+
+        self.overflow = cards.count > Self.overflowStartIndex
+            ? Array(cards[Self.overflowStartIndex...])
+            : []
+
+        self.isGenerating = categoryStatuses.values.contains { $0.status == "generating" }
+    }
+}
+
+// MARK: - Editorial Framing Strings
+
+/// Centralized editorial copy for the capability feed UI.
+///
+/// All user-facing framing strings live here so that `CapabilitiesFeedView`,
+/// `ScrollCTAView`, and `ChatEmptyStateView` can reference a single source of truth
+/// instead of duplicating copy.
+enum FeedFraming {
+
+    // MARK: Section Headers
+
+    /// Hero section header — shown above the primary card.
+    static let heroHeader = "Do this first"
+
+    /// Supporting section header — shown above the secondary cards.
+    static let supportingHeader = "A few useful wins"
+
+    /// Overflow section header — shown above the expandable card list.
+    static let overflowHeader = "More ideas for you"
+
+    // MARK: Time-Aware Hero Eyebrows
+
+    /// Returns a time-aware eyebrow string for the hero card based on the current hour.
+    ///
+    /// - Parameter hour: The hour of the day in 24-hour format (0–23).
+    /// - Returns: A contextual eyebrow string.
+    static func heroEyebrow(forHour hour: Int) -> String {
+        switch hour {
+        case 5..<12:
+            return "Before tomorrow starts"
+        case 12..<17:
+            return "While the afternoon is yours"
+        case 17..<21:
+            return "Before the day wraps up"
+        default:
+            return "Something to knock out"
+        }
+    }
+
+    /// Returns a hero eyebrow for the current time.
+    static var currentHeroEyebrow: String {
+        heroEyebrow(forHour: Calendar.current.component(.hour, from: Date()))
+    }
+
+    // MARK: Feed Chrome
+
+    /// Scroll CTA copy inviting the user to explore more capabilities.
+    static let scrollCTA = "There\u{2019}s a lot more I can do"
+
+    /// Soft closer text at the bottom of the full feed.
+    static let feedCloser = "And anything else you can dream up."
+}

--- a/clients/macos/vellum-assistantTests/CapabilityFeedPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CapabilityFeedPresentationTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class CapabilityFeedPresentationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeCard(id: String = UUID().uuidString, label: String = "Card") -> CapabilityCard {
+        CapabilityCard(
+            id: id,
+            icon: nil,
+            label: label,
+            description: nil,
+            prompt: "do something",
+            category: "productivity",
+            tags: [],
+            batch: 0
+        )
+    }
+
+    private func makeCards(count: Int) -> [CapabilityCard] {
+        (0..<count).map { makeCard(id: "card-\($0)", label: "Card \($0)") }
+    }
+
+    // MARK: - Hero Partitioning
+
+    func testFirstCardBecomesHero() {
+        let cards = makeCards(count: 3)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertEqual(sut.hero?.id, "card-0")
+    }
+
+    func testEmptyCardsProducesNilHero() {
+        let sut = CapabilityFeedPresentation(cards: [])
+
+        XCTAssertNil(sut.hero)
+        XCTAssertTrue(sut.supporting.isEmpty)
+        XCTAssertTrue(sut.overflow.isEmpty)
+    }
+
+    func testSingleCardIsHeroOnly() {
+        let sut = CapabilityFeedPresentation(cards: makeCards(count: 1))
+
+        XCTAssertNotNil(sut.hero)
+        XCTAssertTrue(sut.supporting.isEmpty)
+        XCTAssertTrue(sut.overflow.isEmpty)
+    }
+
+    // MARK: - Supporting Cap
+
+    func testSupportingCapsAtFour() {
+        let cards = makeCards(count: 10)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertEqual(sut.supporting.count, CapabilityFeedPresentation.maxSupportingCount)
+        XCTAssertEqual(sut.supporting.map(\.id), ["card-1", "card-2", "card-3", "card-4"])
+    }
+
+    func testSupportingWithFewerThanFour() {
+        let cards = makeCards(count: 3)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertEqual(sut.supporting.count, 2)
+        XCTAssertEqual(sut.supporting.map(\.id), ["card-1", "card-2"])
+    }
+
+    // MARK: - Overflow
+
+    func testOverflowStartsAtItemSix() {
+        let cards = makeCards(count: 8)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertEqual(sut.overflow.count, 3)
+        XCTAssertEqual(sut.overflow.first?.id, "card-5")
+    }
+
+    func testExactlyFiveCardsProducesNoOverflow() {
+        let cards = makeCards(count: 5)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertNotNil(sut.hero)
+        XCTAssertEqual(sut.supporting.count, 4)
+        XCTAssertTrue(sut.overflow.isEmpty)
+    }
+
+    func testSixCardsProducesOneOverflow() {
+        let cards = makeCards(count: 6)
+        let sut = CapabilityFeedPresentation(cards: cards)
+
+        XCTAssertEqual(sut.overflow.count, 1)
+        XCTAssertEqual(sut.overflow.first?.id, "card-5")
+    }
+
+    // MARK: - Generating Status
+
+    func testIsGeneratingWhenAnyCategoryIsGenerating() {
+        let statuses: [String: CategoryStatus] = [
+            "productivity": CategoryStatus(status: "ready", relevance: 0.8),
+            "communication": CategoryStatus(status: "generating", relevance: nil),
+        ]
+        let sut = CapabilityFeedPresentation(cards: makeCards(count: 2), categoryStatuses: statuses)
+
+        XCTAssertTrue(sut.isGenerating)
+    }
+
+    func testIsNotGeneratingWhenAllReady() {
+        let statuses: [String: CategoryStatus] = [
+            "productivity": CategoryStatus(status: "ready", relevance: 0.8),
+            "communication": CategoryStatus(status: "ready", relevance: 0.6),
+        ]
+        let sut = CapabilityFeedPresentation(cards: makeCards(count: 2), categoryStatuses: statuses)
+
+        XCTAssertFalse(sut.isGenerating)
+    }
+
+    func testIsNotGeneratingWithEmptyStatuses() {
+        let sut = CapabilityFeedPresentation(cards: makeCards(count: 2))
+
+        XCTAssertFalse(sut.isGenerating)
+    }
+
+    // MARK: - Time-Aware Framing
+
+    func testMorningEyebrow() {
+        for hour in 5..<12 {
+            let eyebrow = FeedFraming.heroEyebrow(forHour: hour)
+            XCTAssertEqual(eyebrow, "Before tomorrow starts", "Hour \(hour) should be morning")
+        }
+    }
+
+    func testAfternoonEyebrow() {
+        for hour in 12..<17 {
+            let eyebrow = FeedFraming.heroEyebrow(forHour: hour)
+            XCTAssertEqual(eyebrow, "While the afternoon is yours", "Hour \(hour) should be afternoon")
+        }
+    }
+
+    func testEveningEyebrow() {
+        for hour in 17..<21 {
+            let eyebrow = FeedFraming.heroEyebrow(forHour: hour)
+            XCTAssertEqual(eyebrow, "Before the day wraps up", "Hour \(hour) should be evening")
+        }
+    }
+
+    func testLateNightEyebrow() {
+        for hour in [0, 1, 2, 3, 4, 21, 22, 23] {
+            let eyebrow = FeedFraming.heroEyebrow(forHour: hour)
+            XCTAssertEqual(eyebrow, "Something to knock out", "Hour \(hour) should be late night")
+        }
+    }
+
+    // MARK: - Framing Stability
+
+    func testHeroEyebrowReturnsSameValueForSameHour() {
+        let a = FeedFraming.heroEyebrow(forHour: 9)
+        let b = FeedFraming.heroEyebrow(forHour: 9)
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - Static Framing Strings
+
+    func testSectionHeadersAreNonEmpty() {
+        XCTAssertFalse(FeedFraming.heroHeader.isEmpty)
+        XCTAssertFalse(FeedFraming.supportingHeader.isEmpty)
+        XCTAssertFalse(FeedFraming.overflowHeader.isEmpty)
+    }
+
+    func testScrollCTAMatchesExpectedCopy() {
+        XCTAssertEqual(FeedFraming.scrollCTA, "There\u{2019}s a lot more I can do")
+    }
+
+    func testFeedCloserMatchesExpectedCopy() {
+        XCTAssertEqual(FeedFraming.feedCloser, "And anything else you can dream up.")
+    }
+}


### PR DESCRIPTION
## Summary
- Created `CapabilityFeedPresentation` builder that partitions cards into hero/supporting/overflow buckets
- Centralized editorial framing strings (`FeedFraming`) with time-aware hero eyebrows
- Added focused tests covering mechanical partitioning rules and framing copy

Part of plan: action-concierge-feed.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
