### PR TITLE
feat: add telemetry events for app_open and hatch

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -25,6 +25,7 @@ import {
   createCoreTables,
   createExternalConversationBindingsTables,
   createFollowupsTables,
+  createLifecycleEventsTable,
   createMediaAssetsTables,
   createMessagesFts,
   createNotificationTables,
@@ -443,6 +444,9 @@ export function initializeDb(): void {
 
   // 77. Rename thread_starters → conversation_starters table and indexes
   migrateRenameThreadStartersTable(database);
+
+  // 78. Lifecycle events table for app_open / hatch telemetry
+  createLifecycleEventsTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/lifecycle-events-store.ts
+++ b/assistant/src/memory/lifecycle-events-store.ts
@@ -1,0 +1,63 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db.js";
+import { lifecycleEvents } from "./schema.js";
+
+export interface LifecycleEvent {
+  id: string;
+  eventName: string;
+  createdAt: number;
+}
+
+/** Record a lifecycle event (e.g. app_open, hatch). */
+export function recordLifecycleEvent(eventName: string): LifecycleEvent {
+  const db = getDb();
+  const event: LifecycleEvent = {
+    id: uuid(),
+    eventName,
+    createdAt: Date.now(),
+  };
+  db.insert(lifecycleEvents)
+    .values({
+      id: event.id,
+      eventName: event.eventName,
+      createdAt: event.createdAt,
+    })
+    .run();
+  return event;
+}
+
+/**
+ * Query lifecycle events that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedLifecycleEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): LifecycleEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: lifecycleEvents.id,
+      eventName: lifecycleEvents.eventName,
+      createdAt: lifecycleEvents.createdAt,
+    })
+    .from(lifecycleEvents)
+    .where(
+      afterId
+        ? or(
+            gt(lifecycleEvents.createdAt, afterCreatedAt),
+            and(
+              eq(lifecycleEvents.createdAt, afterCreatedAt),
+              gt(lifecycleEvents.id, afterId),
+            ),
+          )
+        : gt(lifecycleEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(lifecycleEvents.createdAt), asc(lifecycleEvents.id))
+    .limit(limit)
+    .all();
+  return rows;
+}

--- a/assistant/src/memory/migrations/175-create-lifecycle-events.ts
+++ b/assistant/src/memory/migrations/175-create-lifecycle-events.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the lifecycle_events table for tracking app lifecycle telemetry
+ * (app_open, hatch, etc.).
+ */
+export function createLifecycleEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS lifecycle_events (
+      id TEXT PRIMARY KEY,
+      event_name TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -116,6 +116,7 @@ export { migrateCapabilityCardColumns } from "./171-capability-card-columns.js";
 export { migrateRenameCreatedBySessionIdColumns } from "./172-rename-created-by-session-id.js";
 export { migrateRenameSourceSessionIdColumn } from "./173-rename-source-session-id.js";
 export { migrateRenameThreadStartersTable } from "./174-rename-thread-starters-table.js";
+export { createLifecycleEventsTable } from "./175-create-lifecycle-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -138,6 +138,12 @@ export const llmUsageEvents = sqliteTable(
   ],
 );
 
+export const lifecycleEvents = sqliteTable("lifecycle_events", {
+  id: text("id").primaryKey(),
+  eventName: text("event_name").notNull(), // 'app_open' | 'hatch'
+  createdAt: integer("created_at").notNull(),
+});
+
 export const actorTokenRecords = sqliteTable("actor_token_records", {
   id: text("id").primaryKey(),
   tokenHash: text("token_hash").notNull(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -161,6 +161,7 @@ import { skillRouteDefinitions } from "./routes/skills-routes.js";
 import { subagentRouteDefinitions } from "./routes/subagents-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
+import { telemetryRouteDefinitions } from "./routes/telemetry-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
@@ -739,6 +740,7 @@ export class RuntimeHttpServer {
       ...identityRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
+      ...telemetryRouteDefinitions(),
       ...workspaceRouteDefinitions(),
       ...memoryItemRouteDefinitions(),
       ...conversationStarterRouteDefinitions(),

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -1,0 +1,53 @@
+/**
+ * Route handlers for telemetry lifecycle events.
+ *
+ * POST /v1/telemetry/lifecycle — record a lifecycle event (app_open, hatch).
+ */
+
+import { recordLifecycleEvent } from "../../memory/lifecycle-events-store.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("telemetry-routes");
+
+const VALID_EVENT_NAMES = new Set(["app_open", "hatch"]);
+
+export async function handleRecordLifecycleEvent(
+  req: Request,
+): Promise<Response> {
+  let body: { event_name?: string };
+  try {
+    body = (await req.json()) as { event_name?: string };
+  } catch {
+    return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+  }
+
+  const eventName = body.event_name;
+  if (!eventName || !VALID_EVENT_NAMES.has(eventName)) {
+    return httpError(
+      "BAD_REQUEST",
+      `event_name must be one of: ${[...VALID_EVENT_NAMES].join(", ")}`,
+      400,
+    );
+  }
+
+  const event = recordLifecycleEvent(eventName);
+  log.info({ eventName, eventId: event.id }, "Recorded lifecycle event");
+
+  return Response.json({ id: event.id, event_name: event.eventName });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function telemetryRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "telemetry/lifecycle",
+      method: "POST",
+      handler: async ({ req }) => handleRecordLifecycleEvent(req),
+    },
+  ];
+}

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -22,5 +22,14 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
   type: "turn";
 }
 
+/** Lifecycle event — app_open, hatch, etc. */
+export interface LifecycleTelemetryEvent extends TelemetryEventBase {
+  type: "lifecycle";
+  event_name: string;
+}
+
 /** Discriminated union of all telemetry event types. */
-export type TelemetryEvent = LlmUsageTelemetryEvent | TurnTelemetryEvent;
+export type TelemetryEvent =
+  | LlmUsageTelemetryEvent
+  | TurnTelemetryEvent
+  | LifecycleTelemetryEvent;

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -19,6 +19,7 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
+import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
@@ -37,6 +38,10 @@ const CHECKPOINT_KEY_WATERMARK = "telemetry:usage:last_reported_at";
 const CHECKPOINT_KEY_WATERMARK_ID = "telemetry:usage:last_reported_id";
 const CHECKPOINT_KEY_TURN_WATERMARK = "telemetry:turns:last_reported_at";
 const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
+const CHECKPOINT_KEY_LIFECYCLE_WATERMARK =
+  "telemetry:lifecycle:last_reported_at";
+const CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID =
+  "telemetry:lifecycle:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
@@ -100,6 +105,13 @@ export class UsageTelemetryReporter {
       const turnWatermarkId =
         getMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID) ?? undefined;
 
+      // Read lifecycle watermark (compound cursor: createdAt + id)
+      const lifecycleWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK) ?? "0",
+      );
+      const lifecycleWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID) ?? undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -111,8 +123,18 @@ export class UsageTelemetryReporter {
         turnWatermarkId,
         BATCH_SIZE,
       );
