### PR TITLE
fix: resolve Swift concurrency warnings in AssistantCli

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -80,7 +80,7 @@ final class AssistantCli {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
-    private static let forwardedEnvKeys: [String] = [
+    private nonisolated(unsafe) static let forwardedEnvKeys: [String] = [
         "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
@@ -546,7 +546,7 @@ final class AssistantCli {
         proc.standardOutput = stdoutPipe
         proc.standardError = stderrPipe
 
-        var env = Self.makeBaseEnvironment()
+        let env = Self.makeBaseEnvironment()
         proc.environment = env
 
         let stdoutHandle = stdoutPipe.fileHandleForReading


### PR DESCRIPTION
## Summary
- Mark `forwardedEnvKeys` as `nonisolated(unsafe)` to fix main-actor isolation warning when accessed from `nonisolated` `makeBaseEnvironment()` — safe because it's an immutable `let` constant
- Change `var env` to `let env` in `pairDevice()` since it's never mutated

## Original prompt
Fix Swift build warnings in AssistantCli.swift: main actor-isolated static property referenced from nonisolated context, and unmutated variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
