### PR TITLE
fix: log warning when JWT-verified actor resolves to unknown trust class

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -653,6 +653,17 @@ export async function handleSendMessage(
       conversationExternalId: "local",
       actorExternalId: authContext.actorPrincipalId,
     });
+    if (trustCtx.trustClass === "unknown") {
+      log.warn(
+        {
+          actorPrincipalId: authContext.actorPrincipalId,
+          sourceChannel,
+          trustClass: trustCtx.trustClass,
+          principalType: authContext.principalType,
+        },
+        "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+      );
+    }
     conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
   } else {
     // Service principals (svc_gateway) or tokens without an actor ID


### PR DESCRIPTION
## Summary

- Adds a warning log in `handleSendMessage` when a JWT-verified `actor:` principal resolves to `trustClass: "unknown"` during trust resolution
- Logs `actorPrincipalId`, `sourceChannel`, `trustClass`, and `principalType` so the mismatch is immediately diagnosable in logs
- Addresses a silent failure mode where guardian binding drift (e.g. after DB resets) causes the macOS app's authenticated requests to be denied with no logging

## Original prompt

Add defensive logging when a JWT-verified actor principal resolves to trustClass "unknown" in the handleSendMessage path (conversation-routes.ts). When authContext.actorPrincipalId is set but resolveTrustContext returns trustClass "unknown", log a warning with the actorPrincipalId, sourceChannel, and trustClass so the mismatch is easy to diagnose. This helps catch guardian binding drift (e.g., after DB resets) without silently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
