### PR TITLE
fix: keep /grok-multi as alias for backward compatibility

### DIFF
--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -115,6 +115,11 @@ const PROVIDER_MODEL_SHORTCUTS: Record<
     model: "x-ai/grok-4.20-beta",
     displayName: "Grok 4.20 Beta (OpenRouter)",
   },
+  "grok-multi": {
+    provider: "openrouter",
+    model: "x-ai/grok-4.20-beta",
+    displayName: "Grok 4.20 Beta (OpenRouter)",
+  },
 };
 
 /** True when the trimmed content matches a provider shortcut like /opus, /gpt4, etc. */


### PR DESCRIPTION
Adds /grok-multi back as an alias pointing to the same Grok 4.20 Beta model as /grok-beta, preserving backward compatibility for users of the old command.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
