### PR TITLE
fix: resolve relative workspace paths in chat markdown images

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -85,6 +85,15 @@ struct AnimatedImageView: View {
             return
         }
 
+        // Resolve relative workspace paths (e.g. "data/avatar/avatar-image.png")
+        if !urlString.contains("://") {
+            let workspaceDir = NSHomeDirectory() + "/.vellum/workspace"
+            let fileURL = URL(fileURLWithPath: workspaceDir + "/" + urlString)
+            imageData = try? Data(contentsOf: fileURL)
+            loadedImage = imageData.flatMap { NSImage(data: $0) }
+            return
+        }
+
         guard let url = URL(string: urlString) else { return }
 
         do {


### PR DESCRIPTION
## Summary
- Fix broken image rendering when LLM produces markdown images with workspace-relative paths (e.g. `data/avatar/avatar-image.png`)
- `AnimatedImageView.loadImage()` only handled absolute paths (`/...`, `file://...`) and HTTP URLs — relative paths fell through to `URL(string:)` which returned nil
- Add a new branch that detects relative paths (no `://` scheme) and resolves them against `~/.vellum/workspace/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
