### PR TITLE
fix: remove duplicate error display and fix inline error alert scaling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -184,7 +184,6 @@ struct ChatBubble: View {
                                 conversationError: message.conversationError,
                                 onRetry: onRetryConversationError
                             )
-                            .scaleEffect(conversationZoomScale, anchor: .topLeading)
                         } else if shouldShowBubble {
                             bubbleContent
                         }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1799,6 +1799,11 @@ extension ChatViewModel {
                 }
                 let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true, conversationError: typedError)
                 messages.append(errorMsg)
+                // The error is now represented by the inline error card in the
+                // message list. Clear the view-model-level error state so the
+                // toast overlay doesn't show a duplicate on macOS.
+                conversationError = nil
+                errorText = nil
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2113,14 +2113,18 @@ public final class ChatViewModel: ObservableObject {
 
     /// Dismiss the typed conversation error state. Clears both the typed error
     /// and any corresponding `errorText` so the UI can return to normal.
+    /// Also removes inline error messages from the message list.
     public func dismissConversationError() {
         conversationError = nil
         errorText = nil
+        // Remove inline error cards so the message list is cleaned up on retry/dismiss.
+        messages.removeAll(where: { $0.isError })
     }
 
     /// Copy conversation error details to the clipboard for debugging.
     public func copyConversationErrorDebugDetails() {
-        guard let error = conversationError else { return }
+        let error = conversationError ?? messages.last(where: { $0.isError })?.conversationError
+        guard let error else { return }
         var details = """
         Error: \(error.message)
         Category: \(error.category)
@@ -2139,8 +2143,11 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Retry the last message after a conversation error, if the error is retryable.
+    /// The error may live on the view model (toast path) or on the last inline error
+    /// message (inline card path, where `conversationError` was already cleared).
     public func retryAfterConversationError() {
-        guard let error = conversationError, error.isRetryable else { return }
+        let error = conversationError ?? messages.last(where: { $0.isError })?.conversationError
+        guard let error, error.isRetryable else { return }
         guard conversationId != nil else { return }
         // Reset sending state that may still be set if the conversation error arrived
         // while queued messages were pending (pendingQueuedCount > 0).


### PR DESCRIPTION
## Summary
Fixes two issues with inline error alerts flagged in PR #18277 review:

- **Layout misalignment at non-1x zoom**: Removed `.scaleEffect(conversationZoomScale)` from `InlineChatErrorAlert` in `ChatBubble.swift`. `scaleEffect` is a post-layout transform that scales rendering without affecting layout size, causing overlap or whitespace at non-default zoom levels. The component uses fixed design-system sizes that work well without zoom scaling (matching iOS behavior).

- **Duplicate error display on macOS**: Both the `ChatConversationErrorToast` overlay and the inline `InlineChatErrorAlert` card were shown simultaneously. Fixed by clearing the view-model-level `conversationError`/`errorText` after appending the inline error message, so the toast overlay has nothing to show. Updated `retryAfterConversationError()` and `copyConversationErrorDebugDetails()` to fall back to the last inline error message's `conversationError` when the view-model-level state is cleared.

## Test plan
- [ ] Trigger a conversation error at default zoom — verify only the inline error card shows (no toast overlay)
- [ ] Trigger a conversation error at non-default zoom — verify the inline error card is properly aligned with no overlap or whitespace
- [ ] Click retry on the inline error card — verify retry works correctly
- [ ] Verify iOS inline errors still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
