### PR TITLE
Add webSearchMode state and persistence to SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -197,6 +197,9 @@ public final class SettingsStore: ObservableObject {
     /// `services.web-search.provider`.
     @Published var webSearchProvider: String = "anthropic-native"
 
+    /// Current web search mode. Values: "managed" or "your-own".
+    @Published var webSearchMode: String = "your-own"
+
     static let availableWebSearchProviders = ["anthropic-native", "perplexity", "brave"]
 
     static let webSearchProviderDisplayNames: [String: String] = [
@@ -1961,6 +1964,10 @@ public final class SettingsStore: ObservableObject {
            let mode = imageGen["mode"] as? String {
             self.imageGenMode = mode
         }
+        if let webSearch = services["web-search"] as? [String: Any],
+           let mode = webSearch["mode"] as? String {
+            self.webSearchMode = mode
+        }
     }
 
     func setInferenceMode(_ mode: String) {
@@ -1991,6 +1998,22 @@ public final class SettingsStore: ObservableObject {
             try WorkspaceConfigIO.merge(["services": services], into: configPath)
         } catch {
             log.error("Failed to merge workspace config for image-generation mode: \(error)")
+        }
+        scheduleRoutingSourceRefresh()
+    }
+
+    func setWebSearchMode(_ mode: String) {
+        webSearchMode = mode
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var webSearch = services["web-search"] as? [String: Any] ?? [:]
+        webSearch["mode"] = mode
+        services["web-search"] = webSearch
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for web search mode: \(error)")
         }
         scheduleRoutingSourceRefresh()
     }


### PR DESCRIPTION
## Summary
- Add `webSearchMode` published property to SettingsStore (defaults to "your-own")
- Load web search mode from workspace config in `loadServiceModes()`
- Add `setWebSearchMode()` setter that persists to workspace config

Part of plan: web-search-managed-mode.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
