### PR TITLE
fix: switch OpenRouter to Grok 4.20 Beta with reasoning enabled

### DIFF
--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -110,10 +110,10 @@ const PROVIDER_MODEL_SHORTCUTS: Record<
     model: "x-ai/grok-4",
     displayName: "Grok 4 (OpenRouter)",
   },
-  "grok-multi": {
+  "grok-beta": {
     provider: "openrouter",
-    model: "x-ai/grok-4.20-multi-agent-beta",
-    displayName: "Grok 4.20 Multi-Agent (OpenRouter)",
+    model: "x-ai/grok-4.20-beta",
+    displayName: "Grok 4.20 Beta (OpenRouter)",
   },
 };
 

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -42,7 +42,7 @@ const PROVIDER_MODEL_INTENTS: Record<
   },
   openrouter: {
     "latency-optimized": "x-ai/grok-4",
-    "quality-optimized": "x-ai/grok-4.20-multi-agent-beta",
+    "quality-optimized": "x-ai/grok-4.20-beta",
     "vision-optimized": "x-ai/grok-4",
   },
 };

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -19,6 +19,8 @@ export interface OpenAICompatibleProviderOptions {
   providerName?: string;
   providerLabel?: string;
   streamTimeoutMs?: number;
+  /** Extra params spread into every chat.completions.create call (e.g. reasoning). */
+  extraCreateParams?: Record<string, unknown>;
 }
 
 const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
@@ -34,6 +36,7 @@ export class OpenAIProvider implements Provider {
   private client: OpenAI;
   private model: string;
   private streamTimeoutMs: number;
+  private extraCreateParams: Record<string, unknown>;
 
   constructor(
     apiKey: string,
@@ -48,6 +51,7 @@ export class OpenAIProvider implements Provider {
     });
     this.model = model;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
+    this.extraCreateParams = options.extraCreateParams ?? {};
   }
 
   async sendMessage(
@@ -70,6 +74,7 @@ export class OpenAIProvider implements Provider {
           messages: openaiMessages,
           stream: true as const,
           stream_options: { include_usage: true },
+          ...this.extraCreateParams,
         };
 
       if (maxTokens) {

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -19,6 +19,7 @@ export class OpenRouterProvider extends OpenAIProvider {
       providerName: "openrouter",
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
+      extraCreateParams: { reasoning: { enabled: true } },
     });
   }
 }


### PR DESCRIPTION
## Summary
- Switch OpenRouter quality model from `x-ai/grok-4.20-multi-agent-beta` to `x-ai/grok-4.20-beta` — the multi-agent variant has no endpoints supporting tool use
- Enable `reasoning: { enabled: true }` for all OpenRouter requests via a new `extraCreateParams` option on the OpenAI-compatible provider
- Rename `/grok-multi` shortcut to `/grok-beta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
