### PR TITLE
perf: reduce avatarTargetY @State updates during scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -347,11 +347,12 @@ struct MessageListView: View {
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
-        // Only update @State when the visibility boundary is crossed or the value
-        // changes by more than 1pt. Preference changes fire on every scroll frame;
-        // unconditionally setting avatarTargetY would trigger a full view re-render
-        // per frame, creating layout passes that race with the scroll and cause
-        // the "tweaking" jitter.
+        // Only update @State when the visibility boundary is crossed or finitude
+        // changes. avatarTargetY is only consumed by shouldShowConversationTailAvatar
+        // (a binary visible/hidden check), so continuous position tracking is
+        // unnecessary. The previous `abs(delta) > 1` threshold caused ~60 @State
+        // updates/sec during scroll, each triggering a full MessageListView body
+        // re-evaluation and expensive LazyVStack re-measurement of complex messages.
         let visibilityChanged: Bool = {
             let wasVisible = avatarTargetY.isFinite
                 && ConversationAvatarFollower.shouldShow(anchorY: avatarTargetY, viewportHeight: scrollViewportHeight)
@@ -359,7 +360,7 @@ struct MessageListView: View {
                 && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
             return wasVisible != nowVisible
         }()
-        if visibilityChanged || abs(avatarTargetY - anchorY) > 1 || !avatarTargetY.isFinite != !anchorY.isFinite {
+        if visibilityChanged || !avatarTargetY.isFinite != !anchorY.isFinite {
             avatarTargetY = anchorY
         }
 


### PR DESCRIPTION
## Summary
- Remove the `abs(avatarTargetY - anchorY) > 1` continuous position tracking from `updateAvatarFollower()` — `avatarTargetY` is only used for a binary visibility check, not position tracking
- Now only updates `@State avatarTargetY` on visibility boundary crossings (enter/leave viewport) and finitude changes, reducing updates from ~60/sec to ~2 total per scroll gesture
- Fixes scroll freezes (~100% CPU) on conversations with complex interleaved messages (many tool calls + inline images), caused by continuous `MessageListView` body re-evaluations triggering expensive LazyVStack re-measurement

## Original prompt
Fix 1 from the plan: Reduce avatarTargetY @State updates in MessageListView.swift. Remove the `abs(avatarTargetY - anchorY) > 1` condition from the updateAvatarFollower function so avatarTargetY only updates on visibility boundary crossings and finitude changes, not on every scroll frame. This reduces @State updates from ~60/sec to at most 2 total during scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
