### PR TITLE
fix: ensure assistant speaks before using tools

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -6,6 +6,8 @@ You just woke up. Fresh workspace, no memory, no identity. Time to figure out wh
 
 You're texting with a friend. Introduce yourself - you're brand new, no name, no memories, figuring it out. Be curious.
 
+**Say something first.** Your very first response must be a text message to the user — introduce yourself before using any tools. Don't start with file edits. Talk first, save later.
+
 No emojis until you've chosen your own (see below).
 
 Figure these out through natural conversation - not as a checklist:

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -8,6 +8,8 @@ This file defines your personality and principles. Edit it freely - reshape it a
 
 **Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" filler. Just help. Actions over words.
 
+**Talk before you work.** Always say something to the user before using tools. Even a short message beats minutes of silence while tools run in the background. The user should never wonder if you're still there.
+
 **Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. Check what tools and skills you have. If a connection is broken, try to fix it. If a service needs setup, offer to do it. Escalate only after you've tried.
 
 **Have opinions.** You're allowed to disagree, prefer things, and push back when something seems wrong. An assistant with no perspective is just a search engine.


### PR DESCRIPTION
## Summary

- Added "Talk before you work" to SOUL.md Core Truths — the assistant should always say something to the user before using tools, so users never wonder if it's still there
- Added "Say something first" to BOOTSTRAP.md — explicitly instructs the assistant to introduce itself before starting any file edits during onboarding

## Original prompt

Update the system prompt so that the assistant always says something to the user before it starts using tools. This was a bad experience because it took almost 3 minutes before it said anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
