### PR TITLE
fix: don't set httpBody on GET requests in HTTPDaemonClient

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -345,7 +345,11 @@ extension HTTPTransport {
         applyAuth(&request)
 
         do {
-            request.httpBody = try encoder.encode(body)
+            // Only set body for methods that support it — GET requests with
+            // a body cause URLError.dataLengthExceedsMaximum on macOS.
+            if method != "GET" {
+                request.httpBody = try encoder.encode(body)
+            }
             let (_, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
                 log.debug("\(label) succeeded via HTTP")
@@ -384,7 +388,11 @@ extension HTTPTransport {
         applyAuth(&request)
 
         do {
-            request.httpBody = try encoder.encode(body)
+            // Only set body for methods that support it — GET requests with
+            // a body cause URLError.dataLengthExceedsMaximum on macOS.
+            if method != "GET" {
+                request.httpBody = try encoder.encode(body)
+            }
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else { return }
 


### PR DESCRIPTION
## Summary
- On macOS, `URLSession` rejects GET requests with `httpBody` set, throwing `URLError.dataLengthExceedsMaximum` ("resource exceeds maximum size")
- `sendEncodablePost` and `sendEncodablePostAndDispatch` were unconditionally setting `httpBody` even for GET requests, causing Telegram config status and ingress config GET requests to fail on every app launch
- Skip setting `httpBody` when `method == "GET"` — the daemon ignores the body on GET endpoints anyway

## Original prompt
Fix the "resource exceeds maximum size" error shown in the Telegram channel card on every app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
