### PR TITLE
fix: trim document skill description

### DIFF
--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document
-description: Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides). Use when the user says write, draft, compose, or create a blog/article/essay.
+description: Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides)
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📄"


### PR DESCRIPTION
## Summary
- Remove implicit routing instruction from description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
