### PR TITLE
fix: backup skills before clearing and derive skills root safely in vbundle import

### DIFF
--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -755,6 +755,177 @@ describe("commitImport", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Skills/hooks directory clearing tests
+// ---------------------------------------------------------------------------
+
+describe("commitImport — directory clearing", () => {
+  let skillsDir: string;
+  let hooksDir: string;
+
+  beforeEach(() => {
+    skillsDir = join(testDir, "skills");
+    hooksDir = join(testDir, "hooks");
+  });
+
+  afterEach(() => {
+    // Clean up skills/hooks dirs and any backup dirs
+    for (const entry of readdirSync(testDir)) {
+      if (
+        entry.startsWith("skills") ||
+        entry.startsWith("hooks")
+      ) {
+        rmSync(join(testDir, entry), { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("clears stale skills not present in the bundle", () => {
+    mkdirSync(join(skillsDir, "stale-skill"), { recursive: true });
+    writeFileSync(join(skillsDir, "stale-skill", "SKILL.md"), "stale");
+
+    const skillData = new TextEncoder().encode("# New Skill");
+    const vbundle = createValidVBundle([
+      { path: "data/db/assistant.db", data: new Uint8Array([0x01]) },
+      { path: "skills/new-skill/SKILL.md", data: skillData },
+    ]);
+
+    const resolver = new DefaultPathResolver(
+      testDbPath,
+      testConfigPath,
+      undefined,
+      skillsDir,
+    );
+    const result = commitImport({ archiveData: vbundle, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // New skill written
+    expect(existsSync(join(skillsDir, "new-skill", "SKILL.md"))).toBe(true);
+    expect(readFileSync(join(skillsDir, "new-skill", "SKILL.md"), "utf8")).toBe(
+      "# New Skill",
+    );
+
+    // Stale skill removed from active directory
+    expect(existsSync(join(skillsDir, "stale-skill"))).toBe(false);
+  });
+
+  test("preserves backup of existing skills directory", () => {
+    mkdirSync(join(skillsDir, "old-skill"), { recursive: true });
+    writeFileSync(join(skillsDir, "old-skill", "SKILL.md"), "old content");
+
+    const skillData = new TextEncoder().encode("# New Skill");
+    const vbundle = createValidVBundle([
+      { path: "data/db/assistant.db", data: new Uint8Array([0x01]) },
+      { path: "skills/new-skill/SKILL.md", data: skillData },
+    ]);
+
+    const resolver = new DefaultPathResolver(
+      testDbPath,
+      testConfigPath,
+      undefined,
+      skillsDir,
+    );
+    const result = commitImport({ archiveData: vbundle, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+
+    // A backup directory should exist alongside the skills dir
+    const backupDirs = readdirSync(testDir).filter((f) =>
+      f.startsWith("skills.pre-import-backup-"),
+    );
+    expect(backupDirs.length).toBe(1);
+
+    // Backup contains the old skill
+    expect(
+      existsSync(join(testDir, backupDirs[0], "old-skill", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      readFileSync(join(testDir, backupDirs[0], "old-skill", "SKILL.md"), "utf8"),
+    ).toBe("old content");
+  });
+
+  test("skips clearing when resolver has no skills root", () => {
+    // Resolver without skillsDir — resolveRoot returns null
+    const resolver = new DefaultPathResolver(testDbPath, testConfigPath);
+
+    const skillData = new TextEncoder().encode("# Skill");
+    const vbundle = createValidVBundle([
+      { path: "data/db/assistant.db", data: new Uint8Array([0x01]) },
+      { path: "skills/my-skill/SKILL.md", data: skillData },
+    ]);
+
+    const result = commitImport({ archiveData: vbundle, pathResolver: resolver });
+
+    // Skills entry is skipped (no disk target), but import succeeds
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const skillsFile = result.report.files.find(
+      (f) => f.path === "skills/my-skill/SKILL.md",
+    );
+    expect(skillsFile?.action).toBe("skipped");
+  });
+
+  test("clears stale hooks not present in the bundle", () => {
+    mkdirSync(join(hooksDir, "stale-hook"), { recursive: true });
+    writeFileSync(join(hooksDir, "stale-hook", "hook.sh"), "stale");
+
+    const hookData = new TextEncoder().encode("#!/bin/sh\necho new");
+    const vbundle = createValidVBundle([
+      { path: "data/db/assistant.db", data: new Uint8Array([0x01]) },
+      { path: "hooks/new-hook/hook.sh", data: hookData },
+    ]);
+
+    const resolver = new DefaultPathResolver(
+      testDbPath,
+      testConfigPath,
+      undefined,
+      undefined,
+      undefined,
+      hooksDir,
+    );
+    const result = commitImport({ archiveData: vbundle, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(existsSync(join(hooksDir, "new-hook", "hook.sh"))).toBe(true);
+    expect(existsSync(join(hooksDir, "stale-hook"))).toBe(false);
+  });
+
+  test("does not clear directory when bundle has no entries for that prefix", () => {
+    mkdirSync(join(skillsDir, "existing-skill"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "existing-skill", "SKILL.md"),
+      "should survive",
+    );
+
+    // Bundle with only db data, no skills
+    const vbundle = createValidVBundle([
+      { path: "data/db/assistant.db", data: new Uint8Array([0x01]) },
+    ]);
+
+    const resolver = new DefaultPathResolver(
+      testDbPath,
+      testConfigPath,
+      undefined,
+      skillsDir,
+    );
+    const result = commitImport({ archiveData: vbundle, pathResolver: resolver });
+
+    expect(result.ok).toBe(true);
+
+    // Skills directory untouched
+    expect(existsSync(join(skillsDir, "existing-skill", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(
+      readFileSync(join(skillsDir, "existing-skill", "SKILL.md"), "utf8"),
+    ).toBe("should survive");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Auth policy registration tests
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -76,6 +76,8 @@ export interface ImportDryRunReport {
  */
 export interface PathResolver {
   resolve(archivePath: string): string | null;
+  /** Resolves the root directory for a given archive path prefix (e.g. "skills/", "hooks/"). */
+  resolveRoot?(prefix: string): string | null;
 }
 
 export class DefaultPathResolver implements PathResolver {
@@ -87,6 +89,19 @@ export class DefaultPathResolver implements PathResolver {
     private workspaceDir?: string,
     private hooksDir?: string,
   ) {}
+
+  resolveRoot(prefix: string): string | null {
+    switch (prefix) {
+      case "skills/":
+        return this.skillsDir ? resolve(this.skillsDir) : null;
+      case "hooks/":
+        return this.hooksDir ? resolve(this.hooksDir) : null;
+      case "prompts/":
+        return this.workspaceDir ? resolve(this.workspaceDir) : null;
+      default:
+        return null;
+    }
+  }
 
   resolve(archivePath: string): string | null {
     switch (archivePath) {

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -18,7 +18,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  rmSync,
+  renameSync,
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
@@ -155,84 +155,29 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     entryMap = validation.entries;
   }
 
-  // Step 1b: Clear skills directory if the bundle contains skills entries.
-  // This ensures the restored skills match the backup exactly — no stale
-  // skills left behind from the current assistant state.
-  const hasSkillsEntries = manifest.files.some((f) =>
-    f.path.startsWith("skills/"),
-  );
-  if (hasSkillsEntries) {
-    // Derive the skills directory from the resolver by resolving a known
-    // skills path prefix and stripping the relative portion.
-    const firstSkillsEntry = manifest.files.find((f) =>
-      f.path.startsWith("skills/"),
-    )!;
-    const resolvedSkillPath = pathResolver.resolve(firstSkillsEntry.path);
-    if (resolvedSkillPath) {
-      // The resolver maps "skills/<relative>" → "<skillsDir>/<relative>",
-      // so strip the relative suffix to get the skills root directory.
-      const relativeSuffix = firstSkillsEntry.path.slice("skills/".length);
-      const skillsRoot = resolvedSkillPath.slice(
-        0,
-        resolvedSkillPath.length - relativeSuffix.length,
-      );
-      // Remove trailing slash if present (unless it's the root "/")
-      const skillsDirPath =
-        skillsRoot.length > 1 && skillsRoot.endsWith("/")
-          ? skillsRoot.slice(0, -1)
-          : skillsRoot;
+  // Step 1b: Back up and clear directories that will be fully restored from
+  // the bundle. We rename (not delete) to preserve a recoverable backup in
+  // case a later write fails — this prevents irrecoverable data loss.
+  for (const prefix of ["skills/", "hooks/"] as const) {
+    const hasEntries = manifest.files.some((f) => f.path.startsWith(prefix));
+    if (!hasEntries) continue;
 
-      if (existsSync(skillsDirPath)) {
-        try {
-          rmSync(skillsDirPath, { recursive: true, force: true });
-        } catch (err) {
-          return {
-            ok: false,
-            reason: "write_failed",
-            message: `Failed to clear skills directory "${skillsDirPath}": ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          };
-        }
-      }
-    }
-  }
+    const dirRoot = pathResolver.resolveRoot?.(prefix);
+    if (!dirRoot || !existsSync(dirRoot)) continue;
 
-  // Step 1c: Clear hooks directory if the bundle contains hooks entries.
-  // This ensures the restored hooks match the backup exactly — no stale
-  // hooks left behind from the current assistant state.
-  const hasHooksEntries = manifest.files.some((f) =>
-    f.path.startsWith("hooks/"),
-  );
-  if (hasHooksEntries) {
-    const firstHooksEntry = manifest.files.find((f) =>
-      f.path.startsWith("hooks/"),
-    )!;
-    const resolvedHookPath = pathResolver.resolve(firstHooksEntry.path);
-    if (resolvedHookPath) {
-      const relativeSuffix = firstHooksEntry.path.slice("hooks/".length);
-      const hooksRoot = resolvedHookPath.slice(
-        0,
-        resolvedHookPath.length - relativeSuffix.length,
-      );
-      const hooksDirPath =
-        hooksRoot.length > 1 && hooksRoot.endsWith("/")
-          ? hooksRoot.slice(0, -1)
-          : hooksRoot;
-
-      if (existsSync(hooksDirPath)) {
-        try {
-          rmSync(hooksDirPath, { recursive: true, force: true });
-        } catch (err) {
-          return {
-            ok: false,
-            reason: "write_failed",
-            message: `Failed to clear hooks directory "${hooksDirPath}": ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          };
-        }
-      }
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const backupPath = `${dirRoot}.pre-import-backup-${timestamp}`;
+    try {
+      renameSync(dirRoot, backupPath);
+    } catch (err) {
+      const label = prefix.slice(0, -1); // "skills" or "hooks"
+      return {
+        ok: false,
+        reason: "write_failed",
+        message: `Failed to backup ${label} directory "${dirRoot}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
     }
   }
 


### PR DESCRIPTION
Address review feedback from PR #18343:\n\n- Back up existing skills/hooks directories via `renameSync` before clearing to prevent irrecoverable data loss on partial import failure\n- Add `resolveRoot()` method to `PathResolver` interface and `DefaultPathResolver` to safely derive directory roots without fragile string length math\n- Consolidate skills/hooks clearing into a single loop, eliminating code duplication\n- Add 5 test cases covering: stale skill removal, backup preservation, no-skillsDir fallback, hooks clearing, and no-op when bundle has no entries for a prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
