### PR TITLE
Polish Settings Contacts UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -92,7 +92,7 @@ struct ChannelVerificationFlowView: View {
                 }
                 Spacer()
             }
-            VButton(label: "Disconnect", style: .danger) {
+            VButton(label: "Disconnect", style: .dangerGhost) {
                 onRevoke()
             }
         }
@@ -280,7 +280,7 @@ struct ChannelVerificationFlowView: View {
                     .disabled(!canResend)
                     .frame(width: 160)
 
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         onCancelOutbound()
                     }
                 }
@@ -399,7 +399,7 @@ struct ChannelVerificationFlowView: View {
                     .padding(.leading, leadingPadding)
             }
 
-            VButton(label: "Cancel", style: .outlined) {
+            VButton(label: "Cancel", style: .ghost) {
                 onCancelSession()
             }
         }
@@ -447,13 +447,13 @@ struct ChannelVerificationFlowView: View {
             }
 
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Send", style: .outlined) {
+                VButton(label: "Send", style: .primary) {
                     onStartOutbound(destination)
                 }
                 .disabled(destination.isEmpty)
 
                 if let onCancel {
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         onCancel()
                     }
                 }
@@ -468,9 +468,23 @@ struct ChannelVerificationFlowView: View {
         let leadingPadding: CGFloat = showLabel ? labelColumnWidth + VSpacing.sm : 0
 
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text(error)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
+            HStack(alignment: .top, spacing: VSpacing.xs) {
+                VIconView(.triangleAlert, size: 12)
+                    .foregroundColor(VColor.systemNegativeStrong)
+                    .padding(.top, 1)
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeStrong)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(VColor.systemNegativeWeak)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
+            )
             if state.alreadyBound {
                 VButton(label: "Replace", style: .outlined) {
                     onStartSession(true)

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -161,13 +161,10 @@ struct AssistantChannelsDetailView: View {
                     .help("Copy email address")
                 }
             } else {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.triangleAlert, size: 12)
-                        .foregroundColor(VColor.systemNegativeHover)
-                    Text("Not configured — run the Email Setup skill to assign an address")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
+                feedbackMessage(
+                    "Not configured — run the Email Setup skill to assign an address",
+                    tone: .warning
+                )
             }
         }
     }
