### PR TITLE
fix: use OnboardingButton ghost variant for all onboarding Back buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -39,23 +39,13 @@ struct APIKeyEntryStepView: View {
                     saveAndHatch()
                 }
 
-                HStack(spacing: VSpacing.lg) {
-                    Link(destination: URL(string: "https://console.anthropic.com/settings/keys")!) {
-                        Text("Get an API key")
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.primaryBase)
-                    }
-                    .pointerCursor()
-
-                    Button(action: { goBack() }) {
-                        Text("Back")
-                            .font(.system(size: 13))
-                            .foregroundColor(VColor.contentTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .pointerCursor()
+                OnboardingButton(title: "Get an API key", style: .primary) {
+                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
                 }
-                .padding(.top, VSpacing.xs)
+
+                OnboardingButton(title: "Back", style: .ghost) {
+                    goBack()
+                }
             }
         }
         .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -42,14 +42,8 @@ struct APIKeyStepView: View {
                 }
 
                 if !isAuthenticated {
-                    HStack(spacing: VSpacing.lg) {
-                        Button(action: { goBack() }) {
-                            Text("Back")
-                                .font(.system(size: 13))
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        .buttonStyle(.plain)
-                        .pointerCursor()
+                    OnboardingButton(title: "Back", style: .ghost) {
+                        goBack()
                     }
                     .padding(.top, VSpacing.xs)
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -157,7 +157,7 @@ struct HatchingStepView: View {
                     meetExistingAssistant()
                 }
 
-                OnboardingButton(title: "Go Back", style: .tertiary) {
+                OnboardingButton(title: "Go Back", style: .ghost) {
                     goBack()
                 }
             } else {
@@ -165,7 +165,7 @@ struct HatchingStepView: View {
                     retryHatch()
                 }
 
-                OnboardingButton(title: "Go Back", style: .tertiary) {
+                OnboardingButton(title: "Go Back", style: .ghost) {
                     goBack()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -89,13 +89,9 @@ struct ImproveExperienceStepView: View {
                     saveAndContinue()
                 }
 
-                Button(action: { goBack() }) {
-                    Text("Back")
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.contentTertiary)
+                OnboardingButton(title: "Back", style: .ghost) {
+                    goBack()
                 }
-                .buttonStyle(.plain)
-                .pointerCursor()
                 .padding(.top, VSpacing.xs)
             }
         }


### PR DESCRIPTION
## Summary
- Convert all plain Back buttons in onboarding flows to use OnboardingButton with ghost variant for consistent hover effect
- Restructure API key entry step: Get API key becomes a green OnboardingButton (primary), Back button moved below it in vertical layout
- Change HatchingStepView Go Back buttons from tertiary to ghost style

Part of plan: onboard-back-btns.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
