### PR TITLE
Remove channel awareness section, skip injection on happy path

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -9,6 +9,7 @@ import {
   applyRuntimeInjections,
   buildChannelTurnContextBlock,
   injectChannelCapabilityContext,
+  injectChannelCommandContext,
   injectChannelTurnContext,
   injectInboundActorContext,
   injectTemporalContext,
@@ -20,7 +21,6 @@ import {
   stripInboundActorContext,
   stripTemporalContext,
 } from "../daemon/conversation-runtime-assembly.js";
-import { buildChannelAwarenessSection } from "../prompts/system-prompt.js";
 import type { Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -155,7 +155,7 @@ describe("injectChannelCapabilityContext", () => {
     content: [{ type: "text", text: "Hello" }],
   };
 
-  test("injects channel capabilities block for dashboard channel", () => {
+  test("skips injection entirely for desktop happy path (all capabilities true)", () => {
     const caps: ChannelCapabilities = {
       channel: "vellum",
       dashboardCapable: true,
@@ -165,26 +165,9 @@ describe("injectChannelCapabilityContext", () => {
 
     const result = injectChannelCapabilityContext(baseUserMessage, caps);
 
-    // Should prepend a text block with channel_capabilities
-    expect(result.content.length).toBe(2);
-    const injected = result.content[0];
-    expect(injected.type).toBe("text");
-    expect((injected as { type: "text"; text: string }).text).toContain(
-      "<channel_capabilities>",
-    );
-    expect((injected as { type: "text"; text: string }).text).toContain(
-      "dashboard_capable: true",
-    );
-    expect((injected as { type: "text"; text: string }).text).toContain(
-      "supports_dynamic_ui: true",
-    );
-    expect((injected as { type: "text"; text: string }).text).toContain(
-      "</channel_capabilities>",
-    );
-    // Should NOT contain constraint rules for dashboard
-    expect((injected as { type: "text"; text: string }).text).not.toContain(
-      "CHANNEL CONSTRAINTS",
-    );
+    // Message returned unchanged — no injection at all
+    expect(result).toBe(baseUserMessage);
+    expect(result.content.length).toBe(1);
   });
 
   test("injects constraint rules for non-dashboard channel", () => {
@@ -292,6 +275,50 @@ describe("injectChannelCapabilityContext", () => {
     const text = (result.content[0] as { type: "text"; text: string }).text;
     expect(text).toContain("GROUP CHAT ETIQUETTE");
     expect(text).toContain("emoji reactions");
+  });
+
+  test("still injects for group chats even when all capabilities are true", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: true,
+      supportsDynamicUi: true,
+      supportsVoiceInput: true,
+      chatType: "channel",
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    // Not the happy path because chatType is a group type
+    expect(result).not.toBe(baseUserMessage);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("GROUP CHAT ETIQUETTE");
+  });
+
+  test("injects WhatsApp formatting constraint for whatsapp channel", () => {
+    const caps: ChannelCapabilities = {
+      channel: "whatsapp",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Do NOT use markdown tables");
+    expect(text).toContain("bullet lists");
+    expect(text).toContain("CAPS for emphasis");
+  });
+
+  test("does NOT inject WhatsApp formatting for non-whatsapp channels", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toContain("Do NOT use markdown tables");
   });
 });
 
@@ -450,59 +477,11 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildChannelAwarenessSection
-// ---------------------------------------------------------------------------
-
-describe("buildChannelAwarenessSection", () => {
-  test("includes channel awareness heading", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).toContain("## Channel Awareness & Trust Gating");
-  });
-
-  test("includes channel-specific rules", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).toContain("dashboard_capable");
-    expect(section).toContain("supports_dynamic_ui");
-    expect(section).toContain("supports_voice_input");
-  });
-
-  test("includes trust gating rules for permission asks", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).toContain("firstConversationComplete");
-    expect(section).toContain("Permission ask trust gating");
-    expect(section).toContain(
-      "Do NOT proactively ask for elevated permissions",
-    );
-  });
-
-  test("gates microphone permissions on voice capability", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).toContain("Do not ask for microphone permissions");
-  });
-
-  test("gates computer-control on dashboard channel", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).toContain("computer-control permissions on non-dashboard");
-  });
-
-  test("does NOT include group chat etiquette (gated per-turn instead)", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).not.toContain("Group chat etiquette");
-    expect(section).not.toContain("Stay silent when");
-  });
-
-  test("does NOT include Discord references (not a supported channel)", () => {
-    const section = buildChannelAwarenessSection();
-    expect(section).not.toContain("Discord");
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Trust-gating behavior: channel constraints for permission asks
 // ---------------------------------------------------------------------------
 
 describe("trust-gating via channel capabilities", () => {
-  test("vellum channel with macos interface does not add constraint rules", () => {
+  test("vellum channel with macos interface skips injection (happy path)", () => {
     const caps = resolveChannelCapabilities("vellum", "macos");
     const message: Message = {
       role: "user",
@@ -510,10 +489,9 @@ describe("trust-gating via channel capabilities", () => {
     };
 
     const result = injectChannelCapabilityContext(message, caps);
-    const injected = (result.content[0] as { type: "text"; text: string }).text;
 
-    expect(injected).not.toContain("CHANNEL CONSTRAINTS");
-    expect(injected).toContain("dashboard_capable: true");
+    // Happy path: message returned unchanged
+    expect(result).toBe(message);
   });
 
   test("non-dashboard channel adds constraint rules preventing UI references", () => {
@@ -551,6 +529,50 @@ describe("trust-gating via channel capabilities", () => {
     );
     expect(injected).toContain("supports_dynamic_ui: true");
     expect(injected).toContain("dashboard_capable: false");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// injectChannelCommandContext
+// ---------------------------------------------------------------------------
+
+describe("injectChannelCommandContext", () => {
+  const baseUserMessage: Message = {
+    role: "user",
+    content: [{ type: "text", text: "Hello" }],
+  };
+
+  test("injects start command instructions when type is start", () => {
+    const result = injectChannelCommandContext(baseUserMessage, {
+      type: "start",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("command_type: start");
+    expect(text).toContain("warm, brief greeting");
+    expect(text).toContain("Treat /start as a hello");
+    expect(text).toContain("Do NOT reset conversation");
+  });
+
+  test("includes language code and payload when provided", () => {
+    const result = injectChannelCommandContext(baseUserMessage, {
+      type: "start",
+      payload: "ref123",
+      languageCode: "es",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("payload: ref123");
+    expect(text).toContain("language_code: es");
+    expect(text).toContain("warm, brief greeting");
+  });
+
+  test("does NOT inject start instructions for non-start commands", () => {
+    const result = injectChannelCommandContext(baseUserMessage, {
+      type: "help",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("command_type: help");
+    expect(text).not.toContain("warm, brief greeting");
+    expect(text).not.toContain("Treat /start as a hello");
   });
 });
 

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -162,14 +162,15 @@ describe("starter task playbook integration with buildSystemPrompt", () => {
     expect(result).not.toContain("## Starter Task Playbooks");
   });
 
-  test("starter task playbook and channel awareness both present during onboarding", () => {
+  test("starter task playbook present during onboarding (channel awareness removed from static prompt)", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
     const result = buildSystemPrompt();
     const starterIdx = result.indexOf("## Starter Task Playbooks");
-    const channelIdx = result.indexOf("## Channel Awareness & Trust Gating");
     expect(starterIdx).toBeGreaterThan(-1);
-    expect(channelIdx).toBeGreaterThan(-1);
+    // Channel awareness section was removed from the static prompt —
+    // channel-specific rules are now injected per-turn via <channel_capabilities>.
+    expect(result).not.toContain("## Channel Awareness & Trust Gating");
   });
 
   test("all three kickoff intents present in full system prompt during onboarding", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -194,99 +194,6 @@ export function sanitizePttActivationKey(
   return undefined;
 }
 
-// Key code → name mapping for common macOS CGKeyCodes (subset for system prompt labels).
-const KEY_CODE_NAMES: Record<number, string> = {
-  0: "A",
-  1: "S",
-  2: "D",
-  3: "F",
-  4: "H",
-  5: "G",
-  6: "Z",
-  7: "X",
-  8: "C",
-  9: "V",
-  11: "B",
-  12: "Q",
-  13: "W",
-  14: "E",
-  15: "R",
-  16: "Y",
-  17: "T",
-  31: "O",
-  32: "U",
-  34: "I",
-  35: "P",
-  37: "L",
-  38: "J",
-  40: "K",
-  45: "N",
-  46: "M",
-  49: "Space",
-  96: "F5",
-  97: "F6",
-  98: "F7",
-  99: "F3",
-  100: "F8",
-  101: "F9",
-  103: "F11",
-  109: "F10",
-  111: "F12",
-  118: "F4",
-  120: "F2",
-  122: "F1",
-  57: "Caps Lock",
-};
-
-/** Derive a human-readable label from a PTT activation key JSON value. */
-function pttKeyLabel(raw: string): string {
-  // JSON PTTActivator payload
-  if (raw.startsWith("{")) {
-    try {
-      const p = JSON.parse(raw) as {
-        kind: string;
-        keyCode?: number;
-        modifierFlags?: number;
-        mouseButton?: number;
-      };
-      switch (p.kind) {
-        case "modifierOnly": {
-          const flags = p.modifierFlags ?? 0;
-          const parts: string[] = [];
-          if (flags & (1 << 23)) parts.push("Fn");
-          if (flags & (1 << 18)) parts.push("Ctrl");
-          if (flags & (1 << 19)) parts.push("Opt");
-          if (flags & (1 << 17)) parts.push("Shift");
-          if (flags & (1 << 20)) parts.push("Cmd");
-          return parts.length > 0 ? parts.join("+") : "modifier key";
-        }
-        case "key":
-          return KEY_CODE_NAMES[p.keyCode ?? -1] ?? `Key ${p.keyCode}`;
-        case "modifierKey": {
-          const flags = p.modifierFlags ?? 0;
-          const parts: string[] = [];
-          if (flags & (1 << 23)) parts.push("Fn");
-          if (flags & (1 << 18)) parts.push("Ctrl");
-          if (flags & (1 << 19)) parts.push("Opt");
-          if (flags & (1 << 17)) parts.push("Shift");
-          if (flags & (1 << 20)) parts.push("Cmd");
-          const keyName = KEY_CODE_NAMES[p.keyCode ?? -1] ?? `Key ${p.keyCode}`;
-          parts.push(keyName);
-          return parts.join("+");
-        }
-        case "mouseButton":
-          return `Mouse ${p.mouseButton}`;
-        case "none":
-          return "none";
-      }
-    } catch {
-      // fall through
-    }
-  }
-
-  return raw;
-}
-
 /** Optional PTT metadata provided by the client alongside each message. */
 export interface PttMetadata {
   pttActivationKey?: string;
@@ -607,6 +514,16 @@ export function injectChannelCapabilityContext(
   message: Message,
   caps: ChannelCapabilities,
 ): Message {
+  // Happy path: desktop with full capabilities — skip injection entirely.
+  if (
+    caps.dashboardCapable &&
+    caps.supportsDynamicUi &&
+    caps.supportsVoiceInput &&
+    !isGroupChatType(caps.chatType)
+  ) {
+    return message;
+  }
+
   const lines: string[] = ["<channel_capabilities>"];
   lines.push(`channel: ${caps.channel}`);
   lines.push(`dashboard_capable: ${caps.dashboardCapable}`);
@@ -631,36 +548,16 @@ export function injectChannelCapabilityContext(
       "- Defer dashboard-specific actions (e.g. accent color selection) by telling the user",
     );
     lines.push("  they can complete those steps later from the desktop app.");
+
+    if (caps.channel === "whatsapp") {
+      lines.push(
+        "- Do NOT use markdown tables — use bullet lists instead. No markdown headers — use **bold** or CAPS for emphasis.",
+      );
+    }
   }
 
   if (!caps.supportsVoiceInput) {
     lines.push("- Do NOT ask the user to use voice or microphone input.");
-  }
-
-  // PTT state — only relevant on channels that support voice input
-  if (caps.supportsVoiceInput) {
-    if (caps.pttActivationKey && caps.pttActivationKey !== "none") {
-      const keyLabel = pttKeyLabel(caps.pttActivationKey);
-      const isDisabled = keyLabel === "none";
-      if (!isDisabled) {
-        lines.push(`ptt_activation_key: ${keyLabel}`);
-        lines.push(`ptt_enabled: true`);
-        lines.push(
-          `Push-to-talk is configured with the ${keyLabel} key. The user can hold ${keyLabel} to dictate text or start a voice conversation.`,
-        );
-      }
-    } else if (caps.pttActivationKey === "none") {
-      lines.push(`ptt_activation_key: none`);
-      lines.push(`ptt_enabled: false`);
-      lines.push(
-        "Push-to-talk is disabled. You can offer to enable it for the user.",
-      );
-    }
-    if (caps.microphonePermissionGranted !== undefined) {
-      lines.push(
-        `microphone_permission_granted: ${caps.microphonePermissionGranted}`,
-      );
-    }
   }
 
   // Inject group chat etiquette only when the chat type indicates a multi-party
@@ -720,6 +617,13 @@ export function injectChannelCommandContext(
   if (ctx.languageCode) {
     lines.push(`language_code: ${ctx.languageCode}`);
   }
+
+  if (ctx.type === "start") {
+    lines.push(
+      "Respond with a warm, brief greeting (1-3 sentences). Treat /start as a hello. Do NOT reset conversation or mention slash commands. If a payload is present, acknowledge it warmly. Respond in the user's language if available from context, otherwise default to English.",
+    );
+  }
+
   lines.push("</channel_command_context>");
 
   const block = lines.join("\n");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -128,7 +128,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const staticParts: string[] = [];
   if (getIsContainerized()) staticParts.push(buildContainerizedSection());
   staticParts.push(buildCliReferenceSection());
-  staticParts.push(buildChannelAwarenessSection());
   if (!hasNoClient) staticParts.push(buildToolPermissionSection());
   staticParts.push(buildTaskScheduleReminderRoutingSection());
   staticParts.push(buildAttachmentSection());
@@ -399,40 +398,6 @@ function buildSystemPermissionSection(): string {
     "- Accessibility / UI automation → `accessibility`",
     "",
     "Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.",
-  ].join("\n");
-}
-
-export function buildChannelAwarenessSection(): string {
-  return [
-    "## Channel Awareness & Trust Gating",
-    "",
-    "Each turn may include a `<channel_capabilities>` block in the user message describing what the current channel supports. Use this to adapt your behaviour:",
-    "",
-    "### Channel-specific rules",
-    "- When `dashboard_capable` is `false`, never reference the dashboard UI, settings panels, dynamic pages, or visual pickers. Present data as formatted text.",
-    "- When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`.",
-    "- When `supports_voice_input` is `false`, do not ask the user to speak or use their microphone.",
-    "- Non-dashboard channels should defer dashboard-specific actions. Tell the user they can complete those steps later from the desktop app.",
-    "",
-    "### Permission ask trust gating",
-    "- Do NOT proactively ask for elevated permissions (microphone, computer control, file access) until the trust stage field `firstConversationComplete` in USER.md is `true`.",
-    "- Even after `firstConversationComplete`, only ask for permissions that are relevant to the current channel capabilities.",
-    "- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.",
-    "- Do not ask for computer-control permissions on non-dashboard channels.",
-    "- When you do request a permission, be transparent about what it enables and why you need it.",
-    "",
-    "### Push-to-talk awareness",
-    "- The `<channel_capabilities>` block may include `ptt_activation_key` and `ptt_enabled` fields indicating the user's push-to-talk configuration.",
-    '- You can change the push-to-talk activation key using the `voice_config_update` tool. The key is provided as a JSON PTTActivator payload (e.g. `{"kind":"modifierOnly","modifierFlags":8388608}` for Fn).',
-    "- When the user asks about voice input or push-to-talk settings, use the tool to apply changes directly rather than directing them to settings.",
-    "- When `microphone_permission_granted` is `false`, guide the user to grant microphone access in System Settings before using voice features.",
-    "",
-    "### Platform formatting",
-    "- **WhatsApp:** Do not use markdown tables — use bullet lists instead. No markdown headers — use **bold** or CAPS for emphasis.",
-    "",
-    "### Channel command handling",
-    "Some channel turns include a `<channel_command_context>` block indicating the user triggered a bot command (e.g. Telegram `/start`).",
-    "When `command_type` is `start`: generate a warm, brief greeting (1-3 sentences). Treat `/start` verbatim as a hello. Do NOT reset conversation or mention slash commands. If a `payload` is present, acknowledge it warmly. Respond in the same language as the user's locale if available from channel context, otherwise default to English.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Removed the entire `## Channel Awareness & Trust Gating` section (~650 tokens) from the static system prompt
- Skip `<channel_capabilities>` injection entirely on the desktop happy path (all capabilities true) — zero tokens on most requests
- Removed PTT state injection (rare interaction, model can discover on demand)
- Moved WhatsApp formatting rules into the channel capabilities injection (only present on WhatsApp turns)
- Moved channel command handling instructions into `<channel_command_context>` injection (only present when a command is triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
