### PR TITLE
Replace the capability showcase layout with a concierge-style card feed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/CapabilitiesFeedView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilitiesFeedView.swift
@@ -1,132 +1,166 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Masonry-style grid of capability cards grouped by category.
-/// Shows skeleton placeholders for categories still generating.
+/// Concierge-style card feed built from `CapabilityFeedPresentation`.
+///
+/// Displays one hero recommendation, a small set of supporting cards,
+/// and a collapsed overflow section — replacing the old category-grouped grid.
 struct CapabilitiesFeedView: View {
     let cards: [CapabilityCard]
     let categoryStatuses: [String: CategoryStatus]
     let loading: Bool
     let onCardTap: (CapabilityCard) -> Void
 
-    /// Categories in display order.
-    private static let categoryOrder = [
-        "communication",
-        "productivity",
-        "development",
-        "automation",
-        "web_social",
-        "integration",
-        "media",
-    ]
+    @State private var overflowExpanded = false
 
-    /// Human-readable category labels.
-    private static let categoryLabels: [String: String] = [
-        "communication": "Communication",
-        "productivity": "Productivity",
-        "development": "Development",
-        "media": "Media",
-        "automation": "Automation",
-        "web_social": "Web & Social",
-        "integration": "Integration",
-    ]
-
-    private let columns = [
-        GridItem(.flexible(), spacing: VSpacing.md),
-        GridItem(.flexible(), spacing: VSpacing.md),
-        GridItem(.flexible(), spacing: VSpacing.md),
-    ]
-
-    /// Cards grouped by category in display order, filtered to relevant categories.
-    private var groupedCards: [(category: String, label: String, cards: [CapabilityCard])] {
-        let byCategory = Dictionary(grouping: cards, by: { $0.category ?? "other" })
-        return Self.categoryOrder.compactMap { cat in
-            guard let items = byCategory[cat], !items.isEmpty else { return nil }
-            let label = Self.categoryLabels[cat] ?? cat.capitalized
-            return (category: cat, label: label, cards: items)
-        }
-    }
-
-    /// Categories that are still generating (no cards yet, status is "generating").
-    private var generatingCategories: [String] {
-        Self.categoryOrder.filter { cat in
-            let status = categoryStatuses[cat]
-            let hasCards = cards.contains { $0.category == cat }
-            return !hasCards && status?.status == "generating"
-        }
+    private var presentation: CapabilityFeedPresentation {
+        CapabilityFeedPresentation(cards: cards, categoryStatuses: categoryStatuses)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
-            // Section header
-            VStack(alignment: .center, spacing: VSpacing.xs) {
-                Text("Everything I can do for you")
-                    .font(VFont.title)
-                    .foregroundColor(VColor.contentDefault)
+            heroSection
 
-                Text("Personalized for you \u{00B7} Tap any card to start")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.bottom, VSpacing.md)
+            supportingSection
 
-            // Cards grouped by category
-            ForEach(groupedCards, id: \.category) { group in
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text(group.label)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.contentTertiary)
-                        .textCase(.uppercase)
-                        .tracking(0.5)
+            overflowSection
 
-                    LazyVGrid(columns: columns, spacing: VSpacing.md) {
-                        ForEach(group.cards) { card in
-                            CapabilityCardView(card: card) {
-                                onCardTap(card)
-                            }
-                        }
-                    }
+            loadingSection
+
+            closerSection
+        }
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth + 80)
+        .padding(.horizontal, VSpacing.xl)
+    }
+
+    // MARK: - Hero
+
+    @ViewBuilder
+    private var heroSection: some View {
+        if let hero = presentation.hero {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                sectionHeader(FeedFraming.heroHeader, eyebrow: FeedFraming.currentHeroEyebrow)
+
+                CapabilityCardView(card: hero, treatment: .hero) {
+                    onCardTap(hero)
                 }
-            }
-
-            // Skeleton placeholders for categories still generating
-            ForEach(generatingCategories, id: \.self) { cat in
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text(Self.categoryLabels[cat] ?? cat.capitalized)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.contentTertiary)
-                        .textCase(.uppercase)
-                        .tracking(0.5)
-
-                    LazyVGrid(columns: columns, spacing: VSpacing.md) {
-                        ForEach(0..<2, id: \.self) { _ in
-                            CapabilityCardSkeleton()
-                        }
-                    }
-                }
-            }
-
-            // Loading state when no cards or generating categories exist yet
-            if cards.isEmpty && generatingCategories.isEmpty && loading {
-                LazyVGrid(columns: columns, spacing: VSpacing.md) {
-                    ForEach(0..<6, id: \.self) { _ in
-                        CapabilityCardSkeleton()
-                    }
-                }
-            }
-
-            // Soft closer
-            if !cards.isEmpty {
-                Text("And anything else you can dream up.")
-                    .font(.custom("Fraunces", size: 16).italic())
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, VSpacing.lg)
-                    .padding(.bottom, VSpacing.xxxl)
             }
         }
