### PR TITLE
fix: trim phone-calls skill description, fix terminology

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phone-calls
-description: "Make outgoing phone calls, receive incoming calls, and pull up past call transcripts. Everything needed for your assistant to act as an AI receptionist."
+description: "Make outgoing phone calls, receive incoming calls, and pull up past call transcripts"
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📞"
@@ -14,7 +14,7 @@ metadata:
       - "Phone calling setup, Twilio config, placing/receiving calls"
       - "Do NOT improvise Twilio setup from general knowledge"
     avoid-when:
-      - "Don't confuse with voice-setup (local PTT/mic) or guardian-verify-setup"
+      - "Don't confuse with voice-setup (local PTT/mic) or user-verify-setup"
 ---
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.


### PR DESCRIPTION
## Summary
- Remove marketing copy from description
- Fix guardian->user in avoid-when

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
