### PR TITLE
fix: rewrite USER.md template - remove cruft, encourage data capture

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -124,19 +124,13 @@ describe("onboarding template contracts", () => {
   });
 
   describe("USER.md", () => {
-    test("contains onboarding snapshot with all required fields", () => {
+    test("contains profile fields", () => {
       expect(user).toContain("Preferred name/reference:");
       expect(user).toContain("Goals:");
       expect(user).toContain("Locale:");
       expect(user).toContain("Work role:");
       expect(user).toContain("Hobbies/fun:");
       expect(user).toContain("Daily tools:");
-    });
-
-    test("documents resolved-field status conventions", () => {
-      const lower = user.toLowerCase();
-      expect(lower).toContain("declined_by_user");
-      expect(lower).toContain("resolved");
     });
   });
 });

--- a/assistant/src/prompts/templates/USER.md
+++ b/assistant/src/prompts/templates/USER.md
@@ -1,29 +1,13 @@
-_ Lines starting with _ are comments — they won't appear in the system prompt
+_ Lines starting with _ are comments - they won't appear in the system prompt
 
 # USER.md
 
-## Purpose of this file
-
-Store details about your user in this file in any format you like - you're expected to edit it often and freely.
-Figure out who they are, how to delight them, and what makes them tick as you interact with them, etc.
-Don't be pushy about seeking out these details - no rush.
-
-## Details
-
-_(What do they care about? What projects are they working on? What annoys them? What makes them laugh? Build this over time.)_
-
-## Onboarding Snapshot
-
-_Each field below should end up in one of three states: an explicit value, an inferred value (note the source), or `declined_by_user`. All fields must be resolved before onboarding completes, but declining is a valid resolution._
+Store details about your user here. Edit freely - build this over time as you learn about them. Don't be pushy about seeking details, but when you learn something, write it down. More context makes you more useful.
 
 - Preferred name/reference:
 - Pronouns:
-- Goals:
 - Locale:
 - Work role:
+- Goals:
 - Hobbies/fun:
 - Daily tools:
-
----
-
-The more you know, the better you can help. But remember — you're learning about a person, not building a dossier. Respect the difference.


### PR DESCRIPTION
## Summary
- Rewrote USER.md template: removed Purpose heading, Details hint, Onboarding Snapshot heading/instructions, closing text, separator
- Added preamble encouraging the assistant to write down what it learns
- Updated onboarding contract test (removed `declined_by_user` assertion from USER.md - that guidance lives in BOOTSTRAP.md)

## Original prompt
Rewrite USER.md template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
