### PR TITLE
feat: show backup/restore in developer tab for local assistants with auto-restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -357,7 +357,7 @@ extension AssistantBackupsSection {
                 }
             }
         } message: {
-            Text("This will replace the assistant's current data with the backup. This action cannot be undone.")
+            Text("This will replace the assistant's current data with the backup and restart it. This action cannot be undone.")
         }
     }
 
@@ -394,7 +394,15 @@ extension AssistantBackupsSection {
             if httpResponse.statusCode == 200 {
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let success = json["success"] as? Bool, success {
-                    successMessage = "Backup restored successfully. You may need to restart the assistant."
+                    successMessage = "Backup restored. Restarting assistant..."
+
+                    // Auto-restart the assistant so restored state takes effect
+                    let assistantName = assistant.assistantId
+                    Task {
+                        AppDelegate.shared?.assistantCli.stop(name: nil)
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        try? await AppDelegate.shared?.assistantCli.wake(name: assistantName)
+                    }
                 } else {
                     errorMessage = "Import completed with warnings. Check assistant logs for details."
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -73,11 +73,14 @@ struct SettingsDeveloperTab: View {
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
                assistant.isManaged || assistant.isRemote {
                 restartAssistantSection
-                AssistantBackupsSection(assistant: assistant, store: store)
-                    .withRestoreConfirmation
                 if assistant.isManaged {
                     sshTerminalSection
                 }
+            }
+            // Backups (all assistant types)
+            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
+                AssistantBackupsSection(assistant: assistant, store: store)
+                    .withRestoreConfirmation
             }
             // Transfer (local ↔ managed)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),


### PR DESCRIPTION
## Summary
- Move AssistantBackupsSection out of managed/remote gate so it appears for all assistant types including local
- Add auto-restart logic after successful backup restore (stop + wake via CLI)
- Update confirmation dialog to indicate the assistant will be restarted

Part of plan: backup-restore-macos.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
