### PR TITLE
fix: prevent message text truncation and footer overlap in chat bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -348,38 +348,26 @@ struct ChatBubble: View {
                     }
                 } else if hasText {
                     let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
-                    let hasRichContent = segments.contains(where: {
-                        switch $0 {
-                        case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
-                        case .text: return false
-                        }
-                    })
-                    if hasRichContent {
-                        MarkdownSegmentView(
-                            segments: segments,
-                            maxContentWidth: nil,
-                            textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
-                            secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
-                            mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,
-                            tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
-                            codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
-                            codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
-                            hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
-                        )
-                    } else {
-                        Text(markdownText)
-                            .font(.system(size: 14 * conversationZoomScale))
-                            .lineSpacing(6)
-                            .foregroundColor(isUser ? VColor.contentDefault : VColor.contentDefault)
-                            .tint(isUser ? VColor.contentDefault : VColor.primaryBase)
-                            .textSelection(.enabled)
-                            // For assistant messages, fill available width for readability.
-                            // For user messages, let the bubble shrink-wrap to text width.
-                            .frame(maxWidth: isUser ? nil : .infinity, alignment: .leading)
-                            // lineLimit(nil) wraps text in a single measurement pass,
-                            // avoiding the double-measurement that fixedSize causes.
-                            .lineLimit(nil)
-                    }
+                    // Always render through MarkdownSegmentView to keep view
+                    // identity stable across async segment parsing transitions.
+                    // When a large message first renders, resolveSegments returns
+                    // [.text(text)] (plain placeholder) before async parsing
+                    // completes with rich segments (tables, headings, etc.).
+                    // Branching on hasRichContent used to switch between Text and
+                    // MarkdownSegmentView — different view types that caused
+                    // LazyVStack to use stale height measurements, resulting in
+                    // content truncation and footer overlap.
+                    MarkdownSegmentView(
+                        segments: segments,
+                        maxContentWidth: isUser ? nil : nil,
+                        textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
+                        secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
+                        mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,
+                        tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
+                        codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
+                        codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
+                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
+                    )
                 } else if !message.attachments.isEmpty {
                     Text(attachmentSummary)
                         .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -11,29 +11,14 @@ extension ChatBubble {
     func textBubble(for segmentText: String) -> some View {
         let streaming = message.isStreaming
         let segments = resolveSegments(for: segmentText, isStreaming: streaming)
-        let hasRichContent = segments.contains(where: {
-            switch $0 {
-            case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
-            case .text: return false
-            }
-        })
 
         bubbleChrome {
-            if hasRichContent {
-                MarkdownSegmentView(segments: segments)
-            } else {
-                let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
-                Text(attributed)
-                    .font(.system(size: 14 * conversationZoomScale))
-                    .lineSpacing(6)
-                    .foregroundColor(VColor.contentDefault)
-                    .tint(VColor.primaryBase)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
-                    // lineLimit(nil) wraps text in a single measurement pass,
-                    // avoiding the double-measurement that fixedSize causes.
-                    .lineLimit(nil)
-            }
+            // Always render through MarkdownSegmentView to keep view
+            // identity stable across async segment parsing transitions.
+            // Switching between Text and MarkdownSegmentView caused
+            // LazyVStack to use stale height measurements, resulting in
+            // content truncation and footer overlap.
+            MarkdownSegmentView(segments: segments)
         }
         .task(id: "\(segmentText)|\(streaming)") {
             // Only run async parsing for large, non-streaming text with a cache miss

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -392,5 +392,8 @@ struct MarkdownTableView: View {
             .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.contentDefault)
             .textSelection(.enabled)
+            // lineLimit(nil) ensures text wraps within the column width
+            // instead of truncating with "..." on a single line.
+            .lineLimit(nil)
     }
 }


### PR DESCRIPTION
## Summary
- Always render message text through `MarkdownSegmentView` instead of branching between `Text` and `MarkdownSegmentView` based on `hasRichContent` — the view type switch during async segment parsing caused `LazyVStack` to cache stale height measurements, resulting in content truncation ("...") and footer overlap
- Add `.lineLimit(nil)` to `MarkdownTableView` cell text so table content wraps within column width instead of truncating on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
