### PR TITLE
fix: update stale system-prompt tests

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -236,17 +236,10 @@ describe("buildSystemPrompt", () => {
     );
   });
 
-  test("includes swarm guidance section", () => {
+  test("includes external service access section", () => {
     const result = buildSystemPrompt();
-    expect(result).toContain("## Parallel Task Orchestration");
-    expect(result).toContain("swarm_delegate");
-  });
-
-  test("includes external service access preference section", () => {
-    const result = buildSystemPrompt();
-    expect(result).toContain("## External Service Access Preference");
-    expect(result).toContain("CLI tools via host_bash");
-    expect(result).toContain("Browser automation as last resort");
+    expect(result).toContain("## External Service Access");
+    expect(result).toContain("browser automation as last resort");
   });
 
   test("includes external comms identity section", () => {


### PR DESCRIPTION
## Summary
- Remove test for `## Parallel Task Orchestration` which was deleted from the system prompt in #18152
- Update test for `## External Service Access` to match the condensed section from #18153

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23180362170/job/67351821903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
