### PR TITLE
fix: scope permission telemetry to actual user prompt interactions only

### DIFF
--- a/assistant/src/events/tool-permission-telemetry-listener.ts
+++ b/assistant/src/events/tool-permission-telemetry-listener.ts
@@ -8,19 +8,31 @@ const log = getLogger("tool-permission-telemetry");
 export function registerToolPermissionTelemetryListener(
   eventBus: EventBus<AssistantDomainEvents>,
 ): Subscription {
+  // Track which request IDs were actually prompted so we only record
+  // decided telemetry for real user interactions, not auto-allowed tools.
+  const promptedRequestIds = new Set<string>();
+
   return eventBus.onAny((event) => {
     try {
       switch (event.type) {
         case "tool.permission.requested":
+          if (event.payload.requestId) {
+            promptedRequestIds.add(event.payload.requestId);
+          }
           recordLifecycleEvent(
             `permission_prompt:${event.payload.toolName}`,
           );
           return;
-        case "tool.permission.decided":
-          recordLifecycleEvent(
-            `permission_decided:${event.payload.toolName}:${event.payload.decision}`,
-          );
+        case "tool.permission.decided": {
+          const { requestId, toolName, decision } = event.payload;
+          if (requestId && promptedRequestIds.has(requestId)) {
+            promptedRequestIds.delete(requestId);
+            recordLifecycleEvent(
+              `permission_decided:${toolName}:${decision}`,
+            );
+          }
           return;
+        }
         default:
           return;
       }


### PR DESCRIPTION
Address review feedback from PR #18341:

- Filter tool.permission.decided telemetry to only record events where the user actually interacted with a permission prompt
- Track prompted requestIds via a Set; only emit permission_decided telemetry when the requestId had a preceding permission_prompt event
- Exclude auto-allowed operations from telemetry to prevent false 'user interacted' data
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
