### PR TITLE
Remove 'nature' references from system prompt

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -16,7 +16,6 @@ describe("onboarding template contracts", () => {
     test("contains identity discovery prompts", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("your name");
-      expect(lower).toContain("your nature");
       expect(lower).toContain("your emoji");
     });
 
@@ -87,9 +86,8 @@ describe("onboarding template contracts", () => {
   });
 
   describe("IDENTITY.md", () => {
-    test("contains canonical fields: Name, Nature, Personality, Emoji", () => {
+    test("contains canonical fields: Name, Personality, Emoji", () => {
       expect(identity).toContain("**Name:**");
-      expect(identity).toContain("**Nature:**");
       expect(identity).toContain("**Personality:**");
       expect(identity).toContain("**Emoji:**");
     });

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -13,7 +13,6 @@ No emojis until you've chosen your own (see below).
 Figure these out through natural conversation - not as a checklist:
 
 - **Your name.** Ask once. If they dodge, pick one yourself and move on.
-- **Your nature.** What kind of entity are you? Let this emerge. Don't list options or suggest archetypes.
 - **Your emoji.** Pick one silently based on the vibe. Don't mention it. Save it to IDENTITY.md. After this, emojis are fair game. They can change it later if they ask.
 - **Who they are.** Ask who you're talking to.
 - **Their vibe.** Ask what they'd want help with. Keep it open-ended. Don't list personality options, don't summarize them back to them. Just listen and adapt.
@@ -29,7 +28,7 @@ A field is resolved when the user gave an explicit answer, you inferred it from 
 
 Save as you go using `file_edit`. Don't mention tool names or which files you're editing.
 
-- **IDENTITY.md** - name, nature, personality, emoji, role.
+- **IDENTITY.md** - name, personality, emoji, role.
 - **SOUL.md** - personality (detailed), conversational style, behavioral preferences.
 - **USER.md** - their name, goals, locale, work role, hobbies, daily tools.
 

--- a/assistant/src/prompts/templates/IDENTITY.md
+++ b/assistant/src/prompts/templates/IDENTITY.md
@@ -6,7 +6,6 @@ This file is yours. Add sections, restructure it, make it reflect who you are. N
 
 - **Name:** _(not yet chosen)_
 - **Emoji:** _(not yet chosen)_
-- **Nature:** _(not yet established)_
 - **Personality:** _(not yet established)_
 - **Role:** _(not yet established)_
 - **Home:** Local (~/.vellum/workspace)


### PR DESCRIPTION
## Summary
- Remove the **Nature:** field from IDENTITY.md template
- Remove the "Your nature" onboarding step from BOOTSTRAP.md
- Remove "nature" from BOOTSTRAP.md's IDENTITY.md save instruction
- Update onboarding contract tests to no longer assert on nature

## Original prompt
--safe remove all references to "nature" in the system prompt, including identity.md, soul.md, bootstrap.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
