### PR TITLE
fix: extract TelemetryClient to private property in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -52,6 +52,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
     let debugStateWriter = DebugStateWriter()
+    private let telemetryClient: any TelemetryClientProtocol = TelemetryClient()
     private var metricKitManager: MetricKitManager?
 
     // Forwarding accessors — ownership lives in `services`, these keep
@@ -388,8 +389,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
                 if ready {
                     // Record lifecycle telemetry events (fire-and-forget).
-                    Task { await TelemetryClient().recordLifecycleEvent("hatch") }
-                    Task { await TelemetryClient().recordLifecycleEvent("app_open") }
+                    Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
+                    Task { await self.telemetryClient.recordLifecycleEvent("app_open") }
 
                     // If the user is signed in with a local assistant, wait for
                     // credential provisioning to complete before sending the wake-up
@@ -423,7 +424,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             Task {
                 let ready = await awaitDaemonReady(timeout: 10)
                 if ready {
-                    await TelemetryClient().recordLifecycleEvent("app_open")
+                    await self.telemetryClient.recordLifecycleEvent("app_open")
                 }
             }
             showMainWindow()


### PR DESCRIPTION
Address review feedback from #18134 — use single private property for TelemetryClient in AppDelegate per AGENTS.md GatewayHTTPClient migration pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
