### PR TITLE
feat(macos): persist dock icon with assistant avatar after window close

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -251,7 +251,17 @@ extension AppDelegate {
     /// visible.  Called from the global window-close observer and from
     /// individual window dismiss handlers (e.g. crash report) that may run
     /// before `setupWindowObserver()` is installed.
+    ///
+    /// Keeps the dock icon visible when a connected assistant exists so the
+    /// user can click it to re-open the window. Only reverts after explicit
+    /// disconnect (logout, retire, switch assistant).
     func revertActivationPolicyIfNoWindows(excluding closedWindow: NSWindow? = nil) {
+        // Keep the dock icon alive while the user has a connected assistant —
+        // they can click the dock icon to re-open the main window.
+        if UserDefaults.standard.string(forKey: "connectedAssistantId") != nil {
+            return
+        }
+
         let hasVisibleWindows = NSApp.windows.contains { win in
             win.isVisible
             && win !== closedWindow

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -4,14 +4,14 @@ import VellumAssistantShared
 import SwiftUI
 
 /// Delegate that intercepts the window close button to hide the window
-/// instead of closing it, keeping the app running in the menu bar.
+/// instead of closing it, keeping the app running in the dock + menu bar.
+/// The dock icon stays visible (with the assistant's avatar) so the user
+/// can click it to re-open the window. The dock icon only disappears on
+/// explicit disconnect (logout, retire, switch assistant).
 @MainActor
 private class MainWindowCloseDelegate: NSObject, NSWindowDelegate {
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         sender.orderOut(nil)
-        // Switch to accessory policy so the app disappears from the dock
-        // but remains accessible via the menu bar status item.
-        NSApp.setActivationPolicy(.accessory)
         return false
     }
 }


### PR DESCRIPTION
## Summary
- Stop switching to `.accessory` activation policy when the main window is closed — the dock icon now stays visible with the assistant's avatar
- Guard `revertActivationPolicyIfNoWindows` to skip the revert when a connected assistant exists, preventing other window closures (e.g. Settings) from hiding the dock icon while the main window is hidden
- The dock icon only disappears on explicit disconnect: logout, retire, or switch assistant

## Original prompt
If I don't explicitly log out / retire my assistant / switch assistants, I want the dock icon to continue to be my active assistant's avatar even after I close the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
