### PR TITLE
fix: center-align status text on hatching screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -141,8 +141,11 @@ struct HatchingStepView: View {
                 Text("Your assistant will ask a few quick questions to get started.\nThis usually takes less than a minute.")
                     .font(.system(size: 13))
                     .foregroundColor(VColor.contentTertiary)
+                    .multilineTextAlignment(.center)
             }
         }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 320)
     }
 
     // MARK: - Failure Buttons


### PR DESCRIPTION
## Summary
- Add `.multilineTextAlignment(.center)` to the multi-line description text on the HatchingStepView so it aligns with the centered title and subtitle
- Constrain the status text VStack to `maxWidth: 320` for a polished, balanced layout across all states (waking, failed, completed)

## Original prompt
Center-align the multi-line text on the HatchingStepView (waking up screen) and constrain the status text width for a polished layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
