### PR TITLE
fix: remove Parallel Task Orchestration section from system prompt

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -124,7 +124,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   staticParts.push(buildAttachmentSection());
   staticParts.push(buildInChatConfigurationSection());
   // System Permissions section removed — guidance lives in request_system_permission tool description.
-  staticParts.push(buildSwarmGuidanceSection());
+  // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
   staticParts.push(buildMemoryPersistenceSection());
   staticParts.push(buildMemoryRecallSection());
@@ -231,14 +231,6 @@ export function buildExternalCommsIdentitySection(): string {
     "- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.",
   );
   return lines.join("\n");
-}
-
-export function buildSwarmGuidanceSection(): string {
-  return [
-    "## Parallel Task Orchestration",
-    "",
-    'When a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"), load the `orchestration` skill using `skill_load` first, then use `swarm_delegate` to decompose and run them in parallel. For single-focus tasks, work directly — do not decompose them into a swarm.',
-  ].join("\n");
 }
 
 function buildAccessPreferenceSection(hasNoClient: boolean): string {


### PR DESCRIPTION
## Summary
- Removed `buildSwarmGuidanceSection()` function and its call site from the system prompt (~364 chars saved)
- The orchestration skill already has `description`, `activation-hints`, and `avoid-when` metadata that convey the same guidance via the `<available_skills>` catalog

## Original prompt
it and update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
