### PR TITLE
chore: update backwards compatibility policy for launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,7 @@ Proactively remove unused code during every change. Remove code your change make
 
 ## Backwards Compatibility
 
-No aliases, fallback reads, old API shapes, migration shims, or adapters for internal interfaces — proceed with the clean implementation. Remove existing interface backwards-compat code when encountered.
-
-**Exception — persisted state and data.** We have real users with data on disk. Never ship a change that silently breaks existing persisted state. When a change alters workspace file paths, directory structure, data shapes, namespaces, column schemas, or storage formats, include a migration in the same PR.
+We have real users — maintain backwards compatibility for all interfaces, persisted state, and data. Never ship a change that silently breaks existing behavior. When a change alters workspace file paths, directory structure, data shapes, namespaces, column schemas, or storage formats, include a migration in the same PR.
 
 **Which migration strategy to use:**
 


### PR DESCRIPTION
## Summary
- Removed the instruction to skip backwards compatibility for internal interfaces ("No aliases, fallback reads, old API shapes, migration shims, or adapters")
- Updated the section to require backwards compatibility for all interfaces, persisted state, and data — reflecting that we now have real users ahead of launch
- Kept all migration guidance (workspace migrations, DB migrations, idempotency rules) intact

## Original prompt
Remove anything from CLAUDE.md where it says to not worry about backwards compatibility. We're about to launch so we care about this now

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
