### PR TITLE
fix: use VIconView for Key saved indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -72,9 +72,12 @@ struct ImageGenerationServiceCard: View {
                             .foregroundColor(VColor.contentDefault)
 
                         if isConnected && apiKeyText.isEmpty {
-                            Label("Key saved", systemImage: "checkmark.circle.fill")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                            HStack(spacing: VSpacing.xs) {
+                                VIconView(.circleCheck, size: 12)
+                                Text("Key saved")
+                            }
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemPositiveStrong)
                         }
                     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -73,9 +73,12 @@ struct InferenceServiceCard: View {
                             .disabled(store.apiKeySaving)
 
                         if isConnected && apiKeyText.isEmpty {
-                            Label("Key saved", systemImage: "checkmark.circle.fill")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                            HStack(spacing: VSpacing.xs) {
+                                VIconView(.circleCheck, size: 12)
+                                Text("Key saved")
+                            }
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemPositiveStrong)
                         }
 
                         if let error = store.apiKeySaveError {

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -224,9 +224,12 @@ struct WebSearchServiceCard: View {
             .foregroundColor(VColor.contentDefault)
 
             if hasKey && keyText.isEmpty {
-                Label("Key saved", systemImage: "checkmark.circle.fill")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemPositiveStrong)
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleCheck, size: 12)
+                    Text("Key saved")
+                }
+                .font(VFont.caption)
+                .foregroundColor(VColor.systemPositiveStrong)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace `Label("Key saved", systemImage: "checkmark.circle.fill")` with `VIconView(.circleCheck)` + `Text("Key saved")` in HStack
- Applied across InferenceServiceCard, ImageGenerationServiceCard, and WebSearchServiceCard
- Addresses clients/AGENTS.md icon rule violation flagged in PR #18407

Addresses review feedback from #18407.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
