### PR TITLE
feat: add permission prompt telemetry events

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -30,6 +30,7 @@ import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import { createToolDomainEventPublisher } from "../events/tool-domain-event-publisher.js";
 import { registerToolMetricsLoggingListener } from "../events/tool-metrics-listener.js";
 import { registerToolNotificationListener } from "../events/tool-notification-listener.js";
+import { registerToolPermissionTelemetryListener } from "../events/tool-permission-telemetry-listener.js";
 import {
   registerToolProfilingListener,
   ToolProfiler,
@@ -294,6 +295,7 @@ export class Conversation {
     );
     registerToolTraceListener(this.eventBus, this.traceEmitter);
     registerToolProfilingListener(this.eventBus, this.profiler);
+    registerToolPermissionTelemetryListener(this.eventBus);
     const auditToolLifecycleEvent = createToolAuditListener();
     const publishToolDomainEvent = createToolDomainEventPublisher(
       this.eventBus,

--- a/assistant/src/events/tool-permission-telemetry-listener.ts
+++ b/assistant/src/events/tool-permission-telemetry-listener.ts
@@ -1,0 +1,31 @@
+import { recordLifecycleEvent } from "../memory/lifecycle-events-store.js";
+import { getLogger } from "../util/logger.js";
+import type { EventBus, Subscription } from "./bus.js";
+import type { AssistantDomainEvents } from "./domain-events.js";
+
+const log = getLogger("tool-permission-telemetry");
+
+export function registerToolPermissionTelemetryListener(
+  eventBus: EventBus<AssistantDomainEvents>,
+): Subscription {
+  return eventBus.onAny((event) => {
+    try {
+      switch (event.type) {
+        case "tool.permission.requested":
+          recordLifecycleEvent(
+            `permission_prompt:${event.payload.toolName}`,
+          );
+          return;
+        case "tool.permission.decided":
+          recordLifecycleEvent(
+            `permission_decided:${event.payload.toolName}:${event.payload.decision}`,
+          );
+          return;
+        default:
+          return;
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to record permission telemetry event");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Added a new event bus listener (`tool-permission-telemetry-listener`) that records permission prompt interactions as lifecycle telemetry events
- When a permission prompt is triggered, records `permission_prompt:<toolName>`
- When the user responds (allow, deny, always_allow, etc.), records `permission_decided:<toolName>:<decision>`
- Events flow through the existing lifecycle telemetry pipeline to the platform

## Original prompt
Add telemetry events for whenever a permission prompt is triggered and for when the user interacts with it (report what they click). Don't include the tool details just the tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
