### PR TITLE
fix(macos): fix build errors in HighlightedTextView and AssistantCli

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -80,7 +80,7 @@ final class AssistantCli {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
-    private static let forwardedEnvKeys: [String] = [
+    nonisolated(unsafe) private static let forwardedEnvKeys: [String] = [
         "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -169,11 +169,18 @@ struct HighlightedTextView: View {
 
                         // Text content — scrolls both directions
                         ScrollView(.horizontal, showsIndicators: true) {
-                            Text(highlightedText)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: true, vertical: false)
-                                .padding(.vertical, VSpacing.sm)
-                                .padding(.horizontal, VSpacing.md)
+                            Group {
+                                if isEditable {
+                                    Text(highlightedText)
+                                        .textSelection(.disabled)
+                                } else {
+                                    Text(highlightedText)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                            .fixedSize(horizontal: true, vertical: false)
+                            .padding(.vertical, VSpacing.sm)
+                            .padding(.horizontal, VSpacing.md)
                         }
                         .frame(minWidth: geometry.size.width - gutterWidth)
                     }


### PR DESCRIPTION
## Summary
- Fix `HighlightedTextView` compile error: `.textSelection(isEditable ? .disabled : .enabled)` fails because the ternary branches produce incompatible types (`DisabledTextSelectability` vs `EnabledTextSelectability`). Use `Group` with `if/else` instead.
- Fix `AssistantCli` warning (error in Swift 6): restore `nonisolated(unsafe)` on `forwardedEnvKeys` so the `nonisolated` function `makeBaseEnvironment()` can access it.

## Original prompt
Fix macOS build errors: type mismatch in `.textSelection()` ternary and main-actor isolation warning on `forwardedEnvKeys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
