### PR TITLE
fix: update tests and manifest for reason→activity rename

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -283,11 +283,11 @@ describe("host_bash — regression: no proxied-mode additions", () => {
     expect(schemaProps).not.toHaveProperty("credential_ids");
   });
 
-  test("schema only contains the expected properties (command, working_dir, timeout_seconds, reason)", () => {
+  test("schema only contains the expected properties (command, working_dir, timeout_seconds, activity)", () => {
     const propertyNames = Object.keys(schemaProps).sort();
     expect(propertyNames).toEqual([
+      "activity",
       "command",
-      "reason",
       "timeout_seconds",
       "working_dir",
     ]);
@@ -348,10 +348,10 @@ describe("host_bash — regression: no proxied-mode additions", () => {
     expect(definition.name).toBe("host_bash");
   });
 
-  test("required fields contains command and reason", () => {
+  test("required fields contains command and activity", () => {
     expect(
       (definition.input_schema as Record<string, unknown>).required,
-    ).toEqual(["command", "reason"]);
+    ).toEqual(["command", "activity"]);
   });
 });
 

--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -60,7 +60,7 @@ describe("injectActivityField", () => {
 
   test("skips tools in skip set (returns unchanged)", () => {
     const defs = [makeDef("bash"), makeDef("host_bash")];
-    const result = injectActivityField(defs);
+    const result = injectActivityField(defs, new Set(["bash", "host_bash"]));
     // Should be the exact same object references
     expect(Object.is(result[0], defs[0])).toBe(true);
     expect(Object.is(result[1], defs[1])).toBe(true);

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -662,7 +662,7 @@ describe("Shell tool input validation", () => {
     };
     expect(def.name).toBe("bash");
     expect(schema.required).toContain("command");
-    expect(schema.required).toContain("reason");
+    expect(schema.required).toContain("activity");
     expect(schema.properties.command).toBeDefined();
     expect(schema.properties.timeout_seconds).toBeDefined();
     expect(schema.properties.network_mode).toBeDefined();

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -9,12 +9,12 @@
       "input_schema": {
         "type": "object",
         "properties": {
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["reason"]
+        "required": ["activity"]
       },
       "executor": "tools/computer-use-observe.ts",
       "execution_target": "host"
@@ -48,7 +48,7 @@
             "type": "string",
             "description": "Explanation of what you see and why you are clicking here"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -74,7 +74,7 @@
             "type": "string",
             "description": "Explanation of what you are typing and why"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -100,7 +100,7 @@
             "type": "string",
             "description": "Explanation of why you are pressing this key"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -143,7 +143,7 @@
             "type": "string",
             "description": "Explanation of why you are scrolling"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -189,7 +189,7 @@
             "type": "string",
             "description": "Explanation of what you are dragging and why"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -215,7 +215,7 @@
             "type": "string",
             "description": "Explanation of what you are waiting for"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -241,7 +241,7 @@
             "type": "string",
             "description": "Explanation of why you need to open or switch to this app"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -267,7 +267,7 @@
             "type": "string",
             "description": "Explanation of what this script does and why AppleScript is better than UI interaction for this step"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -289,7 +289,7 @@
             "type": "string",
             "description": "Human-readable summary of what was accomplished"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -315,7 +315,7 @@
             "type": "string",
             "description": "Explanation of how you determined the answer"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }


### PR DESCRIPTION
## Summary
- Updated `terminal-tools.test.ts`, `host-shell-tool.test.ts`, and `schema-transforms.test.ts` to expect `activity` instead of `reason` in tool schemas
- Updated `computer-use/TOOLS.json` manifest to rename all `reason` properties to `activity`, matching the core tool definitions
- Fixed `schema-transforms.test.ts` skip-set test to pass an explicit skip set since `ACTIVITY_SKIP_SET` is now empty

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23191516881/job/67388563437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
