### PR TITLE
feat: add heartbeat bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/heartbeat/SKILL.md
+++ b/assistant/src/config/bundled-skills/heartbeat/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: heartbeat
+description: Configure periodic background checklist runs
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "\U0001F493"
+  vellum:
+    display-name: "Heartbeat"
+    activation-hints:
+      - "Set up a heartbeat, periodic checklist, background health check, or recurring background task"
+    avoid-when:
+      - "One-off or recurring schedules with specific payloads - use the schedule skill instead"
+---
+
+The heartbeat feature runs your `HEARTBEAT.md` checklist periodically in a background conversation. Each run, the assistant works through the checklist and flags anything that needs attention.
+
+## Setup
+
+Edit two things in `config.json` using `file_edit`:
+
+1. **Enable heartbeat**: Set `heartbeat.enabled` to `true`.
+2. **Set interval**: Set `heartbeat.intervalMs` (milliseconds between runs, default: 3600000 = 1 hour).
+3. **Optional active hours**: Set `heartbeat.activeHoursStart` and `heartbeat.activeHoursEnd` (0-23) to restrict runs to certain hours. Both must be set together.
+
+Example config.json heartbeat section:
+```json
+{
+  "heartbeat": {
+    "enabled": true,
+    "intervalMs": 1800000,
+    "activeHoursStart": 8,
+    "activeHoursEnd": 22
+  }
+}
+```
+
+Then edit `HEARTBEAT.md` with the checklist items. The assistant will work through this file each heartbeat run.
+
+## Notes
+
+- Toggling `heartbeat.enabled` requires an assistant restart to take effect.
+- Changes to `HEARTBEAT.md` take effect on the next heartbeat run (no restart needed).
+- The heartbeat runs in a separate background conversation, not the user's active chat.


### PR DESCRIPTION
## Summary
- Added `heartbeat` bundled skill with activation hints for "heartbeat, periodic checklist, background health check"
- Contains config.json field documentation (`heartbeat.enabled`, `intervalMs`, `activeHoursStart/End`) and setup instructions
- Zero-cost: only loaded when the user asks about heartbeat configuration

## Original prompt
let's just create a standalone one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
