### PR TITLE
fix: strongly discourage host_bash usage in favor of regular bash

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -49,7 +49,7 @@ function buildHostShellEnv(): Record<string, string> {
 class HostShellTool implements Tool {
   name = "host_bash";
   description =
-    "Execute a shell command on the host machine. Approval-gated: your user must allow each invocation. Do not use for commands that require injected credentials or secrets.";
+    "LAST RESORT — Execute a shell command directly on the user's host machine. You MUST strongly prefer the regular `bash` tool for all commands. Only use `host_bash` when you are absolutely certain the command MUST run on the user's host machine and CANNOT run in the workspace (e.g., managing host-level system services, accessing host-only peripherals, or interacting with host paths outside the workspace). If in doubt, use `bash` instead. Approval-gated: your user must allow each invocation. Do not use for commands that require injected credentials or secrets.";
   category = "host-terminal";
   // host_bash is a weaker-tier escape hatch under CES lockdown. It remains
   // Medium risk by default but persistent approvals are disabled for
@@ -65,7 +65,8 @@ class HostShellTool implements Tool {
         properties: {
           command: {
             type: "string",
-            description: "The host shell command to execute",
+            description:
+              "The host shell command to execute. IMPORTANT: Only use host_bash when the command absolutely must run on the host machine. Strongly prefer the regular `bash` tool for all other commands.",
           },
           activity: {
             type: "string",


### PR DESCRIPTION
## Summary
- Updated `host_bash` tool description to strongly discourage usage, leading with "LAST RESORT" and directing the model to prefer the regular `bash` tool
- Added reinforcing language to the `command` parameter description at the schema level
- Only legitimate use cases (host-level system services, host-only peripherals, host paths outside workspace) are called out as valid

## Original prompt
The vellum assistant is using host_bash too much. Can we change the host_bash tool description to be strongly worded that it should only be used if you're sure the command has to run on the user's machine and not in the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
