### PR TITLE
fix: reset avatar position on conversation open

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -480,6 +480,20 @@ struct MessageListView: View {
     private func restoreScrollToBottom(proxy: ScrollViewProxy) {
         scrollRestoreTask?.cancel()
         hasFreshAnchorMeasurement = false
+
+        // Reset avatar follower state so the avatar starts hidden and only
+        // appears once the conversation tail anchor reports a fresh position
+        // after the scroll settles. Without this, the avatar can flash at a
+        // stale Y from a previous layout pass (e.g. app re-launch where
+        // onAppear calls restoreScrollToBottom without resetting avatar state).
+        avatarSmoothingTask?.cancel()
+        avatarSmoothingTask = nil
+        avatarTargetY = .infinity
+        avatarDisplayY = .infinity
+        pendingAvatarY = nil
+        avatarLastAppliedAt = nil
+        lastTailAnchorY = .infinity
+
         scrollRestoreTask = Task { @MainActor in
             guard !Task.isCancelled else { return }
             // Stage 0: immediate — covers the happy path where layout is already ready.
@@ -1092,12 +1106,10 @@ struct MessageListView: View {
                     conversationSwitchSuppressionTask = nil
                 }
                 isConversationContentHovered = false
-                avatarTargetY = .infinity
-                avatarDisplayY = .infinity
-                pendingAvatarY = nil
-                avatarLastAppliedAt = nil
                 hasPlayedTailEntryAnimation = false
-                lastTailAnchorY = .infinity
+                // Avatar state (avatarTargetY, avatarDisplayY, pendingAvatarY,
+                // avatarLastAppliedAt, lastTailAnchorY) is reset inside
+                // restoreScrollToBottom so the reset is shared with onAppear.
                 restoreScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {


### PR DESCRIPTION
## Summary
- Moved avatar follower state reset into `restoreScrollToBottom()` so both the `onAppear` and `onChange(of: conversationId)` paths reset avatar positioning before scrolling
- Previously, only conversation switches reset the avatar; app launch / thread re-open via `onAppear` could show the avatar at a stale Y from a prior layout pass
- The avatar now starts hidden (`.infinity`) and only appears once the conversation tail anchor reports its position after the scroll lands

## Original prompt
When opening this thread, my assistant's avatar showed up in the wrong place (red arrow), when it should have showed up somewhere in the region the green arrow is pointing. Can you fix this?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
