### PR TITLE
Tighten conversation starter generation cadence

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -5,6 +5,11 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { v4 as uuid } from "uuid";
 
+import {
+  CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+  conversationStartersCheckpointKey,
+} from "../memory/conversation-starters-policy.js";
+
 const testDir = mkdtempSync(
   join(tmpdir(), "conversation-starter-routes-test-"),
 );
@@ -159,6 +164,41 @@ describe("GET /v1/conversation-starters", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("generating");
     expect(body.starters).toHaveLength(0);
+  });
+
+  test("returns empty during the recent-attempt cooldown without re-enqueueing", async () => {
+    insertMemoryItem();
+    const now = Date.now();
+    getSqlite().run(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+      [
+        conversationStartersCheckpointKey(
+          CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+          "default",
+        ),
+        String(now),
+        now,
+      ],
+    );
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: unknown[];
+      total: number;
+      status: string;
+    };
+    const jobCount = (
+      getSqlite()
+        .query(
+          `SELECT COUNT(*) AS count FROM memory_jobs WHERE type = 'generate_conversation_starters'`,
+        )
+        .get() as { count: number }
+    ).count;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("empty");
+    expect(body.starters).toHaveLength(0);
+    expect(jobCount).toBe(0);
   });
 
   test("respects limit parameter", async () => {

--- a/assistant/src/__tests__/conversation-starters-cadence.test.ts
+++ b/assistant/src/__tests__/conversation-starters-cadence.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { v4 as uuid } from "uuid";
+
+const testDir = mkdtempSync(
+  join(tmpdir(), "conversation-starters-cadence-test-"),
+);
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { maybeEnqueueConversationStartersJob } from "../memory/conversation-starters-cadence.js";
+import {
+  CK_CONVERSATION_STARTERS_ITEM_COUNT,
+  CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+  CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS,
+  conversationStartersCheckpointKey,
+} from "../memory/conversation-starters-policy.js";
+import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function clearTables() {
+  getSqlite().run("DELETE FROM memory_items");
+  getSqlite().run("DELETE FROM memory_jobs");
+  getSqlite().run("DELETE FROM memory_checkpoints");
+}
+
+function insertMemoryItem(scopeId = "default", firstSeenAt = Date.now()) {
+  getSqlite().run(
+    `INSERT INTO memory_items (
+      id, kind, subject, statement, status, confidence, fingerprint, scope_id, first_seen_at, last_seen_at
+    ) VALUES (?, 'fact', 'test', 'test statement', 'active', 0.9, ?, ?, ?, ?)`,
+    [uuid(), `fingerprint-${uuid()}`, scopeId, firstSeenAt, firstSeenAt],
+  );
+}
+
+function insertCheckpoint(key: string, value: string, updatedAt = Date.now()) {
+  getSqlite().run(
+    `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+    [key, value, updatedAt],
+  );
+}
+
+function countStarterJobs(): number {
+  return (
+    getSqlite()
+      .query(
+        `SELECT COUNT(*) AS count
+         FROM memory_jobs
+         WHERE type = 'generate_conversation_starters'
+           AND status IN ('pending', 'running')`,
+      )
+      .get() as { count: number }
+  ).count;
+}
+
+beforeEach(() => {
+  clearTables();
+});
+
+describe("maybeEnqueueConversationStartersJob", () => {
+  test("requires at least five memories before the first generation", () => {
+    for (let i = 0; i < 4; i++) {
+      insertMemoryItem();
+    }
+
+    maybeEnqueueConversationStartersJob("default", 1_000_000);
+    expect(countStarterJobs()).toBe(0);
+
+    insertMemoryItem("default", 1_000_001);
+    maybeEnqueueConversationStartersJob("default", 1_000_001);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("uses the bumped thresholds for larger memory sets", () => {
+    for (let i = 0; i < 18; i++) {
+      insertMemoryItem();
+    }
+
+    insertCheckpoint(
+      conversationStartersCheckpointKey(
+        CK_CONVERSATION_STARTERS_ITEM_COUNT,
+        "default",
+      ),
+      "9",
+    );
+    maybeEnqueueConversationStartersJob("default", 2_000_000);
+    expect(countStarterJobs()).toBe(0);
+
+    clearTables();
+    for (let i = 0; i < 18; i++) {
+      insertMemoryItem();
+    }
+    insertCheckpoint(
+      conversationStartersCheckpointKey(
+        CK_CONVERSATION_STARTERS_ITEM_COUNT,
+        "default",
+      ),
+      "8",
+    );
+    maybeEnqueueConversationStartersJob("default", 2_000_001);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("respects the minimum interval after a successful generation", () => {
+    for (let i = 0; i < 25; i++) {
+      insertMemoryItem();
+    }
+
+    insertCheckpoint(
+      conversationStartersCheckpointKey(
+        CK_CONVERSATION_STARTERS_ITEM_COUNT,
+        "default",
+      ),
+      "0",
+    );
+    insertCheckpoint(
+      conversationStartersCheckpointKey(
+        CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+        "default",
+      ),
+      String(3_000_000),
+    );
+
+    maybeEnqueueConversationStartersJob(
+      "default",
+      3_000_000 + CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS - 1,
+    );
+    expect(countStarterJobs()).toBe(0);
+  });
+});

--- a/assistant/src/memory/conversation-starters-cadence.ts
+++ b/assistant/src/memory/conversation-starters-cadence.ts
@@ -8,6 +8,15 @@
 import { and, eq, inArray, like } from "drizzle-orm";
 
 import { getLogger } from "../util/logger.js";
+import {
+  CK_CONVERSATION_STARTERS_ITEM_COUNT,
+  CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+  CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+  CONVERSATION_STARTERS_ATTEMPT_COOLDOWN_MS,
+  CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS,
+  conversationStartersCheckpointKey,
+  conversationStartersGenerationThreshold,
+} from "./conversation-starters-policy.js";
 import { getDb } from "./db.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
 import { rawGet } from "./raw-query.js";
@@ -15,11 +24,43 @@ import { memoryCheckpoints, memoryJobs } from "./schema.js";
 
 const log = getLogger("conversation-starters-cadence");
 
+function readCheckpointInt(scopeId: string, baseKey: string): number {
+  const db = getDb();
+  const checkpoint = db
+    .select({ value: memoryCheckpoints.value })
+    .from(memoryCheckpoints)
+    .where(
+      eq(
+        memoryCheckpoints.key,
+        conversationStartersCheckpointKey(baseKey, scopeId),
+      ),
+    )
+    .get();
+  return checkpoint ? parseInt(checkpoint.value, 10) : 0;
+}
+
+export function hasRecentConversationStarterAttempt(
+  scopeId: string,
+  nowMs = Date.now(),
+): boolean {
+  const lastAttemptAt = readCheckpointInt(
+    scopeId,
+    CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+  );
+  return (
+    lastAttemptAt > 0 &&
+    nowMs - lastAttemptAt < CONVERSATION_STARTERS_ATTEMPT_COOLDOWN_MS
+  );
+}
+
 /**
  * Check whether enough new memory items have accumulated to justify
  * generating a fresh batch of conversation starters.
  */
-export function maybeEnqueueConversationStartersJob(scopeId: string): void {
+export function maybeEnqueueConversationStartersJob(
+  scopeId: string,
+  nowMs = Date.now(),
+): void {
   const db = getDb();
 
   // Count total active memory items
@@ -30,24 +71,24 @@ export function maybeEnqueueConversationStartersJob(scopeId: string): void {
   const totalActive = countRow?.c ?? 0;
   if (totalActive === 0) return;
 
-  // Read checkpoint: item count at last generation (scoped so each scope tracks independently)
-  const checkpointKey = `conversation_starters:item_count_at_last_gen:${scopeId}`;
-  const checkpoint = db
-    .select({ value: memoryCheckpoints.value })
-    .from(memoryCheckpoints)
-    .where(eq(memoryCheckpoints.key, checkpointKey))
-    .get();
-  const lastCount = checkpoint ? parseInt(checkpoint.value, 10) : 0;
+  if (hasRecentConversationStarterAttempt(scopeId, nowMs)) return;
 
-  // Cadence formula
-  let threshold: number;
-  if (totalActive <= 10) {
-    threshold = 1;
-  } else if (totalActive <= 50) {
-    threshold = 5;
-  } else {
-    threshold = 10;
+  const lastGenAt = readCheckpointInt(
+    scopeId,
+    CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+  );
+  if (
+    lastGenAt > 0 &&
+    nowMs - lastGenAt < CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS
+  ) {
+    return;
   }
+
+  const lastCount = readCheckpointInt(
+    scopeId,
+    CK_CONVERSATION_STARTERS_ITEM_COUNT,
+  );
+  const threshold = conversationStartersGenerationThreshold(totalActive);
 
   const delta = totalActive - lastCount;
   if (delta < threshold) return;

--- a/assistant/src/memory/conversation-starters-policy.ts
+++ b/assistant/src/memory/conversation-starters-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared policy for conversation starter generation cadence.
+ */
+
+export const CK_CONVERSATION_STARTERS_ITEM_COUNT =
+  "conversation_starters:item_count_at_last_gen";
+export const CK_CONVERSATION_STARTERS_BATCH =
+  "conversation_starters:generation_batch";
+export const CK_CONVERSATION_STARTERS_LAST_GEN_AT =
+  "conversation_starters:last_gen_at";
+export const CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT =
+  "conversation_starters:last_attempt_at";
+
+export const CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS = 12 * 60 * 60 * 1000;
+export const CONVERSATION_STARTERS_ATTEMPT_COOLDOWN_MS = 15 * 60 * 1000;
+
+export function conversationStartersCheckpointKey(
+  base: string,
+  scopeId: string,
+): string {
+  return `${base}:${scopeId}`;
+}
+
+export function conversationStartersGenerationThreshold(
+  totalActive: number,
+): number {
+  if (totalActive <= 10) return 5;
+  if (totalActive <= 50) return 10;
+  return 20;
+}

--- a/assistant/src/memory/conversation-starters-policy.ts
+++ b/assistant/src/memory/conversation-starters-policy.ts
@@ -11,7 +11,7 @@ export const CK_CONVERSATION_STARTERS_LAST_GEN_AT =
 export const CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT =
   "conversation_starters:last_attempt_at";
 
-export const CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS = 12 * 60 * 60 * 1000;
+export const CONVERSATION_STARTERS_MIN_REGEN_INTERVAL_MS = 5 * 60 * 1000;
 export const CONVERSATION_STARTERS_ATTEMPT_COOLDOWN_MS = 15 * 60 * 1000;
 
 export function conversationStartersCheckpointKey(

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -17,6 +17,13 @@ import {
 } from "../../providers/provider-send-message.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
+import {
+  CK_CONVERSATION_STARTERS_BATCH,
+  CK_CONVERSATION_STARTERS_ITEM_COUNT,
+  CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+  CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+  conversationStartersCheckpointKey,
+} from "../conversation-starters-policy.js";
 import { getDb } from "../db.js";
 import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
@@ -28,14 +35,6 @@ import {
 } from "../schema.js";
 
 const log = getLogger("conversation-starters-gen");
-
-function checkpointKey(base: string, scopeId: string): string {
-  return `${base}:${scopeId}`;
-}
-
-const CK_ITEM_COUNT = "conversation_starters:item_count_at_last_gen";
-const CK_BATCH = "conversation_starters:generation_batch";
-const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
 
 // ── Rollup construction ───────────────────────────────────────────
 
@@ -80,7 +79,15 @@ function buildNewItemsDiff(scopeId: string): string {
   const checkpoint = db
     .select({ value: memoryCheckpoints.value })
     .from(memoryCheckpoints)
-    .where(eq(memoryCheckpoints.key, checkpointKey(CK_LAST_GEN_AT, scopeId)))
+    .where(
+      eq(
+        memoryCheckpoints.key,
+        conversationStartersCheckpointKey(
+          CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+          scopeId,
+        ),
+      ),
+    )
     .get();
   const lastGenAt = checkpoint ? parseInt(checkpoint.value, 10) : 0;
 
@@ -348,6 +355,26 @@ export async function generateConversationStartersJob(
   job: MemoryJob,
 ): Promise<void> {
   const scopeId = asString(job.payload.scopeId) ?? "default";
+  const db = getDb();
+  const now = Date.now();
+
+  const upsertCheckpoint = (key: string, value: string) => {
+    db.insert(memoryCheckpoints)
+      .values({ key, value, updatedAt: now })
+      .onConflictDoUpdate({
+        target: memoryCheckpoints.key,
+        set: { value, updatedAt: now },
+      })
+      .run();
+  };
+
+  upsertCheckpoint(
+    conversationStartersCheckpointKey(
+      CK_CONVERSATION_STARTERS_LAST_ATTEMPT_AT,
+      scopeId,
+    ),
+    String(now),
+  );
 
   const starters = await generateStarters(scopeId);
   if (starters.length === 0) {
@@ -355,14 +382,19 @@ export async function generateConversationStartersJob(
     return;
   }
 
-  const db = getDb();
-  const now = Date.now();
-
   // Determine next batch number
   const batchCheckpoint = db
     .select({ value: memoryCheckpoints.value })
     .from(memoryCheckpoints)
-    .where(eq(memoryCheckpoints.key, checkpointKey(CK_BATCH, scopeId)))
+    .where(
+      eq(
+        memoryCheckpoints.key,
+        conversationStartersCheckpointKey(
+          CK_CONVERSATION_STARTERS_BATCH,
+          scopeId,
+        ),
+      ),
+    )
     .get();
   const nextBatch = batchCheckpoint
     ? parseInt(batchCheckpoint.value, 10) + 1
@@ -409,19 +441,24 @@ export async function generateConversationStartersJob(
   const totalActive = countRow?.c ?? 0;
 
   // Update all three checkpoints
-  const upsertCheckpoint = (key: string, value: string) => {
-    db.insert(memoryCheckpoints)
-      .values({ key, value, updatedAt: now })
-      .onConflictDoUpdate({
-        target: memoryCheckpoints.key,
-        set: { value, updatedAt: now },
-      })
-      .run();
-  };
-
-  upsertCheckpoint(checkpointKey(CK_ITEM_COUNT, scopeId), String(totalActive));
-  upsertCheckpoint(checkpointKey(CK_BATCH, scopeId), String(nextBatch));
-  upsertCheckpoint(checkpointKey(CK_LAST_GEN_AT, scopeId), String(now));
+  upsertCheckpoint(
+    conversationStartersCheckpointKey(
+      CK_CONVERSATION_STARTERS_ITEM_COUNT,
+      scopeId,
+    ),
+    String(totalActive),
+  );
+  upsertCheckpoint(
+    conversationStartersCheckpointKey(CK_CONVERSATION_STARTERS_BATCH, scopeId),
+    String(nextBatch),
+  );
+  upsertCheckpoint(
+    conversationStartersCheckpointKey(
+      CK_CONVERSATION_STARTERS_LAST_GEN_AT,
+      scopeId,
+    ),
+    String(now),
+  );
 
   log.info(
     { scopeId, batch: nextBatch, count: starters.length },

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -6,6 +6,7 @@
 
 import { and, desc, eq, inArray, like } from "drizzle-orm";
 
+import { hasRecentConversationStarterAttempt } from "../../memory/conversation-starters-cadence.js";
 import { getDb } from "../../memory/db.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { rawGet } from "../../memory/raw-query.js";
@@ -184,6 +185,10 @@ function handleListConversationStarters(url: URL): Response {
       ),
     )
     .get();
+
+  if (!existing && hasRecentConversationStarterAttempt(scopeId)) {
+    return Response.json({ starters: [], total: 0, status: "empty" });
+  }
 
   if (!existing) {
     enqueueMemoryJob("generate_conversation_starters", { scopeId });


### PR DESCRIPTION
## Summary
- raise conversation starter regen thresholds and add a 12-hour minimum interval after successful generation
- record last-attempt timestamps and enforce a 15-minute cooldown so empty-state polling cannot keep restarting failed or empty runs
- add cadence and route tests covering the new thresholds and cooldown behavior

## Testing
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/conversation-starter-routes.test.ts src/__tests__/conversation-starters-cadence.test.ts
- export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
