### PR TITLE
Shorten conversation context menu labels

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -282,7 +282,7 @@ struct ConversationListView: View {
                 }
             } label: {
                 Label {
-                    Text(conversation.isPinned ? "Unpin conversation" : "Pin conversation")
+                    Text(conversation.isPinned ? "Unpin" : "Pin")
                 } icon: {
                     VIconView(conversation.isPinned ? .pinOff : .pin, size: 14)
                 }
@@ -292,13 +292,13 @@ struct ConversationListView: View {
         Button {
             beginRenaming(conversation)
         } label: {
-            Label { Text("Rename conversation") } icon: { VIconView(.pencil, size: 14) }
+            Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
         }
 
         Button {
             archiveActiveConversation(conversation)
         } label: {
-            Label { Text("Archive conversation") } icon: { VIconView(.archive, size: 14) }
+            Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
         }
 
         Button {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -48,9 +48,9 @@ struct ConversationActionsDrawer: View {
                 action: presentation.isPinned ? onUnpin : onPin
             )
 
-            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename conversation", action: onRename)
+            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
 
-            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive conversation", action: onArchive)
+            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
         }
         .padding(VSpacing.sm)
         .background(VColor.surfaceLift)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -172,18 +172,18 @@ struct SidebarConversationItem: View {
                     }
                 }
             } label: {
-                Label { Text(conversation.isPinned ? "Unpin conversation" : "Pin conversation") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
+                Label { Text(conversation.isPinned ? "Unpin" : "Pin") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
                 sidebar.renamingConversationId = conversation.id
                 sidebar.renameText = conversation.title
             } label: {
-                Label { Text("Rename conversation") } icon: { VIconView(.pencil, size: 14) }
+                Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
                 conversationManager.archiveConversation(id: conversation.id)
             } label: {
-                Label { Text("Archive conversation") } icon: { VIconView(.archive, size: 14) }
+                Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
                 conversationManager.markConversationUnread(conversationId: conversation.id)
@@ -198,7 +198,7 @@ struct SidebarConversationItem: View {
                 guard let conversationId = conversation.conversationId else { return }
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
             } label: {
-                Label { Text("Send Logs for Conversation") } icon: { VIconView(.upload, size: 14) }
+                Label { Text("Send Logs") } icon: { VIconView(.upload, size: 14) }
             }
             .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
         }


### PR DESCRIPTION
## Summary
- Shortened context menu labels: "Pin conversation" → "Pin", "Rename conversation" → "Rename", "Archive conversation" → "Archive", "Send Logs for Conversation" → "Send Logs"
- Applied consistently across macOS sidebar context menu, macOS conversation actions drawer, and iOS conversation list context menu

## Original prompt
I think we can make the menu items for this more concise. Maybe shorten to just Pin, Rename, Archive, Send Logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
