### PR TITLE
feat: strictly respect image-generation service mode when resolving credentials

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -55,13 +55,12 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const apiKey = await getProviderKeyAsync("gemini");
+  const imageGenMode = config.services["image-generation"].mode;
 
-  // Resolve credentials: prefer direct API key, fall back to managed proxy
+  // Resolve credentials strictly based on mode — no cross-mode fallbacks
   let credentials: ImageGenCredentials | undefined;
-  if (apiKey) {
-    credentials = { type: "direct", apiKey };
-  } else {
+
+  if (imageGenMode === "managed") {
     const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
@@ -71,14 +70,19 @@ export async function run(
         baseUrl: managedBaseUrl,
       };
     }
+  } else {
+    const apiKey = await getProviderKeyAsync("gemini");
+    if (apiKey) {
+      credentials = { type: "direct", apiKey };
+    }
   }
 
   if (!credentials) {
-    return {
-      content:
-        "No Gemini API key configured. Please set your Gemini API key to use image generation.",
-      isError: true,
-    };
+    const hint =
+      imageGenMode === "managed"
+        ? "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode."
+        : "No Gemini API key configured. Please set your Gemini API key in Settings > Models & Services.";
+    return { content: hint, isError: true };
   }
 
   const prompt = input.prompt as string;

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -37,12 +37,12 @@ export async function generateAppIcon(
   appDescription?: string,
 ): Promise<void> {
   const config = getConfig();
-  const apiKey = await getProviderKeyAsync("gemini");
+  const imageGenMode = config.services["image-generation"].mode;
 
+  // Resolve credentials strictly based on mode — no cross-mode fallbacks
   let credentials: ImageGenCredentials | undefined;
-  if (apiKey) {
-    credentials = { type: "direct", apiKey };
-  } else {
+
+  if (imageGenMode === "managed") {
     const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
@@ -52,12 +52,19 @@ export async function generateAppIcon(
         baseUrl: managedBaseUrl,
       };
     }
+  } else {
+    const apiKey = await getProviderKeyAsync("gemini");
+    if (apiKey) {
+      credentials = { type: "direct", apiKey };
+    }
   }
 
   if (!credentials) {
-    log.debug(
-      "No Gemini API key or managed proxy — skipping app icon generation",
-    );
+    const reason =
+      imageGenMode === "managed"
+        ? "Managed proxy is not available"
+        : "No Gemini API key configured";
+    log.debug(`${reason} — skipping app icon generation`);
     return;
   }
 

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -14,12 +14,12 @@ export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
-  const geminiKey = await getProviderKeyAsync("gemini");
+  const imageGenMode = config.services["image-generation"].mode;
 
+  // Resolve credentials strictly based on mode — no cross-mode fallbacks
   let credentials: ImageGenCredentials | undefined;
-  if (geminiKey) {
-    credentials = { type: "direct", apiKey: geminiKey };
-  } else {
+
+  if (imageGenMode === "managed") {
     const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = await resolveManagedProxyContext();
@@ -29,12 +29,19 @@ export async function generateAvatar(
         baseUrl: managedBaseUrl,
       };
     }
+  } else {
+    const geminiKey = await getProviderKeyAsync("gemini");
+    if (geminiKey) {
+      credentials = { type: "direct", apiKey: geminiKey };
+    }
   }
 
   if (!credentials) {
-    throw new ConfigError(
-      "Gemini API key is not configured. Set it via `keys set gemini <key>`.",
-    );
+    const hint =
+      imageGenMode === "managed"
+        ? "Managed proxy is not available. Please log in to Vellum or switch to Your Own mode."
+        : "Gemini API key is not configured. Please set your Gemini API key in Settings > Models & Services.";
+    throw new ConfigError(hint);
   }
 
   const result = await generateImage(credentials, {


### PR DESCRIPTION
## Summary
- Replace fallback-based credential resolution with strict mode-based resolution in all 3 image generation entry points
- Managed mode uses only managed proxy, your-own mode uses only user key — no cross-mode fallbacks
- Add mode-aware error messages when the selected credential source is unavailable
- Applies to: media-generate-image tool, avatar-router, app-icon-generator

Part of plan: img-gen-managed-toggle.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
