### PR TITLE
fix: make workspace files scrollable before entering edit mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -33,12 +33,8 @@ struct HighlightedTextView: View {
                     editableView
                 } else {
                     readOnlyView
-                        .overlay {
-                            Color.clear
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    isActivelyEditing = true
-                                }
+                        .onTapGesture {
+                            isActivelyEditing = true
                         }
                 }
             } else {


### PR DESCRIPTION
## Summary
- Removed the `Color.clear.contentShape(Rectangle())` overlay from the pre-edit view in `HighlightedTextView` that was intercepting scroll events
- Replaced with `.onTapGesture` directly on `readOnlyView`, which allows scroll gestures to pass through to the underlying `ScrollView` while still capturing taps to enter edit mode

## Original prompt
These files should be scrollable even before you click into them to go into edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
