### PR TITLE
fix: complete reason→activity rename across all bundled-skill TOOLS.json files

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -21,7 +21,7 @@
             "type": "string",
             "description": "Working directory for the agent. This determines where the agent runs and where its session is stored. Set this to the project/repo root the user wants the agent to work in. Defaults to current conversation's working directory."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief explanation of why this tool is being called"
           }
@@ -43,7 +43,7 @@
             "type": "string",
             "description": "Optional ACP session ID to query. If omitted, returns all ACP sessions."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief explanation of why this tool is being called"
           }
@@ -65,7 +65,7 @@
             "type": "string",
             "description": "The ID of the ACP session to abort."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -75,7 +75,7 @@
             },
             "required": ["title"]
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -93,7 +93,7 @@
       "input_schema": {
         "type": "object",
         "properties": {
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -114,7 +114,7 @@
             "type": "string",
             "description": "The ID of the app to query records for"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -159,7 +159,7 @@
               "type": "string"
             }
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -181,7 +181,7 @@
             "type": "string",
             "description": "The ID of the app to delete"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -203,7 +203,7 @@
             "type": "string",
             "description": "The ID of the app"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -237,7 +237,7 @@
             "type": "number",
             "description": "Number of lines to return (default: all)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -279,7 +279,7 @@
             "type": "string",
             "description": "Optional short human-readable progress message shown to the user (e.g. 'adding dark mode styles')"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -313,7 +313,7 @@
             "type": "string",
             "description": "Optional short human-readable progress message shown to the user (e.g. 'adding dark mode styles')"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -339,7 +339,7 @@
             "type": "string",
             "description": "Optional description to guide icon generation (e.g. 'a blue calendar with a checkmark'). If omitted, the app name and description are used."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/browser/TOOLS.json
+++ b/assistant/src/config/bundled-skills/browser/TOOLS.json
@@ -17,7 +17,7 @@
             "type": "boolean",
             "description": "If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -35,7 +35,7 @@
       "input_schema": {
         "type": "object",
         "properties": {
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -56,7 +56,7 @@
             "type": "boolean",
             "description": "Capture the full scrollable page instead of just the viewport."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -77,7 +77,7 @@
             "type": "boolean",
             "description": "If true, close all browser pages and the browser context. Default: false (close only the current conversation page)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -102,7 +102,7 @@
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -139,7 +139,7 @@
             "type": "boolean",
             "description": "If true, press Enter after typing the text."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -169,7 +169,7 @@
             "type": "string",
             "description": "Optional CSS selector to target."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -204,7 +204,7 @@
             "type": "string",
             "description": "Optional CSS selector of element to scroll within."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -242,7 +242,7 @@
             "type": "number",
             "description": "The zero-based index of the <option> to select."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -267,7 +267,7 @@
             "type": "string",
             "description": "A CSS selector to target. Used as fallback when element_id is not available."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -300,7 +300,7 @@
             "type": "number",
             "description": "Maximum wait time in milliseconds (default and max: 30000)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -321,7 +321,7 @@
             "type": "boolean",
             "description": "If true, include a list of links found on the page (up to 200)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -342,7 +342,7 @@
             "type": "number",
             "description": "Maximum wait time in milliseconds (default: 30000, max: 120000)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -379,7 +379,7 @@
             "type": "boolean",
             "description": "Press Enter after filling"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/chatgpt-import/TOOLS.json
+++ b/assistant/src/config/bundled-skills/chatgpt-import/TOOLS.json
@@ -13,7 +13,7 @@
             "type": "string",
             "description": "Absolute path to the ChatGPT export ZIP file"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -52,7 +52,7 @@
               "required": ["type", "address"]
             }
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -86,7 +86,7 @@
             "type": "number",
             "description": "Maximum results to return (default 20, max 100)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -112,7 +112,7 @@
             "type": "string",
             "description": "ID of the contact to merge into the kept contact (will be deleted)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -147,7 +147,7 @@
             "type": "string",
             "description": "Pagination token (for list)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -17,7 +17,7 @@
             "type": "string",
             "description": "Initial Markdown content to populate the editor (optional)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -47,7 +47,7 @@
             "enum": ["replace", "append"],
             "description": "Whether to replace all content or append to the end. Defaults to append."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/followups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/followups/TOOLS.json
@@ -29,7 +29,7 @@
             "type": "string",
             "description": "Optional recurrence schedule ID to fire a reminder when overdue"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -64,7 +64,7 @@
             "type": "boolean",
             "description": "When true, return only pending follow-ups past their expected response deadline"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -94,7 +94,7 @@
             "type": "string",
             "description": "Conversation ID to match (used with channel for auto-resolution)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -39,7 +39,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -90,7 +90,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -120,7 +120,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -150,7 +150,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -196,7 +196,7 @@
             "type": "string",
             "description": "BCC recipients (comma-separated email addresses)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -226,7 +226,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -265,7 +265,7 @@
             "type": "string",
             "description": "Filename to save as (required for download)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -303,7 +303,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -338,7 +338,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -411,7 +411,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -466,7 +466,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -504,7 +504,7 @@
             "type": "string",
             "description": "Resume token from a previous scan (rarely needed - scans now cover up to 10,000 messages in a single call)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -541,7 +541,7 @@
             "type": "string",
             "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },

--- a/assistant/src/config/bundled-skills/google-calendar/TOOLS.json
+++ b/assistant/src/config/bundled-skills/google-calendar/TOOLS.json
@@ -38,7 +38,7 @@
             "enum": ["startTime", "updated"],
             "description": "Sort order (default \"startTime\"). Only valid when single_events is true."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -67,7 +67,7 @@
             "type": "string",
             "description": "Calendar ID (default \"primary\")"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -128,7 +128,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -169,7 +169,7 @@
             "type": "string",
             "description": "IANA timezone for interpreting results (e.g. \"America/New_York\")"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },
@@ -208,7 +208,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           },

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -37,7 +37,7 @@
             "type": "number",
             "description": "Number of image variants to generate (1-4, default: 1)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -21,7 +21,7 @@
             "type": "object",
             "description": "Optional JSON metadata to attach to the asset (e.g., pipeline config, source info)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -52,7 +52,7 @@
             "enum": ["registered", "processing", "indexed", "failed"],
             "description": "Filter assets by processing status"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -106,7 +106,7 @@
             "enum": ["api", "local"],
             "description": "Transcription backend: 'api' (OpenAI Whisper cloud) or 'local' (whisper.cpp). Default: 'local'."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -159,7 +159,7 @@
             "minimum": 0,
             "description": "Maximum retry attempts per segment on failure. Default: 3"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -193,7 +193,7 @@
             "type": "string",
             "description": "LLM model to use for analysis. Default: 'claude-sonnet-4-6'"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -240,7 +240,7 @@
             "type": "string",
             "description": "Short descriptive title for the clip (e.g. 'snow-dive-closeup', 'goal-celebration'). Used as the filename. If omitted, falls back to timestamp-based naming."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -17,7 +17,7 @@
             "type": "string",
             "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -54,7 +54,7 @@
             "type": "number",
             "description": "Maximum number of conversations to return (default 200)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -91,7 +91,7 @@
             "type": "number",
             "description": "Maximum number of messages to return (default 50)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -125,7 +125,7 @@
             "type": "number",
             "description": "Maximum number of results to return (default 20)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -182,7 +182,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -216,7 +216,7 @@
             "type": "string",
             "description": "Specific message ID to mark as read (optional)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -250,7 +250,7 @@
             "type": "string",
             "description": "Optional search filter (e.g. 'to:alice@example.com' for Gmail, 'from:@me' for Slack)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -296,7 +296,7 @@
             "type": "string",
             "description": "Draft ID (for delete)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -338,7 +338,7 @@
             "type": "string",
             "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -371,7 +371,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/notifications/TOOLS.json
