### PR TITLE
fix: center Automation empty state in settings panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -101,30 +101,17 @@ struct AssistantChannelsDetailView: View {
 
     // MARK: - Layouts
 
-    /// Settings tab layout: individual bordered cards per channel, own ScrollView.
+    /// Settings tab layout: individual bordered cards per channel (matches Models & Services layout).
     private var borderedLayout: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.xl) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Channels")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.contentDefault)
-                    Text("Manage where \(assistantName) can be reached.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    slackChannelCard
-                    telegramCard
-                    voiceCard
-                    if isEmailEnabled {
-                        emailCard
-                    }
-                }
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            slackChannelCard
+            telegramCard
+            voiceCard
+            if isEmailEnabled {
+                emailCard
             }
-            .padding(VSpacing.lg)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// Contacts tab layout: compact row list with dividers, no ScrollView (container scrolls).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -116,7 +116,7 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
+                if selectedTab == .contacts || selectedTab == .automation || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
                     selectedTabContent
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -116,11 +116,11 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts || selectedTab == .channels || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
+                if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
                     selectedTabContent
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: (selectedTab == .contacts || selectedTab == .channels) ? .top : .center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
                 } else {
                     ScrollView {
                         selectedTabContent


### PR DESCRIPTION
## Summary
- Add `.frame(maxWidth: .infinity, maxHeight: .infinity)` to the Automation tab's VEmptyState so it centers both vertically and horizontally in the content area

## Original prompt
automation empty message has to be vertically and horizontally in a middle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
