### PR TITLE
fix: classify socket-closed errors as retryable for Retry button

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -70,6 +70,7 @@ describe("classifyConversationError", () => {
       "Connection refused by server",
       "connection reset",
       "connection timeout",
+      "The socket connection was closed unexpectedly",
     ];
 
     for (const msg of cases) {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -28,6 +28,7 @@ const NETWORK_PATTERNS = [
   /connection.*refused/i,
   /connection.*reset/i,
   /connection.*timeout/i,
+  /socket.*closed/i,
 ];
 
 // Rate limit patterns (HTTP 429 or explicit rate limit messages)


### PR DESCRIPTION
## Summary
- Add `/socket.*closed/i` pattern to `NETWORK_PATTERNS` in `conversation-error.ts` so that errors like "The socket connection was closed unexpectedly" are classified as retryable network errors instead of falling to the non-retryable default
- Add test case for the new pattern

## Original prompt
The retry button is missing here - please fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
