### PR TITLE
feat: gate Deploy to Vercel behind assistant-level feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -978,6 +978,13 @@ struct DynamicWorkspaceWrapper: View {
                 // Flag stays disabled on error
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
+            if let key = notification.userInfo?["key"] as? String,
+               let enabled = notification.userInfo?["enabled"] as? Bool,
+               key == Self.deployToVercelFlagKey {
+                isDeployToVercelEnabled = enabled
+            }
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -751,6 +751,9 @@ struct DynamicWorkspaceWrapper: View {
     @State private var publishUrlCopied = false
     @State private var showShareDrawer = false
     @State private var shareButtonFrame: CGRect = .zero
+    @State private var isDeployToVercelEnabled = false
+
+    private static let deployToVercelFlagKey = "feature_flags.deploy-to-vercel.enabled"
 
     /// Corner radius for the WKWebView clipping container — no rounding needed since the
     /// outer page container handles corner rounding.
@@ -832,7 +835,7 @@ struct DynamicWorkspaceWrapper: View {
                             ProgressView()
                                 .controlSize(.small)
                                 .frame(height: 32)
-                        } else if sharing.publishedUrl == nil {
+                        } else if sharing.publishedUrl == nil && isDeployToVercelEnabled {
                             VButton(label: "Publish", iconOnly: VIcon.arrowUpRight.rawValue, style: .outlined, iconSize: 32, tooltip: "Publish to Vercel") {
                                 onPublishPage(data.html, data.preview?.title, data.appId)
                             }
@@ -954,7 +957,8 @@ struct DynamicWorkspaceWrapper: View {
                     onPublish: {
                         showShareDrawer = false
                         onPublishPage(data.html, data.preview?.title, data.appId)
-                    }
+                    },
+                    isDeployToVercelEnabled: isDeployToVercelEnabled
                 )
                 .offset(
                     x: shareButtonFrame.maxX - 180,
@@ -962,6 +966,16 @@ struct DynamicWorkspaceWrapper: View {
                 )
                 .zIndex(10)
                 .transition(.opacity)
+            }
+        }
+        .task {
+            do {
+                let flags = try await daemonClient.getFeatureFlags()
+                if let flag = flags.first(where: { $0.key == Self.deployToVercelFlagKey }) {
+                    isDeployToVercelEnabled = flag.enabled
+                }
+            } catch {
+                // Flag stays disabled on error
             }
         }
     }
@@ -1021,18 +1035,21 @@ private struct PublishedButton: View {
 
 // MARK: - Share Drawer
 
-/// Popover menu with "Share" and "Publish to Vercel" options.
+/// Popover menu with "Share" and optionally "Publish to Vercel" options.
 /// Styled to match ConversationSwitcherDrawer / DrawerMenuView.
 private struct ShareDrawer: View {
     let onShare: () -> Void
     let onPublish: () -> Void
+    let isDeployToVercelEnabled: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             ShareDrawerRow(icon: .share, label: "Share", action: onShare)
-            VColor.borderBase.frame(height: 1)
-                .padding(.horizontal, VSpacing.xs)
-            ShareDrawerRow(icon: .arrowUpRight, label: "Publish to Vercel", action: onPublish)
+            if isDeployToVercelEnabled {
+                VColor.borderBase.frame(height: 1)
+                    .padding(.horizontal, VSpacing.xs)
+                ShareDrawerRow(icon: .arrowUpRight, label: "Publish to Vercel", action: onPublish)
+            }
         }
         .padding(.vertical, VSpacing.xs)
         .frame(width: 180)

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -232,6 +232,14 @@
       "label": "Recommended Starts",
       "description": "Show a curated row of recommended starting actions on the empty conversation page, ordered by relevance as confident first-click options",
       "defaultEnabled": false
+    },
+    {
+      "id": "deploy-to-vercel",
+      "scope": "assistant",
+      "key": "feature_flags.deploy-to-vercel.enabled",
+      "label": "Deploy to Vercel",
+      "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `deploy-to-vercel` assistant-scope feature flag (defaultEnabled: `false`) to the registry
- Gates the "Publish to Vercel" row in the share drawer and the standalone publish button behind this flag
- Flag is loaded via `daemonClient.getFeatureFlags()` when the workspace wrapper appears

## Test plan
- [ ] With flag disabled (default): verify the "Publish to Vercel" row does not appear in the share drawer, and the standalone publish button is hidden for non-app pages
- [ ] With flag enabled: verify both publish entry points work as before
- [ ] Verify the "Share" option in the drawer still works regardless of flag state
- [ ] Verify already-published URLs still show the "Published ✓" badge regardless of flag state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
