### PR TITLE
fix: add getProviderKeyAsync to test mocks for image generation

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -47,6 +47,8 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "gemini" ? mockGeminiKey : null,
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "gemini" ? mockGeminiKey : undefined,
 }));
 
 mock.module("../util/platform.js", () => ({

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -11,6 +11,7 @@ import type { ToolContext } from "../tools/types.js";
 // ---------------------------------------------------------------------------
 
 let mockApiKey: string | undefined = "test-gemini-key";
+let mockImageGenMode: "your-own" | "managed" = "your-own";
 let mockGenerateResult = {
   images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
   text: "A beautiful image",
@@ -29,7 +30,7 @@ mock.module("../config/loader.js", () => ({
         model: "claude-opus-4-6",
       },
       "image-generation": {
-        mode: "your-own",
+        mode: mockImageGenMode,
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
@@ -41,6 +42,10 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => {
     if (account === "gemini") return mockApiKey;
+    return undefined;
+  },
+  getProviderKeyAsync: async (provider: string) => {
+    if (provider === "gemini") return mockApiKey;
     return undefined;
   },
 }));
@@ -171,6 +176,7 @@ const CONFIG_DIR = join(
 
 beforeEach(() => {
   mockApiKey = "test-gemini-key";
+  mockImageGenMode = "your-own";
   mockGenerateResult = {
     images: [{ mimeType: "image/png", dataBase64: "generated-data" }],
     text: "A beautiful image",
@@ -208,8 +214,8 @@ describe("image-studio skill script wrapper", () => {
     expect(result.content).toContain("No Gemini API key");
   });
 
-  test("falls back to managed proxy when no API key is configured", async () => {
-    mockApiKey = undefined;
+  test("managed mode uses managed proxy credentials", async () => {
+    mockImageGenMode = "managed";
     mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
     mockManagedProxyContext = {
       enabled: true,
@@ -228,7 +234,19 @@ describe("image-studio skill script wrapper", () => {
     });
   });
 
-  test("prefers direct API key over managed proxy", async () => {
+  test("managed mode returns error when managed proxy is unavailable", async () => {
+    mockImageGenMode = "managed";
+    mockApiKey = "direct-key"; // should be ignored in managed mode
+    mockManagedBaseUrl = undefined;
+
+    const result = await run({ prompt: "a cat" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Managed proxy is not available");
+  });
+
+  test("your-own mode uses direct API key", async () => {
+    mockImageGenMode = "your-own";
     mockApiKey = "direct-key";
     mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
     mockManagedProxyContext = {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-gen-managed-toggle.md.

**Gap:** Test mocks broken — missing getProviderKeyAsync export
**What was expected:** Test mocks should export all functions imported by production code
**What was found:** media-generate-image.test.ts and avatar-e2e.test.ts mocks only exported getSecureKeyAsync, missing getProviderKeyAsync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
