### PR TITLE
fix: deduplicate error and conversation_error display in CLI

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -160,6 +160,7 @@ export async function startCli(): Promise<void> {
   let pendingConfirmation = false;
   let pendingCopySession = false;
   let toolStreaming = false;
+  let lastDisplayedError: string | null = null;
   let eventSubscription: EventStreamWatcher | null = null;
   const spinner = new Spinner();
 
@@ -844,7 +845,10 @@ export async function startCli(): Promise<void> {
 
       case "conversation_error":
         spinner.stop();
-        process.stdout.write(`\n[Error: ${msg.userMessage}]\n`);
+        if (lastDisplayedError !== msg.userMessage) {
+          process.stdout.write(`\n[Error: ${msg.userMessage}]\n`);
+        }
+        lastDisplayedError = null;
         break;
 
       case "error":
@@ -857,6 +861,7 @@ export async function startCli(): Promise<void> {
           rl.removeAllListeners("line");
           rl.on("line", handleLine);
         }
+        lastDisplayedError = msg.message;
         process.stdout.write(`\n[Error: ${msg.message}]\n`);
         prompt();
         break;


### PR DESCRIPTION
Address review feedback from PR #18326:

- Prevent duplicate error messages when agent loop emits both error and conversation_error events for the same exception
- Track last displayed error to avoid showing the same message twice
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
