### PR TITLE
fix: remove unnecessary nonisolated(unsafe) warning in AssistantCli

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -80,7 +80,7 @@ final class AssistantCli {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
-    nonisolated(unsafe) private static let forwardedEnvKeys: [String] = [
+    private static let forwardedEnvKeys: [String] = [
         "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",


### PR DESCRIPTION
## Summary
- Removed `nonisolated(unsafe)` from `forwardedEnvKeys` in `AssistantCli.swift` — the annotation is unnecessary for a `static let` constant with `Sendable` type `[String]`, and the Swift compiler warns about it.

## Original prompt
Fix compiler warning: `'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type '[String]', consider removing it` in `AssistantCli.swift:83`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
