### PR TITLE
refactor: stack composer text field above action bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -439,10 +439,10 @@ struct ComposerView: View {
     @ViewBuilder
     private var textEntryComposer: some View {
         standardComposerShell {
-            HStack(alignment: isSending ? .center : .bottom, spacing: composerTextToButtonsGap) {
+            VStack(spacing: 0) {
                 composerTextField
                     .frame(minHeight: composerActionButtonSize)
-                composerActionButtons
+                composerActionBar
             }
         }
     }
@@ -453,34 +453,13 @@ struct ComposerView: View {
     /// match the ghost-ghost gap, compensating for the filled button having no internal padding.
     private let composerFilledGap: CGFloat = 12
 
-    /// Explicit width for the action buttons area based on the current state.
-    private var composerButtonsWidth: CGFloat {
-        let s = composerActionButtonSize
-        if isSending && !hasPendingConfirmation {
-            return s
-        } else if canSend {
-            // paperclip(ghost) + filledGap + send(primary)
-            return s + composerFilledGap + s
-        } else if inputText.isEmpty && !hasPendingConfirmation {
-            // paperclip(ghost) + ghostGap + mic(ghost) + filledGap + waveform(contrast)
-            return s + composerGhostGap + s + composerFilledGap + s
-        } else {
-            // paperclip(ghost) + ghostGap + mic(ghost)
-            return s + composerGhostGap + s
-        }
-    }
-
+    /// Bottom action bar: paperclip on the left, send/mic/stop on the right.
     @ViewBuilder
-    private var composerActionButtons: some View {
+    private var composerActionBar: some View {
         HStack(spacing: 0) {
+            // Left side
             if isSending && !hasPendingConfirmation {
-                VButton(
-                    label: "Stop generation",
-                    iconOnly: VIcon.square.rawValue,
-                    style: .contrast,
-                    iconSize: composerActionButtonSize,
-                    action: onStop
-                )
+                Spacer()
             } else {
                 VButton(
                     label: "Attach file",
@@ -491,62 +470,69 @@ struct ComposerView: View {
                 )
                 .disabled(!hasAPIKey)
 
-                if canSend {
-                    Spacer().frame(width: composerFilledGap)
-                    VButton(
-                        label: "Send message",
-                        iconOnly: VIcon.arrowUp.rawValue,
-                        style: .primary,
-                        iconSize: composerActionButtonSize
-                    ) {
-                        composerFocus = true
-                        onSend()
-                    }
-                } else if inputText.isEmpty && !hasPendingConfirmation {
-                    Spacer().frame(width: composerGhostGap)
-                    VButton(
-                        label: "Dictate",
-                        iconOnly: VIcon.mic.rawValue,
-                        style: .ghost,
-                        iconSize: composerActionButtonSize,
-                        action: { (onDictateToggle ?? onMicrophoneToggle)() }
-                    )
-                    .disabled(!hasAPIKey)
+                Spacer()
+            }
 
-                    Spacer().frame(width: composerFilledGap)
-                    VButton(
-                        label: "Voice mode",
-                        iconOnly: VIcon.audioWaveform.rawValue,
-                        style: .contrast,
-                        iconSize: composerActionButtonSize,
-                        action: { onVoiceModeToggle?() }
-                    )
-                    .disabled(!hasAPIKey)
-                    .popover(isPresented: $showVoiceModeHover, arrowEdge: .top) {
-                        Text("Start a live voice conversation with your assistant. Unlike the mic button, this is a real-time back-and-forth voice call.")
-                            .font(VFont.caption)
-                            .multilineTextAlignment(.leading)
-                            .frame(width: 200)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(VSpacing.sm)
-                    }
-                    .onHover { hovering in
-                        showVoiceModeHover = hovering
-                    }
-                } else {
-                    Spacer().frame(width: composerGhostGap)
-                    VButton(
-                        label: isRecording ? "Stop recording" : "Start voice input",
-                        iconOnly: VIcon.mic.rawValue,
-                        style: .ghost,
-                        iconSize: composerActionButtonSize,
-                        action: { onMicrophoneToggle() }
-                    )
-                    .disabled(!hasAPIKey)
+            // Right side
+            if isSending && !hasPendingConfirmation {
+                VButton(
+                    label: "Stop generation",
+                    iconOnly: VIcon.square.rawValue,
+                    style: .contrast,
+                    iconSize: composerActionButtonSize,
+                    action: onStop
+                )
+            } else if canSend {
+                VButton(
+                    label: "Send message",
+                    iconOnly: VIcon.arrowUp.rawValue,
+                    style: .primary,
+                    iconSize: composerActionButtonSize
+                ) {
+                    composerFocus = true
+                    onSend()
                 }
+            } else if inputText.isEmpty && !hasPendingConfirmation {
+                VButton(
+                    label: "Dictate",
+                    iconOnly: VIcon.mic.rawValue,
+                    style: .ghost,
+                    iconSize: composerActionButtonSize,
+                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                )
+                .disabled(!hasAPIKey)
+
+                Spacer().frame(width: composerFilledGap)
+                VButton(
+                    label: "Voice mode",
+                    iconOnly: VIcon.audioWaveform.rawValue,
+                    style: .contrast,
+                    iconSize: composerActionButtonSize,
+                    action: { onVoiceModeToggle?() }
+                )
+                .disabled(!hasAPIKey)
+                .popover(isPresented: $showVoiceModeHover, arrowEdge: .top) {
+                    Text("Start a live voice conversation with your assistant. Unlike the mic button, this is a real-time back-and-forth voice call.")
+                        .font(VFont.caption)
+                        .multilineTextAlignment(.leading)
+                        .frame(width: 200)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(VSpacing.sm)
+                }
+                .onHover { hovering in
+                    showVoiceModeHover = hovering
+                }
+            } else {
+                VButton(
+                    label: isRecording ? "Stop recording" : "Start voice input",
+                    iconOnly: VIcon.mic.rawValue,
+                    style: .ghost,
+                    iconSize: composerActionButtonSize,
+                    action: { onMicrophoneToggle() }
+                )
+                .disabled(!hasAPIKey)
             }
         }
-        .frame(width: composerButtonsWidth, alignment: .trailing)
     }
 
     // MARK: - Dictation Inline Mode

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -12,7 +12,6 @@ private let composerLog = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 300
     private let composerActionButtonSize: CGFloat = 32
-    private let composerTextToButtonsGap: CGFloat = 10
 
     // MARK: - ComposerMode
 
@@ -447,8 +446,6 @@ struct ComposerView: View {
         }
     }
 
-    /// Gap between two ghost (frameless) buttons — small since both have internal icon padding.
-    private let composerGhostGap: CGFloat = 2
     /// Gap between a ghost button and a filled (primary/contrast) button — larger to visually
     /// match the ghost-ghost gap, compensating for the filled button having no internal padding.
     private let composerFilledGap: CGFloat = 12


### PR DESCRIPTION
## Summary
- Move the TextField above the action buttons in a VStack layout (like Codex/Slack) instead of side-by-side in an HStack
- Gives the text field full composer width, reducing line wrapping and decoupling text height from button alignment
- Restructure action buttons as a bottom bar: paperclip left, send/mic/stop right

## Test plan
- [ ] Type short and long messages — no clipping at line wrap boundaries
- [ ] Ghost text suggestions appear and accept with Tab
- [ ] Slash commands popup, navigation, and selection work
- [ ] Paperclip, mic, waveform, send, and stop buttons all functional in correct states
- [ ] Attachments strip renders above text field
- [ ] Dictation and voice conversation modes unaffected
- [ ] Drag & drop files onto composer
- [ ] Cmd+Enter send mode works
- [ ] Focus redirect (typing anywhere auto-focuses composer)
- [ ] Window resize and zoom scale changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
