### PR TITLE
fix: gate vbundle directory backup on resolvable entries

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -173,15 +173,22 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // no stale files left behind. Skips embedding-models/ and data/qdrant/
   // (large, regenerable). Also handles old-format bundles that use skills/
   // or hooks/ prefixes.
-  const hasWorkspaceEntries = manifest.files.some(
-    (f) =>
+  //
+  // Gate on resolution: only clear when at least one manifest entry with a
+  // workspace-scoped prefix actually resolves to a valid disk path. This
+  // prevents malformed paths (e.g. "skills/../x") from triggering a
+  // workspace purge while resolving to nothing — which would delete local
+  // data without restoring anything.
+  const hasWorkspaceEntries = manifest.files.some((f) => {
+    const isWorkspaceScoped =
       f.path.startsWith("workspace/") ||
       f.path.startsWith("skills/") ||
       f.path.startsWith("hooks/") ||
       f.path.startsWith("prompts/") ||
       f.path === "data/db/assistant.db" ||
-      f.path === "config/settings.json",
-  );
+      f.path === "config/settings.json";
+    return isWorkspaceScoped && pathResolver.resolve(f.path) !== null;
+  });
 
   if (hasWorkspaceEntries && workspaceDir && existsSync(workspaceDir)) {
     try {


### PR DESCRIPTION
Prevents data loss from crafted or malformed bundles containing unmappable paths (e.g. skills/../x). The backup/clear of skills/hooks directories now only triggers when at least one manifest entry with that prefix actually resolves to a valid path inside the target directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
