### PR TITLE
fix: add type annotation to noopLogger in system-prompt test

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -43,9 +43,12 @@ mock.module("../util/platform.js", () => ({
   readSessionToken: () => null,
 }));
 
-const noopLogger = new Proxy({} as Record<string, unknown>, {
-  get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
-});
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const realLogger = require("../util/logger.js");


### PR DESCRIPTION
## Summary
- Adds explicit `Record<string, unknown>` type annotation to `noopLogger` in `system-prompt.test.ts` to fix TS7022/TS7024 errors introduced by #18125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
