### PR TITLE
fix: filter cached scroll view to vertical-only to avoid grabbing horizontal scrollers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -835,7 +835,7 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
                 }
             }
 
-            if let sv = view as? NSScrollView { return sv }
+            if let sv = view as? NSScrollView, sv.hasVerticalScroller { return sv }
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Adds `hasVerticalScroller` check to the `deepestScrollView` helper, aligning it with the sibling `verticalScrollView` helper
- Prevents the cache from holding a reference to a nested horizontal scroller (e.g. from code blocks), which would break vertical scroll forwarding

Addresses review feedback on #18308.

## Test plan
- [ ] Scroll over a code block with horizontal scroll — verify the "Scroll to latest" pill still forwards vertical scroll correctly
- [ ] Verify normal scroll-through on the pill works as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
