### PR TITLE
fix: forward refBehavior options in recursive schemaDefinesProperty calls

### DIFF
--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -98,7 +98,7 @@ export function schemaDefinesProperty(
     const arr = s[keyword];
     if (Array.isArray(arr)) {
       for (const member of arr) {
-        if (schemaDefinesProperty(member, propertyName)) {
+        if (schemaDefinesProperty(member, propertyName, options)) {
           return true;
         }
       }


### PR DESCRIPTION
Address review feedback from PR #18331:

- Pass options parameter through recursive schemaDefinesProperty calls inside allOf/oneOf/anyOf traversal
- Prevents refBehavior from silently reverting to 'assume-undefined' for nested schemas
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
