### PR TITLE
fix: replace XML skills catalog with markdown bullets

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -186,7 +186,7 @@ function createSkillOnDisk(
 // ---------------------------------------------------------------------------
 
 describe("buildSystemPrompt assistant feature flag filtering", () => {
-  test("flag OFF skill does not appear in <available_skills> section", () => {
+  test("flag OFF skill does not appear in skills catalog", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Contacts",
@@ -224,8 +224,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     const result = buildSystemPrompt();
 
     // browser is explicitly enabled, declared flagged skill is explicitly off
-    expect(result).toContain('id="browser"');
-    expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
+    expect(result).toContain("**browser**");
+    expect(result).not.toContain(`**${DECLARED_SKILL_ID}**`);
   });
 
   test("declared skills hidden when no flag overrides set (registry defaults to false)", () => {
@@ -262,8 +262,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     const result = buildSystemPrompt();
 
     // Both skills declare feature flags with registry defaultEnabled: false
-    expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="email-channel"');
+    expect(result).not.toContain(`**${DECLARED_SKILL_ID}**`);
+    expect(result).not.toContain("**email-channel**");
   });
 
   test("flagged-off skills hidden when all flags are OFF", () => {
@@ -303,8 +303,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="email-channel"');
+    expect(result).not.toContain(`**${DECLARED_SKILL_ID}**`);
+    expect(result).not.toContain("**email-channel**");
   });
 
   test("assistantFeatureFlagValues overrides control visibility", () => {
@@ -335,7 +335,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    expect(result).toContain(`id="${DECLARED_SKILL_ID}"`);
+    expect(result).toContain(`**${DECLARED_SKILL_ID}**`);
   });
 
   test("persisted overrides for undeclared flags are respected", () => {
@@ -368,7 +368,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     // browser declares featureFlag: "browser" and the user
     // explicitly disabled it — that override must be honored.
-    expect(result).not.toContain('id="browser"');
+    expect(result).not.toContain("**browser**");
   });
 
   test("declared flags with no persisted override use registry default", () => {
@@ -399,7 +399,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     const result = buildSystemPrompt();
 
     // browser is declared in the registry with defaultEnabled: true
-    expect(result).toContain('id="browser"');
+    expect(result).toContain("**browser**");
   });
 
   test("skill without featureFlag is never flag-gated", () => {

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -227,10 +227,10 @@ describe("cross-tool routing consistency", () => {
 });
 
 // =====================================================================
-// 4. Activation hints in <available_skills> XML (replaces domain routing sections)
+// 4. Activation hints in skills catalog (replaces domain routing sections)
 // =====================================================================
 
-describe("Activation hints in available_skills XML", () => {
+describe("Activation hints in skills catalog", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -241,61 +241,28 @@ describe("Activation hints in available_skills XML", () => {
     }
   });
 
-  test("available_skills XML does NOT contain location attribute", () => {
+  test("phone-calls skill includes hints and avoid-when in catalog line", () => {
     const prompt = buildSystemPrompt();
-    const start = prompt.indexOf("<available_skills>");
-    const end = prompt.indexOf("</available_skills>");
-    expect(start).not.toBe(-1);
-    expect(end).not.toBe(-1);
-    const skillsXml = prompt.substring(start, end);
-    expect(skillsXml).not.toContain("location=");
+    const line = prompt.split("\n").find((l) => l.includes("**phone-calls**"));
+    expect(line).toBeDefined();
+    // Activation hints and avoid-when are folded into the description
+    expect(line).toContain("Twilio");
+    expect(line).toContain("voice-setup");
   });
 
-  test("phone-calls bundled skill has hints and avoid-when attributes in XML", () => {
+  test("orchestration skill includes hints and avoid-when in catalog line", () => {
     const prompt = buildSystemPrompt();
-    const start = prompt.indexOf("<available_skills>");
-    const end = prompt.indexOf("</available_skills>");
-    expect(start).not.toBe(-1);
-    expect(end).not.toBe(-1);
-    const skillsXml = prompt.substring(start, end);
-    expect(skillsXml).toContain('id="phone-calls"');
-    const skillLine = skillsXml
-      .split("\n")
-      .find((l) => l.includes('id="phone-calls"'));
-    expect(skillLine).toBeDefined();
-    expect(skillLine).toContain("hints=");
-    expect(skillLine).toContain("avoid-when=");
+    const line = prompt.split("\n").find((l) => l.includes("**orchestration**"));
+    expect(line).toBeDefined();
+    expect(line).toContain("parallel");
+    expect(line).toContain("Single-focus");
   });
 
-  test("orchestration bundled skill has hints and avoid-when attributes in XML", () => {
+  test("browser skill includes hints in catalog line", () => {
     const prompt = buildSystemPrompt();
-    const start = prompt.indexOf("<available_skills>");
-    const end = prompt.indexOf("</available_skills>");
-    expect(start).not.toBe(-1);
-    expect(end).not.toBe(-1);
-    const skillsXml = prompt.substring(start, end);
-    expect(skillsXml).toContain('id="orchestration"');
-    const skillLine = skillsXml
-      .split("\n")
-      .find((l) => l.includes('id="orchestration"'));
-    expect(skillLine).toBeDefined();
-    expect(skillLine).toContain("hints=");
-    expect(skillLine).toContain("avoid-when=");
-  });
-
-  test("browser bundled skill has hints attribute in XML", () => {
-    const prompt = buildSystemPrompt();
-    const start = prompt.indexOf("<available_skills>");
-    const end = prompt.indexOf("</available_skills>");
-    expect(start).not.toBe(-1);
-    expect(end).not.toBe(-1);
-    const skillsXml = prompt.substring(start, end);
-    expect(skillsXml).toContain('id="browser"');
-    const skillLine = skillsXml
-      .split("\n")
-      .find((l) => l.includes('id="browser"'));
-    expect(skillLine).toBeDefined();
-    expect(skillLine).toContain("hints=");
+    const line = prompt.split("\n").find((l) => l.includes("**browser**"));
+    expect(line).toBeDefined();
+    expect(line).toContain("browser_*");
   });
 
   test("domain routing sections are no longer in system prompt", () => {

--- a/assistant/src/__tests__/no-domain-routing-in-prompt-guard.test.ts
+++ b/assistant/src/__tests__/no-domain-routing-in-prompt-guard.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 /**
  * Guard test: domain-specific routing sections must NOT appear in the system
  * prompt source file. Routing cues now live in skill frontmatter
- * (`activation-hints` / `avoid-when`) and are projected into `<available_skills>` XML.
+ * (`activation-hints` / `avoid-when`) and are projected into the skills catalog.
  *
  * If this test fails, you are re-introducing hardcoded routing into the system
  * prompt. Instead, add `activation-hints` to the skill's SKILL.md frontmatter.

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -210,13 +210,7 @@ describe("buildSystemPrompt", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("Custom identity");
     expect(result).toContain("## Available Skills");
-    expect(result).toContain("<available_skills>");
-    expect(result).toContain('id="release-checklist"');
-    expect(result).toContain('name="Release Checklist"');
-    expect(result).toContain('description="Deployment checks."');
-    expect(result).toContain(
-      "call `skill_load` to load the full instructions, then use `skill_execute` to invoke the skill's tools.",
-    );
+    expect(result).toContain("**release-checklist**: Deployment checks.");
   });
 
   test("keeps SOUL.md and IDENTITY.md additive with skills", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -396,15 +396,6 @@ function buildDynamicSkillWorkflowSection(
   return lines.join("\n");
 }
 
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
 /**
  * Build a dynamic description for the mcp-setup skill that includes
  * configured MCP server names, so the model knows which servers exist.
@@ -413,44 +404,33 @@ function getMcpSetupDescription(): string {
   const config = getConfig();
   const servers = config.mcp?.servers;
   if (!servers || Object.keys(servers).length === 0) {
-    return "Add, authenticate, list, and remove MCP (Model Context Protocol) servers";
+    return "Add, authenticate, list, and remove MCP servers";
   }
 
   const serverNames = Object.keys(servers).sort();
-  return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load this skill to check status, authenticate, or add/remove servers.`;
+  return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load to check status, authenticate, or add/remove servers.`;
 }
 
 function formatSkillsCatalog(skills: SkillSummary[]): string {
-  const visible = skills;
-  if (visible.length === 0) return "";
+  if (skills.length === 0) return "";
 
-  const lines = ["<available_skills>"];
-  for (const skill of visible) {
-    const idAttr = escapeXml(skill.id);
-    const nameAttr = escapeXml(skill.displayName);
-    const descAttr =
+  const lines = ["## Available Skills", ""];
+  for (const skill of skills) {
+    const desc =
       skill.id === "mcp-setup"
-        ? escapeXml(getMcpSetupDescription())
-        : escapeXml(skill.description);
-    const hintsAttr =
-      skill.activationHints && skill.activationHints.length > 0
-        ? ` hints="${escapeXml(skill.activationHints.join("; "))}"`
-        : "";
-    const avoidAttr =
-      skill.avoidWhen && skill.avoidWhen.length > 0
-        ? ` avoid-when="${escapeXml(skill.avoidWhen.join("; "))}"`
-        : "";
-    lines.push(
-      `<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}"${hintsAttr}${avoidAttr} />`,
-    );
-  }
-  lines.push("</available_skills>");
+        ? getMcpSetupDescription()
+        : skill.description;
 
-  return [
-    "## Available Skills",
-    "The following skills are available. Before executing one, call `skill_load` to load the full instructions, then use `skill_execute` to invoke the skill's tools.",
-    "",
-    lines.join("\n"),
-    "",
-  ].join("\n");
+    // Build a single line: - **id**: description. Hints. Avoid-when.
+    const parts = [desc];
+    if (skill.activationHints && skill.activationHints.length > 0) {
+      parts.push(skill.activationHints.join(". "));
+    }
+    if (skill.avoidWhen && skill.avoidWhen.length > 0) {
+      parts.push(skill.avoidWhen.join(". "));
+    }
+    lines.push(`- **${skill.id}**: ${parts.join(". ")}`);
+  }
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Replaced `<available_skills>` XML format with markdown bullet list (~1,200 chars saved)
- Folded `activation-hints` and `avoid-when` naturally into description text
- Dropped `displayName` (model uses `id` for `skill_load`), preamble instruction, and local `escapeXml`
- Updated tests in system-prompt, intent-routing, feature-flags, and guard tests

## Original prompt
Replace XML skills catalog with markdown bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
