### PR TITLE
fix: make recordLifecycleEvent public

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2065,7 +2065,7 @@ public final class HTTPTransport {
 
     /// Record a lifecycle telemetry event (e.g. app_open, hatch).
     /// Fire-and-forget — failures are logged but do not propagate.
-    func recordLifecycleEvent(_ eventName: String, isRetry: Bool = false) async {
+    public func recordLifecycleEvent(_ eventName: String, isRetry: Bool = false) async {
         guard let url = buildURL(for: .telemetryLifecycle) else { return }
 
         var request = URLRequest(url: url)


### PR DESCRIPTION
## Summary
- `recordLifecycleEvent` was defined as `internal` on `HTTPTransport` (in `VellumAssistantShared` module), making it inaccessible from `AppDelegate.swift` in the app target
- Changed it to `public` so the cross-module call in AppDelegate compiles

## Original prompt
Fix only this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23177583507/job/67343143041

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
