### PR TITLE
feat: export `cancelPendingJobsForConversation` from task-memory-cleanup

### DIFF
--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -42,10 +42,10 @@ export function isConversationFailed(conversationId: string): boolean {
 export function invalidateAssistantInferredItemsForConversation(
   conversationId: string,
 ): number {
-  // Cancel pending extract_items jobs for this conversation's messages
+  // Cancel pending memory jobs for this conversation's messages
   // so the worker never processes them. Jobs already running will be
   // caught by the isConversationFailed check in the extraction handler.
-  cancelPendingExtractionJobsForConversation(conversationId);
+  cancelPendingJobsForConversation(conversationId);
 
   const affected = rawRun(
     `UPDATE memory_items
@@ -94,21 +94,24 @@ export function invalidateAssistantInferredItemsForConversation(
 }
 
 /**
- * Cancel pending `extract_items` jobs whose messageId belongs to the given
- * conversation. This drains the queue so the worker never processes them,
- * complementing the runtime check in the extraction handler.
+ * Cancel all pending/running memory jobs referencing the given conversation.
+ * Covers every job type: `extract_items`, `embed_segment`, `embed_attachment`
+ * (keyed by messageId), `build_conversation_summary` (keyed by conversationId),
+ * and `embed_item` (keyed by itemId sourced from the conversation's messages).
  */
-function cancelPendingExtractionJobsForConversation(
+export function cancelPendingJobsForConversation(
   conversationId: string,
 ): number {
   const now = Date.now();
-  const cancelled = rawRun(
+  let total = 0;
+
+  // Jobs keyed by messageId: extract_items, embed_segment, embed_attachment
+  total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
-            last_error = 'conversation_failed',
+            last_error = 'conversation_wiped',
             updated_at = ?
-      WHERE type IN ('extract_items')
-        AND status IN ('pending', 'running')
+      WHERE status IN ('pending', 'running')
         AND json_extract(payload, '$.messageId') IN (
           SELECT id FROM messages WHERE conversation_id = ?
         )`,
@@ -116,12 +119,41 @@ function cancelPendingExtractionJobsForConversation(
     conversationId,
   );
 
-  if (cancelled > 0) {
+  // Jobs keyed by conversationId: build_conversation_summary
+  total += rawRun(
+    `UPDATE memory_jobs
+        SET status = 'failed',
+            last_error = 'conversation_wiped',
+            updated_at = ?
+      WHERE status IN ('pending', 'running')
+        AND json_extract(payload, '$.conversationId') = ?`,
+    now,
+    conversationId,
+  );
+
+  // Jobs keyed by itemId: embed_item (items sourced from this conversation)
+  total += rawRun(
+    `UPDATE memory_jobs
+        SET status = 'failed',
+            last_error = 'conversation_wiped',
+            updated_at = ?
+      WHERE status IN ('pending', 'running')
+        AND json_extract(payload, '$.itemId') IN (
+          SELECT mis.memory_item_id
+            FROM memory_item_sources mis
+            JOIN messages m ON m.id = mis.message_id
+           WHERE m.conversation_id = ?
+        )`,
+    now,
+    conversationId,
+  );
+
+  if (total > 0) {
     log.info(
-      { conversationId, cancelled },
-      "Cancelled pending extraction jobs for failed conversation",
+      { conversationId, cancelled: total },
+      "Cancelled pending memory jobs for conversation",
     );
   }
 
-  return cancelled;
+  return total;
 }


### PR DESCRIPTION
## Summary
- Adds exported `cancelPendingJobsForConversation()` that cancels all pending/running memory jobs referencing a conversation's messages or conversationId
- Replaces the private `cancelPendingExtractionJobsForConversation` (which only handled `extract_items`) with the broader version
- Updates `invalidateAssistantInferredItemsForConversation` to use the new function

Part of plan: wipe-conv-memory-revert.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
