### PR TITLE
test: add tests for `wipeConversation()`

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -1,0 +1,368 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "conv-wipe-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  getConversation,
+  getMessages,
+  wipeConversation,
+} from "../memory/conversation-crud.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+
+// Initialize db once before all tests
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("wipeConversation", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM memory_item_sources`);
+    db.run(`DELETE FROM memory_segments`);
+    db.run(`DELETE FROM memory_items`);
+    db.run(`DELETE FROM memory_summaries`);
+    db.run(`DELETE FROM memory_embeddings`);
+    db.run(`DELETE FROM memory_jobs`);
+    db.run(`DELETE FROM tool_invocations`);
+    db.run(`DELETE FROM llm_request_logs`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("wipes conversation and all messages", async () => {
+    const conv = createConversation("test");
+    await addMessage(conv.id, "user", "first message");
+    await addMessage(conv.id, "assistant", "second message");
+    await addMessage(conv.id, "user", "third message");
+
+    wipeConversation(conv.id);
+
+    expect(getConversation(conv.id)).toBeNull();
+    expect(getMessages(conv.id)).toEqual([]);
+  });
+
+  test("restores explicitly superseded memory items", async () => {
+    const convA = createConversation("conversation A");
+    const msgA = await addMessage(convA.id, "user", "I like blue");
+
+    const convB = createConversation("conversation B");
+    const msgB = await addMessage(convB.id, "user", "I like red");
+
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert itemA: active preference about color
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('itemA', 'active', 'preference', 'color', 'likes blue', 0.8, 'fp-a', 'default', ${now}, ${now})`,
+    );
+
+    // Insert itemB: active preference about color, supersedes itemA
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, supersedes, first_seen_at, last_seen_at)
+       VALUES ('itemB', 'active', 'preference', 'color', 'likes red', 0.9, 'fp-b', 'default', 'itemA', ${now}, ${now})`,
+    );
+
+    // Mark itemA as superseded by itemB
+    db.run(
+      `UPDATE memory_items SET status = 'superseded', superseded_by = 'itemB' WHERE id = 'itemA'`,
+    );
+
+    // Link itemA to convA's message, itemB to convB's message
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemA', '${msgA.id}', ${now})`,
+    );
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemB', '${msgB.id}', ${now})`,
+    );
+
+    const result = wipeConversation(convB.id);
+
+    // itemA should be restored to active with superseded_by cleared
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+    const itemARow = raw
+      .query("SELECT status, superseded_by FROM memory_items WHERE id = 'itemA'")
+      .get() as { status: string; superseded_by: string | null } | null;
+    expect(itemARow).not.toBeNull();
+    expect(itemARow!.status).toBe("active");
+    expect(itemARow!.superseded_by).toBeNull();
+
+    // itemB should no longer exist (orphaned and deleted by deleteConversation)
+    const itemBRow = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client
+      .query("SELECT * FROM memory_items WHERE id = 'itemB'")
+      .get();
+    expect(itemBRow).toBeNull();
+
+    expect(result.unsupersededItemIds).toContain("itemA");
+  });
+
+  test("does not restore superseded items when superseding item has other sources", async () => {
+    const convA = createConversation("conversation A");
+    const msgA = await addMessage(convA.id, "user", "I like red in A");
+
+    const convB = createConversation("conversation B");
+    const msgB = await addMessage(convB.id, "user", "I like red in B");
+
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert itemOld (will be superseded)
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('itemOld', 'active', 'preference', 'color', 'likes blue', 0.8, 'fp-old', 'default', ${now}, ${now})`,
+    );
+
+    // Insert itemNew (supersedes itemOld)
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, supersedes, first_seen_at, last_seen_at)
+       VALUES ('itemNew', 'active', 'preference', 'color', 'likes red', 0.9, 'fp-new', 'default', 'itemOld', ${now}, ${now})`,
+    );
+
+    // Mark itemOld as superseded
+    db.run(
+      `UPDATE memory_items SET status = 'superseded', superseded_by = 'itemNew' WHERE id = 'itemOld'`,
+    );
+
+    // Link itemNew to BOTH conversations
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgA.id}', ${now})`,
+    );
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgB.id}', ${now})`,
+    );
+
+    wipeConversation(convA.id);
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // itemOld should still be superseded because itemNew has another source (convB)
+    const itemOldRow = raw
+      .query("SELECT status FROM memory_items WHERE id = 'itemOld'")
+      .get() as { status: string } | null;
+    expect(itemOldRow).not.toBeNull();
+    expect(itemOldRow!.status).toBe("superseded");
+
+    // itemNew should still exist (has source from convB)
+    const itemNewRow = raw
+      .query("SELECT * FROM memory_items WHERE id = 'itemNew'")
+      .get();
+    expect(itemNewRow).not.toBeNull();
+  });
+
+  test("restores orphaned subject-match superseded items", async () => {
+    const convB = createConversation("conversation B");
+    const msgB = await addMessage(convB.id, "user", "I use vim");
+
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert itemOld: superseded with no superseded_by link
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('itemOld', 'superseded', 'preference', 'editor', 'uses emacs', 0.7, 'fp-old', 'default', ${now}, ${now})`,
+    );
+
+    // Insert itemNew: active, same kind/subject/scope_id
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('itemNew', 'active', 'preference', 'editor', 'uses vim', 0.9, 'fp-new', 'default', ${now}, ${now})`,
+    );
+
+    // Link itemNew to convB's message
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgB.id}', ${now})`,
+    );
+
+    wipeConversation(convB.id);
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // itemOld should now be active (restored as orphaned subject-match superseded item)
+    const itemOldRow = raw
+      .query("SELECT status FROM memory_items WHERE id = 'itemOld'")
+      .get() as { status: string } | null;
+    expect(itemOldRow).not.toBeNull();
+    expect(itemOldRow!.status).toBe("active");
+  });
+
+  test("deletes conversation summaries", async () => {
+    const conv = createConversation("test");
+    await addMessage(conv.id, "user", "hello");
+
+    const db = getDb();
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert a conversation-scoped summary
+    raw
+      .query(
+        `INSERT INTO memory_summaries (id, scope, scope_key, summary, token_estimate, version, scope_id, start_at, end_at, created_at, updated_at)
+         VALUES ('sum-1', 'conversation', ?, 'test summary', 100, 1, 'default', ?, ?, ?, ?)`,
+      )
+      .run(conv.id, now, now, now, now);
+
+    // Insert a corresponding embedding
+    raw
+      .query(
+        `INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+         VALUES ('emb-sum-1', 'summary', 'sum-1', 'test', 'test', 384, ?, ?)`,
+      )
+      .run(now, now);
+
+    const result = wipeConversation(conv.id);
+
+    // Summary should be deleted
+    const summaryRow = raw
+      .query("SELECT * FROM memory_summaries WHERE id = 'sum-1'")
+      .get();
+    expect(summaryRow).toBeNull();
+
+    // Embedding should be deleted
+    const embeddingRow = raw
+      .query("SELECT * FROM memory_embeddings WHERE id = 'emb-sum-1'")
+      .get();
+    expect(embeddingRow).toBeNull();
+
+    expect(result.deletedSummaryIds).toContain("sum-1");
+  });
+
+  test("cancels pending memory jobs", async () => {
+    const conv = createConversation("test");
+    const msg = await addMessage(conv.id, "user", "hello", undefined, {
+      skipIndexing: true,
+    });
+
+    // Clear any jobs that might have been created by prior operations
+    const db = getDb();
+    db.run(`DELETE FROM memory_jobs`);
+
+    enqueueMemoryJob("extract_items", { messageId: msg.id });
+    enqueueMemoryJob("build_conversation_summary", {
+      conversationId: conv.id,
+    });
+
+    const result = wipeConversation(conv.id);
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Both jobs should be failed with conversation_wiped error
+    const jobs = raw
+      .query("SELECT status, last_error FROM memory_jobs")
+      .all() as Array<{ status: string; last_error: string | null }>;
+
+    for (const job of jobs) {
+      // Skip embed_item jobs enqueued by wipeConversation's unsupersede logic
+      if (job.status === "pending") continue;
+      expect(job.status).toBe("failed");
+      expect(job.last_error).toContain("conversation_wiped");
+    }
+
+    expect(result.cancelledJobCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("wipe of empty conversation succeeds", () => {
+    const conv = createConversation("empty");
+
+    const result = wipeConversation(conv.id);
+
+    expect(getConversation(conv.id)).toBeNull();
+    expect(result.segmentIds).toEqual([]);
+    expect(result.orphanedItemIds).toEqual([]);
+    expect(result.unsupersededItemIds).toEqual([]);
+    expect(result.deletedSummaryIds).toEqual([]);
+    expect(result.cancelledJobCount).toBe(0);
+  });
+
+  test("does not affect other conversations", async () => {
+    const convA = createConversation("conversation A");
+    await addMessage(convA.id, "user", "message in A");
+
+    const convB = createConversation("conversation B");
+    const msgB = await addMessage(convB.id, "user", "message in B");
+
+    const db = getDb();
+    const now = Date.now();
+
+    // Insert a memory item sourced from convB's message
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('itemB', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-b', 'default', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemB', '${msgB.id}', ${now})`,
+    );
+
+    wipeConversation(convA.id);
+
+    // convB should still exist
+    expect(getConversation(convB.id)).not.toBeNull();
+    expect(getMessages(convB.id)).toHaveLength(1);
+
+    // convB's memory item should still exist
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+    const itemBRow = raw
+      .query("SELECT * FROM memory_items WHERE id = 'itemB'")
+      .get();
+    expect(itemBRow).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `conversation-wipe.test.ts` with 8 test cases covering all wipe behaviors
- Tests verify supersession reversion (both explicit and subject-match), summary cleanup, job cancellation, and cross-conversation isolation

Part of plan: wipe-conv-memory-revert.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
