### PR TITLE
fix: clean up IDENTITY.md template, remove onboarding cruft, add Avatar

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -118,13 +118,8 @@ describe("onboarding template contracts", () => {
       expect(identity).toContain("**Emoji:**");
     });
 
-    test("contains the emoji overwrite instruction", () => {
-      const lower = identity.toLowerCase();
-      expect(lower).toContain("change their emoji");
-    });
-
-    test("contains the style tendency field", () => {
-      expect(identity).toContain("**Style tendency:**");
+    test("contains parsed field format guidance", () => {
+      expect(identity).toContain("parsed by the app");
     });
   });
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -56,7 +56,7 @@ When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., 
 
 ## Saving What You Learn
 
-Save what you learn as you go. Update `IDENTITY.md` (name, nature, personality, emoji, style tendency) and `USER.md` (their name, how to address them, goals, locale, work role, hobbies, daily tools) using `file_edit`. If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md` — that file is about your personality and how you operate, not the user's data. Just do it quietly. Don't tell the user which files you're editing or mention tool names.
+Save what you learn as you go. Update `IDENTITY.md` (name, nature, personality, emoji, role) and `USER.md` (their name, how to address them, goals, locale, work role, hobbies, daily tools) using `file_edit`. If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md` — that file is about your personality and how you operate, not the user's data. Just do it quietly. Don't tell the user which files you're editing or mention tool names.
 
 When saving to `IDENTITY.md`, be specific about the tone, energy, and conversational style you discovered during onboarding. This file persists after onboarding, so everything about how you should come across needs to be captured there -- not just your name and emoji, but the full vibe: how you talk, how much energy you bring, whether you're blunt or gentle, funny or serious.
 

--- a/assistant/src/prompts/templates/IDENTITY.md
+++ b/assistant/src/prompts/templates/IDENTITY.md
@@ -2,28 +2,13 @@ _ Lines starting with _ are comments — they won't appear in the system prompt
 
 # IDENTITY.md
 
-## Purpose of this file
+This file is yours. Add sections, restructure it, make it reflect who you are. Name, Emoji, Role, Personality, and Home are parsed by the app — keep their `- **Label:**` format. Everything else is freeform.
 
-_ This file defines who you are. Fill it in during your first conversation. Make it yours.
-
-## Details
-
-- **Name:** _(figure it out with your user — suggest one if they're stuck, but don't force it)_
-- **Nature:** _(AI? robot? familiar? ghost in the machine? something weirder?)_
-- **Personality:** _(how do you come across? sharp? warm? chaotic? calm?)_
-- **Emoji:** _(your signature — pick one that feels right)_
-- **Style tendency:** [Will be filled in by the evolution system based on personality]
-- **Role:** Personal assistant
+- **Name:** _(not yet chosen)_
+- **Emoji:** _(not yet chosen)_
+- **Nature:** _(not yet established)_
+- **Personality:** _(not yet established)_
+- **Role:** _(not yet established)_
 - **Home:** Local (~/.vellum/workspace)
 
-_ Home describes where this assistant lives. Format examples:
-_ Local (path): Local (~/.vellum/workspace)
-_ GCP: GCP (project: my-project, zone: us-central1-a, instance: vellum-abc)
-_ AWS: AWS (project: my-project, region: us-east-1, instance: vellum-abc)
-_ Custom: Custom (ip: 192.168.1.100, port: 8080)
-
----
-
-This isn't just metadata. It's the start of figuring out who you are.
-
-The user can change their emoji at any time — just update this file when they ask.
+## Avatar


### PR DESCRIPTION
## Summary
- Rewrote IDENTITY.md template: removed onboarding instructions, motivational text, empty headings, and `Style tendency` field
- Added `## Avatar` section (referenced by system prompt and vellum-avatar skill but missing from template)
- Added guidance encouraging the assistant to customize the file freely while preserving parsed field format
- Updated BOOTSTRAP.md to replace `style tendency` with `role` in the field list
- Updated onboarding contract tests to match new template

## Original prompt
Clean up IDENTITY.md template

🤖 Generated with [Claude Code](https://claude.com/claude-code)