### PR TITLE
fix: wrap AnyShapeStyle in View for OnboardingButton ghost hover background

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -36,7 +36,7 @@ struct OnboardingButton: View {
                             RoundedRectangle(cornerRadius: VRadius.sm)
                                 .fill(VColor.borderBase.opacity(0.5))
                         } else {
-                            background
+                            Rectangle().fill(background)
                         }
                     }
                 )


### PR DESCRIPTION
## Summary
Fixes build error in `OnboardingButton` where `AnyShapeStyle` (not a `View`) was used inside a `@ViewBuilder` `Group` alongside `RoundedRectangle.fill(...)`. Wraps the shape style in a `View`-conforming construct so both branches return views.

Fixes gap identified during plan review for skip-button-hover.md.

**Gap:** Build error -- AnyShapeStyle used in @ViewBuilder context
**What was expected:** Ghost hover background should compile with both branches returning View types
**What was found:** AnyShapeStyle does not conform to View, causing buildExpression error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
