### PR TITLE
fix: Add Funds button lands on General tab instead of Billing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -161,7 +161,15 @@ struct SettingsPanel: View {
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                if allVisibleTabs.contains(tab) {
+                // Compute visibility inline — same as onAppear. @State
+                // mutations (e.g. isBillingEnabled set in onAppear) may not
+                // have propagated to computed properties yet, so querying
+                // the flag manager directly avoids a stale billingVisible.
+                let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
+                let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
+                let visibleTabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: canShowBilling)
+                    + (isDeveloperEnabled ? [.developer] : [])
+                if visibleTabs.contains(tab) {
                     selectedTab = tab
                 }
                 store.pendingSettingsTab = nil


### PR DESCRIPTION
## Summary
- The `onChange(of: store.pendingSettingsTab)` handler used `allVisibleTabs` which depends on `billingVisible` → `isBillingEnabled` @State. When `onChange` fires before `onAppear` sets `isBillingEnabled` (or before the mutation propagates to computed properties), the billing tab is excluded from the visible list and the pending tab is silently cleared.
- Applied the same inline visibility computation already used in `onAppear`: query `MacOSClientFeatureFlagManager` directly instead of relying on potentially stale @State.

## Original prompt
The "Add funds" button goes to the General tab not the Billing tab, maybe because the Billing tab is conditionally rendered. Please fix this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
