### PR TITLE
fix: mark makeBaseEnvironment() as nonisolated to fix CI build

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -96,7 +96,7 @@ final class AssistantCli {
     /// process environment causes the child to inherit paths into other
     /// apps' containers, triggering the "access data from other apps"
     /// consent dialog.
-    private static func makeBaseEnvironment() -> [String: String] {
+    nonisolated private static func makeBaseEnvironment() -> [String: String] {
         let fullEnv = ProcessInfo.processInfo.environment
         var env: [String: String] = [
             "HOME": FileManager.default.homeDirectoryForCurrentUser.path,


### PR DESCRIPTION
## Summary
- Mark `AssistantCli.makeBaseEnvironment()` as `nonisolated` so it can be called from `Task.detached` in `runCLI()` without violating Swift concurrency actor isolation rules
- Fixes CI build failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/23200505187

## Original prompt
https://github.com/vellum-ai/vellum-assistant/actions/runs/23200505187 fix the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