+      const lifecycleEvents = queryUnreportedLifecycleEvents(
+        lifecycleWatermark,
+        lifecycleWatermarkId,
+        BATCH_SIZE,
+      );
 
-      if (events.length === 0 && turnEvents.length === 0) return;
+      if (
+        events.length === 0 &&
+        turnEvents.length === 0 &&
+        lifecycleEvents.length === 0
+      )
+        return;
 
       // Resolve auth context — skip flush when neither auth mode is viable
       const proxyCtx = await resolveManagedProxyContext();
@@ -151,6 +173,14 @@ export class UsageTelemetryReporter {
           (e): TelemetryEvent => ({
             type: "turn",
             daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+          }),
+        ),
+        ...lifecycleEvents.map(
+          (e): TelemetryEvent => ({
+            type: "lifecycle",
+            daemon_event_id: e.id,
+            event_name: e.eventName,
             recorded_at: e.createdAt,
           }),
         ),
@@ -207,8 +237,25 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID, lastTurn.id);
       }
 
-      // If we got a full batch of either type, there may be more — recurse
-      if (events.length === BATCH_SIZE || turnEvents.length === BATCH_SIZE) {
+      // Advance lifecycle watermark (compound cursor)
+      if (lifecycleEvents.length > 0) {
+        const lastLifecycle = lifecycleEvents[lifecycleEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_LIFECYCLE_WATERMARK,
+          String(lastLifecycle.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID,
+          lastLifecycle.id,
+        );
+      }
+
+      // If we got a full batch of any type, there may be more — recurse
+      if (
+        events.length === BATCH_SIZE ||
+        turnEvents.length === BATCH_SIZE ||
+        lifecycleEvents.length === BATCH_SIZE
+      ) {
         await this._doFlush(batchCount + 1);
       }
     } catch (err) {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -387,6 +387,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 let ready = await awaitDaemonReady(timeout: 15)
 
                 if ready {
+                    // Record lifecycle telemetry events (fire-and-forget).
+                    Task { await daemonClient.httpTransport?.recordLifecycleEvent("hatch") }
+                    Task { await daemonClient.httpTransport?.recordLifecycleEvent("app_open") }
+
                     // If the user is signed in with a local assistant, wait for
                     // credential provisioning to complete before sending the wake-up
                     // greeting, so the managed-proxy key is available for the LLM call.
@@ -414,6 +418,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 }
             }
         } else {
+            // Record app_open telemetry event (fire-and-forget).
+            // The daemon may not be connected yet, so retry briefly.
+            Task {
+                let ready = await awaitDaemonReady(timeout: 10)
+                if ready {
+                    await daemonClient.httpTransport?.recordLifecycleEvent("app_open")
+                }
+            }
             showMainWindow()
             debugStateWriter.start(appDelegate: self)
         }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -429,6 +429,9 @@ public final class HTTPTransport {
         // BTW side-chain
         case btw
 
+        // Telemetry
+        case telemetryLifecycle
+
         // Misc
         case channelVerificationSessions
         case channelVerificationSessionsStatus
@@ -819,6 +822,8 @@ public final class HTTPTransport {
             return ("/v1/channel-verification-sessions/revoke", nil)
         case .registerDeviceToken:
             return ("/v1/device-token", nil)
+        case .telemetryLifecycle:
+            return ("/v1/telemetry/lifecycle", nil)
         }
     }
 
