### PR TITLE
feat: contacts UI polish — selection style, spacing, guardian editing, delete button, channel icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -328,6 +328,16 @@ struct AssistantChannelsDetailView: View {
         case connected
     }
 
+    private func channelIcon(for name: String) -> VIcon {
+        switch name {
+        case "Slack": return .hash
+        case "Telegram": return .send
+        case "Phone Calling": return .phone
+        case "Email": return .mail
+        default: return .messageCircle
+        }
+    }
+
     private func channelRowHeader(
         name: String,
         channelKey: String? = nil,
@@ -339,6 +349,7 @@ struct AssistantChannelsDetailView: View {
     ) -> some View {
         ChannelRowHeader(
             name: name,
+            icon: channelIcon(for: name),
             channelKey: channelKey,
             value: value,
             status: status,
@@ -352,6 +363,7 @@ struct AssistantChannelsDetailView: View {
     /// A single channel row with hover-reveal kebab menu for disconnect.
     private struct ChannelRowHeader: View {
         let name: String
+        var icon: VIcon = .messageCircle
         var channelKey: String?
         let value: String?
         let status: ChannelStatus?
@@ -364,7 +376,9 @@ struct AssistantChannelsDetailView: View {
 
         var body: some View {
             HStack(spacing: VSpacing.sm) {
-                // Left: channel name
+                // Left: channel icon + name
+                VIconView(icon, size: 16)
+                    .foregroundColor(VColor.contentSecondary)
                 Text(name)
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.contentDefault)
@@ -384,7 +398,7 @@ struct AssistantChannelsDetailView: View {
                 if let status, status == .connected {
                     VBadge(label: "Connected", tone: .positive)
                 } else if let setupAction {
-                    VButton(label: "Set up", style: .ghost) {
+                    VButton(label: "Set up", style: .outlined) {
                         setupAction()
                     }
                 }
@@ -416,6 +430,7 @@ struct AssistantChannelsDetailView: View {
                 }
                 .frame(width: 24)
             }
+            .frame(minHeight: 36)
             .contentShape(Rectangle())
             .onHover { hovering in
                 isHovered = hovering

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -134,7 +134,6 @@ struct ContactDetailView: View {
             headerTitle
             headerFields
             headerActions
-            dangerZone
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
@@ -152,16 +151,29 @@ struct ContactDetailView: View {
     }
 
     private var headerTitle: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack(spacing: VSpacing.sm) {
-                Text(displayContact.displayName)
-                    .font(VFont.display)
-                    .foregroundColor(VColor.contentDefault)
-                contactTypeBadge
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.sm) {
+                    Text(displayContact.displayName)
+                        .font(VFont.display)
+                        .foregroundColor(VColor.contentDefault)
+                    contactTypeBadge
+                }
+                Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
             }
-            Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
+            Spacer()
+            VButton(
+                label: "Delete Contact",
+                iconOnly: VIcon.trash.rawValue,
+                style: .dangerGhost,
+                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil,
+                tooltip: "Delete Contact"
+            ) {
+                showDeleteConfirmation = true
+            }
+            .accessibilityLabel("Delete contact")
         }
     }
 
@@ -203,30 +215,6 @@ struct ContactDetailView: View {
 
     private var contactTypeBadge: some View {
         VBadge(label: formatContactType(displayContact.role), tone: .neutral)
-    }
-
-    private var dangerZone: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            SettingsDivider()
-
-            Text("Danger Zone")
-                .font(VFont.inputLabel)
-                .foregroundColor(VColor.contentSecondary)
-
-            Text("Delete this contact and revoke all of their channels.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
-
-            VButton(
-                label: "Delete Contact",
-                leftIcon: VIcon.trash.rawValue,
-                style: .dangerGhost,
-                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil
-            ) {
-                showDeleteConfirmation = true
-            }
-            .accessibilityLabel("Delete contact")
-        }
     }
 
     // MARK: - Channels Section

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -166,14 +166,12 @@ struct ContactDetailView: View {
             Spacer()
             VButton(
                 label: "Delete Contact",
-                iconOnly: VIcon.trash.rawValue,
+                leftIcon: VIcon.trash.rawValue,
                 style: .dangerGhost,
-                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil,
-                tooltip: "Delete Contact"
+                isDisabled: isDeleting || actionInProgress != nil || verificationInProgress != nil
             ) {
                 showDeleteConfirmation = true
             }
-            .accessibilityLabel("Delete contact")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -75,9 +75,15 @@ struct ContactDetailView: View {
                     .padding(VSpacing.lg)
                     .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
-                channelsSection
-                    .padding(VSpacing.lg)
-                    .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
+                GuardianChannelsDetailView(
+                    contact: displayContact,
+                    daemonClient: daemonClient,
+                    store: store,
+                    onSelectAssistant: nil,
+                    showCardBorders: false
+                )
+                .padding(VSpacing.lg)
+                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
             .padding(VSpacing.lg)
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -30,14 +30,13 @@ struct ContactsContainerView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: VSpacing.lg) {
+        HStack(alignment: .top, spacing: 0) {
             // Left pane: contacts list (full height, internal scrolling)
             ContactsListView(
                 viewModel: viewModel,
                 selection: $selection
             )
-            .padding(.leading, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
+            .padding(VSpacing.lg)
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -30,13 +30,14 @@ struct ContactsContainerView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
+        HStack(alignment: .top, spacing: VSpacing.lg) {
             // Left pane: contacts list (full height, internal scrolling)
             ContactsListView(
                 viewModel: viewModel,
                 selection: $selection
             )
-            .padding(VSpacing.lg)
+            .padding(.leading, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -36,7 +36,8 @@ struct ContactsContainerView: View {
                 viewModel: viewModel,
                 selection: $selection
             )
-            .padding(VSpacing.lg)
+            .padding(.leading, VSpacing.lg)
+            .padding(.vertical, VSpacing.lg)
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -113,20 +113,60 @@ struct ContactsContainerView: View {
         }
     }
 
-    /// Guardian detail — name+tag header card, then existing channel content in a second card.
+    /// Guardian detail — editable name+notes header card, then existing channel content in a second card.
     private func guardianDetailView(contact: ContactPayload) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    HStack(spacing: VSpacing.sm) {
-                        Text(contact.displayName)
-                            .font(VFont.display)
-                            .foregroundColor(VColor.contentDefault)
-                        VBadge(label: "Guardian", tone: .neutral)
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    // Title row: display name + badge + interaction count
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack(spacing: VSpacing.sm) {
+                            Text(contact.displayName)
+                                .font(VFont.display)
+                                .foregroundColor(VColor.contentDefault)
+                            VBadge(label: "Guardian", tone: .neutral)
+                        }
+                        Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
                     }
-                    Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+
+                    // Editable fields
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Name")
+                                .font(VFont.inputLabel)
+                                .foregroundColor(VColor.contentSecondary)
+                            VTextField(placeholder: "Your name", text: $guardianEditedName)
+                        }
+
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Notes")
+                                .font(VFont.inputLabel)
+                                .foregroundColor(VColor.contentSecondary)
+                            VTextEditor(
+                                placeholder: "Notes about yourself which AI will take into account",
+                                text: $guardianEditedNotes,
+                                minHeight: 80,
+                                maxHeight: 180
+                            )
+                        }
+                    }
+
+                    // Save button
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(
+                            label: "Save",
+                            style: .primary,
+                            isDisabled: guardianIsSaving || guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ) {
+                            Task { await saveGuardianEdits(contact: contact) }
+                        }
+                        if guardianIsSaving {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
@@ -146,7 +186,47 @@ struct ContactsContainerView: View {
         }
         .background(VColor.surfaceOverlay)
         .id(contact.id)
+        .onAppear {
+            guardianEditedName = contact.displayName
+            guardianEditedNotes = contact.notes ?? ""
+        }
+        .onChange(of: contact) { _, newContact in
+            guardianEditedName = newContact.displayName
+            guardianEditedNotes = newContact.notes ?? ""
+        }
     }
+
+    /// Persists guardian name/notes edits via the contacts API.
+    private func saveGuardianEdits(contact: ContactPayload) async {
+        let trimmedName = guardianEditedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let originalNotes = contact.notes ?? ""
+        if trimmedName == contact.displayName && trimmedNotes == originalNotes {
+            return
+        }
+
+        guardianIsSaving = true
+        do {
+            if let updated = try await contactClient.updateContact(
+                contactId: contact.id,
+                displayName: trimmedName,
+                notes: trimmedNotes
+            ) {
+                guardianEditedName = updated.displayName
+                guardianEditedNotes = updated.notes ?? ""
+                viewModel.loadContacts()
+            }
+        } catch {
+            // Silently fail — user can retry
+        }
+        guardianIsSaving = false
+    }
+
+    @State private var guardianEditedName: String = ""
+    @State private var guardianEditedNotes: String = ""
+    @State private var guardianIsSaving: Bool = false
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -120,7 +120,7 @@ struct ContactsContainerView: View {
                     // Title row: display name + badge + interaction count
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         HStack(spacing: VSpacing.sm) {
-                            Text(contact.displayName)
+                            Text("\(contact.displayName) (You)")
                                 .font(VFont.display)
                                 .foregroundColor(VColor.contentDefault)
                             VBadge(label: "Guardian", tone: .neutral)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -133,7 +133,7 @@ struct ContactsListView: View {
             HStack(spacing: VSpacing.xs) {
                 Text(name)
                     .font(VFont.bodyMedium)
-                    .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentDefault)
+                    .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                     .lineLimit(1)
 
                 Spacer()
@@ -145,7 +145,7 @@ struct ContactsListView: View {
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.md)
             .background(rowBackground(isSelected: isSelected, isHovered: isHovered))
-            .overlay(rowBorder(isSelected: isSelected, isHovered: isHovered))
+            .animation(VAnimation.fast, value: isHovered)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
@@ -205,18 +205,8 @@ struct ContactsListView: View {
         RoundedRectangle(cornerRadius: VRadius.md)
             .fill(
                 isSelected
-                    ? VColor.primaryBase.opacity(0.10)
-                    : (isHovered ? VColor.surfaceBase : Color.clear)
-            )
-    }
-
-    private func rowBorder(isSelected: Bool, isHovered: Bool) -> some View {
-        RoundedRectangle(cornerRadius: VRadius.md)
-            .strokeBorder(
-                isSelected
-                    ? VColor.borderActive
-                    : (isHovered ? VColor.borderBase.opacity(0.45) : Color.clear),
-                lineWidth: 1
+                    ? VColor.surfaceActive
+                    : VColor.surfaceBase.opacity(isHovered ? 1 : 0)
             )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -99,8 +99,10 @@ struct GuardianChannelsDetailView: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                         .multilineTextAlignment(.center)
-                    VButton(label: "Set Up Assistant", style: .outlined) {
-                        onSelectAssistant?()
+                    if let onSelectAssistant {
+                        VButton(label: "Set Up Assistant", style: .outlined) {
+                            onSelectAssistant()
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Match contacts list row selection styling to settings nav (surfaceActive background, no border stroke)
- Fix horizontal spacing between contacts list and detail pane
- Add editable Name and Notes fields to guardian (You) detail view
- Move delete button from "Danger Zone" to top-right of contact header
- Add channel icons to assistant channel rows and change setup buttons to outlined style
- Unify human contact channels section with guardian layout (SettingsCard-based)
- Show "(You)" suffix in guardian detail header

## PRs included
- #18377 — Match contacts list row selection to settings nav style
- #18376 — Equalize horizontal spacing between contacts list and detail pane
- #18391 — Add name and notes editing to guardian detail view
- #18384 — Move delete contact button from danger zone to top-right of panel
- #18382 — Add channel icons and consistent styling to assistant channel cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
