### PR TITLE
fix: align usage dashboard content with settings header

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -9,7 +9,7 @@ struct UsageDashboardPanel: View {
     @State private var breakdownTask: Task<Void, Never>?
 
     var body: some View {
-        VSidePanel(title: "Usage", onClose: onClose, pinnedContent: {
+        VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: VSpacing.lg, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
             timeRangeStrip(store: store)
         }) {
             contentView(store: store)

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -4,14 +4,16 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
     public let title: String
     public let titleFont: Font
     public let uppercased: Bool
+    public let contentPadding: EdgeInsets
     public var onClose: (() -> Void)? = nil
     @ViewBuilder public let pinnedContent: () -> PinnedContent
     @ViewBuilder public let content: () -> Content
 
-    public init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = false, onClose: (() -> Void)? = nil, @ViewBuilder pinnedContent: @escaping () -> PinnedContent, @ViewBuilder content: @escaping () -> Content) {
+    public init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = false, contentPadding: EdgeInsets = EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.lg, trailing: VSpacing.lg), onClose: (() -> Void)? = nil, @ViewBuilder pinnedContent: @escaping () -> PinnedContent, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.titleFont = titleFont
         self.uppercased = uppercased
+        self.contentPadding = contentPadding
         self.onClose = onClose
         self.pinnedContent = pinnedContent
         self.content = content
@@ -42,7 +44,7 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             // own ScrollView (e.g. TraceTimelineView) isn't starved.
             ScrollView {
                 content()
-                    .padding(VSpacing.lg)
+                    .padding(contentPadding)
                     .frame(maxWidth: .infinity, alignment: .top)
             }
             .layoutPriority(-1)


### PR DESCRIPTION
## Summary
- Remove extra outer padding on usage dashboard content so it aligns with the settings panel header

## Original prompt
remove extra padding on outside of usage content, it should align with header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
