### PR TITLE
fix: show explicit "Key saved" indicator on API key fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -66,15 +66,16 @@ struct ImageGenerationServiceCard: View {
                         Text("API Key")
                             .font(VFont.inputLabel)
                             .foregroundColor(VColor.contentSecondary)
-                        SecureField(
-                            isConnected && apiKeyText.isEmpty
-                                ? "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
-                                : "Enter your Gemini API key",
-                            text: $apiKeyText
-                        )
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentDefault)
+                        SecureField("Enter your API key", text: $apiKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+
+                        if isConnected && apiKeyText.isEmpty {
+                            Label("Key saved", systemImage: "checkmark.circle.fill")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                        }
                     }
 
                     // Model picker

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -66,16 +66,17 @@ struct InferenceServiceCard: View {
                         Text("API Key")
                             .font(VFont.inputLabel)
                             .foregroundColor(VColor.contentSecondary)
-                        SecureField(
-                            isConnected && apiKeyText.isEmpty
-                                ? "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
-                                : "Enter your API key",
-                            text: $apiKeyText
-                        )
-                        .vInputStyle()
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentDefault)
-                        .disabled(store.apiKeySaving)
+                        SecureField("Enter your API key", text: $apiKeyText)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .disabled(store.apiKeySaving)
+
+                        if isConnected && apiKeyText.isEmpty {
+                            Label("Key saved", systemImage: "checkmark.circle.fill")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                        }
 
                         if let error = store.apiKeySaveError {
                             Text(error)

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -208,28 +208,27 @@ struct WebSearchServiceCard: View {
     // MARK: - API Key Section
 
     private var apiKeySection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        let hasKey = isPerplexity ? store.hasPerplexityKey : store.hasBraveKey
+        let keyText = isPerplexity ? perplexityKeyText : braveKeyText
+
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("API Key")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
             SecureField(
-                apiKeyPlaceholder,
+                "Enter your API key",
                 text: isPerplexity ? $perplexityKeyText : $braveKeyText
             )
             .vInputStyle()
             .font(VFont.body)
             .foregroundColor(VColor.contentDefault)
-        }
-    }
 
-    private var apiKeyPlaceholder: String {
-        let isConnected = isPerplexity ? store.hasPerplexityKey : store.hasBraveKey
-        let keyText = isPerplexity ? perplexityKeyText : braveKeyText
-        let providerName = isPerplexity ? "Perplexity" : "Brave"
-        if isConnected && keyText.isEmpty {
-            return "••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"
+            if hasKey && keyText.isEmpty {
+                Label("Key saved", systemImage: "checkmark.circle.fill")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemPositiveStrong)
+            }
         }
-        return "Enter your \(providerName) API key"
     }
 
     // MARK: - Save


### PR DESCRIPTION
## Summary
- Replace misleading placeholder-dot pattern in API key `SecureField`s with a consistent "Enter your API key" placeholder
- Add a green checkmark + "Key saved" label below the field when a key is stored in the Keychain
- Applied consistently across Inference, Image Generation, and Web Search service cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
