### PR TITLE
fix: preserve user-turn cache breakpoint for single user message

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -762,8 +762,8 @@ export class AnthropicProvider implements Provider {
       for (let i = 0; i < params.messages.length; i++) {
         if (params.messages[i].role === "user") userIndices.push(i);
       }
-      // slice(-2, -1) gives the second-to-last; empty array if < 2 user turns.
-      for (const idx of userIndices.slice(-2, -1)) {
+      // Prefer the second-to-last user turn; fall back to the last if only one exists.
+      for (const idx of userIndices.length >= 2 ? userIndices.slice(-2, -1) : userIndices.slice(-1)) {
         const content = params.messages[idx].content;
         if (Array.isArray(content) && content.length > 0) {
           (


### PR DESCRIPTION
## Summary
- Fixes a regression from #18024 where conversations with only one user message (the common first agent-loop iteration) received no user-turn cache breakpoint
- `userIndices.slice(-2, -1)` returns `[]` when there's only 1 user turn — now falls back to `userIndices.slice(-1)` in that case
- Preserves the second-to-last optimization when 2+ user turns exist

## Test plan
- [ ] Verify existing cache breakpoint tests pass (they cover single-user-turn scenarios)
- [ ] Confirm multi-turn conversations still cache the second-to-last user turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
