### PR TITLE
refactor: rename remaining tool 'reason' params to 'activity'

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -15,12 +15,8 @@ function makeDef(
 }
 
 describe("ACTIVITY_SKIP_SET", () => {
-  test("contains expected tool names", () => {
-    expect(ACTIVITY_SKIP_SET.has("skill_execute")).toBe(true);
-    expect(ACTIVITY_SKIP_SET.has("bash")).toBe(true);
-    expect(ACTIVITY_SKIP_SET.has("host_bash")).toBe(true);
-    expect(ACTIVITY_SKIP_SET.has("request_system_permission")).toBe(true);
-    expect(ACTIVITY_SKIP_SET.size).toBe(4);
+  test("is empty (all tools now define their own activity property)", () => {
+    expect(ACTIVITY_SKIP_SET.size).toBe(0);
   });
 });
 

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -21,7 +21,7 @@ function proxyExecute(): Promise<ToolExecutionResult> {
   );
 }
 
-const reasonProperty = {
+const activityProperty = {
   type: "string" as const,
   description:
     "Brief non-technical explanation of why this tool is being called",
@@ -69,7 +69,7 @@ export const computerUseClickTool: Tool = {
             description:
               "Explanation of what you see and why you are clicking here",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["reasoning"],
       },
@@ -106,7 +106,7 @@ export const computerUseTypeTextTool: Tool = {
             type: "string",
             description: "Explanation of what you are typing and why",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["text", "reasoning"],
       },
@@ -144,7 +144,7 @@ export const computerUseKeyTool: Tool = {
             type: "string",
             description: "Explanation of why you are pressing this key",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["key", "reasoning"],
       },
@@ -199,7 +199,7 @@ export const computerUseScrollTool: Tool = {
             type: "string",
             description: "Explanation of why you are scrolling",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["direction", "amount", "reasoning"],
       },
@@ -260,7 +260,7 @@ export const computerUseDragTool: Tool = {
             type: "string",
             description: "Explanation of what you are dragging and why",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["reasoning"],
       },
@@ -296,7 +296,7 @@ export const computerUseWaitTool: Tool = {
             type: "string",
             description: "Explanation of what you are waiting for",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["duration_ms", "reasoning"],
       },
@@ -335,7 +335,7 @@ export const computerUseOpenAppTool: Tool = {
             description:
               "Explanation of why you need to open or switch to this app",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["app_name", "reasoning"],
       },
@@ -373,7 +373,7 @@ export const computerUseRunAppleScriptTool: Tool = {
             description:
               "Explanation of what this script does and why AppleScript is better than UI interaction for this step",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["script", "reasoning"],
       },
@@ -406,7 +406,7 @@ export const computerUseDoneTool: Tool = {
             type: "string",
             description: "Human-readable summary of what was accomplished",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["summary"],
       },
@@ -443,7 +443,7 @@ export const computerUseRespondTool: Tool = {
             type: "string",
             description: "Explanation of how you determined the answer",
           },
-          reason: reasonProperty,
+          activity: activityProperty,
         },
         required: ["answer", "reasoning"],
       },
@@ -472,9 +472,9 @@ export const computerUseObserveTool: Tool = {
       input_schema: {
         type: "object",
         properties: {
-          reason: reasonProperty,
+          activity: activityProperty,
         },
-        required: ["reason"],
+        required: ["activity"],
       },
     };
   },

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -67,7 +67,7 @@ class HostShellTool implements Tool {
             type: "string",
             description: "The host shell command to execute",
           },
