### PR TITLE
feat: include workspace prompts and hooks in vbundle backup

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -7,6 +7,8 @@
  * - config/settings.json: the assistant configuration
  * - trust/trust.json: trust rules (optional)
  * - skills/: workspace skills (optional)
+ * - prompts/: workspace prompt files — IDENTITY.md, SOUL.md, USER.md, UPDATES.md (optional)
+ * - hooks/: workspace hooks directory (optional)
  */
 
 import { createHash } from "node:crypto";
@@ -299,6 +301,10 @@ export interface BuildExportVBundleOptions {
   trustPath?: string;
   /** Absolute path to the workspace skills directory. If provided and exists, all non-binary files are included. */
   skillsDir?: string;
+  /** Absolute path to the workspace directory. If provided and exists, prompt files (IDENTITY.md, SOUL.md, USER.md, UPDATES.md) are included. */
+  workspaceDir?: string;
+  /** Absolute path to the workspace hooks directory. If provided and exists, all hook files are included. */
+  hooksDir?: string;
   /**
    * Optional callback to checkpoint the WAL before reading the database file.
    * In WAL mode, committed rows may live in the -wal file and not yet be
@@ -322,7 +328,7 @@ export interface BuildExportVBundleOptions {
 export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
-  const { dbPath, configPath, source, description, checkpoint, trustPath, skillsDir } = options;
+  const { dbPath, configPath, source, description, checkpoint, trustPath, skillsDir, workspaceDir, hooksDir } = options;
 
   // Flush WAL to the main database file before reading so the export
   // captures all committed rows (SQLite WAL mode keeps recent writes
@@ -354,6 +360,23 @@ export function buildExportVBundle(
   // Include workspace skills if the directory exists.
   if (skillsDir && existsSync(skillsDir)) {
     files.push(...walkDirectory(skillsDir, "skills"));
+  }
+
+  // Include workspace prompt files if the directory exists.
+  if (workspaceDir && existsSync(workspaceDir)) {
+    const promptFiles = ["IDENTITY.md", "SOUL.md", "USER.md", "UPDATES.md"];
+    for (const filename of promptFiles) {
+      const filePath = join(workspaceDir, filename);
+      if (existsSync(filePath)) {
+        const data = new Uint8Array(readFileSync(filePath));
+        files.push({ path: `prompts/${filename}`, data });
+      }
+    }
+  }
+
+  // Include workspace hooks if the directory exists.
+  if (hooksDir && existsSync(hooksDir)) {
+    files.push(...walkDirectory(hooksDir, "hooks"));
   }
 
   return buildVBundle({

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -84,6 +84,8 @@ export class DefaultPathResolver implements PathResolver {
     private configPath: string,
     private protectedDir?: string,
     private skillsDir?: string,
+    private workspaceDir?: string,
+    private hooksDir?: string,
   ) {}
 
   resolve(archivePath: string): string | null {
@@ -100,6 +102,22 @@ export class DefaultPathResolver implements PathResolver {
           const resolved = resolve(this.skillsDir, archivePath.slice("skills/".length));
           const skillsRoot = resolve(this.skillsDir);
           if (resolved !== skillsRoot && !resolved.startsWith(skillsRoot + "/")) {
+            return null;
+          }
+          return resolved;
+        }
+        if (archivePath.startsWith("prompts/") && this.workspaceDir) {
+          const resolved = resolve(this.workspaceDir, archivePath.slice("prompts/".length));
+          const workspaceRoot = resolve(this.workspaceDir);
+          if (resolved !== workspaceRoot && !resolved.startsWith(workspaceRoot + "/")) {
+            return null;
+          }
+          return resolved;
+        }
+        if (archivePath.startsWith("hooks/") && this.hooksDir) {
+          const resolved = resolve(this.hooksDir, archivePath.slice("hooks/".length));
+          const hooksRoot = resolve(this.hooksDir);
+          if (resolved !== hooksRoot && !resolved.startsWith(hooksRoot + "/")) {
             return null;
           }
           return resolved;

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -198,6 +198,44 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     }
   }
 
+  // Step 1c: Clear hooks directory if the bundle contains hooks entries.
+  // This ensures the restored hooks match the backup exactly — no stale
+  // hooks left behind from the current assistant state.
+  const hasHooksEntries = manifest.files.some((f) =>
+    f.path.startsWith("hooks/"),
+  );
+  if (hasHooksEntries) {
+    const firstHooksEntry = manifest.files.find((f) =>
+      f.path.startsWith("hooks/"),
+    )!;
+    const resolvedHookPath = pathResolver.resolve(firstHooksEntry.path);
+    if (resolvedHookPath) {
+      const relativeSuffix = firstHooksEntry.path.slice("hooks/".length);
+      const hooksRoot = resolvedHookPath.slice(
+        0,
+        resolvedHookPath.length - relativeSuffix.length,
+      );
+      const hooksDirPath =
+        hooksRoot.length > 1 && hooksRoot.endsWith("/")
+          ? hooksRoot.slice(0, -1)
+          : hooksRoot;
+
+      if (existsSync(hooksDirPath)) {
+        try {
+          rmSync(hooksDirPath, { recursive: true, force: true });
+        } catch (err) {
+          return {
+            ok: false,
+            reason: "write_failed",
+            message: `Failed to clear hooks directory "${hooksDirPath}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          };
+        }
+      }
+    }
+  }
+
   // Step 2: Write files to disk with backups
   const importedFiles: ImportedFileReport[] = [];
   const warnings: string[] = [];

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -22,6 +22,8 @@ import {
   getDbPath,
   getRootDir,
   getWorkspaceConfigPath,
+  getWorkspaceDir,
+  getWorkspaceHooksDir,
   getWorkspaceSkillsDir,
 } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
@@ -146,6 +148,8 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       configPath: getWorkspaceConfigPath(),
       trustPath: join(getRootDir(), "protected", "trust.json"),
       skillsDir: getWorkspaceSkillsDir(),
+      workspaceDir: getWorkspaceDir(),
+      hooksDir: getWorkspaceHooksDir(),
       source: "runtime-export",
       description,
       checkpoint: () => {
@@ -302,6 +306,8 @@ export async function handleMigrationImportPreflight(
       getWorkspaceConfigPath(),
       join(getRootDir(), "protected"),
       getWorkspaceSkillsDir(),
+      getWorkspaceDir(),
+      getWorkspaceHooksDir(),
     );
 
     const report = analyzeImport({
@@ -386,6 +392,8 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       getWorkspaceConfigPath(),
       join(getRootDir(), "protected"),
       getWorkspaceSkillsDir(),
+      getWorkspaceDir(),
+      getWorkspaceHooksDir(),
     );
 
     // Close the live SQLite connection before overwriting assistant.db on disk.


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for backup-restore-macos.md.

**Gap 1:** Workspace prompt files (IDENTITY.md, SOUL.md, USER.md, UPDATES.md) not included in backup — user identity/personality lost on restore
**Gap 2:** Workspace hooks directory not included in backup — custom hooks lost on restore

- Export now includes prompts/ and hooks/ entries in the vbundle archive
- Import resolver handles prompts/ and hooks/ paths with path traversal containment
- Hooks directory cleared before restore (matching skills behavior)
- Fully backward compatible with existing bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
