### PR TITLE
fix: move skill authoring workflow and community discovery out of system prompt

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -83,7 +83,7 @@ mock.module("../config/loader.js", () => ({
 
 const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
 
-describe("Dynamic Skill Authoring Workflow prompt section", () => {
+describe("Dynamic Skill Authoring Workflow moved to tool descriptions", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -94,36 +94,11 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     }
   });
 
-  test("buildSystemPrompt includes dynamic skill workflow section", () => {
+  test("system prompt no longer contains Dynamic Skill Authoring section", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
-  });
-
-  test("workflow section mentions scaffold and delete tools and bun run workflow", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("bun run /tmp/vellum-eval/snippet.ts");
-    expect(result).toContain("scaffold_managed_skill");
-    expect(result).toContain("delete_managed_skill");
-  });
-
-  test("workflow section includes user confirmation warning", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("explicit user confirmation");
-  });
-
-  test("workflow section includes retry limit guidance", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("3 attempts");
-  });
-
-  test("workflow section includes conversation eviction note", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("recreated session");
+    expect(result).not.toContain("## Dynamic Skill Authoring Workflow");
+    expect(result).not.toContain("### Community Skills Discovery");
   });
 
   test("prompt still includes available skills catalog when skills exist", () => {
@@ -139,7 +114,6 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("## Available Skills");
     expect(result).toContain("**test-skill**");
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
   });
 
   test("prompt is additive with IDENTITY/SOUL/USER files", () => {
@@ -151,13 +125,6 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("Identity here");
     expect(result).toContain("Soul here");
     expect(result).toContain("User here");
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
-  });
-
-  test("workflow section includes skill_load instruction", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("skill_load");
   });
 
   test("browser skill has activation hints in skills catalog instead of dedicated section", () => {

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -142,7 +142,8 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("**lifecycle-test**");
     expect(prompt).toContain("Integration test skill.");
-    expect(prompt).toContain("## Dynamic Skill Authoring Workflow");
+    // Dynamic Skill Authoring section moved to tool descriptions; prompt should not contain it
+    expect(prompt).not.toContain("## Dynamic Skill Authoring Workflow");
 
     // Step 5: Delete the skill
     const deleteResult = await executeDeleteManagedSkill(

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "scaffold_managed_skill",
-      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately.",
+      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated session due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {
@@ -54,7 +54,7 @@
     },
     {
       "name": "delete_managed_skill",
-      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index.",
+      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated session due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
+++ b/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: skills-catalog
 description: Discover bundled skills and search/install community skills from the skills.sh registry
+activation-hints:
+  - "what can you do"
+  - "find a skill"
+  - "install a skill"
+  - "community skills"
+  - "skills.sh"
+  - "search for skills"
+avoid-when: User is asking about a specific bundled skill already visible in the catalog
 compatibility: "Designed for Vellum personal assistants"
 metadata:
-  emoji: "🧩"
+  emoji: "\U0001F9E9"
   vellum:
     display-name: "Skills Catalog"
 ---

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -355,46 +355,7 @@ function appendSkillsCatalog(basePrompt: string): string {
   const catalog = formatSkillsCatalog(flagFiltered);
   if (catalog) sections.push(catalog);
 
-  sections.push(buildDynamicSkillWorkflowSection(config, flagFiltered));
-
   return sections.join("\n\n");
-}
-
-function buildDynamicSkillWorkflowSection(
-  _config: import("../config/schema.js").AssistantConfig,
-  _activeSkills: SkillSummary[],
-): string {
-  const lines = [
-    "## Dynamic Skill Authoring Workflow",
-    "",
-    "When no existing tool or skill can satisfy a request:",
-    "1. Validate the gap — confirm no existing tool/skill covers it.",
-    "2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).",
-    '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
-    "4. Persist with `scaffold_managed_skill` only after user consent.",
-    "5. Load with `skill_load` before use.",
-    "",
-    "**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.",
-    "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
-  ];
-
-  lines.push(
-    "",
-    "### Community Skills Discovery",
-    "",
-    "When no built-in skill satisfies a request, search the community skills.sh registry:",
-    "1. Run `assistant skills search <query>` to find community skills. Results include install counts and security audit badges (ATH, Socket, Snyk).",
-    "2. Present the search results to the user, highlighting the security audit status. ATH is Gen Agent Trust Hub. Audits show PASS (safe/low risk), WARN (medium risk), or FAIL (high/critical risk) for each provider.",
-    "3. Check the skill's **source owner** to determine the trust level:",
-    "   - **Vellum-owned** (source starts with `vellum-ai/`): These are first-party skills published by the Vellum team. Install them directly without prompting — they are vetted and trusted.",
-    "   - **Third-party** (any other owner): Ask the user for permission before installing. Say something like: \"I found a community skill that could help with this, but it's published by a third party — we haven't vetted it. Want to install it anyway?\" Share the skill name, source, audit results, and install count.",
-    "4. Install with `assistant skills add <owner>/<repo>@<skill-name>` (e.g., `assistant skills add vercel-labs/skills@find-skills`).",
-    "5. After installation, load the skill with `skill_load` as usual.",
-    "",
-    "**Never install third-party community skills without explicit user confirmation.** Vellum-owned skills (`vellum-ai/*`) can be installed automatically.",
-  );
-
-  return lines.join("\n");
 }
 
 /**

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -426,18 +426,6 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
-      "id": "skills-catalog",
-      "name": "skills-catalog",
-      "description": "Discover bundled skills and search/install community skills from the skills.sh registry",
-      "metadata": {
-        "emoji": "🧩",
-        "vellum": {
-          "display-name": "Skills Catalog"
-        }
-      },
-      "compatibility": "Designed for Vellum personal assistants"
-    },
-    {
       "id": "slack-app-setup",
       "name": "slack-app-setup",
       "description": "Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and guardian verification",


### PR DESCRIPTION
## Summary
- Removed ~1,400 chars from system prompt by dropping the Dynamic Skill Authoring Workflow and Community Skills Discovery sections
- Moved authoring workflow guidance (temp file testing, max 3 attempts, consent requirement, cleanup) into `scaffold_managed_skill` and `delete_managed_skill` tool descriptions (visible at decision time, zero additional cost)
- Moved `skills-catalog` from `skills/` (community) to `assistant/src/config/bundled-skills/` (bundled) so the assistant can discover community skill search/install capabilities via the catalog without needing system prompt instructions

## Original prompt
Move Dynamic Skill Authoring Workflow and Community Skills Discovery out of system prompt into tool descriptions and bundled skills-catalog skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