@@ -178,7 +175,7 @@ struct AssistantChannelsDetailView: View {
         let status = store.channelSetupStatus["telegram"]
         return SettingsCard(title: "Telegram", subtitle: "Message your assistant from Telegram", showBorder: showCardBorders) {
             if status == "ready" {
-                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+                VBadge(label: "Connected", tone: .positive)
             }
         } content: {
             if status == "ready" {
@@ -207,7 +204,7 @@ struct AssistantChannelsDetailView: View {
                                 .lineLimit(1)
                         }
                     }
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
+                    VButton(label: "Disconnect", style: .dangerGhost, isDisabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
@@ -223,7 +220,7 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let error = store.telegramError {
-                Text(error).font(VFont.caption).foregroundColor(VColor.systemNegativeStrong)
+                feedbackMessage(error)
             }
 
         }
@@ -256,11 +253,11 @@ struct AssistantChannelsDetailView: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .outlined, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                    VButton(label: "Connect", style: .primary, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                         store.saveTelegramToken(botToken: telegramBotTokenText)
                         telegramBotTokenText = ""
                     }
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         telegramSetupExpanded = false
                         telegramBotTokenText = ""
                     }
@@ -275,7 +272,7 @@ struct AssistantChannelsDetailView: View {
         let status = store.channelSetupStatus["slack"]
         return SettingsCard(title: "Slack", subtitle: "Message your assistant from Slack", showBorder: showCardBorders) {
             if status == "ready" {
-                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+                VBadge(label: "Connected", tone: .positive)
             }
         } content: {
             if status == "ready" {
@@ -305,7 +302,7 @@ struct AssistantChannelsDetailView: View {
                             }
                         }
                     }
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
+                    VButton(label: "Disconnect", style: .dangerGhost, isDisabled: store.slackChannelSaveInProgress) {
                         store.clearSlackChannelConfig()
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -322,7 +319,7 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let error = store.slackChannelError {
-                Text(error).font(VFont.caption).foregroundColor(VColor.systemNegativeStrong)
+                feedbackMessage(error)
             }
 
         }
@@ -362,7 +359,7 @@ struct AssistantChannelsDetailView: View {
                 HStack(spacing: VSpacing.sm) {
                     VButton(
                         label: "Connect",
-                        style: .outlined,
+                        style: .primary,
                         isDisabled: slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ) {
@@ -373,7 +370,7 @@ struct AssistantChannelsDetailView: View {
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
                     }
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         slackChannelSetupExpanded = false
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -389,7 +386,7 @@ struct AssistantChannelsDetailView: View {
         let status = store.channelSetupStatus["phone"]
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio", showBorder: showCardBorders) {
             if status == "ready" {
-                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+                VBadge(label: "Connected", tone: .positive)
             }
         } content: {
             // Phone number dropdown: show when credentials are configured
@@ -414,7 +411,7 @@ struct AssistantChannelsDetailView: View {
             }
 
             if status == "ready" {
-                VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
+                VButton(label: "Disconnect", style: .dangerGhost, isDisabled: store.twilioSaveInProgress) {
                     store.clearTwilioCredentials()
                     store.channelSetupStatus["phone"] = "not_configured"
                 }
@@ -427,15 +424,11 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let warning = store.twilioWarning {
-                Text(warning)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeHover)
+                feedbackMessage(warning, tone: .warning)
             }
 
             if let error = store.twilioError {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                feedbackMessage(error)
             }
 
         }
@@ -471,7 +464,7 @@ struct AssistantChannelsDetailView: View {
                 HStack(spacing: VSpacing.sm) {
                     VButton(
                         label: "Connect",
-                        style: .outlined,
+                        style: .primary,
                         isDisabled: voiceAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                             voiceAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ) {
@@ -482,7 +475,7 @@ struct AssistantChannelsDetailView: View {
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
                     }
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         voiceSetupExpanded = false
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
@@ -490,6 +483,34 @@ struct AssistantChannelsDetailView: View {
                 }
             }
         }
+    }
+
+    private enum FeedbackTone {
+        case error
+        case warning
+    }
+
+    private func feedbackMessage(_ text: String, tone: FeedbackTone = .error) -> some View {
+        let foreground = tone == .warning ? VColor.systemMidStrong : VColor.systemNegativeStrong
+        let background = tone == .warning ? VColor.systemMidWeak : VColor.systemNegativeWeak
+
+        return HStack(alignment: .top, spacing: VSpacing.xs) {
+            VIconView(.triangleAlert, size: 12)
+                .foregroundColor(foreground)
+                .padding(.top, 1)
+            Text(text)
+                .font(VFont.caption)
+                .foregroundColor(foreground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(background)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(foreground.opacity(0.16), lineWidth: 1)
+        )
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -72,17 +72,11 @@ struct ContactDetailView: View {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 headerSection
                     .padding(VSpacing.lg)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.xl)
-                            .stroke(VColor.borderDisabled, lineWidth: 2)
-                    )
+                    .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                 channelsSection
                     .padding(VSpacing.lg)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.xl)
-                            .stroke(VColor.borderDisabled, lineWidth: 2)
-                    )
+                    .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
             .padding(VSpacing.lg)
         }
@@ -135,10 +129,11 @@ struct ContactDetailView: View {
     // MARK: - Header Section
 
     private var headerSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
             headerTitle
             headerFields
             headerActions
+            dangerZone
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
@@ -183,23 +178,12 @@ struct ContactDetailView: View {
                 Text("Notes")
                     .font(VFont.inputLabel)
                     .foregroundColor(VColor.contentSecondary)
-                ZStack(alignment: .topLeading) {
-                    if editedNotes.isEmpty {
-                        Text("Optional notes about the human which AI will take into account")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentTertiary)
-                            .padding(.horizontal, VSpacing.xs)
-                            .padding(.vertical, VSpacing.sm)
-                    }
-                    TextEditor(text: $editedNotes)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentDefault)
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: 60, maxHeight: 160)
-                }
-                .padding(VSpacing.xs)
-                .background(VColor.surfaceActive)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                VTextEditor(
+                    placeholder: "Optional notes about the human which AI will take into account",
+                    text: $editedNotes,
+                    minHeight: 80,
+                    maxHeight: 180
+                )
             }
         }
     }
@@ -209,29 +193,59 @@ struct ContactDetailView: View {
             VButton(label: "Save", style: .primary, isDisabled: isSaving || editedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                 Task { await saveCardEdits() }
             }
-            VButton(label: "Delete Contact", style: .danger, isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil) {
+            if isSaving {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private var contactTypeBadge: some View {
+        VBadge(label: formatContactType(displayContact.role), tone: .neutral)
+    }
+
+    private var dangerZone: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            SettingsDivider()
+
+            Text("Danger Zone")
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+
+            Text("Delete this contact and revoke all of their channels.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+
+            VButton(
+                label: "Delete Contact",
+                leftIcon: VIcon.trash.rawValue,
+                style: .dangerGhost,
+                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil
+            ) {
                 showDeleteConfirmation = true
             }
             .accessibilityLabel("Delete contact")
         }
     }
 
-    private var contactTypeBadge: some View {
-        Text(formatContactType(displayContact.role))
-            .font(VFont.captionMedium)
-            .foregroundColor(VColor.contentDefault)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(tagColor(for: displayContact.role))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm + 2))
-    }
-
-    private func tagColor(for role: String?) -> Color {
-        switch role {
-        case "guardian": return VColor.tagGuardian
-        case "assistant": return VColor.tagAssistant
-        default: return VColor.tagHuman
+    private func inlineMessage(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.xs) {
+            VIconView(.triangleAlert, size: 12)
+                .foregroundColor(VColor.systemNegativeStrong)
+                .padding(.top, 1)
+            Text(text)
+                .font(VFont.caption)
+                .foregroundColor(VColor.systemNegativeStrong)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.systemNegativeWeak)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
+        )
     }
 
     // MARK: - Channels Section
