### PR TITLE
fix: move recordLifecycleEvent outside requestId guard in permission telemetry

### DIFF
--- a/assistant/src/events/tool-permission-telemetry-listener.ts
+++ b/assistant/src/events/tool-permission-telemetry-listener.ts
@@ -21,8 +21,8 @@ export function registerToolPermissionTelemetryListener(
           const { requestId, toolName } = event.payload;
           if (requestId) {
             promptedToolCalls.add(`${requestId}:${toolName}`);
-            recordLifecycleEvent(`permission_prompt:${toolName}`);
           }
+          recordLifecycleEvent(`permission_prompt:${toolName}`);
           return;
         }
         case "tool.permission.decided": {


### PR DESCRIPTION
Fixes silent telemetry loss when tool.permission.requested events are emitted without a requestId. The lifecycle event recording was accidentally scoped inside the if(requestId) guard in #18369 — this moves it back to unconditional execution while keeping the per-tool-call Set tracking inside the guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
