### PR TITLE
fix: encode boolean query parameters as true/false instead of 1/0

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -474,7 +474,11 @@ extension HTTPTransport {
             if let s = value as? String {
                 stringValue = s
             } else if let n = value as? NSNumber {
-                stringValue = n.stringValue
+                if CFGetTypeID(n) == CFBooleanGetTypeID() {
+                    stringValue = n.boolValue ? "true" : "false"
+                } else {
+                    stringValue = n.stringValue
+                }
             } else {
                 continue
             }


### PR DESCRIPTION
Address review feedback from PR #18344:

- Handle boolean NSNumber values specially in appendQueryItems
- Encode booleans as 'true'/'false' instead of '1'/'0' to match server expectations
- Other numeric NSNumber values continue to use stringValue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
