### PR TITLE
Surface logout HTTP errors via errorMessage instead of silently swallowing

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -173,8 +173,10 @@ public final class AuthManager {
     public func logout() async {
         do {
             _ = try await authService.logout()
+            errorMessage = nil
         } catch {
             log.error("Logout request failed: baseURL=\(self.authService.baseURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
         }
         await SessionTokenManager.deleteTokenAsync()
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
@@ -182,7 +184,6 @@ public final class AuthManager {
         UserDefaults.standard.removeObject(forKey: "managed_assistant_id")
         UserDefaults.standard.removeObject(forKey: "managed_platform_base_url")
         state = .unauthenticated
-        errorMessage = nil
     }
 
     private func generateCodeVerifier() -> String {


### PR DESCRIPTION
## Summary
- Make AuthManager.logout() set errorMessage when the HTTP DELETE to /_allauth/app/v1/auth/session fails, instead of just logging the error
- Move errorMessage = nil into the success path so errors are preserved for callers to check

Part of plan: unify-logout-error-toast.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
