### PR TITLE
Unify non-onboarding login to use error toast instead of inline text

### DIFF
--- a/clients/macos/vellum-assistant/App/AuthManager+LoginToast.swift
+++ b/clients/macos/vellum-assistant/App/AuthManager+LoginToast.swift
@@ -1,0 +1,18 @@
+import VellumAssistantShared
+
+extension AuthManager {
+    /// Performs WorkOS login, showing an error toast on failure.
+    /// Clears `errorMessage` after toasting so inline displays don't double-show.
+    func loginWithToast(
+        showToast: @escaping (String, ToastInfo.Style) -> Void,
+        onSuccess: (() -> Void)? = nil
+    ) async {
+        await startWorkOSLogin()
+        if let error = errorMessage {
+            showToast(error, .error)
+            errorMessage = nil
+        } else if isAuthenticated {
+            onSuccess?()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -584,7 +584,9 @@ struct MainWindowView: View {
                             onSignIn: {
                                 sidebar.showPreferencesDrawer = false
                                 Task {
-                                    await authManager.startWorkOSLogin()
+                                    await authManager.loginWithToast(showToast: { msg, style in
+                                        windowState.showToast(message: msg, style: style)
+                                    })
                                 }
                             },
                             onOpenBilling: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -25,7 +25,7 @@ extension MainWindowView {
         case .chat:
             chatView
         case .settings:
-            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager)
+            SettingsPanel(onClose: { windowState.selection = nil }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager, showToast: { msg, style in windowState.showToast(message: msg, style: style) })
         case .debug:
             DebugPanel(
                 traceStore: traceStore,
@@ -406,7 +406,7 @@ extension MainWindowView {
     func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager)
+            SettingsPanel(onClose: { windowState.dismissOverlay() }, store: settingsStore, daemonClient: daemonClient, conversationManager: conversationManager, authManager: authManager, showToast: { msg, style in windowState.showToast(message: msg, style: style) })
         case .debug:
             DebugPanel(
                 traceStore: traceStore,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -55,6 +55,7 @@ struct SettingsPanel: View {
     var daemonClient: DaemonClient?
     @ObservedObject var conversationManager: ConversationManager
     var authManager: AuthManager
+    var showToast: ((String, ToastInfo.Style) -> Void)?
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
 
     @State private var apiKeyText: String = ""
@@ -314,7 +315,7 @@ struct SettingsPanel: View {
     private var selectedTabContent: some View {
         switch selectedTab {
         case .account:
-            SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, onSignIn: {
+            SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, showToast: showToast, onSignIn: {
                 // Re-bootstrap actor credentials first so the actor token is
                 // available when ensureLocalAssistantApiKey() waits for it.
                 // This mirrors the pattern in proceedToApp() and
@@ -360,7 +361,8 @@ struct SettingsPanel: View {
             InferenceServiceCard(
                 store: store,
                 authManager: authManager,
-                apiKeyText: $apiKeyText
+                apiKeyText: $apiKeyText,
+                showToast: showToast
             )
 
             // WEB SEARCH
@@ -374,7 +376,8 @@ struct SettingsPanel: View {
             ImageGenerationServiceCard(
                 store: store,
                 authManager: authManager,
-                apiKeyText: $imageGenKeyText
+                apiKeyText: $imageGenKeyText,
+                showToast: showToast
             )
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -12,6 +12,7 @@ struct ImageGenerationServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     @Binding var apiKeyText: String
+    var showToast: ((String, ToastInfo.Style) -> Void)?
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -105,7 +106,11 @@ struct ImageGenerationServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    await authManager.startWorkOSLogin()
+                    if let showToast {
+                        await authManager.loginWithToast(showToast: showToast)
+                    } else {
+                        await authManager.startWorkOSLogin()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -12,6 +12,7 @@ struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     @Binding var apiKeyText: String
+    var showToast: ((String, ToastInfo.Style) -> Void)?
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -112,7 +113,11 @@ struct InferenceServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    await authManager.startWorkOSLogin()
+                    if let showToast {
+                        await authManager.loginWithToast(showToast: showToast)
+                    } else {
+                        await authManager.startWorkOSLogin()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -8,6 +8,7 @@ struct SettingsGeneralTab: View {
     var daemonClient: DaemonClient?
     var authManager: AuthManager
     var onClose: () -> Void
+    var showToast: ((String, ToastInfo.Style) -> Void)?
     var onSignIn: (() -> Void)?
 
     @State private var showingPairingQR: Bool = false
@@ -99,18 +100,14 @@ struct SettingsGeneralTab: View {
                     isDisabled: authManager.isSubmitting
                 ) {
                     Task {
-                        await authManager.startWorkOSLogin()
-                        if authManager.isAuthenticated {
-                            onSignIn?()
+                        if let showToast {
+                            await authManager.loginWithToast(showToast: showToast, onSuccess: { onSignIn?() })
+                        } else {
+                            await authManager.startWorkOSLogin()
+                            if authManager.isAuthenticated { onSignIn?() }
                         }
                     }
                 }
-            }
-
-            if let error = authManager.errorMessage {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeStrong)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `AuthManager.loginWithToast()` helper that wraps `startWorkOSLogin()` with error toast display
- Thread `showToast` closure from `MainWindowView`/`PanelCoordinator` through `SettingsPanel` to all login call sites
- Replace direct `startWorkOSLogin()` calls with `loginWithToast()` in Settings Account, DrawerMenu, InferenceServiceCard, and ImageGenerationServiceCard
- Remove inline error text from `SettingsGeneralTab`

Part of plan: unified-login-error-toast.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
