### PR TITLE
fix: only show retry button on active error, not historical errors

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -216,7 +216,7 @@ struct ChatContentView: View {
                 onSurfaceRefetch: { surfaceId, conversationId in
                     viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
                 },
-                onRetryConversationError: message.isError ? { viewModel.retryAfterConversationError() } : nil
+                onRetryConversationError: message.isError && index == messages.count - 1 ? { viewModel.retryAfterConversationError() } : nil
             )
             .id(message.id)
             .transition(.asymmetric(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1433,7 +1433,7 @@ private struct MessageCellView: View, Equatable {
                 onTemporaryAllow: onTemporaryAllow,
                 activeConfirmationRequestId: activePendingRequestId,
                 onRetryFailedMessage: onRetryFailedMessage,
-                onRetryConversationError: message.isError ? onRetryConversationError : nil,
+                onRetryConversationError: message.isError && index == displayMessages.count - 1 ? onRetryConversationError : nil,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,


### PR DESCRIPTION
Fixes retry button appearing on all historical error messages. Now only shows the retry button on the last/active error message where retryAfterConversationError() would actually work.

Both iOS (ChatContentView.swift) and macOS (MessageListView.swift) now gate the retry button on `index == messages.count - 1`, ensuring only the most recent (active) error message displays a functional retry button.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
