### PR TITLE
fix: make WAL checkpoint best-effort in migration export

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -149,11 +149,18 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       description,
       checkpoint: () => {
         const dbPath = getDbPath();
-        const db = new Database(dbPath);
         try {
-          db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-        } finally {
-          db.close();
+          const db = new Database(dbPath);
+          try {
+            db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+          } finally {
+            db.close();
+          }
+        } catch (err) {
+          // Best-effort: if the DB can't be checkpointed (e.g. not a valid
+          // SQLite file, missing WAL, etc.) we still proceed with the export
+          // using whatever is on disk.
+          log.warn({ err }, "WAL checkpoint failed — exporting without checkpoint");
         }
       },
     });


### PR DESCRIPTION
## Summary
- Wrapped the WAL checkpoint callback in `handleMigrationExport` with a try/catch so that checkpoint failures (e.g. invalid/missing SQLite DB) log a warning instead of crashing the entire export with a 500
- This is the correct production behavior too — checkpoint is best-effort WAL flushing, and a failure shouldn't prevent exporting what's on disk

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23208513860/job/67450564318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
