### PR TITLE
fix: wait for gateway readiness before credential bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -362,6 +362,21 @@ extension AppDelegate {
                 }
             }
 
+            // Wait for the daemon (and gateway) to be reachable. The bootstrap
+            // injects credentials via GatewayHTTPClient which connects to the
+            // local gateway — if we proceed before it's listening we get
+            // "Could not connect to the server."
+            if !self.daemonClient.isConnected {
+                log.info("Waiting for daemon connection before credential bootstrap...")
+                for attempt in 1...20 {
+                    if self.daemonClient.isConnected { break }
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    if attempt == 20 {
+                        log.warning("Daemon not connected after 10s — proceeding with credential bootstrap anyway")
+                    }
+                }
+            }
+
             do {
                 #if DEBUG
                 let credentialStorage = FileCredentialStorage()


### PR DESCRIPTION
## Summary
- Add a daemon connection wait (up to 10s, polling every 500ms) in `ensureLocalAssistantApiKey()` after the actor token wait
- Fixes the "Failed to set up Vellum credentials" toast that appeared on every app launch when the gateway wasn't ready yet

## Original prompt
Can you use the clipboard icon for copying the error like we do in other places?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
