### PR TITLE
fix: double period and avoid-when polarity in skills catalog

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -247,6 +247,7 @@ describe("Activation hints in skills catalog", () => {
     expect(line).toBeDefined();
     // Activation hints and avoid-when are folded into the description
     expect(line).toContain("Twilio");
+    expect(line).toContain("Avoid: ");
     expect(line).toContain("voice-setup");
   });
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -383,13 +383,13 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
         ? getMcpSetupDescription()
         : skill.description;
 
-    // Build a single line: - **id**: description. Hints. Avoid-when.
-    const parts = [desc];
+    // Build a single line: - **id**: description. Hints. Avoid: ...
+    const parts = [desc.replace(/\.\s*$/, "")];
     if (skill.activationHints && skill.activationHints.length > 0) {
       parts.push(skill.activationHints.join(". "));
     }
     if (skill.avoidWhen && skill.avoidWhen.length > 0) {
-      parts.push(skill.avoidWhen.join(". "));
+      parts.push(`Avoid: ${skill.avoidWhen.join(". ")}`);
     }
     lines.push(`- **${skill.id}**: ${parts.join(". ")}`);
   }


### PR DESCRIPTION
Address review feedback from #18170:
- Strip trailing period from skill descriptions before joining with ". " to prevent double periods
- Prefix avoid-when entries with "Avoid: " to preserve negative routing polarity
- Add test assertion for the Avoid prefix in catalog lines

Note: The test assertion issue (XML format check) was already fixed in the merged PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
