### PR TITLE
Add Managed/Your Own toggle to WebSearchServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -358,8 +358,10 @@ struct SettingsPanel: View {
             // WEB SEARCH
             WebSearchServiceCard(
                 store: store,
+                authManager: authManager,
                 perplexityKeyText: $perplexityKeyText,
-                braveKeyText: $braveKeyText
+                braveKeyText: $braveKeyText,
+                showToast: showToast
             )
 
             // IMAGE GENERATION

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -1,16 +1,24 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Card for configuring the web search provider (Anthropic, Perplexity, Brave).
+/// Card for the web search service with Managed/Your Own mode toggle.
 ///
-/// Shows a provider dropdown and conditionally displays an API key field
-/// when Perplexity or Brave is selected. Matches InferenceServiceCard styling.
+/// Shows different content based on mode, inference mode, and auth state:
+/// - **Managed + Managed inference + logged in**: Message that web search is included.
+/// - **Managed + Managed inference + not logged in**: Login prompt.
+/// - **Managed + Your Own inference**: Message that managed web search is not yet available.
+/// - **Your Own + Your Own inference**: Provider picker (Provider Native, Perplexity, Brave) + API key.
+/// - **Your Own + Managed inference**: Provider picker (Perplexity, Brave only) + API key.
 @MainActor
 struct WebSearchServiceCard: View {
     @ObservedObject var store: SettingsStore
+    var authManager: AuthManager
     @Binding var perplexityKeyText: String
     @Binding var braveKeyText: String
+    var showToast: ((String, ToastInfo.Style) -> Void)?
 
+    /// Local draft of the mode selection — only persisted on Save.
+    @State private var draftMode: String = "your-own"
     /// Snapshot of the provider at card appear — used to detect provider changes.
     @State private var initialProvider: String = ""
 
@@ -26,8 +34,35 @@ struct WebSearchServiceCard: View {
         isPerplexity || isBrave
     }
 
+    private var isLoggedIn: Bool {
+        authManager.isAuthenticated
+    }
+
+    /// The available providers depend on the current inference mode.
+    /// Provider Native requires Your Own inference (it uses the user's own API key).
+    private var availableProviders: [String] {
+        store.inferenceMode == "your-own"
+            ? ["inference-provider-native", "perplexity", "brave"]
+            : ["perplexity", "brave"]
+    }
+
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
+        if draftMode == "managed" {
+            // Managed + Your Own inference: managed web search is not yet available.
+            if store.inferenceMode == "your-own" {
+                return false
+            }
+            // Managed + Managed inference but not logged in: nothing actionable.
+            if !isLoggedIn {
+                return false
+            }
+            // Managed + Managed inference + logged in: only mode change matters.
+            return draftMode != store.webSearchMode
+        }
+
+        // Your Own mode: detect mode, provider, and API key changes.
+        let modeChanged = draftMode != store.webSearchMode
         let providerChanged = store.webSearchProvider != initialProvider
         let hasNewKey: Bool = {
             if isPerplexity {
@@ -37,43 +72,113 @@ struct WebSearchServiceCard: View {
             }
             return false
         }()
-        return providerChanged || hasNewKey
+        return modeChanged || providerChanged || hasNewKey
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            header
+        ServiceModeCard(
+            title: "Web Search",
+            subtitle: "Configure which web search provider to use for online research",
+            draftMode: $draftMode,
+            hasChanges: hasChanges,
+            isSaving: false,
+            onSave: { save() },
+            onReset: {
+                if isPerplexity {
+                    store.clearPerplexityKey()
+                    perplexityKeyText = ""
+                } else if isBrave {
+                    store.clearBraveKey()
+                    braveKeyText = ""
+                }
+            },
+            showReset: draftMode == "your-own" && needsAPIKey
+                && (isPerplexity ? store.hasPerplexityKey : store.hasBraveKey),
+            managedContent: {
+                if store.inferenceMode == "your-own" {
+                    managedUnavailableMessage
+                } else if isLoggedIn {
+                    managedIncludedMessage
+                } else {
+                    managedLoginPrompt
+                }
+            },
+            yourOwnContent: {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    providerPicker
 
-            Divider()
-                .background(VColor.borderBase)
-
-            providerPicker
-
-            if needsAPIKey {
-                apiKeySection
+                    if needsAPIKey {
+                        apiKeySection
+                    }
+                }
             }
-
-            actionButtons
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
+        )
         .onAppear {
+            draftMode = store.webSearchMode
             initialProvider = store.webSearchProvider
+        }
+        .onChange(of: store.webSearchMode) { _, newValue in
+            draftMode = newValue
+        }
+        .onChange(of: store.inferenceMode) { _, newValue in
+            // Auto-correct invalid states when inference mode changes.
+            if newValue == "your-own" && draftMode == "managed" {
+                // Managed web search is not yet available without managed inference.
+                draftMode = "your-own"
+            }
+            if newValue == "managed" && store.webSearchProvider == "inference-provider-native" {
+                // Provider Native requires Your Own inference.
+                store.setWebSearchProvider("perplexity")
+            }
         }
     }
 
-    // MARK: - Header
+    // MARK: - Managed Content
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text("Web Search")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.contentDefault)
-            Text("Configure which web search provider to use for online research")
-                .font(VFont.sectionDescription)
+    private var managedIncludedMessage: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("Web search is included with managed inference.")
+                .font(VFont.body)
                 .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    private var managedUnavailableMessage: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("Managed web search is not yet available when using your own inference provider.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    private var managedLoginPrompt: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("In order to use the managed web search service, you must be logged in to Vellum.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
+            VButton(
+                label: authManager.isSubmitting ? "Logging in..." : "Log In",
+                style: .primary,
+                isDisabled: authManager.isSubmitting
+            ) {
+                Task {
+                    if let showToast {
+                        await authManager.loginWithToast(showToast: showToast)
+                    } else {
+                        await authManager.startWorkOSLogin()
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
     }
 
     // MARK: - Provider Picker
@@ -89,7 +194,7 @@ struct WebSearchServiceCard: View {
                     get: { store.webSearchProvider },
                     set: { store.setWebSearchProvider($0) }
                 ),
-                options: SettingsStore.availableWebSearchProviders.map { provider in
+                options: availableProviders.map { provider in
                     (label: SettingsStore.webSearchProviderDisplayNames[provider] ?? provider, value: provider)
                 }
             )
@@ -123,39 +228,26 @@ struct WebSearchServiceCard: View {
         return "Enter your \(providerName) API key"
     }
 
-    // MARK: - Action Buttons
-
-    private var actionButtons: some View {
-        HStack(spacing: VSpacing.sm) {
-            VButton(label: "Save", style: .primary, isDisabled: !hasChanges) {
-                save()
-            }
-            if needsAPIKey && (isPerplexity ? store.hasPerplexityKey : store.hasBraveKey) {
-                VButton(label: "Reset", style: .danger) {
-                    if isPerplexity {
-                        store.clearPerplexityKey()
-                    } else {
-                        store.clearBraveKey()
-                    }
-                }
-            }
-        }
-    }
-
     // MARK: - Save
 
     private func save() {
-        // Always persist provider selection
-        store.setWebSearchProvider(store.webSearchProvider)
-
-        // Persist API key if entered for the current provider
-        if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            store.savePerplexityKey(perplexityKeyText)
-            perplexityKeyText = ""
+        // Persist mode if changed
+        if draftMode != store.webSearchMode {
+            store.setWebSearchMode(draftMode)
         }
-        if isBrave && !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            store.saveBraveKey(braveKeyText)
-            braveKeyText = ""
+
+        // In your-own mode, persist provider and API keys.
+        if draftMode == "your-own" {
+            store.setWebSearchProvider(store.webSearchProvider)
+
+            if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                store.savePerplexityKey(perplexityKeyText)
+                perplexityKeyText = ""
+            }
+            if isBrave && !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                store.saveBraveKey(braveKeyText)
+                braveKeyText = ""
+            }
         }
 
         // Update initial provider to reflect persisted state


### PR DESCRIPTION
## Summary
- Rewrite WebSearchServiceCard to use ServiceModeCard with Managed/Your Own segmented toggle
- Managed content adapts to inference mode: shows "included" message (managed inference), login prompt (not logged in), or "not yet available" (your-own inference)
- Your Own content dynamically filters provider list based on inference mode (Provider Native only when inference is Your Own)
- Auto-corrects invalid states when inference mode changes

Part of plan: web-search-managed-mode.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
