### PR TITLE
fix: show user email in account settings when logged in

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -76,7 +76,10 @@ struct SettingsGeneralTab: View {
     // MARK: - Account Section
 
     private var accountSection: some View {
-        SettingsCard(title: "Account", subtitle: "Log in to your account") {
+        SettingsCard(
+            title: "Account",
+            subtitle: authManager.currentUser?.email ?? authManager.currentUser?.display ?? "Log in to your account"
+        ) {
             if authManager.isLoading {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()


### PR DESCRIPTION
## Summary
- The Account settings card subtitle was hardcoded to "Log in to your account" even when the user was authenticated
- Now dynamically shows the user's email or display name when logged in, falling back to "Log in to your account" when not authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
