### PR TITLE
fix: move activation-hints/avoid-when to metadata.vellum

### DIFF
--- a/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
+++ b/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: skills-catalog
 description: Discover bundled skills and search/install community skills from the skills.sh registry
-activation-hints:
-  - "what can you do"
-  - "find a skill"
-  - "install a skill"
-  - "community skills"
-  - "skills.sh"
-  - "search for skills"
-avoid-when: User is asking about a specific bundled skill already visible in the catalog
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "\U0001F9E9"
   vellum:
     display-name: "Skills Catalog"
+    activation-hints:
+      - "what can you do"
+      - "find a skill"
+      - "install a skill"
+      - "community skills"
+      - "skills.sh"
+      - "search for skills"
+    avoid-when:
+      - "User is asking about a specific bundled skill already visible in the catalog"
 ---
 
 You can help the user discover what skills are available and find community skills to extend the assistant's capabilities.


### PR DESCRIPTION
Address review feedback from #18187 — move activation-hints and avoid-when from top-level frontmatter into metadata.vellum where the parser expects them. Also convert avoid-when from a bare string to a YAML array.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
