### PR TITLE
fix: correct hasNoClient fallback messaging

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -215,7 +215,7 @@ function buildAccessPreferenceSection(hasNoClient: boolean): string {
     return [
       "## External Service Access",
       "",
-      "Priority: (1) sandbox `bash` - install tools yourself, only fall back to host when you need local files/auth; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).",
+      "Priority: (1) sandbox `bash` — install tools yourself; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).",
     ].join("\n");
   }
 


### PR DESCRIPTION
Address review feedback from #18153 — the hasNoClient branch of buildAccessPreferenceSection told the model to 'fall back to host when you need local files/auth', but host tools (host_bash, host_file_read, etc.) are explicitly disabled when hasNoClient is true. Removed the misleading host fallback guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
