### PR TITLE
fix: enqueue Qdrant cleanup for deleted summaries in wipe callers

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -324,6 +324,12 @@ Examples:
           targetId: itemId,
         });
       }
+      for (const summaryId of result.deletedSummaryIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "summary",
+          targetId: summaryId,
+        });
+      }
 
       log.info(
         `Wiped conversation "${conversation.title ?? "Untitled"}". ` +

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -151,6 +151,12 @@ export function conversationManagementRouteDefinitions(
             targetId: itemId,
           });
         }
+        for (const summaryId of result.deletedSummaryIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "summary",
+            targetId: summaryId,
+          });
+        }
         log.info(
           {
             conversationId: resolvedId,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for wipe-conv-memory-revert.md.

**Gap:** Missing Qdrant vector cleanup for deleted summaries
**What was expected:** Both HTTP endpoint and CLI should enqueue delete_qdrant_vectors for deletedSummaryIds
**What was found:** Only segmentIds and orphanedItemIds were cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
