### PR TITLE
fix: correct fire_at guidance for recurring schedules

### DIFF
--- a/assistant/src/config/bundled-skills/notifications/TOOLS.json
+++ b/assistant/src/config/bundled-skills/notifications/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "send_notification",
-      "description": "Send an immediate notification. Fires instantly with no delay capability. For future or scheduled alerts, use schedule_create with fire_at instead. The router decides channels/copy from preferences and urgency hints. Include a confidence score (0-1).",
+      "description": "Send an immediate notification. Fires instantly with no delay capability. For one-time future alerts, use schedule_create with fire_at. For recurring alerts, use schedule_create with expression (cron/RRULE). The router decides channels/copy from preferences and urgency hints. Include a confidence score (0-1).",
       "category": "notifications",
       "risk": "medium",
       "input_schema": {


### PR DESCRIPTION
Address review feedback from #18143 — fix send_notification tool description to distinguish one-time alerts (fire_at) from recurring alerts (expression/RRULE) instead of blanket fire_at guidance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
