### PR TITLE
fix: convert FnKeyStepView Back button to OnboardingButton ghost

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -134,18 +134,12 @@ struct FnKeyStepView: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
 
-                Button(action: {
+                OnboardingButton(title: "Back", style: .ghost) {
                     stopPolling()
                     withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
                         state.currentStep = 3
                     }
-                }) {
-                    Text("Back")
-                        .font(.system(size: 13))
-                        .foregroundColor(VColor.contentTertiary)
                 }
-                .buttonStyle(.plain)
-                .pointerCursor()
             }
             .padding(.top, VSpacing.xs)
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for onboard-back-btns.md.

**Gap:** FnKeyStepView.swift Back button not converted to OnboardingButton ghost
**What was expected:** All Back buttons across onboarding steps use OnboardingButton with .ghost style
**What was found:** FnKeyStepView.swift still used a plain Button with manual styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
