### PR TITLE
fix: correct heartbeat SKILL.md count and tool reference

### DIFF
--- a/assistant/src/config/bundled-skills/heartbeat/SKILL.md
+++ b/assistant/src/config/bundled-skills/heartbeat/SKILL.md
@@ -16,7 +16,7 @@ The heartbeat feature runs your `HEARTBEAT.md` checklist periodically in a backg
 
 ## Setup
 
-Edit two things in `config.json` using `file_edit`:
+Edit `config.json` using `file_edit`:
 
 1. **Enable heartbeat**: Set `heartbeat.enabled` to `true`.
 2. **Set interval**: Set `heartbeat.intervalMs` (milliseconds between runs, default: 3600000 = 1 hour).


### PR DESCRIPTION
Address review feedback from #18167 — fix 'Edit two things' to match actual count of three items. Dropped the inaccurate count rather than saying "three things" since the list is self-explanatory. Kept `file_edit` reference since it is a real tool in this project.

Closes #18167 feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
