### PR TITLE
Add confirmation modal to inference save flow for web search impact

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -18,6 +18,8 @@ struct InferenceServiceCard: View {
     @State private var draftMode: String = "your-own"
     /// Snapshot of the model at card appear — used to detect model-only changes.
     @State private var initialModel: String = ""
+    /// Whether to show the web search impact confirmation alert.
+    @State private var showWebSearchAlert = false
 
     private var isConnected: Bool {
         store.hasKey
@@ -25,6 +27,24 @@ struct InferenceServiceCard: View {
 
     private var isLoggedIn: Bool {
         authManager.isAuthenticated
+    }
+
+    /// True when changing inference mode would invalidate the current web search config.
+    private var wouldInvalidateWebSearch: Bool {
+        let modeChanging = draftMode != store.inferenceMode
+        guard modeChanging else { return false }
+
+        // Switching to Your Own inference while web search is Managed
+        // (managed web search requires managed inference).
+        if draftMode == "your-own" && store.webSearchMode == "managed" {
+            return true
+        }
+        // Switching to Managed inference while web search uses Provider Native
+        // (Provider Native requires Your Own inference).
+        if draftMode == "managed" && store.webSearchProvider == "inference-provider-native" {
+            return true
+        }
+        return false
     }
 
     /// True when the user has made changes worth saving.
@@ -101,6 +121,15 @@ struct InferenceServiceCard: View {
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
         }
+        .alert("Heads up", isPresented: $showWebSearchAlert) {
+            Button("Go Back", role: .cancel) {}
+            Button("Continue") { performSave() }
+        } message: {
+            Text(
+                "Changing your inference mode will also update your Web Search settings."
+                    + " You'll need to review and save them below."
+            )
+        }
     }
 
     // MARK: - Managed Login Prompt
@@ -152,6 +181,14 @@ struct InferenceServiceCard: View {
     // MARK: - Save
 
     private func save() {
+        if wouldInvalidateWebSearch {
+            showWebSearchAlert = true
+            return
+        }
+        performSave()
+    }
+
+    private func performSave() {
         store.apiKeySaveError = nil
 
         // Persist mode if changed


### PR DESCRIPTION
## Summary
- When saving inference mode changes that would invalidate the current web search configuration, show a native macOS alert before proceeding
- Two trigger conditions: switching to Your Own inference while web search is Managed, or switching to Managed inference while web search provider is Provider Native
- On "Go Back" the save is cancelled; on "Continue" the save proceeds and the existing auto-correction in WebSearchServiceCard handles the web search state

## Original prompt
Add a confirmation modal to the Inference card save flow. When saving inference mode changes that would invalidate the current web search configuration (Managed→Your Own while web search is Managed, OR Your Own→Managed while web search provider is "inference-provider-native"), show a modal with:

Title: "Heads up"
Body: "Changing your inference mode will also update your Web Search settings. You'll need to review and save them below."
Buttons: "Go Back" / "Continue"

On "Go Back": dismiss modal, don't save.
On "Continue": dismiss modal, proceed with save (which triggers the existing auto-correction in WebSearchServiceCard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
