### PR TITLE
fix: use clipboard icon for toast copyable detail button

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -70,7 +70,7 @@ public struct VToast: View {
                                 showCopied = false
                             }
                         } label: {
-                            VIconView(showCopied ? .check : .copy, size: 12)
+                            VIconView(showCopied ? .check : .clipboard, size: 12)
                                 .foregroundColor(showCopied ? VColor.systemPositiveStrong : VColor.contentSecondary)
                                 .frame(width: 24, height: 24)
                         }


### PR DESCRIPTION
## Summary
- Switch VToast copyableDetail button from `.copy` (doc-on-doc) icon to `.clipboard` icon to match the pattern used elsewhere in the app

## Original prompt
Can you use the clipboard icon for copying the error like we do in other places?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
