### PR TITLE
feat: add ImageGenerationServiceCard with Managed/Your Own toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -370,38 +370,11 @@ struct SettingsPanel: View {
             )
 
             // IMAGE GENERATION
-            ServiceCredentialCard(
-                title: "Image Generation",
-                subtitle: "Enables AI image generation via Gemini",
-                isConnected: store.hasImageGenKey,
-                keyPlaceholder: "Enter your Gemini API key",
-                isManagedProxy: store.providerRoutingSources["gemini"] == "managed-proxy",
-                keyText: $imageGenKeyText,
-                onSave: {
-                    store.saveImageGenKey(imageGenKeyText)
-                    imageGenKeyText = ""
-                },
-                onReset: {
-                    store.clearImageGenKey()
-                    imageGenKeyText = ""
-                }
-            ) {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Model")
-                        .font(VFont.inputLabel)
-                        .foregroundColor(VColor.contentSecondary)
-                    VDropdown(
-                        placeholder: "Select a model…",
-                        selection: Binding(
-                            get: { store.selectedImageGenModel },
-                            set: { store.setImageGenModel($0) }
-                        ),
-                        options: SettingsStore.availableImageGenModels.map { model in
-                            (label: SettingsStore.imageGenModelDisplayNames[model] ?? model, value: model)
-                        }
-                    )
-                }
-            }
+            ImageGenerationServiceCard(
+                store: store,
+                authManager: authManager,
+                apiKeyText: $imageGenKeyText
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for the image generation service with Managed/Your Own mode toggle.
+///
+/// Shows different content based on mode and auth state:
+/// - **Managed + logged in**: Model picker, Save button
+/// - **Managed + not logged in**: Empty state prompting login
+/// - **Your Own**: Gemini API key field, model picker, Save + Reset buttons
+@MainActor
+struct ImageGenerationServiceCard: View {
+    @ObservedObject var store: SettingsStore
+    var authManager: AuthManager
+    @Binding var apiKeyText: String
+
+    /// Local draft of the mode selection — only persisted on Save.
+    @State private var draftMode: String = "your-own"
+    /// Snapshot of the model at card appear — used to detect model-only changes.
+    @State private var initialModel: String = ""
+
+    private var isConnected: Bool {
+        store.hasImageGenKey
+    }
+
+    private var isLoggedIn: Bool {
+        authManager.isAuthenticated
+    }
+
+    /// True when the user has made changes worth saving.
+    private var hasChanges: Bool {
+        let modeChanged = draftMode != store.imageGenMode
+        let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let modelChanged = store.selectedImageGenModel != initialModel
+        return modeChanged || hasNewKey || modelChanged
+    }
+
+    var body: some View {
+        ServiceModeCard(
+            title: "Image Generation",
+            subtitle: "Configure which provider and model to use for AI image generation",
+            draftMode: $draftMode,
+            hasChanges: hasChanges,
+            isSaving: false,
+            onSave: { save() },
+            onReset: {
+                store.clearImageGenKey()
+                apiKeyText = ""
+            },
+            showReset: draftMode == "your-own" && isConnected,
+            managedContent: {
+                if isLoggedIn {
+                    modelPicker
+                } else {
+                    managedLoginPrompt
+                }
+            },
+            yourOwnContent: {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    // API Key field
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        Text("API Key")
+                            .font(VFont.inputLabel)
+                            .foregroundColor(VColor.contentSecondary)
+                        SecureField(
+                            isConnected && apiKeyText.isEmpty
+                                ? "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
+                                : "Enter your Gemini API key",
+                            text: $apiKeyText
+                        )
+                        .vInputStyle()
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                    }
+
+                    // Model picker
+                    modelPicker
+                }
+            }
+        )
+        .onAppear {
+            draftMode = store.imageGenMode
+            initialModel = store.selectedImageGenModel
+        }
+        .onChange(of: store.imageGenMode) { _, newValue in
+            // Sync draft when external changes arrive (e.g. daemon reload)
+            draftMode = newValue
+        }
+    }
+
+    // MARK: - Managed Login Prompt
+
+    private var managedLoginPrompt: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("In order to use the managed image generation service, you must be logged in to Vellum.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
+            VButton(
+                label: authManager.isSubmitting ? "Logging in..." : "Log In",
+                style: .primary,
+                isDisabled: authManager.isSubmitting
+            ) {
+                Task {
+                    await authManager.startWorkOSLogin()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Model Picker
+
+    private var modelPicker: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Active Model")
+                .font(VFont.inputLabel)
+                .foregroundColor(VColor.contentSecondary)
+            VDropdown(
+                placeholder: "Select a model\u{2026}",
+                selection: Binding(
+                    get: { store.selectedImageGenModel },
+                    set: { store.selectedImageGenModel = $0 }
+                ),
+                options: SettingsStore.availableImageGenModels.map { model in
+                    (label: SettingsStore.imageGenModelDisplayNames[model] ?? model, value: model)
+                }
+            )
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        // Persist mode if changed
+        if draftMode != store.imageGenMode {
+            store.setImageGenMode(draftMode)
+        }
+
+        // Persist API key if entered and in your-own mode
+        let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if draftMode == "your-own" && !trimmedKey.isEmpty {
+            store.saveImageGenKey(trimmedKey)
+            apiKeyText = ""
+        }
+
+        // Persist model selection
+        store.setImageGenModel(store.selectedImageGenModel)
+        initialModel = store.selectedImageGenModel
+    }
+}


### PR DESCRIPTION
## Summary
- Create ImageGenerationServiceCard wrapping ServiceModeCard with Managed/Your Own toggle
- Managed mode: model picker when logged in, login prompt when not
- Your Own mode: Gemini API key field + model picker
- Replace ServiceCredentialCard for Image Generation in SettingsPanel

Part of plan: img-gen-managed-toggle.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
