### PR TITLE
fix: update system-prompt test for removed Memory Persistence section

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -272,11 +272,9 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("## Routing: Starter Tasks");
   });
 
-  test("includes memory persistence section", () => {
+  test("does not include removed memory persistence section", () => {
     const result = buildSystemPrompt();
-    expect(result).toContain("## Memory Persistence");
-    expect(result).toContain("memory_manage");
-    expect(result).toContain("Saved > unsaved. Always.");
+    expect(result).not.toContain("## Memory Persistence");
   });
 
   test("config section uses workspace directory from platform util", () => {


### PR DESCRIPTION
## Summary
- The `## Memory Persistence` section was removed from the system prompt (guidance moved to tool descriptions), but the test still asserted its presence
- Updated the test to assert the section is NOT present, matching the current source

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23181247929/job/67354475990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
