### PR TITLE
fix: match contacts list row selection to settings nav style

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -133,7 +133,7 @@ struct ContactsListView: View {
             HStack(spacing: VSpacing.xs) {
                 Text(name)
                     .font(VFont.bodyMedium)
-                    .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentDefault)
+                    .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                     .lineLimit(1)
 
                 Spacer()
@@ -145,7 +145,7 @@ struct ContactsListView: View {
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.md)
             .background(rowBackground(isSelected: isSelected, isHovered: isHovered))
-            .overlay(rowBorder(isSelected: isSelected, isHovered: isHovered))
+            .animation(VAnimation.fast, value: isHovered)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
@@ -205,18 +205,8 @@ struct ContactsListView: View {
         RoundedRectangle(cornerRadius: VRadius.md)
             .fill(
                 isSelected
-                    ? VColor.primaryBase.opacity(0.10)
-                    : (isHovered ? VColor.surfaceBase : Color.clear)
-            )
-    }
-
-    private func rowBorder(isSelected: Bool, isHovered: Bool) -> some View {
-        RoundedRectangle(cornerRadius: VRadius.md)
-            .strokeBorder(
-                isSelected
-                    ? VColor.borderActive
-                    : (isHovered ? VColor.borderBase.opacity(0.45) : Color.clear),
-                lineWidth: 1
+                    ? VColor.surfaceActive
+                    : VColor.surfaceBase.opacity(isHovered ? 1 : 0)
             )
     }
 }


### PR DESCRIPTION
## Summary
- Align contact list row selection styling with SettingsNavRow: surfaceActive background, no border stroke
- Change unselected text color from contentDefault to contentSecondary
- Add VAnimation.fast hover animation to match nav row behavior

Part of plan: contacts-ui-polish.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
