### PR TITLE
feat: add `assistant conversations wipe` CLI command

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -10,8 +10,10 @@ import {
   createConversation,
   getConversation,
   getMessages,
+  wipeConversation,
 } from "../../memory/conversation-crud.js";
 import { listConversations } from "../../memory/conversation-queries.js";
+import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import {
   selectEmbeddingBackend,
   SPARSE_EMBEDDING_VERSION,
@@ -252,5 +254,82 @@ Examples:
       }
 
       log.info("Done.");
+    });
+
+  conversations
+    .command("wipe <conversationId>")
+    .description("Wipe a conversation and revert all memory changes it made")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  conversationId   Conversation ID (or unique prefix). Supports prefix matching.
+
+Permanently wipes the conversation and reverts all memory changes it caused:
+restores superseded memory items, deletes conversation summaries, and cancels
+pending memory jobs. This action cannot be undone.
+
+Examples:
+  $ assistant conversations wipe abc123
+  $ assistant conversations wipe abc123 --yes`,
+    )
+    .action(async (conversationId: string, opts?: { yes?: boolean }) => {
+      initializeDb();
+
+      // Resolve conversation with prefix matching (same pattern as `export`)
+      let conversation = getConversation(conversationId);
+      if (!conversation) {
+        const all = listConversations(Number.MAX_SAFE_INTEGER);
+        const match = all.find((c) => c.id.startsWith(conversationId));
+        if (match) {
+          conversation = match;
+        } else {
+          log.error(`Conversation not found: ${conversationId}`);
+          process.exit(1);
+        }
+      }
+
+      if (!opts?.yes) {
+        const readline = await import("node:readline");
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        const answer = await new Promise<string>((resolve) => {
+          rl.question(
+            `Wipe conversation "${conversation!.title ?? "Untitled"}" and revert all memory changes? (y/N) `,
+            resolve,
+          );
+        });
+        rl.close();
+        if (answer.toLowerCase() !== "y") {
+          log.info("Cancelled");
+          return;
+        }
+      }
+
+      const result = wipeConversation(conversation.id);
+
+      // Enqueue Qdrant cleanup
+      for (const segId of result.segmentIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "segment",
+          targetId: segId,
+        });
+      }
+      for (const itemId of result.orphanedItemIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "item",
+          targetId: itemId,
+        });
+      }
+
+      log.info(
+        `Wiped conversation "${conversation.title ?? "Untitled"}". ` +
+          `Restored ${result.unsupersededItemIds.length} memory items, ` +
+          `deleted ${result.deletedSummaryIds.length} summaries, ` +
+          `cancelled ${result.cancelledJobCount} jobs.`,
+      );
     });
 }


### PR DESCRIPTION
## Summary
- Adds `assistant conversations wipe <id>` CLI command with confirmation prompt
- Supports prefix matching for conversation IDs (same pattern as `export`)
- `--yes` flag to skip confirmation
- Prints summary of restored items, deleted summaries, and cancelled jobs

Part of plan: wipe-conv-memory-revert.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
