### PR TITLE
fix: compute code viewer line height from font metrics

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -233,11 +233,13 @@ struct HighlightedTextView: View {
         .background(Self.gutterBackground)
     }
 
-    /// Approximate line height for the mono font to align line numbers with text lines.
-    private var lineHeight: CGFloat {
-        // DMMono-Regular at 13pt has ~16pt line height in SwiftUI's default rendering
-        16
-    }
+    /// Line height for the text content font, computed from actual NSFont metrics
+    /// so the gutter stays aligned even if the font or size changes.
+    private static let lineHeight: CGFloat = {
+        let nsFont = NSFont(name: "DMMono-Regular", size: 13)
+            ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        return ceil(nsFont.lineHeight)
+    }()
 
     private func gutterWidth(for lineCount: Int) -> CGFloat {
         let digitCount = max(3, "\(lineCount)".count)


### PR DESCRIPTION
## Summary
- Replace the hardcoded `lineHeight = 16` in `HighlightedTextView` with a value computed from `NSFont.lineHeight` for DMMono-Regular at 13pt
- This ensures the line number gutter stays aligned with the text content regardless of actual font metrics

## Original prompt
These line numbers are misaligned with the actual text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
