### PR TITLE
fix: update config-schema test for web-search provider rename

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -96,7 +96,7 @@ describe("AssistantConfigSchema", () => {
       "gemini-3.1-flash-image-preview",
     );
     expect(result.services["image-generation"].mode).toBe("your-own");
-    expect(result.services["web-search"].provider).toBe("anthropic-native");
+    expect(result.services["web-search"].provider).toBe("inference-provider-native");
     expect(result.services["web-search"].mode).toBe("your-own");
     expect(result.maxTokens).toBe(16000);
     expect(result.thinking).toEqual({


### PR DESCRIPTION
## Summary
- Update the `parses empty object with full defaults` test to expect `inference-provider-native` instead of the old `anthropic-native` default for web-search provider
- The schema default was renamed in #18358 but the test expectation wasn't updated

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23204900064/job/67437397107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
