### PR TITLE
fix: use NSFont ascender/descender/leading for code viewer line height

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -223,7 +223,7 @@ struct HighlightedTextView: View {
                 Text("\(num)")
                     .font(VFont.monoSmall)
                     .foregroundStyle(Self.gutterTextColor)
-                    .frame(height: lineHeight)
+                    .frame(height: Self.lineHeight)
             }
         }
         .padding(.top, VSpacing.sm)
@@ -238,7 +238,7 @@ struct HighlightedTextView: View {
     private static let lineHeight: CGFloat = {
         let nsFont = NSFont(name: "DMMono-Regular", size: 13)
             ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        return ceil(nsFont.lineHeight)
+        return ceil(nsFont.ascender - nsFont.descender + nsFont.leading)
     }()
 
     private func gutterWidth(for lineCount: Int) -> CGFloat {


### PR DESCRIPTION
## Summary
- Replace `nsFont.lineHeight` (which doesn't exist on `NSFont`) with `nsFont.ascender - nsFont.descender + nsFont.leading`
- Add `Self.` prefix to access the static `lineHeight` property from an instance method

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23187846262/job/67375848917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
