### PR TITLE
Fix error toast overflow on long messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -677,7 +677,6 @@ struct MainWindowView: View {
                         actionLabel: "Open Settings",
                         onAction: { windowState.selection = .panel(.settings) }
                     )
-                    .fixedSize(horizontal: true, vertical: false)
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
                     .padding(.top, VSpacing.sm)
                     .animation(VAnimation.fast, value: windowState.hasAPIKey)
@@ -989,7 +988,6 @@ private struct ErrorToastOverlay: View {
                     actionLabel: "Open Settings",
                     onAction: onOpenSettings
                 )
-                .fixedSize(horizontal: true, vertical: false)
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
@@ -1000,7 +998,6 @@ private struct ErrorToastOverlay: View {
                     onCopyDebugInfo: onCopyDebugInfo,
                     onDismiss: onDismissConversationError
                 )
-                .fixedSize(horizontal: true, vertical: false)
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
@@ -1012,7 +1009,6 @@ private struct ErrorToastOverlay: View {
                     onAction: errorManager.isSecretBlockError ? onSendAnyway : (errorManager.isRetryableError || (errorManager.isConnectionError && errorManager.hasRetryPayload)) ? onRetryLastMessage : nil,
                     onDismiss: onDismissError
                 )
-                .fixedSize(horizontal: true, vertical: false)
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
         }


### PR DESCRIPTION
## Summary
- Remove `.fixedSize(horizontal: true, vertical: false)` from all `ChatConversationErrorToast` call sites — this was forcing the toast to expand to its natural content width, overriding the 70% viewport cap set by `.containerRelativeFrame`
- Long error messages now wrap to multiple lines within the 70% max width instead of overflowing off-screen

## Original prompt
Error message overflows when too long. The text should wrap to a second line if the text is too long. Width of the error toast should be no more than 70% of the width of the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
