### PR TITLE
fix(macos): add nonisolated to forwardedEnvKeys for nonisolated access

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -80,7 +80,7 @@ final class AssistantCli {
 
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
-    private static let forwardedEnvKeys: [String] = [
+    nonisolated private static let forwardedEnvKeys: [String] = [
         "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",


### PR DESCRIPTION
## Summary
- Added `nonisolated` modifier to `forwardedEnvKeys` static property on the `@MainActor` class `AssistantCli`
- This fixes the Swift 6 language mode warning where the main actor-isolated property was referenced from the `nonisolated` `makeBaseEnvironment()` method
- Safe because the property is an immutable `let` of `Sendable` type `[String]`

## Original prompt
Fix: warning: main actor-isolated static property 'forwardedEnvKeys' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
