### PR TITLE
fix: enable isRichText so NSTextView renders syntax highlighting attributes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
@@ -102,7 +102,7 @@ struct SyntaxTextView: NSViewRepresentable {
         let textView = NSTextView()
         textView.isEditable = true
         textView.isSelectable = true
-        textView.isRichText = false
+        textView.isRichText = true
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false


### PR DESCRIPTION
## Summary
- Change `isRichText` from `false` to `true` on the NSTextView in SyntaxTextView
- With `isRichText = false`, NSTextView ignores per-character attributes in the text storage and only uses its own `font`/`textColor` properties — making syntax highlighting invisible
- With `isRichText = true`, the text storage attributes set by `SyntaxTheme.applyHighlighting` are rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
