### PR TITLE
fix: preserve conversationError state for downstream consumers and fix error message cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -992,7 +992,7 @@ private struct ErrorToastOverlay: View {
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
-            if let conversationError = errorManager.conversationError, !conversationError.isCreditsExhausted {
+            if let conversationError = errorManager.conversationError, !conversationError.isCreditsExhausted, !errorManager.isConversationErrorDisplayedInline {
                 ChatConversationErrorToast(
                     error: conversationError,
                     onRetry: onRetryConversationError,

--- a/clients/shared/Features/Chat/ChatErrorManager.swift
+++ b/clients/shared/Features/Chat/ChatErrorManager.swift
@@ -24,6 +24,12 @@ public final class ChatErrorManager: ObservableObject {
     /// Typed conversation error, richer than `errorText` and used for structured retry UI.
     @Published public var conversationError: ConversationError?
 
+    /// Whether the conversation error is already displayed as an inline error card
+    /// in the message list. When true, the toast overlay suppresses its duplicate
+    /// display while downstream consumers (credits-exhausted recovery, sidebar state,
+    /// iOS banner) continue to see the typed error state.
+    @Published public var isConversationErrorDisplayedInline: Bool = false
+
     /// Supplemental diagnostic hint shown alongside a daemon connection error.
     /// Nil when no connection error is active or the error has been dismissed.
     @Published public var connectionDiagnosticHint: String? = nil

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1799,11 +1799,11 @@ extension ChatViewModel {
                 }
                 let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true, conversationError: typedError)
                 messages.append(errorMsg)
-                // The error is now represented by the inline error card in the
-                // message list. Clear the view-model-level error state so the
-                // toast overlay doesn't show a duplicate on macOS.
-                conversationError = nil
-                errorText = nil
+                // Mark the error as displayed inline so the toast overlay
+                // suppresses its duplicate display, while keeping the typed
+                // error state available for downstream consumers (credits-
+                // exhausted recovery, sidebar state, iOS banner).
+                errorManager.isConversationErrorDisplayedInline = true
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1161,6 +1161,7 @@ public final class ChatViewModel: ObservableObject {
                 pendingSuggestionRequestId = nil
                 errorText = nil
                 conversationError = nil
+                errorManager.isConversationErrorDisplayedInline = false
                 lastFailedMessageText = nil
                 lastFailedMessageDisplayText = nil
                 lastFailedMessageAttachments = nil
@@ -1215,6 +1216,7 @@ public final class ChatViewModel: ObservableObject {
         pendingSuggestionRequestId = nil
         errorText = nil
         conversationError = nil
+        errorManager.isConversationErrorDisplayedInline = false
         lastFailedMessageText = nil
         lastFailedMessageDisplayText = nil
         lastFailedMessageAttachments = nil
@@ -1971,6 +1973,7 @@ public final class ChatViewModel: ObservableObject {
         }
         errorText = nil
         conversationError = nil
+        errorManager.isConversationErrorDisplayedInline = false
         isSending = true
         isThinking = true
         suggestion = nil
@@ -2099,6 +2102,7 @@ public final class ChatViewModel: ObservableObject {
     public func dismissError() {
         conversationError = nil
         errorText = nil
+        errorManager.isConversationErrorDisplayedInline = false
         lastFailedMessageText = nil
         lastFailedMessageDisplayText = nil
         lastFailedMessageAttachments = nil
@@ -2113,12 +2117,15 @@ public final class ChatViewModel: ObservableObject {
 
     /// Dismiss the typed conversation error state. Clears both the typed error
     /// and any corresponding `errorText` so the UI can return to normal.
-    /// Also removes inline error messages from the message list.
+    /// Also removes the most recent inline error message from the message list.
     public func dismissConversationError() {
         conversationError = nil
         errorText = nil
-        // Remove inline error cards so the message list is cleaned up on retry/dismiss.
-        messages.removeAll(where: { $0.isError })
+        errorManager.isConversationErrorDisplayedInline = false
+        // Remove only the most recent inline error card (not all historical ones).
+        if let lastErrorIndex = messages.lastIndex(where: { $0.isError }) {
+            messages.remove(at: lastErrorIndex)
+        }
     }
 
     /// Copy conversation error details to the clipboard for debugging.


### PR DESCRIPTION
Address review feedback from PR #18337:

- Stop clearing conversationError/errorText immediately after inline error append
- Add isConversationErrorDisplayedInline flag to ChatErrorManager to suppress toast overlay duplicate without losing error state
- Preserve error state for credits-exhausted recovery UI, sidebar state, and iOS banner
- Fix dismissConversationError to only remove the most recent error, not all historical ones
- Reset inline flag at all error-clearing call sites for consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
