### PR TITLE
test: add coverage for nested $ref with refBehavior in schemaDefinesProperty

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -219,6 +219,57 @@ describe("schemaDefinesProperty", () => {
     ).toBe(true);
   });
 
+  test("returns true for $ref nested in allOf with assume-defined refBehavior", () => {
+    const schema = {
+      allOf: [{ $ref: "#/definitions/Foo" }],
+    };
+    expect(
+      schemaDefinesProperty(schema, "activity", {
+        refBehavior: "assume-defined",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for $ref nested in allOf with assume-undefined refBehavior", () => {
+    const schema = {
+      allOf: [{ $ref: "#/definitions/Foo" }],
+    };
+    expect(
+      schemaDefinesProperty(schema, "activity", {
+        refBehavior: "assume-undefined",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true for $ref nested in oneOf with assume-defined refBehavior", () => {
+    const schema = {
+      oneOf: [{ $ref: "#/definitions/Foo" }],
+    };
+    expect(
+      schemaDefinesProperty(schema, "activity", {
+        refBehavior: "assume-defined",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for $ref nested in anyOf with assume-defined refBehavior", () => {
+    const schema = {
+      anyOf: [{ $ref: "#/definitions/Foo" }],
+    };
+    expect(
+      schemaDefinesProperty(schema, "activity", {
+        refBehavior: "assume-defined",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for $ref nested in allOf with default refBehavior (fail-closed)", () => {
+    const schema = {
+      allOf: [{ $ref: "#/definitions/Foo" }],
+    };
+    expect(schemaDefinesProperty(schema, "activity")).toBe(false);
+  });
+
   test("returns false for null schema", () => {
     expect(schemaDefinesProperty(null, "activity")).toBe(false);
   });


### PR DESCRIPTION
Address review feedback from PR #18350:

- Add test cases for $ref nested inside allOf/oneOf/anyOf with explicit refBehavior options
- Validates that refBehavior is correctly forwarded through recursive schemaDefinesProperty calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
