### PR TITLE
fix: skip empty integration section in system prompt assembly

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -177,7 +177,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // tool routing lives in tool descriptions.
   // External Communications Identity removed — guidance lives in messaging
   // and phone-calls skill SKILL.md files.
-  dynamicParts.push(buildIntegrationSection());
+  const integrationSection = buildIntegrationSection();
+  if (integrationSection) dynamicParts.push(integrationSection);
 
   const dynamicWithSkills = appendSkillsCatalog(dynamicParts.join("\n\n"));
 


### PR DESCRIPTION
## Summary
- Only push `buildIntegrationSection()` result to `dynamicParts` when non-empty, preventing a trailing `\n\n` from the join
- Fixes 9 failing tests in `system-prompt.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23182313997/job/67357724169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
