### PR TITLE
fix: preserve user-chosen service modes across app restarts

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -398,10 +398,9 @@ extension AppDelegate {
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
 
-                // After successful managed-proxy bootstrap, set all service modes to "managed".
-                // This overwrites the schema default ("your-own") that the daemon materializes
-                // on first load. If the user later switches mode in settings, the per-service
-                // setter will overwrite individual values.
+                // Set service modes to "managed" for any services that don't already have a
+                // mode configured. On first bootstrap this sets all three; on subsequent app
+                // restarts the user's existing choices are preserved.
                 WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "managed")
 
                 self.localBootstrapDidComplete = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -132,10 +132,8 @@ struct APIKeyEntryStepView: View {
         APIKeyManager.setKey(trimmed, for: "anthropic")
         APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
-        // After BYOK onboarding, set all service modes to "your-own".
-        // This overwrites the schema default that the daemon materializes on
-        // first load. If the user later switches mode in settings, the per-service
-        // setter will overwrite individual values.
+        // Set service modes to "your-own" for any services that don't already
+        // have a mode configured (first-time BYOK onboarding).
         WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own")
 
         saveModelToConfig("claude-opus-4-6")

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -94,24 +94,37 @@ public enum WorkspaceConfigIO {
         }
     }
 
-    /// Sets the service mode for all services (inference, image-generation, web-search).
+    /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").
+    /// Existing user-chosen modes are preserved so that app restarts don't reset preferences.
     public static func initializeServiceDefaults(defaultMode mode: String, into path: String? = nil) {
         let existingConfig = read(from: path)
         var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var changed = false
 
         var inference = services["inference"] as? [String: Any] ?? [:]
-        inference["mode"] = mode
-        services["inference"] = inference
+        if inference["mode"] == nil {
+            inference["mode"] = mode
+            services["inference"] = inference
+            changed = true
+        }
 
         var imageGen = services["image-generation"] as? [String: Any] ?? [:]
-        imageGen["mode"] = mode
-        services["image-generation"] = imageGen
+        if imageGen["mode"] == nil {
+            imageGen["mode"] = mode
+            services["image-generation"] = imageGen
+            changed = true
+        }
 
         var webSearch = services["web-search"] as? [String: Any] ?? [:]
-        webSearch["mode"] = mode
-        services["web-search"] = webSearch
+        if webSearch["mode"] == nil {
+            webSearch["mode"] = mode
+            services["web-search"] = webSearch
+            changed = true
+        }
 
-        try? merge(["services": services], into: path)
+        if changed {
+            try? merge(["services": services], into: path)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `WorkspaceConfigIO.initializeServiceDefaults()` now only sets service modes (inference, web search, image generation) when they aren't already configured
- Previously it unconditionally overwrote all modes to "managed" on every app restart during managed-proxy bootstrap, resetting user preferences
- On first bootstrap all three modes are still set; on subsequent restarts existing user choices are preserved

## Original prompt
When I restart the macos desktop app, these values get set back to managed in the UI even if I had them on your own before. Please investigate and fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
