### PR TITLE
fix: update test assertions from New thread to New conversation

### DIFF
--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -13,7 +13,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
             activeViewModel: nil,
             isConversationVisible: true
         )
-        XCTAssertEqual(p.displayTitle, "New thread")
+        XCTAssertEqual(p.displayTitle, "New conversation")
         XCTAssertFalse(p.isStarted)
         XCTAssertFalse(p.showsActionsMenu)
         XCTAssertFalse(p.canCopy)
@@ -26,7 +26,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
             activeViewModel: nil,
             isConversationVisible: false
         )
-        XCTAssertEqual(p.displayTitle, "New thread")
+        XCTAssertEqual(p.displayTitle, "New conversation")
         XCTAssertFalse(p.showsActionsMenu)
     }
 

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -64,7 +64,7 @@ final class DocumentEditorConversationVisibilityTests: XCTestCase {
         )
 
         XCTAssertEqual(presentation.displayTitle, "Doc Session Conversation",
-                        "Document editor should show actual conversation title, not 'New thread'")
+                        "Document editor should show actual conversation title, not 'New conversation'")
         XCTAssertTrue(presentation.isStarted)
         XCTAssertTrue(presentation.showsActionsMenu)
     }
@@ -76,7 +76,7 @@ final class DocumentEditorConversationVisibilityTests: XCTestCase {
             isConversationVisible: true
         )
 
-        XCTAssertEqual(presentation.displayTitle, "New thread")
+        XCTAssertEqual(presentation.displayTitle, "New conversation")
         XCTAssertFalse(presentation.isStarted)
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rename-thread-to-conversation-ui.md.

**Gap:** Test assertions still expect old "New thread" string
**What was expected:** Tests should pass with updated string values
**What was found:** Three XCTAssertEqual calls still assert against "New thread" instead of "New conversation"

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
