### PR TITLE
fix: cancel copiedResetTask on disappear in VToast

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -124,6 +124,9 @@ public struct VToast: View {
             UIAccessibility.post(notification: .announcement, argument: "\(style): \(message)")
             #endif
         }
+        .onDisappear {
+            copiedResetTask?.cancel()
+        }
     }
 
     /// Use danger style for error toasts, primary for everything else.


### PR DESCRIPTION
Address review feedback from PR #18398:

- Add onDisappear cancellation for copiedResetTask to prevent mutating @State on a removed view
- Follows the same cleanup pattern used by sibling views (VBusyIndicator, VLoadingIndicator) per clients/AGENTS.md conventions

Closes JARVIS-0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
