### PR TITLE
fix: prevent remove button tap from triggering attachment preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -24,31 +24,39 @@ extension ComposerView {
         let isImage = attachment.mimeType.hasPrefix("image/")
 
         return HStack(spacing: VSpacing.sm) {
-            if isImage, let nsImage = attachment.thumbnailImage {
-                Image(nsImage: nsImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 28, height: 28)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            } else {
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(VColor.borderBase.opacity(0.5))
-                    .frame(width: 28, height: 28)
-                    .overlay {
-                        VIconView(iconForMimeType(attachment.mimeType, filename: attachment.filename), size: 14)
-                            .foregroundColor(VColor.contentSecondary)
-                    }
+            HStack(spacing: VSpacing.sm) {
+                if isImage, let nsImage = attachment.thumbnailImage {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 28, height: 28)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                } else {
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.borderBase.opacity(0.5))
+                        .frame(width: 28, height: 28)
+                        .overlay {
+                            VIconView(iconForMimeType(attachment.mimeType, filename: attachment.filename), size: 14)
+                                .foregroundColor(VColor.contentSecondary)
+                        }
+                }
+
+                Text(attachment.filename)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Text("· \(fileSize)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
             }
-
-            Text(attachment.filename)
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-
-            Text("· \(fileSize)")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
+            .contentShape(Rectangle())
+            .if(isImage) { view in
+                view
+                    .onTapGesture { openAttachmentPreview(attachment) }
+                    .pointerCursor()
+            }
 
             Button {
                 onRemoveAttachment(attachment.id)
@@ -64,12 +72,6 @@ extension ComposerView {
         .background(VColor.borderBase.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .frame(maxWidth: 280)
-        .if(isImage) { view in
-            view
-                .contentShape(Rectangle())
-                .onTapGesture { openAttachmentPreview(attachment) }
-                .pointerCursor()
-        }
     }
 }
 


### PR DESCRIPTION
Fixes tap gesture conflict where clicking the remove button on a composer attachment chip could also trigger the image preview. Restructures the view so the tap gesture only applies to the image/label area, not the remove button.

Addresses review feedback on #18226.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
