### PR TITLE
perf: gate avatarDisplayY updates behind visibility + dead-zone

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -341,6 +341,10 @@ struct MessageListView: View {
 
     private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
         let y = anchorY + ConversationAvatarFollower.verticalOffset
+        // Dead-zone: skip @State update when position hasn't moved meaningfully.
+        // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
+        // sub-pixel jitter during scroll would otherwise cause continuous re-renders.
+        guard abs(avatarDisplayY - y) > 2 else { return }
         withAnimation(ConversationAvatarFollower.spring) {
             avatarDisplayY = y
         }
@@ -370,6 +374,19 @@ struct MessageListView: View {
             pendingAvatarY = nil
             avatarLastAppliedAt = nil
             if avatarDisplayY != .infinity { avatarDisplayY = .infinity }
+            return
+        }
+
+        // Skip position tracking when the avatar is off-screen. The avatar
+        // overlay is hidden via shouldShowConversationTailAvatar, so updating
+        // avatarDisplayY for an invisible element just wastes layout passes.
+        let nowVisible = ConversationAvatarFollower.shouldShow(
+            anchorY: anchorY, viewportHeight: scrollViewportHeight
+        )
+        guard nowVisible else {
+            avatarSmoothingTask?.cancel()
+            avatarSmoothingTask = nil
+            pendingAvatarY = nil
             return
         }
 


### PR DESCRIPTION
## Summary
- Add 2pt dead-zone to `applyAvatarDisplayY` — skip `@State avatarDisplayY` update when position hasn't moved meaningfully, preventing continuous body re-evaluations from sub-pixel scroll jitter
- Gate position tracking in `updateAvatarFollower` behind a visibility check — when the avatar is off-screen (scrolled away from conversation tail), skip smoothing delay computation and display Y updates entirely
- Complements #18305 (avatarTargetY fix) to further reduce unnecessary `MessageListView` body re-evaluations during scroll

## Original prompt
Fix 2 from the plan: Gate avatarDisplayY updates behind visibility + dead-zone in MessageListView.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
