### PR TITLE
fix: don't repeat error text below inline error alert card

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1834,11 +1834,18 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({ agentLoopRun });
       await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-      // The providerErrorUserMessage should trigger a synthesized assistant_text_delta
+      // The error should be sent as a conversation_error (not as an
+      // assistant_text_delta, which would cause duplicate text rendering
+      // alongside the InlineChatErrorAlert card).
       const textDeltas = events.filter(
         (e) => e.type === "assistant_text_delta",
       );
-      expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+      expect(textDeltas).toHaveLength(0);
+
+      const conversationErrors = events.filter(
+        (e) => e.type === "conversation_error",
+      );
+      expect(conversationErrors.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1494,11 +1494,10 @@ export async function runAgentLoopImpl(
         errChannelMeta,
       );
       newMessages.push(errorAssistantMessage);
-      onEvent({
-        type: "assistant_text_delta",
-        text: state.providerErrorUserMessage,
-        conversationId: ctx.conversationId,
-      });
+      // Do NOT send assistant_text_delta here — handleProviderError already
+      // emitted a conversation_error event for this same error text, and the
+      // client renders it as an InlineChatErrorAlert. Sending a text delta
+      // would create a duplicate plain-text bubble below the alert card.
     }
 
     const restoredHistory = [...preRepairMessages, ...newMessages];


### PR DESCRIPTION
## Summary
- Remove redundant `assistant_text_delta` emission for provider errors in the agent loop post-processing
- `handleProviderError` already sends a `conversation_error` event for the same error, which the client renders as an `InlineChatErrorAlert` card
- The text delta was creating a second plain-text bubble with identical content below the alert card
- Error text is still persisted to the DB and conversation history (just not sent as a streaming delta)

## Original prompt
When displaying the inline error block, don't repeat the same text again below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
