### PR TITLE
feat: inline error alert cards in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -176,7 +176,13 @@ struct ChatBubble: View {
                     if !isUser && hasInterleavedContent {
                         interleavedContent
                     } else {
-                        if shouldShowBubble {
+                        if message.isError && hasText {
+                            InlineChatErrorAlert(
+                                message: message.text,
+                                conversationError: message.conversationError
+                            )
+                            .scaleEffect(conversationZoomScale, anchor: .topLeading)
+                        } else if shouldShowBubble {
                             bubbleContent
                         }
 
@@ -334,23 +340,7 @@ struct ChatBubble: View {
                     SkillInvocationChip(data: skillInvocation)
                 }
 
-                if message.isError && hasText {
-                    HStack(alignment: .top, spacing: VSpacing.sm) {
-                        VIconView(.triangleAlert, size: 14 * conversationZoomScale)
-                            .foregroundColor(VColor.systemNegativeStrong)
-                            .padding(.top, 1)
-                        Text(message.text)
-                            .font(.system(size: 14 * conversationZoomScale))
-                            .lineSpacing(6)
-                            .foregroundColor(VColor.contentDefault)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            // lineLimit(nil) lets text wrap naturally in a single measurement
-                            // pass, avoiding the double-measurement that fixedSize causes
-                            // (measure at ideal size, then constrain to proposed width).
-                            .lineLimit(nil)
-                    }
-                } else if hasText {
+                if hasText {
                     let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
                     // Always render through MarkdownSegmentView to keep view
                     // identity stable across async segment parsing transitions.

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1611,6 +1611,7 @@ public struct ChatMessage: Identifiable, Equatable {
         && lhs.isStreaming == rhs.isStreaming
         && lhs.status == rhs.status
         && lhs.isError == rhs.isError
+        && lhs.conversationError == rhs.conversationError
         && lhs.toolCalls == rhs.toolCalls
         && lhs.attachments.count == rhs.attachments.count
         && lhs.inlineSurfaces == rhs.inlineSurfaces
@@ -1646,6 +1647,9 @@ public struct ChatMessage: Identifiable, Equatable {
     /// When true, this message represents a conversation error (rate limit, network failure, etc.)
     /// and should be rendered with distinct error styling (red box) instead of a normal bubble.
     public var isError: Bool
+    /// Typed error metadata for inline error display (category icon, recovery suggestion, etc.).
+    /// Populated when the error originates from a `ConversationErrorMessage`.
+    public var conversationError: ConversationError?
     /// The daemon's persisted message ID, populated from history responses.
     /// Nil for freshly streamed messages that haven't been loaded from history.
     /// Used for anchoring diagnostics exports so the daemon can locate the message.
@@ -1671,7 +1675,7 @@ public struct ChatMessage: Identifiable, Equatable {
         textSegments.joined(separator: "\n")
     }
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false, conversationError: ConversationError? = nil) {
         self.id = id
         self.role = role
         self.textSegments = text.isEmpty ? [] : [text]
@@ -1686,6 +1690,7 @@ public struct ChatMessage: Identifiable, Equatable {
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
         self.isError = isError
+        self.conversationError = conversationError
     }
 
     /// Synthesize `ToolConfirmationData` entries from persisted per-tool-call confirmation data.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1792,11 +1792,8 @@ extension ChatViewModel {
                    messages.last?.toolCalls.isEmpty == true {
                     messages.removeAll(where: { $0.id == existingId })
                 }
-                // macOS shows ChatConversationErrorToast; only append inline error on iOS where the toast is unavailable
-                #if os(iOS)
-                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true)
+                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true, conversationError: typedError)
                 messages.append(errorMsg)
-                #endif
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+/// A polished inline alert card rendered in the chat message list for conversation errors.
+///
+/// Replaces the raw error text with a structured alert that shows:
+/// - Category-specific icon and title
+/// - Error message body
+/// - Recovery suggestion
+///
+/// When `conversationError` metadata is available, the alert renders with full
+/// category-aware styling. Falls back to a generic alert for plain `isError` messages.
+public struct InlineChatErrorAlert: View {
+    let message: String
+    let conversationError: ConversationError?
+
+    public init(message: String, conversationError: ConversationError? = nil) {
+        self.message = message
+        self.conversationError = conversationError
+    }
+
+    private var category: ConversationErrorCategory {
+        conversationError?.category ?? .unknown
+    }
+
+    private var accentColor: Color {
+        switch category {
+        case .rateLimit, .providerNetwork, .contextTooLarge, .providerOrdering, .providerWebSearch:
+            return VColor.systemMidStrong
+        case .conversationAborted:
+            return VColor.systemPositiveStrong
+        default:
+            return VColor.systemNegativeStrong
+        }
+    }
+
+    private var icon: VIcon {
+        switch category {
+        case .providerNetwork: return .wifiOff
+        case .rateLimit: return .clockAlert
+        case .providerApi, .providerOrdering, .providerWebSearch: return .cloudOff
+        case .providerBilling: return .creditCard
+        case .contextTooLarge: return .fileText
+        case .conversationAborted: return .circleStop
+        case .processingFailed, .regenerateFailed: return .refreshCw
+        case .authenticationRequired: return .lock
+        case .unknown: return .circleAlert
+        }
+    }
+
+    private var categoryTitle: String {
+        switch category {
+        case .providerNetwork: return "Network Error"
+        case .rateLimit: return "Rate Limited"
+        case .providerApi: return "API Error"
+        case .providerBilling: return "Billing Error"
+        case .providerOrdering: return "Processing Error"
+        case .providerWebSearch: return "Web Search Error"
+        case .contextTooLarge: return "Context Too Large"
+        case .conversationAborted: return "Conversation Stopped"
+        case .processingFailed: return "Processing Failed"
+        case .regenerateFailed: return "Regeneration Failed"
+        case .authenticationRequired: return "Authentication Required"
+        case .unknown: return "Error"
+        }
+    }
+
+    private var recoverySuggestion: String? {
+        conversationError?.recoverySuggestion
+    }
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            // Left accent bar — provides category color at a glance
+            RoundedRectangle(cornerRadius: 2)
+                .fill(accentColor)
+                .frame(width: 3)
+                .padding(.vertical, 1)
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Header: icon + category title
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(icon, size: 13)
+                        .foregroundColor(accentColor)
+                    Text(categoryTitle)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentEmphasized)
+                }
+
+                // Error message body
+                Text(message)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // Recovery suggestion
+                if let suggestion = recoverySuggestion {
+                    Text(suggestion)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.leading, VSpacing.md)
+            .padding(.trailing, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(accentColor.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .strokeBorder(accentColor.opacity(0.15), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+}

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -252,22 +252,9 @@ public struct MessageBubbleView: View {
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .textSelection(.enabled)
         } else if message.isError {
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                VIconView(.triangleAlert, size: 13)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                    .padding(.top, 1)
-                Text(text)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentDefault)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(VSpacing.md)
-            .background(VColor.systemNegativeStrong.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .strokeBorder(VColor.systemNegativeStrong.opacity(0.3), lineWidth: 1)
+            InlineChatErrorAlert(
+                message: text,
+                conversationError: message.conversationError
             )
             .contextMenu {
                 if let onRegenerate {


### PR DESCRIPTION
## Summary
- Conversation errors now render as structured inline alert cards in the chat message list (both macOS and iOS) instead of raw text
- Each alert shows a left accent bar colored by error category, a category-specific icon and title, the error message, and a recovery suggestion
- macOS now also appends inline error messages to the chat (previously only showed the top toast; iOS already had inline errors but unstyled)
- Added `conversationError: ConversationError?` to `ChatMessage` to carry typed error metadata through to the view layer

## Test plan
- [ ] Trigger a conversation error (e.g. invalid API key, network disconnect) and verify the inline alert renders with icon, title, message, and recovery suggestion
- [ ] Verify the macOS toast still appears above the composer alongside the new inline alert
- [ ] Verify iOS renders the same styled alert card
- [ ] Verify non-error messages render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
