### PR TITLE
fix: use .copy icon for VToast clipboard button per AGENTS.md convention

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -73,7 +73,7 @@ public struct VToast: View {
                                 showCopied = false
                             }
                         } label: {
-                            VIconView(showCopied ? .check : .clipboard, size: 12)
+                            VIconView(showCopied ? .check : .copy, size: 12)
                                 .foregroundColor(showCopied ? VColor.systemPositiveStrong : VColor.contentSecondary)
                                 .frame(width: 24, height: 24)
                         }


### PR DESCRIPTION
Reverts .clipboard back to .copy for the VToast copyable detail button. The AGENTS.md icon table designates .copy as the standard icon for copy-to-clipboard actions, and every other copy button in the codebase uses .copy consistently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
