### PR TITLE
fix: filter current-conversation segments with missing messageId in memory recall

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -366,12 +366,20 @@ export async function buildMemoryRecall(
     const inContextMessageIds = getInContextMessageIds(conversationId);
     if (inContextMessageIds) {
       for (const [key, c] of candidateMap) {
-        if (
-          c.type === "segment" &&
-          c.messageId &&
-          inContextMessageIds.has(c.messageId)
-        ) {
-          candidateMap.delete(key);
+        if (c.type === "segment") {
+          if (c.messageId) {
+            // Segment has a known source message — filter only if that
+            // message is still in the context window.
+            if (inContextMessageIds.has(c.messageId)) {
+              candidateMap.delete(key);
+            }
+          } else if (c.conversationId === conversationId) {
+            // Segment from the current conversation but missing messageId
+            // (e.g. legacy Qdrant points without message_id payload).
+            // We can't determine whether it's compacted, so err on the
+            // side of filtering to avoid token bloat from redundant segments.
+            candidateMap.delete(key);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #18062 about segments bypassing the in-context filter when `messageId` is missing.
- When a segment candidate has no `messageId` but its `conversationId` matches the current conversation, it is now filtered out as a safe default — we can't determine if it's compacted, so we err on the side of preventing token bloat.
- Segments from other conversations are unaffected (they don't match the conversationId check).

## Test plan
- [x] Existing retriever tests cover the happy path (messageId present)
- [x] Logic is straightforward: missing messageId + same conversation = filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
