### PR TITLE
fix: add avatar CLI to secure-keys allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -250,6 +250,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
+      "cli/commands/avatar.ts", // CLI avatar generation API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `cli/commands/avatar.ts` to the `ALLOWED_IMPORTERS` set in `credential-security-invariants.test.ts`
- The avatar CLI command imports `getSecureKeyAsync` for API key lookup during avatar generation, but was missing from the allowlist

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23204685251/job/67436607711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
