### PR TITLE
fix: handle transient errors in API key validation and restore local-first save

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -32,18 +32,26 @@ export async function validateAnthropicApiKey(
       if (error.status === 401) {
         return { valid: false, reason: "API key is invalid or expired." };
       }
-      return {
-        valid: false,
-        reason: `Anthropic API error (${error.status}): ${error.message}`,
-      };
+      if (error.status === 403) {
+        return {
+          valid: false,
+          reason: `Anthropic API error (${error.status}): ${error.message}`,
+        };
+      }
+      // Transient errors (429, 5xx, etc.) — validation is inconclusive,
+      // allow the key to be stored rather than blocking the user.
+      log.warn(
+        { status: error.status },
+        "Anthropic API returned a transient error during key validation — allowing key storage",
+      );
+      return { valid: true };
     }
-    return {
-      valid: false,
-      reason:
-        error instanceof Error
-          ? error.message
-          : "Failed to validate API key.",
-    };
+    // Network errors — validation is inconclusive, allow key storage.
+    log.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      "Network error during Anthropic key validation — allowing key storage",
+    );
+    return { valid: true };
   }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -717,6 +717,14 @@ public final class SettingsStore: ObservableObject {
         guard !trimmed.isEmpty else { return }
         apiKeySaveError = nil
         apiKeySaving = true
+
+        // Persist locally first so the key survives reconnect/retry flows
+        // even if the daemon is unreachable or validation is inconclusive.
+        APIKeyManager.setKey(trimmed, for: "anthropic")
+        removeDeletionTombstone(type: "api_key", name: "anthropic")
+        hasKey = true
+        maskedKey = Self.maskKey(trimmed)
+
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: "anthropic", value: trimmed)
             apiKeySaving = false
@@ -724,10 +732,6 @@ public final class SettingsStore: ObservableObject {
                 apiKeySaveError = error
                 return
             }
-            APIKeyManager.setKey(trimmed, for: "anthropic")
-            removeDeletionTombstone(type: "api_key", name: "anthropic")
-            hasKey = true
-            maskedKey = Self.maskKey(trimmed)
             scheduleRoutingSourceRefresh()
             onSuccess?()
         }


### PR DESCRIPTION
## Summary
- Only treat HTTP 401/403 from Anthropic as definitive validation failures; 429, 5xx, and network errors are inconclusive and allow key storage with a warning log
- Restore local-first key persistence in `SettingsStore.saveAPIKey` — key is saved to local keychain before remote sync, so it survives when the daemon is unreachable
- Addresses review feedback from PR #18118

## Test plan
- [ ] Save a valid API key while Anthropic API is healthy — key saved and validated
- [ ] Simulate transient API error (e.g. 503) — key should still be saved with warning logged
- [ ] Save with invalid key (401) — error shown, key still in local keychain for retry
- [ ] Save key when daemon is unreachable — key persisted locally for later sync
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
