### PR TITLE
fix: strip non-text content from error tool results

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1327,6 +1327,158 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(userMsgs[2].content[0].cache_control).toBeUndefined();
     expect(userMsgs[2].content[1].cache_control).toBeUndefined();
   });
+
+  // -----------------------------------------------------------------------
+  // is_error + contentBlocks — non-text blocks must be stripped
+  // -----------------------------------------------------------------------
+
+  test("is_error tool_result strips non-text contentBlocks (images)", async () => {
+    const messages: Message[] = [
+      userMsg("Do something"),
+      toolUseMsg("tu_img", "file_read"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_img",
+            content: "Error: file not found",
+            is_error: true,
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "iVBOR",
+                },
+              },
+              { type: "text", text: "extra error detail" },
+            ],
+          },
+        ],
+      },
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        tool_use_id?: string;
+        is_error?: boolean;
+        content?: unknown;
+      }>;
+    }>;
+
+    const toolResult = sent[2].content.find(
+      (b) => b.type === "tool_result" && b.tool_use_id === "tu_img",
+    )!;
+    expect(toolResult.is_error).toBe(true);
+
+    // Content should be an array with only text blocks (no images)
+    const parts = toolResult.content as Array<{ type: string }>;
+    expect(Array.isArray(parts)).toBe(true);
+    expect(parts.every((p) => p.type === "text")).toBe(true);
+    // Original text + the extra text contentBlock
+    expect(parts).toHaveLength(2);
+  });
+
+  test("is_error tool_result with only image contentBlocks falls back to text-only", async () => {
+    const messages: Message[] = [
+      userMsg("Do something"),
+      toolUseMsg("tu_img2", "file_read"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_img2",
+            content: "Error: file not found",
+            is_error: true,
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "iVBOR",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        tool_use_id?: string;
+        is_error?: boolean;
+        content?: unknown;
+      }>;
+    }>;
+
+    const toolResult = sent[2].content.find(
+      (b) => b.type === "tool_result" && b.tool_use_id === "tu_img2",
+    )!;
+    expect(toolResult.is_error).toBe(true);
+
+    // All images stripped → no usable blocks → falls back to text-only content
+    expect(toolResult.content).toBe("Error: file not found");
+  });
+
+  test("non-error tool_result preserves image contentBlocks", async () => {
+    const messages: Message[] = [
+      userMsg("Do something"),
+      toolUseMsg("tu_img3", "file_read"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_img3",
+            content: "Success",
+            is_error: false,
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "iVBOR",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        tool_use_id?: string;
+        is_error?: boolean;
+        content?: unknown;
+      }>;
+    }>;
+
+    const toolResult = sent[2].content.find(
+      (b) => b.type === "tool_result" && b.tool_use_id === "tu_img3",
+    )!;
+    expect(toolResult.is_error).toBe(false);
+
+    // Non-error: images should be preserved in the content array
+    const parts = toolResult.content as Array<{ type: string }>;
+    expect(Array.isArray(parts)).toBe(true);
+    expect(parts.some((p) => p.type === "image")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1092,12 +1092,17 @@ export class AnthropicProvider implements Provider {
         };
       case "tool_result": {
         const toolUseId = sanitizeToolId(block.tool_use_id);
-        if (block.contentBlocks && block.contentBlocks.length > 0) {
+        // Anthropic API: when is_error is true, all content must be type "text".
+        // Filter out non-text blocks (e.g. images) for error results.
+        const usableBlocks = block.is_error
+          ? block.contentBlocks?.filter((cb) => cb.type === "text")
+          : block.contentBlocks;
+        if (usableBlocks && usableBlocks.length > 0) {
           // Build rich content array: text + images for Anthropic's native multi-part tool results
           const parts: Anthropic.ToolResultBlockParam["content"] = [
             { type: "text" as const, text: block.content },
           ];
-          for (const cb of block.contentBlocks) {
+          for (const cb of usableBlocks) {
             if (cb.type === "image") {
               parts.push({
                 type: "image" as const,


### PR DESCRIPTION
## Summary
- Fix Anthropic API 400 error: `all content must be type 'text' if 'is_error' is true`
- When a tool result has `is_error: true` and `contentBlocks` containing images, filter out non-text blocks before sending to the API
- If all contentBlocks are non-text (only images), fall back to the text-only path

## Original prompt
Fix bug in `assistant/src/providers/anthropic/client.ts` where tool results with `is_error: true` can contain non-text content blocks (like images), which the Anthropic API rejects with: `all content must be type 'text' if 'is_error' is true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
