### PR TITLE
fix: add visibility check for deep-linked settings tab in init

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -80,7 +80,17 @@ struct SettingsPanel: View {
         // the selection didSet, which consumes pendingSettingsTab on the
         // first instance and leaves the second with .general).
         if let pending = store.pendingSettingsTab {
-            _selectedTab = State(initialValue: pending)
+            // Validate that the deep-linked tab is actually visible before
+            // accepting it. @AppStorage isn't wired to UserDefaults in init,
+            // so read connectedOrgId directly from UserDefaults.
+            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+            let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
+            // Contacts and developer flags load asynchronously, so default
+            // to false at init time — those tabs aren't visible yet.
+            let visibleTabs = SettingsTab.primaryTabs(contactsEnabled: false, billingEnabled: canShowBilling)
+            if visibleTabs.contains(pending) {
+                _selectedTab = State(initialValue: pending)
+            }
         }
     }
 


### PR DESCRIPTION
Address review feedback from PR #18395:

- Add tab visibility validation in SettingsPanel init before accepting a pending deep-link tab
- Read connectedOrgId from UserDefaults directly (since @AppStorage isn't wired in init)
- Fall back to .general if the deep-linked tab isn't currently visible
- Prevents deep-links from landing on hidden/gated tabs (Billing, Contacts, Developer)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
