### PR TITLE
fix: gate name_preference_note on both display-name fields being emitted

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -824,6 +824,30 @@ describe("injectInboundActorContext", () => {
     );
   });
 
+  test("omits name_preference_note when member name matches canonical and is suppressed", () => {
+    const ctx: InboundActorContext = {
+      sourceChannel: "telegram",
+      canonicalActorIdentity: "Jeff",
+      actorIdentifier: "@jeff_handle",
+      actorDisplayName: "Jeff",
+      actorSenderDisplayName: "Jeffrey",
+      actorMemberDisplayName: "Jeff",
+      trustClass: "trusted_contact",
+      guardianIdentity: "guardian-user-1",
+      memberStatus: "active",
+      memberPolicy: "allow",
+    };
+
+    const result = injectInboundActorContext(baseUserMessage, ctx);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    // actor_member_display_name matches canonical → omitted by differs() guard
+    expect(text).not.toContain("actor_member_display_name:");
+    // actor_sender_display_name differs from canonical → emitted
+    expect(text).toContain("actor_sender_display_name: Jeffrey");
+    // name_preference_note must NOT appear since actor_member_display_name was omitted
+    expect(text).not.toContain("name_preference_note:");
+  });
+
   test("sanitizes inline actor context values to prevent line injection", () => {
     const ctx: InboundActorContext = {
       sourceChannel: "telegram",

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -805,8 +805,8 @@ export function buildInboundActorContextBlock(
     lines.push(`contact_interaction_count: ${ctx.contactInteractionCount}`);
   }
   if (
-    ctx.actorMemberDisplayName &&
-    ctx.actorSenderDisplayName &&
+    differs(ctx.actorMemberDisplayName) &&
+    differs(ctx.actorSenderDisplayName) &&
     sanitizeInlineContextValue(ctx.actorMemberDisplayName) !==
       sanitizeInlineContextValue(ctx.actorSenderDisplayName)
   ) {


### PR DESCRIPTION
## Summary
- Gate `name_preference_note` emission on both `actor_member_display_name` and `actor_sender_display_name` passing the `differs()` guard
- Prevents the model from seeing a note referencing fields that were omitted by dedup logic
- Adds test for the edge case where member name matches canonical identity

Address review feedback from #18192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
