### PR TITLE
fix: handle empty btw responses in overlay and add diagnostic logging

### DIFF
--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -116,6 +116,7 @@ async function handleBtw(
             ? conversation.systemPrompt
             : buildSystemPrompt({ excludeBootstrap: true });
 
+          let textDeltaCount = 0;
           await conversation.provider.sendMessage(
             messages,
             tools,
@@ -128,6 +129,7 @@ async function handleBtw(
               },
               onEvent: (event) => {
                 if (event.type === "text_delta") {
+                  textDeltaCount++;
                   controller.enqueue(
                     encoder.encode(
                       `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
@@ -138,6 +140,13 @@ async function handleBtw(
               signal: combinedSignal,
             },
           );
+
+          if (textDeltaCount === 0) {
+            log.warn(
+              { conversationKey, messageCount: messages.length },
+              "btw side-chain completed with no text deltas",
+            );
+          }
 
           controller.enqueue(
             encoder.encode(`event: btw_complete\ndata: {}\n\n`),

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -425,10 +425,20 @@ struct ChatView: View {
                     .accessibilityLabel("Dismiss btw response")
                 }
 
-                Text(btwText.isEmpty && btwLoading ? "Thinking..." : btwText)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentDefault)
-                    .textSelection(.enabled)
+                if btwLoading && btwText.isEmpty {
+                    Text("Thinking...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentTertiary)
+                } else if !btwLoading && btwText.isEmpty {
+                    Text("No response received.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentTertiary)
+                } else {
+                    Text(btwText)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                        .textSelection(.enabled)
+                }
 
                 if !btwLoading {
                     Text("Press Escape to dismiss")


### PR DESCRIPTION
## Summary
- **btw overlay empty state**: When `/btw` stream completes with no text deltas, the overlay now shows "No response received." instead of blank content
- **Diagnostic logging**: Added a warning log in the btw route handler when the LLM call completes with zero text_delta events, to help diagnose why responses may be empty

## Original prompt
changes to both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
