### PR TITLE
fix: route telemetry lifecycle through GatewayHTTPClient and add route policy

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -291,6 +291,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "usage/daily", scopes: ["settings.read"] },
   { endpoint: "usage/breakdown", scopes: ["settings.read"] },
 
+  // Lifecycle telemetry
+  { endpoint: "telemetry/lifecycle", scopes: ["settings.write"] },
+
   // Debug
   { endpoint: "debug", scopes: ["settings.read"] },
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -388,8 +388,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
                 if ready {
                     // Record lifecycle telemetry events (fire-and-forget).
-                    Task { await daemonClient.httpTransport?.recordLifecycleEvent("hatch") }
-                    Task { await daemonClient.httpTransport?.recordLifecycleEvent("app_open") }
+                    Task { await TelemetryClient().recordLifecycleEvent("hatch") }
+                    Task { await TelemetryClient().recordLifecycleEvent("app_open") }
 
                     // If the user is signed in with a local assistant, wait for
                     // credential provisioning to complete before sending the wake-up
@@ -423,7 +423,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             Task {
                 let ready = await awaitDaemonReady(timeout: 10)
                 if ready {
-                    await daemonClient.httpTransport?.recordLifecycleEvent("app_open")
+                    await TelemetryClient().recordLifecycleEvent("app_open")
                 }
             }
             showMainWindow()

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -429,9 +429,6 @@ public final class HTTPTransport {
         // BTW side-chain
         case btw
 
-        // Telemetry
-        case telemetryLifecycle
-
         // Misc
         case channelVerificationSessions
         case channelVerificationSessionsStatus
@@ -822,8 +819,6 @@ public final class HTTPTransport {
             return ("/v1/channel-verification-sessions/revoke", nil)
         case .registerDeviceToken:
             return ("/v1/device-token", nil)
-        case .telemetryLifecycle:
-            return ("/v1/telemetry/lifecycle", nil)
         }
     }
 
@@ -1188,8 +1183,6 @@ public final class HTTPTransport {
             return ("\(prefix)/channel-verification-sessions/revoke/", nil)
         case .registerDeviceToken:
             return ("\(prefix)/device-token/", nil)
-        case .telemetryLifecycle:
-            return ("\(prefix)/telemetry/lifecycle/", nil)
         }
     }
 
@@ -2060,37 +2053,6 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Conversation seen signal error: \(error.localizedDescription)")
-        }
-    }
-
-    /// Record a lifecycle telemetry event (e.g. app_open, hatch).
-    /// Fire-and-forget — failures are logged but do not propagate.
-    public func recordLifecycleEvent(_ eventName: String, isRetry: Bool = false) async {
-        guard let url = buildURL(for: .telemetryLifecycle) else { return }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        applyAuth(&request)
-
-        let body: [String: Any] = ["event_name": eventName]
-
-        do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body)
-            let (data, response) = try await URLSession.shared.data(for: request)
-
-            if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = refreshResult {
-                        await recordLifecycleEvent(eventName, isRetry: true)
-                    }
-                } else if http.statusCode != 200 {
-                    log.warning("Lifecycle event '\(eventName)' recording failed (\(http.statusCode))")
-                }
-            }
-        } catch {
-            log.warning("Lifecycle event '\(eventName)' recording error: \(error.localizedDescription)")
         }
     }
 

--- a/clients/shared/Network/TelemetryClient.swift
+++ b/clients/shared/Network/TelemetryClient.swift
@@ -1,0 +1,34 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "TelemetryClient")
+
+/// Focused client for telemetry operations routed through the gateway.
+@MainActor
+public protocol TelemetryClientProtocol {
+    func recordLifecycleEvent(_ eventName: String) async
+}
+
+/// Gateway-backed implementation of ``TelemetryClientProtocol``.
+@MainActor
+public struct TelemetryClient: TelemetryClientProtocol {
+    nonisolated public init() {}
+
+    /// Record a lifecycle telemetry event (e.g. app_open, hatch).
+    /// Fire-and-forget — failures are logged but do not propagate.
+    public func recordLifecycleEvent(_ eventName: String) async {
+        let body: [String: Any] = ["event_name": eventName]
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/telemetry/lifecycle",
+                json: body,
+                timeout: 10
+            )
+            if !response.isSuccess {
+                log.warning("Lifecycle event '\(eventName)' recording failed (HTTP \(response.statusCode))")
+            }
+        } catch {
+            log.warning("Lifecycle event '\(eventName)' recording error: \(error.localizedDescription)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `TelemetryClient.swift` as a focused `GatewayHTTPClient`-backed client for lifecycle telemetry, replacing the legacy `HTTPTransport.recordLifecycleEvent` method
- Remove `telemetryLifecycle` endpoint enum case and path mappings from `HTTPDaemonClient.swift`
- Update `AppDelegate.swift` call sites to use `TelemetryClient()` instead of `daemonClient.httpTransport?.recordLifecycleEvent()`
- Register route policy for `telemetry/lifecycle` with `settings.write` scope in `route-policy.ts`

Addresses review feedback on #18112.

## Test plan
- [ ] Verify macOS app builds with `./build.sh`
- [ ] Confirm lifecycle events are still recorded on app open and hatch
- [ ] Verify route policy enforcement for telemetry/lifecycle endpoint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
