### PR TITLE
fix(macos): resolve strict-concurrency warning on forwardedEnvKeys

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -80,7 +80,7 @@ final class AssistantCli {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
-    private static let forwardedEnvKeys: [String] = [
+    private nonisolated(unsafe) static let forwardedEnvKeys: [String] = [
         "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",


### PR DESCRIPTION
## Summary
- Mark `AssistantCli.forwardedEnvKeys` as `nonisolated(unsafe)` to fix a Swift strict-concurrency warning where a `@MainActor`-isolated static property was accessed from the `nonisolated` method `makeBaseEnvironment()`
- Safe because the property is an immutable `let` constant of a `Sendable` type (`[String]`)

## Original prompt
Fix: Swift warning — main actor-isolated static property `forwardedEnvKeys` can not be referenced from a nonisolated context (error in Swift 6 language mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
