### PR TITLE
Address Contacts review follow-ups

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -468,23 +468,7 @@ struct ChannelVerificationFlowView: View {
         let leadingPadding: CGFloat = showLabel ? labelColumnWidth + VSpacing.sm : 0
 
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack(alignment: .top, spacing: VSpacing.xs) {
-                VIconView(.triangleAlert, size: 12)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                    .padding(.top, 1)
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(VColor.systemNegativeWeak)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
-            )
+            VInlineMessage(error)
             if state.alreadyBound {
                 VButton(label: "Replace", style: .outlined) {
                     onStartSession(true)

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -161,7 +161,7 @@ struct AssistantChannelsDetailView: View {
                     .help("Copy email address")
                 }
             } else {
-                feedbackMessage(
+                VInlineMessage(
                     "Not configured — run the Email Setup skill to assign an address",
                     tone: .warning
                 )
@@ -220,7 +220,7 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let error = store.telegramError {
-                feedbackMessage(error)
+                VInlineMessage(error)
             }
 
         }
@@ -319,7 +319,7 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let error = store.slackChannelError {
-                feedbackMessage(error)
+                VInlineMessage(error)
             }
 
         }
@@ -424,11 +424,11 @@ struct AssistantChannelsDetailView: View {
             }
 
             if let warning = store.twilioWarning {
-                feedbackMessage(warning, tone: .warning)
+                VInlineMessage(warning, tone: .warning)
             }
 
             if let error = store.twilioError {
-                feedbackMessage(error)
+                VInlineMessage(error)
             }
 
         }
@@ -483,34 +483,6 @@ struct AssistantChannelsDetailView: View {
                 }
             }
         }
-    }
-
-    private enum FeedbackTone {
-        case error
-        case warning
-    }
-
-    private func feedbackMessage(_ text: String, tone: FeedbackTone = .error) -> some View {
-        let foreground = tone == .warning ? VColor.systemMidStrong : VColor.systemNegativeStrong
-        let background = tone == .warning ? VColor.systemMidWeak : VColor.systemNegativeWeak
-
-        return HStack(alignment: .top, spacing: VSpacing.xs) {
-            VIconView(.triangleAlert, size: 12)
-                .foregroundColor(foreground)
-                .padding(.top, 1)
-            Text(text)
-                .font(VFont.caption)
-                .foregroundColor(foreground)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(background)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(foreground.opacity(0.16), lineWidth: 1)
-        )
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -229,26 +229,6 @@ struct ContactDetailView: View {
         }
     }
 
-    private func inlineMessage(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.xs) {
-            VIconView(.triangleAlert, size: 12)
-                .foregroundColor(VColor.systemNegativeStrong)
-                .padding(.top, 1)
-            Text(text)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(VColor.systemNegativeWeak)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
-        )
-    }
-
     // MARK: - Channels Section
 
     private var channelsSection: some View {
@@ -289,7 +269,7 @@ struct ContactDetailView: View {
             }
 
             if let errorMessage {
-                inlineMessage(errorMessage)
+                VInlineMessage(errorMessage)
             }
         }
         .task {
@@ -525,7 +505,7 @@ struct ContactDetailView: View {
 
                 // Inline error display so the message appears inside the channel card
                 if let inviteError, inviteErrorChannel == type {
-                    inlineMessage(inviteError)
+                    VInlineMessage(inviteError)
                 }
             } else if type == "phone" {
                 // Phone channel: code-based invite flow
@@ -564,7 +544,7 @@ struct ContactDetailView: View {
 
                 // Inline error display so the message appears inside the channel card
                 if let inviteError, inviteErrorChannel == type {
-                    inlineMessage(inviteError)
+                    VInlineMessage(inviteError)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -163,7 +163,7 @@ struct GuardianChannelsDetailView: View {
             }
 
             if errorChannelType == type, let errorMessage {
-                inlineMessage(errorMessage)
+                VInlineMessage(errorMessage)
             }
         }
     }
@@ -352,25 +352,6 @@ struct GuardianChannelsDetailView: View {
 
             actionInProgress = nil
         }
-    }
-
-    private func inlineMessage(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.xs) {
-            VIconView(.triangleAlert, size: 12)
-                .foregroundColor(VColor.systemNegativeStrong)
-                .padding(.top, 1)
-            Text(text)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .background(VColor.systemNegativeWeak)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .stroke(VColor.systemNegativeStrong.opacity(0.16), lineWidth: 1)
-        )
     }
 
     // MARK: - Verification Flow Content

