### PR TITLE
refactor: extract ServiceModeCard shared component for Managed/Your Own service cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Reusable card for services with a Managed/Your Own mode toggle.
+///
+/// Provides the outer card chrome (title, subtitle, segmented control,
+/// divider, action buttons) and delegates mode-specific content to callers
+/// via ViewBuilder closures.
+@MainActor
+struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
+    let title: String
+    let subtitle: String
+    @Binding var draftMode: String
+    let hasChanges: Bool
+    let isSaving: Bool
+    let onSave: () -> Void
+    /// Optional reset action -- shown only in Your Own mode when `showReset` is true.
+    let onReset: (() -> Void)?
+    let showReset: Bool
+    @ViewBuilder let managedContent: () -> ManagedContent
+    @ViewBuilder let yourOwnContent: () -> YourOwnContent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Header: title + subtitle + mode toggle
+            header
+
+            Divider()
+                .background(VColor.borderBase)
+
+            // Mode-specific content
+            if draftMode == "managed" {
+                managedContent()
+            } else {
+                yourOwnContent()
+            }
+
+            // Action buttons
+            actionButtons
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .vCard(background: VColor.surfaceOverlay)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack {
+                Text(title)
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.contentDefault)
+                Spacer()
+                VSegmentedControl(
+                    items: [
+                        (label: "Managed", tag: "managed"),
+                        (label: "Your Own", tag: "your-own"),
+                    ],
+                    selection: $draftMode,
+                    style: .pill
+                )
+                .frame(width: 220)
+            }
+            Text(subtitle)
+                .font(VFont.sectionDescription)
+                .foregroundColor(VColor.contentTertiary)
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: VSpacing.sm) {
+            if draftMode == "managed" {
+                VButton(
+                    label: isSaving ? "Saving..." : "Save",
+                    style: .primary,
+                    isDisabled: !hasChanges || isSaving
+                ) { onSave() }
+            } else {
+                VButton(
+                    label: isSaving ? "Validating..." : "Save",
+                    style: .primary,
+                    isDisabled: !hasChanges || isSaving
+                ) { onSave() }
+                if showReset, let onReset {
+                    VButton(label: "Reset", style: .danger, isDisabled: isSaving) {
+                        onReset()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create ServiceModeCard generic SwiftUI component for the Managed/Your Own toggle pattern
- Provides card chrome (title, subtitle, segmented control, divider, action buttons)
- Delegates mode-specific content to callers via ViewBuilder closures
- Will be used by ImageGenerationServiceCard (PR 4) and InferenceServiceCard refactor (PR 5)

Part of plan: img-gen-managed-toggle.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
