### PR TITLE
fix: cancel stale copy-feedback Task in VToast and add Gallery example

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -26,6 +26,7 @@ public struct VToast: View {
     public var onDismiss: (() -> Void)?
 
     @State private var showCopied = false
+    @State private var copiedResetTask: Task<Void, Never>?
 
     public init(
         message: String,
@@ -65,8 +66,10 @@ public struct VToast: View {
                             UIPasteboard.general.string = detail
                             #endif
                             showCopied = true
-                            Task {
+                            copiedResetTask?.cancel()
+                            copiedResetTask = Task {
                                 try? await Task.sleep(nanoseconds: 1_500_000_000)
+                                guard !Task.isCancelled else { return }
                                 showCopied = false
                             }
                         } label: {

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -177,6 +177,29 @@ struct FeedbackGallerySection: View {
 
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
+            // MARK: - VToast with Copyable Detail
+            GallerySectionHeader(
+                title: "VToast with Copyable Detail",
+                description: "Error toast with a clipboard button that copies debug information."
+            )
+
+            VStack(spacing: VSpacing.md) {
+                VToast(
+                    message: "Request failed unexpectedly.",
+                    style: .error,
+                    copyableDetail: "RequestError: timeout after 30s at /v1/chat/completions (req_abc123)"
+                )
+                VToast(
+                    message: "Could not connect to provider.",
+                    style: .error,
+                    copyableDetail: "ConnectionRefused: 127.0.0.1:8080",
+                    primaryAction: VToastAction(label: "Retry") {},
+                    onDismiss: {}
+                )
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
             // MARK: - VToast with Actions
             GallerySectionHeader(
                 title: "VToast with Actions",


### PR DESCRIPTION
Fixes race condition where rapid clicks on the VToast copy button caused premature checkmark dismissal. Stores the reset Task in a @State property and cancels it before creating a new one. Also adds a Gallery example showcasing the copyableDetail feature per AGENTS.md design system rules.

Addresses review feedback from #18378.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
