### PR TITLE
fix: restrict vbundle prompt resolver to accepted filenames

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -19,6 +19,14 @@ import { join, resolve } from "node:path";
 
 import type { ManifestType } from "./vbundle-validator.js";
 
+/** Only these prompt filenames are accepted during import. */
+const ALLOWED_PROMPT_FILENAMES = new Set([
+  "IDENTITY.md",
+  "SOUL.md",
+  "USER.md",
+  "UPDATES.md",
+]);
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -123,10 +131,13 @@ export class DefaultPathResolver implements PathResolver {
     if (archivePath.startsWith("prompts/") && this.workspaceDir) {
       // Old bundles stored prompts as prompts/IDENTITY.md etc — these map
       // to the workspace root (e.g. workspace/IDENTITY.md).
-      const resolved = resolve(
-        this.workspaceDir,
-        archivePath.slice("prompts/".length),
-      );
+      // Only accepted prompt filenames resolve — unknown entries are
+      // skipped so they cannot trigger workspace clearing.
+      const filename = archivePath.slice("prompts/".length);
+      if (!ALLOWED_PROMPT_FILENAMES.has(filename)) {
+        return null;
+      }
+      const resolved = resolve(this.workspaceDir, filename);
       const wsRoot = resolve(this.workspaceDir);
       if (resolved !== wsRoot && !resolved.startsWith(wsRoot + "/")) {
         return null;


### PR DESCRIPTION
## Summary
- Re-add `ALLOWED_PROMPT_FILENAMES` guard to `DefaultPathResolver.resolve()` so only recognized prompt filenames (`IDENTITY.md`, `SOUL.md`, `USER.md`, `UPDATES.md`) resolve from `prompts/` entries
- Prevents bundles with only unrecognized prompt paths from triggering workspace clearing

## Context
PR #18374 added this guard but PR #18380 (workspace walk refactor) removed it. The Codex review feedback about gating prompt cleanup on accepted entries is still valid in the current code — without the guard, `prompts/unknown.md` resolves and contributes to `hasWorkspaceEntries`, potentially triggering a full workspace purge.

The Devin backup concern is now moot: PR #18380 replaced the per-file `unlinkSync` Step 1d with a full workspace clearing step that applies uniformly to all file types (skills, hooks, prompts, etc).

Addresses review feedback from PR #18374.

## Test plan
- [ ] Verify `prompts/unknown.md` no longer resolves in `DefaultPathResolver`
- [ ] Verify `prompts/IDENTITY.md` still resolves correctly
- [ ] Verify workspace clearing is not triggered when bundle contains only unrecognized prompt entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
