### PR TITLE
Fix avatar AI generation to use proxied network mode

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -97,10 +97,15 @@ Tell the user their avatar has been updated. The client will pick up the new ima
 
 ## Mode 3: AI-Generated Image
 
-The user describes what they want their avatar to look like. Use the CLI to generate the avatar:
+The user describes what they want their avatar to look like. Use the `bash` tool to run the CLI command below.
 
-```bash
-assistant avatar generate --description "<user's description>"
+**IMPORTANT: You MUST set `network_mode` to `"proxied"` on this tool call. Without it, the command cannot reach the image generation API and will fail.**
+
+```json
+{
+  "command": "assistant avatar generate --description \"<user's description>\"",
+  "network_mode": "proxied"
+}
 ```
 
 This generates an image using AI, saves it to `data/avatar/avatar-image.png`, and removes any native character files automatically. The generated avatar will appear automatically in the client.


### PR DESCRIPTION
## Summary
- Update the vellum-avatar skill to require `network_mode: "proxied"` when running `assistant avatar generate`
- Without this, the sandbox blocks all network access and the CLI command fails with "Unable to connect"
- Show the tool call as a JSON example so the LLM reliably sets the flag

## Test plan
- [x] Verified that without `network_mode: "proxied"`, avatar generation fails with connection error
- [x] Verified that with `network_mode: "proxied"`, the command reaches the managed proxy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
