### PR TITLE
fix: propagate conversationId/messageId during candidate merge

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -354,6 +354,15 @@ export async function buildMemoryRecall(
     if (c.text.length > existing.text.length) {
       existing.text = c.text;
     }
+    // Propagate metadata that the first source may lack (e.g. legacy
+    // Qdrant points missing conversation_id / message_id). The recency
+    // source always has these from the DB, so merging fills the gap.
+    if (c.conversationId && !existing.conversationId) {
+      existing.conversationId = c.conversationId;
+    }
+    if (c.messageId && !existing.messageId) {
+      existing.messageId = c.messageId;
+    }
   }
 
   // ── Step 5b: Filter out current-conversation segments still in context ──


### PR DESCRIPTION
## Summary
- Fix merge step in memory retriever to propagate `conversationId` and `messageId` when merging duplicate candidates from semantic + recency search
- Addresses review feedback from PR #18060: legacy Qdrant points missing `conversation_id` could bypass the current-conversation segment filter

## Test plan
- [x] Code review — change is additive (only fills in missing fields, never overwrites existing ones)
- [x] Existing retriever tests cover the merge path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
