### PR TITLE
fix: never cache a single-user-turn message (revert 552c68a5 fallback)

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -770,8 +770,8 @@ export class AnthropicProvider implements Provider {
       for (let i = 0; i < params.messages.length; i++) {
         if (params.messages[i].role === "user") userIndices.push(i);
       }
-      // Prefer the second-to-last user turn; fall back to the last if only one exists.
-      for (const idx of userIndices.length >= 2 ? userIndices.slice(-2, -1) : userIndices.slice(-1)) {
+      // slice(-2, -1) gives the second-to-last; empty array if < 2 user turns.
+      for (const idx of userIndices.slice(-2, -1)) {
         const content = params.messages[idx].content;
         if (Array.isArray(content) && content.length > 0) {
           (


### PR DESCRIPTION
## Summary
- Reverts the cache_control fallback introduced in #18129 that cached the last (only) user turn when there was only one user message
- The second-to-last user turn is the correct breakpoint: the last turn is always new (fresh temporal context or tool result) and will never produce a cache hit, so caching it wastes a cache_control slot
- Fixes 5 failing test assertions in `anthropic-provider.test.ts` that verified no `cache_control` is set on single-user-turn conversations

## Original prompt
Fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/23178696678/job/67346741114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
