### PR TITLE
feat: raise tool result client truncation cap from 2K to 20K chars

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -168,12 +168,12 @@ export function emitLlmCallStartedIfNeeded(
 }
 
 // ── Client Payload Size Caps ─────────────────────────────────────────
-// The client truncates tool results anyway (2 000 chars in ChatViewModel),
+// The client truncates tool results anyway (20 000 chars in ChatViewModel),
 // but the full string can be megabytes (file_read, bash output). Capping
 // here avoids sending oversized payloads which get decoded on the
 // client's main thread.
 
-const TOOL_RESULT_MAX_CHARS = 2_000;
+const TOOL_RESULT_MAX_CHARS = 20_000;
 const TOOL_RESULT_TRUNCATION_SUFFIX = "...[truncated]";
 
 // tool_input_delta streams accumulated JSON as tools run. For non-app

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1527,7 +1527,7 @@ extension ChatViewModel {
                 }
             }
             if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
-                let truncatedResult = msg.result.count > 2000 ? String(msg.result.prefix(2000)) + "...[truncated]" : msg.result
+                let truncatedResult = msg.result.count > 20000 ? String(msg.result.prefix(20000)) + "...[truncated]" : msg.result
                 messages[msgIndex].toolCalls[tcIndex].result = truncatedResult
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2555,7 +2555,7 @@ public final class ChatViewModel: ObservableObject {
                     // Truncate tool result for memory safety
                     let truncatedResult: String? = {
                         guard let result = tc.result else { return nil }
-                        return result.count > 2000 ? String(result.prefix(2000)) + "...[truncated]" : result
+                        return result.count > 20000 ? String(result.prefix(20000)) + "...[truncated]" : result
                     }()
 
                     // Decode image once — pass decoded image directly to avoid double-decode


### PR DESCRIPTION
## Summary
- Raised the tool result truncation cap for client display from 2,000 to 20,000 characters
- This affects the payload sent from the daemon to the client app — the assistant model's own truncation limits are unchanged

## Original prompt
let's raise the cap from 2000 characters to 20000 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)