### PR TITLE
fix: update test assertions for lowered file_write/file_edit/asset_materialize risk

### DIFF
--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -314,8 +314,8 @@ describe("AssetMaterializeTool metadata", () => {
     ).toHaveProperty("destination_path");
   });
 
-  test("tool has MEDIUM risk level", () => {
-    expect(assetMaterializeTool.defaultRiskLevel).toBe(RiskLevel.Medium);
+  test("tool has LOW risk level", () => {
+    expect(assetMaterializeTool.defaultRiskLevel).toBe(RiskLevel.Low);
   });
 
   test("tool category is assets", () => {

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -201,18 +201,18 @@ describe("Permission Checker", () => {
       });
     });
 
-    // file_write is always medium
+    // file_write is always low (sandboxed)
     describe("file_write", () => {
-      test("file_write is always medium risk", async () => {
+      test("file_write is always low risk", async () => {
         const risk = await classifyRisk("file_write", {
           path: "/tmp/file.txt",
         });
-        expect(risk).toBe(RiskLevel.Medium);
+        expect(risk).toBe(RiskLevel.Low);
       });
 
-      test("file_write with any path is medium risk", async () => {
+      test("file_write with any path is low risk", async () => {
         const risk = await classifyRisk("file_write", { path: "/etc/passwd" });
-        expect(risk).toBe(RiskLevel.Medium);
+        expect(risk).toBe(RiskLevel.Low);
       });
     });
 
@@ -673,14 +673,13 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("allow");
     });
 
-    test("file_write → auto-allow (Low risk)", async () => {
+    test("file_write → auto-allow (workspace-scoped)", async () => {
       const result = await check(
         "file_write",
         { path: "/tmp/file.txt" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Low risk");
     });
 
     test("file_write outside workspace → auto-allow (Low risk)", async () => {
@@ -1486,12 +1485,12 @@ describe("Permission Checker", () => {
       expect(result.matchedRule!.id).toBe("default:allow-file_edit-updates");
     });
 
-    test("file_write of non-workspace file is not auto-allowed", async () => {
+    test("file_write of non-workspace file is auto-allowed (Low risk)", async () => {
       const otherPath = join(checkerTestDir, "workspace", "OTHER.md");
       // Use a workingDir that doesn't contain the path so it's not workspace-scoped
       const result = await check("file_write", { path: otherPath }, "/home");
-      // Medium risk with no matching allow rule → prompt
-      expect(result.decision).toBe("prompt");
+      // Low risk → auto-allowed even outside workspace
+      expect(result.decision).toBe("allow");
     });
   });
 
@@ -4583,24 +4582,24 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.reason).toContain("Workspace mode");
   });
 
-  test("file_write within workspace → allow (Low risk)", async () => {
+  test("file_write within workspace → allow (workspace-scoped)", async () => {
     const result = await check(
       "file_write",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("Workspace mode");
   });
 
-  test("file_edit within workspace → allow (Low risk)", async () => {
+  test("file_edit within workspace → allow (workspace-scoped)", async () => {
     const result = await check(
       "file_edit",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
     expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
+    expect(result.reason).toContain("Workspace mode");
   });
 
   // ── file operations outside workspace follow risk-based fallback ──

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -37,6 +37,7 @@ mock.module("../util/logger.js", () => ({
 const testConfig: Record<string, any> = {
   permissions: { mode: "workspace" as "strict" | "workspace" },
   skills: { load: { extraDirs: [] as string[] } },
+  sandbox: { enabled: false },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -327,20 +328,19 @@ describe("ephemeral-permissions", () => {
       testConfig.permissions.mode = "workspace";
     });
 
-    test("workspace mode prompts for workspace-scoped file_write (medium risk)", async () => {
+    test("workspace mode auto-allows workspace-scoped file_write (low risk)", async () => {
       const filePath = join(testDir, "workspace-test-file.txt");
       const result = await check("file_write", { path: filePath }, testDir);
-      expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("medium risk");
+      expect(result.decision).toBe("allow");
     });
 
-    test("workspace mode still prompts for file_write outside workspace", async () => {
+    test("workspace mode auto-allows file_write outside workspace (low risk)", async () => {
       const result = await check(
         "file_write",
         { path: "/etc/config" },
         testDir,
       );
-      expect(result.decision).toBe("prompt");
+      expect(result.decision).toBe("allow");
     });
 
     test("explicit deny rule overrides workspace mode auto-allow", async () => {


### PR DESCRIPTION
## Summary
- Update checker.test.ts: file_write and file_edit risk assertions from Medium to Low, and workspace-scoped reason strings
- Update asset-materialize-tool.test.ts: risk level assertion from Medium to Low
- Update ephemeral-permissions.test.ts: add missing `sandbox` config mock and update file_write assertions from prompt→allow

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23194687992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
