### PR TITLE
fix: remove dead isPlatformManaged() code

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -49,7 +49,7 @@ export async function initializeProvidersAndTools(
   }
 
   // Rehydrate the platform assistant ID from the credential store so
-  // isPlatformManaged() works after assistant restarts.
+  // shouldUsePlatformCallbacks() works after assistant restarts.
   try {
     const key = credentialKey("vellum", "platform_assistant_id");
     const persisted = await getSecureKeyAsync(key);

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -24,27 +24,9 @@ import {
   getPlatformInternalApiKey,
 } from "../config/env.js";
 import { getIsContainerized } from "../config/env-registry.js";
-import { isManagedProxyEnabledSync } from "../providers/managed-proxy/context.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("platform-callback-registration");
-
-/**
- * Whether this is a platform-managed deployment with usable managed credentials.
- *
- * True when PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID are both set **and**
- * the managed proxy prerequisites (including the assistant API key) were
- * satisfied the last time `resolveManagedProxyContext()` ran. This prevents
- * the system prompt from claiming managed credentials are available during
- * partial/failed platform bootstrap where the API key is missing.
- */
-export function isPlatformManaged(): boolean {
-  return (
-    !!getPlatformBaseUrl() &&
-    !!getPlatformAssistantId() &&
-    isManagedProxyEnabledSync()
-  );
-}
 
 /**
  * Whether the daemon should register callback routes with the platform.


### PR DESCRIPTION
Address review feedback from #18145 — remove isPlatformManaged() which was left as dead code after its only call site was removed. Also removes the now-unused isManagedProxyEnabledSync import and updates a stale comment in providers-setup.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