-          reason: {
+          activity: {
             type: "string",
             description:
               'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
@@ -83,7 +83,7 @@ class HostShellTool implements Tool {
               "Optional timeout in seconds. Uses configured default and max limits.",
           },
         },
-        required: ["command", "reason"],
+        required: ["command", "activity"],
       },
     };
   }

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -37,9 +37,9 @@ export function createMcpTool(
 ): Tool {
   const namespacedName = mcpToolName(serverId, metadata.name);
   const riskLevel = riskMap[serverConfig.defaultRiskLevel] ?? RiskLevel.High;
-  const serverDefinesReason = schemaDefinesProperty(
+  const serverDefinesActivity = schemaDefinesProperty(
     metadata.inputSchema,
-    "reason",
+    "activity",
   );
 
   return {
@@ -64,14 +64,14 @@ export function createMcpTool(
       _context: ToolContext,
     ): Promise<ToolExecutionResult> {
       try {
-        // Strip injected reason before sending to MCP server
-        const { reason: _reason, ...mcpInput } = input as Record<
+        // Strip injected activity before sending to MCP server
+        const { activity: _activity, ...mcpInput } = input as Record<
           string,
           unknown
         > & {
-          reason?: unknown;
+          activity?: unknown;
         };
-        const forwardInput = serverDefinesReason ? input : mcpInput;
+        const forwardInput = serverDefinesActivity ? input : mcpInput;
         const result = await manager.callTool(
           serverId,
           metadata.name,

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -2,16 +2,9 @@ import type { ToolDefinition } from "../providers/types.js";
 
 /**
  * Tools that should never have an `activity` field injected into their schema.
+ * Now empty — all tools define their own `activity` property or get it injected.
  */
-export const ACTIVITY_SKIP_SET = new Set<string>([
-  "skill_execute",
-  "bash",
-  "host_bash",
-  "request_system_permission",
-]);
-
-/** @deprecated Use ACTIVITY_SKIP_SET */
-export const REASON_SKIP_SET = ACTIVITY_SKIP_SET;
+export const ACTIVITY_SKIP_SET = new Set<string>();
 
 /**
  * Injects an `activity` string property into each tool definition's input
@@ -63,9 +56,6 @@ export function injectActivityField(
     };
   });
 }
-
-/** @deprecated Use injectActivityField */
-export const injectReasonField = injectActivityField;
 
 /**
  * Checks whether a JSON Schema defines a given property name.

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -27,7 +27,7 @@ export class SkillExecuteTool implements Tool {
             description:
               "Tool-specific parameters as documented in the skill's instructions",
           },
-          reason: {
+          activity: {
             type: "string",
             description:
               "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -71,13 +71,13 @@ class RequestSystemPermissionTool implements Tool {
             enum: [...PERMISSION_TYPES],
             description: "The macOS system permission to request",
           },
-          reason: {
+          activity: {
             type: "string",
             description:
               "Short explanation of why this permission is needed (shown to the user)",
           },
         },
-        required: ["permission_type", "reason"],
+        required: ["permission_type", "activity"],
       },
     };
   }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -100,7 +100,7 @@ class ShellTool implements Tool {
             type: "string",
             description: "The shell command to execute",
           },
-          reason: {
+          activity: {
             type: "string",
             description:
               'Brief non-technical explanation of what this command does and why, shown to a non-technical user in the permission prompt. Avoid jargon and technical terms. Good: "to check if a required program is installed on your computer". Bad: "to check if gcloud CLI is installed". Good: "to download a helper program". Bad: "to run npm install".',
@@ -123,7 +123,7 @@ class ShellTool implements Tool {
               'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
           },
         },
-        required: ["command", "reason"],
+        required: ["command", "activity"],
       },
     };
   }


### PR DESCRIPTION
## Summary
- Renamed `reason` → `activity` in all remaining tool schemas (bash, host_bash, skill_execute, request_system_permission, and all 11 computer-use tools)
- Updated MCP tool factory to strip the injected `activity` field (instead of the old `reason`) before forwarding to MCP servers
- Emptied `ACTIVITY_SKIP_SET` and removed deprecated `REASON_SKIP_SET`/`injectReasonField` aliases — all tools now define their own `activity` property, so the `schemaDefinesProperty` check handles deduplication naturally

## Original prompt
Let's change the remaining tools that still have "reason" to "activity"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
