### PR TITLE
fix: classify streaming errors as retryable so Retry button appears

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -276,6 +276,37 @@ describe("classifyConversationError", () => {
     });
   });
 
+  describe("streaming corruption errors", () => {
+    const cases = [
+      "Unexpected event order, got message_start before receiving message_stop",
+      "Anthropic request failed: Unexpected event order, got message_start before receiving \"message_stop\"",
+      "stream ended without producing a Message",
+      "request ended without sending any chunks",
+      "stream has ended, this shouldn't happen",
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_API (retryable)`, () => {
+        const result = classifyConversationError(new Error(msg), baseCtx);
+        expect(result.code).toBe("PROVIDER_API");
+        expect(result.retryable).toBe(true);
+        expect(result.userMessage).toContain("interrupted");
+        expect(result.errorCategory).toBe("stream_corruption");
+      });
+    }
+
+    it("classifies ProviderError without statusCode with streaming message as PROVIDER_API", () => {
+      const err = new ProviderError(
+        "Unexpected event order, got message_start before receiving message_stop",
+        "anthropic",
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("stream_corruption");
+    });
+  });
+
   describe("abort/cancel errors (non-user-initiated)", () => {
     it('classifies "aborted" as CONVERSATION_ABORTED', () => {
       const result = classifyConversationError(

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -85,6 +85,14 @@ const WEB_SEARCH_ORDERING_PATTERNS = [
   /web_search.*tool_result/i,
 ];
 
+// Streaming corruption patterns (Anthropic SDK throws non-HTTP errors for SSE issues)
+const STREAMING_ERROR_PATTERNS = [
+  /unexpected event order/i,
+  /stream ended without producing/i,
+  /request ended without sending any chunks/i,
+  /stream has ended.*this shouldn't happen/i,
+];
+
 // User-initiated cancellation patterns — these should NOT produce conversation_error
 const CANCEL_PATTERNS = [/abort/i, /cancel/i];
 
@@ -288,6 +296,11 @@ export function isOrderingError(message: string): boolean {
   return ORDERING_ERROR_PATTERNS.some((p) => p.test(message));
 }
 
+/** Check whether an error message indicates an Anthropic SDK streaming corruption. */
+export function isStreamingError(message: string): boolean {
+  return STREAMING_ERROR_PATTERNS.some((p) => p.test(message));
+}
+
 function classifyByMessage(
   message: string,
 ): Omit<ClassifiedConversationError, "debugDetails"> {
@@ -370,6 +383,16 @@ function classifyByMessage(
         errorCategory: "provider_timeout",
       };
     }
+  }
+
+  // Streaming corruption errors (Anthropic SDK SSE issues — transient, retryable)
+  if (isStreamingError(message)) {
+    return {
+      code: "PROVIDER_API",
+      userMessage: "The AI provider's response was interrupted. Please try again.",
+      retryable: true,
+      errorCategory: "stream_corruption",
+    };
   }
 
   // Non-user abort/failure (e.g. AbortError from internal logic, not user cancel)


### PR DESCRIPTION
## Summary
- Add `STREAMING_ERROR_PATTERNS` to `conversation-error.ts` matching known Anthropic SDK streaming corruption messages (`Unexpected event order`, `stream ended without producing`, etc.)
- Classify these as `PROVIDER_API` with `retryable: true` and `errorCategory: "stream_corruption"` so the client renders a Retry button in the error toast
- Complements #18275 (provider-level retries) — when automatic retries are exhausted, users can now manually retry from the UI

## Original prompt
Should there be a retry button here? (screenshot of "Processing failed: Unexpected event order" with no Retry button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
