### PR TITLE
Remove em dash suppression from system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -119,12 +119,6 @@ function basePrompt(result: string): string {
     boundaryIdx >= 0
       ? result.slice(boundaryIdx + SYSTEM_PROMPT_CACHE_BOUNDARY.length)
       : result;
-  // Strip the hardcoded em-dash instruction preamble (in case boundary is absent)
-  const emDashLine =
-    "IMPORTANT: Never use em dashes (\u2014) in your messages. Use commas, periods, or just start a new sentence instead.";
-  if (s.startsWith(emDashLine)) {
-    s = s.slice(emDashLine.length).replace(/^\n\n/, "");
-  }
   for (const heading of [
     "## Configuration",
     "## Skills Catalog",

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -134,9 +134,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // the first cache block so they remain cached even when workspace files
   // (IDENTITY.md, SOUL.md, USER.md, etc.) are edited between turns.
   const staticParts: string[] = [];
-  staticParts.push(
-    "IMPORTANT: Never use em dashes (—) in your messages. Use commas, periods, or just start a new sentence instead.",
-  );
   if (getIsContainerized()) staticParts.push(buildContainerizedSection());
   staticParts.push(buildCliReferenceSection());
   staticParts.push(buildPostToolResponseSection());


### PR DESCRIPTION
## Summary
- Removed the `IMPORTANT: Never use em dashes...` instruction from the system prompt preamble
- This was an unnecessary stylistic constraint taking up tokens in every request

## Original prompt
Get rid of this: `IMPORTANT: Never use em dashes (—) in your messages. Use commas, periods, or just start a new sentence instead.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
