### PR TITLE
fix: use per-tool-call key for permission telemetry and guard undefined requestId

### DIFF
--- a/assistant/src/events/tool-permission-telemetry-listener.ts
+++ b/assistant/src/events/tool-permission-telemetry-listener.ts
@@ -8,25 +8,28 @@ const log = getLogger("tool-permission-telemetry");
 export function registerToolPermissionTelemetryListener(
   eventBus: EventBus<AssistantDomainEvents>,
 ): Subscription {
-  // Track which request IDs were actually prompted so we only record
+  // Track which tool calls were actually prompted so we only record
   // decided telemetry for real user interactions, not auto-allowed tools.
-  const promptedRequestIds = new Set<string>();
+  // Uses a composite key (requestId:toolName) because requestId is per-message,
+  // not per-tool-call — parallel tool_use blocks share the same requestId.
+  const promptedToolCalls = new Set<string>();
 
   return eventBus.onAny((event) => {
     try {
       switch (event.type) {
-        case "tool.permission.requested":
-          if (event.payload.requestId) {
-            promptedRequestIds.add(event.payload.requestId);
+        case "tool.permission.requested": {
+          const { requestId, toolName } = event.payload;
+          if (requestId) {
+            promptedToolCalls.add(`${requestId}:${toolName}`);
+            recordLifecycleEvent(`permission_prompt:${toolName}`);
           }
-          recordLifecycleEvent(
-            `permission_prompt:${event.payload.toolName}`,
-          );
           return;
+        }
         case "tool.permission.decided": {
           const { requestId, toolName, decision } = event.payload;
-          if (requestId && promptedRequestIds.has(requestId)) {
-            promptedRequestIds.delete(requestId);
+          const key = requestId ? `${requestId}:${toolName}` : undefined;
+          if (key && promptedToolCalls.has(key)) {
+            promptedToolCalls.delete(key);
             recordLifecycleEvent(
               `permission_decided:${toolName}:${decision}`,
             );


### PR DESCRIPTION
Address review feedback from PR #18356:

- Track prompted permissions using a composite key (requestId + toolName) instead of requestId alone to handle parallel tool execution correctly
- Guard prompt telemetry recording to require a defined requestId, preventing orphaned prompt records
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
