### PR TITLE
fix: address system prompt cache boundary PR feedback

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -67,6 +67,7 @@ import {
   PLACEHOLDER_BLOCKS_OMITTED,
   PLACEHOLDER_EMPTY_TURN,
 } from "../providers/anthropic/client.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../prompts/system-prompt.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,6 +154,25 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     await provider.sendMessage([userMsg("Hi")]);
 
     expect(lastStreamParams!.system).toBeUndefined();
+  });
+
+  test("splits system prompt into two cache blocks on boundary marker", async () => {
+    const staticBlock = "You are a helpful assistant.";
+    const dynamicBlock = "User workspace files here.";
+    const prompt = staticBlock + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamicBlock;
+
+    await provider.sendMessage([userMsg("Hi")], undefined, prompt);
+
+    const system = lastStreamParams!.system as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string };
+    }>;
+    expect(system).toHaveLength(2);
+    expect(system[0].text).toBe(staticBlock);
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[1].text).toBe(dynamicBlock);
+    expect(system[1].cache_control).toEqual({ type: "ephemeral" });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -134,9 +134,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   staticParts.push(buildTaskScheduleReminderRoutingSection());
   staticParts.push(buildAttachmentSection());
   staticParts.push(buildInChatConfigurationSection());
-  if (!isOnboardingComplete()) {
-    staticParts.push(buildStarterTaskPlaybookSection());
-  }
   if (!hasNoClient) staticParts.push(buildSystemPermissionSection());
   staticParts.push(buildSwarmGuidanceSection());
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
@@ -189,6 +186,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         "- When you are satisfied all updates have been actioned or communicated, delete `UPDATES.md` to signal completion.",
       ].join("\n"),
     );
+  }
+  if (!isOnboardingComplete()) {
+    dynamicParts.push(buildStarterTaskPlaybookSection());
   }
   dynamicParts.push(buildConfigSection(hasNoClient));
   dynamicParts.push(buildExternalCommsIdentitySection());

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,6 +1,7 @@
 import type * as genai from "@google/genai";
 import { ApiError, GoogleGenAI } from "@google/genai";
 
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
 import { ProviderError } from "../../util/errors.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
@@ -65,7 +66,10 @@ export class GeminiProvider implements Provider {
       const geminiConfig: genai.GenerateContentConfig = {};
 
       if (systemPrompt) {
-        geminiConfig.systemInstruction = systemPrompt;
+        geminiConfig.systemInstruction = systemPrompt.replaceAll(
+          SYSTEM_PROMPT_CACHE_BOUNDARY,
+          "\n",
+        );
       }
       if (maxTokens) {
         geminiConfig.maxOutputTokens = maxTokens;

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
 import { ProviderError } from "../../util/errors.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
@@ -224,7 +225,10 @@ export class OpenAIProvider implements Provider {
     const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
 
     if (systemPrompt) {
-      result.push({ role: "system", content: systemPrompt });
+      result.push({
+        role: "system",
+        content: systemPrompt.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n"),
+      });
     }
 
     for (const msg of messages) {


### PR DESCRIPTION
## Summary
- Move `isOnboardingComplete()` check from static to dynamic block — filesystem check changes mid-conversation, defeating cache stability
- Strip `SYSTEM_PROMPT_CACHE_BOUNDARY` marker in OpenAI and Gemini providers so non-Anthropic models don't see the implementation detail
- Add test coverage for two-block system prompt splitting in Anthropic provider

Addresses review feedback from #18016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
