### PR TITLE
feat: add ghost style to OnboardingButton and polish Skip button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -5,6 +5,7 @@ enum OnboardingButtonStyle {
     case primary
     case secondary
     case tertiary
+    case ghost
 }
 
 struct OnboardingButton: View {
@@ -18,19 +19,30 @@ struct OnboardingButton: View {
     @State private var visible = false
     @State private var isHovered = false
 
+    private var isGhost: Bool { style == .ghost }
+
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 15, weight: .medium))
+                .font(isGhost ? VFont.caption : .system(size: 15, weight: .medium))
                 .foregroundColor(foregroundColor)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, VSpacing.xl)
-                .padding(.vertical, VSpacing.lg)
+                .if(!isGhost) { $0.frame(maxWidth: .infinity) }
+                .padding(.horizontal, isGhost ? VSpacing.sm : VSpacing.xl)
+                .padding(.vertical, isGhost ? VSpacing.xs : VSpacing.lg)
                 .contentShape(Rectangle())
-                .background(background)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                .background(
+                    Group {
+                        if isGhost && isHovered && !disabled {
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(VColor.borderBase.opacity(0.5))
+                        } else {
+                            background
+                        }
+                    }
+                )
+                .clipShape(RoundedRectangle(cornerRadius: isGhost ? VRadius.sm : VRadius.lg))
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
+                    RoundedRectangle(cornerRadius: isGhost ? VRadius.sm : VRadius.lg)
                         .stroke(borderColor, lineWidth: style == .primary ? 0 : 1)
                 )
         }
@@ -65,6 +77,8 @@ struct OnboardingButton: View {
             return disabled ? VColor.primaryBase.opacity(0.3) : VColor.primaryBase
         case .tertiary:
             return disabled ? VColor.contentDefault.opacity(0.3) : VColor.contentDefault.opacity(0.85)
+        case .ghost:
+            return disabled ? VColor.contentSecondary.opacity(0.3) : VColor.contentSecondary
         }
     }
 
@@ -75,6 +89,8 @@ struct OnboardingButton: View {
         case .secondary:
             return AnyShapeStyle(Color.clear)
         case .tertiary:
+            return AnyShapeStyle(Color.clear)
+        case .ghost:
             return AnyShapeStyle(Color.clear)
         }
     }
@@ -87,6 +103,8 @@ struct OnboardingButton: View {
             return VColor.primaryBase.opacity(disabled ? 0.2 : 0.5)
         case .tertiary:
             return VColor.contentDefault.opacity(disabled ? 0.1 : 0.25)
+        case .ghost:
+            return .clear
         }
     }
 
@@ -100,7 +118,7 @@ struct OnboardingButton: View {
         VColor.surfaceOverlay
         VStack(spacing: VSpacing.xl) {
             OnboardingButton(title: "Say hello", style: .primary) {}
-            OnboardingButton(title: "Skip", style: .tertiary) {}
+            OnboardingButton(title: "Skip", style: .ghost) {}
             OnboardingButton(title: "Disabled", style: .primary, disabled: true) {}
         }
         .frame(width: 300)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -44,7 +44,7 @@ struct ReauthView: View {
                 .foregroundColor(VColor.contentSecondary)
                 .padding(.bottom, VSpacing.xxl)
 
-            VStack(spacing: VSpacing.sm) {
+            VStack(spacing: VSpacing.md) {
                 if authManager.isLoading {
                     HStack(spacing: VSpacing.sm) {
                         ProgressView()
@@ -82,19 +82,12 @@ struct ReauthView: View {
                 }
 
                 if hasNonManagedAssistant {
-                    Button {
-                        // Pre-select a non-managed assistant so proceedToApp() doesn't
-                        // fall back to a managed assistant whose session was invalidated.
+                    OnboardingButton(title: "Skip", style: .ghost) {
                         if let nonManaged = LockfileAssistant.loadAll().first(where: { !$0.isManaged }) {
                             UserDefaults.standard.set(nonManaged.assistantId, forKey: "connectedAssistantId")
                         }
                         onComplete()
-                    } label: {
-                        Text("Skip")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentSecondary)
                     }
-                    .buttonStyle(.plain)
                     .accessibilityLabel("Skip")
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -55,7 +55,7 @@ struct WakeUpStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         // Buttons
-        VStack(spacing: VSpacing.sm) {
+        VStack(spacing: VSpacing.md) {
             if authManager?.isLoading == true {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
@@ -82,15 +82,10 @@ struct WakeUpStepView: View {
                 }
                 .accessibilityLabel("Log In")
 
-                Button {
+                OnboardingButton(title: "Skip", style: .ghost) {
                     state?.skippedAuth = true
                     onStartWithAPIKey()
-                } label: {
-                    Text("Skip")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentSecondary)
                 }
-                .buttonStyle(.plain)
                 .accessibilityLabel("Skip")
             } else {
                 OnboardingButton(title: "Get Started", style: .primary) {


### PR DESCRIPTION
## Summary
- Add `.ghost` style to `OnboardingButton` — no background, no border, caption font, secondary text color, with subtle hover background
- Replace raw `Button` Skip controls in `WakeUpStepView` and `ReauthView` with `OnboardingButton(title: "Skip", style: .ghost)`
- Increase spacing between "Log In" and "Skip" from `VSpacing.sm` (8px) to `VSpacing.md` (12px)

Part of plan: skip-button-hover.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
