### PR TITLE
fix: update stale 'Send diagnostics' copy to 'Share Diagnostics' in developer tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -924,7 +924,7 @@ struct SettingsDeveloperTab: View {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.triangleAlert, size: 12)
                         .foregroundColor(VColor.systemNegativeHover)
-                    Text("Send diagnostics is disabled. Non-fatal events will be silently dropped unless you enable \"Send diagnostics\" in the Privacy tab.")
+                    Text("Share Diagnostics is disabled. Non-fatal events will be silently dropped unless you enable \"Share Diagnostics\" in the Privacy tab.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemNegativeHover)
                 }


### PR DESCRIPTION
## Summary
Fixes copy inconsistency found during plan review for img-gen-managed-toggle.md.

**Gap:** SettingsDeveloperTab references old 'Send diagnostics' label
**What was expected:** All references should use the current 'Share Diagnostics' label
**What was found:** Developer tab still used the old copy while Privacy tab uses the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
