### PR TITLE
fix: update test assertions to match markdown skills catalog format

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -425,7 +425,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     const result = buildSystemPrompt();
 
     // Skills without featureFlag declared are never gated — always pass through
-    expect(result).toContain('id="my-skill"');
+    expect(result).toContain("**my-skill**");
   });
 });
 

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -138,7 +138,7 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
 
     const result = buildSystemPrompt();
     expect(result).toContain("## Available Skills");
-    expect(result).toContain('id="test-skill"');
+    expect(result).toContain("**test-skill**");
     expect(result).toContain("## Dynamic Skill Authoring Workflow");
   });
 
@@ -160,12 +160,12 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("skill_load");
   });
 
-  test("browser skill has activation hints in available_skills XML instead of dedicated section", () => {
+  test("browser skill has activation hints in skills catalog instead of dedicated section", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    // Browser routing moved from dedicated section to frontmatter hints
+    // Browser routing moved from dedicated section to inline hints in catalog bullet
     expect(result).not.toContain("Browser Skill Prerequisite");
-    expect(result).toContain('id="browser"');
-    expect(result).toContain("hints=");
+    expect(result).toContain("**browser**");
+    expect(result).toContain("Load first if you need browser_* tools");
   });
 });

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -138,10 +138,10 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(found!.name).toBe("Lifecycle Test");
     expect(found!.description).toBe("Integration test skill.");
 
-    // Step 4: Verify skill appears in system prompt
+    // Step 4: Verify skill appears in system prompt (markdown bullet: **id**: description)
     const prompt = buildSystemPrompt();
-    expect(prompt).toContain("lifecycle-test");
-    expect(prompt).toContain("Lifecycle Test");
+    expect(prompt).toContain("**lifecycle-test**");
+    expect(prompt).toContain("Integration test skill.");
     expect(prompt).toContain("## Dynamic Skill Authoring Workflow");
 
     // Step 5: Delete the skill


### PR DESCRIPTION
## Summary
- Update test assertions in 3 test files to match the new markdown bullet format (`**skill-id**: description`) introduced by #18170, which replaced the XML `<skill id="...">` catalog format
- Fix `managed-skill-lifecycle`, `assistant-feature-flags-integration`, and `dynamic-skill-workflow-prompt` tests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23182571489/job/67358511973

🤖 Generated with [Claude Code](https://claude.com/claude-code)