### PR TITLE
fix: use new-format workspace/ paths in import clearing tests

### DIFF
--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -378,12 +378,12 @@ describe("handleMigrationImport", () => {
   });
 
   test("workspace is cleared before restore — files are created fresh", async () => {
-    // With workspace clearing, existing files are removed before writing,
-    // so all files in the bundle are "created" (not "overwritten") and
-    // no backups are made.
+    // Only new-format bundles (workspace/ prefix) trigger workspace clearing.
+    // With clearing, existing files are removed before writing, so all files
+    // in the bundle are "created" (not "overwritten") and no backups are made.
     const newDbData = new Uint8Array([0x01, 0x02, 0x03]);
     const vbundle = createValidVBundle([
-      { path: "data/db/assistant.db", data: newDbData },
+      { path: "workspace/data/db/assistant.db", data: newDbData },
     ]);
     const req = new Request("http://localhost/v1/migrations/import", {
       method: "POST",
@@ -397,17 +397,20 @@ describe("handleMigrationImport", () => {
     expect(body.success).toBe(true);
     expect(body.summary.backups_created).toBe(0);
 
-    const dbFile = body.files.find((f) => f.path === "data/db/assistant.db");
+    const dbFile = body.files.find(
+      (f) => f.path === "workspace/data/db/assistant.db",
+    );
     expect(dbFile).toBeDefined();
     expect(dbFile!.action).toBe("created");
   });
 
   test("reports all files as created after workspace clear", async () => {
+    // New-format workspace/ paths trigger clearing — both files are fresh.
     const newDbData = new Uint8Array([0xaa, 0xbb]);
     const newConfigData = new TextEncoder().encode('{"provider":"openai"}');
     const vbundle = createValidVBundle([
-      { path: "data/db/assistant.db", data: newDbData },
-      { path: "config/settings.json", data: newConfigData },
+      { path: "workspace/data/db/assistant.db", data: newDbData },
+      { path: "workspace/config.json", data: newConfigData },
     ]);
     const req = new Request("http://localhost/v1/migrations/import", {
       method: "POST",
@@ -420,9 +423,11 @@ describe("handleMigrationImport", () => {
 
     expect(body.success).toBe(true);
 
-    const dbFile = body.files.find((f) => f.path === "data/db/assistant.db");
+    const dbFile = body.files.find(
+      (f) => f.path === "workspace/data/db/assistant.db",
+    );
     const configFile = body.files.find(
-      (f) => f.path === "config/settings.json",
+      (f) => f.path === "workspace/config.json",
     );
 
     // Both are "created" because workspace was cleared before writing


### PR DESCRIPTION
## Summary
- Two tests in `migration-import-commit-http.test.ts` were failing because they used old-format bundle paths (`data/db/assistant.db`, `config/settings.json`) while expecting workspace clearing behavior
- Workspace clearing was intentionally narrowed to only trigger for new-format `workspace/` prefix entries, but these tests weren't updated to match
- Updated both tests to use `workspace/` prefixed paths so the clearing logic triggers and the assertions hold

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23207676879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
