### PR TITLE
fix: MCP compatibility and risk cache for reason→activity rename

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -205,9 +205,18 @@ describe("schemaDefinesProperty", () => {
     expect(schemaDefinesProperty(schema, "activity")).toBe(false);
   });
 
-  test("returns false for $ref (fail-closed)", () => {
+  test("returns false for $ref with default behavior (fail-closed)", () => {
     const schema = { $ref: "#/definitions/Foo" };
     expect(schemaDefinesProperty(schema, "activity")).toBe(false);
+  });
+
+  test("returns true for $ref with assume-defined behavior (fail-open)", () => {
+    const schema = { $ref: "#/definitions/Foo" };
+    expect(
+      schemaDefinesProperty(schema, "activity", {
+        refBehavior: "assume-defined",
+      }),
+    ).toBe(true);
   });
 
   test("returns false for null schema", () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -48,10 +48,10 @@ function riskCacheKey(
   workingDir?: string,
   manifestOverride?: ManifestOverride,
 ): string {
-  // Strip `reason` before computing the cache key — it is cosmetic and varies
-  // per invocation even for identical tool operations, causing unnecessary
-  // cache misses.
-  const { reason: _reason, ...cacheableInput } = input;
+  // Strip `reason` and `activity` before computing the cache key — they are
+  // cosmetic status text that varies per invocation even for identical tool
+  // operations, causing unnecessary cache misses.
+  const { reason: _reason, activity: _activity, ...cacheableInput } = input;
   const inputJson = JSON.stringify(cacheableInput);
   const hash = createHash("sha256")
     .update(inputJson)

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -40,6 +40,7 @@ export function createMcpTool(
   const serverDefinesActivity = schemaDefinesProperty(
     metadata.inputSchema,
     "activity",
+    { refBehavior: "assume-defined" },
   );
 
   return {

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -60,21 +60,28 @@ export function injectActivityField(
 /**
  * Checks whether a JSON Schema defines a given property name.
  * Walks `allOf`, `oneOf`, `anyOf` recursively.
- * Fail-closed on `$ref`: returns false if a `$ref` is encountered.
+ *
+ * `$ref` handling is configurable via `refBehavior`:
+ * - `'assume-undefined'` (default): fail-closed, treat `$ref` as not defining
+ *   the property. Good for injection (safe to double-inject).
+ * - `'assume-defined'`: fail-open, treat `$ref` as possibly defining the
+ *   property. Good for stripping decisions (don't strip what the server may need).
  */
 export function schemaDefinesProperty(
   schema: unknown,
   propertyName: string,
+  options?: { refBehavior?: "assume-defined" | "assume-undefined" },
 ): boolean {
   if (schema == null || typeof schema !== "object") {
     return false;
   }
 
   const s = schema as Record<string, unknown>;
+  const refBehavior = options?.refBehavior ?? "assume-undefined";
 
-  // Fail-closed on $ref - we can't resolve it, so treat as "doesn't define it"
+  // $ref: we can't resolve it, so use the configured behavior
   if ("$ref" in s) {
-    return false;
+    return refBehavior === "assume-defined";
   }
 
   // Check direct properties


### PR DESCRIPTION
Fixes several issues from the reason→activity rename:

- **Risk cache**: Strip `activity` (in addition to `reason`) from cache key computation so identical tool operations don't miss cache due to varying status text
- **$ref-based MCP schemas**: Add `refBehavior` option to `schemaDefinesProperty` — MCP tool factory now uses `assume-defined` so activity isn't stripped from servers that define it via `$ref`
- **Test coverage**: Added test for `assume-defined` $ref behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
