### PR TITLE
fix: change truncated badge color from red to yellow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -689,11 +689,11 @@ private struct StepDetailRow: View {
                     if isTruncated {
                         Text("truncated")
                             .font(VFont.caption)
-                            .foregroundColor(VColor.systemNegativeHover)
+                            .foregroundColor(VColor.systemMidStrong)
                             .padding(.horizontal, VSpacing.xs)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.xs)
-                                    .fill(VColor.systemNegativeHover.opacity(0.12))
+                                    .fill(VColor.systemMidStrong.opacity(0.12))
                             )
                     }
                 }

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -122,11 +122,11 @@ public struct ToolCallChip: View {
                             if isTruncated {
                                 Text("truncated")
                                     .font(VFont.caption)
-                                    .foregroundColor(VColor.systemNegativeHover)
+                                    .foregroundColor(VColor.systemMidStrong)
                                     .padding(.horizontal, VSpacing.xs)
                                     .background(
                                         RoundedRectangle(cornerRadius: VRadius.xs)
-                                            .fill(VColor.systemNegativeHover.opacity(0.12))
+                                            .fill(VColor.systemMidStrong.opacity(0.12))
                                     )
                             }
                         }


### PR DESCRIPTION
## Summary
- Changed the "truncated" badge color on tool call results from red (`systemNegativeHover`) to yellow/warning (`systemMidStrong`) so it feels less alarming
- Truncation is informational (the assistant still saw the full output), not an error — yellow better communicates this
- Updated both `ToolCallChip.swift` (shared/iOS) and `AssistantProgressView.swift` (macOS)

## Original prompt
the orange is more like red, can we make it yellow instead so it's less scary?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
