### PR TITLE
fix: harden vbundle workspace walk — gate clearing, exclude old-format bundles, re-add hooks, strip SQLite aux files

### DIFF
--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -766,13 +766,13 @@ describe("commitImport — workspace clearing", () => {
     }
   });
 
-  test("clears stale skills via workspace clearing", () => {
+  test("clears stale files via workspace clearing (new-format workspace/ entries)", () => {
     mkdirSync(join(skillsDir, "stale-skill"), { recursive: true });
     writeFileSync(join(skillsDir, "stale-skill", "SKILL.md"), "stale");
 
     const skillData = new TextEncoder().encode("# New Skill");
     const vbundle = createValidVBundle([
-      { path: "skills/new-skill/SKILL.md", data: skillData },
+      { path: "workspace/skills/new-skill/SKILL.md", data: skillData },
     ]);
 
     const resolver = new DefaultPathResolver(undefined, testDir);
@@ -795,13 +795,13 @@ describe("commitImport — workspace clearing", () => {
     expect(existsSync(join(skillsDir, "stale-skill"))).toBe(false);
   });
 
-  test("clears stale hooks via workspace clearing", () => {
-    mkdirSync(join(hooksDir, "stale-hook"), { recursive: true });
-    writeFileSync(join(hooksDir, "stale-hook", "hook.sh"), "stale");
+  test("old-format skills/ entries do not trigger workspace clearing", () => {
+    mkdirSync(join(skillsDir, "stale-skill"), { recursive: true });
+    writeFileSync(join(skillsDir, "stale-skill", "SKILL.md"), "stale");
 
-    const hookData = new TextEncoder().encode("#!/bin/sh\necho new");
+    const skillData = new TextEncoder().encode("# New Skill");
     const vbundle = createValidVBundle([
-      { path: "hooks/new-hook/hook.sh", data: hookData },
+      { path: "skills/new-skill/SKILL.md", data: skillData },
     ]);
 
     const resolver = new DefaultPathResolver(undefined, testDir);
@@ -814,8 +814,41 @@ describe("commitImport — workspace clearing", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    expect(existsSync(join(hooksDir, "new-hook", "hook.sh"))).toBe(true);
-    expect(existsSync(join(hooksDir, "stale-hook"))).toBe(false);
+    // New skill written
+    expect(existsSync(join(skillsDir, "new-skill", "SKILL.md"))).toBe(true);
+
+    // Stale skill survives — old-format bundles don't trigger workspace clearing
+    expect(existsSync(join(skillsDir, "stale-skill", "SKILL.md"))).toBe(true);
+  });
+
+  test("hooks/ entries import to hooksDir (not workspace/hooks/)", () => {
+    // Use a separate hooks dir outside the workspace, like production layout
+    const externalHooksDir = join(testDir, ".hooks-external");
+    mkdirSync(externalHooksDir, { recursive: true });
+
+    const hookData = new TextEncoder().encode("#!/bin/sh\necho new");
+    const vbundle = createValidVBundle([
+      { path: "hooks/new-hook/hook.sh", data: hookData },
+    ]);
+
+    const resolver = new DefaultPathResolver(undefined, testDir, externalHooksDir);
+    const result = commitImport({
+      archiveData: vbundle,
+      pathResolver: resolver,
+      workspaceDir: testDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Hook written to the external hooks dir, not workspace/hooks/
+    expect(existsSync(join(externalHooksDir, "new-hook", "hook.sh"))).toBe(true);
+    expect(
+      readFileSync(join(externalHooksDir, "new-hook", "hook.sh"), "utf8"),
+    ).toBe("#!/bin/sh\necho new");
+
+    // Cleanup
+    rmSync(externalHooksDir, { recursive: true, force: true });
   });
 
   test("without workspaceDir, no clearing happens", () => {

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -344,6 +344,17 @@ function walkDirectory(
         }
         walk(fullPath);
       } else if (stat.isFile()) {
+        // Skip SQLite auxiliary files — these are ephemeral and race-prone
+        // with the live DB connection. The WAL is checkpointed before the
+        // walk, so the main .db file has all committed rows.
+        if (
+          entry.name.endsWith("-wal") ||
+          entry.name.endsWith("-shm") ||
+          entry.name.endsWith("-journal")
+        ) {
+          continue;
+        }
+
         const data = new Uint8Array(readFileSync(fullPath));
 
         // Skip binary files unless explicitly included
@@ -384,6 +395,12 @@ export interface BuildExportVBundleOptions {
   /** Absolute path to trust.json. If provided and the file exists, it is included in the archive. */
   trustPath?: string;
   /**
+   * Absolute path to the hooks directory (~/.vellum/hooks/).
+   * Hooks live outside the workspace, so they must be included explicitly.
+   * Included in the archive under the "hooks/" prefix for backward compat.
+   */
+  hooksDir?: string;
+  /**
    * Absolute path to the workspace directory (~/.vellum/workspace/).
    * When provided and exists, the entire directory tree is walked and
    * included in the archive under the "workspace/" prefix, skipping
@@ -416,7 +433,8 @@ export interface BuildExportVBundleOptions {
 export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
-  const { source, description, checkpoint, trustPath, workspaceDir } = options;
+  const { source, description, checkpoint, trustPath, workspaceDir, hooksDir } =
+    options;
 
   // Flush WAL to the main database file before reading so the export
   // captures all committed rows (SQLite WAL mode keeps recent writes
@@ -436,6 +454,11 @@ export function buildExportVBundle(
         skipDirs: ["embedding-models", "data/qdrant"],
       }),
     );
+  }
+
+  // Include hooks directory if it exists (lives at ~/.vellum/hooks/, outside workspace).
+  if (hooksDir && existsSync(hooksDir) && lstatSync(hooksDir).isDirectory()) {
+    files.push(...walkDirectory(hooksDir, "hooks"));
   }
 
   // Include trust rules if the file exists (lives in protected/, outside workspace).

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -90,6 +90,7 @@ export class DefaultPathResolver implements PathResolver {
   constructor(
     private protectedDir?: string,
     private workspaceDir?: string,
+    private hooksDir?: string,
   ) {}
 
   resolve(archivePath: string): string | null {
@@ -144,13 +145,12 @@ export class DefaultPathResolver implements PathResolver {
       }
       return resolved;
     }
-    if (archivePath.startsWith("hooks/") && this.workspaceDir) {
+    if (archivePath.startsWith("hooks/") && this.hooksDir) {
       const resolved = resolve(
-        this.workspaceDir,
-        "hooks",
+        this.hooksDir,
         archivePath.slice("hooks/".length),
       );
-      const hooksRoot = resolve(this.workspaceDir, "hooks");
+      const hooksRoot = resolve(this.hooksDir);
       if (resolved !== hooksRoot && !resolved.startsWith(hooksRoot + "/")) {
         return null;
       }

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -169,26 +169,22 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   const DATA_SKIP_DIRS = new Set(["qdrant"]);
 
   // Step 1b: Clear the workspace directory before restore if the bundle
-  // contains workspace/ entries. This ensures an exact-match restore with
-  // no stale files left behind. Skips embedding-models/ and data/qdrant/
-  // (large, regenerable). Also handles old-format bundles that use skills/
-  // or hooks/ prefixes.
+  // contains new-format workspace/ entries. This ensures an exact-match
+  // restore with no stale files left behind. Skips embedding-models/ and
+  // data/qdrant/ (large, regenerable).
   //
-  // Gate on resolution: only clear when at least one manifest entry with a
-  // workspace-scoped prefix actually resolves to a valid disk path. This
-  // prevents malformed paths (e.g. "skills/../x") from triggering a
-  // workspace purge while resolving to nothing — which would delete local
-  // data without restoring anything.
-  const hasWorkspaceEntries = manifest.files.some((f) => {
-    const isWorkspaceScoped =
-      f.path.startsWith("workspace/") ||
-      f.path.startsWith("skills/") ||
-      f.path.startsWith("hooks/") ||
-      f.path.startsWith("prompts/") ||
-      f.path === "data/db/assistant.db" ||
-      f.path === "config/settings.json";
-    return isWorkspaceScoped && !!pathResolver.resolve(f.path);
-  });
+  // Only new-format bundles (workspace/ prefix) trigger clearing. Old-format
+  // bundles (skills/, hooks/, data/db/*, config/*) wrote specific files
+  // without clearing — preserving that behavior avoids wiping workspace
+  // data when importing legacy bundles.
+  //
+  // Gate on resolution: at least one workspace/ entry must resolve to a
+  // valid disk path. This prevents path-traversal entries (e.g.
+  // "workspace/../../etc/passwd") from triggering a workspace purge while
+  // resolving to nothing.
+  const hasWorkspaceEntries = manifest.files.some(
+    (f) => f.path.startsWith("workspace/") && !!pathResolver.resolve(f.path),
+  );
 
   if (hasWorkspaceEntries && workspaceDir && existsSync(workspaceDir)) {
     try {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -20,6 +20,7 @@ import { clearCache as clearTrustCache } from "../../permissions/trust-store.js"
 import { getLogger } from "../../util/logger.js";
 import {
   getDbPath,
+  getHooksDir,
   getRootDir,
   getWorkspaceDir,
 } from "../../util/platform.js";
@@ -142,6 +143,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
   try {
     const { archive, manifest } = buildExportVBundle({
       trustPath: join(getRootDir(), "protected", "trust.json"),
+      hooksDir: getHooksDir(),
       workspaceDir: getWorkspaceDir(),
       source: "runtime-export",
       description,
@@ -297,6 +299,7 @@ export async function handleMigrationImportPreflight(
     const pathResolver = new DefaultPathResolver(
       join(getRootDir(), "protected"),
       getWorkspaceDir(),
+      getHooksDir(),
     );
 
     const report = analyzeImport({
@@ -379,6 +382,7 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     const pathResolver = new DefaultPathResolver(
       join(getRootDir(), "protected"),
       getWorkspaceDir(),
+      getHooksDir(),
     );
 
     // Close the live SQLite connection before overwriting assistant.db on disk.


### PR DESCRIPTION
Address review feedback from PR #18380:

- Gate workspace clearing on at least one resolvable workspace/ entry (prevents path traversal attacks from triggering destructive clear)
- Restrict workspace clearing to new-format bundles (workspace/ prefix) so old-format bundles don't wipe all workspace data
- Re-add hooks directory to export explicitly (hooks live at ~/.vellum/hooks, outside workspace walk)
- Fix backward-compat import resolver to map hooks/ entries to getHooksDir() instead of workspace/hooks/
- Exclude SQLite auxiliary files (-wal, -shm, -journal) from workspace walk export to prevent DB inconsistency

Closes JARVIS-0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
