### PR TITLE
fix: silence unused 'daemonClient' warning in SettingsDeveloperTab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -751,7 +751,7 @@ struct SettingsDeveloperTab: View {
     // MARK: - Assistant Feature Flags
 
     private func loadAssistantFlags() async {
-        guard let daemonClient else { return }
+        guard daemonClient != nil else { return }
         isLoadingAssistantFlags = true
         assistantFlagsError = nil
         do {


### PR DESCRIPTION
## Summary
- Replace `guard let daemonClient` with `guard daemonClient != nil` in `loadAssistantFlags()` to silence the Swift compiler warning about an unused binding

## Original prompt
Fix Swift build warning: `value 'daemonClient' was defined but never used; consider replacing with boolean test` at SettingsDeveloperTab.swift:754

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
