### PR TITLE
fix: add managed+logged-out guard to ImageGenerationServiceCard.hasChanges

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -28,6 +28,10 @@ struct ImageGenerationServiceCard: View {
 
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
+        // In managed mode when not logged in, there is nothing actionable to save.
+        if draftMode == "managed" && !isLoggedIn {
+            return false
+        }
         let modeChanged = draftMode != store.imageGenMode
         let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let modelChanged = store.selectedImageGenModel != initialModel


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-gen-managed-toggle.md.

**Gap:** ImageGenerationServiceCard missing managed+logged-out guard in hasChanges
**What was expected:** Save should be disabled when managed mode is selected but user is not logged in
**What was found:** hasChanges did not include the guard, allowing Save when managed+not-logged-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
