### PR TITLE
fix: prevent duplicate rendering of panel-display surfaces on macOS

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1599,6 +1599,11 @@ extension ChatViewModel {
                     log.info("Skipping inline surface - no preview metadata")
                     break
                 }
+            } else if msg.display == "panel" {
+                // Non-dynamic-page surfaces with "panel" display are rendered as
+                // floating panels by SurfaceManager — skip inline rendering to
+                // avoid showing duplicates (one inline, one in a panel window).
+                break
             }
             #endif
 


### PR DESCRIPTION
## Summary
- When a surface (form, card, etc.) has `display: "panel"`, it was rendered both as a floating NSPanel window AND inline in the chat — producing a visible duplicate
- Added a guard in `ChatViewModel+MessageHandling.swift` that skips inline rendering for non-dynamic-page surfaces with `"panel"` display, since SurfaceManager already handles them as floating panels
- Dynamic pages are unaffected — they intentionally dual-render (full page in workspace + compact preview card inline)

## Original prompt
Fix duplicate assistant-created UI rendering (one inline, one as a separate window) when surfaces use panel display mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
