### PR TITLE
feat: add name and notes editing to guardian detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -113,20 +113,60 @@ struct ContactsContainerView: View {
         }
     }
 
-    /// Guardian detail — name+tag header card, then existing channel content in a second card.
+    /// Guardian detail — editable name+notes header card, then existing channel content in a second card.
     private func guardianDetailView(contact: ContactPayload) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    HStack(spacing: VSpacing.sm) {
-                        Text(contact.displayName)
-                            .font(VFont.display)
-                            .foregroundColor(VColor.contentDefault)
-                        VBadge(label: "Guardian", tone: .neutral)
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    // Title row: display name + badge + interaction count
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack(spacing: VSpacing.sm) {
+                            Text(contact.displayName)
+                                .font(VFont.display)
+                                .foregroundColor(VColor.contentDefault)
+                            VBadge(label: "Guardian", tone: .neutral)
+                        }
+                        Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
                     }
-                    Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+
+                    // Editable fields
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Name")
+                                .font(VFont.inputLabel)
+                                .foregroundColor(VColor.contentSecondary)
+                            VTextField(placeholder: "Your name", text: $guardianEditedName)
+                        }
+
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Notes")
+                                .font(VFont.inputLabel)
+                                .foregroundColor(VColor.contentSecondary)
+                            VTextEditor(
+                                placeholder: "Notes about yourself which AI will take into account",
+                                text: $guardianEditedNotes,
+                                minHeight: 80,
+                                maxHeight: 180
+                            )
+                        }
+                    }
+
+                    // Save button
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(
+                            label: "Save",
+                            style: .primary,
+                            isDisabled: guardianIsSaving || guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ) {
+                            Task { await saveGuardianEdits(contact: contact) }
+                        }
+                        if guardianIsSaving {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
@@ -146,7 +186,47 @@ struct ContactsContainerView: View {
         }
         .background(VColor.surfaceOverlay)
         .id(contact.id)
+        .onAppear {
+            guardianEditedName = contact.displayName
+            guardianEditedNotes = contact.notes ?? ""
+        }
+        .onChange(of: contact) { _, newContact in
+            guardianEditedName = newContact.displayName
+            guardianEditedNotes = newContact.notes ?? ""
+        }
     }
+
+    /// Persists guardian name/notes edits via the contacts API.
+    private func saveGuardianEdits(contact: ContactPayload) async {
+        let trimmedName = guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let originalNotes = contact.notes ?? ""
+        if trimmedName == contact.displayName && trimmedNotes == originalNotes {
+            return
+        }
+
+        guardianIsSaving = true
+        do {
+            if let updated = try await contactClient.updateContact(
+                contactId: contact.id,
+                displayName: trimmedName,
+                notes: trimmedNotes
+            ) {
+                guardianEditedName = updated.displayName
+                guardianEditedNotes = updated.notes ?? ""
+                viewModel.loadContacts()
+            }
+        } catch {
+            // Silently fail — user can retry
+        }
+        guardianIsSaving = false
+    }
+
+    @State private var guardianEditedName: String = ""
+    @State private var guardianEditedNotes: String = ""
+    @State private var guardianIsSaving: Bool = false
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 


### PR DESCRIPTION
## Summary
- Add editable Name and Notes fields to guardian contact detail header
- Add Save button that persists changes via the contacts API
- No delete button for guardian contacts (by design)

Part of plan: contacts-ui-polish.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
