### PR TITLE
docs: add missing skill portability rules to skills/AGENTS.md

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,6 +1,7 @@
 # Skills Contribution Guide
 
 - **Skills must be self-contained and portable**
+  - No interactive prompts. Use relative paths only.
   - Use `scripts/` for supporting logic with inline dependencies
   - When including code assets, utilities, or tools, load the [scripts best practices specification](https://agentskills.io/skill-creation/using-scripts.md) first
   - **External dependencies in Bun/TypeScript scripts**: pin versions directly in the import path (e.g., `import { Command } from "commander@13.1.0"`). Bun auto-installs missing packages at runtime when no `node_modules` directory is found. Do NOT add a `package.json` or `bun.lock` to skill directories - this disables Bun's auto-install behavior and breaks portability.


### PR DESCRIPTION
## Summary
- Adds "No interactive prompts. Use relative paths only." to `skills/AGENTS.md`
- These rules were previously in the root AGENTS.md "Skill Independence" section which was removed in #18317 in favor of a pointer to `skills/AGENTS.md`
- Addresses Devin review feedback on #18339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
