### PR TITLE
fix: resolve lint errors in vbundle-pax-and-symlink test

### DIFF
--- a/assistant/src/__tests__/vbundle-pax-and-symlink.test.ts
+++ b/assistant/src/__tests__/vbundle-pax-and-symlink.test.ts
@@ -6,7 +6,6 @@
  * - Builder emits PAX headers for paths >100 bytes; validator parses them
  * - buildExportVBundle follows symlinks when checking skillsDir
  */
-import { createHash } from "node:crypto";
 import {
   mkdirSync,
   mkdtempSync,
@@ -65,7 +64,7 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
-import { buildVBundle, buildExportVBundle } from "../runtime/migrations/vbundle-builder.js";
+import { buildExportVBundle, buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
 
 afterAll(() => {
@@ -90,7 +89,7 @@ describe("PAX extended header round-trip", () => {
     const fileData = new TextEncoder().encode("# Long path skill content");
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
 
-    const { archive, manifest } = buildVBundle({
+    const { archive } = buildVBundle({
       files: [
         { path: "data/db/assistant.db", data: dbData },
         { path: longPath, data: fileData },


### PR DESCRIPTION
## Summary
- Remove unused `createHash` import from `node:crypto`
- Sort import specifiers alphabetically (`buildExportVBundle` before `buildVBundle`)
- Remove unused `manifest` destructuring from first `buildVBundle` call

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23205591571/job/67439946672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
