### PR TITLE
fix: remove Tool Routing section from system prompt

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -105,11 +105,25 @@ const scheduleCreateDef = scheduleToolsJson.tools.find(
   (t: { name: string }) => t.name === "schedule_create",
 );
 
+// Load send_notification description from the bundled skill TOOLS.json
+const notifToolsJson = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "../config/bundled-skills/notifications/TOOLS.json",
+    ),
+    "utf-8",
+  ),
+);
+const sendNotificationDef = notifToolsJson.tools.find(
+  (t: { name: string }) => t.name === "send_notification",
+);
+
 // =====================================================================
-// 1. System prompt: buildTaskScheduleReminderRoutingSection
+// 1. Routing section removed from system prompt — guidance in tool descriptions
 // =====================================================================
 
-describe("Task/Schedule routing section in system prompt", () => {
+describe("Task/Schedule routing NOT in system prompt (moved to tool descriptions)", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -120,54 +134,11 @@ describe("Task/Schedule routing section in system prompt", () => {
     }
   });
 
-  test("system prompt includes the routing section heading", () => {
+  test("system prompt does not contain the old routing section", () => {
     const prompt = buildSystemPrompt();
-    expect(prompt).toContain(
+    expect(prompt).not.toContain(
       "## Tool Routing: Tasks vs Schedules vs Notifications",
     );
-  });
-
-  test("routing section lists all three tools in the summary table", () => {
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain("`task_list_add`");
-    expect(prompt).toContain("`schedule_create`");
-    expect(prompt).toContain("`send_notification`");
-  });
-
-  test("routing section warns that send_notification is immediate-only", () => {
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain("send_notification` is immediate-only");
-    expect(prompt).toContain("fires NOW");
-  });
-
-  test("routing section includes quick routing rules", () => {
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain("Quick routing rules");
-    expect(prompt).toContain("Future time, one-shot");
-    expect(prompt).toContain("Recurring pattern");
-    expect(prompt).toContain("No time, track as work");
-  });
-
-  test("routing section documents entity type routing", () => {
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain(
-      "Entity type routing: work items vs task templates",
-    );
-    expect(prompt).toContain("**Work items**");
-    expect(prompt).toContain("**Task templates**");
-  });
-
-  test("routing section references the Time-Based Actions skill", () => {
-    const prompt = buildSystemPrompt();
-    expect(prompt).toContain("Time-Based Actions");
-  });
-
-  test("routing section is present in the system prompt", () => {
-    const prompt = buildSystemPrompt();
-    const taskRoutingIdx = prompt.indexOf(
-      "## Tool Routing: Tasks vs Schedules vs Notifications",
-    );
-    expect(taskRoutingIdx).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -225,6 +196,18 @@ describe("schedule_create tool description", () => {
   test("does NOT suggest it handles task queue items", () => {
     expect(scheduleCreateDef.description).not.toContain("task queue");
     expect(scheduleCreateDef.description).not.toContain("one-off");
+  });
+});
+
+describe("send_notification tool description", () => {
+  test("states it fires immediately with no delay", () => {
+    expect(sendNotificationDef).toBeDefined();
+    expect(sendNotificationDef.description).toContain("immediate");
+    expect(sendNotificationDef.description).toContain("no delay");
+  });
+
+  test("redirects to schedule_create for future alerts", () => {
+    expect(sendNotificationDef.description).toContain("schedule_create");
   });
 });
 

--- a/assistant/src/config/bundled-skills/notifications/TOOLS.json
+++ b/assistant/src/config/bundled-skills/notifications/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "send_notification",
-      "description": "Send a notification through the unified notification router. The router decides channels/copy from preferences and urgency hints. Include a confidence score (0-1).",
+      "description": "Send an immediate notification. Fires instantly with no delay capability. For future or scheduled alerts, use schedule_create with fire_at instead. The router decides channels/copy from preferences and urgency hints. Include a confidence score (0-1).",
       "category": "notifications",
       "risk": "medium",
       "input_schema": {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -129,7 +129,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   if (getIsContainerized()) staticParts.push(buildContainerizedSection());
   staticParts.push(buildCliReferenceSection());
   // Tool Permissions section removed — guidance lives in tool descriptions.
-  staticParts.push(buildTaskScheduleReminderRoutingSection());
+  // Tool Routing section removed — guidance lives in tool descriptions.
   staticParts.push(buildAttachmentSection());
   staticParts.push(buildInChatConfigurationSection());
   if (!hasNoClient) staticParts.push(buildSystemPermissionSection());
@@ -199,39 +199,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   );
 }
 
-function buildTaskScheduleReminderRoutingSection(): string {
-  return [
-    "## Tool Routing: Tasks vs Schedules vs Notifications",
-    "",
-    'Three tools, each for a different purpose. Load the "Time-Based Actions" skill for the full decision framework.',
-    "",
-    "| Tool | Purpose |",
-    "|------|---------|",
-    '| `task_list_add` | Track work — no time trigger ("add to my tasks", "remind me to X" without a time) |',
-    '| `schedule_create` | Any time-based automation — recurring cron/RRULE ("every day at 9am") OR one-shot future alert with `fire_at` ("remind me at 3pm") |',
-    "| `send_notification` | **Immediate-only** — fires instantly, NO delay capability |",
-    "",
-    "### Critical: `send_notification` is immediate-only",
-    "NEVER use `send_notification` for future-time requests — it fires NOW. Use `schedule_create` with `fire_at` for any delayed alert.",
-    "",
-    "### Quick routing rules",
-    "- Future time, one-shot → `schedule_create` with `fire_at`",
-    "- Recurring pattern → `schedule_create`",
-    "- No time, track as work → `task_list_add`",
-    "- Instant alert → `send_notification`",
-    "- Modify existing task → `task_list_update` (NOT `task_list_add`)",
-    "- Remove task → `task_list_remove` (NOT `task_list_update`)",
-    "",
-    "### Entity type routing: work items vs task templates",
-    "",
-    "Two entity types with separate ID spaces — do NOT mix:",
-    "- **Work items** (task queue) — task_list_add, task_list_show, task_list_update, task_list_remove",
-    "- **Task templates** (reusable definitions) — task_save, task_list, task_run, task_delete",
-    "",
-    'If an error says "entity mismatch", read the corrective action and selector fields it provides to pick the right tool.',
-    "",
-  ].join("\n");
-}
 
 function buildAttachmentSection(): string {
   return [


### PR DESCRIPTION
## Summary
- Removed the entire `## Tool Routing: Tasks vs Schedules vs Notifications` section from the system prompt (~1,200 chars saved)
- Added "immediate, no delay" constraint and schedule_create redirect to the `send_notification` tool description (the critical footgun-prevention line)
- `schedule_create` and `task_list_add` descriptions already had proper cross-routing hints
- Updated intent-routing tests to verify the section is gone and the new description content exists

## Original prompt
Remove the "Tool Routing: Tasks vs Schedules vs Notifications" section from the system prompt. Move critical routing hints into tool descriptions for send_notification, schedule_create, and task_list_add. Then update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt to reflect the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
