### PR TITLE
fix: rename stale session variable names to conversation in conversation-routes.ts

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -493,16 +493,16 @@ function makeHubPublisher(
     }
 
     // ServerMessage is a large union; conversationId exists on most but not all variants.
-    const msgSessionId =
+    const msgConversationId =
       "conversationId" in msg &&
       typeof (msg as { conversationId?: unknown }).conversationId === "string"
         ? (msg as { conversationId: string }).conversationId
         : undefined;
-    const resolvedSessionId = msgSessionId ?? conversationId;
+    const resolvedConversationId = msgConversationId ?? conversationId;
     const event = buildAssistantEvent(
       DAEMON_INTERNAL_ASSISTANT_ID,
       msg,
-      resolvedSessionId,
+      resolvedConversationId,
     );
     hubChain = (async () => {
       await hubChain;
@@ -942,7 +942,7 @@ export async function handleSendMessage(
       );
 
       // Defer event publishing to next tick so the HTTP response reaches the
-      // client first. This ensures the client's serverToLocalSessionMap is
+      // client first. This ensures the client's serverToLocalConversationMap is
       // populated before SSE events arrive, preventing dropped events in new
       // desktop conversations.
       //


### PR DESCRIPTION
## Summary
- Renames local variables `msgSessionId` → `msgConversationId` and `resolvedSessionId` → `resolvedConversationId`
- Updates stale comment referencing `serverToLocalSessionMap` → `serverToLocalConversationMap`

## Original prompt
fix these two remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
