### PR TITLE
Add workspace migration 007 to rename anthropic-native web search provider

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -18,6 +18,7 @@ export const VALID_WEB_SEARCH_PROVIDERS = [
   "perplexity",
   "brave",
   "anthropic-native",
+  "inference-provider-native",
 ] as const;
 
 export const InferenceServiceSchema = z.object({
@@ -38,7 +39,9 @@ export type ImageGenerationService = z.infer<
 
 export const WebSearchServiceSchema = z.object({
   mode: ServiceModeSchema.default("your-own"),
-  provider: z.enum(VALID_WEB_SEARCH_PROVIDERS).default("anthropic-native"),
+  provider: z
+    .enum(VALID_WEB_SEARCH_PROVIDERS)
+    .default("inference-provider-native"),
 });
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -281,6 +281,7 @@ export async function initializeProviders(
     (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
   const inferenceMode = config.services.inference.mode;
   const useNativeWebSearch =
+    config.services["web-search"].provider === "inference-provider-native" ||
     config.services["web-search"].provider === "anthropic-native";
 
   // Anthropic

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -44,9 +44,13 @@ interface PerplexityResponse {
 function getWebSearchProvider(): WebSearchProvider {
   const config = getConfig();
   const configured = config.services["web-search"].provider ?? "perplexity";
-  // 'anthropic-native' is handled by the Anthropic client directly;
-  // fall back to perplexity for other providers.
-  if (configured === "anthropic-native") return "perplexity";
+  // 'inference-provider-native' (and legacy 'anthropic-native') is handled by
+  // the inference provider client directly; fall back to perplexity for other providers.
+  if (
+    configured === "inference-provider-native" ||
+    configured === "anthropic-native"
+  )
+    return "perplexity";
   return configured as WebSearchProvider;
 }
 

--- a/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
+++ b/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const webSearchProviderRenameMigration: WorkspaceMigration = {
+  id: "007-web-search-provider-rename",
+  description:
+    'Rename web-search provider from "anthropic-native" to "inference-provider-native"',
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = config.services;
+    if (!services || typeof services !== "object" || Array.isArray(services))
+      return;
+
+    const webSearch = (services as Record<string, unknown>)["web-search"];
+    if (!webSearch || typeof webSearch !== "object" || Array.isArray(webSearch))
+      return;
+
+    const ws = webSearch as Record<string, unknown>;
+    if (ws.provider !== "anthropic-native") return;
+
+    ws.provider = "inference-provider-native";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -4,6 +4,7 @@ import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
 import { servicesConfigMigration } from "./006-services-config.js";
+import { webSearchProviderRenameMigration } from "./007-web-search-provider-rename.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -17,4 +18,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   extractCollectUsageDataMigration,
   addSendDiagnosticsMigration,
   servicesConfigMigration,
+  webSearchProviderRenameMigration,
 ];


### PR DESCRIPTION
## Summary
- Add `"inference-provider-native"` to the web search providers enum alongside `"anthropic-native"` (both valid during transition)
- Update runtime code (registry + web-search tool) to recognize both values
- Add workspace migration 007 to rename persisted `"anthropic-native"` configs to `"inference-provider-native"`

Part of plan: web-search-managed-mode.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
