### PR TITLE
fix: move Avatar Customisation from system prompt to skill

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -216,16 +216,6 @@ function buildInChatConfigurationSection(): string {
     "## In-Chat Configuration",
     "",
     "When the user needs to configure a value, collect it conversationally in the chat. Never direct the user to the Settings page for initial setup — Settings is for reviewing and updating existing configuration.",
-    "",
-    "### Avatar Customisation",
-    "",
-    "When the user asks to change, update, or customise your avatar, load the **vellum-avatar** skill using `skill_load`. The skill covers building a native character from traits, uploading an image, or generating one with AI.",
-    "",
-    "**After any avatar change**, always update the `## Avatar` section in `IDENTITY.md` with a brief description of the current avatar appearance. This ensures you remember what you look like across sessions. Example:",
-    "```",
-    "## Avatar",
-    "A friendly purple cat with green eyes wearing a tiny hat",
-    "```",
   ].join("\n");
 }
 

--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -122,6 +122,7 @@ The generated avatar will appear automatically in the client.
 - For native characters, walk through each trait one at a time (body shape, then eye style, then color). Describe the options conversationally so the user can choose without seeing them.
 - For AI generation, ask the user to describe the avatar they want. Be encouraging — suggest they include details like style, colors, mood, or a character concept.
 - After any avatar change, confirm it was applied and let the user know they can change it again anytime.
+- **After any avatar change**, update the `## Avatar` section in `IDENTITY.md` with a brief description of the current avatar appearance. This ensures you remember what you look like across sessions. Example: `## Avatar\nA friendly purple cat with green eyes wearing a tiny hat`
 
 ## Mutual Exclusivity Rule
 


### PR DESCRIPTION
## Summary
- Removed `### Avatar Customisation` subsection from the system prompt (~400 chars saved per request)
- Added the IDENTITY.md update instruction to `skills/vellum-avatar/SKILL.md` UX Guidelines — this instruction now lives in the skill itself, loaded only when needed
- The skill catalog already lists vellum-avatar with a description containing "avatar" and "customize", so the model discovers it naturally

## Original prompt
it and update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
