### PR TITLE
fix: add dismantleNSView teardown and weak textView capture in SyntaxTextView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
@@ -165,6 +165,11 @@ struct SyntaxTextView: NSViewRepresentable {
         return scrollView
     }
 
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        NotificationCenter.default.removeObserver(coordinator)
+        coordinator.rehighlightTask?.cancel()
+    }
+
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? NSTextView else { return }
         let coordinator = context.coordinator
@@ -210,7 +215,7 @@ struct SyntaxTextView: NSViewRepresentable {
         var language: SyntaxLanguage
         var isUpdatingFromSwiftUI = false
         weak var textView: NSTextView?
-        private var rehighlightTask: Task<Void, Never>?
+        var rehighlightTask: Task<Void, Never>?
 
         init(_ parent: SyntaxTextView) {
             self.parent = parent
@@ -235,8 +240,8 @@ struct SyntaxTextView: NSViewRepresentable {
             rehighlightTask?.cancel()
             rehighlightTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 150_000_000)
-                guard !Task.isCancelled else { return }
-                self?.rehighlight(textView)
+                guard !Task.isCancelled, let self, let textView = self.textView else { return }
+                self.rehighlight(textView)
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes 3 teardown gaps identified during plan review round 2 for editable-syntax-highlight.md.

- **dismantleNSView:** Add teardown method that removes NotificationCenter observer and cancels in-flight rehighlight task
- **Weak textView capture:** Use coordinator's weak textView reference in rehighlight task closure instead of strong capture of local variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
