### PR TITLE
Fix Channels settings layout to match Models & Services

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -101,30 +101,17 @@ struct AssistantChannelsDetailView: View {
 
     // MARK: - Layouts
 
-    /// Settings tab layout: individual bordered cards per channel, own ScrollView.
+    /// Settings tab layout: individual bordered cards per channel (matches Models & Services layout).
     private var borderedLayout: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.xl) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Channels")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.contentDefault)
-                    Text("Manage where \(assistantName) can be reached.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    slackChannelCard
-                    telegramCard
-                    voiceCard
-                    if isEmailEnabled {
-                        emailCard
-                    }
-                }
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            slackChannelCard
+            telegramCard
+            voiceCard
+            if isEmailEnabled {
+                emailCard
             }
-            .padding(VSpacing.lg)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// Contacts tab layout: compact row list with dividers, no ScrollView (container scrolls).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -116,11 +116,11 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts || selectedTab == .channels || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
+                if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
                     selectedTabContent
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: (selectedTab == .contacts || selectedTab == .channels) ? .top : .center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
                 } else {
                     ScrollView {
                         selectedTabContent


### PR DESCRIPTION
## Summary
- Remove the "Channels" title and subtitle header from the Settings > Channels page
- Remove the internal ScrollView wrapper so the page scrolls with the settings container
- Use the same VStack + `.frame(maxWidth:)` pattern as the Models & Services tab for consistent layout

## Original prompt
fix channels layout to match Model & Services layout, remove Channels title and subtitle from Settings/Channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
