### PR TITLE
fix: match contacts layout size to other settings tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -85,9 +85,7 @@ struct ContactDetailView: View {
                 .padding(VSpacing.lg)
                 .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
-            .padding(VSpacing.lg)
         }
-        .background(VColor.surfaceOverlay)
         .confirmationDialog(
             "Delete \(displayContact.displayName)?",
             isPresented: $showDeleteConfirmation,

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -30,7 +30,7 @@ struct ContactsContainerView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
+        HStack(alignment: .top, spacing: VSpacing.lg) {
             // Left pane: contacts list (full height, internal scrolling)
             ContactsListView(
                 viewModel: viewModel,
@@ -38,8 +38,6 @@ struct ContactsContainerView: View {
             )
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
-            .background(VColor.surfaceOverlay)
-
             // Right pane: detail, loading, or placeholder
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 // Loading state — contacts are being fetched

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -36,8 +36,6 @@ struct ContactsContainerView: View {
                 viewModel: viewModel,
                 selection: $selection
             )
-            .padding(.leading, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             .background(VColor.surfaceOverlay)
@@ -182,9 +180,7 @@ struct ContactsContainerView: View {
                 .padding(VSpacing.lg)
                 .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
-            .padding(VSpacing.lg)
         }
-        .background(VColor.surfaceOverlay)
         .id(contact.id)
         .onAppear {
             guardianEditedName = contact.displayName
@@ -241,9 +237,7 @@ struct ContactsContainerView: View {
                         .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
                 }
             }
-            .padding(VSpacing.lg)
         }
-        .background(VColor.surfaceOverlay)
         .task {
             cachedAssistantName = AssistantDisplayName.firstUserFacing(from: [IdentityInfo.load()?.name]) ?? AssistantDisplayName.placeholder
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -144,9 +144,11 @@ struct SettingsPanel: View {
 
                 if selectedTab == .contacts {
                     selectedTabContent
+                        .padding(.top, VSpacing.lg)
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        .frame(maxWidth: 900, alignment: .top)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     ScrollView {
                         selectedTabContent

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -142,12 +142,11 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
+                if selectedTab == .contacts {
                     selectedTabContent
-                        .padding(.top, VSpacing.lg)
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 } else {
                     ScrollView {
                         selectedTabContent

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -144,8 +144,10 @@ struct SettingsPanel: View {
 
                 if selectedTab == .contacts || (selectedTab == .archivedConversations && conversationManager.archivedConversations.isEmpty) {
                     selectedTabContent
+                        .padding(.top, VSpacing.lg)
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
+                        .frame(maxWidth: 900, alignment: .top)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
                 } else {
                     ScrollView {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -147,7 +147,6 @@ struct SettingsPanel: View {
                         .padding(.top, VSpacing.lg)
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: 900, alignment: .top)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: selectedTab == .contacts ? .top : .center)
                 } else {
                     ScrollView {


### PR DESCRIPTION
## Summary
- Apply `maxWidth: 900` and top padding to contacts tab to match the layout of other settings tabs
- Contacts previously used full-width with no top padding, making it visually inconsistent with other tabs

## Original prompt
--safe size for contacts layout and layout is different compare to other settings, let's try and see if we can adopt size of the other settings layout to contacts and see how it looks like

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