@@ -274,9 +288,7 @@ struct ContactDetailView: View {
             }
 
             if let errorMessage {
-                Text(errorMessage)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                inlineMessage(errorMessage)
             }
         }
         .task {
@@ -298,13 +310,12 @@ struct ContactDetailView: View {
         channelsByType: [String: [ContactChannelPayload]]
     ) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Section header
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Channels")
-                    .font(VFont.display)
+                    .font(VFont.sectionTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Text("Set up different ways to interact with your Assistant")
-                    .font(VFont.bodyMedium)
+                    .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
             }
 
@@ -400,72 +411,21 @@ struct ContactDetailView: View {
         let isVerified = channel.status == "active" && channel.verifiedAt != nil
 
         if isVerified {
-            // Danger "Disable" button for verified channels
-            Button {
+            VButton(label: "Disable", style: .dangerGhost, size: .compact, isDisabled: anyActionInFlight) {
                 updateChannelStatus(channelId: channel.id, status: "revoked")
-            } label: {
-                Text("Disable")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.systemNegativeStrong, lineWidth: 1)
-                    )
             }
-            .buttonStyle(.plain)
-            .disabled(anyActionInFlight)
         } else if channel.status == "unverified" || channel.status == "pending" {
-            // "Invite" button for unverified channels
-            Button {
+            VButton(label: "Send Verification", style: .outlined, size: .compact, isDisabled: anyActionInFlight) {
                 initiateVerification(for: channel)
-            } label: {
-                Text("Send Verification")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.primaryBase)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.primaryBase, lineWidth: 1)
-                    )
             }
-            .buttonStyle(.plain)
-            .disabled(anyActionInFlight)
         } else if channel.status == "blocked" {
-            Button {
+            VButton(label: "Restore", style: .outlined, size: .compact, isDisabled: anyActionInFlight) {
                 updateChannelStatus(channelId: channel.id, status: "active")
-            } label: {
-                Text("Restore")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.primaryBase)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.primaryBase, lineWidth: 1)
-                    )
             }
-            .buttonStyle(.plain)
-            .disabled(anyActionInFlight)
         } else {
-            // Active but not verified — show revoke
-            Button {
+            VButton(label: "Disable", style: .dangerGhost, size: .compact, isDisabled: anyActionInFlight) {
                 updateChannelStatus(channelId: channel.id, status: "revoked")
-            } label: {
-                Text("Disable")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.systemNegativeStrong, lineWidth: 1)
-                    )
             }
-            .buttonStyle(.plain)
-            .disabled(anyActionInFlight)
         }
     }
 
@@ -494,36 +454,15 @@ struct ContactDetailView: View {
             Spacer()
 
             if isReady {
-                // Primary outlined "Invite" button
-                Button {
+                VButton(label: "Invite", style: .outlined, size: .compact) {
                     inviteExpanded.insert(type)
                     if type == "telegram" || type == "slack" {
                         createInviteForChannel(type: type)
                     }
-                } label: {
-                    Text("Invite")
-                        .font(VFont.inputLabel)
-                        .foregroundColor(VColor.primaryBase)
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.xs)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .stroke(VColor.primaryBase, lineWidth: 1)
-                        )
                 }
-                .buttonStyle(.plain)
                 .accessibilityHint("\(channelLabel(for: type)) is not connected for this contact")
             } else {
-                // Disabled "Not Available" button
-                Text("Not Available")
-                    .font(VFont.inputLabel)
-                    .foregroundColor(VColor.contentDisabled)
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.xs)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.sm)
-                            .stroke(VColor.borderDisabled, lineWidth: 1)
-                    )
+                VBadge(label: "Not Available", tone: .neutral)
             }
         }
     }
