### PR TITLE
refactor: rename user-facing "thread" copy to "conversation" across all clients

### DIFF
--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -21,9 +21,9 @@ struct PrivateConversationsSection: View {
         Form {
             if store.privateConversations.isEmpty {
                 Section {
-                    Text("No private threads yet.")
+                    Text("No private conversations yet.")
                         .foregroundStyle(.secondary)
-                    Text("Private threads are excluded from your main chat history. Use them for sensitive threads that you don't want mixed with your regular threads.")
+                    Text("Private conversations are excluded from your main chat history. Use them for sensitive conversations that you don't want mixed with your regular conversations.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -54,9 +54,9 @@ struct PrivateConversationsSection: View {
                         }
                     }
                 } header: {
-                    Text("Private Threads")
+                    Text("Private Conversations")
                 } footer: {
-                    Text("These threads are not included in your regular chat history and are excluded from session restoration.")
+                    Text("These conversations are not included in your regular chat history and are excluded from session restoration.")
                 }
             }
 
@@ -65,20 +65,20 @@ struct PrivateConversationsSection: View {
                     newConversationName = ""
                     showingCreateSheet = true
                 } label: {
-                    Label { Text("New Private Thread") } icon: { VIconView(.shield, size: 14) }
+                    Label { Text("New Private Conversation") } icon: { VIconView(.shield, size: 14) }
                 }
             }
         }
-        .navigationTitle("Private Threads")
+        .navigationTitle("Private Conversations")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showingCreateSheet) {
             createConversationSheet
         }
