### PR TITLE
fix: clear errorMessage after logout on iOS to prevent stale error display

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -137,7 +137,12 @@ struct DaemonConnectionSection: View {
                         LabeledContent("Name", value: display)
                     }
                     Button("Log Out", role: .destructive) {
-                        Task { await authManager.logout() }
+                        Task {
+                            await authManager.logout()
+                            // Clear any stale error from a failed logout HTTP request so it
+                            // doesn't appear inline next to the login button on iOS.
+                            authManager.errorMessage = nil
+                        }
                     }
                 } else {
                     Button {

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -175,7 +175,12 @@ struct AccountSection: View {
                     LabeledContent("Name", value: display)
                 }
                 Button("Log Out", role: .destructive) {
-                    Task { await authManager.logout() }
+                    Task {
+                        await authManager.logout()
+                        // Clear any stale error from a failed logout HTTP request so it
+                        // doesn't appear inline next to the login button on iOS.
+                        authManager.errorMessage = nil
+                    }
                 }
             } else {
                 Button {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-logout-error-toast.md.

**Gap:** iOS logout callers show stale/confusing errorMessage after failed logout
**What was expected:** All callers of AuthManager.logout() should handle the new errorMessage behavior (now sets error on HTTP failure instead of clearing)
**What was found:** iOS call sites display errorMessage inline — a failed logout HTTP request would leave a confusing network error visible next to the login button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
