### PR TITLE
Retune capability-card generation for action-concierge copy and stable ordering

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -30,6 +30,7 @@ mock.module("../util/logger.js", () => ({
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   conversationStarterRouteDefinitions,
+  orderCardsForHero,
   orderStrongestFirst,
 } from "../runtime/routes/conversation-starter-routes.js";
 
@@ -67,6 +68,7 @@ function clearTables() {
   getSqlite().run("DELETE FROM memory_items");
   getSqlite().run("DELETE FROM memory_jobs");
   getSqlite().run("DELETE FROM memory_checkpoints");
+  getSqlite().run("DELETE FROM capability_card_categories");
 }
 
 function insertStarter(overrides: {
@@ -320,5 +322,249 @@ describe("orderStrongestFirst", () => {
 
     // All three distinct categories should appear in the top 3
     expect(uniqueTop.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orderCardsForHero unit tests
+// ---------------------------------------------------------------------------
+
+describe("orderCardsForHero", () => {
+  function makeCard(
+    label: string,
+    category: string,
+    opts: { highPriority?: boolean; batch?: number } = {},
+  ) {
+    const tags: string[] = [];
+    if (opts.highPriority) tags.push("__high_priority__");
+    tags.push("Quick win");
+    return {
+      id: uuid(),
+      icon: "lucide-sparkles",
+      label,
+      description: `desc for ${label}`,
+      prompt: `prompt for ${label}`,
+      category,
+      tags: tags.join(","),
+      batch: opts.batch ?? 1,
+    };
+  }
+
+  test("returns empty array for empty input", () => {
+    expect(orderCardsForHero([], new Map())).toEqual([]);
+  });
+
+  test("returns single card unchanged", () => {
+    const card = makeCard("A", "development");
+    expect(orderCardsForHero([card], new Map())).toEqual([card]);
+  });
+
+  test("high_priority cards come first", () => {
+    const normal = makeCard("Normal", "development");
+    const priority = makeCard("Priority", "media", { highPriority: true });
+
+    const ordered = orderCardsForHero([normal, priority], new Map());
+    expect(ordered[0].label).toBe("Priority");
+    expect(ordered[1].label).toBe("Normal");
+  });
+
+  test("contextual cluster beats active_work and discovery", () => {
+    const discovery = makeCard("Discovery", "media");
+    const activeWork = makeCard("Active", "development");
+    const contextual = makeCard("Contextual", "communication");
+
+    const ordered = orderCardsForHero(
+      [discovery, activeWork, contextual],
+      new Map(),
+    );
+    expect(ordered[0].label).toBe("Contextual");
+    expect(ordered[1].label).toBe("Active");
+    expect(ordered[2].label).toBe("Discovery");
+  });
+
+  test("higher category relevance wins within same cluster", () => {
+    const lowRel = makeCard("Low", "media");
+    const highRel = makeCard("High", "automation");
+
+    const relevance = new Map([
+      ["media", 0.7],
+      ["automation", 0.95],
+    ]);
+
+    const ordered = orderCardsForHero([lowRel, highRel], relevance);
+    // Both are discovery cluster — automation has higher relevance
+    expect(ordered[0].label).toBe("High");
+    expect(ordered[1].label).toBe("Low");
+  });
+
+  test("high_priority overrides cluster precedence", () => {
+    const contextual = makeCard("Contextual", "communication");
+    const priorityDiscovery = makeCard("Priority Discovery", "media", {
+      highPriority: true,
+    });
+
+    const ordered = orderCardsForHero(
+      [contextual, priorityDiscovery],
+      new Map(),
+    );
+    // high_priority takes precedence over cluster
+    expect(ordered[0].label).toBe("Priority Discovery");
+    expect(ordered[1].label).toBe("Contextual");
+  });
+
+  test("produces deterministic output for same input", () => {
+    const cards = [
+      makeCard("A", "development"),
+      makeCard("B", "communication"),
+      makeCard("C", "media", { highPriority: true }),
+      makeCard("D", "productivity"),
+    ];
+
+    const relevance = new Map([
+      ["development", 0.9],
+      ["communication", 0.8],
+    ]);
+
+    const run1 = orderCardsForHero([...cards], relevance);
+    const run2 = orderCardsForHero([...cards], relevance);
+    expect(run1.map((c) => c.label)).toEqual(run2.map((c) => c.label));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card route integration tests
+// ---------------------------------------------------------------------------
+
+function insertCard(overrides: {
+  label: string;
+  prompt: string;
+  category: string;
+  tags?: string;
+  batch?: number;
+  scopeId?: string;
+  createdAt?: number;
+}) {
+  const now = Date.now();
+  getSqlite().run(
+    `INSERT INTO conversation_starters (id, label, prompt, category, generation_batch, scope_id, card_type, tags, icon, description, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'card', ?, 'lucide-sparkles', 'desc', ?)`,
+    uuid(),
+    overrides.label,
+    overrides.prompt,
+    overrides.category,
+    overrides.batch ?? 1,
+    overrides.scopeId ?? "default",
+    overrides.tags ?? "Quick win",
+    overrides.createdAt ?? now,
+  );
+}
+
+function insertCategoryRelevance(
+  category: string,
+  relevance: number,
+  scopeId = "default",
+) {
+  getSqlite().run(
+    `INSERT OR REPLACE INTO capability_card_categories (scope_id, category, relevance, generation_batch, created_at)
+     VALUES (?, ?, ?, 1, ?)`,
+    scopeId,
+    category,
+    relevance,
+    Date.now(),
+  );
+}
+
+describe("GET /v1/conversation-starters?card_type=card", () => {
+  test("returns cards with tags as arrays and strips internal tags", async () => {
+    insertCard({
+      label: "Clear inbox",
+      prompt: "Help me clear my inbox",
+      category: "communication",
+      tags: "__high_priority__,Quick win,2 min",
+    });
+
+    const res = await dispatch("conversation-starters?card_type=card");
+    const body = (await res.json()) as {
+      cards: Array<{ label: string; tags: string[] }>;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.cards).toHaveLength(1);
+    // Internal __high_priority__ tag should be stripped
+    expect(body.cards[0].tags).toEqual(["Quick win", "2 min"]);
+    expect(body.cards[0].tags).not.toContain("__high_priority__");
+  });
+
+  test("orders cards with high_priority first", async () => {
+    const now = Date.now();
+    insertCard({
+      label: "Normal card",
+      prompt: "p1",
+      category: "development",
+      tags: "High leverage",
+      createdAt: now + 2,
+    });
+    insertCard({
+      label: "Priority card",
+      prompt: "p2",
+      category: "media",
+      tags: "__high_priority__,Quick win",
+      createdAt: now + 1,
+    });
+    insertCategoryRelevance("development", 0.9);
+    insertCategoryRelevance("media", 0.7);
+
+    const res = await dispatch("conversation-starters?card_type=card");
+    const body = (await res.json()) as {
+      cards: Array<{ label: string }>;
+    };
+
+    expect(body.cards[0].label).toBe("Priority card");
+    expect(body.cards[1].label).toBe("Normal card");
+  });
+
+  test("orders by cluster precedence when no high_priority", async () => {
+    const now = Date.now();
+    insertCard({
+      label: "Discovery card",
+      prompt: "p1",
+      category: "media",
+      createdAt: now + 3,
+    });
+    insertCard({
+      label: "Active work card",
+      prompt: "p2",
+      category: "development",
+      createdAt: now + 2,
+    });
+    insertCard({
+      label: "Contextual card",
+      prompt: "p3",
+      category: "communication",
+      createdAt: now + 1,
+    });
+
+    const res = await dispatch("conversation-starters?card_type=card");
+    const body = (await res.json()) as {
+      cards: Array<{ label: string; category: string }>;
+    };
+
+    // contextual > active_work > discovery
+    expect(body.cards[0].label).toBe("Contextual card");
+    expect(body.cards[1].label).toBe("Active work card");
+    expect(body.cards[2].label).toBe("Discovery card");
+  });
+
+  test("returns empty status when no memory items", async () => {
+    const res = await dispatch("conversation-starters?card_type=card");
+    const body = (await res.json()) as {
+      cards: unknown[];
+      total: number;
+      status: string;
+    };
+
+    expect(body.status).toBe("empty");
+    expect(body.cards).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/job-handlers/capability-cards.ts
+++ b/assistant/src/memory/job-handlers/capability-cards.ts
@@ -32,7 +32,7 @@ import {
 
 const log = getLogger("capability-cards-gen");
 
-/** Capability categories for the feed (knowledge dropped — not actionable). */
+/** Capability categories for the feed. */
 export const CAPABILITY_CARD_CATEGORIES = [
   "communication",
   "productivity",
@@ -61,6 +61,44 @@ const CATEGORY_DESCRIPTIONS: Record<CapabilityCardCategory, string> = {
   integration:
     "Third-party services, APIs, syncing data across tools, connecting services",
 };
+
+/**
+ * Internal clusters that guide card generation intent. Categories map to one
+ * of these clusters to shape copy tone and priority signals.
+ */
+export type CardCluster = "contextual" | "active_work" | "discovery";
+
+export const CATEGORY_CLUSTER: Record<CapabilityCardCategory, CardCluster> = {
+  communication: "contextual",
+  productivity: "active_work",
+  development: "active_work",
+  media: "discovery",
+  automation: "discovery",
+  web_social: "discovery",
+  integration: "discovery",
+};
+
+/** Cluster precedence — lower index = higher hero-candidate priority. */
+export const CLUSTER_PRECEDENCE: CardCluster[] = [
+  "contextual",
+  "active_work",
+  "discovery",
+];
+
+/**
+ * Allowed action-value tags. The LLM must choose from this set instead of
+ * tool/integration taxonomy labels.
+ */
+const ACTION_VALUE_TAGS = [
+  "Quick win",
+  "Most useful tonight",
+  "Unblocks tomorrow",
+  "High leverage",
+  "Work",
+  "Personal",
+  "2 min",
+  "5 min",
+] as const;
 
 /**
  * Curated subset of VIcon names the LLM can choose from, organized by
@@ -130,11 +168,24 @@ interface GeneratedCard {
   description: string;
   prompt: string;
   tags: string[];
+  high_priority: boolean;
 }
 
 interface GenerationResult {
   relevance: number;
   cards: GeneratedCard[];
+}
+
+/** Cluster-specific prompt guidance for outcome-first copy generation. */
+function buildClusterPrompt(cluster: CardCluster): string {
+  switch (cluster) {
+    case "contextual":
+      return "These cards address something happening right now — an unread message, an upcoming meeting, a recent notification. Emphasize timeliness and the relief of handling it. high_priority is appropriate here when there is a clear deadline or unread item.";
+    case "active_work":
+      return "These cards relate to work the user is actively doing — open PRs, in-progress tasks, ongoing projects. Emphasize momentum and getting unblocked. high_priority is appropriate only if there is a concrete blocker or imminent deadline.";
+    case "discovery":
+      return "These cards surface capabilities the user might not know about or hasn't tried yet. Emphasize the payoff and how little effort it takes. high_priority should almost never be true for discovery cards.";
+  }
 }
 
 async function generateCardsForCategory(
@@ -154,6 +205,7 @@ async function generateCardsForCategory(
   }
 
   const skills = buildSkillsSummary();
+  const cluster = CATEGORY_CLUSTER[category];
   const icons = ICON_PALETTE[category] ?? [];
   const allIcons = [
     ...icons,
@@ -165,26 +217,30 @@ async function generateCardsForCategory(
     "lucide-briefcase",
   ];
 
-  const systemPrompt = `You are generating capability cards for a personal AI assistant's new conversation page. These cards showcase what the assistant can do, personalized to the user's context.
+  const clusterGuidance = buildClusterPrompt(cluster);
+
+  const systemPrompt = `You are generating action-concierge cards for a personal AI assistant. Each card should read like a service the user would want — outcome-first, emphasizing what they get, not what the system does internally.
 
 You are generating cards for the "${category}" category: ${CATEGORY_DESCRIPTIONS[category]}.
+Cluster intent: ${cluster} — ${clusterGuidance}
 
 Given the user's memories below, do two things:
 1. Assess how relevant this category is to this user (0.0–1.0). A score of 0.7+ means the user has clear context that makes this category actionable. Score lower if the user's memories have little relation to this category.
-2. If relevant (0.7+), generate 2–3 capability cards that cross the user's context with what the assistant can do in this area.
+2. If relevant (0.7+), generate 2–3 cards ordered strongest-first (the card you're most confident delivers value should come first).
 
 For each card, provide:
 - icon: One of these Lucide icon names: ${allIcons.join(", ")}
-- title: Action-oriented, verb-first, max 50 chars (e.g., "Triage your inbox", "Debug the auth middleware")
-- description: One line explaining the outcome, personalized to the user's context, max 120 chars
+- title: Outcome-first, user-desire-oriented, max 50 chars. Frame as what the user gets, not what the tool does. Good: "Clear your inbox before standup", "Unblock the auth PR". Bad: "Run email triage", "Check PR status".
+- description: One line explaining the concrete payoff, personalized to the user's context, max 120 chars
 - prompt: The full message that will be sent when clicked (1-2 natural sentences, as if the user typed it)
-- tags: 1-3 short labels for integrations/tools involved (e.g., "Gmail", "Calendar", "Linear")
+- tags: 1-2 action-value labels from this list ONLY: ${ACTION_VALUE_TAGS.join(", ")}. Choose labels that signal urgency, payoff, or effort — never use tool or integration names as tags.
+- high_priority: true ONLY if there is a concrete why-now moment (e.g., a meeting in the next few hours, an unread thread from today, a deploy deadline). Do not mark cards as high_priority for general usefulness.
 
 Rules:
 - Be specific to THIS user — generic suggestions are not useful.
-- Titles should be concise and scannable, starting with a verb.
+- Cards should feel like services the user would want, not internal task tickets.
+- Return cards strongest-first — the first card should be the most compelling.
 - Prompts should be natural, as if the user typed them.
-- Tags should reference actual tools/services relevant to the suggestion.
 - If relevance is below 0.7, you may return an empty cards array.
 
 ${rollup}
@@ -237,10 +293,23 @@ ${skills}`;
                     tags: {
                       type: "array",
                       items: { type: "string" },
-                      description: "1-3 integration/tool tags",
+                      description:
+                        "1-2 action-value labels from the allowed set",
+                    },
+                    high_priority: {
+                      type: "boolean",
+                      description:
+                        "true only for concrete why-now moments, false otherwise",
                     },
                   },
-                  required: ["icon", "title", "description", "prompt", "tags"],
+                  required: [
+                    "icon",
+                    "title",
+                    "description",
+                    "prompt",
+                    "tags",
+                    "high_priority",
+                  ],
                 },
               },
             },
@@ -283,6 +352,8 @@ ${skills}`;
       return { relevance, cards: [] };
     }
 
+    // Preserve model order (strongest-first) and cap visible tags at 2
+    const allowedTags = new Set<string>(ACTION_VALUE_TAGS);
     const cards = input.cards
       .filter(
         (c) =>
@@ -300,8 +371,13 @@ ${skills}`;
         description: truncate(c.description ?? "", 120, ""),
         prompt: truncate(c.prompt, 500, ""),
         tags: Array.isArray(c.tags)
-          ? c.tags.filter((t): t is string => typeof t === "string").slice(0, 3)
+          ? c.tags
+              .filter(
+                (t): t is string => typeof t === "string" && allowedTags.has(t),
+              )
+              .slice(0, 2)
           : [],
+        high_priority: c.high_priority === true,
       }));
 
     return { relevance, cards };
@@ -377,8 +453,13 @@ export async function generateCapabilityCardsJob(
     )
     .run();
 
-  // Insert new cards
+  // Insert new cards — encode high_priority as a tag prefix so the route
+  // layer can read the signal without a schema migration.
   for (const card of result.cards) {
+    const tagParts = [...card.tags];
+    if (card.high_priority) {
+      tagParts.unshift("__high_priority__");
+    }
     db.insert(conversationStarters)
       .values({
         id: uuid(),
@@ -386,7 +467,7 @@ export async function generateCapabilityCardsJob(
         prompt: card.prompt,
         icon: card.icon,
         description: card.description,
-        tags: card.tags.join(","),
+        tags: tagParts.join(","),
         category,
         cardType: "card",
         generationBatch: nextBatch,

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -7,7 +7,11 @@
 import { and, desc, eq, inArray, like } from "drizzle-orm";
 
 import { getDb } from "../../memory/db.js";
-import { CAPABILITY_CARD_CATEGORIES } from "../../memory/job-handlers/capability-cards.js";
+import {
+  CAPABILITY_CARD_CATEGORIES,
+  type CardCluster,
+  CLUSTER_PRECEDENCE,
+} from "../../memory/job-handlers/capability-cards.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { rawAll, rawGet } from "../../memory/raw-query.js";
 import {
@@ -93,6 +97,88 @@ export function orderStrongestFirst<T extends StarterItem>(items: T[]): T[] {
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Hero-candidate ordering for capability cards
+// ---------------------------------------------------------------------------
+
+/** Sentinel tag stored by the card generator to signal priority. */
+const HIGH_PRIORITY_TAG = "__high_priority__";
+
+/** Map categories to their cluster for precedence lookup. */
+const CATEGORY_TO_CLUSTER: Record<string, CardCluster> = {
+  communication: "contextual",
+  productivity: "active_work",
+  development: "active_work",
+  media: "discovery",
+  automation: "discovery",
+  web_social: "discovery",
+  integration: "discovery",
+};
+
+interface CardItem {
+  id: string;
+  icon: string | null;
+  label: string;
+  description: string | null;
+  prompt: string;
+  category: string | null;
+  tags: string | null;
+  batch: number;
+}
+
+/**
+ * Order capability cards so the first card is a stable hero candidate.
+ *
+ * Ordering signals (applied in priority order):
+ * 1. high_priority cards come first (concrete why-now moments)
+ * 2. Cluster precedence: contextual > active_work > discovery
+ * 3. Category relevance from capability_card_categories table
+ * 4. Model order preserved within each group (strongest-first from generation)
+ */
+export function orderCardsForHero(
+  cards: CardItem[],
+  categoryRelevance: Map<string, number>,
+): CardItem[] {
+  if (cards.length <= 1) return cards;
+
+  const clusterIndex = new Map(CLUSTER_PRECEDENCE.map((c, i) => [c, i]));
+
+  return [...cards].sort((a, b) => {
+    // 1. high_priority first
+    const aHigh = a.tags?.includes(HIGH_PRIORITY_TAG) ? 1 : 0;
+    const bHigh = b.tags?.includes(HIGH_PRIORITY_TAG) ? 1 : 0;
+    if (aHigh !== bHigh) return bHigh - aHigh;
+
+    // 2. Cluster precedence
+    const aCluster =
+      clusterIndex.get(CATEGORY_TO_CLUSTER[a.category ?? ""] ?? "discovery") ??
+      2;
+    const bCluster =
+      clusterIndex.get(CATEGORY_TO_CLUSTER[b.category ?? ""] ?? "discovery") ??
+      2;
+    if (aCluster !== bCluster) return aCluster - bCluster;
+
+    // 3. Category relevance (higher is better)
+    const aRel = categoryRelevance.get(a.category ?? "") ?? 0;
+    const bRel = categoryRelevance.get(b.category ?? "") ?? 0;
+    if (aRel !== bRel) return bRel - aRel;
+
+    // 4. Preserve model order (already sorted by batch desc, createdAt desc)
+    return 0;
+  });
+}
+
+/**
+ * Strip the internal high_priority sentinel from the tags string before
+ * returning cards to clients.
+ */
+function stripInternalTags(tagsStr: string | null): string[] {
+  if (!tagsStr) return [];
+  return tagsStr
+    .split(",")
+    .filter((t) => t !== HIGH_PRIORITY_TAG && t.length > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +292,8 @@ function handleListCapabilityCards(url: URL): Response {
     conditions.push(eq(conversationStarters.category, categoryFilter));
   }
 
-  const cards = db
+  // Fetch more than limit so ordering can surface the best hero candidates
+  const rawCards = db
     .select({
       id: conversationStarters.id,
       icon: conversationStarters.icon,
@@ -223,13 +310,32 @@ function handleListCapabilityCards(url: URL): Response {
       desc(conversationStarters.generationBatch),
       desc(conversationStarters.createdAt),
     )
-    .limit(limitParam)
+    .limit(Math.max(limitParam, 50))
     .all();
 
-  // Transform tags from comma-separated string to array
-  const transformedCards = cards.map((c) => ({
+  // Build category relevance map for ordering
+  const relevanceRows = db
+    .select({
+      category: capabilityCardCategories.category,
+      relevance: capabilityCardCategories.relevance,
+    })
+    .from(capabilityCardCategories)
+    .where(eq(capabilityCardCategories.scopeId, scopeId))
+    .all();
+  const categoryRelevance = new Map(
+    relevanceRows.map((r) => [r.category, r.relevance]),
+  );
+
+  // Apply hero-candidate ordering, then limit
+  const orderedCards = orderCardsForHero(rawCards, categoryRelevance).slice(
+    0,
+    limitParam,
+  );
+
+  // Transform tags: strip internal sentinels, split to array
+  const transformedCards = orderedCards.map((c) => ({
     ...c,
-    tags: c.tags ? c.tags.split(",").filter(Boolean) : [],
+    tags: stripInternalTags(c.tags),
   }));
 
   // Build per-category status map


### PR DESCRIPTION
## Summary
- Rewrote card generation prompts to produce outcome-first, user-desire-oriented copy
- Introduced internal clusters (contextual, active_work, discovery) to guide tone and priority
- Constrained visible tags to action-value labels (Quick win, High leverage, 2 min, etc.) instead of tool/integration taxonomy
- Added high_priority signal for concrete why-now moments, encoded as tag sentinel to avoid schema migration
- Capped visible chips at two per card
- Added deterministic hero-candidate ordering using high_priority, cluster precedence, and category relevance
- Extended conversation starter route tests to cover card ordering and card route integration

Part of plan: action-concierge-feed.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
