### PR TITLE
fix: classify 5xx errors as transient in API key validation and fix tombstone race

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -620,13 +620,16 @@ public final class SettingsStore: ObservableObject {
         hasKey = true
         maskedKey = Self.maskKey(trimmed)
 
+        // Remove any stale deletion tombstone eagerly — the user's intent is to
+        // save a new key, so any prior clear is superseded. Deferring this until
+        // after async validation creates a race: if the daemon reconnects before
+        // validation completes, replayDeletionTombstones would DELETE the new key.
+        removeDeletionTombstone(type: "api_key", name: "anthropic")
+
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: "anthropic", value: trimmed)
             apiKeySaving = false
             if result.success {
-                // Only remove the tombstone after the daemon accepts the key,
-                // so a pending offline-clear is preserved on transient failure.
-                removeDeletionTombstone(type: "api_key", name: "anthropic")
                 scheduleRoutingSourceRefresh()
                 onSuccess?()
             } else if let error = result.error {
@@ -910,12 +913,15 @@ public final class SettingsStore: ObservableObject {
             if response.isSuccess {
                 return (true, nil, false)
             }
+            // 5xx errors are server-side / transient — don't treat them as
+            // definitive validation failures (which would wipe the local key).
+            let isServerError = response.statusCode >= 500
             // Try to parse error message from response body
             if let parsed = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
                let errorMsg = parsed["error"] as? String {
-                return (false, errorMsg, false)
+                return (false, errorMsg, isServerError)
             }
-            return (false, "Failed to save API key (HTTP \(response.statusCode)).", false)
+            return (false, "Failed to save API key (HTTP \(response.statusCode)).", isServerError)
         } catch {
             return (false, "Could not reach assistant. Please check that it is running.", true)
         }


### PR DESCRIPTION
Fixes two issues in saveAPIKey flow:

1. **5xx errors now treated as transient** — `syncKeyToDaemonWithValidation` previously marked all non-2xx responses as `isTransient: false`, causing `saveAPIKey` to delete the local key on any failure. Now only 4xx errors (true validation failures like 401/422) trigger key deletion; 5xx server errors are transient and preserve the local key for retry on reconnect.

2. **Tombstone removal is now eager** — `removeDeletionTombstone` was previously called only on validation success, creating a race: user clears key → saves new key while daemon unreachable → daemon reconnects → `syncAllKeysToDaemon` pushes new key but `replayDeletionTombstones` immediately deletes it. Now the tombstone is removed synchronously before async validation begins, since saving a new key always supersedes a prior clear.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
