### PR TITLE
fix: repair failing CI tests for memory recall and conversation starters

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -97,9 +97,9 @@ function insertStarter(overrides: {
 
 function insertMemoryItem(scopeId = "default") {
   getSqlite().run(
-    `INSERT INTO memory_items (id, kind, subject, statement, importance, status, scope_id, first_seen_at, updated_at)
-     VALUES (?, 'fact', 'test', 'test statement', 5, 'active', ?, ?, ?)`,
-    [uuid(), scopeId, Date.now(), Date.now()],
+    `INSERT INTO memory_items (id, kind, subject, statement, importance, status, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+     VALUES (?, 'fact', 'test', 'test statement', 5, 'active', 0.8, ?, ?, ?, ?)`,
+    [uuid(), uuid(), scopeId, Date.now(), Date.now()],
   );
 }
 

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -323,7 +323,7 @@ describe("Memory lifecycle E2E regression", () => {
         totalOutputTokens: 0,
         totalEstimatedCost: 0,
         contextSummary: null,
-        contextCompactedMessageCount: 0,
+        contextCompactedMessageCount: 1,
         contextCompactedAt: null,
       })
       .run();

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -112,6 +112,7 @@ function insertConversation(
   db: ReturnType<typeof getDb>,
   id: string,
   createdAt: number,
+  contextCompactedMessageCount = 0,
 ) {
   db.insert(conversations)
     .values({
@@ -123,7 +124,7 @@ function insertConversation(
       totalOutputTokens: 0,
       totalEstimatedCost: 0,
       contextSummary: null,
-      contextCompactedMessageCount: 0,
+      contextCompactedMessageCount,
       contextCompactedAt: null,
     })
     .run();
@@ -629,7 +630,7 @@ describe("Memory Recall Quality", () => {
     test("invalidated items are excluded from recall", async () => {
       const db = getDb();
       const now = 1_700_000_275_000;
-      insertConversation(db, "conv-invalid-status", now);
+      insertConversation(db, "conv-invalid-status", now, 1);
       insertMessage(
         db,
         "msg-invalid-status",
@@ -989,7 +990,7 @@ describe("Memory Recall Quality", () => {
     test("precision@k guard verifies pipeline completes with seeded segments", async () => {
       const db = getDb();
       const now = 1_700_000_700_000;
-      insertConversation(db, "conv-pk", now);
+      insertConversation(db, "conv-pk", now, 3);
 
       const prefs = [
         {

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -1807,7 +1807,7 @@ describe("Memory regressions", () => {
         totalOutputTokens: 0,
         totalEstimatedCost: 0,
         contextSummary: null,
-        contextCompactedMessageCount: 0,
+        contextCompactedMessageCount: 1,
         contextCompactedAt: null,
       })
       .run();
@@ -2052,7 +2052,7 @@ describe("Memory regressions", () => {
         totalOutputTokens: 0,
         totalEstimatedCost: 0,
         contextSummary: null,
-        contextCompactedMessageCount: 0,
+        contextCompactedMessageCount: 1,
         contextCompactedAt: null,
       })
       .run();
@@ -2126,7 +2126,7 @@ describe("Memory regressions", () => {
         totalOutputTokens: 0,
         totalEstimatedCost: 0,
         contextSummary: null,
-        contextCompactedMessageCount: 0,
+        contextCompactedMessageCount: 1,
         contextCompactedAt: null,
       })
       .run();

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -62,21 +62,41 @@ export function orderStrongestFirst<T extends StarterItem>(items: T[]): T[] {
 
   const result: T[] = [];
   let lastCategory: string | null = null;
+  const seenCategories = new Set<string>();
 
   while (result.length < items.length) {
     let picked = false;
 
-    // First pass: pick from a group whose category differs from last
+    // First pass: prefer categories not yet seen at all (maximizes diversity in
+    // top positions), skipping only the immediately preceding category.
     for (const group of sortedGroups) {
       if (group.idx >= group.items.length) continue;
       const candidate = group.items[group.idx];
       const cat = candidate.category ?? "other";
-      if (cat !== lastCategory) {
+      if (cat !== lastCategory && !seenCategories.has(cat)) {
         result.push(candidate);
         group.idx++;
         lastCategory = cat;
+        seenCategories.add(cat);
         picked = true;
         break;
+      }
+    }
+
+    // Second pass: pick from any group whose category differs from last
+    if (!picked) {
+      for (const group of sortedGroups) {
+        if (group.idx >= group.items.length) continue;
+        const candidate = group.items[group.idx];
+        const cat = candidate.category ?? "other";
+        if (cat !== lastCategory) {
+          result.push(candidate);
+          group.idx++;
+          lastCategory = cat;
+          seenCategories.add(cat);
+          picked = true;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix `orderStrongestFirst` to prioritize unseen categories in top positions: adds a first pass that prefers categories not yet seen before falling back to any category different from the last one
- Fix `insertMemoryItem` test helper in `conversation-starter-routes.test.ts` to use correct `memory_items` columns (remove non-existent `updated_at`, add required `confidence`, `fingerprint`, `last_seen_at`)
- Fix memory recall tests that seed segments into the current conversation: Step 5b of the retriever (added in #18060) filters in-context segments; tests must set `contextCompactedMessageCount` to mark seeded messages as compacted so they pass through the filter

## Original prompt
Fix only this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23177583488/job/67343132313

🤖 Generated with [Claude Code](https://claude.com/claude-code)