### PR TITLE
fix: replace em dash in schedule skill description

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schedule
-description: Recurring and one-shot scheduling — cron, RRULE, or single fire-at time
+description: Recurring and one-shot scheduling - cron, RRULE, or single fire-at time
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📅"


### PR DESCRIPTION
## Summary
- Replace em dash with regular dash in schedule skill frontmatter description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
