### PR TITLE
copy: simplify privacy toggle labels and descriptions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -36,10 +36,10 @@ struct ImproveExperienceStepView: View {
                     // Usage analytics toggle
                     HStack {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Share usage analytics")
+                            Text("Share Analytics")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.contentSecondary)
-                            Text("Send anonymized usage metrics (e.g. token counts, feature adoption) to help us improve the product. No personal data or message content is included.")
+                            Text("Send anonymous product usage data. Your conversations and personal data are never included.")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.contentTertiary)
                         }
@@ -52,10 +52,10 @@ struct ImproveExperienceStepView: View {
                     // Diagnostics toggle
                     HStack {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Send diagnostics")
+                            Text("Share Diagnostics")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.contentSecondary)
-                            Text("Share crash reports, error diagnostics, and performance metrics (hang rate, responsiveness) to help us improve stability. No personal data or message content is included.")
+                            Text("Send crash reports and performance metrics. Your conversations and personal data are never included.")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.contentTertiary)
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -22,10 +22,10 @@ struct SettingsPrivacyTab: View {
         SettingsCard(title: "Privacy") {
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Share usage analytics")
+                    Text("Share Analytics")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentSecondary)
-                    Text("Send anonymized usage metrics (e.g. token counts, feature adoption) to help us improve the product. No personal data or message content is included.")
+                    Text("Send anonymous product usage data. Your conversations and personal data are never included.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
@@ -43,10 +43,10 @@ struct SettingsPrivacyTab: View {
 
             HStack {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Send diagnostics")
+                    Text("Share Diagnostics")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentSecondary)
-                    Text("Share crash reports, error diagnostics, and performance metrics (hang rate, responsiveness) to help us improve stability. No personal data or message content is included.")
+                    Text("Send crash reports and performance metrics. Your conversations and personal data are never included.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }


### PR DESCRIPTION
## Summary
- Renamed "Share usage analytics" → "Share Analytics" and "Send diagnostics" → "Share Diagnostics" for conciseness
- Simplified descriptions to one-line copy with a clear privacy reassurance ("Your conversations and personal data are never included")
- Updated both the onboarding setup flow (`ImproveExperienceStepView`) and the settings privacy tab (`SettingsPrivacyTab`) with identical copy

## Original prompt
Update the analytics and diagnostics toggle copy in both the onboarding setup flow and the settings privacy page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
