### PR TITLE
fix: use NSFont metrics instead of UIFont lineHeight in code viewer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -238,7 +238,9 @@ struct HighlightedTextView: View {
     private static let lineHeight: CGFloat = {
         let nsFont = NSFont(name: "DMMono-Regular", size: 13)
             ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        return ceil(nsFont.lineHeight)
+        // NSFont doesn't have lineHeight (that's UIFont); compute from metrics.
+        // descender is negative, so subtracting it adds the absolute value.
+        return ceil(nsFont.ascender - nsFont.descender + nsFont.leading)
     }()
 
     private func gutterWidth(for lineCount: Int) -> CGFloat {


### PR DESCRIPTION
## Summary
- `NSFont.lineHeight` doesn't exist on macOS (it's a `UIFont` property on iOS), causing the Swift build to fail on CI
- Replaced with `nsFont.ascender - nsFont.descender + nsFont.leading` which is the standard macOS way to compute line height from font metrics

## Original prompt
Fix this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
