### PR TITLE
fix: use instanceDir for workspace path resolution in multi-instance setups

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -99,14 +99,13 @@ final class AvatarAppearanceManager {
     }
 
     private var customAvatarURL: URL {
-        // Resolve from the connected assistant's baseDataDir so multi-instance
+        // Resolve from the connected assistant's workspace dir so multi-instance
         // setups (e.g. XDG-based paths) find the correct avatar file.
         if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
            let assistant = LockfileAssistant.loadByName(assistantId),
-           let baseDataDir = assistant.baseDataDir {
-            // baseDataDir is the .vellum root (e.g. ~/.local/share/vellum/assistants/foo/.vellum)
-            return URL(fileURLWithPath: baseDataDir)
-                .appendingPathComponent("workspace/data/avatar/avatar-image.png")
+           let workspace = assistant.workspaceDir {
+            return URL(fileURLWithPath: workspace)
+                .appendingPathComponent("data/avatar/avatar-image.png")
         }
         return Self.workspaceCustomAvatarURL()
     }

--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -87,13 +87,13 @@ struct AnimatedImageView: View {
 
         // Resolve relative workspace paths (e.g. "data/avatar/avatar-image.png")
         if !urlString.contains("://") {
-            // Use the connected assistant's baseDataDir for multi-instance support,
+            // Use the connected assistant's workspace dir for multi-instance support,
             // falling back to the default ~/.vellum/workspace path.
             let workspaceDir: String
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                let assistant = LockfileAssistant.loadByName(assistantId),
-               let baseDataDir = assistant.baseDataDir {
-                workspaceDir = baseDataDir + "/workspace"
+               let resolved = assistant.workspaceDir {
+                workspaceDir = resolved
             } else {
                 workspaceDir = NSHomeDirectory() + "/.vellum/workspace"
             }

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -56,6 +56,19 @@ public struct LockfileAssistant {
         cloud.lowercased() == "vellum"
     }
 
+    /// The resolved workspace directory for this assistant, accounting for both
+    /// the canonical `instanceDir` (post-migration) and legacy `baseDataDir`.
+    public var workspaceDir: String? {
+        if let instanceDir {
+            return instanceDir + "/.vellum/workspace"
+        }
+        if let baseDataDir {
+            // Legacy: baseDataDir already includes the .vellum segment
+            return baseDataDir + "/workspace"
+        }
+        return nil
+    }
+
     /// Resolve the assistant's local runtime HTTP port from the lockfile when
     /// available, otherwise fall back to the current process environment.
     public func resolvedDaemonPort(environment: [String: String]? = nil) -> Int {


### PR DESCRIPTION
Address review feedback from PR #18328:

## Summary
- Add `workspaceDir` computed property on `LockfileAssistant` that correctly resolves workspace paths for both canonical `instanceDir` (post-migration) and legacy `baseDataDir` entries
- Fix `AnimatedImageView.swift` to use `workspaceDir` instead of deprecated `baseDataDir`
- Fix `AvatarAppearanceManager.swift` (pre-existing same issue) to use `workspaceDir`

## Problem
After CLI migration (`migrateLegacyEntry()`), `baseDataDir` is removed from lockfile entries and moved to `resources.instanceDir`. Newly-created multi-instance entries never set `baseDataDir` at all. This caused workspace-relative image paths to silently fall back to `~/.vellum/workspace`, which is incorrect for secondary instances.

## Test plan
- [x] Verify workspace path resolution uses `instanceDir + /.vellum/workspace` for post-migration entries
- [x] Verify legacy `baseDataDir` fallback still works for unmigrated entries
- [x] Verify default `~/.vellum/workspace` fallback when neither field is set
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