+++ b/assistant/src/config/bundled-skills/notifications/TOOLS.json
@@ -66,7 +66,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/orchestration/TOOLS.json
+++ b/assistant/src/config/bundled-skills/orchestration/TOOLS.json
@@ -21,7 +21,7 @@
             "type": "number",
             "description": "Maximum concurrent workers (1-6, default from config)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }

--- a/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
+++ b/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
@@ -26,7 +26,7 @@
             "enum": ["assistant_number", "user_number"],
             "description": "Which phone number to use as the caller ID. assistant_number uses the AI assistant's Twilio number; user_number uses the user's verified personal number."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -48,7 +48,7 @@
             "type": "string",
             "description": "Specific call session ID to check. If omitted, checks for an active call in the current conversation."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -74,7 +74,7 @@
             "type": "string",
             "description": "Reason for ending the call"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/playbooks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/playbooks/TOOLS.json
@@ -34,7 +34,7 @@
             "type": "number",
             "description": "Relative priority \u2014 higher numbers take precedence. Defaults to 0."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -60,7 +60,7 @@
             "type": "string",
             "description": "Filter by category (e.g. \"scheduling\", \"triage\"). Omit to show all."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -106,7 +106,7 @@
             "type": "number",
             "description": "Updated priority"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -128,7 +128,7 @@
             "type": "string",
             "description": "ID of the playbook to delete (from playbook_list results)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -52,7 +52,7 @@
             "type": "object",
             "description": "Additional routing metadata (e.g. preferred channel identifiers)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -78,7 +78,7 @@
             "type": "string",
             "description": "If provided, show detailed info and recent runs for this specific job."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -139,7 +139,7 @@
             "type": "object",
             "description": "Additional routing metadata (e.g. preferred channel identifiers)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -161,7 +161,7 @@
             "type": "string",
             "description": "The ID of the schedule to delete"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/screen-watch/TOOLS.json
