### PR TITLE
feat: handle trust rules and skills paths in vbundle import resolver

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -15,6 +15,7 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import type { ManifestType } from "./vbundle-validator.js";
 
@@ -81,6 +82,8 @@ export class DefaultPathResolver implements PathResolver {
   constructor(
     private dbPath: string,
     private configPath: string,
+    private protectedDir?: string,
+    private skillsDir?: string,
   ) {}
 
   resolve(archivePath: string): string | null {
@@ -90,6 +93,12 @@ export class DefaultPathResolver implements PathResolver {
       case "config/settings.json":
         return this.configPath;
       default:
+        if (archivePath === "trust/trust.json" && this.protectedDir) {
+          return join(this.protectedDir, "trust.json");
+        }
+        if (archivePath.startsWith("skills/") && this.skillsDir) {
+          return join(this.skillsDir, archivePath.slice("skills/".length));
+        }
         return null;
     }
   }


### PR DESCRIPTION
## Summary
- Extend DefaultPathResolver constructor with optional protectedDir and skillsDir parameters
- Add resolution for trust/trust.json to the protected directory
- Add prefix-based resolution for skills/ paths to the workspace skills directory

Part of plan: backup-restore-macos.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
