### PR TITLE
fix: move delete contact button from danger zone to top-right of panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -134,7 +134,6 @@ struct ContactDetailView: View {
             headerTitle
             headerFields
             headerActions
-            dangerZone
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
@@ -152,16 +151,29 @@ struct ContactDetailView: View {
     }
 
     private var headerTitle: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack(spacing: VSpacing.sm) {
-                Text(displayContact.displayName)
-                    .font(VFont.display)
-                    .foregroundColor(VColor.contentDefault)
-                contactTypeBadge
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.sm) {
+                    Text(displayContact.displayName)
+                        .font(VFont.display)
+                        .foregroundColor(VColor.contentDefault)
+                    contactTypeBadge
+                }
+                Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
             }
-            Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
+            Spacer()
+            VButton(
+                label: "Delete Contact",
+                iconOnly: VIcon.trash.rawValue,
+                style: .dangerGhost,
+                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil,
+                tooltip: "Delete Contact"
+            ) {
+                showDeleteConfirmation = true
+            }
+            .accessibilityLabel("Delete contact")
         }
     }
 
@@ -203,30 +215,6 @@ struct ContactDetailView: View {
 
     private var contactTypeBadge: some View {
         VBadge(label: formatContactType(displayContact.role), tone: .neutral)
-    }
-
-    private var dangerZone: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            SettingsDivider()
-
-            Text("Danger Zone")
-                .font(VFont.inputLabel)
-                .foregroundColor(VColor.contentSecondary)
-
-            Text("Delete this contact and revoke all of their channels.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
-
-            VButton(
-                label: "Delete Contact",
-                leftIcon: VIcon.trash.rawValue,
-                style: .dangerGhost,
-                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil
-            ) {
-                showDeleteConfirmation = true
-            }
-            .accessibilityLabel("Delete contact")
-        }
     }
 
     // MARK: - Channels Section


### PR DESCRIPTION
## Summary
- Remove Danger Zone section from contact detail header
- Add icon-only trash button to top-right of header title row
- Confirmation dialog and disabled states preserved

Part of plan: contacts-ui-polish.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
