### PR TITLE
fix: sort imports in system-prompt.ts

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -15,9 +15,9 @@ import {
   getWorkspacePromptPath,
   isMacOS,
 } from "../util/platform.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
 import { resolveUserPronouns, resolveUserReference } from "./user-reference.js";
 
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
 const log = getLogger("system-prompt");


### PR DESCRIPTION
## Summary
- Move `SYSTEM_PROMPT_CACHE_BOUNDARY` import above `user-reference.js` import to satisfy `simple-import-sort/imports` ESLint rule

## Original prompt
Fix only this CI issue in this failing job: https://github.com/vellum-ai/vellum-assistant/actions/runs/23179281044/job/67348535502

🤖 Generated with [Claude Code](https://claude.com/claude-code)