### PR TITLE
fix: Add funds button navigates to billing tab instead of general

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -137,14 +137,23 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
-            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
+            let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
+            isBillingEnabled = billingEnabled
             store.refreshAPIKeyState()
             store.loadProviderRoutingSources()
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
             if let pending = store.pendingSettingsTab {
-                if allVisibleTabs.contains(pending) {
+                // Compute visibility inline using the fresh local value — @State
+                // mutations within .onAppear may not propagate to computed
+                // properties (billingVisible → allVisibleTabs) until the next
+                // render cycle, which caused "Add funds" to land on the General
+                // tab instead of Billing.
+                let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
+                let visibleTabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: canShowBilling)
+                    + (isDeveloperEnabled ? [.developer] : [])
+                if visibleTabs.contains(pending) {
                     selectedTab = pending
                 }
                 store.pendingSettingsTab = nil


### PR DESCRIPTION
## Summary
- Fixed "Add funds" button in the drawer menu navigating to the General settings tab instead of Billing
- Root cause: `@State` mutation of `isBillingEnabled` in `.onAppear` wasn't propagating to the `billingVisible` computed property (used by `allVisibleTabs`) within the same closure, so the billing tab wasn't found in the visible tabs list
- Fix computes tab visibility inline using the fresh local value from `MacOSClientFeatureFlagManager`

## Original prompt
Fix this issue in the desktop app - it should go to the billing settings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
