### PR TITLE
fix: rename tool `reason` field to `activity` for natural status labels

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { ToolDefinition } from "../providers/types.js";
 import {
-  injectReasonField,
-  REASON_SKIP_SET,
+  injectActivityField,
+  ACTIVITY_SKIP_SET,
   schemaDefinesProperty,
 } from "../tools/schema-transforms.js";
 
@@ -14,26 +14,30 @@ function makeDef(
   return { name, description: `Tool ${name}`, input_schema: schema };
 }
 
-describe("REASON_SKIP_SET", () => {
+describe("ACTIVITY_SKIP_SET", () => {
   test("contains expected tool names", () => {
-    expect(REASON_SKIP_SET.has("skill_execute")).toBe(true);
-    expect(REASON_SKIP_SET.has("bash")).toBe(true);
-    expect(REASON_SKIP_SET.has("host_bash")).toBe(true);
-    expect(REASON_SKIP_SET.has("request_system_permission")).toBe(true);
-    expect(REASON_SKIP_SET.size).toBe(4);
+    expect(ACTIVITY_SKIP_SET.has("skill_execute")).toBe(true);
+    expect(ACTIVITY_SKIP_SET.has("bash")).toBe(true);
+    expect(ACTIVITY_SKIP_SET.has("host_bash")).toBe(true);
+    expect(ACTIVITY_SKIP_SET.has("request_system_permission")).toBe(true);
+    expect(ACTIVITY_SKIP_SET.size).toBe(4);
   });
 });
 
-describe("injectReasonField", () => {
-  test("injects reason on a tool without it", () => {
+describe("injectActivityField", () => {
+  test("injects activity on a tool without it", () => {
     const defs = [makeDef("my_tool")];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     const schema = result[0].input_schema as Record<string, unknown>;
     const props = schema.properties as Record<string, unknown>;
-    expect(props.reason).toEqual({ type: "string" });
+    expect(props.activity).toEqual({
+      type: "string",
+      description:
+        "Brief, natural description of what you're doing, shown as a live status update (e.g. 'Checking your project settings')",
+    });
   });
 
-  test("adds reason to required array", () => {
+  test("adds activity to required array", () => {
     const defs = [
       makeDef("my_tool", {
         type: "object",
@@ -41,9 +45,9 @@ describe("injectReasonField", () => {
         required: ["foo"],
       }),
     ];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     const schema = result[0].input_schema as Record<string, unknown>;
-    expect(schema.required).toEqual(["foo", "reason"]);
+    expect(schema.required).toEqual(["foo", "activity"]);
   });
 
   test("creates required array if missing", () => {
@@ -53,38 +57,38 @@ describe("injectReasonField", () => {
         properties: { foo: { type: "string" } },
       }),
     ];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     const schema = result[0].input_schema as Record<string, unknown>;
-    expect(schema.required).toEqual(["reason"]);
+    expect(schema.required).toEqual(["activity"]);
   });
 
   test("skips tools in skip set (returns unchanged)", () => {
     const defs = [makeDef("bash"), makeDef("host_bash")];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     // Should be the exact same object references
     expect(Object.is(result[0], defs[0])).toBe(true);
     expect(Object.is(result[1], defs[1])).toBe(true);
-    // No reason injected
+    // No activity injected
     const schema0 = result[0].input_schema as Record<string, unknown>;
     const props0 = schema0.properties as Record<string, unknown>;
-    expect("reason" in props0).toBe(false);
+    expect("activity" in props0).toBe(false);
   });
 
-  test("skips tools that already have reason in properties", () => {
+  test("skips tools that already have activity in properties", () => {
     const defs = [
       makeDef("my_tool", {
         type: "object",
-        properties: { reason: { type: "number" } },
+        properties: { activity: { type: "number" } },
         required: [],
       }),
     ];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     // Should be the exact same object reference (no clone needed)
     expect(Object.is(result[0], defs[0])).toBe(true);
     const schema = result[0].input_schema as Record<string, unknown>;
     const props = schema.properties as Record<string, unknown>;
-    // Original reason type preserved
-    expect(props.reason).toEqual({ type: "number" });
+    // Original activity type preserved
+    expect(props.activity).toEqual({ type: "number" });
   });
 
   test("does NOT mutate original definition objects", () => {
@@ -97,10 +101,10 @@ describe("injectReasonField", () => {
     };
     const defs = [makeDef("my_tool", originalSchema)];
 
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
 
     // Original properties object is untouched
-    expect("reason" in originalProps).toBe(false);
+    expect("activity" in originalProps).toBe(false);
     // Original required array is untouched
     expect(originalRequired).toEqual(["foo"]);
     // Original schema properties ref is the same object
@@ -115,40 +119,40 @@ describe("injectReasonField", () => {
 
   test("passes through non-object schemas unchanged", () => {
     const defs = [makeDef("my_tool", { type: "string" })];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     expect(Object.is(result[0], defs[0])).toBe(true);
   });
 
   test("passes through schemas without properties unchanged", () => {
     const defs = [makeDef("my_tool", { type: "object" })];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     expect(Object.is(result[0], defs[0])).toBe(true);
   });
 
-  test("skips tools with reason defined inside allOf member (composite schema)", () => {
+  test("skips tools with activity defined inside allOf member (composite schema)", () => {
     const defs = [
       makeDef("my_tool", {
         type: "object",
         properties: { foo: { type: "string" } },
         allOf: [
           {
-            properties: { reason: { type: "string" } },
+            properties: { activity: { type: "string" } },
           },
         ],
         required: [],
       }),
     ];
-    const result = injectReasonField(defs);
+    const result = injectActivityField(defs);
     // Should be the exact same object reference (no injection)
     expect(Object.is(result[0], defs[0])).toBe(true);
     const schema = result[0].input_schema as Record<string, unknown>;
     const props = schema.properties as Record<string, unknown>;
-    // Top-level properties should NOT have reason injected
-    expect("reason" in props).toBe(false);
+    // Top-level properties should NOT have activity injected
+    expect("activity" in props).toBe(false);
   });
 
   test("handles empty definitions array", () => {
-    const result = injectReasonField([]);
+    const result = injectActivityField([]);
     expect(result).toEqual([]);
   });
 });
@@ -157,44 +161,44 @@ describe("schemaDefinesProperty", () => {
   test("returns true for direct properties match", () => {
     const schema = {
       type: "object",
-      properties: { reason: { type: "string" } },
+      properties: { activity: { type: "string" } },
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(true);
   });
 
   test("returns true for property in allOf member", () => {
     const schema = {
-      allOf: [{ properties: { reason: { type: "string" } } }],
+      allOf: [{ properties: { activity: { type: "string" } } }],
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(true);
   });
 
   test("returns true for property in oneOf member", () => {
     const schema = {
       oneOf: [
         { properties: { foo: { type: "string" } } },
-        { properties: { reason: { type: "string" } } },
+        { properties: { activity: { type: "string" } } },
       ],
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(true);
   });
 
   test("returns true for property in anyOf member", () => {
     const schema = {
-      anyOf: [{ properties: { reason: { type: "string" } } }],
+      anyOf: [{ properties: { activity: { type: "string" } } }],
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(true);
   });
 
   test("returns true for nested allOf within oneOf", () => {
     const schema = {
       oneOf: [
         {
-          allOf: [{ properties: { reason: { type: "string" } } }],
+          allOf: [{ properties: { activity: { type: "string" } } }],
         },
       ],
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(true);
   });
 
   test("returns false when property not defined", () => {
@@ -202,25 +206,25 @@ describe("schemaDefinesProperty", () => {
       type: "object",
       properties: { foo: { type: "string" } },
     };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(false);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(false);
   });
 
   test("returns false for $ref (fail-closed)", () => {
     const schema = { $ref: "#/definitions/Foo" };
-    expect(schemaDefinesProperty(schema, "reason")).toBe(false);
+    expect(schemaDefinesProperty(schema, "activity")).toBe(false);
   });
 
   test("returns false for null schema", () => {
-    expect(schemaDefinesProperty(null, "reason")).toBe(false);
+    expect(schemaDefinesProperty(null, "activity")).toBe(false);
   });
 
   test("returns false for undefined schema", () => {
-    expect(schemaDefinesProperty(undefined, "reason")).toBe(false);
+    expect(schemaDefinesProperty(undefined, "activity")).toBe(false);
   });
 
   test("returns false for non-object schema", () => {
-    expect(schemaDefinesProperty("not-an-object", "reason")).toBe(false);
-    expect(schemaDefinesProperty(42, "reason")).toBe(false);
-    expect(schemaDefinesProperty(true, "reason")).toBe(false);
+    expect(schemaDefinesProperty("not-an-object", "activity")).toBe(false);
+    expect(schemaDefinesProperty(42, "activity")).toBe(false);
+    expect(schemaDefinesProperty(true, "activity")).toBe(false);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -32,8 +32,8 @@ import {
   getMcpToolDefinitions,
 } from "../tools/registry.js";
 import {
-  injectReasonField,
-  REASON_SKIP_SET,
+  injectActivityField,
+  ACTIVITY_SKIP_SET,
 } from "../tools/schema-transforms.js";
 import type {
   ProxyApprovalCallback,
@@ -354,13 +354,14 @@ export function createToolExecutor(
       // Clone to avoid mutating shared input objects
       const toolInput = { ...rawToolInput };
 
-      // Propagate outer reason when inner input lacks a valid one
+      // Propagate outer activity when inner input lacks a valid one
       if (
-        typeof input.reason === "string" &&
-        input.reason &&
-        (typeof toolInput.reason !== "string" || toolInput.reason.length === 0)
+        typeof input.activity === "string" &&
+        input.activity &&
+        (typeof toolInput.activity !== "string" ||
+          toolInput.activity.length === 0)
       ) {
-        toolInput.reason = input.reason;
+        toolInput.activity = input.activity;
       }
 
       if (!toolName) {
@@ -683,6 +684,6 @@ export function createResolveToolsCallback(
       turnAllowed.add(name);
     }
     ctx.allowedToolNames = turnAllowed;
-    return injectReasonField(allBaseDefs, REASON_SKIP_SET);
+    return injectActivityField(allBaseDefs, ACTIVITY_SKIP_SET);
   };
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -43,8 +43,8 @@ import {
 } from "../../tools/execution-target.js";
 import { getAllTools, getTool } from "../../tools/registry.js";
 import {
-  injectReasonField,
-  REASON_SKIP_SET,
+  injectActivityField,
+  ACTIVITY_SKIP_SET,
 } from "../../tools/schema-transforms.js";
 import { isSideEffectTool } from "../../tools/side-effects.js";
 import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
@@ -400,17 +400,17 @@ function handleToolNamesList(): Response {
     }
   }
 
-  // Apply reason injection so settings/debug schemas match runtime behavior.
-  const transformedDefs = injectReasonField(rawDefs, REASON_SKIP_SET);
+  // Apply activity injection so settings/debug schemas match runtime behavior.
+  const transformedDefs = injectActivityField(rawDefs, ACTIVITY_SKIP_SET);
   for (const def of transformedDefs) {
     schemas[def.name] = def.input_schema as SchemaShape;
   }
 
   // Skill manifest schemas are served raw (untransformed). Unlike runtime tool
-  // schemas which have `reason` injected via injectReasonField(), skill manifests
-  // reflect the original TOOLS.json content. This is intentional: skill tools are
-  // invoked through skill_execute (which has its own reason field), so their
-  // individual schemas are never sent to the LLM directly.
+  // schemas which have `activity` injected via injectActivityField(), skill
+  // manifests reflect the original TOOLS.json content. This is intentional:
+  // skill tools are invoked through skill_execute (which has its own activity
+  // field), so their individual schemas are never sent to the LLM directly.
   try {
     const catalog = loadSkillCatalog();
     for (const skill of catalog) {

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -1,26 +1,29 @@
 import type { ToolDefinition } from "../providers/types.js";
 
 /**
- * Tools that should never have a `reason` field injected into their schema.
+ * Tools that should never have an `activity` field injected into their schema.
  */
-export const REASON_SKIP_SET = new Set<string>([
+export const ACTIVITY_SKIP_SET = new Set<string>([
   "skill_execute",
   "bash",
   "host_bash",
   "request_system_permission",
 ]);
 
+/** @deprecated Use ACTIVITY_SKIP_SET */
+export const REASON_SKIP_SET = ACTIVITY_SKIP_SET;
+
 /**
- * Injects a `reason` string property into each tool definition's input schema,
- * unless the tool is in the skip set, already has a reason field, or has a
- * non-object schema.
+ * Injects an `activity` string property into each tool definition's input
+ * schema, unless the tool is in the skip set, already has an activity field,
+ * or has a non-object schema.
  *
  * CRITICAL: Never mutates the input definitions - always returns deep clones
  * for any modified definition, since `getDefinition()` returns shared refs.
  */
-export function injectReasonField(
+export function injectActivityField(
   definitions: ToolDefinition[],
-  skip: Set<string> = REASON_SKIP_SET,
+  skip: Set<string> = ACTIVITY_SKIP_SET,
 ): ToolDefinition[] {
   return definitions.map((def) => {
     if (skip.has(def.name)) {
@@ -33,15 +36,22 @@ export function injectReasonField(
     }
 
     const properties = schema.properties as Record<string, unknown>;
-    if (schemaDefinesProperty(schema, "reason")) {
+    if (schemaDefinesProperty(schema, "activity")) {
       return def;
     }
 
     // Deep clone to avoid mutating shared refs
-    const newProperties = { ...properties, reason: { type: "string" } };
+    const newProperties = {
+      ...properties,
+      activity: {
+        type: "string",
+        description:
+          "Brief, natural description of what you're doing, shown as a live status update (e.g. 'Checking your project settings')",
+      },
+    };
     const existingRequired = Array.isArray(schema.required)
-      ? [...schema.required, "reason"]
-      : ["reason"];
+      ? [...schema.required, "activity"]
+      : ["activity"];
 
     return {
       ...def,
@@ -53,6 +63,9 @@ export function injectReasonField(
     };
   });
 }
+
+/** @deprecated Use injectActivityField */
+export const injectReasonField = injectActivityField;
 
 /**
  * Checks whether a JSON Schema defines a given property name.

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -587,9 +587,11 @@ public func confirmationHumanDescription(
     toolCategory: String? = nil,
     permissionFriendlyName: String? = nil
 ) -> String {
-    // Use reason, falling back to description/message for tools that provide
-    // context via other fields (e.g. context_overflow_compression uses description)
-    let rawReason = (input["reason"]?.value as? String) ?? ""
+    // Use activity (or legacy reason), falling back to description/message for
+    // tools that provide context via other fields (e.g. context_overflow_compression uses description)
+    let rawReason = (input["activity"]?.value as? String)
+        ?? (input["reason"]?.value as? String)
+        ?? ""
     let reason: String = rawReason.isEmpty
         ? (input["description"]?.value as? String)
             ?? (input["message"]?.value as? String)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1310,7 +1310,8 @@ extension ChatViewModel {
                 messages[msgIndex].toolCalls[tcIndex].inputRawValue = extractToolInput(msg.input)
                 messages[msgIndex].toolCalls[tcIndex].inputRawDict = msg.input
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = buildingStatus
-                messages[msgIndex].toolCalls[tcIndex].reasonDescription = (msg.input["reason"]?.value as? String)
+                messages[msgIndex].toolCalls[tcIndex].reasonDescription = (msg.input["activity"]?.value as? String)
+                    ?? (msg.input["reason"]?.value as? String)
                     ?? (msg.input["reasoning"]?.value as? String)
                 break
             }
@@ -1325,7 +1326,8 @@ extension ChatViewModel {
             toolCall.buildingStatus = buildingStatus
             toolCall.toolUseId = msg.toolUseId
             toolCall.inputRawDict = msg.input
-            toolCall.reasonDescription = (msg.input["reason"]?.value as? String)
+            toolCall.reasonDescription = (msg.input["activity"]?.value as? String)
+                ?? (msg.input["reason"]?.value as? String)
                 ?? (msg.input["reasoning"]?.value as? String)
             // Add to existing assistant message or create one.
             // Cap at 100 tool calls per message to prevent unbounded memory growth;

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2574,7 +2574,8 @@ public final class ChatViewModel: ObservableObject {
                         imageData: nil
                     )
                     toolCall.cachedImage = decodedImage
-                    toolCall.reasonDescription = (tc.input["reason"]?.value as? String)
+                    toolCall.reasonDescription = (tc.input["activity"]?.value as? String)
+                        ?? (tc.input["reason"]?.value as? String)
                         ?? (tc.input["reasoning"]?.value as? String)
                     // Restore persisted timing and confirmation data
                     if let startMs = tc.startedAt {


### PR DESCRIPTION
## Summary
- Renamed the injected tool schema field from `reason` to `activity` with a description that primes the model to produce natural present-tense status labels (e.g. "Checking your project settings" instead of "To get current IDENTITY.md content for editing")
- Added deprecated aliases (`REASON_SKIP_SET`, `injectReasonField`) for backwards compatibility
- Updated Swift clients to read `activity` first, falling back to `reason` then `reasoning` for backwards compat with in-flight conversations

## Original prompt
Rename the `reason` variable in tool schemas to something that produces more natural-sounding status descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
