### PR TITLE
fix: move System Permissions section to request_system_permission tool description

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -123,7 +123,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // Tool Routing section removed — guidance lives in tool descriptions.
   staticParts.push(buildAttachmentSection());
   staticParts.push(buildInChatConfigurationSection());
-  if (!hasNoClient) staticParts.push(buildSystemPermissionSection());
+  // System Permissions section removed — guidance lives in request_system_permission tool description.
   staticParts.push(buildSwarmGuidanceSection());
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
   staticParts.push(buildMemoryPersistenceSection());
@@ -209,21 +209,6 @@ function buildInChatConfigurationSection(): string {
 }
 
 
-
-function buildSystemPermissionSection(): string {
-  return [
-    "## System Permissions",
-    "",
-    'When a tool execution fails with a permission/access error (e.g. "Operation not permitted", "EACCES", sandbox denial), use `request_system_permission` to ask your user to grant the required macOS permission through System Settings.',
-    "",
-    "Common cases:",
-    "- Reading files in ~/Documents, ~/Desktop, ~/Downloads → `full_disk_access`",
-    "- Screen capture / recording → `screen_recording`",
-    "- Accessibility / UI automation → `accessibility`",
-    "",
-    "Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.",
-  ].join("\n");
-}
 
 export function buildExternalCommsIdentitySection(): string {
   const userRef = resolveUserReference();

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -53,8 +53,9 @@ const FRIENDLY_NAMES: Record<PermissionType, string> = {
 class RequestSystemPermissionTool implements Tool {
   name = "request_system_permission";
   description =
-    "Ask the user to grant a macOS system permission (e.g. Full Disk Access) via System Settings. " +
-    "Use this when a tool execution fails because of a TCC/permission error.";
+    "Ask the user to grant a macOS system permission via System Settings. " +
+    "Use when a tool fails with a permission/access error (e.g. 'Operation not permitted', 'EACCES', sandbox denial). " +
+    "Do not explain how to open System Settings manually — this tool handles it with a clickable button.";
   category = "system";
   defaultRiskLevel = RiskLevel.High;
 


### PR DESCRIPTION
## Summary
- Removed the `buildSystemPermissionSection()` function and its call site from the system prompt (~554 chars saved)
- Enhanced the `request_system_permission` tool description to include the routing guidance (when to use it, don't explain Settings manually)
- The "common cases" list was dropped — the enum values on `permission_type` are self-descriptive enough

## Original prompt
it and update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)