### PR TITLE
fix: validate Anthropic API key on save in Settings

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -16,6 +16,37 @@ import type {
 
 const log = getLogger("anthropic-client");
 
+/**
+ * Validate an Anthropic API key by making a lightweight GET /v1/models call.
+ * Returns `{ valid: true }` on success or `{ valid: false, reason: string }` on failure.
+ */
+export async function validateAnthropicApiKey(
+  apiKey: string,
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+  try {
+    const client = new Anthropic({ apiKey });
+    await client.models.list({ limit: 1 });
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof Anthropic.APIError) {
+      if (error.status === 401) {
+        return { valid: false, reason: "API key is invalid or expired." };
+      }
+      return {
+        valid: false,
+        reason: `Anthropic API error (${error.status}): ${error.message}`,
+      };
+    }
+    return {
+      valid: false,
+      reason:
+        error instanceof Error
+          ? error.message
+          : "Failed to validate API key.",
+    };
+  }
+}
+
 const TOOL_ID_RE = /[^a-wyzA-Z0-9_-]/g;
 
 const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { setSentryOrganizationId } from "../../instrument.js";
+import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -129,6 +130,21 @@ export async function handleAddSecret(
           400,
         );
       }
+      // Validate Anthropic API keys before storing
+      if (name === "anthropic") {
+        const validation = await validateAnthropicApiKey(value);
+        if (!validation.valid) {
+          log.warn(
+            { provider: name, reason: validation.reason },
+            "API key validation failed",
+          );
+          return Response.json(
+            { success: false, error: validation.reason },
+            { status: 422 },
+          );
+        }
+      }
+
       const stored = await setSecureKeyAsync(name, value);
       if (!stored) {
         return httpError(

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -142,6 +142,13 @@ struct InferenceServiceCard: View {
                 .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
+                .disabled(store.apiKeySaving)
+
+                if let error = store.apiKeySaveError {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
             }
 
             // Model picker
@@ -177,11 +184,15 @@ struct InferenceServiceCard: View {
             if draftMode == "managed" && !isLoggedIn {
                 EmptyView()
             } else {
-                VButton(label: "Save", style: .primary, isDisabled: !hasChanges) {
+                VButton(
+                    label: store.apiKeySaving ? "Validating..." : "Save",
+                    style: .primary,
+                    isDisabled: !hasChanges || store.apiKeySaving
+                ) {
                     save()
                 }
                 if draftMode == "your-own" && isConnected {
-                    VButton(label: "Reset", style: .danger) {
+                    VButton(label: "Reset", style: .danger, isDisabled: store.apiKeySaving) {
                         store.clearAPIKey()
                         apiKeyText = ""
                     }
@@ -193,16 +204,22 @@ struct InferenceServiceCard: View {
     // MARK: - Save
 
     private func save() {
+        store.apiKeySaveError = nil
+
         // Persist mode if changed
         if draftMode != store.inferenceMode {
             store.setInferenceMode(draftMode)
         }
 
-        // Persist API key if entered and in your-own mode
+        // Persist API key if entered and in your-own mode.
+        // saveAPIKey is async (validates with the provider before storing).
+        // The key text is kept until validation succeeds so the user can retry.
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if draftMode == "your-own" && !trimmedKey.isEmpty {
-            store.saveAPIKey(trimmedKey)
-            apiKeyText = ""
+            let keyTextBinding = $apiKeyText
+            store.saveAPIKey(trimmedKey, onSuccess: {
+                keyTextBinding.wrappedValue = ""
+            })
         }
 
         // Persist model selection

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -29,6 +29,8 @@ public final class SettingsStore: ObservableObject {
     @Published var hasElevenLabsKey: Bool
     @Published var hasVercelKey: Bool = false
     @Published var maskedKey: String = ""
+    @Published var apiKeySaveError: String?
+    @Published var apiKeySaving: Bool = false
     @Published var maskedBraveKey: String = ""
     @Published var maskedPerplexityKey: String = ""
     @Published var maskedImageGenKey: String = ""
@@ -710,15 +712,25 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - API Key Actions
 
-    func saveAPIKey(_ raw: String) {
+    func saveAPIKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed, for: "anthropic")
-        removeDeletionTombstone(type: "api_key", name: "anthropic")
-        syncKeyToDaemon(provider: "anthropic", value: trimmed)
-        hasKey = true
-        maskedKey = Self.maskKey(trimmed)
-        scheduleRoutingSourceRefresh()
+        apiKeySaveError = nil
+        apiKeySaving = true
+        Task {
+            let result = await syncKeyToDaemonWithValidation(provider: "anthropic", value: trimmed)
+            apiKeySaving = false
+            if let error = result.error {
+                apiKeySaveError = error
+                return
+            }
+            APIKeyManager.setKey(trimmed, for: "anthropic")
+            removeDeletionTombstone(type: "api_key", name: "anthropic")
+            hasKey = true
+            maskedKey = Self.maskKey(trimmed)
+            scheduleRoutingSourceRefresh()
+            onSuccess?()
+        }
     }
 
     func clearAPIKey() {
@@ -935,6 +947,32 @@ public final class SettingsStore: ObservableObject {
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
         Task {
             _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", body: bodyData)
+        }
+    }
+
+    /// Sync an API key to the daemon with server-side validation.
+    /// Returns a result indicating success or a validation error message.
+    private func syncKeyToDaemonWithValidation(provider: String, value: String) async -> (success: Bool, error: String?) {
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else {
+            return (false, "No connected assistant. Please restart the app.")
+        }
+        let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            return (false, "Failed to encode request.")
+        }
+        do {
+            let response = try await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", body: bodyData)
+            if response.isSuccess {
+                return (true, nil)
+            }
+            // Try to parse error message from response body
+            if let parsed = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+               let errorMsg = parsed["error"] as? String {
+                return (false, errorMsg)
+            }
+            return (false, "Failed to save API key (HTTP \(response.statusCode)).")
+        } catch {
+            return (false, "Could not reach assistant. Please check that it is running.")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add server-side API key validation in the daemon's `handleAddSecret` — calls Anthropic's `GET /v1/models` with the provided key before storing it; returns 422 with error details on failure
- Update macOS `SettingsStore.saveAPIKey` to check the daemon response and surface errors; key is only stored locally after successful validation
- Show "Validating..." on the Save button and inline error text in `InferenceServiceCard` when validation fails

## Original prompt
Add API key validation when saving in the Settings panel. After storing the key locally, make a lightweight GET /v1/models call to Anthropic's API to verify the key is valid before syncing to the daemon. Show visible error feedback to the user if validation fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
