### PR TITLE
fix: update system-prompt test helper to strip new dynamic sections

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -126,6 +126,9 @@ function basePrompt(result: string): string {
     "## Configuration",
     "## Skills Catalog",
     "## Available Skills",
+    "## External Communications Identity",
+    "## Connected Services",
+    "## Dynamic Skill Authoring Workflow",
   ]) {
     if (s.startsWith(heading)) {
       s = "";
@@ -277,13 +280,6 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("## Memory Persistence");
   });
 
-  test("config section uses workspace directory from platform util", () => {
-    const result = buildSystemPrompt();
-    expect(result).toContain(
-      `Your configuration directory is \`${TEST_DIR}/\`.`,
-    );
-  });
-
   test("omits user skills from catalog when none are configured", () => {
     const result = buildSystemPrompt();
     // No user skill directories exist, so no user skills should appear.
@@ -366,12 +362,6 @@ describe("buildSystemPrompt", () => {
   test("omits update handling instructions when UPDATES.md is absent", () => {
     const result = buildSystemPrompt();
     expect(result).not.toContain("### Update Handling");
-  });
-
-  test("config section lists UPDATES.md", () => {
-    const result = buildSystemPrompt();
-    expect(result).toContain("`UPDATES.md`");
-    expect(result).toContain("Release update notes");
   });
 
   test("strips comment lines starting with _ from prompt files", () => {


### PR DESCRIPTION
## Summary
- Fix `basePrompt()` test helper to strip the newly-added `## External Communications Identity`, `## Connected Services`, and `## Dynamic Skill Authoring Workflow` sections from the dynamic block, so it returns only workspace file content as intended.
- Remove two stale tests (`config section uses workspace directory from platform util` and `config section lists UPDATES.md`) that asserted on Configuration section content which was already removed from the system prompt.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23182165690/job/67357276972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
