### PR TITLE
fix: replace flaky setTimeout with promise in oauth2 loopback test

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -484,17 +484,22 @@ describe("OAuth2 gateway transport", () => {
       };
 
       let capturedAuthUrl = "";
+      let urlReady!: () => void;
+      const urlReadyPromise = new Promise<void>((r) => {
+        urlReady = r;
+      });
       const flowPromise = startOAuth2Flow(
         BASE_OAUTH_CONFIG,
         {
           openUrl: (url) => {
             capturedAuthUrl = url;
+            urlReady();
           },
         },
         { callbackTransport: "loopback" },
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await urlReadyPromise;
 
       const authUrl = new URL(capturedAuthUrl);
       const redirectUri = authUrl.searchParams.get("redirect_uri")!;


### PR DESCRIPTION
## Summary
- The `token exchange failure propagates error` test in `oauth2-gateway-transport.test.ts` used a fixed 50ms `setTimeout` to wait for the loopback server's `openUrl` callback, which was racy on CI
- Replaced with a promise that resolves when `openUrl` is actually called, eliminating the timing dependency

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23207313323/job/67446223277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
