### PR TITLE
fix: trim slack skill description

### DIFF
--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack
-description: Scan channels, summarize threads, and manage Slack with privacy guardrails
+description: Scan channels, summarize threads, and manage Slack
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💬"


### PR DESCRIPTION
## Summary
- Remove marketing qualifier from description

🤖 Generated with [Claude Code](https://claude.com/claude-code)