### PR TITLE
feat: open image preview when clicking composer attachment chip

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -64,6 +64,31 @@ extension ComposerView {
         .background(VColor.borderBase.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .frame(maxWidth: 280)
+        .if(isImage) { view in
+            view
+                .contentShape(Rectangle())
+                .onTapGesture { openAttachmentPreview(attachment) }
+                .pointerCursor()
+        }
+    }
+}
+
+// MARK: - Attachment Preview
+
+extension ComposerView {
+    func openAttachmentPreview(_ attachment: ChatAttachment) {
+        guard !attachment.data.isEmpty,
+              let data = Data(base64Encoded: attachment.data),
+              !data.isEmpty else { return }
+        let tempDir = FileManager.default.temporaryDirectory
+        let sanitized = (attachment.filename as NSString).lastPathComponent
+        let fileURL = tempDir.appendingPathComponent(sanitized.isEmpty ? "image" : sanitized)
+        do {
+            try data.write(to: fileURL)
+            NSWorkspace.shared.open(fileURL)
+        } catch {
+            // Silently fail — not critical
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add tap gesture to image attachment chips in the composer so clicking them opens a full-size preview in the system image viewer
- Reuses the same `NSWorkspace.shared.open()` pattern already used for sent message image attachments
- Shows pointer cursor on image chips to indicate clickability

## Original prompt
when I click an image I added to the chat it should open up a preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)