### PR TITLE
fix: prevent title model from generating refusal-style titles

### DIFF
--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -146,7 +146,6 @@ export async function generateAndPersistConversationTitle(
       signal: combinedSignal,
     },
   );
-
   const textBlock = response.content.find((b) => b.type === "text");
   if (textBlock && textBlock.type === "text") {
     let title = normalizeTitle(textBlock.text);
@@ -312,7 +311,7 @@ function buildTitlePrompt(
   assistantResponse?: string,
 ): string {
   const parts: string[] = [
-    "Generate a very short title for this conversation. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting.",
+    "Generate a very short title summarizing the TOPIC of this conversation. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the message, do NOT assess feasibility, and do NOT comment on your own capabilities.",
   ];
 
   if (context) {
@@ -369,7 +368,7 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
 
 function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
   const parts: string[] = [
-    "Generate a very short title for this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting.",
+    "Generate a very short title summarizing the TOPIC of this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the messages, do NOT assess feasibility, and do NOT comment on your own capabilities.",
     "",
     "Recent messages:",
   ];


### PR DESCRIPTION
## Summary
- Fix title generation prompts to tell the LLM to summarize the **topic** of the conversation, not respond to the message
- Haiku was producing titles like "Unable to Access External Websites" when users asked to read a URL, because it was treating the user message as a prompt to answer rather than a topic to title
- Updated both `buildTitlePrompt` and `buildRegenerationPrompt` with explicit instructions to not assess feasibility or comment on capabilities

## Test plan
- [ ] Send a message like "can you read https://example.com?" and verify the title describes the topic (e.g. "Read Example Website") rather than a refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
