### PR TITLE
perf: skip compositingGroup for interleaved messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -236,11 +236,14 @@ struct ChatBubble: View {
                 // Uses layoutPriority instead of fixedSize to avoid forcing
                 // full height measurement during lazy placement.
                 .layoutPriority(1)
-                // For non-streaming messages, flatten the render tree into a single
-                // compositing layer, reducing recursive SwiftUI layout passes.
-                // Uses compositingGroup instead of drawingGroup to preserve text selection.
+                // For non-streaming, non-interleaved messages, flatten the render
+                // tree into a single compositing layer to reduce layout passes.
                 // Skipped during streaming to avoid re-compositing on every token delta.
-                .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming))
+                // Also skipped for interleaved messages (text + tool calls + images)
+                // where the complex view hierarchy makes re-compositing expensive —
+                // async task completions (markdown parsing, image decoding) would
+                // trigger full re-compositing of the entire message on every change.
+                .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming && !hasInterleavedContent))
 
             if !isUser { Spacer(minLength: 0) }
         }


### PR DESCRIPTION
## Summary
- Skip `.compositingGroup()` for messages with interleaved content (multiple block types like text + tool calls + images)
- Complex interleaved messages create deep view hierarchies where re-compositing the entire tree on any subview change is expensive — async completions (markdown parsing, image decoding) trigger full re-compositing
- Simple messages (plain text, user bubbles) still benefit from the compositing optimization

## Original prompt
Fix 3 from the plan: Skip .compositingGroup() for interleaved messages in ChatBubble.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
