### PR TITLE
fix: wrap SQLite run() params in arrays in conversation-starter test

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -447,14 +447,16 @@ function insertCard(overrides: {
   getSqlite().run(
     `INSERT INTO conversation_starters (id, label, prompt, category, generation_batch, scope_id, card_type, tags, icon, description, created_at)
      VALUES (?, ?, ?, ?, ?, ?, 'card', ?, 'lucide-sparkles', 'desc', ?)`,
-    uuid(),
-    overrides.label,
-    overrides.prompt,
-    overrides.category,
-    overrides.batch ?? 1,
-    overrides.scopeId ?? "default",
-    overrides.tags ?? "Quick win",
-    overrides.createdAt ?? now,
+    [
+      uuid(),
+      overrides.label,
+      overrides.prompt,
+      overrides.category,
+      overrides.batch ?? 1,
+      overrides.scopeId ?? "default",
+      overrides.tags ?? "Quick win",
+      overrides.createdAt ?? now,
+    ],
   );
 }
 
@@ -466,10 +468,7 @@ function insertCategoryRelevance(
   getSqlite().run(
     `INSERT OR REPLACE INTO capability_card_categories (scope_id, category, relevance, generation_batch, created_at)
      VALUES (?, ?, ?, 1, ?)`,
-    scopeId,
-    category,
-    relevance,
-    Date.now(),
+    [scopeId, category, relevance, Date.now()],
   );
 }
 


### PR DESCRIPTION
## Summary

- `getSqlite().run()` expects `SQLQueryBindings[]` (an array) but params were passed as individual spread arguments at lines 450 and 469 in `conversation-starter-routes.test.ts`
- Wrapped both call sites' parameters in arrays to match the expected type signature

## Original prompt
Fix only this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23177583488/job/67343132329

🤖 Generated with [Claude Code](https://claude.com/claude-code)