### PR TITLE
fix: weather skill ui_show availability and field coverage

### DIFF
--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -30,11 +30,11 @@ export const uiShowTool: Tool = {
   description:
     "Show structured data or UI to the user. For long-form writing use the document skill; for interactive apps use the app-builder skill.\n\n" +
     "Surface types (data shapes):\n" +
-    "- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: \"weather_forecast\" (native weather widget), \"task_progress\" (live step tracker - update via ui_update on data.templateData)\n" +
+    "- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: \"weather_forecast\" (native weather widget), \"task_progress\" (live step tracker - update via ui_update on data.templateData; shape: { title, status: \"in_progress\"|\"completed\"|\"failed\", steps: [{ label, status: \"pending\"|\"in_progress\"|\"completed\"|\"failed\", detail? }] })\n" +
     '- table: { columns: [{ id, label, width? }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +
-    '- form: { fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, fields }], submitLabel? }\n' +
+    '- form: { description?, fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, description?, fields }], pageLabels?: { next?, back?, submit? }, submitLabel? }\n' +
     '- list: { items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }\n' +
-    "- confirmation: { message, detail?, confirmLabel?, cancelLabel?, destructive? }\n" +
+    "- confirmation: { message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }\n" +
     "- dynamic_page: { html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }\n" +
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }",
   category: "ui-surface",

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -41,10 +41,10 @@ The command returns JSON with:
 
 ## Presenting Results
 
-Use `ui_show` with the `weather_forecast` card template for a native weather widget:
+**If a UI surface tool is available**, present weather data visually using the `weather_forecast` card template for a native weather widget:
 
 ```
-ui_show surface_type="card" data={
+surface_type="card" data={
   title: "Weather",
   template: "weather_forecast",
   templateData: {
@@ -57,6 +57,8 @@ ui_show surface_type="card" data={
 ```
 
 Map weather condition codes to SF Symbol names (e.g. "sun.max.fill", "cloud.rain.fill", "cloud.fill", "snowflake").
+
+**Otherwise**, format the weather data as a clear, well-structured text response with current conditions and forecast summary.
 
 ## Temperature Units
 


### PR DESCRIPTION
## Summary
- Restore `confirmedLabel?` and `description?` fields that were dropped from the `ui_show` tool description
- Add `task_progress` templateData shape back into the tool description since it has no skill-based home
- Make weather SKILL.md conditional on UI tool availability with a plain-text fallback
- Remove direct `ui_show` tool name reference from weather SKILL.md for portability

Addresses review feedback from #18188.

## Test plan
- [ ] Verify `ui_show` tool description includes all supported fields
- [ ] Verify weather skill works on channels with and without dynamic UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