-        .frame(maxWidth: VSpacing.chatBubbleMaxWidth + 200) // Wider than hero for 3-col grid
-        .padding(.horizontal, VSpacing.xl)
+    }
+
+    // MARK: - Supporting
+
+    @ViewBuilder
+    private var supportingSection: some View {
+        if !presentation.supporting.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                sectionHeader(FeedFraming.supportingHeader)
+
+                ForEach(presentation.supporting) { card in
+                    CapabilityCardView(card: card, treatment: .compact) {
+                        onCardTap(card)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Overflow
+
+    @ViewBuilder
+    private var overflowSection: some View {
+        if !presentation.overflow.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Button {
+                    withAnimation(VAnimation.standard) {
+                        overflowExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(FeedFraming.overflowHeader)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.contentTertiary)
+                            .textCase(.uppercase)
+                            .tracking(0.5)
+
+                        Spacer()
+
+                        VIcon.chevronDown.image
+                            .resizable()
+                            .frame(width: 12, height: 12)
+                            .foregroundColor(VColor.contentTertiary)
+                            .rotationEffect(.degrees(overflowExpanded ? 180 : 0))
+                            .animation(VAnimation.standard, value: overflowExpanded)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    overflowExpanded
+                        ? "Collapse more ideas"
+                        : "Show \(presentation.overflow.count) more ideas"
+                )
+
+                if overflowExpanded {
+                    ForEach(presentation.overflow) { card in
+                        CapabilityCardView(card: card, treatment: .compact) {
+                            onCardTap(card)
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        }
+    }
+
+    // MARK: - Loading
+
+    @ViewBuilder
+    private var loadingSection: some View {
+        if cards.isEmpty && loading {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                CapabilityCardSkeleton(treatment: .hero)
+
+                ForEach(0..<2, id: \.self) { _ in
+                    CapabilityCardSkeleton(treatment: .compact)
+                }
+            }
+        } else if presentation.isGenerating {
+            CapabilityCardSkeleton(treatment: .compact)
+        }
+    }
+
+    // MARK: - Closer
+
+    @ViewBuilder
+    private var closerSection: some View {
+        if !cards.isEmpty {
+            Text(FeedFraming.feedCloser)
+                .font(.custom("Fraunces", size: 16).italic())
+                .foregroundColor(VColor.contentTertiary)
+                .frame(maxWidth: .infinity)
+                .padding(.top, VSpacing.lg)
+                .padding(.bottom, VSpacing.xxxl)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String, eyebrow: String? = nil) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            if let eyebrow {
+                Text(eyebrow)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
+                    .italic()
+            }
+
+            Text(title)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.contentTertiary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/CapabilityCardView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilityCardView.swift
@@ -1,9 +1,18 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// A single capability card in the feed, showing an icon, title, description, and tag pills.
+/// Visual treatment for a capability card in the concierge feed.
+enum CardTreatment {
+    /// Full-width, visually dominant card with stronger contrast and explicit CTA.
+    case hero
+    /// Lighter, scannable card for the supporting and overflow buckets.
+    case compact
+}
+
+/// A single capability card with two visual treatments: hero and compact.
 struct CapabilityCardView: View {
     let card: CapabilityCard
+    var treatment: CardTreatment = .compact
     let onTap: () -> Void
 
     @State private var isHovered = false
@@ -14,54 +23,18 @@ struct CapabilityCardView: View {
 
     var body: some View {
         Button(action: onTap) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                HStack(spacing: VSpacing.sm) {
-                    resolvedIcon.image
-                        .resizable()
-                        .frame(width: 16, height: 16)
-                        .foregroundColor(VColor.contentSecondary)
-
-                    Text(card.label)
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                }
-
-                if let desc = card.description, !desc.isEmpty {
-                    Text(desc)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                        .lineLimit(3)
-                        .multilineTextAlignment(.leading)
-                }
-
-                if !card.tags.isEmpty {
-                    HStack(spacing: VSpacing.xs) {
-                        ForEach(card.tags, id: \.self) { tag in
-                            Text(tag)
-                                .font(VFont.small)
-                                .foregroundColor(VColor.contentSecondary)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, VSpacing.xxs)
-                                .background(
-                                    RoundedRectangle(cornerRadius: VRadius.sm)
-                                        .fill(VColor.surfaceOverlay)
-                                )
-                        }
-                    }
+            Group {
+                switch treatment {
+                case .hero:
+                    heroContent
+                case .compact:
+                    compactContent
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(VSpacing.lg)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(isHovered ? VColor.surfaceOverlay : VColor.surfaceActive)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(VColor.borderBase, lineWidth: 0.5)
-            )
+            .padding(treatment == .hero ? VSpacing.xl : VSpacing.lg)
+            .background(cardBackground)
+            .overlay(cardBorder)
             .offset(y: isHovered ? -2 : 0)
             .shadow(
                 color: isHovered ? VColor.borderBase.opacity(0.15) : .clear,
@@ -74,28 +47,127 @@ struct CapabilityCardView: View {
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
     }
+
+    // MARK: - Hero Treatment
+
+    private var heroContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.sm) {
+                resolvedIcon.image
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .foregroundColor(VColor.primaryBase)
+
+                Spacer()
+            }
+
+            Text(card.label)
+                .font(VFont.cardTitle)
+                .foregroundColor(VColor.contentEmphasized)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+
+            if let desc = card.description, !desc.isEmpty {
+                Text(desc)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                    .lineLimit(4)
+                    .multilineTextAlignment(.leading)
+            }
+
+            tagChips
+
+            // CTA row
+            HStack(spacing: VSpacing.xs) {
+                Text("Start")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.primaryBase)
+
+                VIcon.arrowRight.image
+                    .resizable()
+                    .frame(width: 12, height: 12)
+                    .foregroundColor(VColor.primaryBase)
+            }
+            .padding(.top, VSpacing.xs)
+        }
+    }
+
+    // MARK: - Compact Treatment
+
+    private var compactContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                resolvedIcon.image
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .foregroundColor(VColor.contentSecondary)
+
+                Text(card.label)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.contentDefault)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+
+            if let desc = card.description, !desc.isEmpty {
+                Text(desc)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+
+            tagChips
+        }
+    }
+
+    // MARK: - Shared Elements
+
+    @ViewBuilder
+    private var tagChips: some View {
+        if !card.tags.isEmpty {
+            HStack(spacing: VSpacing.xs) {
+                ForEach(card.tags, id: \.self) { tag in
+                    Text(tag)
+                        .font(VFont.small)
+                        .foregroundColor(VColor.contentSecondary)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(VColor.surfaceOverlay)
+                        )
+                }
+            }
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: VRadius.lg)
+            .fill(isHovered ? VColor.surfaceOverlay : VColor.surfaceActive)
+    }
+
+    private var cardBorder: some View {
+        RoundedRectangle(cornerRadius: VRadius.lg)
+            .stroke(VColor.borderBase, lineWidth: 0.5)
+    }
 }
 
 /// Skeleton placeholder for a card that is still being generated.
 struct CapabilityCardSkeleton: View {
+    var treatment: CardTreatment = .compact
+
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
-                VSkeletonBone()
-                    .frame(width: 16, height: 16)
-
-                VSkeletonBone()
-                    .frame(width: 120, height: 14)
+        Group {
+            switch treatment {
+            case .hero:
+                heroSkeleton
+            case .compact:
+                compactSkeleton
             }
-
-            VSkeletonBone()
-                .frame(height: 12)
-
-            VSkeletonBone()
-                .frame(width: 80, height: 12)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.lg)
+        .padding(treatment == .hero ? VSpacing.xl : VSpacing.lg)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.surfaceActive)
@@ -104,5 +176,32 @@ struct CapabilityCardSkeleton: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.borderBase.opacity(0.3), lineWidth: 0.5)
         )
