### PR TITLE
fix: reset isConversationErrorDisplayedInline in retryLastMessage to prevent stale suppression

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2299,6 +2299,7 @@ public final class ChatViewModel: ObservableObject {
         lastFailedSendError = nil
         errorText = nil
         connectionDiagnosticHint = nil
+        errorManager.isConversationErrorDisplayedInline = false
 
         if conversationId == nil {
             pendingUserMessageDisplayText = displayText


### PR DESCRIPTION
Address review feedback from PR #18357:

- Reset isConversationErrorDisplayedInline flag in retryLastMessage() to prevent stale suppression of future toast errors after auto-retry-on-reconnect
- Ensures error UI is always visible when a new error occurs after retry
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
