### PR TITLE
fix: trim sequences skill description

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/SKILL.md
+++ b/assistant/src/config/bundled-skills/sequences/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sequences
-description: Create and manage automated email drip sequences with enrollment, scheduling, and analytics
+description: Create and manage automated email drip sequences
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📧"


### PR DESCRIPTION
## Summary
- Remove verbose qualifier from sequences skill description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
