### PR TITLE
fix: replace remaining em dash in computer-use TOOLS.json manifest

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -227,7 +227,7 @@
     },
     {
       "name": "computer_use_open_app",
-      "description": "Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps \u2014 more reliable and explicit.",
+      "description": "Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps - more reliable and explicit.",
       "category": "computer-use",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Replace `\u2014` (em dash) with `-` (regular dash) in the `computer_use_open_app` description in `TOOLS.json`
- This was missed in #18184 because the em dash was a JSON escape sequence (`\u2014`) rather than a literal UTF-8 character
- Fixes the `computer-use-skill-manifest-regression` test that compares manifest descriptions to core definitions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23182802519/job/67359221680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
