### PR TITLE
fix: enter draft mode after archiving last conversation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -635,10 +635,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         // If all non-private conversations are now archived, sleep the assistant
-        // so it stops running and sending notifications.
+        // so it stops running and sending notifications, and enter draft mode so
+        // the UI shows the new-conversation state instead of a stale loading view.
         if visibleConversations.isEmpty {
             log.info("All conversations archived — sleeping assistant")
             sleepAssistantAfterArchive()
+            enterDraftMode()
         } else if activeConversationId == id {
             // The archived conversation was active — select an adjacent visible one.
             let visibleAfter = conversations[index...].dropFirst().first(where: { !$0.isArchived })


### PR DESCRIPTION
## Summary
- When all conversations are archived, `activeConversationId` was left pointing to the archived conversation whose `ChatViewModel` had already been removed, causing a stale loading state
- Added `enterDraftMode()` call after `sleepAssistantAfterArchive()` so the UI transitions to the "new conversation" screen

## Original prompt
When I archive the last conversation I get into this weird loading state. It should take me back to the new conversation state instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
