### PR TITLE
fix: make NSTextView editable in workspace file editor

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -260,7 +260,14 @@ private struct LineNumberTextEditor: NSViewRepresentable {
         textContainer.widthTracksTextView = false
         layoutManager.addTextContainer(textContainer)
 
-        let textView = NSTextView(frame: .zero, textContainer: textContainer)
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+
+        let contentSize = scrollView.contentSize
+        let textView = NSTextView(frame: NSRect(origin: .zero, size: contentSize), textContainer: textContainer)
         textView.isEditable = true
         textView.isSelectable = true
         textView.allowsUndo = true
@@ -273,6 +280,8 @@ private struct LineNumberTextEditor: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 4, height: 8)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.minSize = NSSize(width: contentSize.width, height: 0)
         textView.maxSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -280,12 +289,7 @@ private struct LineNumberTextEditor: NSViewRepresentable {
         textView.string = text
         textView.delegate = context.coordinator
 
-        let scrollView = NSScrollView()
         scrollView.documentView = textView
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = true
-        scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = false
 
         // Install the line number ruler
         let ruler = LineNumberRulerView(textView: textView)
@@ -294,6 +298,11 @@ private struct LineNumberTextEditor: NSViewRepresentable {
         scrollView.rulersVisible = true
 
         context.coordinator.textView = textView
+
+        // Make the text view first responder so the user can immediately type
+        DispatchQueue.main.async {
+            textView.window?.makeFirstResponder(textView)
+        }
 
         return scrollView
     }


### PR DESCRIPTION
## Summary
- Fix the `LineNumberTextEditor` NSTextView not being editable after the line-numbers-in-edit-mode change
- Set `autoresizingMask = [.width]` and `minSize` so the text view properly fills the scroll view
- Create the scroll view first so the text view gets a proper initial frame from `contentSize`
- Make the text view first responder on appear so the cursor is immediately active

## Original prompt
the line numbers shouldn't go away when I click on the file to go into edit mode (follow-up fix for editability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