+++ b/assistant/src/config/bundled-skills/screen-watch/TOOLS.json
@@ -21,7 +21,7 @@
             "type": "string",
             "description": "What to focus on observing"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are watching and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }

--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -55,7 +55,7 @@
             "type": "boolean",
             "description": "Whether to stop the sequence when the contact replies (default true)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -78,7 +78,7 @@
             "enum": ["active", "paused", "archived"],
             "description": "Filter by sequence status"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -99,7 +99,7 @@
             "type": "string",
             "description": "Sequence ID"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -177,7 +177,7 @@
             },
             "description": "Replacement steps (replaces all existing steps)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -202,7 +202,7 @@
             "type": "string",
             "description": "Sequence ID to delete"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -242,7 +242,7 @@
             "type": "object",
             "description": "Optional context object with personalization variables for the enrolled contacts"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -276,7 +276,7 @@
             ],
             "description": "Filter by enrollment status"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -305,7 +305,7 @@
             "type": "boolean",
             "description": "Set to true to enroll contacts (default false = preview mode)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -327,7 +327,7 @@
             "type": "string",
             "description": "Optional sequence ID for detailed step funnel view"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -17,7 +17,7 @@
           "value": {
             "description": "The new value for the setting (type depends on setting)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are changing and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
@@ -39,7 +39,7 @@
             "enum": ["microphone", "speech_recognition"],
             "description": "The System Settings pane to open"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
@@ -70,7 +70,7 @@
             ],
             "description": "The settings tab to navigate to"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -42,7 +42,7 @@
             "items": { "type": "string" },
             "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
@@ -68,7 +68,7 @@
             "type": "boolean",
             "description": "Whether to remove the skill from SKILLS.md index (default: true)."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }

