### PR TITLE
fix: fail export on checkpoint failure, narrow SQLite suffix filter

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -348,9 +348,9 @@ function walkDirectory(
         // with the live DB connection. The WAL is checkpointed before the
         // walk, so the main .db file has all committed rows.
         if (
-          entry.name.endsWith("-wal") ||
-          entry.name.endsWith("-shm") ||
-          entry.name.endsWith("-journal")
+          entry.name.endsWith(".db-wal") ||
+          entry.name.endsWith(".db-shm") ||
+          entry.name.endsWith(".db-journal")
         ) {
           continue;
         }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -148,19 +148,12 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       source: "runtime-export",
       description,
       checkpoint: () => {
+        const dbPath = getDbPath();
+        const db = new Database(dbPath);
         try {
-          const dbPath = getDbPath();
-          const db = new Database(dbPath);
-          try {
-            db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-          } finally {
-            db.close();
-          }
-        } catch (err) {
-          log.warn(
-            { err },
-            "WAL checkpoint failed — exporting without checkpoint",
-          );
+          db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+        } finally {
+          db.close();
         }
       },
     });


### PR DESCRIPTION
## Summary
- Abort vbundle export if WAL checkpoint fails instead of logging and continuing with incomplete data
- Narrow SQLite auxiliary file exclusion from generic `-wal/-shm/-journal` suffix to `*.db-wal/*.db-shm/*.db-journal` to prevent false positives

Addresses review feedback from #18417.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
