### PR TITLE
perf: cache scroll view reference in ScrollWheelPassthrough

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -807,13 +807,22 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
 
     class Coordinator {
         weak var view: NSView?
+        /// Cached scroll view reference to avoid O(n) view hierarchy traversal
+        /// on every scroll event. Weak so it self-clears if the scroll view is
+        /// deallocated (e.g. window close).
+        weak var cachedScrollView: NSScrollView?
         var monitor: Any?
 
         /// Finds the deepest NSScrollView whose frame contains the event point.
         /// This ensures we forward to the chat scroll view, not the sidebar.
+        /// Caches the result after first lookup since the scroll view doesn't
+        /// change during the lifetime of this coordinator.
         func findScrollView(for event: NSEvent) -> NSScrollView? {
+            if let cached = cachedScrollView, cached.window != nil { return cached }
             guard let contentView = view?.window?.contentView else { return nil }
-            return Self.deepestScrollView(in: contentView, containing: event.locationInWindow)
+            let found = Self.deepestScrollView(in: contentView, containing: event.locationInWindow)
+            cachedScrollView = found
+            return found
         }
 
         private static func deepestScrollView(in view: NSView, containing windowPoint: NSPoint) -> NSScrollView? {


### PR DESCRIPTION
## Summary
- Cache the scroll view reference in `ScrollWheelPassthrough.Coordinator` after first lookup via a weak property
- Avoids an O(n) recursive DFS of the entire NSView hierarchy on every scroll wheel event
- The scroll view doesn't change during the coordinator's lifetime, so the cached reference is always valid (weak ref self-clears on dealloc)

## Original prompt
Fix 4 from the plan: Cache scroll view reference in ScrollWheelPassthrough in ChatView.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
