### PR TITLE
fix: make WebSearchServiceCard auto-correction draft-only for consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -19,15 +19,17 @@ struct WebSearchServiceCard: View {
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
+    /// Local draft of the provider selection — only persisted on Save.
+    @State private var draftProvider: String = "inference-provider-native"
     /// Snapshot of the provider at card appear — used to detect provider changes.
     @State private var initialProvider: String = ""
 
     private var isPerplexity: Bool {
-        store.webSearchProvider == "perplexity"
+        draftProvider == "perplexity"
     }
 
     private var isBrave: Bool {
-        store.webSearchProvider == "brave"
+        draftProvider == "brave"
     }
 
     private var needsAPIKey: Bool {
@@ -63,7 +65,7 @@ struct WebSearchServiceCard: View {
 
         // Your Own mode: detect mode, provider, and API key changes.
         let modeChanged = draftMode != store.webSearchMode
-        let providerChanged = store.webSearchProvider != initialProvider
+        let providerChanged = draftProvider != initialProvider
         let hasNewKey: Bool = {
             if isPerplexity {
                 return !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -115,10 +117,15 @@ struct WebSearchServiceCard: View {
         )
         .onAppear {
             draftMode = store.webSearchMode
+            draftProvider = store.webSearchProvider
             initialProvider = store.webSearchProvider
         }
         .onChange(of: store.webSearchMode) { _, newValue in
             draftMode = newValue
+        }
+        .onChange(of: store.webSearchProvider) { _, newValue in
+            draftProvider = newValue
+            initialProvider = newValue
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Auto-correct invalid states when inference mode changes.
@@ -126,9 +133,9 @@ struct WebSearchServiceCard: View {
                 // Managed web search is not yet available without managed inference.
                 draftMode = "your-own"
             }
-            if newValue == "managed" && store.webSearchProvider == "inference-provider-native" {
+            if newValue == "managed" && draftProvider == "inference-provider-native" {
                 // Provider Native requires Your Own inference.
-                store.setWebSearchProvider("perplexity")
+                draftProvider = "perplexity"
             }
         }
     }
@@ -190,10 +197,7 @@ struct WebSearchServiceCard: View {
                 .foregroundColor(VColor.contentSecondary)
             VDropdown(
                 placeholder: "Select a provider\u{2026}",
-                selection: Binding(
-                    get: { store.webSearchProvider },
-                    set: { store.setWebSearchProvider($0) }
-                ),
+                selection: $draftProvider,
                 options: availableProviders.map { provider in
                     (label: SettingsStore.webSearchProviderDisplayNames[provider] ?? provider, value: provider)
                 }
@@ -238,7 +242,7 @@ struct WebSearchServiceCard: View {
 
         // In your-own mode, persist provider and API keys.
         if draftMode == "your-own" {
-            store.setWebSearchProvider(store.webSearchProvider)
+            store.setWebSearchProvider(draftProvider)
 
             if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 store.savePerplexityKey(perplexityKeyText)
@@ -251,6 +255,6 @@ struct WebSearchServiceCard: View {
         }
 
         // Update initial provider to reflect persisted state
-        initialProvider = store.webSearchProvider
+        initialProvider = draftProvider
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for web-search-managed-mode.md.

**Gap:** Inconsistent auto-correction persistence in WebSearchServiceCard
**What was expected:** Both auto-correction branches should behave consistently (draft-only)
**What was found:** Provider auto-correction persisted immediately via store.setWebSearchProvider, while mode auto-correction was draft-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
