### PR TITLE
fix: use specific assistant ID in backup restore auto-restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -399,7 +399,7 @@ extension AssistantBackupsSection {
                     // Auto-restart the assistant so restored state takes effect
                     let assistantName = assistant.assistantId
                     Task {
-                        AppDelegate.shared?.assistantCli.stop(name: nil)
+                        AppDelegate.shared?.assistantCli.stop(name: assistantName)
                         try? await Task.sleep(nanoseconds: 500_000_000)
                         try? await AppDelegate.shared?.assistantCli.wake(name: assistantName)
                     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for backup-restore-macos.md.

**Gap:** Auto-restart uses stop(name: nil) instead of specific assistant name
**What was expected:** Stop/wake should target the specific assistant being restored
**What was found:** stop(name: nil) would stop the default assistant, not necessarily the one being restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
