### PR TITLE
feat: use file-based CredentialStorage in debug builds to avoid Keychain prompts

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -193,16 +193,20 @@ extension AppDelegate {
                 }
             }
 
-            // Clear locally-cached credentials from Keychain for all local assistants
-            let keychainStorage = KeychainCredentialStorage()
+            // Clear locally-cached credentials for all local assistants
+            #if DEBUG
+            let credStorage = FileCredentialStorage()
+            #else
+            let credStorage = KeychainCredentialStorage()
+            #endif
             for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistant.assistantId)
-                _ = keychainStorage.delete(account: credentialAccount)
+                _ = credStorage.delete(account: credentialAccount)
             }
             // Also clear for the connected assistant in case it's not in the lockfile
             if let assistantId = connectedAssistantId {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistantId)
-                _ = keychainStorage.delete(account: credentialAccount)
+                _ = credStorage.delete(account: credentialAccount)
             }
 
             // Stop all non-current local daemons to clear in-memory managed proxy
@@ -359,7 +363,11 @@ extension AppDelegate {
             }
 
             do {
+                #if DEBUG
+                let credentialStorage = FileCredentialStorage()
+                #else
                 let credentialStorage = KeychainCredentialStorage()
+                #endif
                 let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
                 let outcome = try await bootstrapService.bootstrap(
                     runtimeAssistantId: assistantId,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -507,7 +507,13 @@ struct SettingsDeveloperTab: View {
             isManaged: assistant.isManaged,
             organizationId: orgId,
             userId: userId,
-            credentialStorage: KeychainCredentialStorage()
+            credentialStorage: {
+                #if DEBUG
+                return FileCredentialStorage()
+                #else
+                return KeychainCredentialStorage()
+                #endif
+            }()
         )
     }
 

--- a/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
@@ -1,0 +1,105 @@
+#if os(macOS)
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "FileCredentialStorage"
+)
+
+/// File-based CredentialStorage for DEBUG builds.
+///
+/// Stores each credential as an individual file under
+/// `~/.vellum/protected/credentials/` with 0600 permissions.
+/// This avoids macOS Keychain authorization prompts that fire on
+/// every rebuild because the binary's cdhash changes.
+///
+/// Mirrors the approach used by `SigningIdentityManager` which stores
+/// the Ed25519 signing key on disk for the same reason.
+struct FileCredentialStorage: CredentialStorage {
+
+    private static let credentialsDir: URL = {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".vellum/protected/credentials")
+    }()
+
+    /// Returns the file URL for a given credential account name.
+    /// The account name is sanitized to a safe filename by replacing
+    /// characters that are not alphanumerics, hyphens, or underscores.
+    private func fileURL(for account: String) -> URL {
+        let safeName = account.replacingOccurrences(
+            of: "[^a-zA-Z0-9_\\-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return Self.credentialsDir.appendingPathComponent(safeName)
+    }
+
+    /// Ensures the credentials directory exists with 0700 permissions.
+    private func ensureDirectory() -> Bool {
+        let dir = Self.credentialsDir
+        if FileManager.default.fileExists(atPath: dir.path) {
+            return true
+        }
+        do {
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: dir.path
+            )
+            return true
+        } catch {
+            log.error("Failed to create credentials directory: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    func get(account: String) -> String? {
+        let url = fileURL(for: account)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return String(data: data, encoding: .utf8)
+        } catch {
+            log.error("Failed to read credential '\(account)': \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func set(account: String, value: String) -> Bool {
+        guard ensureDirectory() else { return false }
+        let url = fileURL(for: account)
+        do {
+            try value.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            return true
+        } catch {
+            log.error("Failed to write credential '\(account)': \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    func delete(account: String) -> Bool {
+        let url = fileURL(for: account)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return true // Already gone
+        }
+        do {
+            try FileManager.default.removeItem(at: url)
+            return true
+        } catch {
+            log.error("Failed to delete credential '\(account)': \(error.localizedDescription)")
+            return false
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Added `FileCredentialStorage` in `clients/macos/vellum-assistant/Security/` that stores credentials as individual files at `~/.vellum/protected/credentials/` with 0600 permissions, mirroring the `SigningIdentityManager` file-based approach
- Updated all 3 `KeychainCredentialStorage()` call sites (`performLogout`, `ensureLocalAssistantApiKey`, `SettingsDeveloperTab`) to use `#if DEBUG` / `#else` to swap in `FileCredentialStorage` in debug builds
- Production behavior is completely unchanged — `#if !DEBUG` paths continue using `KeychainCredentialStorage`

## Original prompt

In debug builds, swap KeychainCredentialStorage for a file-based CredentialStorage implementation to avoid macOS Keychain prompts on every rebuild. The keychain broker server is already guarded with `#if !DEBUG`, and `SigningIdentityManager` was already migrated away from Keychain for this exact reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
