### PR TITLE
fix: parameterize job cancellation reason for task-failure vs wipe paths

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -842,7 +842,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     // Two jobs for the failed conversation should be cancelled
     expect(failedJobs).toHaveLength(2);
     for (const j of failedJobs) {
-      expect(j.lastError).toBe("conversation_wiped");
+      expect(j.lastError).toBe("conversation_failed");
     }
 
     // The job for the other conversation should remain pending

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -45,7 +45,7 @@ export function invalidateAssistantInferredItemsForConversation(
   // Cancel pending memory jobs for this conversation's messages
   // so the worker never processes them. Jobs already running will be
   // caught by the isConversationFailed check in the extraction handler.
-  cancelPendingJobsForConversation(conversationId);
+  cancelPendingJobsForConversation(conversationId, "conversation_failed");
 
   const affected = rawRun(
     `UPDATE memory_items
@@ -101,6 +101,7 @@ export function invalidateAssistantInferredItemsForConversation(
  */
 export function cancelPendingJobsForConversation(
   conversationId: string,
+  reason: string = "conversation_wiped",
 ): number {
   const now = Date.now();
   let total = 0;
@@ -109,12 +110,13 @@ export function cancelPendingJobsForConversation(
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
-            last_error = 'conversation_wiped',
+            last_error = ?,
             updated_at = ?
       WHERE status IN ('pending', 'running')
         AND json_extract(payload, '$.messageId') IN (
           SELECT id FROM messages WHERE conversation_id = ?
         )`,
+    reason,
     now,
     conversationId,
   );
@@ -123,10 +125,11 @@ export function cancelPendingJobsForConversation(
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
-            last_error = 'conversation_wiped',
+            last_error = ?,
             updated_at = ?
       WHERE status IN ('pending', 'running')
         AND json_extract(payload, '$.conversationId') = ?`,
+    reason,
     now,
     conversationId,
   );
@@ -135,7 +138,7 @@ export function cancelPendingJobsForConversation(
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
-            last_error = 'conversation_wiped',
+            last_error = ?,
             updated_at = ?
       WHERE status IN ('pending', 'running')
         AND json_extract(payload, '$.itemId') IN (
@@ -144,6 +147,7 @@ export function cancelPendingJobsForConversation(
             JOIN messages m ON m.id = mis.message_id
            WHERE m.conversation_id = ?
         )`,
+    reason,
     now,
     conversationId,
   );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for wipe-conv-memory-revert.md.

**Gap:** Task-failure error string changed to 'conversation_wiped'
**What was expected:** Task failures should use 'conversation_failed', wipes should use 'conversation_wiped'
**What was found:** Both paths used 'conversation_wiped'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
