### PR TITLE
fix: trim gmail skill description

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmail
-description: Archive, label, draft, unsubscribe, and manage Gmail with smart inbox tools
+description: Archive, label, draft, unsubscribe, and manage Gmail
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📨"


### PR DESCRIPTION
## Summary
- Remove marketing qualifier from description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
