### PR TITLE
fix: correct stale test expectation for user timezone display

### DIFF
--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -80,13 +80,16 @@ describe("buildTemporalContext", () => {
     });
     expect(sameResult).not.toContain("User timezone:");
 
-    // When different, include it
+    // When user timezone differs from host, it becomes the primary timezone
+    // and the host timezone is shown as a secondary annotation
     const diffResult = buildTemporalContext({
       nowMs: WED_FEB_18,
       hostTimeZone: "UTC",
       userTimeZone: "America/New_York",
     });
-    expect(diffResult).toContain("User timezone: America/New_York");
+    expect(diffResult).toContain("Timezone: America/New_York");
+    expect(diffResult).toContain("Assistant host timezone: UTC");
+    expect(diffResult).not.toContain("User timezone:");
   });
 
   test("shows assistant host timezone only when different from primary timezone", () => {


### PR DESCRIPTION
## Summary
- Fix failing test `shows user timezone only when different from primary timezone` in `date-context.test.ts`
- When `userTimeZone` is passed without an explicit `timeZone` override, the user timezone becomes the primary timezone — the test incorrectly expected a `"User timezone:"` line instead of checking that the primary `"Timezone:"` line reflects the user's timezone

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23183789201/job/67362285910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
