### PR TITLE
fix(macos): remove LSUIElement so dock icon persists with assistant avatar

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -233,7 +233,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 
 ## Key Constraints
 
-- **LSUIElement app** — no dock icon; uses `.accessory` activation policy. Must temporarily switch to `.regular` when showing Settings window.
+- **Dock icon** — the app always shows a dock icon (no `LSUIElement`). The dock icon displays the assistant's avatar via `applicationIconImage`. On explicit disconnect (logout/retire/switch with no remaining assistants), `setActivationPolicy(.accessory)` hides the dock icon.
 - **`Bundle.main.bundleIdentifier` is nil** in SPM builds. All `os.Logger` instances use hardcoded fallback `"com.vellum.vellum-assistant"`.
 - **Adding .swift files**: Auto-picked up by SPM. No manual project file edits needed. New files go in `vellum-assistant/` (library target); only `@main` entry point lives in `vellum-assistant-app/`.
 - **Popover close delay** — 300ms initial delay before session starts to let the popover close and target app regain focus.

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -729,8 +729,6 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>6.0</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
-    <key>LSUIElement</key>
-    <true/>
     $LSE_ENVIRONMENT_PLIST
     $COMMIT_SHA_PLIST
     <key>LSMinimumSystemVersion</key>

--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -9,14 +9,13 @@ struct VellumAssistantApp: App {
         // The Settings scene exists solely to host the .commands menu items
         // below.  It renders EmptyView — no actual content — but SwiftUI
         // still creates a managed NSWindow for it.  During activation-policy
-        // transitions (.accessory → .regular) macOS can restore/show this
-        // window, producing a "ghost" blank window that appears as a second
-        // app instance.
+        // transitions (e.g. .accessory → .regular on disconnect/reconnect)
+        // macOS can restore/show this window, producing a "ghost" blank
+        // window.
         //
         // Mitigations (see AppDelegate):
         //  • Saved frame removed on every launch to prevent restoration.
         //  • NSWindow.allowsAutomaticWindowTabbing = false.
-        //  • Policy transitions only happen synchronously on window close.
         //  • dismissSettingsGhostWindows() runs after each policy transition.
         Settings {
             EmptyView()

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>LSUIElement</key>
-    <true/>
     <key>NSScreenRecordingUsageDescription</key>
     <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
## Summary
- Remove `LSUIElement` from both `Info.plist` (SPM) and `build.sh` (release) so the app always has a dock presence
- The dock icon displays the assistant's avatar via `applicationIconImage` (existing behavior)
- On explicit disconnect (logout/retire/switch with no remaining assistants), the app still switches to `.accessory` activation policy to hide the dock icon
- Update CLAUDE.md to reflect the new dock icon behavior

## Original prompt
If I don't explicitly log out / retire my assistant / switch assistants, I want the dock icon to continue to be my active assistant's avatar even after I close the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