+    }
+
+    private var heroSkeleton: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            skeletonBone(width: 20, height: 20)
+            skeletonBone(width: 200, height: 18)
+            skeletonBone(height: 14)
+            skeletonBone(width: 160, height: 14)
+        }
+    }
+
+    private var compactSkeleton: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                skeletonBone(width: 16, height: 16)
+                skeletonBone(width: 120, height: 14)
+            }
+            skeletonBone(height: 12)
+            skeletonBone(width: 80, height: 12)
+        }
+    }
+
+    private func skeletonBone(width: CGFloat? = nil, height: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: VRadius.sm)
+            .fill(VColor.surfaceOverlay)
+            .frame(width: width, height: height)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/CapabilityFeedPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/CapabilityFeedPresentation.swift
@@ -95,8 +95,8 @@ enum FeedFraming {
 
     // MARK: Feed Chrome
 
-    /// Scroll CTA copy inviting the user to explore more capabilities.
-    static let scrollCTA = "There\u{2019}s a lot more I can do"
+    /// Scroll CTA copy inviting the user to explore what they could do next.
+    static let scrollCTA = "See what else you could do"
 
     /// Soft closer text at the bottom of the full feed.
     static let feedCloser = "And anything else you can dream up."

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -59,8 +59,8 @@ struct ChatEmptyStateView: View {
     // MARK: - Greeting Data
 
     static let placeholderTexts = [
-        "Ask me anything...",
-        "Tell me what you need...",
+        "What would help right now?",
+        "What should we tackle?",
         "Say the word...",
         "Go ahead, I'm listening...",
         "Type or hold Fn to talk...",

--- a/clients/macos/vellum-assistant/Features/Chat/FloatingMiniComposer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/FloatingMiniComposer.swift
@@ -24,7 +24,7 @@ struct FloatingMiniComposer: View {
                         }
                     }
 
-                    Text("Type a message\u{2026}")
+                    Text("Back to composer\u{2026}")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentTertiary)
 

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// "There's a lot more I can do" scroll prompt with a bouncing chevron.
+/// "See what else you could do" scroll prompt with a bouncing chevron.
 /// Fades in ~1 second after appearing.
 struct ScrollCTAView: View {
     let onTap: () -> Void
@@ -12,7 +12,7 @@ struct ScrollCTAView: View {
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: VSpacing.sm) {
-                Text("There\u{2019}s a lot more I can do")
+                Text("See what else you could do")
                     .font(.custom("Fraunces", size: 14).italic())
                     .foregroundColor(VColor.contentTertiary)
 

--- a/clients/macos/vellum-assistantTests/CapabilityFeedPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CapabilityFeedPresentationTests.swift
@@ -168,7 +168,7 @@ final class CapabilityFeedPresentationTests: XCTestCase {
     }
 
     func testScrollCTAMatchesExpectedCopy() {
-        XCTAssertEqual(FeedFraming.scrollCTA, "There\u{2019}s a lot more I can do")
+        XCTAssertEqual(FeedFraming.scrollCTA, "See what else you could do")
     }
 
     func testFeedCloserMatchesExpectedCopy() {


### PR DESCRIPTION
## Summary
- Rewrote CapabilitiesFeedView to use CapabilityFeedPresentation: hero card, supporting cards, collapsed overflow
- Split CapabilityCardView into hero and compact supporting treatments
- Updated empty-state copy across ChatEmptyStateView, ScrollCTAView, and FloatingMiniComposer to read as 'what to do next'
- Removed cluster-based taxonomy from visible UI

Part of plan: action-concierge-feed.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
