### PR TITLE
fix: add web-search service mode to initializeServiceDefaults

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -108,6 +108,10 @@ public enum WorkspaceConfigIO {
         imageGen["mode"] = mode
         services["image-generation"] = imageGen
 
+        var webSearch = services["web-search"] as? [String: Any] ?? [:]
+        webSearch["mode"] = mode
+        services["web-search"] = webSearch
+
         try? merge(["services": services], into: path)
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-gen-managed-toggle.md.

**Gap:** initializeServiceDefaults missing web-search service mode
**What was expected:** The method should set mode for all services including web-search
**What was found:** Only inference and image-generation were set, omitting web-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
