### PR TITLE
fix: use NSTextView.scrollableTextView() for proper text system init

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxTextView.swift
@@ -99,7 +99,24 @@ struct SyntaxTextView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let textView = NSTextView()
+        // Use Apple's standard factory which properly initializes the text system
+        // (text storage, layout manager, text container, and scroll view sizing).
+        let scrollView = NSTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return scrollView
+        }
+
+        // Appearance
+        textView.font = SyntaxTheme.nsMonoFont
+        textView.textColor = SyntaxTheme.nsContentDefault
+        textView.backgroundColor = NSColor(VColor.surfaceOverlay)
+        textView.insertionPointColor = SyntaxTheme.nsContentDefault
+        textView.selectedTextAttributes = [
+            .backgroundColor: NSColor(VColor.primaryBase.opacity(0.3))
+        ]
+        textView.textContainerInset = NSSize(width: VSpacing.md, height: VSpacing.sm)
+
+        // Behavior
         textView.isEditable = true
         textView.isSelectable = true
         textView.isRichText = true
@@ -110,17 +127,8 @@ struct SyntaxTextView: NSViewRepresentable {
         textView.isAutomaticTextCompletionEnabled = false
         textView.usesFindBar = true
         textView.isIncrementalSearchingEnabled = true
-        textView.font = SyntaxTheme.nsMonoFont
-        textView.backgroundColor = NSColor(VColor.surfaceOverlay)
-        textView.insertionPointColor = SyntaxTheme.nsContentDefault
-        textView.selectedTextAttributes = [
-            .backgroundColor: NSColor(VColor.primaryBase.opacity(0.3))
-        ]
-        textView.textContainerInset = NSSize(width: VSpacing.md, height: VSpacing.sm)
-        textView.delegate = context.coordinator
-        textView.string = text
 
-        // Configure text view and container for horizontal scrolling (no line wrap)
+        // Horizontal scrolling (no line wrap)
         textView.isHorizontallyResizable = true
         textView.maxSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
@@ -134,14 +142,16 @@ struct SyntaxTextView: NSViewRepresentable {
             )
         }
 
-        let scrollView = NSScrollView()
-        scrollView.hasVerticalScroller = true
+        // Content
+        textView.delegate = context.coordinator
+        textView.string = text
+
+        // Scroll view
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = false
-        scrollView.documentView = textView
 
-        // Set up line number gutter
+        // Line number gutter
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
         let rulerView = LineNumberRulerView(scrollView: scrollView, textView: textView)


### PR DESCRIPTION
## Summary
- Replace manual `NSTextView()` + `NSScrollView()` creation with Apple's `NSTextView.scrollableTextView()` factory method which properly initializes the text system (frame sizing, autoresizing mask, text container configuration)
- Explicitly set `textView.textColor` as a safeguard for text visibility
- The manually-created NSTextView with zero frame wasn't laying out text properly because the text system wasn't initialized to work with the scroll view

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
