### PR TITLE
fix(macos): prevent text wrapping in workspace editor to keep line numbers aligned

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -50,10 +50,14 @@ struct HighlightedTextView: View {
 
     /// TextEditor-based editable view with a pure SwiftUI line number gutter.
     /// Reuses the same gutter pattern as the read-only view for consistency.
+    /// Wraps the editor in a horizontal ScrollView to prevent text wrapping,
+    /// which would misalign line numbers with their corresponding lines.
     private var editableView: some View {
         let lines = text.components(separatedBy: "\n")
         let lineCount = lines.count
         let gutterWidth = gutterWidth(for: lineCount)
+        let maxLineLength = lines.map(\.count).max() ?? 0
+        let contentMinWidth = CGFloat(maxLineLength) * Self.charWidth + VSpacing.md * 2
 
         return VStack(spacing: 0) {
             if isSearchVisible {
@@ -66,17 +70,24 @@ struct HighlightedTextView: View {
             }
 
             GeometryReader { geometry in
+                let availableWidth = geometry.size.width - gutterWidth
                 ScrollView([.vertical]) {
                     HStack(alignment: .top, spacing: 0) {
                         lineNumberGutter(lineCount: lineCount, width: gutterWidth)
 
-                        TextEditor(text: editableBinding)
-                            .font(VFont.mono)
-                            .foregroundStyle(VColor.contentDefault)
-                            .scrollContentBackground(.hidden)
-                            .scrollDisabled(true)
-                            .background(Self.editorBackground)
-                            .frame(minWidth: geometry.size.width - gutterWidth)
+                        ScrollView(.horizontal, showsIndicators: true) {
+                            TextEditor(text: editableBinding)
+                                .font(VFont.mono)
+                                .foregroundStyle(VColor.contentDefault)
+                                .scrollContentBackground(.hidden)
+                                .scrollDisabled(true)
+                                .background(Self.editorBackground)
+                                .frame(
+                                    minWidth: max(availableWidth, contentMinWidth),
+                                    minHeight: geometry.size.height
+                                )
+                        }
+                        .frame(minWidth: availableWidth)
                     }
                     .frame(minHeight: geometry.size.height, alignment: .topLeading)
                 }
@@ -256,6 +267,15 @@ struct HighlightedTextView: View {
         let nsFont = NSFont(name: "DMMono-Regular", size: 13)
             ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         return ceil(nsFont.ascender - nsFont.descender + nsFont.leading)
+    }()
+
+    /// Width of a single monospace character, used to calculate the minimum editor
+    /// width that prevents text wrapping and keeps line numbers aligned.
+    private static let charWidth: CGFloat = {
+        let nsFont = NSFont(name: "DMMono-Regular", size: 13)
+            ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let attributes: [NSAttributedString.Key: Any] = [.font: nsFont]
+        return ("M" as NSString).size(withAttributes: attributes).width
     }()
 
     private func gutterWidth(for lineCount: Int) -> CGFloat {


### PR DESCRIPTION
## Summary
- Wrapped the edit-mode `TextEditor` in a horizontal `ScrollView` to prevent text wrapping, matching the read-only view's horizontal scroll behavior
- Added a `charWidth` static property (computed from font metrics) to calculate the minimum editor width based on the longest line
- Long lines now scroll horizontally instead of wrapping, keeping line numbers perfectly aligned with their content

## Original prompt
When I go into edit mode the lines become misaligned with the line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
