### PR TITLE
fix: restore individual card borders in Settings/Channels tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -10,6 +10,7 @@ struct AssistantChannelsDetailView: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
     var isEmailEnabled: Bool = false
+    var showCardBorders: Bool = true
 
     // Telegram credential entry
     @State private var telegramBotTokenText = ""
@@ -30,26 +31,11 @@ struct AssistantChannelsDetailView: View {
 
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xl) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Channels")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.contentDefault)
-                Text("Once set up, you and others you trust can talk to your assistant in these channels.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-
-            VStack(alignment: .leading, spacing: 0) {
-                telegramCard
-                SettingsDivider().padding(.vertical, VSpacing.sm)
-                slackChannelCard
-                SettingsDivider().padding(.vertical, VSpacing.sm)
-                voiceCard
-                if isEmailEnabled {
-                    SettingsDivider().padding(.vertical, VSpacing.sm)
-                    emailCard
-                }
+        Group {
+            if showCardBorders {
+                borderedLayout
+            } else {
+                flatLayout
             }
         }
         .onAppear {
@@ -89,10 +75,64 @@ struct AssistantChannelsDetailView: View {
         }
     }
 
+    // MARK: - Layouts
+
+    /// Settings tab layout: individual bordered cards per channel, own ScrollView.
+    private var borderedLayout: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.xl) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Channels")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Once set up, you and others you trust can talk to your assistant in these channels.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    telegramCard
+                    slackChannelCard
+                    voiceCard
+                    if isEmailEnabled {
+                        emailCard
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+        }
+    }
+
+    /// Contacts tab layout: flat cards with dividers, no ScrollView (container scrolls).
+    private var flatLayout: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Channels")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.contentDefault)
+                Text("Once set up, you and others you trust can talk to your assistant in these channels.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                telegramCard
+                SettingsDivider().padding(.vertical, VSpacing.sm)
+                slackChannelCard
+                SettingsDivider().padding(.vertical, VSpacing.sm)
+                voiceCard
+                if isEmailEnabled {
+                    SettingsDivider().padding(.vertical, VSpacing.sm)
+                    emailCard
+                }
+            }
+        }
+    }
+
     // MARK: - Email Channel Card
 
     private var emailCard: some View {
-        SettingsCard(title: "Email", subtitle: "Send and receive emails as your assistant", showBorder: false) {
+        SettingsCard(title: "Email", subtitle: "Send and receive emails as your assistant", showBorder: showCardBorders) {
             if let email = store.assistantEmail {
                 HStack(spacing: VSpacing.sm) {
                     VIconView(.circleCheck, size: 14)
@@ -136,7 +176,7 @@ struct AssistantChannelsDetailView: View {
 
     private var telegramCard: some View {
         let status = store.channelSetupStatus["telegram"]
-        return SettingsCard(title: "Telegram", subtitle: "Message your assistant from Telegram", showBorder: false) {
+        return SettingsCard(title: "Telegram", subtitle: "Message your assistant from Telegram", showBorder: showCardBorders) {
             if status == "ready" {
                 VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
             }
@@ -233,7 +273,7 @@ struct AssistantChannelsDetailView: View {
 
     private var slackChannelCard: some View {
         let status = store.channelSetupStatus["slack"]
-        return SettingsCard(title: "Slack", subtitle: "Message your assistant from Slack", showBorder: false) {
+        return SettingsCard(title: "Slack", subtitle: "Message your assistant from Slack", showBorder: showCardBorders) {
             if status == "ready" {
                 VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
             }
@@ -347,7 +387,7 @@ struct AssistantChannelsDetailView: View {
 
     private var voiceCard: some View {
         let status = store.channelSetupStatus["phone"]
-        return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio", showBorder: false) {
+        return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio", showBorder: showCardBorders) {
             if status == "ready" {
                 VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
             }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -192,7 +192,7 @@ struct ContactsContainerView: View {
 
                 // Channels section in bordered card
                 if let store {
-                    AssistantChannelsDetailView(store: store, daemonClient: daemonClient, isEmailEnabled: isEmailEnabled)
+                    AssistantChannelsDetailView(store: store, daemonClient: daemonClient, isEmailEnabled: isEmailEnabled, showCardBorders: false)
                         .padding(VSpacing.lg)
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.xl)


### PR DESCRIPTION
## Summary
- Add showCardBorders parameter to AssistantChannelsDetailView (defaults to true)
- Settings → Channels tab: original layout with individual bordered SettingsCards per channel + ScrollView
- Contacts → Assistant: flat layout with dividers, no individual card borders (wrapped by container)

## Original prompt
Settings/Channels should look exactly how they looked before, but channels inside Contacts should look how it's looking currently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
