### PR TITLE
fix: collapse interface/channel turn context when all values match

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1031,7 +1031,7 @@ describe("applyRuntimeInjections with inboundActorContext", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildChannelTurnContextBlock", () => {
-  test("formats block with all three channel fields", () => {
+  test("collapses to single field when all channels match", () => {
     const block = buildChannelTurnContextBlock({
       turnContext: {
         userMessageChannel: "telegram",
@@ -1041,9 +1041,7 @@ describe("buildChannelTurnContextBlock", () => {
     });
     expect(block).toBe(
       "<channel_turn_context>\n" +
-        "user_message_channel: telegram\n" +
-        "assistant_message_channel: telegram\n" +
-        "conversation_origin_channel: telegram\n" +
+        "channel: telegram\n" +
         "</channel_turn_context>",
     );
   });
@@ -1097,7 +1095,7 @@ describe("injectChannelTurnContext", () => {
     expect(injected.type).toBe("text");
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toContain("<channel_turn_context>");
-    expect(text).toContain("user_message_channel: telegram");
+    expect(text).toContain("channel: telegram");
     expect(text).toContain("</channel_turn_context>");
   });
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -652,14 +652,18 @@ export function buildChannelTurnContextBlock(
   params: ChannelTurnContextParams,
 ): string {
   const { turnContext, conversationOriginChannel } = params;
+  const user = turnContext.userMessageChannel;
+  const assistant = turnContext.assistantMessageChannel;
+  const origin = conversationOriginChannel ?? "unknown";
+
   const lines: string[] = ["<channel_turn_context>"];
-  lines.push(`user_message_channel: ${turnContext.userMessageChannel}`);
-  lines.push(
-    `assistant_message_channel: ${turnContext.assistantMessageChannel}`,
-  );
-  lines.push(
-    `conversation_origin_channel: ${conversationOriginChannel ?? "unknown"}`,
-  );
+  if (user === assistant && user === origin) {
+    lines.push(`channel: ${user}`);
+  } else {
+    lines.push(`user_message_channel: ${user}`);
+    lines.push(`assistant_message_channel: ${assistant}`);
+    lines.push(`conversation_origin_channel: ${origin}`);
+  }
   lines.push("</channel_turn_context>");
   return lines.join("\n");
 }
@@ -956,14 +960,18 @@ export function buildInterfaceTurnContextBlock(
   params: InterfaceTurnContextParams,
 ): string {
   const { turnContext, conversationOriginInterface } = params;
+  const user = turnContext.userMessageInterface;
+  const assistant = turnContext.assistantMessageInterface;
+  const origin = conversationOriginInterface ?? "unknown";
+
   const lines: string[] = ["<interface_turn_context>"];
-  lines.push(`user_message_interface: ${turnContext.userMessageInterface}`);
-  lines.push(
-    `assistant_message_interface: ${turnContext.assistantMessageInterface}`,
-  );
-  lines.push(
-    `conversation_origin_interface: ${conversationOriginInterface ?? "unknown"}`,
-  );
+  if (user === assistant && user === origin) {
+    lines.push(`interface: ${user}`);
+  } else {
+    lines.push(`user_message_interface: ${user}`);
+    lines.push(`assistant_message_interface: ${assistant}`);
+    lines.push(`conversation_origin_interface: ${origin}`);
+  }
   lines.push("</interface_turn_context>");
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Collapse `<interface_turn_context>` and `<channel_turn_context>` to a single field when all three values (user, assistant, origin) are identical
- Common single-device case: ~297 chars -> ~95 chars per turn (~200 chars saved)
- Mixed-interface turns (e.g. user on Telegram, assistant on vellum) still emit all three fields

## Original prompt
Condense interface_turn_context and channel_turn_context when all values match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
