### PR TITLE
fix: prevent path traversal in skills import resolver

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -15,7 +15,7 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import type { ManifestType } from "./vbundle-validator.js";
 
@@ -97,7 +97,12 @@ export class DefaultPathResolver implements PathResolver {
           return join(this.protectedDir, "trust.json");
         }
         if (archivePath.startsWith("skills/") && this.skillsDir) {
-          return join(this.skillsDir, archivePath.slice("skills/".length));
+          const resolved = resolve(this.skillsDir, archivePath.slice("skills/".length));
+          const skillsRoot = resolve(this.skillsDir);
+          if (resolved !== skillsRoot && !resolved.startsWith(skillsRoot + "/")) {
+            return null;
+          }
+          return resolved;
         }
         return null;
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for backup-restore-macos.md.

**Gap:** Path traversal vulnerability in skills import resolver
**What was expected:** Resolved paths should stay within the skills directory
**What was found:** No containment check — crafted archive paths like skills/../../ could write outside skillsDir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
