### PR TITLE
fix: strip legacy memory_context blocks from old conversation history

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -250,7 +250,7 @@ The recall pipeline runs on every turn that passes the `needsMemory` gate (skips
 9. **Two-layer XML injection** (`formatting.ts`): Budget-aware rendering into four XML sections:
 
    ```xml
-   <memory_context>
+   <memory_context __injected>
 
    <user_identity>
    <!-- identity-kind tier 1 items (plain statements) -->
@@ -273,7 +273,7 @@ The recall pipeline runs on every turn that passes the `needsMemory` gate (skips
 
    Empty sections are omitted. Each section has a per-item token budget (150 tokens for tier 1, 100 for tier 2). Tier 1 sections consume budget first; tier 2 uses the remainder.
 
-10. **Injection strategy**: The rendered `<memory_context>` block is prepended as a text content block to the last user message (`injectMemoryRecallAsUserBlock`), following the same pattern as workspace, temporal, and other runtime injections. Stripping is handled by the generic `stripUserTextBlocksByPrefix` mechanism matching the `<memory_context>` prefix. This avoids synthetic message pairs and preserves prompt prefix caching between turns.
+10. **Injection strategy**: The rendered `<memory_context __injected>` block is prepended as a text content block to the last user message (`injectMemoryRecallAsUserBlock`), following the same pattern as workspace, temporal, and other runtime injections. Stripping is handled by the generic `stripUserTextBlocksByPrefix` mechanism matching the `<memory_context __injected>` prefix (with a backward-compat entry for the legacy `<memory_context>` prefix from older history). This avoids synthetic message pairs and preserves prompt prefix caching between turns.
 
 ### Internal-Only Trust Gating
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1024,6 +1024,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<interface_turn_context>",
   "<turn_context>",
   "<memory_context __injected>",
+  "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
   "<voice_call_control>",
   "<workspace_top_level>",
   TEMPORAL_INJECTED_PREFIX,


### PR DESCRIPTION
## Summary
- Add backward-compat `<memory_context>` prefix to `RUNTIME_INJECTION_PREFIXES` so `stripInjectedContext()` also strips legacy blocks from pre-`__injected` conversation history
- Update `assistant/docs/architecture/memory.md` to reflect the `<memory_context __injected>` tag rename (example XML and injection strategy paragraph)

Addresses review feedback from #18133.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
