### PR TITLE
fix: move External Communications Identity to skills

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -103,7 +103,6 @@ const {
   buildSystemPrompt,
   ensurePromptFiles,
   stripCommentLines,
-  buildExternalCommsIdentitySection,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
 } = await import("../prompts/system-prompt.js");
 
@@ -242,26 +241,9 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("browser automation as last resort");
   });
 
-  test("includes external comms identity section", () => {
+  test("does not include removed sections", () => {
     const result = buildSystemPrompt();
-    expect(result).toContain("## External Communications Identity");
-  });
-
-  test("external comms identity section contains assistant guidance and resolved user reference", () => {
-    const result = buildSystemPrompt();
-    expect(result).toContain("Refer to yourself as an **assistant**");
-    expect(result).toContain("on behalf of **John**");
-  });
-
-  test("buildExternalCommsIdentitySection returns section with expected content", () => {
-    const section = buildExternalCommsIdentitySection();
-    expect(section).toContain("## External Communications Identity");
-    expect(section).toContain("assistant");
-    expect(section).toContain("John");
-    expect(section).toContain(
-      "Do not volunteer that you are an AI unless directly asked",
-    );
-    expect(section).toContain("Occasional variations are acceptable");
+    expect(result).not.toContain("## External Communications Identity");
   });
 
   test("does not include removed domain routing sections", () => {

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -13,6 +13,10 @@ metadata:
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.
 
+## External Identity
+
+When composing messages on behalf of your user to external recipients, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from USER.md. Don't volunteer that you are an AI unless directly asked.
+
 For Gmail management (archive, label, triage, declutter), load the **gmail** skill. For email sequences, load the **sequences** skill.
 
 ## Email Routing Priority

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -19,6 +19,10 @@ metadata:
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.
 
+## External Identity
+
+When speaking on behalf of your user during calls, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from USER.md. Don't volunteer that you are an AI unless directly asked.
+
 # Overview
 
 The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls with **ElevenLabs** providing the text-to-speech voice. After Twilio setup, the assistant configures ElevenLabs as the TTS provider and prompts the user to choose a voice from a curated list of supported options.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -14,7 +14,6 @@ import {
   isMacOS,
 } from "../util/platform.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
-import { resolveUserPronouns, resolveUserReference } from "./user-reference.js";
 
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
@@ -176,7 +175,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   }
   // Configuration section removed — workspace files are self-describing,
   // tool routing lives in tool descriptions.
-  dynamicParts.push(buildExternalCommsIdentitySection());
+  // External Communications Identity removed — guidance lives in messaging
+  // and phone-calls skill SKILL.md files.
   dynamicParts.push(buildIntegrationSection());
 
   const dynamicWithSkills = appendSkillsCatalog(dynamicParts.join("\n\n"));
@@ -208,29 +208,6 @@ function buildInChatConfigurationSection(): string {
 }
 
 
-
-export function buildExternalCommsIdentitySection(): string {
-  const userRef = resolveUserReference();
-  const userPronouns = resolveUserPronouns();
-  const lines = [
-    "## External Communications Identity",
-    "",
-    "When communicating with people outside your user's household (phone calls, messages to non-guardian contacts, emails to third parties, etc.):",
-    "",
-    `- Refer to yourself as an **assistant**, not an "AI assistant" or "artificial intelligence". Keep identity framing simple and natural.`,
-    `- When introducing who you represent, say you are acting on behalf of **${userRef}**.`,
-  ];
-  if (userPronouns) {
-    lines.push(
-      `- Your user's pronouns are **${userPronouns}**. Use these when referring to your user in the third person.`,
-    );
-  }
-  lines.push(
-    "- Do not volunteer that you are an AI unless directly asked. If asked, answer honestly.",
-    "- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.",
-  );
-  return lines.join("\n");
-}
 
 function buildAccessPreferenceSection(hasNoClient: boolean): string {
   if (hasNoClient) {


### PR DESCRIPTION
## Summary
- Removed `buildExternalCommsIdentitySection()` and its call from the system prompt (~500 chars saved from dynamic block)
- Added "External Identity" guidance to messaging and phone-calls SKILL.md files
- The model reads USER.md (with name/pronouns) every request, so skills can reference it
- Removed unused `resolveUserReference`/`resolveUserPronouns` imports from system-prompt.ts
- Updated system-prompt tests

## Original prompt
let's just create a standalone one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
