### PR TITLE
fix: gate memory-context stripping to injected blocks only

### DIFF
--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -551,7 +551,7 @@ describe("extractUserTimeZoneFromRecall", () => {
   });
 
   test("extracts IANA timezone from user_identity section", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <user_identity>
 User's timezone is America/New_York
@@ -563,7 +563,7 @@ User works as a software engineer
   });
 
   test("extracts timezone from 'timezone: ...' line in identity", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <user_identity>
 - name: Alice
@@ -576,7 +576,7 @@ User works as a software engineer
   });
 
   test("extracts UTC offset timezone", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <user_identity>
 User's time zone is UTC+5:30
@@ -590,7 +590,7 @@ User's time zone is UTC+5:30
   });
 
   test("falls back to scanning full text when no identity section", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <relevant_context>
 <episode source="Mar 5">
@@ -603,7 +603,7 @@ User mentioned their timezone is Asia/Tokyo
   });
 
   test("returns null when no timezone info present", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <user_identity>
 User's name is Bob
@@ -615,7 +615,7 @@ User works at Acme Corp
   });
 
   test("prefers identity section over other sections", () => {
-    const text = `<memory_context>
+    const text = `<memory_context __injected>
 
 <user_identity>
 User's timezone is America/Chicago

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -366,13 +366,13 @@ describe("Memory lifecycle E2E regression", () => {
     expect(recall.enabled).toBe(true);
     expect(recall.injectedText.length).toBeGreaterThan(0);
     expect(recall.injectedTokens).toBeGreaterThan(0);
-    expect(recall.injectedText).toContain("<memory_context>");
+    expect(recall.injectedText).toContain("<memory_context __injected>");
     expect(recall.injectedText).toContain("</memory_context>");
   });
 
   test("stripping removes <memory_context> block from injected recall", () => {
     const memoryRecallText =
-      "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
     const originalMessages: Message[] = [
       {
         role: "user",
@@ -394,7 +394,7 @@ describe("Memory lifecycle E2E regression", () => {
     expect(b1.type === "text" && b1.text).toBe("Actual user request");
 
     // Stripped by prefix-based stripping (same mechanism as workspace/temporal)
-    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context>"]);
+    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context __injected>"]);
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0].content).toHaveLength(1);
     const cb0 = cleaned[0].content[0];

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -311,7 +311,7 @@ describe("Memory regressions", () => {
 
   test("memory recall injection as user block and stripped from runtime history", () => {
     const memoryRecallText =
-      "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
     const originalMessages: Message[] = [
       {
         role: "user",
@@ -333,7 +333,7 @@ describe("Memory regressions", () => {
     expect(b1.type === "text" && b1.text).toBe("Actual user request");
 
     // Stripped by prefix-based stripping
-    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context>"]);
+    const cleaned = stripUserTextBlocksByPrefix(injected, ["<memory_context __injected>"]);
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0].content).toHaveLength(1);
     const cb0 = cleaned[0].content[0];
@@ -342,9 +342,9 @@ describe("Memory regressions", () => {
 
   test("prefix-based stripping removes all <memory_context> blocks from merged content", () => {
     const memoryRecallText =
-      "<memory_context>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nuser prefers concise answers\n</relevant_context>\n\n</memory_context>";
     // Simulate deep-repair merging where multiple memory context blocks exist.
-    // Prefix-based stripping removes all blocks starting with <memory_context>.
+    // Prefix-based stripping removes all blocks starting with <memory_context __injected>.
     const mergedUserMessage: Message = {
       role: "user",
       content: [
@@ -357,7 +357,7 @@ describe("Memory regressions", () => {
 
     const cleaned = stripUserTextBlocksByPrefix(
       [mergedUserMessage],
-      ["<memory_context>"],
+      ["<memory_context __injected>"],
     );
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0].content).toEqual([
@@ -376,7 +376,7 @@ describe("Memory regressions", () => {
       },
     ];
     const recallText =
-      "<memory_context>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
     const result = injectMemoryRecallAsUserBlock(history, recallText);
     // Same number of messages — no synthetic pair
     expect(result).toHaveLength(3);
@@ -399,7 +399,7 @@ describe("Memory regressions", () => {
 
   test("stripUserTextBlocksByPrefix removes memory_context block from user message", () => {
     const recallText =
-      "<memory_context>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nSome recalled fact\n</relevant_context>\n\n</memory_context>";
     const msgs: Message[] = [
       { role: "user", content: [{ type: "text" as const, text: "Hello" }] },
       {
@@ -414,7 +414,7 @@ describe("Memory regressions", () => {
         ],
       },
     ];
-    const cleaned = stripUserTextBlocksByPrefix(msgs, ["<memory_context>"]);
+    const cleaned = stripUserTextBlocksByPrefix(msgs, ["<memory_context __injected>"]);
     expect(cleaned).toHaveLength(3);
     const c0 = cleaned[0].content[0];
     const c1 = cleaned[1].content[0];

--- a/assistant/src/daemon/conversation-memory.ts
+++ b/assistant/src/daemon/conversation-memory.ts
@@ -71,7 +71,7 @@ export function needsMemory(messages: Message[], content: string): boolean {
  * Memory context is injected as a text content block prepended to the
  * last user message (same pattern as workspace/temporal injections).
  * Stripping is handled by `stripUserTextBlocksByPrefix` matching the
- * `<memory_context>` prefix in `RUNTIME_INJECTION_PREFIXES`.
+ * `<memory_context __injected>` prefix in `RUNTIME_INJECTION_PREFIXES`.
  */
 export async function prepareMemoryContext(
   ctx: MemoryPrepareContext,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1075,7 +1075,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<guardian_context>",
   "<inbound_actor_context>",
   "<interface_turn_context>",
-  "<memory_context>",
+  "<memory_context __injected>",
   "<voice_call_control>",
   "<workspace_top_level>",
   TEMPORAL_INJECTED_PREFIX,

--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -778,7 +778,7 @@ describe("Memory Retriever Pipeline", () => {
     ];
 
     const recallText =
-      "<memory_context>\n\n<relevant_context>\ntest\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\ntest\n</relevant_context>\n\n</memory_context>";
     const result = injectMemoryRecallAsUserBlock(msgs, recallText);
 
     // Same number of messages — no synthetic pair added
@@ -812,7 +812,7 @@ describe("Memory Retriever Pipeline", () => {
     ];
 
     const recallText =
-      "<memory_context>\n\n<relevant_context>\nfact\n</relevant_context>\n\n</memory_context>";
+      "<memory_context __injected>\n\n<relevant_context>\nfact\n</relevant_context>\n\n</memory_context>";
     const result = injectMemoryRecallAsUserBlock(msgs, recallText);
 
     expect(result).toHaveLength(3);

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -744,7 +744,7 @@ function enrichSourceLabels(candidates: TieredCandidate[]): void {
  * message rather than a separate synthetic message pair.
  *
  * Stripping is handled by `stripUserTextBlocksByPrefix` matching the
- * `<memory_context>` prefix in `RUNTIME_INJECTION_PREFIXES`, so no
+ * `<memory_context __injected>` prefix in `RUNTIME_INJECTION_PREFIXES`, so no
  * dedicated strip function is needed.
  */
 export function injectMemoryRecallAsUserBlock(

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -126,7 +126,7 @@ export function buildTwoLayerInjection(params: {
   // Reserve tokens for XML wrapper overhead (<memory_context>, section tags,
   // newlines between sections) so the final assembled text stays within budget.
   const WRAPPER_OVERHEAD_TOKENS = estimateTextTokens(
-    "<memory_context>\n\n\n\n</memory_context>",
+    "<memory_context __injected>\n\n\n\n</memory_context>",
   );
   const SECTION_TAG_TOKENS = estimateTextTokens(
     "<possibly_relevant>\n\n</possibly_relevant>",
@@ -201,7 +201,7 @@ export function buildTwoLayerInjection(params: {
 
   if (sections.length === 0) return "";
 
-  return `<memory_context>\n\n${sections.join("\n\n")}\n\n</memory_context>`;
+  return `<memory_context __injected>\n\n${sections.join("\n\n")}\n\n</memory_context>`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Added `__injected` attribute to `<memory_context>` tags emitted by the formatting pipeline, changing the tag to `<memory_context __injected>`
- Updated the stripping prefix in `RUNTIME_INJECTION_PREFIXES` to match `<memory_context __injected>` instead of bare `<memory_context>`
- This prevents user messages that happen to start with `<memory_context>` (e.g. discussing XML, pasting diagnostics) from being silently stripped from persisted history

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/18065#discussion_r2943851863

## Test plan
- Updated all test fixtures to use the new `<memory_context __injected>` tag format
- Existing tests validate injection and stripping continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
