### PR TITLE
fix: trim verbose CLI enumeration in system prompt

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -360,7 +360,7 @@ export function buildCliReferenceSection(): string {
   return [
     "## Assistant CLI",
     "",
-    "The `assistant` CLI is available in the sandbox for managing configuration, credentials, OAuth connections, memory, contacts, hooks, MCP servers, skills, notifications, schedules, and more. Always use the `bash` tool (never `host_bash`) when running `assistant` commands.",
+    "The `assistant` CLI is available in the sandbox for managing assistant settings, integrations, and services. Always use the `bash` tool (never `host_bash`) when running `assistant` commands.",
     "",
     "Run `assistant --help` to see all available commands, or `assistant <command> --help` for detailed help on any subcommand.",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Replaced verbose CLI feature enumeration ("configuration, credentials, OAuth connections, memory, contacts, hooks, MCP servers, skills, notifications, schedules, and more") with concise "assistant settings, integrations, and services" (~81 chars saved)
- The model discovers subcommands via `assistant --help`

## Original prompt
it and update /Users/sidd/Downloads/annotated-llm-request-9-verbatim.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
