### PR TITLE
fix: invalidate trust cache after vbundle import and update builder docs

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -5,6 +5,8 @@
  * - manifest.json: metadata with schema_version, checksums, and bundle info
  * - data/db/assistant.db: the SQLite database with conversations and memory
  * - config/settings.json: the assistant configuration
+ * - trust/trust.json: trust rules (optional)
+ * - skills/: workspace skills (optional)
  */
 
 import { createHash } from "node:crypto";

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -16,6 +16,7 @@ import { Database } from "bun:sqlite";
 
 import { invalidateConfigCache } from "../../config/loader.js";
 import { resetDb } from "../../memory/db-connection.js";
+import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getDbPath,
@@ -432,8 +433,9 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       );
     }
 
-    // Invalidate in-process config cache so imported settings.json takes effect
+    // Invalidate in-process caches so imported settings.json and trust.json take effect
     invalidateConfigCache();
+    clearTrustCache();
 
     return Response.json(result.report);
   } catch (err) {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for backup-restore-macos.md.

**Gap 1:** Trust cache not invalidated after import writes trust.json
**Gap 2:** File header comment doesn't document new trust/skills entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
