### PR TITLE
fix: prevent close event from racing guardian token lease during docker hatch

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -806,24 +806,38 @@ async function tailContainerUntilReady(opts: {
     const handleLine = (line: string): void => {
       writeToLogFile(logFd, `${new Date().toISOString()} [docker] ${line}\n`);
       if (line.includes(sentinel)) {
-        process.nextTick(async () => {
+        // Mark settled synchronously so the `close` event handler cannot
+        // race and resolve the promise before the token lease completes.
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+
+        (async () => {
+          log(
+            `Guardian token lease: starting for ${instanceName} at ${runtimeUrl}`,
+          );
           try {
-            await leaseGuardianToken(runtimeUrl, instanceName);
+            const tokenData = await leaseGuardianToken(
+              runtimeUrl,
+              instanceName,
+            );
+            log(
+              `Guardian token lease: success (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
+            );
           } catch (err) {
-            const msg = `\u26a0\ufe0f  Could not lease guardian token: ${err instanceof Error ? err.message : err}`;
-            log(msg);
+            const detail =
+              err instanceof Error ? (err.stack ?? err.message) : String(err);
+            log(`\u26a0\ufe0f  Guardian token lease: FAILED — ${detail}`);
           }
 
-          settle(() => {
-            log("");
-            log(`\u2705 Docker containers are up and running!`);
-            log(`   Name: ${instanceName}`);
-            log(`   Runtime: ${runtimeUrl}`);
-            log("");
-            child.kill();
-            resolve({ ready: true });
-          });
-        });
+          log("");
+          log(`\u2705 Docker containers are up and running!`);
+          log(`   Name: ${instanceName}`);
+          log(`   Runtime: ${runtimeUrl}`);
+          log("");
+          child.kill();
+          resolve({ ready: true });
+        })();
       }
     };
 


### PR DESCRIPTION
## Summary
- Fix race condition where the docker logs `close` event could resolve the hatch promise before `leaseGuardianToken()` finished writing `guardian-token.json`
- The sentinel handler used `process.nextTick()` to schedule the token lease, but the child process could close before the next tick ran, causing `settle()` to resolve the promise early
- Fix by setting `settled=true` synchronously when the sentinel is detected, preventing any other handler from resolving first
- Improve hatch.log diagnostics: log token lease start, success (with principalId/expiresAt), and failure (with full stack trace)

## Test plan
- [ ] Run `vellum hatch --remote docker` and verify `~/.config/vellum/assistants/<id>/guardian-token.json` is written
- [ ] Check `hatch.log` for "Guardian token lease: success" line
- [ ] Kill the docker container immediately after sentinel appears to verify the race is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