--- a/assistant/src/config/bundled-skills/slack/TOOLS.json
+++ b/assistant/src/config/bundled-skills/slack/TOOLS.json
@@ -33,7 +33,7 @@
             "enum": ["text", "blocks"],
             "description": "Output format: 'text' returns JSON (default), 'blocks' returns Slack Block Kit structured output"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -54,7 +54,7 @@
             "type": "string",
             "description": "The Slack channel ID to get details for"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -84,7 +84,7 @@
             },
             "description": "Channel IDs to add, remove, or set (not needed for 'list')"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -118,7 +118,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -148,7 +148,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -182,7 +182,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -208,7 +208,7 @@
             "type": "number",
             "description": "Confidence score (0-1) for this action"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -258,7 +258,7 @@
             "enum": ["restricted", "standard"],
             "description": "Trust level override: 'restricted' limits tool access, 'standard' uses defaults (for 'set' action)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -25,7 +25,7 @@
             "type": "boolean",
             "description": "Whether to present the subagent's result to the user when it completes. Defaults to true. Set to false for internal/silent processing."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -47,7 +47,7 @@
             "type": "string",
             "description": "Optional subagent ID to query. If omitted, returns all subagents for this conversation."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -69,7 +69,7 @@
             "type": "string",
             "description": "The ID of the subagent to abort."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -95,7 +95,7 @@
             "type": "string",
             "description": "The message content to send to the subagent."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -117,7 +117,7 @@
             "type": "string",
             "description": "The ID of the subagent whose output to read."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/tasks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/tasks/TOOLS.json
@@ -17,7 +17,7 @@
             "type": "string",
             "description": "Optional override for the auto-generated task title"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -50,7 +50,7 @@
               "type": "string"
             }
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -67,7 +67,7 @@
       "input_schema": {
         "type": "object",
         "properties": {
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -91,7 +91,7 @@
             },
             "description": "One or more task IDs to delete."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -123,7 +123,7 @@
             ],
             "description": "Optional status filter. A single status string (e.g. \"queued\") or an array of statuses to include."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -180,7 +180,7 @@
             },
             "description": "Tools the task will need at execution time. Always specify this \u2014 think about what tools are needed to accomplish the task (e.g. [\"host_bash\"] for shell commands, [\"host_file_read\", \"host_file_write\"] for file operations, [\"web_search\"] for web lookups). The user must approve these before the task runs. Pass [] if no tools are needed."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -259,7 +259,7 @@
             "type": "number",
             "description": "Disambiguation filter: pick the Nth oldest match (1 = oldest, 2 = second oldest, etc.) when multiple items share the same title/task_id."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -311,7 +311,7 @@
             "type": "number",
             "description": "Disambiguator: 1-indexed creation order among matches (1 = oldest, 2 = second oldest, etc.)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -340,7 +340,7 @@
             "type": "string",
             "description": "Work item title to search for (case-insensitive substring match)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/transcribe/TOOLS.json
+++ b/assistant/src/config/bundled-skills/transcribe/TOOLS.json
@@ -22,7 +22,7 @@
             "enum": ["api", "local"],
             "description": "Transcription backend: 'api' for OpenAI Whisper API (cloud), 'local' for whisper.cpp (on-device)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }

--- a/assistant/src/config/bundled-skills/watcher/TOOLS.json
+++ b/assistant/src/config/bundled-skills/watcher/TOOLS.json
@@ -33,7 +33,7 @@
             "type": "object",
             "description": "Provider-specific configuration (e.g. filter criteria)"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -59,7 +59,7 @@
             "type": "boolean",
             "description": "When true, only show enabled watchers. Defaults to false."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -101,7 +101,7 @@
             "type": "object",
             "description": "New provider-specific configuration"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -123,7 +123,7 @@
             "type": "string",
             "description": "The ID of the watcher to delete"
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
@@ -153,7 +153,7 @@
             "type": "number",
             "description": "Maximum number of events to return. Defaults to 50."
           },
-          "reason": {
+          "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }


### PR DESCRIPTION
Renames the reason parameter to activity in all remaining bundled-skill TOOLS.json files, completing the migration started in PR #18242.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
