### PR TITLE
fix: check timezone source directly instead of inferring from missing User timezone line

### DIFF
--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -51,7 +51,7 @@ Use the injected `<temporal_context>` block as the authoritative clock source:
 - `Current local time` + `Timezone` are the active local-calendar interpretation.
 - `Timezone source` tells you whether local-time interpretation is user-specific or host fallback. When a `User timezone:` line is present, the user's timezone differs from the primary timezone.
 
-When no `User timezone:` line is present (i.e. `Timezone source: assistant_host_fallback`) and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
+When `Timezone source: assistant_host_fallback` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
 If the user confirms a timezone, suggest saving it in Settings -> Appearance -> User timezone so future reminders resolve correctly without re-asking.
 
 ## Relative Time Parsing


### PR DESCRIPTION
Fixes the time-based-actions SKILL.md instruction that incorrectly equated the absence of a User timezone: line with assistant_host_fallback source. The User timezone line is also absent when the user's configured timezone matches the host timezone. Now checks Timezone source: assistant_host_fallback directly.

Closes #18211
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
