### PR TITLE
fix: update stale cache comments in ChatBubble after dead code removal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -479,8 +479,8 @@ struct ChatBubble: View {
     //
     // Prevents a single huge message from consuming disproportionate cache
     // space.  Text over `maxCacheableTextLength` is parsed but never stored.
-    // `estimatedCacheBytes` tracks a rough byte budget across all three
-    // caches; when it exceeds `maxCacheBytes` the oldest entries are evicted.
+    // `estimatedCacheBytes` tracks a rough byte budget across the segment
+    // cache; when it exceeds `maxCacheBytes` the oldest entries are evicted.
 
     static let maxCacheableTextLength = 10_000
     static let maxCacheBytes = 5_000_000
@@ -488,9 +488,9 @@ struct ChatBubble: View {
     @MainActor static var estimatedCacheBytes: Int = 0
 
     /// Estimate the in-memory cost of caching the given text's parsed result.
-    /// Uses `utf8.count * 10` as a conservative estimate: AttributedString carries
-    /// significant overhead beyond raw bytes (attribute containers, font metrics,
-    /// paragraph style objects), so 3x was too low and allowed the budget to be exceeded.
+    /// Uses `utf8.count * 10` as a conservative multiplier: parsed MarkdownSegment
+    /// arrays carry overhead beyond raw bytes (segment structs, string copies,
+    /// enum metadata), so 3x was too low and allowed the budget to be exceeded.
     static func estimatedBytes(for text: String) -> Int {
         text.utf8.count * 10
     }


### PR DESCRIPTION
Address review feedback from PR #18342:

- Update comment that referenced 'all three caches' to reflect current cache count
- Update estimatedBytes(for:) docstring to remove stale AttributedString overhead reference
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
