### PR TITLE
fix: align settings card dropdowns with text fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -173,7 +173,6 @@ struct InferenceServiceCard: View {
                     (label: SettingsStore.modelDisplayNames[model] ?? model, value: model)
                 }
             )
-            .frame(width: 400)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
@@ -69,6 +69,9 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
                     .foregroundColor(VColor.contentTertiary)
             }
 
+            Divider()
+                .background(VColor.borderBase)
+
             // API Key field — collapsed under disclosure when managed proxy without user key
             if isManagedProxy && !isConnected {
                 DisclosureGroup("Override with your own key", isExpanded: $showKeyOverride) {

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -93,7 +93,6 @@ struct WebSearchServiceCard: View {
                     (label: SettingsStore.webSearchProviderDisplayNames[provider] ?? provider, value: provider)
                 }
             )
-            .frame(width: 400)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove fixed `.frame(width: 400)` from model and provider dropdowns in InferenceServiceCard and WebSearchServiceCard so they stretch full-width to match the API key text fields
- Add missing `Divider()` between header and content in ServiceCredentialCard for visual consistency with the other settings cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)