### PR TITLE
fix: restore user message width and composer clearing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -358,7 +358,7 @@ struct ChatBubble: View {
                     // content truncation and footer overlap.
                     MarkdownSegmentView(
                         segments: segments,
-                        maxContentWidth: nil,
+                        maxContentWidth: isUser ? nil : VSpacing.chatBubbleMaxWidth,
                         textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
                         secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
                         mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -421,8 +421,7 @@ struct ComposerView: View {
             content()
         }
         .padding(.vertical, VSpacing.sm)
-        .padding(.leading, VSpacing.md)
-        .padding(.trailing, VSpacing.sm)
+        .padding(.horizontal, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.window)
                 .fill(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -68,6 +68,9 @@ struct ComposerView: View {
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
+    /// Incremented when inputText is cleared externally (e.g. after send) to force
+    /// the TextField to rebuild, clearing its stale field editor buffer.
+    @State private var composerResetId = 0
 
     @State var showSlashMenu = false
     @State var slashFilter = ""
@@ -187,6 +190,7 @@ struct ComposerView: View {
         .lineSpacing(4)
         .foregroundColor(hasSlashHighlight ? .clear : VColor.contentDefault)
         .tint(VColor.primaryBase)
+        .id(composerResetId)
         .focused($composerFocus)
         .disabled(!hasAPIKey)
         .onSubmit { handleComposerSubmit() }
@@ -276,6 +280,13 @@ struct ComposerView: View {
         .onChange(of: inputText) {
             if inputText.isEmpty {
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
+                // Force TextField rebuild to clear its stale field editor buffer.
+                // On macOS, TextField(axis: .vertical) can desync when the binding
+                // is cleared externally — the field editor writes stale text back.
+                composerResetId += 1
+                DispatchQueue.main.async {
+                    composerFocus = true
+                }
             } else {
                 updateSlashState()
             }
@@ -375,9 +386,10 @@ struct ComposerView: View {
     /// selection, ghost-text acceptance, and pending-confirmation approval
     /// all working regardless of how "send" is triggered.
     private func performSendAction() {
-        inputText = inputText.replacingOccurrences(
-            of: "\\n$", with: "", options: .regularExpression
-        )
+        // Do not mutate inputText before onSend(). The ViewModel already trims
+        // whitespace, and mutating here races with the ViewModel's clearing of
+        // inputText — the TextField's internal buffer can write stale text back
+        // through the binding, preventing the composer from clearing.
         if ghostSuffix != nil { onAcceptSuggestion() }
         if showSlashMenu {
             handleSlashNavigation(.select)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -34,7 +34,7 @@ struct MarkdownSegmentView: View {
                         .foregroundColor(textColor)
                         .tint(tintColor)
                         .textSelection(.enabled)
-                        .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
+                        .optionalMaxWidth(maxContentWidth)
                         // lineLimit(nil) wraps text in a single measurement pass, avoiding
                         // the double-measurement that fixedSize causes (measure at ideal
                         // size, then constrain to proposed width).
@@ -51,7 +51,7 @@ struct MarkdownSegmentView: View {
                         .font(headingFont)
                         .foregroundColor(textColor)
                         .textSelection(.enabled)
-                        .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
+                        .optionalMaxWidth(maxContentWidth)
                         // lineLimit(nil) avoids the double-measurement from fixedSize.
                         .lineLimit(nil)
                         .padding(.top, level == 1 ? 4 : 2)
@@ -74,7 +74,7 @@ struct MarkdownSegmentView: View {
                                 .padding(VSpacing.sm)
                         }
                     }
-                    .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
+                    .frame(maxWidth: maxContentWidth ?? VSpacing.chatBubbleMaxWidth, alignment: .leading)
                     .background(codeBackgroundColor)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
@@ -90,7 +90,7 @@ struct MarkdownSegmentView: View {
                     Rectangle()
                         .fill(hrColor)
                         .frame(height: 1)
-                        .frame(maxWidth: maxContentWidth ?? .infinity)
+                        .optionalMaxWidth(maxContentWidth)
                         .padding(.vertical, VSpacing.xs)
                 }
             }
@@ -98,6 +98,7 @@ struct MarkdownSegmentView: View {
     }
 
     // MARK: - Segment Grouping
+
 
     /// Groups of segments for rendering.
     private enum SegmentGroup {
@@ -355,5 +356,20 @@ private extension AttributedString {
         let ns = NSMutableAttributedString(self)
         ns.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: ns.length))
         self = AttributedString(ns)
+    }
+}
+
+// MARK: - Optional Max Width
+
+private extension View {
+    /// Applies `.frame(maxWidth:alignment:)` only when a width is provided.
+    /// When `nil`, no frame is applied — the view shrink-wraps to its content.
+    @ViewBuilder
+    func optionalMaxWidth(_ width: CGFloat?) -> some View {
+        if let width {
+            self.frame(maxWidth: width, alignment: .leading)
+        } else {
+            self
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -74,7 +74,7 @@ struct MarkdownSegmentView: View {
                                 .padding(VSpacing.sm)
                         }
                     }
-                    .frame(maxWidth: maxContentWidth ?? VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                    .optionalMaxWidth(maxContentWidth)
                     .background(codeBackgroundColor)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 


### PR DESCRIPTION
## Summary
- Restore user message shrink-wrap width lost in #18232 — user bubbles now hug their text instead of filling the full container
- Fix composer not clearing after sending messages with code blocks — TextField(axis: .vertical) field editor desync on macOS
- Equalize composer shell horizontal padding (was 12pt left / 8pt right, now 8pt both sides)

## Context
- PR #18232 merged two rendering paths (plain text + rich markdown) into a single `MarkdownSegmentView` call, but lost the `isUser ? nil : .infinity` width distinction that kept user bubbles compact
- `MarkdownSegmentView` treated `nil` maxContentWidth as `.infinity`, forcing all elements to fill width via `.frame(maxWidth: .infinity)`
- Added `optionalMaxWidth` helper that skips the frame modifier entirely when nil
- Composer clearing fix: increment `.id()` on the TextField when inputText becomes empty, forcing SwiftUI to rebuild the field editor

Fixes LUM-245

## Test plan
- [ ] Short user message — bubble hugs text, right-aligned
- [ ] Long user message — wraps within 680pt
- [ ] Assistant message with code block — fills width as before
- [ ] Assistant plain text — fills width as before
- [ ] Send message with triple-backtick code blocks — composer clears
- [ ] Send again immediately after code blocks — composer clears
- [ ] Paperclip and voice button have equal side padding
- [ ] Ghost text suggestions still appear and accept with Tab
- [ ] Slash commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
