### PR TITLE
fix: use instance-aware workspace root for relative chat image URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -87,7 +87,16 @@ struct AnimatedImageView: View {
 
         // Resolve relative workspace paths (e.g. "data/avatar/avatar-image.png")
         if !urlString.contains("://") {
-            let workspaceDir = NSHomeDirectory() + "/.vellum/workspace"
+            // Use the connected assistant's baseDataDir for multi-instance support,
+            // falling back to the default ~/.vellum/workspace path.
+            let workspaceDir: String
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+               let assistant = LockfileAssistant.loadByName(assistantId),
+               let baseDataDir = assistant.baseDataDir {
+                workspaceDir = baseDataDir + "/workspace"
+            } else {
+                workspaceDir = NSHomeDirectory() + "/.vellum/workspace"
+            }
             let fileURL = URL(fileURLWithPath: workspaceDir + "/" + urlString)
             imageData = try? Data(contentsOf: fileURL)
             loadedImage = imageData.flatMap { NSImage(data: $0) }


### PR DESCRIPTION
Fixes hardcoded ~/.vellum/workspace path in AnimatedImageView to use the instance-aware workspace root via LockfileAssistant, supporting multi-instance setups where BASE_DATA_DIR may differ.

Addresses review feedback on #18231.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
