### PR TITLE
test: add test coverage for skills path traversal guard in DefaultPathResolver

### DIFF
--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -690,6 +690,48 @@ describe("DefaultPathResolver", () => {
     );
     expect(resolver.resolve("unknown/path.txt")).toBeNull();
   });
+
+  test("resolves valid skills path when skillsDir is provided", () => {
+    const resolver = new DefaultPathResolver(
+      "/some/db.db",
+      "/some/config.json",
+      undefined,
+      "/home/user/.vellum/workspace/skills",
+    );
+    expect(resolver.resolve("skills/my-skill/SKILL.md")).toBe(
+      "/home/user/.vellum/workspace/skills/my-skill/SKILL.md",
+    );
+  });
+
+  test("returns null for skills path traversal attempt (../../etc/passwd)", () => {
+    const resolver = new DefaultPathResolver(
+      "/some/db.db",
+      "/some/config.json",
+      undefined,
+      "/home/user/.vellum/workspace/skills",
+    );
+    expect(resolver.resolve("skills/../../etc/passwd")).toBeNull();
+  });
+
+  test("returns null for skills path traversal attempt (../../../.ssh/authorized_keys)", () => {
+    const resolver = new DefaultPathResolver(
+      "/some/db.db",
+      "/some/config.json",
+      undefined,
+      "/home/user/.vellum/workspace/skills",
+    );
+    expect(
+      resolver.resolve("skills/../../../.ssh/authorized_keys"),
+    ).toBeNull();
+  });
+
+  test("returns null for skills paths when skillsDir is not provided", () => {
+    const resolver = new DefaultPathResolver(
+      "/some/db.db",
+      "/some/config.json",
+    );
+    expect(resolver.resolve("skills/my-skill/SKILL.md")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Address review feedback from PR #18332:

- Add tests for DefaultPathResolver with skillsDir parameter
- Verify valid skills paths resolve correctly
- Verify path traversal attempts (../) are rejected and return null
- Verify skills paths return null when skillsDir is not provided
- Ensures security-critical path traversal prevention has proper test coverage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