--- a/clients/shared/DesignSystem/Core/Feedback/VInlineMessage.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInlineMessage.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Compact inline feedback banner for form-level status and error messaging.
+public struct VInlineMessage: View {
+    public enum Tone {
+        case info
+        case success
+        case warning
+        case error
+    }
+
+    public let message: String
+    public var tone: Tone
+
+    public init(_ message: String, tone: Tone = .error) {
+        self.message = message
+        self.tone = tone
+    }
+
+    public var body: some View {
+        HStack(alignment: .top, spacing: VSpacing.xs) {
+            VIconView(icon, size: 12)
+                .foregroundColor(foregroundColor)
+                .padding(.top, 1)
+                .accessibilityHidden(true)
+
+            Text(message)
+                .font(VFont.caption)
+                .foregroundColor(foregroundColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(borderColor, lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private var icon: VIcon {
+        switch tone {
+        case .info:
+            return .info
+        case .success:
+            return .circleCheck
+        case .warning, .error:
+            return .triangleAlert
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch tone {
+        case .info:
+            return VColor.primaryBase
+        case .success:
+            return VColor.systemPositiveStrong
+        case .warning:
+            return VColor.systemMidStrong
+        case .error:
+            return VColor.systemNegativeStrong
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch tone {
+        case .info:
+            return VColor.primaryBase.opacity(0.10)
+        case .success:
+            return VColor.systemPositiveWeak
+        case .warning:
+            return VColor.systemMidWeak
+        case .error:
+            return VColor.systemNegativeWeak
+        }
+    }
+
+    private var borderColor: Color {
+        switch tone {
+        case .info:
+            return VColor.primaryBase.opacity(0.18)
+        case .success:
+            return VColor.systemPositiveStrong.opacity(0.14)
+        case .warning:
+            return VColor.systemMidStrong.opacity(0.16)
+        case .error:
+            return VColor.systemNegativeStrong.opacity(0.16)
+        }
+    }
+}

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -45,11 +45,11 @@ public struct VInputChromeModifier: ViewModifier {
                     lineWidth: isFocused ? 1.5 : 1
                 )
             )
+            .clipShape(shape)
             .shadow(
                 color: isFocused ? VColor.primaryBase.opacity(0.10) : .clear,
                 radius: 4
             )
-            .clipShape(shape)
     }
 }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -122,6 +122,23 @@ struct FeedbackGallerySection: View {
 
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
+            // MARK: - VInlineMessage
+            GallerySectionHeader(
+                title: "VInlineMessage",
+                description: "Compact inline banner for form status, warnings, and errors."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    VInlineMessage("This setting will sync the next time the assistant reconnects.", tone: .info)
+                    VInlineMessage("Your Twilio configuration is incomplete.", tone: .warning)
+                    VInlineMessage("This Telegram token was rejected by the provider.", tone: .error)
+                    VInlineMessage("Phone verification is complete.", tone: .success)
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
             // MARK: - VShortcutTag
             GallerySectionHeader(
                 title: "VShortcutTag",


### PR DESCRIPTION
## Summary
- fix the shared input chrome so focused fields render their glow outside the clipped shape
- extract a reusable `VInlineMessage` feedback primitive and replace the duplicated Contacts/channel verification error banners
- add gallery coverage for the new inline feedback component

## Context
- addresses the Devin review follow-ups from #18146
- Apple refs checked (2026-03-17): SwiftUI `View.shadow(color:radius:x:y:)`, `View.clipShape(_:style:)`, `View.fixedSize(horizontal:vertical:)`

## Verification
- `cd clients && swift build --target VellumAssistantShared`
- `cd clients && swift build --target vellum-assistant`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
