### PR TITLE
feat: add copyable error detail to credential bootstrap toast

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -396,7 +396,8 @@ extension AppDelegate {
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
                 self.mainWindow?.windowState.showToast(
                     message: "Failed to set up Vellum credentials. You may need to log out and log in again.",
-                    style: .error
+                    style: .error,
+                    copyableDetail: error.localizedDescription
                 )
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -263,8 +263,8 @@ public final class MainWindowState: ObservableObject {
     ///     by the user (via the X button), as opposed to a primary action.
     /// - Returns: The unique ID of the displayed toast, useful for targeted dismissal.
     @discardableResult
-    func showToast(message: String, style: ToastInfo.Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) -> UUID {
-        let toast = ToastInfo(message: message, style: style, primaryAction: primaryAction, onDismiss: onDismiss)
+    func showToast(message: String, style: ToastInfo.Style, copyableDetail: String? = nil, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) -> UUID {
+        let toast = ToastInfo(message: message, style: style, copyableDetail: copyableDetail, primaryAction: primaryAction, onDismiss: onDismiss)
         toastInfo = toast
         return toast.id
     }
@@ -304,14 +304,16 @@ struct ToastInfo {
     let id: UUID
     let message: String
     let style: Style
+    let copyableDetail: String?
     let primaryAction: VToastAction?
     /// Called when the toast is dismissed via the X button (not via primary action).
     let onDismiss: (() -> Void)?
 
-    init(message: String, style: Style, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) {
+    init(message: String, style: Style, copyableDetail: String? = nil, primaryAction: VToastAction? = nil, onDismiss: (() -> Void)? = nil) {
         self.id = UUID()
         self.message = message
         self.style = style
+        self.copyableDetail = copyableDetail
         self.primaryAction = primaryAction
         self.onDismiss = onDismiss
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -690,6 +690,7 @@ struct MainWindowView: View {
                 VToast(
                     message: toast.message,
                     style: toast.style == .success ? .success : toast.style == .warning ? .warning : .error,
+                    copyableDetail: toast.copyableDetail,
                     primaryAction: toast.primaryAction,
                     onDismiss: { windowState.dismissToast() }
                 )

--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -20,19 +20,24 @@ public struct VToast: View {
 
     public let message: String
     public var style: Style = .info
+    public var copyableDetail: String?
     public var primaryAction: VToastAction?
     public var secondaryAction: VToastAction?
     public var onDismiss: (() -> Void)?
 
+    @State private var showCopied = false
+
     public init(
         message: String,
         style: Style = .info,
+        copyableDetail: String? = nil,
         primaryAction: VToastAction? = nil,
         secondaryAction: VToastAction? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.message = message
         self.style = style
+        self.copyableDetail = copyableDetail
         self.primaryAction = primaryAction
         self.secondaryAction = secondaryAction
         self.onDismiss = onDismiss
@@ -49,8 +54,30 @@ public struct VToast: View {
 
             Spacer(minLength: 0)
 
-            if primaryAction != nil || secondaryAction != nil || onDismiss != nil {
+            if copyableDetail != nil || primaryAction != nil || secondaryAction != nil || onDismiss != nil {
                 HStack(spacing: VSpacing.sm) {
+                    if let detail = copyableDetail {
+                        Button {
+                            #if os(macOS)
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(detail, forType: .string)
+                            #elseif os(iOS)
+                            UIPasteboard.general.string = detail
+                            #endif
+                            showCopied = true
+                            Task {
+                                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                                showCopied = false
+                            }
+                        } label: {
+                            VIconView(showCopied ? .check : .copy, size: 12)
+                                .foregroundColor(showCopied ? VColor.systemPositiveStrong : VColor.contentSecondary)
+                                .frame(width: 24, height: 24)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Copy error details")
+                        .help("Copy error details")
+                    }
                     if let secondary = secondaryAction {
                         VButton(label: secondary.label, style: .outlined, action: secondary.action)
                     }


### PR DESCRIPTION
## Summary
- Add `copyableDetail` parameter to `VToast` that shows a copy icon button when set — clicking copies the detail string to clipboard with brief checkmark feedback
- Thread the new field through `ToastInfo` and `MainWindowState.showToast`
- Pass `error.localizedDescription` as the copyable detail on the credential bootstrap failure toast so users can see/copy the specific error

## Original prompt
make the error toast more specific (keep the user friendly error but allow copying the error by clicking an icon like we do in other places). Then check the logs afterwards to figure out what went wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
