### PR TITLE
fix: replace unused `if let daemonClient` bindings with boolean tests in SettingsPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -260,7 +260,7 @@ struct SettingsPanel: View {
                             // Persist the flag so it survives relaunch
                             Task {
                                 do {
-                                    if let daemonClient {
+                                    if daemonClient != nil {
                                         try await featureFlagClient.setFeatureFlag(key: Self.developerFeatureFlagKey, enabled: true)
                                     } else {
                                         try WorkspaceConfigIO.merge([
@@ -504,7 +504,7 @@ struct SettingsPanel: View {
     // MARK: - Feature Flag Loading
 
     private func loadFeatureFlags() async {
-        if let daemonClient {
+        if daemonClient != nil {
             do {
                 let flags = try await featureFlagClient.getFeatureFlags()
                 if let contactsFlag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {


### PR DESCRIPTION
## Summary
- Replace `if let daemonClient {` with `if daemonClient != nil {` at two locations in `SettingsPanel.swift` (lines 263 and 507) to fix Swift compiler warnings about unused bindings

## Original prompt
Fix Swift warnings: `value 'daemonClient' was defined but never used; consider replacing with boolean test` in SettingsPanel.swift at lines 263 and 507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