@@ -578,7 +517,7 @@ struct ContactDetailView: View {
                         VButton(label: "Invite", style: .outlined, isDisabled: inviteInProgress != nil) {
                             createInviteForChannel(type: type)
                         }
-                        VButton(label: "Cancel", style: .outlined) {
+                        VButton(label: "Cancel", style: .ghost) {
                             inviteExpanded.remove(type)
                             if inviteResult?.type == type {
                                 inviteResult = nil
@@ -591,9 +530,7 @@ struct ContactDetailView: View {
 
                 // Inline error display so the message appears inside the channel card
                 if let inviteError, inviteErrorChannel == type {
-                    Text(inviteError)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                    inlineMessage(inviteError)
                 }
             } else if type == "phone" {
                 // Phone channel: code-based invite flow
@@ -605,10 +542,7 @@ struct ContactDetailView: View {
                         if type == "phone" {
                             TextField("+1234567890", text: $invitePhoneNumber)
                                 .font(VFont.mono)
-                                .textFieldStyle(.plain)
-                                .padding(VSpacing.sm)
-                                .background(VColor.surfaceActive)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                                .vInputStyle()
                         }
                         if inviteResult?.type != type {
                             HStack(spacing: VSpacing.sm) {
@@ -619,7 +553,7 @@ struct ContactDetailView: View {
                                 ) {
                                     createInviteForChannel(type: type)
                                 }
-                                VButton(label: "Cancel", style: .outlined) {
+                                VButton(label: "Cancel", style: .ghost) {
                                     inviteExpanded.remove(type)
                                     inviteError = nil
                                     inviteErrorChannel = nil
@@ -635,9 +569,7 @@ struct ContactDetailView: View {
 
                 // Inline error display so the message appears inside the channel card
                 if let inviteError, inviteErrorChannel == type {
-                    Text(inviteError)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                    inlineMessage(inviteError)
                 }
             }
         }
@@ -704,10 +636,7 @@ struct ContactDetailView: View {
                     .foregroundColor(VColor.contentSecondary)
                 TextField(type == "telegram" ? "@username" : "@display_name", text: $inviteHandleInput)
                     .font(VFont.mono)
-                    .textFieldStyle(.plain)
-                    .padding(VSpacing.sm)
-                    .background(VColor.surfaceActive)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    .vInputStyle()
             }
 
             // Buttons: Send reveals the already-generated invite code (the invite
@@ -717,7 +646,7 @@ struct ContactDetailView: View {
                     inviteCodeRevealed = true
                 }
                 .disabled(inviteHandleInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                VButton(label: "Cancel", style: .outlined) {
+                VButton(label: "Cancel", style: .ghost) {
                     inviteExpanded.remove(type)
                     if inviteResult?.type == type {
                         inviteResult = nil
@@ -879,7 +808,7 @@ struct ContactDetailView: View {
                         }
                     }
 
-                    VButton(label: "Cancel", style: .outlined) {
+                    VButton(label: "Cancel", style: .ghost) {
                         inviteExpanded.remove(type)
                         inviteResult = nil
                         inviteError = nil
@@ -916,7 +845,7 @@ struct ContactDetailView: View {
                     }
                 }
 
-                VButton(label: "Cancel", style: .outlined) {
+                VButton(label: "Cancel", style: .ghost) {
                     inviteExpanded.remove(type)
                     inviteResult = nil
                     inviteError = nil
@@ -930,7 +859,7 @@ struct ContactDetailView: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentSecondary)
 
-                VButton(label: "Cancel", style: .outlined) {
+                VButton(label: "Cancel", style: .ghost) {
                     inviteExpanded.remove(type)
                     inviteResult = nil
                     inviteError = nil
@@ -1411,4 +1340,3 @@ struct ContactDetailView: View {
     }
     .preferredColorScheme(.dark)
 }
-

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -118,19 +118,12 @@ struct ContactsContainerView: View {
     private func guardianDetailView(contact: ContactPayload) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Header card matching assistant/human style
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(spacing: VSpacing.sm) {
                         Text(contact.displayName)
                             .font(VFont.display)
                             .foregroundColor(VColor.contentDefault)
-                        Text("Guardian")
-                            .font(VFont.captionMedium)
-                            .foregroundColor(VColor.contentDefault)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xs)
-                            .background(VColor.tagGuardian)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm + 2))
+                        VBadge(label: "Guardian", tone: .neutral)
                     }
                     Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
                         .font(VFont.caption)
@@ -138,23 +131,17 @@ struct ContactsContainerView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .stroke(VColor.borderDisabled, lineWidth: 2)
-                )
+                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
-                // Channels card
                 GuardianChannelsDetailView(
                     contact: contact,
                     daemonClient: daemonClient,
                     store: store,
-                    onSelectAssistant: { selection = .assistant }
+                    onSelectAssistant: { selection = .assistant },
+                    showCardBorders: false
                 )
                 .padding(VSpacing.lg)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .stroke(VColor.borderDisabled, lineWidth: 2)
-                )
+                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
             .padding(VSpacing.lg)
         }
@@ -168,36 +155,22 @@ struct ContactsContainerView: View {
     private var assistantDetailView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Header card matching human contact style
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     HStack(spacing: VSpacing.sm) {
                         Text(cachedAssistantName)
                             .font(VFont.display)
                             .foregroundColor(VColor.contentDefault)
-                        Text("Assistant")
-                            .font(VFont.captionMedium)
-                            .foregroundColor(VColor.contentDefault)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xs)
-                            .background(VColor.tagAssistant)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm + 2))
+                        VBadge(label: "Assistant", tone: .neutral)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.xl)
-                        .stroke(VColor.borderDisabled, lineWidth: 2)
-                )
+                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
-                // Channels section in bordered card
                 if let store {
                     AssistantChannelsDetailView(store: store, daemonClient: daemonClient, isEmailEnabled: isEmailEnabled, showCardBorders: false)
                         .padding(VSpacing.lg)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.xl)
-                                .stroke(VColor.borderDisabled, lineWidth: 2)
-                        )
+                        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
                 }
             }
             .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Contacts list panel matching the Figma design: a single bordered card
-/// with header, assistant/guardian rows, divider, search, and contact rows
-/// with colored role tags and channel name text.
+/// Contacts list panel for the Settings > Contacts page.
 @MainActor
 struct ContactsListView: View {
     @ObservedObject var viewModel: ContactsViewModel
@@ -41,25 +39,22 @@ struct ContactsListView: View {
 
     private var contactsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Header: "Contacts" + add button
             HStack {
                 Text("Contacts")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()
-                VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .outlined, size: .compact) {
+                VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
                     viewModel.isCreatingContact = true
                 }
                 .accessibilityLabel("Add contact")
             }
 
-            // Pinned rows (assistant + guardian)
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 contactListRow(
                     name: cachedAssistantDisplayName,
                     channelText: "Assistant channels",
                     tag: "Assistant",
-                    tagColor: VColor.tagAssistant,
                     isSelected: selection == .assistant,
                     isHovered: isAssistantHovered,
                     onTap: { selection = .assistant },
@@ -71,7 +66,6 @@ struct ContactsListView: View {
                         name: "\(guardian.displayName) (You)",
                         channelText: channelNamesText(guardian.channels),
                         tag: "Guardian",
-                        tagColor: VColor.tagGuardian,
                         isSelected: selection == .contact(guardian.id),
                         isHovered: hoveredContactId == guardian.id,
                         onTap: { selection = .contact(guardian.id) },
@@ -80,21 +74,18 @@ struct ContactsListView: View {
                 }
             }
 
-            VColor.surfaceBase.frame(height: 1)
+            SettingsDivider()
 
-            // Contacts area — fills remaining height
+            searchBar
+
             if viewModel.hasNonGuardianContacts {
                 ScrollView {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        searchBar
-                            .padding(.top, VSpacing.sm)
-
                         ForEach(viewModel.otherContacts, id: \.id) { contact in
                             contactListRow(
                                 name: contact.displayName,
                                 channelText: channelNamesText(contact.channels),
                                 tag: formatContactType(contact.role),
-                                tagColor: tagColor(for: contact.role),
                                 isSelected: selection == .contact(contact.id),
                                 isHovered: hoveredContactId == contact.id,
                                 onTap: { selection = .contact(contact.id) },
@@ -132,10 +123,7 @@ struct ContactsListView: View {
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .stroke(VColor.borderDisabled, lineWidth: 2)
-        )
+        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
     }
 
     // MARK: - Contact List Row
@@ -144,7 +132,6 @@ struct ContactsListView: View {
         name: String,
         channelText: String,
         tag: String,
-        tagColor: Color,
         isSelected: Bool,
         isHovered: Bool,
         onTap: @escaping () -> Void,
@@ -155,33 +142,31 @@ struct ContactsListView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(name)
                         .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentDefault)
                         .lineLimit(1)
 
                     Text(channelText)
                         .font(VFont.small)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundColor(isSelected ? VColor.contentSecondary : VColor.contentTertiary)
                         .lineLimit(1)
                 }
 
                 Spacer()
 
-                Text(tag)
-                    .font(VFont.captionMedium)
-                    .foregroundColor(VColor.contentDefault)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-                    .background(tagColor)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm + 2))
+                VBadge(label: tag, tone: .neutral)
             }
             .padding(VSpacing.sm)
-            .background(
-                isSelected
-                    ? VColor.surfaceActive
-                    : (isHovered ? VColor.surfaceActive.opacity(0.5) : VColor.surfaceOverlay)
-            )
+            .background(rowBackground(isSelected: isSelected, isHovered: isHovered))
+            .overlay(rowBorder(isSelected: isSelected, isHovered: isHovered))
+            .overlay(alignment: .leading) {
+                Capsule()
+                    .fill(isSelected ? VColor.primaryBase : .clear)
+                    .frame(width: 4)
+                    .padding(.vertical, VSpacing.sm)
+                    .padding(.leading, 2)
+            }
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .contentShape(Rectangle())
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
         .buttonStyle(.plain)
         .onHover(perform: onHover)
@@ -190,17 +175,7 @@ struct ContactsListView: View {
     // MARK: - Search Bar
 
     private var searchBar: some View {
-        HStack(spacing: VSpacing.xs) {
-            VIconView(.search, size: 12)
-                .foregroundColor(VColor.contentTertiary)
-            TextField("Search Contacts", text: $viewModel.searchQuery)
-                .textFieldStyle(.plain)
-                .font(VFont.body)
-                .foregroundColor(VColor.contentDefault)
-        }
-        .padding(VSpacing.sm)
-        .background(VColor.surfaceBase)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        VSearchBar(placeholder: "Search Contacts", text: $viewModel.searchQuery)
     }
 
     // MARK: - Loading State
@@ -262,11 +237,22 @@ struct ContactsListView: View {
         }
     }
 
-    private func tagColor(for role: String?) -> Color {
-        switch role {
-        case "guardian": return VColor.tagGuardian
-        case "assistant": return VColor.tagAssistant
-        default: return VColor.tagHuman
-        }
+    private func rowBackground(isSelected: Bool, isHovered: Bool) -> some View {
+        RoundedRectangle(cornerRadius: VRadius.md)
+            .fill(
+                isSelected
+                    ? VColor.primaryBase.opacity(0.10)
+                    : (isHovered ? VColor.surfaceBase : Color.clear)
+            )
+    }
+
+    private func rowBorder(isSelected: Bool, isHovered: Bool) -> some View {
+        RoundedRectangle(cornerRadius: VRadius.md)
+            .strokeBorder(
+                isSelected
+                    ? VColor.borderActive
+                    : (isHovered ? VColor.borderBase.opacity(0.45) : Color.clear),
+                lineWidth: 1
+            )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -14,6 +14,7 @@ struct GuardianChannelsDetailView: View {
     var daemonClient: DaemonClient?
     var store: SettingsStore?
     var onSelectAssistant: (() -> Void)?
+    var showCardBorders: Bool = true
 
     @State var currentContact: ContactPayload?
     @State private var isLoadingReadiness: Bool = true
@@ -26,6 +27,7 @@ struct GuardianChannelsDetailView: View {
     @State private var verificationStoreRevision: Int = 0
     @State private var actionInProgress: String? = nil
     @State private var errorMessage: String? = nil
+    @State private var errorChannelType: String? = nil
 
     var displayContact: ContactPayload {
         currentContact ?? contact
@@ -34,52 +36,12 @@ struct GuardianChannelsDetailView: View {
     var body: some View {
         let _ = verificationStoreRevision
 
-        ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Header
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Channels")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.contentDefault)
-                    Text("Once verified, your assistant will recognize you when you message from these channels.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-
-                // One card per channel type (only show configured or existing)
-                let visibleTypes = Self.allChannelTypes.filter { type in
-                    let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
-                    return hasExisting || channelReadiness[type]?.ready == true
-                }
-
-                if isLoadingReadiness && visibleTypes.isEmpty {
-                    ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.xl)
-                } else if visibleTypes.isEmpty {
-                    VStack(spacing: VSpacing.md) {
-                        VIconView(.messageCircle, size: 24)
-                            .foregroundColor(VColor.contentTertiary)
-                        Text("No Channels Available")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentSecondary)
-                        Text("Set up channels on your assistant first to verify your identity.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
-                            .multilineTextAlignment(.center)
-                        VButton(label: "Set Up Assistant", style: .outlined) {
-                            onSelectAssistant?()
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, VSpacing.xl)
-                } else {
-                    ForEach(visibleTypes, id: \.self) { type in
-                        channelCard(for: type)
-                    }
-                }
+        Group {
+            if showCardBorders {
+                ScrollView { content }
+            } else {
+                content
             }
-            .padding(VSpacing.lg)
         }
         .onAppear {
             startVerificationCountdownTimer()
@@ -102,18 +64,78 @@ struct GuardianChannelsDetailView: View {
         }
     }
 
+    private var visibleTypes: [String] {
+        Self.allChannelTypes.filter { type in
+            let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
+            return hasExisting || channelReadiness[type]?.ready == true
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Channels")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.contentDefault)
+                Text("Once verified, your assistant will recognize you when you message from these channels.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+
+            if isLoadingReadiness && visibleTypes.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, VSpacing.xl)
+            } else if visibleTypes.isEmpty {
+                VStack(spacing: VSpacing.md) {
+                    VIconView(.messageCircle, size: 24)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text("No Channels Available")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("Set up channels on your assistant first to verify your identity.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .multilineTextAlignment(.center)
+                    VButton(label: "Set Up Assistant", style: .outlined) {
+                        onSelectAssistant?()
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, VSpacing.xl)
+            } else if showCardBorders {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    ForEach(visibleTypes, id: \.self) { type in
+                        channelCard(for: type)
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(visibleTypes.enumerated()), id: \.element) { index, type in
+                        channelCard(for: type)
+                        if index < visibleTypes.count - 1 {
+                            SettingsDivider()
+                                .padding(.vertical, VSpacing.sm)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(showCardBorders ? VSpacing.lg : 0)
+    }
+
     // MARK: - Channel Card
 
     @ViewBuilder
     private func channelCard(for type: String) -> some View {
-        SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type)) {
+        SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type), showBorder: showCardBorders) {
             let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
             let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
                 ?? existingChannels.first
             if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
-                VBadge(style: .label("Verified"), color: VColor.systemPositiveStrong)
+                VBadge(label: "Verified", tone: .positive)
             } else if store?.channelVerificationState(for: type).verified == true {
-                VBadge(style: .label("Verified"), color: VColor.systemPositiveStrong)
+                VBadge(label: "Verified", tone: .positive)
             }
         } content: {
             let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
@@ -137,6 +159,10 @@ struct GuardianChannelsDetailView: View {
                     dismissedChannels.remove(type)
                     setupExpanded.insert(type)
                 }
+            }
+
+            if errorChannelType == type, let errorMessage {
+                inlineMessage(errorMessage)
             }
         }
     }
@@ -165,8 +191,8 @@ struct GuardianChannelsDetailView: View {
             }
 
             if daemonClient != nil {
-                VButton(label: "Disconnect", style: .danger, isDisabled: actionInProgress != nil) {
-                    disconnectChannel(channelId: channel.id)
+                VButton(label: "Disconnect", style: .dangerGhost, isDisabled: actionInProgress != nil) {
+                    disconnectChannel(channelId: channel.id, type: type)
                 }
             }
         }
@@ -280,11 +306,12 @@ struct GuardianChannelsDetailView: View {
 
     // MARK: - Disconnect Channel
 
-    private func disconnectChannel(channelId: String) {
+    private func disconnectChannel(channelId: String, type: String) {
         guard let daemonClient else { return }
         guard actionInProgress == nil else { return }
         actionInProgress = channelId
         errorMessage = nil
+        errorChannelType = nil
 
         Task {
             let stream = daemonClient.subscribe()
@@ -293,6 +320,7 @@ struct GuardianChannelsDetailView: View {
                 try daemonClient.sendUpdateContactChannel(channelId: channelId, status: "revoked")
             } catch {
                 errorMessage = "Failed to update channel: \(error.localizedDescription)"
+                errorChannelType = type
                 actionInProgress = nil
                 return
             }
@@ -303,6 +331,7 @@ struct GuardianChannelsDetailView: View {
                         try? daemonClient.sendGetContact(contactId: displayContact.id)
                     } else {
                         errorMessage = response.error ?? "Failed to update channel"
+                        errorChannelType = type
                         actionInProgress = nil
                         return
                     }
@@ -322,6 +351,25 @@ struct GuardianChannelsDetailView: View {
 
             actionInProgress = nil
         }
+    }
+
+    private func inlineMessage(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.xs) {
+            VIconView(.triangleAlert, size: 12)
+                .foregroundColor(VColor.systemNegativeStrong)
+                .padding(.top, 1)
+            Text(text)
+                .font(VFont.caption)
+                .foregroundColor(VColor.systemNegativeStrong)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.systemNegativeWeak)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
+        )
     }
 
     // MARK: - Verification Flow Content

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -7,12 +7,34 @@ public struct VBadge: View {
         case label(String)
     }
 
+    public enum Tone {
+        case accent
+        case neutral
+        case positive
+        case warning
+        case danger
+    }
+
+    public enum Emphasis {
+        case solid
+        case subtle
+    }
+
     public let style: Style
     public var color: Color = VColor.primaryBase
+    public var tone: Tone?
+    public var emphasis: Emphasis = .solid
 
     public init(style: Style, color: Color = VColor.primaryBase) {
         self.style = style
         self.color = color
+    }
+
+    public init(label: String, tone: Tone = .accent, emphasis: Emphasis = .subtle) {
+        self.style = .label(label)
+        self.color = VColor.primaryBase
+        self.tone = tone
+        self.emphasis = emphasis
     }
 
     public var body: some View {
@@ -35,13 +57,89 @@ public struct VBadge: View {
         case .label(let text):
             Text(text)
                 .font(VFont.caption)
-                .foregroundColor(VColor.auxWhite)
-                .padding(.horizontal, VSpacing.md)
+                .foregroundColor(labelForegroundColor)
+                .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs)
-                .background(color)
+                .background(labelBackgroundColor)
+                .overlay(
+                    Capsule()
+                        .stroke(labelBorderColor, lineWidth: labelBorderWidth)
+                )
                 .clipShape(Capsule())
                 .accessibilityLabel(text)
         }
     }
-}
 
+    private var labelForegroundColor: Color {
+        guard let tone else { return VColor.auxWhite }
+
+        switch (tone, emphasis) {
+        case (.accent, .solid), (.positive, .solid), (.danger, .solid):
+            return VColor.auxWhite
+        case (.warning, .solid):
+            return VColor.contentEmphasized
+        case (.neutral, .solid):
+            return VColor.contentSecondary
+        case (.accent, .subtle):
+            return VColor.primaryBase
+        case (.neutral, .subtle):
+            return VColor.contentSecondary
+        case (.positive, .subtle):
+            return VColor.systemPositiveStrong
+        case (.warning, .subtle):
+            return VColor.systemMidStrong
+        case (.danger, .subtle):
+            return VColor.systemNegativeStrong
+        }
+    }
+
+    private var labelBackgroundColor: Color {
+        guard let tone else { return color }
+
+        switch (tone, emphasis) {
+        case (.accent, .solid):
+            return VColor.primaryBase
+        case (.neutral, .solid):
+            return VColor.surfaceBase
+        case (.positive, .solid):
+            return VColor.systemPositiveStrong
+        case (.warning, .solid):
+            return VColor.systemMidStrong
+        case (.danger, .solid):
+            return VColor.systemNegativeStrong
+        case (.accent, .subtle):
+            return VColor.primaryBase.opacity(0.10)
+        case (.neutral, .subtle):
+            return VColor.surfaceBase
+        case (.positive, .subtle):
+            return VColor.systemPositiveWeak
+        case (.warning, .subtle):
+            return VColor.systemMidWeak
+        case (.danger, .subtle):
+            return VColor.systemNegativeWeak
+        }
+    }
+
+    private var labelBorderColor: Color {
+        guard let tone else { return Color.clear }
+
+        switch (tone, emphasis) {
+        case (_, .solid):
+            return Color.clear
+        case (.accent, .subtle):
+            return VColor.primaryBase.opacity(0.18)
+        case (.neutral, .subtle):
+            return VColor.borderBase.opacity(0.55)
+        case (.positive, .subtle):
+            return VColor.systemPositiveStrong.opacity(0.14)
+        case (.warning, .subtle):
+            return VColor.systemMidStrong.opacity(0.16)
+        case (.danger, .subtle):
+            return VColor.systemNegativeStrong.opacity(0.16)
+        }
+    }
+
+    private var labelBorderWidth: CGFloat {
+        tone == nil ? 0 : 1
+    }
+}

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct VSearchBar: View {
     public let placeholder: String
     @Binding public var text: String
+    @FocusState private var isFocused: Bool
 
     public init(placeholder: String = "Search...", text: Binding<String>) {
         self.placeholder = placeholder
@@ -10,7 +11,7 @@ public struct VSearchBar: View {
     }
 
     public var body: some View {
-        HStack(spacing: VSpacing.sm) {
+        HStack(spacing: VSpacing.md) {
             VIconView(.search, size: 12)
                 .foregroundColor(VColor.contentTertiary)
 
@@ -18,6 +19,7 @@ public struct VSearchBar: View {
                 .textFieldStyle(.plain)
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
+                .focused($isFocused)
 
             if !text.isEmpty {
                 Button(action: { text = "" }) {
@@ -31,7 +33,6 @@ public struct VSearchBar: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
-        .background(VColor.surfaceActive)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .vInputChrome(isFocused: isFocused)
     }
 }

--- a/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
@@ -28,12 +28,7 @@ public struct VTextEditor: View {
             .frame(minHeight: minHeight, maxHeight: maxHeight, alignment: .topLeading)
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(VColor.surfaceActive)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(isFocused ? VColor.borderBase : VColor.borderBase.opacity(0.5), lineWidth: 1)
-            )
+            .vInputChrome(isFocused: isFocused)
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
-/// A ViewModifier that applies the design system input styling.
-/// Strips the native macOS text field background and applies VColor.surfaceActive.
+/// A ViewModifier that applies the shared input chrome across text inputs.
 /// Use on raw TextField / SecureField instances: `.vInputStyle()`
 public struct VInputStyleModifier: ViewModifier {
     public init() {}
@@ -12,18 +11,45 @@ public struct VInputStyleModifier: ViewModifier {
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.xs)
             .frame(height: 32)
-            .background(VColor.surfaceActive)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.borderBase, lineWidth: 1)
-            )
+            .vInputChrome()
     }
 }
 
 extension View {
     public func vInputStyle() -> some View {
         modifier(VInputStyleModifier())
+    }
+
+    public func vInputChrome(isFocused: Bool = false, cornerRadius: CGFloat = VRadius.md) -> some View {
+        modifier(VInputChromeModifier(isFocused: isFocused, cornerRadius: cornerRadius))
+    }
+}
+
+public struct VInputChromeModifier: ViewModifier {
+    public let isFocused: Bool
+    public let cornerRadius: CGFloat
+
+    public init(isFocused: Bool = false, cornerRadius: CGFloat = VRadius.md) {
+        self.isFocused = isFocused
+        self.cornerRadius = cornerRadius
+    }
+
+    public func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+
+        content
+            .background(shape.fill(VColor.surfaceBase))
+            .overlay(
+                shape.strokeBorder(
+                    isFocused ? VColor.borderActive : VColor.borderBase.opacity(0.72),
+                    lineWidth: isFocused ? 1.5 : 1
+                )
+            )
+            .shadow(
+                color: isFocused ? VColor.primaryBase.opacity(0.10) : .clear,
+                radius: 4
+            )
+            .clipShape(shape)
     }
 }
 
@@ -70,12 +96,7 @@ public struct VTextField: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
-        .background(VColor.surfaceActive)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(isFocused ? VColor.borderBase : VColor.borderBase.opacity(0.5), lineWidth: 1)
-        )
+        .vInputChrome(isFocused: isFocused)
     }
 }
 


### PR DESCRIPTION
## Summary
- systemize the Contacts settings surface around a calmer shared panel, badge, and input language
- distinguish selected rows from inputs, tone down destructive actions, and separate the contact danger zone
- attach verification and channel errors to their source with shared inline error treatments

## Verification
- `cd clients && swift build --target VellumAssistantShared`
- `cd clients && swift build --target vellum-assistant`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
