### PR TITLE
feat: auto-wake daemon when connection fails

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -157,6 +157,15 @@ extension AppDelegate {
         daemonClient.recoveryPlatform = "macos"
         daemonClient.recoveryDeviceId = PairingQRCodeSheet.computeHostId()
 
+        // Auto-wake: if a connection attempt finds the daemon process dead,
+        // wake it via the CLI before retrying.
+        daemonClient.wakeHandler = { [weak self] in
+            guard let self else { return }
+            let name = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? "default"
+            log.info("Auto-wake: waking assistant '\(name, privacy: .private)' via CLI")
+            try await self.assistantCli.wake(name: name)
+        }
+
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -587,6 +587,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon broadcasts a `contacts_changed` event (contact table mutated).
     public var onContactsChanged: ((ContactsChanged) -> Void)?
 
+    // MARK: - Auto-Wake
+
+    /// Optional closure invoked when a connection attempt fails because the daemon process
+    /// is not alive. The macOS app sets this to call `assistantCli.wake(name:)` so the
+    /// daemon is automatically restarted before retrying the connection.
+    /// Set by the app layer — `DaemonClient` never imports platform-specific types.
+    public var wakeHandler: (@MainActor @Sendable () async throws -> Void)?
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -64,6 +64,25 @@ extension DaemonClient {
             isConnecting = false
             log.info("connect: transport connected successfully to \(baseURL, privacy: .public), SSE should be running")
         } catch {
+            #if os(macOS)
+            // Auto-wake: if the daemon process is not alive and a wake handler is
+            // configured, try waking the daemon and retrying the connection once.
+            if let wakeHandler, !DaemonClient.isDaemonProcessAlive(environment: config.instanceDir.map { ["BASE_DATA_DIR": $0] }) {
+                log.info("connect: daemon process not alive — attempting auto-wake before retry")
+                do {
+                    try await wakeHandler()
+                    log.info("connect: auto-wake succeeded, retrying connection to \(baseURL, privacy: .public)")
+                    try await transport.connect()
+                    isAuthenticated = true
+                    isConnecting = false
+                    log.info("connect: retry after auto-wake succeeded for \(baseURL, privacy: .public)")
+                    return
+                } catch {
+                    log.error("connect: auto-wake or retry failed for \(baseURL, privacy: .public): \(error)")
+                }
+            }
+            #endif
+
             isConnecting = false
             httpTransport = nil
             log.error("connect: transport connection failed for \(baseURL, privacy: .public): \(error)")


### PR DESCRIPTION
## Summary

- Adds `wakeHandler` closure property on `DaemonClient` (shared code, no platform imports)
- When `connect()` fails and the daemon process is dead, invokes the handler to wake it and retries once
- macOS app wires the handler in `setupDaemonClient()` to call `assistantCli.wake(name:)`

## Original prompt
Add defensive auto-wake logic so that whenever the app tries to communicate with the daemon and it's not running, it automatically wakes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