@@ -1183,6 +1188,8 @@ public final class HTTPTransport {
             return ("\(prefix)/channel-verification-sessions/revoke/", nil)
         case .registerDeviceToken:
             return ("\(prefix)/device-token/", nil)
+        case .telemetryLifecycle:
+            return ("\(prefix)/telemetry/lifecycle/", nil)
         }
     }
 
@@ -2053,6 +2060,37 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Conversation seen signal error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Record a lifecycle telemetry event (e.g. app_open, hatch).
+    /// Fire-and-forget — failures are logged but do not propagate.
+    func recordLifecycleEvent(_ eventName: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .telemetryLifecycle) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["event_name": eventName]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await recordLifecycleEvent(eventName, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.warning("Lifecycle event '\(eventName)' recording failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.warning("Lifecycle event '\(eventName)' recording error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `lifecycle` telemetry event type with `app_open` and `hatch` event names, persisted in a new `lifecycle_events` SQLite table
- Integrate lifecycle events into the existing `UsageTelemetryReporter` flush pipeline (same watermark-based at-least-once delivery pattern as LLM usage and turn events)
- Add `POST /v1/telemetry/lifecycle` daemon endpoint for clients to record lifecycle events
- Wire up macOS client to send `app_open` on every launch and `hatch` on first launch, once the daemon is connected

## Original prompt
Can you add telemetry events for when a user opens the app and also when a user hatches their assistant?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
