### PR TITLE
feat: update image gen models to Nano Banana 2 and Nano Banana Pro

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -55,7 +55,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -39,7 +39,7 @@ let currentConfig: Record<string, unknown> = {
     "image-generation": {
       mode: "your-own",
       provider: "gemini",
-      model: "gemini-2.5-flash-image",
+      model: "gemini-3.1-flash-image-preview",
     },
     "web-search": { mode: "your-own", provider: "anthropic-native" },
   },
@@ -142,7 +142,7 @@ beforeEach(() => {
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },
@@ -215,7 +215,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -253,7 +253,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -295,7 +295,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -327,7 +327,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -358,7 +358,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -390,7 +390,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },
@@ -416,7 +416,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -27,7 +27,7 @@ const geminiGenerateContentFn = mock(async () => geminiGenerateContentResult);
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    imageGenModel: "gemini-2.5-flash-image",
+    imageGenModel: "gemini-3.1-flash-image-preview",
     services: {
       inference: {
         mode: "your-own",
@@ -37,7 +37,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -38,7 +38,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -76,7 +76,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -93,7 +93,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.inference.mode).toBe("your-own");
     expect(result.services["image-generation"].provider).toBe("gemini");
     expect(result.services["image-generation"].model).toBe(
-      "gemini-2.5-flash-image",
+      "gemini-3.1-flash-image-preview",
     );
     expect(result.services["image-generation"].mode).toBe("your-own");
     expect(result.services["web-search"].provider).toBe("anthropic-native");

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -64,7 +64,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -62,7 +62,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -55,7 +55,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -90,7 +90,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -41,7 +41,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -69,7 +69,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -69,7 +69,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -73,7 +73,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -71,7 +71,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -66,7 +66,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/gemini-image-service.test.ts
+++ b/assistant/src/__tests__/gemini-image-service.test.ts
@@ -111,7 +111,7 @@ describe("generateImage", () => {
     expect(result.images).toHaveLength(1);
     expect(result.images[0].mimeType).toBe("image/png");
     expect(result.images[0].dataBase64).toBe("abc123");
-    expect(result.resolvedModel).toBe("gemini-2.5-flash-image");
+    expect(result.resolvedModel).toBe("gemini-3.1-flash-image-preview");
   });
 
   test("generate mode collects text commentary from response", async () => {
@@ -168,7 +168,7 @@ describe("generateImage", () => {
 
     expect(lastGenerateParams).not.toBeNull();
     expect((lastGenerateParams as Record<string, unknown>).model).toBe(
-      "gemini-2.5-flash-image",
+      "gemini-3.1-flash-image-preview",
     );
   });
 
@@ -180,12 +180,12 @@ describe("generateImage", () => {
       {
         prompt: "test",
         mode: "generate",
-        model: "gemini-3-pro-image",
+        model: "gemini-3-pro-image-preview",
       },
     );
 
     expect((lastGenerateParams as Record<string, unknown>).model).toBe(
-      "gemini-3-pro-image",
+      "gemini-3-pro-image-preview",
     );
   });
 

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -142,7 +142,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -65,7 +65,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -33,7 +33,7 @@ const mockConfig = {
     "image-generation": {
       mode: "your-own",
       provider: "gemini",
-      model: "gemini-2.5-flash-image",
+      model: "gemini-3.1-flash-image-preview",
     },
     "web-search": { mode: "your-own", provider: "anthropic-native" },
   },

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -14,7 +14,7 @@ let mockApiKey: string | undefined = "test-gemini-key";
 let mockGenerateResult = {
   images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
   text: "A beautiful image",
-  resolvedModel: "gemini-2.5-flash-image",
+  resolvedModel: "gemini-3.1-flash-image-preview",
 };
 let mockGenerateError: Error | null = null;
 let lastGenerateCredentials: unknown = null;
@@ -31,7 +31,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },
@@ -174,7 +174,7 @@ beforeEach(() => {
   mockGenerateResult = {
     images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
     text: "A beautiful image",
-    resolvedModel: "gemini-2.5-flash-image",
+    resolvedModel: "gemini-3.1-flash-image-preview",
   };
   mockGenerateError = null;
   mockAttachments = [];
@@ -250,7 +250,7 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Generated 1 image");
-    expect(result.content).toContain("gemini-2.5-flash-image");
+    expect(result.content).toContain("gemini-3.1-flash-image-preview");
     expect(result.content).toContain("A beautiful image");
     expect(result.contentBlocks).toHaveLength(1);
     expect(result.contentBlocks![0]).toEqual({
@@ -270,7 +270,7 @@ describe("image-studio skill script wrapper", () => {
         { mimeType: "image/png", dataBase64: "img2" },
       ],
       text: undefined as unknown as string,
-      resolvedModel: "gemini-2.5-flash-image",
+      resolvedModel: "gemini-3.1-flash-image-preview",
     };
 
     const result = await run({ prompt: "test", variants: 2 }, fakeContext);
@@ -357,8 +357,7 @@ describe("image-studio TOOLS.json manifest", () => {
     expect(props.mode.enum).toEqual(["generate", "edit"]);
     expect(props.attachment_ids.type).toBe("array");
     expect(props.model.enum).toEqual([
-      "gemini-2.5-flash-image",
-      "gemini-3-pro-image",
+      "gemini-3.1-flash-image-preview",
       "gemini-3-pro-image-preview",
     ]);
     expect(props.variants.type).toBe("number");

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -52,7 +52,7 @@ function makeProvidersConfig(provider: string, model: string): ProvidersConfig {
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -69,7 +69,7 @@ function makeProvidersConfig(provider: string, model: string): ProvidersConfig {
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -25,7 +25,7 @@ describe("provider registry (ollama)", () => {
         "image-generation": {
           mode: "your-own",
           provider: "gemini",
-          model: "gemini-2.5-flash-image",
+          model: "gemini-3.1-flash-image-preview",
         },
         "web-search": { mode: "your-own", provider: "anthropic-native" },
       },

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -24,7 +24,7 @@ const mockConfig = {
     "image-generation": {
       mode: "your-own" as const,
       provider: "gemini",
-      model: "gemini-2.5-flash-image",
+      model: "gemini-3.1-flash-image-preview",
     },
     "web-search": { mode: "your-own" as const, provider: "anthropic-native" },
   },

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -64,7 +64,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/swarm-conversation-integration.test.ts
+++ b/assistant/src/__tests__/swarm-conversation-integration.test.ts
@@ -44,7 +44,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -56,7 +56,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -36,7 +36,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -75,7 +75,7 @@ mock.module("../config/loader.js", () => ({
       "image-generation": {
         mode: "your-own",
         provider: "gemini",
-        model: "gemini-2.5-flash-image",
+        model: "gemini-3.1-flash-image-preview",
       },
       "web-search": { mode: "your-own", provider: "anthropic-native" },
     },

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -23,8 +23,8 @@ You are an image generation assistant. When the user asks you to create or edit 
 
 ## Models
 
-- `gemini-2.5-flash-image` (default) - fast, good quality
-- `gemini-3-pro-image` - higher quality, slower
+- `gemini-3.1-flash-image-preview` (default) - Nano Banana 2, fast, good quality
+- `gemini-3-pro-image-preview` - Nano Banana Pro, higher quality, slower
 
 ## Tips
 

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -28,8 +28,7 @@
           "model": {
             "type": "string",
             "enum": [
-              "gemini-2.5-flash-image",
-              "gemini-3-pro-image",
+              "gemini-3.1-flash-image-preview",
               "gemini-3-pro-image-preview"
             ],
             "description": "Which model to use for generation. If omitted, uses the user's configured preference."

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -30,7 +30,7 @@ export type InferenceService = z.infer<typeof InferenceServiceSchema>;
 export const ImageGenerationServiceSchema = z.object({
   mode: ServiceModeSchema.default("your-own"),
   provider: z.enum(VALID_IMAGE_GEN_PROVIDERS).default("gemini"),
-  model: z.string().default("gemini-2.5-flash-image"),
+  model: z.string().default("gemini-3.1-flash-image-preview"),
 });
 export type ImageGenerationService = z.infer<
   typeof ImageGenerationServiceSchema

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -7,7 +7,7 @@ interface ImageGenerationRequest {
   mode: "generate" | "edit";
   /** Base64-encoded source images for edit mode */
   sourceImages?: Array<{ mimeType: string; dataBase64: string }>;
-  /** Model override; defaults to 'gemini-2.5-flash-image' */
+  /** Model override; defaults to 'gemini-3.1-flash-image-preview' */
   model?: string;
   /** Number of output variants (1-4, default 1) */
   variants?: number;
@@ -43,10 +43,9 @@ interface ImageGenerationResult {
 
 // --- Constants ---
 
-const DEFAULT_MODEL = "gemini-2.5-flash-image";
+const DEFAULT_MODEL = "gemini-3.1-flash-image-preview";
 const ALLOWED_MODELS = new Set([
-  "gemini-2.5-flash-image",
-  "gemini-3-pro-image",
+  "gemini-3.1-flash-image-preview",
   "gemini-3-pro-image-preview",
 ]);
 const MAX_VARIANTS = 4;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -40,7 +40,7 @@ public final class SettingsStore: ObservableObject {
 
     @Published var selectedModel: String = "claude-opus-4-6"
     @Published var configuredProviders: Set<String> = ["ollama"]
-    @Published var selectedImageGenModel: String = "gemini-2.5-flash-image"
+    @Published var selectedImageGenModel: String = "gemini-3.1-flash-image-preview"
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
@@ -55,13 +55,13 @@ public final class SettingsStore: ObservableObject {
     ]
 
     static let availableImageGenModels: [String] = [
-        "gemini-2.5-flash-image",
+        "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
     ]
 
     static let imageGenModelDisplayNames: [String: String] = [
-        "gemini-2.5-flash-image": "Gemini 2.5 Flash Image",
-        "gemini-3-pro-image-preview": "Gemini 3 Pro Image (Preview)",
+        "gemini-3.1-flash-image-preview": "Nano Banana 2",
+        "gemini-3-pro-image-preview": "Nano Banana Pro",
     ]
 
     // MARK: - Settings Values


### PR DESCRIPTION
## Summary
- Update image generation model options to "Nano Banana 2" (`gemini-3.1-flash-image-preview`, default) and "Nano Banana Pro" (`gemini-3-pro-image-preview`)
- Update display names, model IDs, and defaults across macOS client, assistant backend, config schema, SKILL.md, and TOOLS.json
- Update all test fixtures to use the new default model ID

## Original prompt
The options here should be Nano Banana 2 - this should be the default and use gemini-3.1-flash-image-preview and Nano Banana Pro - this should use gemini-3-pro-image-preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
