### PR TITLE
fix: remove redundant host_bash guidance from command parameter description

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -65,8 +65,7 @@ class HostShellTool implements Tool {
         properties: {
           command: {
             type: "string",
-            description:
-              "The host shell command to execute. IMPORTANT: Only use host_bash when the command absolutely must run on the host machine. Strongly prefer the regular `bash` tool for all other commands.",
+            description: "The host shell command to execute.",
           },
           activity: {
             type: "string",


### PR DESCRIPTION
Address review feedback from PR #18347:

- Remove duplicated 'prefer bash' guidance from the command parameter description since it's already in the tool-level description
- Reduces prompt token waste (~25 tokens per request)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
