### PR TITLE
fix: keep avatarTargetY fresh with relaxed threshold to prevent stale flush

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -351,12 +351,12 @@ struct MessageListView: View {
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
-        // Only update @State when the visibility boundary is crossed or finitude
-        // changes. avatarTargetY is only consumed by shouldShowConversationTailAvatar
-        // (a binary visible/hidden check), so continuous position tracking is
-        // unnecessary. The previous `abs(delta) > 1` threshold caused ~60 @State
-        // updates/sec during scroll, each triggering a full MessageListView body
-        // re-evaluation and expensive LazyVStack re-measurement of complex messages.
+        // Only update @State when the visibility boundary is crossed, finitude
+        // changes, or the stored value drifts too far from reality. The relaxed
+        // threshold (20pt) keeps avatarTargetY fresh enough that the coalescing
+        // flush path (onChange of shouldCoalesceAvatarUpdates) won't see a large
+        // stale jump, while still avoiding the ~60 @State updates/sec that the
+        // original 1pt threshold caused during scroll.
         let visibilityChanged: Bool = {
             let wasVisible = avatarTargetY.isFinite
                 && ConversationAvatarFollower.shouldShow(anchorY: avatarTargetY, viewportHeight: scrollViewportHeight)
@@ -364,7 +364,7 @@ struct MessageListView: View {
                 && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
             return wasVisible != nowVisible
         }()
-        if visibilityChanged || !avatarTargetY.isFinite != !anchorY.isFinite {
+        if visibilityChanged || abs(avatarTargetY - anchorY) > 20 || !avatarTargetY.isFinite != !anchorY.isFinite {
             avatarTargetY = anchorY
         }
 


### PR DESCRIPTION
PR #18305 removed the `abs(avatarTargetY - anchorY) > 1` threshold to avoid ~60 @State updates/sec during scroll. However, this left `avatarTargetY` potentially stale — when `onChange(of: shouldCoalesceAvatarUpdates)` flushes with `pendingAvatarY ?? avatarTargetY`, the stale value could cause a visible position jump.

Restores the threshold with a relaxed 20pt value. This keeps `avatarTargetY` within 20pt of reality (preventing large jumps on flush) while dramatically reducing update frequency compared to the original 1pt threshold.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
