### PR TITLE
fix: remove dead PTT code

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -15,7 +15,6 @@ import {
   injectTemporalContext,
   isGroupChatType,
   resolveChannelCapabilities,
-  sanitizePttActivationKey,
   stripChannelCapabilityContext,
   stripChannelTurnContext,
   stripInboundActorContext,
@@ -135,7 +134,7 @@ describe("resolveChannelCapabilities", () => {
   });
 
   test("propagates chatType when provided", () => {
-    const caps = resolveChannelCapabilities("telegram", null, null, "group");
+    const caps = resolveChannelCapabilities("telegram", null, "group");
     expect(caps.chatType).toBe("group");
   });
 
@@ -1226,73 +1225,6 @@ describe("applyRuntimeInjections with channelTurnContext", () => {
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// sanitizePttActivationKey
-// ---------------------------------------------------------------------------
-
-describe("sanitizePttActivationKey", () => {
-  test("returns undefined for null/undefined input", () => {
-    expect(sanitizePttActivationKey(null)).toBeUndefined();
-    expect(sanitizePttActivationKey(undefined)).toBeUndefined();
-  });
-
-  test("passes through valid JSON PTTActivator payloads", () => {
-    const modifierOnly = JSON.stringify({
-      kind: "modifierOnly",
-      modifierFlags: 8388608,
-    });
-    expect(sanitizePttActivationKey(modifierOnly)).toBe(modifierOnly);
-    const keyPayload = JSON.stringify({ kind: "key", keyCode: 49 });
-    expect(sanitizePttActivationKey(keyPayload)).toBe(keyPayload);
-    const nonePayload = JSON.stringify({ kind: "none" });
-    expect(sanitizePttActivationKey(nonePayload)).toBe(nonePayload);
-  });
-
-  test("returns undefined for invalid keys", () => {
-    expect(
-      sanitizePttActivationKey("malicious\nprompt injection"),
-    ).toBeUndefined();
-    expect(sanitizePttActivationKey("arbitrary_value")).toBeUndefined();
-    expect(sanitizePttActivationKey("")).toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// resolveChannelCapabilities sanitizes pttActivationKey
-// ---------------------------------------------------------------------------
-
-describe("resolveChannelCapabilities with PTT metadata", () => {
-  test("sanitizes valid JSON PTTActivator pttActivationKey", () => {
-    const key = JSON.stringify({
-      kind: "modifierOnly",
-      modifierFlags: 8388608,
-    });
-    const caps = resolveChannelCapabilities("macos", "macos", {
-      pttActivationKey: key,
-    });
-    expect(caps.pttActivationKey).toBe(key);
-  });
-
-  test("sanitizes invalid pttActivationKey to undefined", () => {
-    const caps = resolveChannelCapabilities("macos", "macos", {
-      pttActivationKey: "evil\nprompt",
-    });
-    expect(caps.pttActivationKey).toBeUndefined();
-  });
-
-  test("passes through microphonePermissionGranted", () => {
-    const key = JSON.stringify({
-      kind: "modifierOnly",
-      modifierFlags: 8388608,
-    });
-    const caps = resolveChannelCapabilities("macos", "macos", {
-      pttActivationKey: key,
-      microphonePermissionGranted: true,
-    });
-    expect(caps.microphonePermissionGranted).toBe(true);
   });
 });
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -33,10 +33,6 @@ export interface ChannelCapabilities {
   supportsDynamicUi: boolean;
   /** Whether the channel supports voice/microphone input. */
   supportsVoiceInput: boolean;
-  /** Push-to-talk activation key (e.g. 'fn', 'ctrl', 'fn_shift', 'none'). Only present on desktop clients. */
-  pttActivationKey?: string;
-  /** Whether the client has been granted microphone permission by the OS. */
-  microphonePermissionGranted?: boolean;
   /** Chat type from the gateway (e.g. "private", "group", "supergroup", "channel", "im", "mpim"). */
   chatType?: string;
 }
@@ -165,46 +161,10 @@ export function inboundActorContextFromTrust(
   };
 }
 
-/**
- * Validate a PTT activation key string. Accepts JSON PTTActivator payloads
- * from the custom key feature. Returns the key as-is if valid, undefined otherwise.
- */
-export function sanitizePttActivationKey(
-  key: string | undefined | null,
-): string | undefined {
-  if (key == null) return undefined;
-
-  // Parse as a JSON PTTActivator payload
-  if (key.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(key) as { kind?: string };
-      if (
-        parsed.kind &&
-        ["modifierOnly", "key", "modifierKey", "mouseButton", "none"].includes(
-          parsed.kind,
-        )
-      ) {
-        return key;
-      }
-    } catch {
-      // fall through
-    }
-  }
-
-  return undefined;
-}
-
-/** Optional PTT metadata provided by the client alongside each message. */
-export interface PttMetadata {
-  pttActivationKey?: string;
-  microphonePermissionGranted?: boolean;
-}
-
 /** Derive channel capabilities from source channel + interface identifiers. */
 export function resolveChannelCapabilities(
   sourceChannel?: string | null,
   sourceInterface?: string | null,
-  pttMetadata?: PttMetadata | null,
   chatType?: string | null,
 ): ChannelCapabilities {
   // Normalise legacy pseudo-channel IDs to canonical ChannelId values.
@@ -250,10 +210,6 @@ export function resolveChannelCapabilities(
         dashboardCapable: supportsDesktopUi,
         supportsDynamicUi: supportsDesktopUi || iface === "vellum",
         supportsVoiceInput: supportsDesktopUi,
-        pttActivationKey: sanitizePttActivationKey(
-          pttMetadata?.pttActivationKey,
-        ),
-        microphonePermissionGranted: pttMetadata?.microphonePermissionGranted,
         chatType: resolvedChatType,
       };
     }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -915,7 +915,6 @@ export class DaemonServer {
       resolveChannelCapabilities(
         sourceChannel,
         sourceInterface,
-        null,
         options?.transport?.chatType,
       ),
     );


### PR DESCRIPTION
Address review feedback from #18141 — remove leftover PTT code that became dead after PTT state injection was removed from the channel capability context block:

- Remove `PttMetadata` interface and `sanitizePttActivationKey` function
- Remove `pttActivationKey` and `microphonePermissionGranted` fields from `ChannelCapabilities` interface
- Remove `pttMetadata` parameter from `resolveChannelCapabilities`
- Remove PTT field assignments in the vellum case of `resolveChannelCapabilities`
- Update callers in `server.ts` to drop the now-removed `null` pttMetadata argument
- Remove `sanitizePttActivationKey` and PTT metadata test blocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
