### PR TITLE
feat: pass trust and skills paths to migration export and import handlers

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -13,10 +13,17 @@
 
 import { Database } from "bun:sqlite";
 
+import { join } from "node:path";
+
 import { invalidateConfigCache } from "../../config/loader.js";
 import { resetDb } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
-import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
+import {
+  getDbPath,
+  getRootDir,
+  getWorkspaceConfigPath,
+  getWorkspaceSkillsDir,
+} from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { buildExportVBundle } from "../migrations/vbundle-builder.js";
@@ -137,6 +144,8 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     const { archive, manifest } = buildExportVBundle({
       dbPath: getDbPath(),
       configPath: getWorkspaceConfigPath(),
+      trustPath: join(getRootDir(), "protected", "trust.json"),
+      skillsDir: getWorkspaceSkillsDir(),
       source: "runtime-export",
       description,
       checkpoint: () => {
@@ -291,6 +300,8 @@ export async function handleMigrationImportPreflight(
     const pathResolver = new DefaultPathResolver(
       getDbPath(),
       getWorkspaceConfigPath(),
+      join(getRootDir(), "protected"),
+      getWorkspaceSkillsDir(),
     );
 
     const report = analyzeImport({
@@ -373,6 +384,8 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     const pathResolver = new DefaultPathResolver(
       getDbPath(),
       getWorkspaceConfigPath(),
+      join(getRootDir(), "protected"),
+      getWorkspaceSkillsDir(),
     );
 
     // Close the live SQLite connection before overwriting assistant.db on disk.


### PR DESCRIPTION
## Summary
- Wire trustPath and skillsDir to buildExportVBundle() in the export handler
- Wire protectedDir and skillsDir to DefaultPathResolver in import and import-preflight handlers
- Backups now include trust rules and workspace skills; restores write them to the correct locations

Part of plan: backup-restore-macos.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