-        .alert("Rename Thread", isPresented: Binding(
+        .alert("Rename Conversation", isPresented: Binding(
             get: { renamingConversation != nil },
             set: { if !$0 { renamingConversation = nil } }
         )) {
-            TextField("Thread name", text: $renameText)
+            TextField("Conversation name", text: $renameText)
             Button("Cancel", role: .cancel) { renamingConversation = nil }
             Button("Save") {
                 if let conversation = renamingConversation, !renameText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -87,9 +87,9 @@ struct PrivateConversationsSection: View {
                 renamingConversation = nil
             }
         } message: {
-            Text("Enter a new name for this private thread.")
+            Text("Enter a new name for this private conversation.")
         }
-        .alert("Delete Thread", isPresented: $showingDeleteConfirmation) {
+        .alert("Delete Conversation", isPresented: $showingDeleteConfirmation) {
             Button("Cancel", role: .cancel) { conversationToDelete = nil }
             Button("Delete", role: .destructive) {
                 if let conversation = conversationToDelete {
@@ -139,13 +139,13 @@ struct PrivateConversationsSection: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Thread name", text: $newConversationName)
+                    TextField("Conversation name", text: $newConversationName)
                         .autocapitalization(.words)
                 } footer: {
-                    Text("Give this private thread a name so you can identify it later.")
+                    Text("Give this private conversation a name so you can identify it later.")
                 }
             }
-            .navigationTitle("New Private Thread")
+            .navigationTitle("New Private Conversation")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -156,7 +156,7 @@ struct PrivateConversationsSection: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Create") {
                         let name = newConversationName.trimmingCharacters(in: .whitespacesAndNewlines)
-                        _ = store.newPrivateConversation(name: name.isEmpty ? "Private Thread" : name)
+                        _ = store.newPrivateConversation(name: name.isEmpty ? "Private Conversation" : name)
                         showingCreateSheet = false
                     }
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -62,7 +62,7 @@ extension AppDelegate {
         fileMenu.addItem(newChatItem)
 
         let markAllSeenItem = NSMenuItem(
-            title: "Mark All Threads as Seen",
+            title: "Mark All Conversations as Seen",
             action: #selector(markAllConversationsSeen),
             keyEquivalent: "k"
         )
@@ -278,7 +278,7 @@ extension AppDelegate {
         guard !markedIds.isEmpty else { return }
         let count = markedIds.count
         let toastId = mainWindow?.windowState.showToast(
-            message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
+            message: "Marked \(count) conversation\(count == 1 ? "" : "s") as seen",
             style: .success,
             primaryAction: VToastAction(label: "Undo") { [weak self] in
                 self?.mainWindow?.conversationManager.restoreUnseen(conversationIds: markedIds)
@@ -302,7 +302,7 @@ extension AppDelegate {
         menu.addItem(newChatItem)
 
         let markAllSeenItem = NSMenuItem(
-            title: "Mark All Threads as Seen",
+            title: "Mark All Conversations as Seen",
             action: #selector(markAllConversationsSeen),
             keyEquivalent: ""
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -14,7 +14,7 @@ struct ConversationHeaderPresentation {
 
     init(activeConversation: ConversationModel?, activeViewModel: ChatViewModel?, isConversationVisible: Bool) {
         guard isConversationVisible, let conversation = activeConversation else {
-            self.displayTitle = "New thread"
+            self.displayTitle = "New conversation"
             self.isStarted = false
             self.showsActionsMenu = false
             self.isPrivateConversation = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -39,7 +39,7 @@ struct ConversationActionsDrawer: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if presentation.canCopy {
-                SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full thread", action: onCopy)
+                SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
             }
 
             SidebarPrimaryRow(
@@ -48,9 +48,9 @@ struct ConversationActionsDrawer: View {
                 action: presentation.isPinned ? onUnpin : onPin
             )
 
-            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename thread", action: onRename)
+            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename conversation", action: onRename)
 
-            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive thread", action: onArchive)
+            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive conversation", action: onArchive)
         }
         .padding(VSpacing.sm)
         .background(VColor.surfaceLift)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -123,7 +123,7 @@ extension MainWindowView {
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .clipped()
-        .alert("Rename Thread", isPresented: Binding(
+        .alert("Rename Conversation", isPresented: Binding(
             get: { sidebar.renamingConversationId != nil },
             set: { if !$0 { sidebar.renamingConversationId = nil } }
         )) {
@@ -139,7 +139,7 @@ extension MainWindowView {
                 sidebar.renamingConversationId = nil
             }
         } message: {
-            Text("Enter a new name for this thread")
+            Text("Enter a new name for this conversation")
         }
     }
 
@@ -210,7 +210,7 @@ extension MainWindowView {
                     guard !markedIds.isEmpty else { return }
                     let count = markedIds.count
                     let toastId = windowState.showToast(
-                        message: "Marked \(count) thread\(count == 1 ? "" : "s") as seen",
+                        message: "Marked \(count) conversation\(count == 1 ? "" : "s") as seen",
                         style: .success,
                         primaryAction: VToastAction(label: "Undo") {
                             conversationManager.restoreUnseen(conversationIds: markedIds)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -202,7 +202,7 @@ struct MainWindowView: View {
         guard !markdown.isEmpty else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(markdown, forType: .string)
-        windowState.showToast(message: "Thread copied to clipboard", style: .success)
+        windowState.showToast(message: "Conversation copied to clipboard", style: .success)
     }
 
     private var conversationHeaderPresentation: ConversationHeaderPresentation {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -13,7 +13,7 @@ enum SettingsTab: String {
     case privacy = "Privacy"
     case voice = "Voice"
     case billing = "Billing"
-    case archivedConversations = "Archived Threads"
+    case archivedConversations = "Archived Conversations"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -12,7 +12,7 @@ struct ConversationSwitcherDrawer: View {
 
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
-            Text("\(regularConversations.count) threads")
+            Text("\(regularConversations.count) conversations")
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -134,7 +134,7 @@ struct SidebarConversationItem: View {
             onSelect?()
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel("Thread: \(conversation.title)")
+        .accessibilityLabel("Conversation: \(conversation.title)")
         .accessibilityAction(.default) {
             selectConversation()
         }
@@ -172,18 +172,18 @@ struct SidebarConversationItem: View {
                     }
                 }
             } label: {
-                Label { Text(conversation.isPinned ? "Unpin thread" : "Pin thread") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
+                Label { Text(conversation.isPinned ? "Unpin conversation" : "Pin conversation") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
                 sidebar.renamingConversationId = conversation.id
                 sidebar.renameText = conversation.title
             } label: {
-                Label { Text("Rename thread") } icon: { VIconView(.pencil, size: 14) }
+                Label { Text("Rename conversation") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
                 conversationManager.archiveConversation(id: conversation.id)
             } label: {
-                Label { Text("Archive thread") } icon: { VIconView(.archive, size: 14) }
+                Label { Text("Archive conversation") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
                 conversationManager.markConversationUnread(conversationId: conversation.id)
@@ -198,7 +198,7 @@ struct SidebarConversationItem: View {
                 guard let conversationId = conversation.conversationId else { return }
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
             } label: {
-                Label { Text("Send Logs for Thread") } icon: { VIconView(.upload, size: 14) }
+                Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
             }
             .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -9,7 +9,7 @@ struct SidebarConversationsHeader: View {
 
     var body: some View {
         HStack {
-            Text("Threads")
+            Text("Conversations")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(VColor.contentDefault)
             Spacer()
@@ -23,7 +23,7 @@ struct SidebarConversationsHeader: View {
                 )
                 .disabled(isLoading)
             }
-            VButton(label: "New thread", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewConversation)
+            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewConversation)
                 .disabled(isLoading)
                 .opacity(isLoading ? 0.4 : 1)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -8,8 +8,8 @@ struct SettingsArchivedConversationsTab: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             if conversationManager.archivedConversations.isEmpty {
                 VEmptyState(
-                    title: "No archived threads",
-                    subtitle: "Threads you archive will appear here.",
+                    title: "No archived conversations",
+                    subtitle: "Conversations you archive will appear here.",
                     icon: VIcon.archive.rawValue
                 )
             } else {

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -60,7 +60,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerWebSearch:
             return "This is usually temporary — click Retry to continue."
         case .contextTooLarge:
-            return "Start a new thread to reset context, or try a shorter message."
+            return "Start a new conversation to reset context, or try a shorter message."
         case .conversationAborted:
             return "Send a new message to continue the conversation."
         case .processingFailed:


### PR DESCRIPTION
## Summary
- Replaces all user-facing UI strings saying "thread" with "conversation" across macOS, iOS, and shared Swift clients (37 string replacements across 12 files)
- Excludes email threads, Slack threads, OS threads, legacy migration keys, and voice command backward-compat synonyms

Part of plan: rename-thread-to-conversation-ui.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
