### PR TITLE
fix: handle conversation_error events in CLI renderer

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -842,6 +842,11 @@ export async function startCli(): Promise<void> {
         renderConfirmationPrompt(msg);
         break;
 
+      case "conversation_error":
+        spinner.stop();
+        process.stdout.write(`\n[Error: ${msg.userMessage}]\n`);
+        break;
+
       case "error":
         spinner.stop();
         generating = false;


### PR DESCRIPTION
## Summary
- Add `conversation_error` event handling to the CLI renderer in `cli.ts`
- PR #18283 removed the `assistant_text_delta` emission for provider errors (to fix duplicate error display), but the CLI didn't handle the `conversation_error` event that replaced it
- Without this fix, provider errors would be silent in the built-in CLI

## Test plan
- [ ] Trigger a provider error (e.g. invalid API key) in CLI mode and verify the error message is displayed
- [ ] Verify the macOS/desktop client still shows the InlineChatErrorAlert card (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
