### PR TITLE
Complete rename of anthropic-native to inference-provider-native across codebase

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -56,7 +56,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -40,7 +40,7 @@ let currentConfig: Record<string, unknown> = {
       provider: "gemini",
       model: "gemini-3.1-flash-image-preview",
     },
-    "web-search": { mode: "your-own", provider: "anthropic-native" },
+    "web-search": { mode: "your-own", provider: "inference-provider-native" },
   },
 };
 
@@ -142,7 +142,7 @@ beforeEach(() => {
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   };
 });
@@ -214,7 +214,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -251,7 +254,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -292,7 +298,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -323,7 +332,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -353,7 +365,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -384,7 +399,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 
@@ -409,7 +427,10 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     };
 

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -39,7 +39,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -40,7 +40,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadConfig: () => ({}),

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -78,7 +78,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadConfig: () => ({}),

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -96,7 +96,9 @@ describe("AssistantConfigSchema", () => {
       "gemini-3.1-flash-image-preview",
     );
     expect(result.services["image-generation"].mode).toBe("your-own");
-    expect(result.services["web-search"].provider).toBe("anthropic-native");
+    expect(result.services["web-search"].provider).toBe(
+      "inference-provider-native",
+    );
     expect(result.services["web-search"].mode).toBe("your-own");
     expect(result.maxTokens).toBe(16000);
     expect(result.thinking).toEqual({

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -66,7 +66,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/conversation-pre-run-repair.test.ts
@@ -64,7 +64,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -57,7 +57,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -91,7 +91,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -43,7 +43,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -71,7 +71,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -71,7 +71,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -75,7 +75,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -73,7 +73,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -67,7 +67,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadConfig: () => ({}),

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -144,7 +144,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -66,7 +66,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadConfig: () => ({}),
@@ -252,7 +252,9 @@ describe("Activation hints in skills catalog", () => {
 
   test("orchestration skill includes hints and avoid-when in catalog line", () => {
     const prompt = buildSystemPrompt();
-    const line = prompt.split("\n").find((l) => l.includes("**orchestration**"));
+    const line = prompt
+      .split("\n")
+      .find((l) => l.includes("**orchestration**"));
     expect(line).toBeDefined();
     expect(line).toContain("parallel");
     expect(line).toContain("Single-focus");

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -34,7 +34,7 @@ const mockConfig = {
       provider: "gemini",
       model: "gemini-3.1-flash-image-preview",
     },
-    "web-search": { mode: "your-own", provider: "anthropic-native" },
+    "web-search": { mode: "your-own", provider: "inference-provider-native" },
   },
 };
 

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -34,7 +34,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -54,7 +54,7 @@ function makeProvidersConfig(provider: string, model: string): ProvidersConfig {
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   };
 }

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -71,7 +71,7 @@ function makeProvidersConfig(provider: string, model: string): ProvidersConfig {
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   };
 }

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -27,7 +27,10 @@ describe("provider registry (ollama)", () => {
           provider: "gemini",
           model: "gemini-3.1-flash-image-preview",
         },
-        "web-search": { mode: "your-own", provider: "anthropic-native" },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
       },
     });
 

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -26,7 +26,10 @@ const mockConfig = {
       provider: "gemini",
       model: "gemini-3.1-flash-image-preview",
     },
-    "web-search": { mode: "your-own" as const, provider: "anthropic-native" },
+    "web-search": {
+      mode: "your-own" as const,
+      provider: "inference-provider-native",
+    },
   },
 };
 

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -66,7 +66,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-conversation-integration.test.ts
+++ b/assistant/src/__tests__/swarm-conversation-integration.test.ts
@@ -46,7 +46,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -58,7 +58,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
 }));

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -38,7 +38,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   getSwarmDisabledConfig: () => ({

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -76,7 +76,7 @@ mock.module("../config/loader.js", () => ({
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },
-      "web-search": { mode: "your-own", provider: "anthropic-native" },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
     },
   }),
   loadConfig: () => ({}),

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -17,7 +17,6 @@ export const VALID_IMAGE_GEN_PROVIDERS = ["gemini", "openai"] as const;
 export const VALID_WEB_SEARCH_PROVIDERS = [
   "perplexity",
   "brave",
-  "anthropic-native",
   "inference-provider-native",
 ] as const;
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -281,8 +281,7 @@ export async function initializeProviders(
     (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
   const inferenceMode = config.services.inference.mode;
   const useNativeWebSearch =
-    config.services["web-search"].provider === "inference-provider-native" ||
-    config.services["web-search"].provider === "anthropic-native";
+    config.services["web-search"].provider === "inference-provider-native";
 
   // Anthropic
   const anthropicCreds = await resolveProviderCredentials(

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -383,8 +383,8 @@ describe("web_search tool", () => {
     expect(capturedUrl).toContain("perplexity");
   });
 
-  test("maps anthropic-native to perplexity", async () => {
-    mockWebSearchProvider = "anthropic-native";
+  test("maps inference-provider-native to perplexity", async () => {
+    mockWebSearchProvider = "inference-provider-native";
     mockPerplexitySecureKey = "pplx-key";
     let capturedUrl = "";
     globalThis.fetch = (async (url: string) => {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -44,13 +44,9 @@ interface PerplexityResponse {
 function getWebSearchProvider(): WebSearchProvider {
   const config = getConfig();
   const configured = config.services["web-search"].provider ?? "perplexity";
-  // 'inference-provider-native' (and legacy 'anthropic-native') is handled by
-  // the inference provider client directly; fall back to perplexity for other providers.
-  if (
-    configured === "inference-provider-native" ||
-    configured === "anthropic-native"
-  )
-    return "perplexity";
+  // 'inference-provider-native' is handled by the inference provider client
+  // directly; fall back to perplexity for other providers.
+  if (configured === "inference-provider-native") return "perplexity";
   return configured as WebSearchProvider;
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -195,15 +195,15 @@ public final class SettingsStore: ObservableObject {
 
     /// The selected web search provider, persisted in workspace config under
     /// `services.web-search.provider`.
-    @Published var webSearchProvider: String = "anthropic-native"
+    @Published var webSearchProvider: String = "inference-provider-native"
 
     /// Current web search mode. Values: "managed" or "your-own".
     @Published var webSearchMode: String = "your-own"
 
-    static let availableWebSearchProviders = ["anthropic-native", "perplexity", "brave"]
+    static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
 
     static let webSearchProviderDisplayNames: [String: String] = [
-        "anthropic-native": "Anthropic",
+        "inference-provider-native": "Provider Native",
         "perplexity": "Perplexity",
         "brave": "Brave",
     ]


### PR DESCRIPTION
## Summary
- Remove `"anthropic-native"` from the web search providers enum (only `"inference-provider-native"`, `"perplexity"`, `"brave"` remain)
- Simplify runtime checks in registry and web-search tool to only check the new value
- Update macOS client defaults and display name from "Anthropic" to "Provider Native"
- Update all ~30 test fixtures from `"anthropic-native"` to `"inference-provider-native"`

Part of plan: web-search-managed-mode.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
