### PR TITLE
docs: clarify bash vs host_bash in avatar skill

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 You are helping the user customize their assistant's avatar. There are three ways to set an avatar: building a native character from traits, uploading a custom image, or generating one with AI. When the user says they want to change their avatar, present all three options and ask which they prefer.
 
+**All commands in this skill use the `bash` tool.** `$VELLUM_DATA_DIR` and `$INTERNAL_GATEWAY_BASE_URL` are available in the sandbox environment — do not use `host_bash`.
+
 ## Avatar Modes
 
 The avatar system supports two representations:


### PR DESCRIPTION
## Summary
- Add a note to the avatar SKILL.md clarifying that all commands use the `bash` tool (not `host_bash`)
- `$VELLUM_DATA_DIR` and `$INTERNAL_GATEWAY_BASE_URL` are available in the sandbox, so `host_bash` is unnecessary

## Original prompt
Add a note to the avatar skill clarifying that all commands use the `bash` tool and that `$VELLUM_DATA_DIR` is sandbox-accessible, to prevent the assistant from incorrectly using `host_bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
