### PR TITLE
fix: extract SYSTEM_PROMPT_CACHE_BOUNDARY to break circular import TDZ

### DIFF
--- a/assistant/src/prompts/cache-boundary.ts
+++ b/assistant/src/prompts/cache-boundary.ts
@@ -1,0 +1,8 @@
+/**
+ * The SYSTEM_PROMPT_CACHE_BOUNDARY marker is a lightweight constant kept in its
+ * own file so that providers (openai, gemini) can import it without pulling in
+ * the full system-prompt module and its heavy transitive dependencies, which
+ * would otherwise create a circular import cycle.
+ */
+export const SYSTEM_PROMPT_CACHE_BOUNDARY =
+  "\n<!-- SYSTEM_PROMPT_CACHE_BOUNDARY -->\n";

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -17,6 +17,9 @@ import {
 } from "../util/platform.js";
 import { resolveUserPronouns, resolveUserReference } from "./user-reference.js";
 
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
+export { SYSTEM_PROMPT_CACHE_BOUNDARY };
+
 const log = getLogger("system-prompt");
 
 const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
@@ -115,9 +118,6 @@ export interface BuildSystemPromptOptions {
  * cache blocks so that static instructions stay cached even when workspace
  * files change between turns.
  */
-export const SYSTEM_PROMPT_CACHE_BOUNDARY =
-  "\n<!-- SYSTEM_PROMPT_CACHE_BOUNDARY -->\n";
-
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const hasNoClient = options?.hasNoClient ?? false;
 

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -1,7 +1,7 @@
 import type * as genai from "@google/genai";
 import { ApiError, GoogleGenAI } from "@google/genai";
 
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { ProviderError } from "../../util/errors.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/system-prompt.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { ProviderError } from "../../util/errors.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";


### PR DESCRIPTION
## Summary
- Extracts `SYSTEM_PROMPT_CACHE_BOUNDARY` from `prompts/system-prompt.ts` into a new minimal `prompts/cache-boundary.ts` file
- Updates `providers/openai/client.ts` and `providers/gemini/client.ts` to import from `cache-boundary.ts` instead of the heavy `system-prompt.ts`
- Fixes a TDZ (Temporal Dead Zone) error in `openai-provider.test.ts`: importing `system-prompt.ts` from a provider triggered a circular chain (`system-prompt` → `config/skills` → `system-prompt`) that caused `OpenAIProvider` to be uninitialized when `OllamaProvider` tried to extend it

## Original prompt
Fix only this CI issue in this failing job: https://github.com/vellum-ai/vellum-assistant/actions/runs/23178881825/job/67347321410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
