### PR TITLE
fix: remove unused variable in provider error scenarios test

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -479,7 +479,7 @@ describe("RetryProvider — streaming corruption retries", () => {
     );
     const provider = new RetryProvider(inner);
 
-    const result = await provider.sendMessage(MESSAGES);
+    await provider.sendMessage(MESSAGES);
     expect(inner.calls).toBe(2);
   });
 


### PR DESCRIPTION
## Summary
- Remove unused `result` variable assignment at line 482 in `provider-error-scenarios.test.ts` that was causing a lint failure (`@typescript-eslint/no-unused-vars`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23195568047/job/67402895621

🤖 Generated with [Claude Code](https://claude.com/claude-code)