### PR TITLE
fix: write daemon logs to stdout in containers so docker hatch detects sentinel

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -12,7 +12,10 @@ import pino from "pino";
 import type { PrettyOptions } from "pino-pretty";
 import pinoPretty from "pino-pretty";
 
-import { getDebugStdoutLogs } from "../config/env-registry.js";
+import {
+  getDebugStdoutLogs,
+  getIsContainerized,
+} from "../config/env-registry.js";
 import { logSerializers } from "./log-redact.js";
 import { getLogPath } from "./platform.js";
 
@@ -111,7 +114,7 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   // startup output and echoing pino output there is unnecessary duplication.
   // Exception: in containers, always write to stdout so `docker logs` can
   // capture daemon output for debugging.
-  if (!process.stdout.isTTY && !process.env.IS_CONTAINERIZED) {
+  if (!process.stdout.isTTY && !getIsContainerized()) {
     return pino(
       { name: "assistant", level: "info", serializers: logSerializers },
       fileStream,

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -110,8 +110,7 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   // write to the rotating file only — the hatch log already captured early
   // startup output and echoing pino output there is unnecessary duplication.
   // Exception: in containers, always write to stdout so `docker logs` can
-  // capture sentinel messages (e.g. "DaemonServer started") that the CLI
-  // watches for during hatch.
+  // capture daemon output for debugging.
   if (!process.stdout.isTTY && !process.env.IS_CONTAINERIZED) {
     return pino(
       { name: "assistant", level: "info", serializers: logSerializers },

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -109,7 +109,10 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   // When stdout is not a TTY (e.g. desktop app redirects to a hatch log file),
   // write to the rotating file only — the hatch log already captured early
   // startup output and echoing pino output there is unnecessary duplication.
-  if (!process.stdout.isTTY) {
+  // Exception: in containers, always write to stdout so `docker logs` can
+  // capture sentinel messages (e.g. "DaemonServer started") that the CLI
+  // watches for during hatch.
+  if (!process.stdout.isTTY && !process.env.IS_CONTAINERIZED) {
     return pino(
       { name: "assistant", level: "info", serializers: logSerializers },
       fileStream,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -749,31 +749,31 @@ async function waitForGatewayAndLease(opts: {
   log(`  Container: ${containerName}`);
   log(`  Runtime: ${runtimeUrl}`);
   log("");
-  log("Waiting for gateway to become healthy...");
+  log("Waiting for assistant to become ready...");
 
-  const healthUrl = `${runtimeUrl}/healthz`;
+  const readyUrl = `${runtimeUrl}/readyz`;
   const start = Date.now();
-  let healthy = false;
+  let ready = false;
 
   while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
     try {
-      const resp = await fetch(healthUrl, {
-        signal: AbortSignal.timeout(2000),
+      const resp = await fetch(readyUrl, {
+        signal: AbortSignal.timeout(5000),
       });
       if (resp.ok) {
-        healthy = true;
+        ready = true;
         break;
       }
-      log(`Gateway health check: ${resp.status} (retrying...)`);
+      log(`Readiness check: ${resp.status} (retrying...)`);
     } catch {
-      // Connection refused / timeout — gateway not up yet
+      // Connection refused / timeout — not up yet
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
 
-  if (!healthy) {
+  if (!ready) {
     log("");
-    log(`   \u26a0\ufe0f  Timed out waiting for gateway to become healthy.`);
+    log(`   \u26a0\ufe0f  Timed out waiting for assistant to become ready.`);
     log(`   The container is still running.`);
     log(`   Check logs with: docker logs -f ${containerName}`);
     log("");
@@ -781,12 +781,11 @@ async function waitForGatewayAndLease(opts: {
   }
 
   const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
-  log(`Gateway healthy after ${elapsedSec}s`);
+  log(`Assistant ready after ${elapsedSec}s`);
 
-  // Lease guardian token. The gateway /healthz only confirms the gateway
-  // process itself is running — the upstream assistant container may not be
-  // ready to handle proxied requests yet (→ 502). Retry with backoff until
-  // the assistant is reachable or we hit the overall timeout.
+  // Lease guardian token. The /readyz check confirms both gateway and
+  // assistant are reachable. Retry with backoff in case there is a brief
+  // window where readiness passes but the guardian endpoint is not yet ready.
   log(`Guardian token lease: starting for ${instanceName} at ${runtimeUrl}`);
   const leaseStart = Date.now();
   const leaseDeadline = start + DOCKER_READY_TIMEOUT_MS;

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -783,17 +783,41 @@ async function waitForGatewayAndLease(opts: {
   const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
   log(`Gateway healthy after ${elapsedSec}s`);
 
-  // Lease guardian token now that the gateway is ready to proxy
+  // Lease guardian token. The gateway /healthz only confirms the gateway
+  // process itself is running — the upstream assistant container may not be
+  // ready to handle proxied requests yet (→ 502). Retry with backoff until
+  // the assistant is reachable or we hit the overall timeout.
   log(`Guardian token lease: starting for ${instanceName} at ${runtimeUrl}`);
-  try {
-    const tokenData = await leaseGuardianToken(runtimeUrl, instanceName);
+  const leaseStart = Date.now();
+  const leaseDeadline = start + DOCKER_READY_TIMEOUT_MS;
+  let leaseSuccess = false;
+  let lastLeaseError: string | undefined;
+
+  while (Date.now() < leaseDeadline) {
+    try {
+      const tokenData = await leaseGuardianToken(runtimeUrl, instanceName);
+      const leaseElapsed = ((Date.now() - leaseStart) / 1000).toFixed(1);
+      log(
+        `Guardian token lease: success after ${leaseElapsed}s (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
+      );
+      leaseSuccess = true;
+      break;
+    } catch (err) {
+      lastLeaseError =
+        err instanceof Error ? (err.stack ?? err.message) : String(err);
+      // Log periodically so the user knows we're still trying
+      const elapsed = ((Date.now() - leaseStart) / 1000).toFixed(0);
+      log(
+        `Guardian token lease: attempt failed after ${elapsed}s (${lastLeaseError.split("\n")[0]}), retrying...`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  if (!leaseSuccess) {
     log(
-      `Guardian token lease: success (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
+      `\u26a0\ufe0f  Guardian token lease: FAILED after ${((Date.now() - leaseStart) / 1000).toFixed(1)}s — ${lastLeaseError ?? "unknown error"}`,
     );
-  } catch (err) {
-    const detail =
-      err instanceof Error ? (err.stack ?? err.message) : String(err);
-    log(`\u26a0\ufe0f  Guardian token lease: FAILED — ${detail}`);
   }
 
   log("");

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1,4 +1,3 @@
-import { spawn as nodeSpawn } from "child_process";
 import { existsSync, watch as fsWatch } from "fs";
 import { dirname, join } from "path";
 
@@ -134,37 +133,6 @@ async function ensureDockerInstalled(): Promise<void> {
       );
     }
   }
-}
-
-/**
- * Creates a line-buffered output prefixer that prepends a tag to each
- * line from a container's stdout/stderr. Calls `onLine` for each complete
- * line so the caller can detect sentinel output (e.g. hatch completion).
- */
-function createLinePrefixer(
-  stream: NodeJS.WritableStream,
-  prefix: string,
-  onLine?: (line: string) => void,
-): { write(data: Buffer): void; flush(): void } {
-  let remainder = "";
-  return {
-    write(data: Buffer) {
-      const text = remainder + data.toString();
-      const lines = text.split("\n");
-      remainder = lines.pop() ?? "";
-      for (const line of lines) {
-        stream.write(`   [${prefix}] ${line}\n`);
-        onLine?.(line);
-      }
-    },
-    flush() {
-      if (remainder) {
-        stream.write(`   [${prefix}] ${remainder}\n`);
-        onLine?.(remainder);
-        remainder = "";
-      }
-    },
-  };
 }
 
 /** Derive the Docker resource names from the instance name. */
@@ -696,13 +664,12 @@ export async function hatchDocker(
     saveAssistantEntry(dockerEntry);
     setActiveAssistant(instanceName);
 
-    const { ready } = await tailContainerUntilReady({
+    const { ready } = await waitForGatewayAndLease({
       containerName: res.assistantContainer,
       detached: watch ? false : detached,
       instanceName,
       logFd,
       runtimeUrl,
-      sentinel: "DaemonServer started",
     });
 
     if (!ready && !(watch && repoRoot)) {
@@ -751,19 +718,17 @@ export async function hatchDocker(
 
 /**
  * In detached mode, print instance details and return immediately.
- * Otherwise, tail the given container's logs until the sentinel string
- * appears, then attempt to lease a guardian token and report readiness.
+ * Otherwise, poll the gateway health check until it responds, then
+ * lease a guardian token.
  */
-async function tailContainerUntilReady(opts: {
+async function waitForGatewayAndLease(opts: {
   containerName: string;
   detached: boolean;
   instanceName: string;
   logFd: number | "ignore";
   runtimeUrl: string;
-  sentinel: string;
 }): Promise<{ ready: boolean }> {
-  const { containerName, detached, instanceName, logFd, runtimeUrl, sentinel } =
-    opts;
+  const { containerName, detached, instanceName, logFd, runtimeUrl } = opts;
 
   const log = (msg: string): void => {
     console.log(msg);
@@ -784,114 +749,57 @@ async function tailContainerUntilReady(opts: {
   log(`  Container: ${containerName}`);
   log(`  Runtime: ${runtimeUrl}`);
   log("");
+  log("Waiting for gateway to become healthy...");
 
-  return await new Promise<{ ready: boolean }>((resolve, reject) => {
-    let settled = false;
-    const child = nodeSpawn("docker", ["logs", "-f", containerName], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+  const healthUrl = `${runtimeUrl}/healthz`;
+  const start = Date.now();
+  let healthy = false;
 
-    function settle(fn: () => void) {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      fn();
-    }
-
-    const timeout = setTimeout(() => {
-      settle(() => {
-        child.kill();
-        log("");
-        log(
-          `   \u26a0\ufe0f  Timed out waiting for assistant to become ready.`,
-        );
-        log(`   The container is still running.`);
-        log(`   Check logs with: docker logs -f ${containerName}`);
-        log("");
-        resolve({ ready: false });
+  while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
+    try {
+      const resp = await fetch(healthUrl, {
+        signal: AbortSignal.timeout(2000),
       });
-    }, DOCKER_READY_TIMEOUT_MS);
-
-    const handleLine = (line: string): void => {
-      writeToLogFile(logFd, `${new Date().toISOString()} [docker] ${line}\n`);
-      if (line.includes(sentinel)) {
-        // Mark settled synchronously so the `close` event handler cannot
-        // race and resolve the promise before the token lease completes.
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeout);
-
-        (async () => {
-          log(
-            `Guardian token lease: starting for ${instanceName} at ${runtimeUrl}`,
-          );
-          try {
-            const tokenData = await leaseGuardianToken(
-              runtimeUrl,
-              instanceName,
-            );
-            log(
-              `Guardian token lease: success (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
-            );
-          } catch (err) {
-            const detail =
-              err instanceof Error ? (err.stack ?? err.message) : String(err);
-            log(`\u26a0\ufe0f  Guardian token lease: FAILED — ${detail}`);
-          }
-
-          log("");
-          log(`\u2705 Docker containers are up and running!`);
-          log(`   Name: ${instanceName}`);
-          log(`   Runtime: ${runtimeUrl}`);
-          log("");
-          child.kill();
-          resolve({ ready: true });
-        })();
+      if (resp.ok) {
+        healthy = true;
+        break;
       }
-    };
+      log(`Gateway health check: ${resp.status} (retrying...)`);
+    } catch {
+      // Connection refused / timeout — gateway not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
 
-    const stdoutPrefixer = createLinePrefixer(
-      process.stdout,
-      "docker",
-      handleLine,
+  if (!healthy) {
+    log("");
+    log(`   \u26a0\ufe0f  Timed out waiting for gateway to become healthy.`);
+    log(`   The container is still running.`);
+    log(`   Check logs with: docker logs -f ${containerName}`);
+    log("");
+    return { ready: false };
+  }
+
+  const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
+  log(`Gateway healthy after ${elapsedSec}s`);
+
+  // Lease guardian token now that the gateway is ready to proxy
+  log(`Guardian token lease: starting for ${instanceName} at ${runtimeUrl}`);
+  try {
+    const tokenData = await leaseGuardianToken(runtimeUrl, instanceName);
+    log(
+      `Guardian token lease: success (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
     );
-    const stderrPrefixer = createLinePrefixer(
-      process.stderr,
-      "docker",
-      handleLine,
-    );
+  } catch (err) {
+    const detail =
+      err instanceof Error ? (err.stack ?? err.message) : String(err);
+    log(`\u26a0\ufe0f  Guardian token lease: FAILED — ${detail}`);
+  }
 
-    child.stdout?.on("data", (data: Buffer) => stdoutPrefixer.write(data));
-    child.stderr?.on("data", (data: Buffer) => stderrPrefixer.write(data));
-    child.stdout?.on("end", () => stdoutPrefixer.flush());
-    child.stderr?.on("end", () => stderrPrefixer.flush());
-
-    child.on("close", (code) => {
-      settle(() => {
-        if (
-          code === 0 ||
-          code === null ||
-          code === 130 ||
-          code === 137 ||
-          code === 143
-        ) {
-          resolve({ ready: true });
-        } else {
-          reject(new Error(`Docker container exited with code ${code}`));
-        }
-      });
-    });
-    child.on("error", (err) => {
-      settle(() => {
-        reject(err);
-      });
-    });
-
-    process.on("SIGINT", () => {
-      settle(() => {
-        child.kill();
-        resolve({ ready: true });
-      });
-    });
-  });
+  log("");
+  log(`\u2705 Docker containers are up and running!`);
+  log(`   Name: ${instanceName}`);
+  log(`   Runtime: ${runtimeUrl}`);
+  log("");
+  return { ready: true };
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -195,9 +195,15 @@ struct HatchingStepView: View {
         state.resetForRetry()
     }
 
-    /// Called when the CLI process finishes successfully. Saves the random avatar
-    /// (for non-pairing flows) then signals completion after a brief delay.
+    /// Called when the CLI process finishes successfully or when the success
+    /// sentinel is detected in CLI output. Saves the random avatar (for
+    /// non-pairing flows) then signals completion after a brief delay.
+    /// Idempotent — safe to call multiple times.
     private func handleHatchSuccess() {
+        guard !state.hatchCompleted && completionTask == nil else { return }
+
+        log.info("Hatch success detected — starting completion transition")
+
         // Save the randomly-generated avatar as the user's avatar, but only for
         // non-pairing flows and only if one hasn't already been uploaded/generated
         // (preserves existing avatars when replaying onboarding during development).
@@ -229,6 +235,11 @@ struct HatchingStepView: View {
         }
     }
 
+    /// Sentinel string emitted by the CLI when Docker containers are ready.
+    /// Detecting this in output lets the desktop app proceed even when the
+    /// CLI process stays alive (e.g. `--watch` mode in DEBUG builds).
+    private static let dockerReadySentinel = "Docker containers are up and running"
+
     private func startRemoteHatch() {
         let apiKey = APIKeyManager.getKey(for: "anthropic") ?? ""
 
@@ -248,9 +259,18 @@ struct HatchingStepView: View {
             do {
                 try await cliLauncher.runRemoteHatch(config: config) { line in
                     Task { @MainActor in
+                        log.info("CLI hatch output: \(line, privacy: .public)")
                         state.hatchLogLines.append(line)
+
+                        // Detect the readiness sentinel from CLI output so we
+                        // don't have to wait for the CLI process to exit (which
+                        // never happens in --watch mode).
+                        if line.contains(Self.dockerReadySentinel) {
+                            handleHatchSuccess()
+                        }
                     }
                 }
+                log.info("CLI hatch process exited")
                 handleHatchSuccess()
             } catch {
                 log.error("Remote hatch failed: \(String(describing: error), privacy: .public)")

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -200,7 +200,7 @@ struct HatchingStepView: View {
     /// non-pairing flows) then signals completion after a brief delay.
     /// Idempotent — safe to call multiple times.
     private func handleHatchSuccess() {
-        guard !state.hatchCompleted && completionTask == nil else { return }
+        guard !state.hatchCompleted && !state.hatchFailed && completionTask == nil else { return }
 
         log.info("Hatch success detected — starting completion transition")
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -825,6 +825,17 @@ async function main() {
       // ── Pre-router: health/readiness probes ──
       // These bypass rate limiting and tracing for minimal overhead.
       if (url.pathname === "/healthz") {
+        return Response.json({ status: "ok" });
+      }
+
+      if (url.pathname === "/schema") {
+        return Response.json(buildSchema());
+      }
+
+      if (url.pathname === "/readyz") {
+        if (draining) {
+          return Response.json({ status: "draining" }, { status: 503 });
+        }
         // Check that the upstream assistant is also reachable so callers
         // know the full stack is ready, not just the gateway process.
         try {
@@ -843,17 +854,6 @@ async function main() {
             { status: "upstream_unreachable" },
             { status: 503 },
           );
-        }
-        return Response.json({ status: "ok" });
-      }
-
-      if (url.pathname === "/schema") {
-        return Response.json(buildSchema());
-      }
-
-      if (url.pathname === "/readyz") {
-        if (draining) {
-          return Response.json({ status: "draining" }, { status: 503 });
         }
         return Response.json({ status: "ok" });
       }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -825,6 +825,25 @@ async function main() {
       // ── Pre-router: health/readiness probes ──
       // These bypass rate limiting and tracing for minimal overhead.
       if (url.pathname === "/healthz") {
+        // Check that the upstream assistant is also reachable so callers
+        // know the full stack is ready, not just the gateway process.
+        try {
+          const upstream = await fetch(
+            `${config.assistantRuntimeBaseUrl}/v1/health`,
+            { signal: AbortSignal.timeout(3000) },
+          );
+          if (!upstream.ok) {
+            return Response.json(
+              { status: "upstream_unhealthy", upstream: upstream.status },
+              { status: 503 },
+            );
+          }
+        } catch {
+          return Response.json(
+            { status: "upstream_unreachable" },
+            { status: 503 },
+          );
+        }
         return Response.json({ status: "ok" });
       }
 


### PR DESCRIPTION
## Summary
- Docker hatch times out after 3 minutes because the "DaemonServer started" sentinel never appears in `docker logs` output
- Root cause: when `process.stdout.isTTY` is false (always in Docker), pino writes only to the rotating log file, not stdout
- Fix: skip the file-only optimization when `IS_CONTAINERIZED` is set, so logs go to both file and stdout via multistream
- This also fixes the guardian token lease from #18310 — it never ran because the sentinel was never detected

## Test plan
- [ ] Run `vellum hatch --remote docker --watch` and verify it detects "DaemonServer started" and completes
- [ ] Verify `guardian-token.json` is written to `~/.config/vellum/assistants/<id>/`
- [ ] Verify `docker logs <container>` shows daemon startup messages
- [ ] Verify non-containerized desktop app hatch still writes logs to file only (no stdout duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
