### PR TITLE
fix: replace `!== null` with truthiness check in vbundle-importer

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -187,7 +187,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       f.path.startsWith("prompts/") ||
       f.path === "data/db/assistant.db" ||
       f.path === "config/settings.json";
-    return isWorkspaceScoped && pathResolver.resolve(f.path) !== null;
+    return isWorkspaceScoped && !!pathResolver.resolve(f.path);
   });
 
   if (hasWorkspaceEntries && workspaceDir && existsSync(workspaceDir)) {


### PR DESCRIPTION
## Summary
- Fix lint error (`no-restricted-syntax`) in `vbundle-importer.ts` line 190: replace `!== null` with `!!` truthiness check

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23206667932/job/67443888852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
