### PR TITLE
fix: align task-memory-cleanup test with conversation_wiped error string

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -842,7 +842,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     // Two jobs for the failed conversation should be cancelled
     expect(failedJobs).toHaveLength(2);
     for (const j of failedJobs) {
-      expect(j.lastError).toBe("conversation_failed");
+      expect(j.lastError).toBe("conversation_wiped");
     }
 
     // The job for the other conversation should remain pending


### PR DESCRIPTION
## Summary
- The source `task-memory-cleanup.ts` was updated in #18424 to use `"conversation_wiped"` as the `lastError` string when cancelling pending jobs, but the test still expected `"conversation_failed"`
- Updated the test assertion to match the current source behavior

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23208144570/job/67449259330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
