### PR TITLE
fix: restore guardian-verify-setup skill ID in phone-calls avoid-when

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -14,7 +14,7 @@ metadata:
       - "Phone calling setup, Twilio config, placing/receiving calls"
       - "Do NOT improvise Twilio setup from general knowledge"
     avoid-when:
-      - "Don't confuse with voice-setup (local PTT/mic) or user-verify-setup"
+      - "Don't confuse with voice-setup (local PTT/mic) or guardian-verify-setup"
 ---
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.


### PR DESCRIPTION
## Summary
- Reverted `user-verify-setup` back to `guardian-verify-setup` in phone-calls SKILL.md avoid-when
- `guardian-verify-setup` is a skill ID (proper noun referencing `skills/guardian-verify-setup/`), not user-facing terminology - it should not have been renamed in the guardian->user cleanup

## Original prompt
Fix incorrect guardian->user rename of skill ID reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
