### PR TITLE
fix: prevent SIGBUS crash in interleaved content bubble overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -86,12 +86,16 @@ struct ChatBubble: View {
         }
     }
 
-    @ViewBuilder
     private var bubbleBorderOverlay: some View {
-        if message.isError || (isUser && message.status == .sendFailed) {
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .strokeBorder(VColor.systemNegativeStrong.opacity(0.3), lineWidth: 1)
-        }
+        // Always produce a non-Optional view type. Using @ViewBuilder with
+        // a bare `if` (no else) wraps the result in Optional<StrokeBorderShapeView>.
+        // Combined with the simplified textBubble return type (no _ConditionalContent),
+        // the Optional variant triggers a SwiftUI attribute graph bug during lazy
+        // list layout: the .none payload's undefined bytes get misinterpreted as
+        // ARC references, causing swift_retain on read-only metadata (SIGBUS).
+        RoundedRectangle(cornerRadius: VRadius.lg)
+            .strokeBorder(VColor.systemNegativeStrong.opacity(0.3), lineWidth: 1)
+            .opacity((message.isError || (isUser && message.status == .sendFailed)) ? 1 : 0)
     }
 
     func bubbleChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {


### PR DESCRIPTION
## Summary
- **Root cause**: `bubbleBorderOverlay` used `@ViewBuilder` with a bare `if` (no `else`), producing `Optional<StrokeBorderShapeView>`. After #18232 simplified `textBubble`'s return type, this triggered a SwiftUI attribute graph bug during lazy list layout — the `.none` payload's undefined bytes were misinterpreted as ARC references, crashing in `swift_retain` on read-only SwiftUICore metadata (`EXC_BAD_ACCESS / SIGBUS`).
- **Fix**: Replace the conditional `@ViewBuilder` with `.opacity(0/1)` so the overlay always produces a non-Optional view type, avoiding the type confusion entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
