### PR TITLE
fix: apply diversity ordering to conversation starter responses

### DIFF
--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -156,7 +156,7 @@ function handleListConversationStarters(url: URL): Response {
   // If starters exist, return them immediately.
   if (total > 0) {
     return Response.json({
-      starters: rawItems,
+      starters: orderStrongestFirst(rawItems),
       total,
       status: "ready",
     });


### PR DESCRIPTION
## Summary
- The `handleListConversationStarters` route returned `rawItems` directly from the DB query without passing them through `orderStrongestFirst`, so starters were ordered by batch/createdAt only — no category diversity
- Wrapped the response with `orderStrongestFirst(rawItems)` so the top starters maximize category variety

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23180492026/job/67352226679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
