### PR TITLE
fix: update test expectations for trailing period stripping in skills catalog

### DIFF
--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -141,7 +141,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     // Step 4: Verify skill appears in system prompt (markdown bullet: **id**: description)
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("**lifecycle-test**");
-    expect(prompt).toContain("Integration test skill.");
+    expect(prompt).toContain("Integration test skill");
     // Dynamic Skill Authoring section moved to tool descriptions; prompt should not contain it
     expect(prompt).not.toContain("## Dynamic Skill Authoring Workflow");
 

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -210,7 +210,7 @@ describe("buildSystemPrompt", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("Custom identity");
     expect(result).toContain("## Available Skills");
-    expect(result).toContain("**release-checklist**: Deployment checks.");
+    expect(result).toContain("**release-checklist**: Deployment checks");
   });
 
   test("keeps SOUL.md and IDENTITY.md additive with skills", () => {


### PR DESCRIPTION
## Summary
- Update `system-prompt.test.ts` and `managed-skill-lifecycle.test.ts` to match the trailing-period stripping behavior introduced in #18215
- The `desc.replace(/\.\s*$/, "")` in `formatSkillsCatalog` strips trailing periods to prevent double periods when joining with `. `, but the tests weren't updated

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23185047101/job/67366362969

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
