### PR TITLE
refactor: remove maxTokensPerSession from config schema and rate limit enforcement

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -76,7 +76,7 @@ mock.module("../config/loader.js", () => ({
       summaryModel: "mock-model",
       maxSummaryTokens: 512,
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     timeouts: { permissionTimeoutSec: 300 },
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -42,7 +42,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
     services: {

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -34,7 +34,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -33,7 +33,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
@@ -41,7 +41,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -31,7 +31,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -54,7 +54,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     calls: mockCallsConfig,
   }),
@@ -62,7 +62,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     calls: mockCallsConfig,
     ingress: {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -129,7 +129,6 @@ describe("AssistantConfigSchema", () => {
     });
     expect(result.rateLimit).toEqual({
       maxRequestsPerMinute: 0,
-      maxTokensPerSession: 0,
     });
     expect(result.secretDetection).toEqual({
       enabled: true,
@@ -153,7 +152,7 @@ describe("AssistantConfigSchema", () => {
         shellMaxTimeoutSec: 300,
         permissionTimeoutSec: 60,
       },
-      rateLimit: { maxRequestsPerMinute: 10, maxTokensPerSession: 100000 },
+      rateLimit: { maxRequestsPerMinute: 10 },
       secretDetection: {
         enabled: false,
         action: "block" as const,
@@ -350,13 +349,6 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  test("rejects non-integer rateLimit values", () => {
-    const result = AssistantConfigSchema.safeParse({
-      rateLimit: { maxTokensPerSession: 3.5 },
-    });
-    expect(result.success).toBe(false);
-  });
-
   test("rejects negative auditLog.retentionDays", () => {
     const result = AssistantConfigSchema.safeParse({
       auditLog: { retentionDays: -7 },
@@ -375,11 +367,10 @@ describe("AssistantConfigSchema", () => {
 
   test("accepts zero for non-negative fields", () => {
     const result = AssistantConfigSchema.parse({
-      rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+      rateLimit: { maxRequestsPerMinute: 0 },
       auditLog: { retentionDays: 0 },
     });
     expect(result.rateLimit.maxRequestsPerMinute).toBe(0);
-    expect(result.rateLimit.maxTokensPerSession).toBe(0);
     expect(result.auditLog.retentionDays).toBe(0);
   });
 
@@ -1131,11 +1122,10 @@ describe("loadConfig with schema validation", () => {
 
   test("falls back for invalid rateLimit values", () => {
     writeConfig({
-      rateLimit: { maxRequestsPerMinute: -1, maxTokensPerSession: 3.5 },
+      rateLimit: { maxRequestsPerMinute: -1 },
     });
     const config = loadConfig();
     expect(config.rateLimit.maxRequestsPerMinute).toBe(0);
-    expect(config.rateLimit.maxTokensPerSession).toBe(0);
   });
 
   test("falls back for invalid auditLog.retentionDays", () => {

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -47,7 +47,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -50,7 +50,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
     ui: {},
   }),

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -38,7 +38,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
     ui: {},
   }),

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -32,7 +32,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -78,7 +78,7 @@ mock.module("../config/loader.js", () => ({
       summaryModel: "mock-model",
       maxSummaryTokens: 512,
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     timeouts: { permissionTimeoutSec: 1 },
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -31,7 +31,7 @@ mock.module("../config/loader.js", () => ({
       summaryModel: "mock-model",
       maxSummaryTokens: 512,
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -45,7 +45,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -45,7 +45,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     services: {
       inference: {
         mode: "your-own",

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -69,7 +69,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     timeouts: { permissionTimeoutSec: 1 },
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -29,7 +29,7 @@ mock.module("../config/loader.js", () => ({
     model: "claude-opus-4-6",
     provider: "anthropic",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
     services: {

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -52,7 +52,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -52,7 +52,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -35,7 +35,7 @@ mock.module("../config/loader.js", () => ({
       compactThreshold: 0.8,
       summaryBudgetRatio: 0.05,
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     memory: { enabled: false },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -55,7 +55,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     memory: { enabled: false },
     daemon: {
       startupSocketWaitMs: 5000,

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -53,7 +53,7 @@ mock.module("../config/loader.js", () => ({
         nonInteractiveLatestTurnCompression: "truncate",
       },
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     memory: { enabled: false },
     daemon: {
       startupSocketWaitMs: 5000,

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -58,7 +58,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     calls: {
       enabled: true,
@@ -80,7 +80,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     ingress: {
       publicBaseUrl: "https://test.example.com",

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -29,7 +29,7 @@ const mockConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: true,
     action: "warn" as const,

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -39,7 +39,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -16,7 +16,7 @@ const mockConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: true,
     action: "warn" as const,

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -53,7 +53,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     timeouts: { shellDefaultTimeoutSec: 30, shellMaxTimeoutSec: 60 },
     sandbox: { enabled: false, backend: "native" },
   }),

--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -83,7 +83,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -57,7 +57,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -78,7 +78,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -64,7 +64,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -53,7 +53,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/ratelimit.test.ts
+++ b/assistant/src/__tests__/ratelimit.test.ts
@@ -38,7 +38,6 @@ describe("RateLimitProvider", () => {
     test("allows requests under the limit", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 5,
-        maxTokensPerSession: 0,
       };
       const provider = new RateLimitProvider(makeProvider(), config);
 
@@ -50,7 +49,6 @@ describe("RateLimitProvider", () => {
     test("throws RateLimitError when exceeding request limit", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 2,
-        maxTokensPerSession: 0,
       };
       const provider = new RateLimitProvider(makeProvider(), config);
 
@@ -63,7 +61,6 @@ describe("RateLimitProvider", () => {
     test("unlimited when maxRequestsPerMinute is 0", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 0,
-        maxTokensPerSession: 0,
       };
       const provider = new RateLimitProvider(makeProvider(), config);
 
@@ -73,56 +70,10 @@ describe("RateLimitProvider", () => {
     });
   });
 
-  describe("session token limiting", () => {
-    test("allows requests under the token budget", async () => {
-      const config: RateLimitConfig = {
-        maxRequestsPerMinute: 0,
-        maxTokensPerSession: 1000,
-      };
-      const provider = new RateLimitProvider(makeProvider(), config);
-
-      // Each call uses 150 tokens (100 input + 50 output)
-      for (let i = 0; i < 6; i++) {
-        await provider.sendMessage(messages);
-      }
-      // 6 * 150 = 900, still under 1000
-    });
-
-    test("throws RateLimitError when token budget exhausted", async () => {
-      const config: RateLimitConfig = {
-        maxRequestsPerMinute: 0,
-        maxTokensPerSession: 300,
-      };
-      const provider = new RateLimitProvider(makeProvider(), config);
-
-      // 150 tokens per call
-      await provider.sendMessage(messages); // 150
-      await provider.sendMessage(messages); // 300
-
-      expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
-    });
-
-    test("unlimited when maxTokensPerSession is 0", async () => {
-      const config: RateLimitConfig = {
-        maxRequestsPerMinute: 0,
-        maxTokensPerSession: 0,
-      };
-      const provider = new RateLimitProvider(
-        makeProvider({ usage: { inputTokens: 10000, outputTokens: 10000 } }),
-        config,
-      );
-
-      for (let i = 0; i < 10; i++) {
-        await provider.sendMessage(messages);
-      }
-    });
-  });
-
   describe("passthrough behavior", () => {
     test("delegates to inner provider", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 0,
-        maxTokensPerSession: 0,
       };
       const inner = makeProvider({ model: "custom-model" });
       const provider = new RateLimitProvider(inner, config);
@@ -134,7 +85,6 @@ describe("RateLimitProvider", () => {
     test("preserves provider name", () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 0,
-        maxTokensPerSession: 0,
       };
       const provider = new RateLimitProvider(makeProvider(), config);
       expect(provider.name).toBe("mock");
@@ -143,7 +93,6 @@ describe("RateLimitProvider", () => {
     test("passes through all arguments to inner provider", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 0,
-        maxTokensPerSession: 0,
       };
       let receivedArgs: unknown[] = [];
       const inner: Provider = {
@@ -173,27 +122,10 @@ describe("RateLimitProvider", () => {
     });
   });
 
-  describe("combined limits", () => {
-    test("enforces both limits simultaneously", async () => {
-      const config: RateLimitConfig = {
-        maxRequestsPerMinute: 10,
-        maxTokensPerSession: 300,
-      };
-      const provider = new RateLimitProvider(makeProvider(), config);
-
-      // Token limit should hit first (2 * 150 = 300)
-      await provider.sendMessage(messages);
-      await provider.sendMessage(messages);
-
-      expect(provider.sendMessage(messages)).rejects.toThrow(RateLimitError);
-    });
-  });
-
   describe("shared request timestamps", () => {
     test("multiple providers sharing timestamps enforce a global rate limit", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 2,
-        maxTokensPerSession: 0,
       };
       const shared: number[] = [];
       const provider1 = new RateLimitProvider(makeProvider(), config, shared);
@@ -215,7 +147,6 @@ describe("RateLimitProvider", () => {
     test("out-of-order timestamps are pruned correctly (clock skew)", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 3,
-        maxTokensPerSession: 0,
       };
       const shared: number[] = [];
       const provider = new RateLimitProvider(makeProvider(), config, shared);
@@ -236,7 +167,6 @@ describe("RateLimitProvider", () => {
     test("waitSec uses actual oldest timestamp under clock skew", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 2,
-        maxTokensPerSession: 0,
       };
       const shared: number[] = [];
       const provider = new RateLimitProvider(makeProvider(), config, shared);
@@ -266,7 +196,6 @@ describe("RateLimitProvider", () => {
       const highLimit = 200_000;
       const config: RateLimitConfig = {
         maxRequestsPerMinute: highLimit,
-        maxTokensPerSession: 0,
       };
       const shared: number[] = [];
       const provider = new RateLimitProvider(makeProvider(), config, shared);
@@ -286,7 +215,6 @@ describe("RateLimitProvider", () => {
     test("shared array reference survives pruning", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 100,
-        maxTokensPerSession: 0,
       };
       const shared: number[] = [];
       const provider1 = new RateLimitProvider(makeProvider(), config, shared);
@@ -311,7 +239,6 @@ describe("RateLimitProvider", () => {
     test("concurrent calls are rate-limited because timestamp is recorded before await", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 1,
-        maxTokensPerSession: 0,
       };
       // Slow provider that yields to the event loop
       const inner: Provider = {
@@ -343,7 +270,6 @@ describe("RateLimitProvider", () => {
     test("failed inner calls still count toward request rate", async () => {
       const config: RateLimitConfig = {
         maxRequestsPerMinute: 1,
-        maxTokensPerSession: 0,
       };
       const inner: Provider = {
         name: "failing",

--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -52,7 +52,7 @@ const mockConfig = {
       network: "none" as const,
     },
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: false,
     action: "warn" as const,

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -43,7 +43,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
   }),
 }));
 

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -50,7 +50,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -42,7 +42,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
   }),
 }));

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -20,7 +20,7 @@ const mockConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: true,
     action: "warn" as "redact" | "warn" | "block",

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -52,7 +52,7 @@ mock.module("../config/loader.js", () => ({
     model: "test",
     provider: "test",
     memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
     contextWindow: { maxInputTokens: 200000 },
     services: {

--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -34,7 +34,7 @@ const mockConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: true,
     action: "warn" as const,

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -17,7 +17,7 @@ const mockConfig = {
     shellMaxTimeoutSec: 600,
     permissionTimeoutSec: 300,
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: true,
     action: "warn" as const,

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -32,7 +32,7 @@ mock.module("../config/loader.js", () => ({
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
     },
-    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: {
       enabled: false,
       action: "warn" as const,

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -26,7 +26,7 @@ const mockConfig = {
       network: "none" as const,
     },
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: false,
     action: "warn" as const,

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -35,7 +35,7 @@ const mockConfig = {
       network: "none" as const,
     },
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: false,
     action: "warn" as const,

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -44,7 +44,7 @@ const mockConfig = {
       network: "none" as const,
     },
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: false,
     action: "warn" as const,

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -121,7 +121,7 @@ const mockConfigObj = {
   model: "test",
   provider: "test",
   memory: { enabled: false },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: { enabled: false },
   elevenlabs: { voiceId: DEFAULT_ELEVENLABS_VOICE_ID },
   calls: {

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -37,7 +37,7 @@ const mockConfig = {
       network: "none" as const,
     },
   },
-  rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  rateLimit: { maxRequestsPerMinute: 0 },
   secretDetection: {
     enabled: false,
     action: "warn" as const,

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -53,16 +53,6 @@ export const RateLimitConfigSchema = z
       )
       .default(0)
       .describe("Maximum number of LLM requests per minute (0 = unlimited)"),
-    maxTokensPerSession: z
-      .number({ error: "rateLimit.maxTokensPerSession must be a number" })
-      .int("rateLimit.maxTokensPerSession must be an integer")
-      .nonnegative(
-        "rateLimit.maxTokensPerSession must be a non-negative integer",
-      )
-      .default(0)
-      .describe(
-        "Maximum total tokens (input + output) per conversation session (0 = unlimited)",
-      ),
   })
   .describe("Rate limiting for LLM provider requests");
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -758,10 +758,7 @@ export class DaemonServer {
           config.providerOrder,
         );
         const { rateLimit } = config;
-        if (
-          rateLimit.maxRequestsPerMinute > 0 ||
-          rateLimit.maxTokensPerSession > 0
-        ) {
+        if (rateLimit.maxRequestsPerMinute > 0) {
           provider = new RateLimitProvider(
             provider,
             rateLimit,

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -15,7 +15,6 @@ export class RateLimitProvider implements Provider {
   public readonly name: string;
 
   private requestTimestamps: number[];
-  private sessionTokens = 0;
 
   constructor(
     private readonly inner: Provider,
@@ -33,7 +32,6 @@ export class RateLimitProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     this.enforceRequestRate();
-    this.enforceTokenBudget();
 
     // Record the request timestamp before the await to prevent concurrent
     // calls from bypassing the rate limit during the async gap.
@@ -45,8 +43,6 @@ export class RateLimitProvider implements Provider {
       systemPrompt,
       options,
     );
-
-    this.recordTokens(response.usage.inputTokens + response.usage.outputTokens);
 
     return response;
   }
@@ -89,39 +85,8 @@ export class RateLimitProvider implements Provider {
     }
   }
 
-  private enforceTokenBudget(): void {
-    const limit = this.config.maxTokensPerSession;
-    if (limit <= 0) return;
-
-    if (this.sessionTokens >= limit) {
-      log.warn(
-        {
-          provider: this.name,
-          sessionTokens: this.sessionTokens,
-          limit,
-        },
-        `Session token budget exhausted for ${this.name}: ${this.sessionTokens.toLocaleString()}/${limit.toLocaleString()}`,
-      );
-      throw new RateLimitError(
-        `Session token budget exhausted: ${this.sessionTokens.toLocaleString()}/${limit.toLocaleString()} tokens used. Start a new session to continue.`,
-      );
-    }
-  }
-
   private recordRequest(): void {
     if (this.config.maxRequestsPerMinute <= 0) return;
     this.requestTimestamps.push(Date.now());
-  }
-
-  private recordTokens(tokens: number): void {
-    if (this.config.maxTokensPerSession <= 0) return;
-    this.sessionTokens += tokens;
-    log.debug(
-      {
-        sessionTokens: this.sessionTokens,
-        limit: this.config.maxTokensPerSession,
-      },
-      "Token usage updated",
-    );
   }
 }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -134,10 +134,7 @@ export class SubagentManager {
       appConfig.providerOrder,
     );
     const { rateLimit } = appConfig;
-    if (
-      rateLimit.maxRequestsPerMinute > 0 ||
-      rateLimit.maxTokensPerSession > 0
-    ) {
+    if (rateLimit.maxRequestsPerMinute > 0) {
       provider = new RateLimitProvider(
         provider,
         rateLimit,


### PR DESCRIPTION
## Summary
- Remove cumulative token budget enforcement from RateLimitProvider (sessionTokens tracking, enforceTokenBudget, recordTokens)
- Remove maxTokensPerSession from RateLimitConfigSchema and all test fixtures (46 files)
- Simplify conditionals in server.ts and manager.ts to only check maxRequestsPerMinute

Part of plan: remove-max-tokens-per-session.md (PR 1 of 1, combined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
