### PR TITLE
fix: update resolveUserPronouns for new USER.md format

### DIFF
--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -26,8 +26,12 @@ mock.module("node:fs", () => ({
 }));
 
 // Import after mocks are in place
-const { resolveUserReference, resolveGuardianName, DEFAULT_USER_REFERENCE } =
-  await import("../prompts/user-reference.js");
+const {
+  resolveUserReference,
+  resolveUserPronouns,
+  resolveGuardianName,
+  DEFAULT_USER_REFERENCE,
+} = await import("../prompts/user-reference.js");
 
 describe("resolveUserReference", () => {
   beforeEach(() => {
@@ -68,6 +72,82 @@ describe("resolveUserReference", () => {
     mockFileExists = true;
     mockFileContent = "- Preferred name/reference:   Alice   \n";
     expect(resolveUserReference()).toBe("Alice");
+  });
+});
+
+describe("resolveUserPronouns", () => {
+  beforeEach(() => {
+    mockFileExists = false;
+    mockFileContent = "";
+  });
+
+  test("returns null when USER.md does not exist", () => {
+    mockFileExists = false;
+    expect(resolveUserPronouns()).toBeNull();
+  });
+
+  test("returns pronouns from flat USER.md (no Onboarding Snapshot)", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "# USER.md",
+      "",
+      "- Preferred name/reference: Alice",
+      "- Pronouns: she/her",
+      "- Locale: en-US",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBe("she/her");
+  });
+
+  test("returns null when pronouns field is empty in flat format", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "# USER.md",
+      "",
+      "- Preferred name/reference: Alice",
+      "- Pronouns:",
+      "- Locale: en-US",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBeNull();
+  });
+
+  test("returns pronouns from legacy Onboarding Snapshot section", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "## Onboarding Snapshot",
+      "",
+      "- Pronouns: they/them",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBe("they/them");
+  });
+
+  test("prefers pronouns above Onboarding Snapshot over inside it", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "Pronouns: he/him",
+      "",
+      "## Onboarding Snapshot",
+      "",
+      "- Pronouns: she/her",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBe("he/him");
+  });
+
+  test("returns null for declined_by_user", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "- Preferred name/reference: Alice",
+      "- Pronouns: declined_by_user",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBeNull();
+  });
+
+  test("strips inferred: prefix", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "- Preferred name/reference: Alice",
+      "- Pronouns: inferred: she/her",
+    ].join("\n");
+    expect(resolveUserPronouns()).toBe("she/her");
   });
 });
 

--- a/assistant/src/prompts/user-reference.ts
+++ b/assistant/src/prompts/user-reference.ts
@@ -24,9 +24,9 @@ function readPreferredNameFromUserMd(): string | null {
  * Resolve the name/reference the assistant uses when referring to
  * the human it represents in external communications.
  *
- * Reads the "Preferred name/reference:" field from the Onboarding
- * Snapshot section of USER.md.  Falls back to "my human" when the
- * file is missing, unreadable, or the field is empty.
+ * Reads the "Preferred name/reference:" field from USER.md.
+ * Falls back to "my human" when the file is missing, unreadable,
+ * or the field is empty.
  */
 export function resolveUserReference(): string {
   const preferredName = readPreferredNameFromUserMd();
@@ -41,10 +41,10 @@ export function resolveUserReference(): string {
  * file is missing, the field is empty, or the value is a sentinel like
  * `declined_by_user`.
  *
- * Priority order:
- *   1. Any `Pronouns:` line outside the Onboarding Snapshot section
- *      (explicit user update post-onboarding takes precedence).
- *   2. The structured `- Pronouns:` field inside the Onboarding Snapshot.
+ * When a legacy `## Onboarding Snapshot` section exists, a `Pronouns:`
+ * line *above* that section takes priority (explicit post-onboarding edit).
+ * Otherwise falls back to the structured `- Pronouns:` field anywhere
+ * in the file.
  */
 export function resolveUserPronouns(): string | null {
   const content = readTextFileSync(getWorkspacePromptPath("USER.md"));
@@ -52,8 +52,8 @@ export function resolveUserPronouns(): string | null {
 
   const snapshotIdx = content.indexOf("## Onboarding Snapshot");
 
-  // 1. Check for a Pronouns line outside the Onboarding Snapshot section.
-  //    This represents an explicit post-onboarding update and takes priority.
+  // 1. Legacy format: check for a Pronouns line outside the Onboarding
+  //    Snapshot section (explicit post-onboarding update takes priority).
   if (snapshotIdx >= 0) {
     const beforeSnapshot = content.slice(0, snapshotIdx);
     const outsideMatch = beforeSnapshot.match(/Pronouns:[ \t]*(.*)/);
@@ -62,13 +62,11 @@ export function resolveUserPronouns(): string | null {
     }
   }
 
-  // 2. Fall back to the structured field in the Onboarding Snapshot.
-  if (snapshotIdx >= 0) {
-    const section = content.slice(snapshotIdx);
-    const match = section.match(/^- Pronouns:[ \t]*(.*)/m);
-    if (match && match[1].trim()) {
-      return cleanPronounValue(match[1].trim());
-    }
+  // 2. Search the entire file for the structured `- Pronouns:` field.
+  //    Handles both legacy (inside Onboarding Snapshot) and new flat format.
+  const match = content.match(/^- Pronouns:[ \t]*(.*)/m);
+  if (match && match[1].trim()) {
+    return cleanPronounValue(match[1].trim());
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Fix `resolveUserPronouns()` which was broken by the removal of `## Onboarding Snapshot` header from USER.md template in #18164
- The structured `- Pronouns:` field search is no longer gated on the snapshot header — it searches the entire file
- Added comprehensive test coverage for `resolveUserPronouns()` covering both flat and legacy formats
- Updated JSDoc comments to remove stale references to Onboarding Snapshot

## Test plan
- [x] Tests cover flat USER.md format (no Onboarding Snapshot section)
- [x] Tests cover legacy format with Onboarding Snapshot section  
- [x] Tests cover priority: above-snapshot > inside-snapshot
- [x] Tests cover edge cases: empty field, declined_by_user, inferred: prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
