### PR TITLE
fix: auto-retry Bun socket-close errors at the provider level

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -66,11 +66,12 @@ describe("classifyConversationError", () => {
       "ETIMEDOUT",
       "ENOTFOUND",
       "socket hang up",
+      "The socket connection was closed unexpectedly",
+      "Anthropic request failed: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
       "fetch failed",
       "Connection refused by server",
       "connection reset",
       "connection timeout",
-      "The socket connection was closed unexpectedly",
     ];
 
     for (const msg of cases) {

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -49,6 +49,11 @@ mock.module("../util/retry.js", () => {
     return status === 429 || status >= 500;
   }
 
+  const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
+    /socket.*closed unexpectedly/i,
+    /socket hang up/i,
+  ];
+
   function isRetryableNetworkError(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
     const retryableCodes = new Set([
@@ -62,6 +67,18 @@ mock.module("../util/retry.js", () => {
     if (error.cause instanceof Error) {
       const causeCode = (error.cause as NodeJS.ErrnoException).code;
       if (causeCode && retryableCodes.has(causeCode)) return true;
+    }
+    if (
+      RETRYABLE_NETWORK_MESSAGE_PATTERNS.some((p) => p.test(error.message))
+    ) {
+      return true;
+    }
+    const cause = error.cause;
+    if (
+      cause instanceof Error &&
+      RETRYABLE_NETWORK_MESSAGE_PATTERNS.some((p) => p.test(cause.message))
+    ) {
+      return true;
     }
     return false;
   }
@@ -387,6 +404,34 @@ describe("RetryProvider — network error retries", () => {
   test("retries on ECONNRESET in error cause chain", async () => {
     const cause = new Error("socket hangup");
     (cause as NodeJS.ErrnoException).code = "ECONNRESET";
+    const outer = new Error("fetch failed", { cause });
+    const inner = makeFlaky(1, outer);
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(inner.calls).toBe(2);
+    expect(result.content[0]).toMatchObject({ type: "text", text: "ok" });
+  });
+
+  test("retries on Bun 'socket connection was closed unexpectedly' (ProviderError wrapping)", async () => {
+    const inner = makeFlaky(
+      1,
+      new ProviderError(
+        "Anthropic request failed: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+        "anthropic",
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(inner.calls).toBe(2);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("retries on 'socket connection was closed unexpectedly' in error cause", async () => {
+    const cause = new Error(
+      "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+    );
     const outer = new Error("fetch failed", { cause });
     const inner = makeFlaky(1, outer);
     const provider = new RetryProvider(inner);

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -23,12 +23,12 @@ const NETWORK_PATTERNS = [
   /ETIMEDOUT/i,
   /ENOTFOUND/i,
   /socket hang up/i,
+  /socket.*closed unexpectedly/i,
   /network.*error/i,
   /fetch failed/i,
   /connection.*refused/i,
   /connection.*reset/i,
   /connection.*timeout/i,
-  /socket.*closed/i,
 ];
 
 // Rate limit patterns (HTTP 429 or explicit rate limit messages)

--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -75,8 +75,18 @@ export function isRetryableStatus(status: number): boolean {
 }
 
 /**
+ * Message patterns that indicate a retryable network/transport error even
+ * when no errno code is present (e.g. Bun's native fetch socket errors).
+ */
+const RETRYABLE_NETWORK_MESSAGE_PATTERNS = [
+  /socket.*closed unexpectedly/i,
+  /socket hang up/i,
+];
+
+/**
  * Whether an error is a retryable network error (ECONNRESET, ECONNREFUSED, etc.).
- * Checks both the error itself and one level of `cause` chain.
+ * Checks errno codes on the error and one level of `cause` chain, then falls
+ * back to message-based detection for runtime-specific errors (e.g. Bun fetch).
  */
 export function isRetryableNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -94,6 +104,24 @@ export function isRetryableNetworkError(error: unknown): boolean {
   if (error.cause instanceof Error) {
     const causeCode = (error.cause as NodeJS.ErrnoException).code;
     if (causeCode && retryableCodes.has(causeCode)) return true;
+  }
+
+  // Fall back to message-based detection for errors without errno codes
+  // (e.g. Bun's "The socket connection was closed unexpectedly")
+  if (
+    RETRYABLE_NETWORK_MESSAGE_PATTERNS.some((p) => p.test(error.message))
+  ) {
+    return true;
+  }
+
+  // Also check the cause's message (ProviderError wraps the original message
+  // but the cause retains the raw transport-level text)
+  const cause = error.cause;
+  if (
+    cause instanceof Error &&
+    RETRYABLE_NETWORK_MESSAGE_PATTERNS.some((p) => p.test(cause.message))
+  ) {
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Add message-based pattern matching (`/socket.*closed unexpectedly/i`) to `isRetryableNetworkError()` so Bun's socket close errors are automatically retried up to 3 times with exponential backoff — previously these errors had no errno code and slipped through
- Also check the `.cause` chain for the pattern, since `ProviderError` wraps the original transport error
- Refine the conversation-error classifier pattern from `/socket.*closed/i` to `/socket.*closed unexpectedly/i` for precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
