### PR TITLE
fix: sort imports in migration-routes.ts to satisfy eslint

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -11,9 +11,8 @@
  * results with is_valid flag and detailed error descriptions.
  */
 
-import { Database } from "bun:sqlite";
-
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 
 import { invalidateConfigCache } from "../../config/loader.js";
 import { resetDb } from "../../memory/db-connection.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `migration-routes.ts` by reordering `node:path` before `bun:sqlite` and removing the unnecessary blank line between them

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23202995599/job/67430388644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
