### PR TITLE
revert: restore original settings side nav structure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -685,7 +685,7 @@ extension AppDelegate {
     public func showSettingsTab(_ tab: String) {
         // Don't gate on feature flags here — let SettingsPanel decide visibility
         // based on its own flag state when it processes pendingSettingsTab.
-        if let settingsTab = SettingsTab.fromRawValue(tab) {
+        if let settingsTab = SettingsTab(rawValue: tab) {
             services.settingsStore.pendingSettingsTab = settingsTab
         }
         showSettingsWindow(nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -2,27 +2,25 @@ import SwiftUI
 import VellumAssistantShared
 
 enum SettingsTab: String {
-    case account = "Account"
-    case channels = "Channels"
+    case general = "General"
     case modelsAndServices = "Models & Services"
-    case automation = "Automation"
-    case contacts = "Contacts"
-    case appearance = "Appearance"
-    case permissionsAndPrivacy = "Permissions"
-    case accessibility = "Accessibility"
-    case privacy = "Privacy"
     case voice = "Voice"
+    case permissionsAndPrivacy = "Permissions & Privacy"
+    case contacts = "Contacts"
     case billing = "Billing"
     case archivedConversations = "Archived Conversations"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
     static func primaryTabs(contactsEnabled: Bool = false, billingEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [.account, .channels, .modelsAndServices, .voice, .automation]
+        var tabs: [SettingsTab] = [.general]
         if contactsEnabled {
             tabs.append(.contacts)
         }
-        tabs.append(contentsOf: [.appearance, .permissionsAndPrivacy, .accessibility, .privacy])
+        tabs.append(contentsOf: [
+            .voice, .modelsAndServices,
+            .permissionsAndPrivacy,
+        ])
         if billingEnabled {
             tabs.append(.billing)
         }
@@ -30,16 +28,9 @@ enum SettingsTab: String {
         return tabs
     }
 
-    /// Resolves a tab name string to a SettingsTab, with backward compatibility for old names.
+    /// Resolves a tab name string to a SettingsTab. Only accepts current canonical names.
     static func fromRawValue(_ value: String, contactsEnabled: Bool = false, billingEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
-        // Support old raw values for backward compatibility
-        let tab: SettingsTab?
-        switch value {
-        case "General": tab = .account
-        case "Permissions & Privacy": tab = .permissionsAndPrivacy
-        default: tab = SettingsTab(rawValue: value)
-        }
-        guard let tab else { return nil }
+        guard let tab = SettingsTab(rawValue: value) else { return nil }
         // Block feature-flagged tabs when disabled
         if tab == .contacts && !contactsEnabled { return nil }
         if tab == .billing && !billingEnabled { return nil }
@@ -71,7 +62,7 @@ struct SettingsPanel: View {
     @State private var notificationsGranted: Bool = false
     @State private var notificationBadgesGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
-    @State private var selectedTab: SettingsTab = .account
+    @State private var selectedTab: SettingsTab = .general
     @State private var isContactsEnabled: Bool = false
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
@@ -116,11 +107,11 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts || selectedTab == .channels || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
+                if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
                     selectedTabContent
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: (selectedTab == .contacts || selectedTab == .channels) ? .top : .center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
                 } else {
                     ScrollView {
                         selectedTabContent
@@ -178,7 +169,7 @@ struct SettingsPanel: View {
         }
         .onChange(of: billingVisible) { _, visible in
             if !visible && selectedTab == .billing {
-                selectedTab = .account
+                selectedTab = .general
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
@@ -187,12 +178,12 @@ struct SettingsPanel: View {
                 if key == Self.contactsFeatureFlagKey {
                     isContactsEnabled = enabled
                     if !enabled && selectedTab == .contacts {
-                        selectedTab = .account
+                        selectedTab = .general
                     }
                 } else if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
                     if !enabled && selectedTab == .developer {
-                        selectedTab = .account
+                        selectedTab = .general
                     }
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
@@ -314,7 +305,7 @@ struct SettingsPanel: View {
     @ViewBuilder
     private var selectedTabContent: some View {
         switch selectedTab {
-        case .account:
+        case .general:
             SettingsGeneralTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose, showToast: showToast, onSignIn: {
                 // Re-bootstrap actor credentials first so the actor token is
                 // available when ensureLocalAssistantApiKey() waits for it.
@@ -326,24 +317,14 @@ struct SettingsPanel: View {
                 }
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
             })
-        case .channels:
-            AssistantChannelsDetailView(store: store, daemonClient: daemonClient, isEmailEnabled: isEmailEnabled)
         case .modelsAndServices:
             integrationsContent
-        case .automation:
-            VEmptyState(title: "Automation", subtitle: "Coming soon", icon: VIcon.zap.rawValue)
-        case .contacts:
-            ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled)
-        case .appearance:
-            SettingsAppearanceTab(store: store)
-        case .permissionsAndPrivacy:
-            permissionsContent
-        case .accessibility:
-            accessibilityContent
-        case .privacy:
-            SettingsPrivacyTab(store: store)
         case .voice:
             VoiceSettingsView(store: store)
+        case .permissionsAndPrivacy:
+            permissionsAndPrivacyContent
+        case .contacts:
+            ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled)
         case .billing:
             SettingsBillingTab(authManager: authManager)
         case .archivedConversations:
@@ -383,15 +364,24 @@ struct SettingsPanel: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Permissions Tab
+    // MARK: - Permissions & Privacy Tab
 
-    private var permissionsContent: some View {
+    private var permissionsAndPrivacyContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // PERMISSIONS section (OS permissions)
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("System Permissions")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.contentDefault)
+
+                permissionRow(
+                    label: "Accessibility",
+                    subtitle: "Allows your assistant to click, type, and control apps on your behalf.",
+                    granted: accessibilityGranted
+                ) {
+                    _ = PermissionManager.accessibilityStatus(prompt: true)
+                    startPermissionPolling()
+                }
 
                 permissionRow(
                     label: "Screen Recording",
@@ -463,31 +453,10 @@ struct SettingsPanel: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .vCard(background: VColor.surfaceOverlay)
             }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
 
-    // MARK: - Accessibility Tab
+            // PRIVACY section
+            SettingsPrivacyTab(store: store)
 
-    private var accessibilityContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Accessibility Permissions")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.contentDefault)
-
-                permissionRow(
-                    label: "Accessibility",
-                    subtitle: "Allows your assistant to click, type, and control apps on your behalf.",
-                    granted: accessibilityGranted
-                ) {
-                    _ = PermissionManager.accessibilityStatus(prompt: true)
-                    startPermissionPolling()
-                }
-            }
-            .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .vCard(background: VColor.surfaceOverlay)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// General settings tab — account/platform sign-in card.
+/// General settings tab — account/platform login card followed by appearance settings.
 @MainActor
 struct SettingsGeneralTab: View {
     @ObservedObject var store: SettingsStore
@@ -19,6 +19,7 @@ struct SettingsGeneralTab: View {
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
                 mobilePairingCard
             }
+            SettingsAppearanceTab(store: store)
         }
         .onAppear {
             Task { await authManager.checkSession() }


### PR DESCRIPTION
## Summary
- Revert settings side nav tabs to the pre-#18054 structure: General, Contacts (if enabled), Voice, Models & Services, Permissions & Privacy, Billing, Archived Conversations
- Remove the expanded nav tabs (Account, Channels, Automation, Appearance, Accessibility, Privacy) that were introduced in #18054
- Merge Accessibility and Privacy back into the combined Permissions & Privacy tab

## Original prompt
--safe revert settings side nav to a state before this PR: https://github.com/vellum-ai/vellum-assistant/pull/18054 settings side nav shouldn't be like that

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
