### PR TITLE
feat: add retry button to inline conversation error alerts

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -215,7 +215,8 @@ struct ChatContentView: View {
                 },
                 onSurfaceRefetch: { surfaceId, conversationId in
                     viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
-                }
+                },
+                onRetryConversationError: message.isError ? { viewModel.retryAfterConversationError() } : nil
             )
             .id(message.id)
             .transition(.asymmetric(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -28,6 +28,8 @@ struct ChatBubble: View {
     var activeConfirmationRequestId: String? = nil
     /// Called when the user taps "Retry" on a failed message.
     var onRetryFailedMessage: ((UUID) -> Void)?
+    /// Called when the user taps "Retry" on an inline conversation error.
+    var onRetryConversationError: (() -> Void)?
 
     var isLatestAssistantMessage: Bool = false
     /// When true, the assistant is still processing after tool calls completed.
@@ -179,7 +181,8 @@ struct ChatBubble: View {
                         if message.isError && hasText {
                             InlineChatErrorAlert(
                                 message: message.text,
-                                conversationError: message.conversationError
+                                conversationError: message.conversationError,
+                                onRetry: onRetryConversationError
                             )
                             .scaleEffect(conversationZoomScale, anchor: .topLeading)
                         } else if shouldShowBubble {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -50,6 +50,8 @@ struct ChatView: View {
     var onSurfaceRefetch: ((String, String) -> Void)?
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
+    /// Called when the user taps "Retry" on an inline conversation error.
+    var onRetryConversationError: (() -> Void)?
     var subagentDetailStore: SubagentDetailStore
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
@@ -238,6 +240,7 @@ struct ChatView: View {
                             onRehydrateMessage: onRehydrateMessage,
                             onSurfaceRefetch: onSurfaceRefetch,
                             onRetryFailedMessage: onRetryFailedMessage,
+                            onRetryConversationError: onRetryConversationError,
                             subagentDetailStore: subagentDetailStore,
                             creditsExhaustedError: creditsExhaustedError,
                             onAddFunds: onAddFunds,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -86,6 +86,8 @@ struct MessageListView: View {
     var onSurfaceRefetch: ((String, String) -> Void)?
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
+    /// Called when the user taps "Retry" on an inline conversation error.
+    var onRetryConversationError: (() -> Void)?
     var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Credits Exhausted (inline banner)
@@ -681,6 +683,7 @@ struct MessageListView: View {
                             onRehydrateMessage: onRehydrateMessage,
                             onSurfaceRefetch: onSurfaceRefetch,
                             onRetryFailedMessage: onRetryFailedMessage,
+                            onRetryConversationError: onRetryConversationError,
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             onModelPickerSelect: onModelPickerSelect,
@@ -1259,6 +1262,8 @@ private struct MessageCellView: View, Equatable {
     var onSurfaceRefetch: ((String, String) -> Void)?
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
+    /// Called when the user taps "Retry" on an inline conversation error.
+    var onRetryConversationError: (() -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
     var onModelPickerSelect: ((UUID, String) -> Void)?
@@ -1410,6 +1415,7 @@ private struct MessageCellView: View, Equatable {
                 onTemporaryAllow: onTemporaryAllow,
                 activeConfirmationRequestId: activePendingRequestId,
                 onRetryFailedMessage: onRetryFailedMessage,
+                onRetryConversationError: message.isError ? onRetryConversationError : nil,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -683,6 +683,9 @@ struct ActiveChatViewWrapper: View {
             onRetryFailedMessage: { messageId in
                 viewModel.retryFailedMessage(id: messageId)
             },
+            onRetryConversationError: {
+                viewModel.retryAfterConversationError()
+            },
             subagentDetailStore: viewModel.subagentDetailStore,
             resolveHttpPort: daemonClient.httpPortResolver,
             isHistoryLoaded: viewModel.isHistoryLoaded,

--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -12,10 +12,12 @@ import SwiftUI
 public struct InlineChatErrorAlert: View {
     let message: String
     let conversationError: ConversationError?
+    let onRetry: (() -> Void)?
 
-    public init(message: String, conversationError: ConversationError? = nil) {
+    public init(message: String, conversationError: ConversationError? = nil, onRetry: (() -> Void)? = nil) {
         self.message = message
         self.conversationError = conversationError
+        self.onRetry = onRetry
     }
 
     private var category: ConversationErrorCategory {
@@ -99,6 +101,24 @@ public struct InlineChatErrorAlert: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                         .fixedSize(horizontal: false, vertical: true)
+                }
+
+                // Retry button
+                if conversationError?.isRetryable == true, let onRetry {
+                    Button(action: onRetry) {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.rotateCcw, size: 11)
+                            Text("Retry")
+                        }
+                        .font(VFont.captionMedium)
+                        .foregroundColor(accentColor)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xs)
+                        .background(accentColor.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Retry")
                 }
             }
             .padding(.leading, VSpacing.md)

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -20,6 +20,8 @@ public struct MessageBubbleView: View {
     public let onSurfaceRefetch: ((String, String) -> Void)?
     /// Called when the user taps "Retry" on a per-message send failure.
     public let onRetryFailedMessage: ((UUID) -> Void)?
+    /// Called when the user taps "Retry" on an inline conversation error.
+    public let onRetryConversationError: (() -> Void)?
 
     public init(
         message: ChatMessage,
@@ -29,7 +31,8 @@ public struct MessageBubbleView: View {
         onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
         onGuardianAction: ((String, String) -> Void)? = nil,
         onSurfaceRefetch: ((String, String) -> Void)? = nil,
-        onRetryFailedMessage: ((UUID) -> Void)? = nil
+        onRetryFailedMessage: ((UUID) -> Void)? = nil,
+        onRetryConversationError: (() -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
@@ -39,6 +42,7 @@ public struct MessageBubbleView: View {
         self.onGuardianAction = onGuardianAction
         self.onSurfaceRefetch = onSurfaceRefetch
         self.onRetryFailedMessage = onRetryFailedMessage
+        self.onRetryConversationError = onRetryConversationError
     }
 
     public var body: some View {
@@ -254,7 +258,8 @@ public struct MessageBubbleView: View {
         } else if message.isError {
             InlineChatErrorAlert(
                 message: text,
-                conversationError: message.conversationError
+                conversationError: message.conversationError,
+                onRetry: onRetryConversationError
             )
             .contextMenu {
                 if let onRegenerate {


### PR DESCRIPTION
## Summary
- Added a **Retry** button to `InlineChatErrorAlert` that appears for retryable conversation errors (network, rate limit, processing, etc.)
- Threaded `onRetryConversationError` callback through the macOS view chain: `PanelCoordinator` → `ChatView` → `MessageListView` → `ChatBubble` → `InlineChatErrorAlert`
- Also wired up in the iOS `ChatContentView` → `MessageBubbleView` → `InlineChatErrorAlert` path

## Original prompt
I should be able to retry this error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
