### PR TITLE
fix: only auto-wake daemon for local assistant connections

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -67,7 +67,7 @@ extension DaemonClient {
             #if os(macOS)
             // Auto-wake: if the daemon process is not alive and a wake handler is
             // configured, try waking the daemon and retrying the connection once.
-            if let wakeHandler, !DaemonClient.isDaemonProcessAlive(environment: config.instanceDir.map { ["BASE_DATA_DIR": $0] }) {
+            if let wakeHandler, config.transportMetadata.routeMode == .runtimeFlat, !DaemonClient.isDaemonProcessAlive(environment: config.instanceDir.map { ["BASE_DATA_DIR": $0] }) {
                 log.info("connect: daemon process not alive — attempting auto-wake before retry")
                 do {
                     try await wakeHandler()


### PR DESCRIPTION
## Summary
- Adds a `config.transportMetadata.routeMode == .runtimeFlat` guard to the auto-wake branch in `DaemonConnection.swift`
- Prevents auto-wake from triggering when connected to managed/remote assistants, where `instanceDir` is nil and `isDaemonProcessAlive` incorrectly falls back to the default local PID path

## Test plan
- [ ] Verify local assistant connection still auto-wakes when daemon is not running
- [ ] Verify managed/remote assistant connection failures no longer attempt auto-wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
