### PR TITLE
fix: sort imports in schema-transforms consumers

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import type { ToolDefinition } from "../providers/types.js";
 import {
-  injectActivityField,
   ACTIVITY_SKIP_SET,
+  injectActivityField,
   schemaDefinesProperty,
 } from "../tools/schema-transforms.js";
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -32,8 +32,8 @@ import {
   getMcpToolDefinitions,
 } from "../tools/registry.js";
 import {
-  injectActivityField,
   ACTIVITY_SKIP_SET,
+  injectActivityField,
 } from "../tools/schema-transforms.js";
 import type {
   ProxyApprovalCallback,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -43,8 +43,8 @@ import {
 } from "../../tools/execution-target.js";
 import { getAllTools, getTool } from "../../tools/registry.js";
 import {
-  injectActivityField,
   ACTIVITY_SKIP_SET,
+  injectActivityField,
 } from "../../tools/schema-transforms.js";
 import { isSideEffectTool } from "../../tools/side-effects.js";
 import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in three files that import from `schema-transforms.js`
- `ACTIVITY_SKIP_SET` now sorts before `injectActivityField` (alphabetical order)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23186885341/job/67372547086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
