### PR TITLE
fix: use FeedFraming.scrollCTA constant instead of hardcoded string

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollCTAView.swift
@@ -12,7 +12,7 @@ struct ScrollCTAView: View {
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: VSpacing.sm) {
-                Text("See what else you could do")
+                Text(FeedFraming.scrollCTA)
                     .font(.custom("Fraunces", size: 14).italic())
                     .foregroundColor(VColor.contentTertiary)
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for action-concierge-feed.md.

**Gap:** FeedFraming.scrollCTA unused in ScrollCTAView
**What was expected:** Centralized framing strings used across all views
**What was found:** ScrollCTAView hardcoded the string instead of using the constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)