### PR TITLE
fix: update telemetry ingest path to /v1/telemetry/ingest

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -193,7 +193,7 @@ describe("UsageTelemetryReporter", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("https://test.vellum.ai/v1/assistants/telemetry/ingest/");
+    expect(url).toBe("https://test.vellum.ai/v1/telemetry/ingest/");
     expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
       "Api-Key test-key",
     );

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -45,7 +45,7 @@ const CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID =
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
-const TELEMETRY_PATH = "/v1/assistants/telemetry/ingest/";
+const TELEMETRY_PATH = "/v1/telemetry/ingest/";
 
 // ---------------------------------------------------------------------------
 // Reporter


### PR DESCRIPTION
## Summary
- Update `TELEMETRY_PATH` constant from `/v1/assistants/telemetry/ingest/` to `/v1/telemetry/ingest/`
- Update test assertion to match the new path

Part of plan: telemetry-ingest-path.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
