### PR TITLE
docs: consolidate AGENTS.md redundancies and deduplicate CLI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Bun + TypeScript monorepo with multiple packages:
 - `gateway/` — Channel ingress gateway (Bun + TypeScript)
 - `packages/` — Shared internal packages (e.g. `ces-contracts` for CES wire-protocol schemas)
 - `scripts/` — Utility scripts
-- `skills/` — First-party skill catalog (portable skill packages). See `skills/AGENTS.md`.
+- `skills/` — First-party skill catalog (portable skill packages). See `skills/AGENTS.md` for contribution rules and portability requirements.
 - `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`). Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks; repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/` as local skill directories. The `/update` command uses `vellum ps`, `vellum sleep`, and `vellum wake` to manage assistant lifecycle.
 
 ## Development
@@ -97,7 +97,7 @@ Use `modelIntent` (`'latency-optimized'`, `'quality-optimized'`, `'vision-optimi
 
 ## Tooling Direction
 
-Do not add new tool registrations using the `class ____Tool implements Tool` pattern. Prefer skills in `assistant/src/config/bundled-skills/` that teach the model CLI tools. When touching existing tool-based flows, migrate toward skill-driven CLI usage.
+Do not add new tool registrations. See `assistant/src/tools/AGENTS.md` for the full no-new-tools policy, approved CES exceptions, and what to do instead.
 
 ## System Prompt Minimalism
 
@@ -109,13 +109,7 @@ Adding content to the system prompt is a **last resort**. The system prompt is t
 
 Only add to the system prompt when the behavior cannot be achieved any other way. When you must, keep additions minimal and look for existing content to condense or remove to offset the addition.
 
-**Exception — Credential Execution Service (CES) tools**: The three CES tools (`run_authenticated_command`, `make_authenticated_request`, `manage_secure_command_tool`) are approved exceptions to the no-new-tools policy. They are thin RPC stubs that forward execution to the `credential-executor/` package across a hard process boundary. Skills cannot provide this isolation because they run inside the assistant process. CES grants and audit logs are CES-owned durable state — the assistant never reads or writes them directly. `host_bash` is outside the CES strong secrecy guarantee; secure generic authenticated HTTP must not run through `run_authenticated_command`. See [`assistant/docs/credential-execution-service.md`](assistant/docs/credential-execution-service.md).
-
-## Skill Independence
-
-Skills must be self-contained and portable — no coupling to daemon tools, internals, or repo-specific modules. Use `scripts/` for supporting logic with inline dependencies. No interactive prompts. Relative paths only. Ask: "Could this skill be copied into a different project and still work?"
-
-Follow the [Agent Skills specification](https://agentskills.io/specification) for SKILL.md format, directory structure, and naming conventions.
+CES tools are the only approved exception — see `assistant/src/tools/AGENTS.md` for details.
 
 ## User-Facing Terminology: "daemon" vs "assistant"
 

--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -6,14 +6,11 @@ Commands in `assistant/src/cli/` are scoped to a **single running assistant inst
 
 This contrasts with `cli/`, which manages the **lifecycle of assistant instances** (create, start, stop, delete) and operates across instances. See `cli/AGENTS.md`.
 
-## When a command belongs here vs `cli/`
+## Scope
 
-| `assistant/src/cli/` (this directory)               | `cli/`                                          |
-| --------------------------------------------------- | ----------------------------------------------- |
-| Operates within a single assistant's workspace      | Operates on or across assistant instances       |
-| Manages instance-local state (config, memory, etc.) | Manages lifecycle (create, start, stop, delete) |
-| Implicitly scoped to the running assistant          | Requires specifying which assistant to target   |
-| May require or start the daemon                     | Works without an assistant process running      |
+Commands here operate on a **single running assistant's** local state — config, memory, contacts, trust rules, conversations, autonomy, etc. They are implicitly scoped to the running assistant and may require or start the daemon.
+
+For commands that manage the **lifecycle of assistant instances** (create, start, stop, delete), see `cli/AGENTS.md`.
 
 Examples: `config`, `contacts`, `memory`, `autonomy`, `conversations`, `doctor` belong here. `hatch`, `wake`, `sleep`, `retire`, `ps`, `ssh` belong in `cli/`.
 

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -6,14 +6,11 @@ The `cli/` package (`@vellumai/cli`) manages the **lifecycle of Vellum assistant
 
 This contrasts with `assistant/src/cli/`, where commands are scoped to a **single running assistant** and operate on its local state (config, memory, contacts, etc.).
 
-## When a command belongs here vs `assistant/src/cli/`
+## Scope
 
-| `cli/` (this package)                           | `assistant/src/cli/`                                |
-| ----------------------------------------------- | --------------------------------------------------- |
-| Operates on or across assistant instances       | Operates within a single assistant's workspace      |
-| Manages lifecycle (create, start, stop, delete) | Manages instance-local state (config, memory, etc.) |
-| Requires specifying which assistant to target   | Implicitly scoped to the running assistant          |
-| Works without an assistant process running      | May require or start the daemon                     |
+Commands here operate on or across **assistant instances** — creating, starting, stopping, connecting to, and deleting them. They require specifying which assistant to target and work without an assistant process running.
+
+For commands scoped to a **single running assistant's** local state (config, memory, contacts), see `assistant/src/cli/AGENTS.md`.
 
 Examples: `hatch`, `wake`, `sleep`, `retire`, `ps`, `ssh` belong here. `config`, `contacts`, `memory` belong in `assistant/src/cli/`.
 
@@ -30,9 +27,7 @@ Commands that act on a specific assistant should accept an assistant name or ID 
 
 ## Help Text Standards
 
-Every command must have high-quality `--help` output optimized for AI/LLM
-consumption. Help text is a primary interface — both humans and AI agents read
-it to understand what a command does and how to use it.
+Every command must have high-quality `--help` output. Follow the same standards as `assistant/src/cli/AGENTS.md` § Help Text Standards, adapted for this package's manual argv parsing (no Commander.js).
 
 ### Requirements
 

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,6 +1,7 @@
 # Skills Contribution Guide
 
 - **Skills must be self-contained and portable**
+  - No interactive prompts. Use relative paths only.
   - Use `scripts/` for supporting logic with inline dependencies
   - When including code assets, utilities, or tools, load the [scripts best practices specification](https://agentskills.io/skill-creation/using-scripts.md) first
   - **External dependencies in Bun/TypeScript scripts**: pin versions directly in the import path (e.g., `import { Command } from "commander@13.1.0"`). Bun auto-installs missing packages at runtime when no `node_modules` directory is found. Do NOT add a `package.json` or `bun.lock` to skill directories - this disables Bun's auto-install behavior and breaks portability.


### PR DESCRIPTION
## Summary
- Shortened root AGENTS.md "Tooling Direction" and "System Prompt Minimalism" CES exception to pointers to `assistant/src/tools/AGENTS.md`, eliminating duplicated policy statements
- Removed redundant "Skill Independence" section from root (already covered by `skills/AGENTS.md` pointer in Project Structure)
- Replaced mirror-image comparison tables in `assistant/src/cli/AGENTS.md` and `cli/AGENTS.md` with concise scope descriptions and cross-references
- Trimmed duplicated help text standards preamble in `cli/AGENTS.md` to reference `assistant/src/cli/AGENTS.md`

## Test plan
- [x] Verified all cross-references point to existing files with the expected content
- [x] Verified no orphaned references to removed sections exist in the codebase
- [x] Verified "See Also" links in root AGENTS.md remain valid
- [x] Confirmed no information was lost — all content exists in the referenced subdirectory files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
