### PR TITLE
Promote conversation starters flag and sharpen chip ordering

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -185,7 +185,7 @@ describe("GET /v1/conversation-starters", () => {
     expect(body.total).toBe(6);
   });
 
-  test("surfaces non-repetitive starters early when alternatives exist", async () => {
+  test("surfaces category-diverse starters first", async () => {
     const now = Date.now();
     insertStarter({
       label: "Dev 1",
@@ -217,7 +217,10 @@ describe("GET /v1/conversation-starters", () => {
       starters: Array<{ label: string; category: string }>;
     };
 
-    expect(body.starters[0]?.category).not.toBe(body.starters[1]?.category);
+    const firstThreeCategories = body.starters
+      .slice(0, 3)
+      .map((starter) => starter.category);
+    expect(new Set(firstThreeCategories).size).toBe(3);
   });
 });
 
@@ -272,7 +275,7 @@ describe("orderStrongestFirst", () => {
     ]);
   });
 
-  test("avoids adjacent duplicates when alternatives exist", () => {
+  test("maximizes early category diversity when alternatives exist", () => {
     const items = [
       makeItem("Dev 1", "development"),
       makeItem("Dev 2", "development"),

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -45,59 +45,58 @@ export function orderStrongestFirst<T extends StarterItem>(items: T[]): T[] {
     group.push(item);
   }
 
-  // Round-robin pick from categories sorted by group size (largest first)
-  // to spread diversity across the top positions.
+  // Prefer categories with the most remaining items so the row stays varied
+  // early without burying the dominant themes entirely.
   const sortedGroups = [...byCategory.entries()]
     .sort((a, b) => b[1].length - a[1].length)
     .map(([, group]) => ({ items: group, idx: 0 }));
 
   const result: T[] = [];
-  let lastCategory: string | null = null;
   const seenCategories = new Set<string>();
+  let lastCategory: string | null = null;
 
   while (result.length < items.length) {
     let picked = false;
+    const availableGroups = sortedGroups.filter(
+      (group) => group.idx < group.items.length,
+    );
 
-    // First pass: prefer categories not yet seen at all (maximizes diversity in
-    // top positions), skipping only the immediately preceding category.
-    for (const group of sortedGroups) {
+    const unseenGroups = availableGroups.filter((group) => {
+      const category = group.items[group.idx]?.category ?? "other";
+      return category !== lastCategory && !seenCategories.has(category);
+    });
+
+    const nextGroups =
+      unseenGroups.length > 0
+        ? unseenGroups
+        : availableGroups.filter((group) => {
+            const category = group.items[group.idx]?.category ?? "other";
+            return category !== lastCategory;
+          });
+
+    // First pass: prefer unseen categories, then avoid adjacent duplicates.
+    for (const group of nextGroups) {
       if (group.idx >= group.items.length) continue;
       const candidate = group.items[group.idx];
       const cat = candidate.category ?? "other";
-      if (cat !== lastCategory && !seenCategories.has(cat)) {
-        result.push(candidate);
-        group.idx++;
-        lastCategory = cat;
-        seenCategories.add(cat);
-        picked = true;
-        break;
-      }
-    }
-
-    // Second pass: pick from any group whose category differs from last
-    if (!picked) {
-      for (const group of sortedGroups) {
-        if (group.idx >= group.items.length) continue;
-        const candidate = group.items[group.idx];
-        const cat = candidate.category ?? "other";
-        if (cat !== lastCategory) {
-          result.push(candidate);
-          group.idx++;
-          lastCategory = cat;
-          seenCategories.add(cat);
-          picked = true;
-          break;
-        }
-      }
+      result.push(candidate);
+      group.idx++;
+      seenCategories.add(cat);
+      lastCategory = cat;
+      picked = true;
+      break;
     }
 
     // Fallback: if all remaining items share the same category, just pick next
     if (!picked) {
-      for (const group of sortedGroups) {
+      for (const group of availableGroups) {
         if (group.idx < group.items.length) {
-          result.push(group.items[group.idx]);
+          const candidate = group.items[group.idx];
+          const cat = candidate.category ?? "other";
+          result.push(candidate);
           group.idx++;
-          lastCategory = group.items[group.idx - 1].category ?? "other";
+          seenCategories.add(cat);
+          lastCategory = cat;
           picked = true;
           break;
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -14,6 +14,7 @@ struct MainWindowView: View {
     let traceStore: TraceStore
     let usageDashboardStore: UsageDashboardStore
     @ObservedObject var windowState: MainWindowState
+    @StateObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
     @State private var selectedConversationId: UUID?
     @State var sharing = SharingState()
     @State var sidebar = SidebarInteractionState()
@@ -77,6 +78,9 @@ struct MainWindowView: View {
         self.settingsStore = settingsStore
         self.authManager = authManager
         self.windowState = windowState
+        self._assistantFeatureFlagStore = StateObject(
+            wrappedValue: AssistantFeatureFlagStore()
+        )
         self.documentManager = documentManager
         self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -363,9 +363,13 @@ extension MainWindowView {
     var chatView: some View {
         if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
+            let conversationStartersEnabled = assistantFeatureFlagStore.isEnabled(
+                Self.conversationStartersFeatureFlagKey
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
+                conversationStartersEnabled: conversationStartersEnabled,
                 daemonClient: daemonClient,
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
@@ -568,6 +572,7 @@ func openFilePicker(viewModel: ChatViewModel) {
 struct ActiveChatViewWrapper: View {
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var windowState: MainWindowState
+    let conversationStartersEnabled: Bool
     let daemonClient: DaemonClient
     @ObservedObject var ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
@@ -589,10 +594,6 @@ struct ActiveChatViewWrapper: View {
     private var isBootstrapTimedOut: Bool { bootstrapStateRaw == "timedOut" }
 
     var body: some View {
-        let conversationStartersEnabled = AssistantFeatureFlagResolver.isEnabled(
-            MainWindowView.conversationStartersFeatureFlagKey
-        )
-
         ChatView(
             messages: viewModel.messages,
             inputText: Binding(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -5,6 +5,9 @@ import UniformTypeIdentifiers
 // MARK: - Panel Coordination Extension
 
 extension MainWindowView {
+    fileprivate static let conversationStartersFeatureFlagKey =
+        "feature_flags.conversation-starters.enabled"
+
     // MARK: - Config-Driven Slot Rendering
 
     @ViewBuilder
@@ -586,6 +589,10 @@ struct ActiveChatViewWrapper: View {
     private var isBootstrapTimedOut: Bool { bootstrapStateRaw == "timedOut" }
 
     var body: some View {
+        let conversationStartersEnabled = AssistantFeatureFlagResolver.isEnabled(
+            MainWindowView.conversationStartersFeatureFlagKey
+        )
+
         ChatView(
             messages: viewModel.messages,
             inputText: Binding(
@@ -690,8 +697,8 @@ struct ActiveChatViewWrapper: View {
             conversationId: conversationId,
             daemonGreeting: viewModel.emptyStateGreeting,
             onRequestGreeting: { [weak viewModel] in viewModel?.generateGreeting() },
-            conversationStarters: MacOSClientFeatureFlagManager.shared.isEnabled("conversation_starters_enabled") ? viewModel.conversationStarters : [],
-            conversationStartersLoading: MacOSClientFeatureFlagManager.shared.isEnabled("conversation_starters_enabled") && viewModel.conversationStartersLoading,
+            conversationStarters: conversationStartersEnabled ? viewModel.conversationStarters : [],
+            conversationStartersLoading: conversationStartersEnabled && viewModel.conversationStartersLoading,
             onSelectStarter: { [weak viewModel] starter in
                 viewModel?.inputText = starter.prompt
             },

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -4,28 +4,38 @@ import VellumAssistantShared
 /// Resolves assistant-scoped feature flags from workspace config plus the
 /// bundled unified registry, mirroring the daemon's precedence order.
 enum AssistantFeatureFlagResolver {
+    static func registryDefaults(from registry: FeatureFlagRegistry?) -> [String: Bool] {
+        Dictionary(
+            uniqueKeysWithValues: (registry?.assistantScopeFlags() ?? []).map {
+                ($0.key, $0.defaultEnabled)
+            }
+        )
+    }
+
+    static func resolvedFlags(
+        config: [String: Any],
+        registryDefaults: [String: Bool]
+    ) -> [String: Bool] {
+        let persistedFlags = (config["assistantFeatureFlagValues"] as? [String: Bool]) ?? [:]
+        return registryDefaults.merging(persistedFlags) { _, persisted in persisted }
+    }
+
+    static func resolvedFlags(
+        config: [String: Any],
+        registry: FeatureFlagRegistry?
+    ) -> [String: Bool] {
+        resolvedFlags(config: config, registryDefaults: registryDefaults(from: registry))
+    }
+
     static func isEnabled(
         _ key: String,
         config: [String: Any]? = nil,
         registry: FeatureFlagRegistry? = nil
     ) -> Bool {
-        let registryDefaults = Dictionary(
-            uniqueKeysWithValues: ((registry ?? loadFeatureFlagRegistry())?.assistantScopeFlags() ?? []).map {
-                ($0.key, $0.defaultEnabled)
-            }
+        let resolved = resolvedFlags(
+            config: config ?? WorkspaceConfigIO.read(),
+            registry: registry ?? loadFeatureFlagRegistry()
         )
-
-        let config = config ?? WorkspaceConfigIO.read()
-        let persistedFlags = (config["assistantFeatureFlagValues"] as? [String: Bool]) ?? [:]
-
-        if let explicit = persistedFlags[key] {
-            return explicit
-        }
-
-        if let defaultEnabled = registryDefaults[key] {
-            return defaultEnabled
-        }
-
-        return true
+        return resolved[key] ?? true
     }
 }

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -1,0 +1,31 @@
+import Foundation
+import VellumAssistantShared
+
+/// Resolves assistant-scoped feature flags from workspace config plus the
+/// bundled unified registry, mirroring the daemon's precedence order.
+enum AssistantFeatureFlagResolver {
+    static func isEnabled(
+        _ key: String,
+        config: [String: Any]? = nil,
+        registry: FeatureFlagRegistry? = nil
+    ) -> Bool {
+        let registryDefaults = Dictionary(
+            uniqueKeysWithValues: ((registry ?? loadFeatureFlagRegistry())?.assistantScopeFlags() ?? []).map {
+                ($0.key, $0.defaultEnabled)
+            }
+        )
+
+        let config = config ?? WorkspaceConfigIO.read()
+        let persistedFlags = (config["assistantFeatureFlagValues"] as? [String: Bool]) ?? [:]
+
+        if let explicit = persistedFlags[key] {
+            return explicit
+        }
+
+        if let defaultEnabled = registryDefaults[key] {
+            return defaultEnabled
+        }
+
+        return true
+    }
+}

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagStore.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagStore.swift
@@ -1,0 +1,52 @@
+import Combine
+import Foundation
+import VellumAssistantShared
+
+/// Caches assistant-scoped feature flags for the app session so SwiftUI views
+/// can read resolved values without disk access during body evaluation.
+@MainActor
+final class AssistantFeatureFlagStore: ObservableObject {
+    @Published private var resolvedFlags: [String: Bool]
+
+    private let registryDefaults: [String: Bool]
+    private let readConfig: () -> [String: Any]
+    private var flagChangeCancellable: AnyCancellable?
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        registry: FeatureFlagRegistry? = loadFeatureFlagRegistry(),
+        readConfig: @escaping () -> [String: Any] = { WorkspaceConfigIO.read() }
+    ) {
+        self.readConfig = readConfig
+        self.registryDefaults = AssistantFeatureFlagResolver.registryDefaults(from: registry)
+        self.resolvedFlags = AssistantFeatureFlagResolver.resolvedFlags(
+            config: readConfig(),
+            registryDefaults: self.registryDefaults
+        )
+
+        flagChangeCancellable = notificationCenter.publisher(for: .assistantFeatureFlagDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] notification in
+                guard let self else { return }
+
+                if let key = notification.userInfo?["key"] as? String,
+                   let enabled = notification.userInfo?["enabled"] as? Bool {
+                    self.resolvedFlags[key] = enabled
+                    return
+                }
+
+                self.reloadFromDisk()
+            }
+    }
+
+    func isEnabled(_ key: String) -> Bool {
+        resolvedFlags[key] ?? registryDefaults[key] ?? true
+    }
+
+    func reloadFromDisk() {
+        resolvedFlags = AssistantFeatureFlagResolver.resolvedFlags(
+            config: readConfig(),
+            registryDefaults: registryDefaults
+        )
+    }
+}

--- a/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
@@ -54,4 +54,45 @@ final class AssistantFeatureFlagResolverTests: XCTestCase {
 
         XCTAssertTrue(enabled)
     }
+
+    @MainActor
+    func testStoreCachesResolvedFlagsAfterInitialLoad() {
+        var readCount = 0
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false),
+            readConfig: {
+                readCount += 1
+                return [:]
+            }
+        )
+
+        XCTAssertFalse(store.isEnabled(conversationStartersKey))
+        XCTAssertFalse(store.isEnabled(conversationStartersKey))
+        XCTAssertEqual(readCount, 1)
+    }
+
+    @MainActor
+    func testStoreAppliesFlagChangeNotificationsWithoutReloadingConfig() {
+        let notificationCenter = NotificationCenter()
+        var readCount = 0
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: notificationCenter,
+            registry: makeRegistry(defaultEnabled: false),
+            readConfig: {
+                readCount += 1
+                return [:]
+            }
+        )
+
+        notificationCenter.post(
+            name: .assistantFeatureFlagDidChange,
+            object: nil,
+            userInfo: ["key": conversationStartersKey, "enabled": true]
+        )
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertTrue(store.isEnabled(conversationStartersKey))
+        XCTAssertEqual(readCount, 1)
+    }
 }

--- a/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class AssistantFeatureFlagResolverTests: XCTestCase {
+    private let conversationStartersKey = "feature_flags.conversation-starters.enabled"
+
+    private func makeRegistry(defaultEnabled: Bool) -> FeatureFlagRegistry {
+        FeatureFlagRegistry(
+            version: 1,
+            flags: [
+                FeatureFlagDefinition(
+                    id: "conversation-starters",
+                    scope: .assistant,
+                    key: conversationStartersKey,
+                    label: "Recommended Starts",
+                    description: "Show conversation starter chips",
+                    defaultEnabled: defaultEnabled
+                )
+            ]
+        )
+    }
+
+    func testUsesAssistantRegistryDefaultWhenNoOverrideExists() {
+        let enabled = AssistantFeatureFlagResolver.isEnabled(
+            conversationStartersKey,
+            config: [:],
+            registry: makeRegistry(defaultEnabled: false)
+        )
+
+        XCTAssertFalse(enabled)
+    }
+
+    func testPersistedAssistantOverrideWinsOverRegistryDefault() {
+        let enabled = AssistantFeatureFlagResolver.isEnabled(
+            conversationStartersKey,
+            config: [
+                "assistantFeatureFlagValues": [
+                    conversationStartersKey: true
+                ]
+            ],
+            registry: makeRegistry(defaultEnabled: false)
+        )
+
+        XCTAssertTrue(enabled)
+    }
+
+    func testUndeclaredAssistantFlagsDefaultToEnabled() {
+        let enabled = AssistantFeatureFlagResolver.isEnabled(
+            "feature_flags.unknown.enabled",
+            config: [:],
+            registry: makeRegistry(defaultEnabled: false)
+        )
+
+        XCTAssertTrue(enabled)
+    }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -227,18 +227,10 @@
     },
     {
       "id": "conversation-starters",
-      "scope": "macos",
-      "key": "conversation_starters_enabled",
+      "scope": "assistant",
+      "key": "feature_flags.conversation-starters.enabled",
       "label": "Recommended Starts",
       "description": "Show a curated row of recommended starting actions on the empty conversation page, ordered by relevance as confident first-click options",
-      "defaultEnabled": false
-    },
-    {
-      "id": "capability-feed",
-      "scope": "macos",
-      "key": "capability_feed_enabled",
-      "label": "Action Concierge Feed",
-      "description": "Show the action concierge card feed on the new conversation page with hero-first layout, supporting cards, and expandable overflow",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- move conversation starters onto the canonical assistant-scoped feature flag `feature_flags.conversation-starters.enabled`
- resolve that flag on macOS from assistant feature-flag state instead of the macOS-only flag manager
- make strongest-first ordering prioritize early category diversity for the chip row

## Stack
- builds on #18123

## Testing
- `cd assistant && bun test src/__tests__/assistant-feature-flag-guard.test.ts src/__tests__/assistant-feature-flag-guardrails.test.ts src/__tests__/conversation-starter-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd clients/macos && ./build.sh test --filter AssistantFeatureFlagResolverTests`
- `cd clients/macos && ./build.sh test --filter ConversationStarterPillsTests`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
