### PR TITLE
Add logoutWithToast extension and show error/success toast on logout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -169,7 +169,16 @@ extension AppDelegate {
             // Capture actor token before logout clears session state
             let actorToken = ActorTokenManager.getToken()
 
-            await authManager.logout()
+            // Capture managed status before logout clears UserDefaults
+            let wasManaged = isCurrentAssistantManaged
+
+            if !wasManaged {
+                await authManager.logoutWithToast { [weak self] msg, style in
+                    self?.mainWindow?.windowState.showToast(message: msg, style: style)
+                }
+            } else {
+                await authManager.logout()
+            }
 
             // Clear managed proxy credentials from the running daemon (local assistants only)
             if !isCurrentAssistantManaged && !isCurrentAssistantRemote {
@@ -232,9 +241,6 @@ extension AppDelegate {
             // Reset dock icon to default before tearing down UI
             AvatarAppearanceManager.shared.resetForDisconnect()
 
-            // Capture managed status before it gets reset during teardown
-            let wasManaged = isCurrentAssistantManaged
-
             if !wasManaged {
                 // Self-hosted (local or remote): clear auth state but keep the
                 // app running. The user can sign in again from Settings > General.
@@ -252,10 +258,6 @@ extension AppDelegate {
                 hasSetupDaemon = false
 
                 AvatarAppearanceManager.shared.reloadAvatar()
-                mainWindow?.windowState.showToast(
-                    message: "Logged out. You can log in again from Settings.",
-                    style: .success
-                )
             } else {
                 // Managed (platform): full teardown — close everything and
                 // show the reauth screen.
@@ -312,6 +314,7 @@ extension AppDelegate {
                 hasSetupApp = false
                 hasSetupDaemon = false
                 showAuthWindow(reusingWindow: detachedWindow)
+                authManager.errorMessage = nil
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AuthManager+LogoutToast.swift
+++ b/clients/macos/vellum-assistant/App/AuthManager+LogoutToast.swift
@@ -1,0 +1,17 @@
+import VellumAssistantShared
+
+extension AuthManager {
+    /// Performs logout, showing an error toast on HTTP failure or a success toast on clean logout.
+    /// Clears `errorMessage` after toasting so inline displays don't double-show.
+    func logoutWithToast(
+        showToast: @escaping (String, ToastInfo.Style) -> Void
+    ) async {
+        await logout()
+        if let error = errorMessage {
+            showToast(error, .error)
+            errorMessage = nil
+        } else {
+            showToast("Logged out. You can log in again from Settings.", .success)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create AuthManager+LogoutToast.swift with logoutWithToast(showToast:) mirroring the loginWithToast pattern
- Update performLogout() to use logoutWithToast for non-managed path, showing error toast on HTTP failure or success toast on clean logout
- Remove hardcoded success toast, capture wasManaged before logout clears UserDefaults

Part of plan: unify-logout-error-toast.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
