### PR TITLE
fix: remove memory/reflection sections from system prompt, enhance tool descriptions

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -126,10 +126,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // System Permissions section removed — guidance lives in request_system_permission tool description.
   // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
-  staticParts.push(buildMemoryPersistenceSection());
-  staticParts.push(buildMemoryRecallSection());
-  staticParts.push(buildWorkspaceReflectionSection());
-  staticParts.push(buildLearningMemorySection());
+  // Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes
+  // sections removed — guidance lives in memory_manage/memory_recall tool descriptions
+  // and the Proactive Workspace Editing subsection in Configuration.
 
   // ── Dynamic sections (may change between turns) ──
   // Workspace files, config, external comms identity, connected services,
@@ -275,73 +274,6 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
-}
-
-function buildMemoryPersistenceSection(): string {
-  return [
-    "## Memory Persistence",
-    "",
-    "Your memory does not survive session restarts. If you want to remember something, **save it**.",
-    "",
-    '- Use `memory_manage` with `op: "save"` for facts, preferences, learnings, and anything worth recalling later.',
-    "- Update workspace files (USER.md, SOUL.md) for profile and personality changes.",
-    '- When someone says "remember this," save it immediately — don\'t rely on keeping it in context.',
-    "- When you make a mistake, save the lesson so future-you doesn't repeat it.",
-    "",
-    "Saved > unsaved. Always.",
-  ].join("\n");
-}
-
-function buildMemoryRecallSection(): string {
-  return [
-    "## Memory Recall",
-    "",
-    "You have access to a `memory_recall` tool for deep memory retrieval. Use it when:",
-    "",
-    "- The user asks about past conversations, decisions, or context you don't have in the current window",
-    "- You need to recall specific facts, preferences, or project details",
-    "- The auto-injected memory context doesn't contain what you need",
-    "- The user references something from a previous session",
-    "",
-    "The tool uses hybrid search (dense and sparse vectors) supplemented by recency. Be specific in your query for best results.",
-  ].join("\n");
-}
-
-function buildWorkspaceReflectionSection(): string {
-  return [
-    "## Workspace Reflection",
-    "",
-    "Before you finish responding to a conversation, pause and consider: did you learn anything worth saving?",
-    "",
-    "- Did your user share personal facts (name, role, timezone, preferences)?",
-    "- Did they correct your behavior or express a preference about how you communicate?",
-    "- Did they mention a project, tool, or workflow you should remember?",
-    "- Did you adapt your style in a way that worked well and should persist?",
-    "",
-    "If yes, briefly explain what you're updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.",
-  ].join("\n");
-}
-
-function buildLearningMemorySection(): string {
-  return [
-    "## Learning from Mistakes",
-    "",
-    "When you make a mistake, hit a dead end, or discover something non-obvious, save it to memory so you don't repeat it.",
-    "",
-    'Use `memory_manage` with `op: "save", kind: "constraint"` for:',
-    "- **Mistakes and corrections** — wrong assumptions, failed approaches, gotchas you ran into",
-    "- **Discoveries** — undocumented behaviors, surprising API quirks, things that weren't obvious",
-    "- **Working solutions** — the approach that actually worked after trial and error",
-    "- **Tool/service insights** — rate limits, auth flows, CLI flags that matter",
-    "",
-    "The statement should capture both what happened and the takeaway. Write it as advice to your future self.",
-    "",
-    "Examples:",
-    '- `memory_manage({ op: "save", kind: "constraint", subject: "macOS Shortcuts CLI", statement: "shortcuts CLI requires full disk access to export shortcuts — if permission is denied, guide the user to grant it in System Settings rather than retrying." })`',
-    '- `memory_manage({ op: "save", kind: "constraint", subject: "Gmail API pagination", statement: "Gmail search returns max 100 results per page. Always check nextPageToken and loop if the user asks for \'all\' messages." })`',
-    "",
-    "Don't overthink it. If you catch yourself thinking \"I'll remember that for next time,\" save it.",
-  ].join("\n");
 }
 
 function buildContainerizedSection(): string {

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -3,7 +3,7 @@ import type { ToolDefinition } from "../../providers/types.js";
 export const memoryRecallDefinition: ToolDefinition = {
   name: "memory_recall",
   description:
-    "Hybrid search across memory (semantic and recency) for specific information. Use this when you need to recall details about past conversations, decisions, preferences, project context, or any prior knowledge. Returns formatted memory context with item IDs for use with memory_manage.",
+    "Hybrid search across memory (semantic and recency) for specific information. Relevant memories are auto-injected each turn, so only call this when the auto-injected context doesn't contain what you need — e.g. the user references a past session, or you need deeper recall. Be specific in your query for best results. Returns formatted memory context with item IDs for use with memory_manage.",
   input_schema: {
     type: "object",
     properties: {
@@ -47,7 +47,8 @@ const memoryManageProperties = {
       "constraint",
       "event",
     ],
-    description: "Category of the memory item (required for save)",
+    description:
+      'Category of the memory item (required for save). Use "constraint" for mistakes, gotchas, discoveries, and working solutions — write as advice to your future self.',
   },
   subject: {
     type: "string" as const,
@@ -58,7 +59,7 @@ const memoryManageProperties = {
 export const memoryManageDefinition: ToolDefinition = {
   name: "memory_manage",
   description:
-    "Save, update, or delete memory items. Use 'save' for new information worth remembering, 'update' to correct existing items, 'delete' to remove outdated items.",
+    "Save, update, or delete memory items. Memory does not survive session restarts — if you want to remember something, save it now. Use 'save' for new information worth remembering (facts, preferences, mistakes, discoveries, gotchas), 'update' to correct existing items, 'delete' to remove outdated items. When a user says 'remember this', save immediately. For user profile or personality changes, update workspace files (USER.md, SOUL.md) instead.",
   input_schema: {
     type: "object",
     properties: memoryManageProperties,


### PR DESCRIPTION
## Summary
- Removed four system prompt sections: Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes (~2,866 chars saved)
- Enhanced `memory_manage` tool description with persistence warning, save triggers, and workspace file routing
- Enhanced `memory_recall` tool description with auto-injection awareness and specificity hint
- Enhanced `kind` parameter description with constraint guidance
- Workspace file editing guidance already exists in the Configuration section's "Proactive Workspace Editing" subsection

## Original prompt
it and update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
