### PR TITLE
fix: keep personality in IDENTITY.md so parsers stay aligned with BOOTSTRAP.md

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -27,8 +27,8 @@ A field is resolved when the user gave an explicit answer, you inferred it from 
 
 Save as you go using `file_edit`. Don't mention tool names or which files you're editing.
 
-- **IDENTITY.md** - name, nature, emoji, role.
-- **SOUL.md** - personality, conversational style, behavioral preferences.
+- **IDENTITY.md** - name, nature, personality, emoji, role.
+- **SOUL.md** - personality (detailed), conversational style, behavioral preferences.
 - **USER.md** - their name, goals, locale, work role, hobbies, daily tools.
 
 ## Completion Gate


### PR DESCRIPTION
## Summary
- Address review feedback from #18165 — BOOTSTRAP.md directed personality only to SOUL.md, but `parseIdentityFields` and `handleGetIdentity` still read personality from IDENTITY.md
- Restore personality to the IDENTITY.md saving instruction so parsers continue to work
- SOUL.md keeps detailed personality, conversational style, and behavioral preferences

## Context
After #18165, onboarding via BOOTSTRAP.md would write personality only to SOUL.md, leaving the IDENTITY.md `**Personality:**` field as `_(not yet established)_`. Since `parseIdentityFields` (used by `identity_changed` SSE events) and `handleGetIdentity` (used by `/identity` API) read exclusively from IDENTITY.md, clients would display stale personality data.

## Test plan
- [x] Verify `onboarding-template-contract.test.ts` still passes (personality keyword present in BOOTSTRAP.md)
- [x] Verify IDENTITY.md template still has `**Personality:**` field
- [x] Confirm parsers in `identity.ts` and `identity-routes.ts` unchanged — they read from IDENTITY.md which now gets personality during onboarding

Addresses feedback from #18165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
