### PR TITLE
fix(macos): make Cmd+Q hide window instead of quitting to preserve dock avatar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -156,6 +156,7 @@ extension AppDelegate {
             }
             DispatchQueue.main.async {
                 self?.assistantCli.stop()
+                self?.isExplicitTermination = true
                 NSApp.terminate(nil)
             }
         }
@@ -724,6 +725,7 @@ extension AppDelegate {
                 failAlert.runModal()
             }
 
+            self.isExplicitTermination = true
             NSApp.terminate(nil)
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -265,11 +265,19 @@ extension AppDelegate {
         restartItem.image = VIcon.refreshCw.nsImage
         menu.addItem(restartItem)
 
-        let quitItem = NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(performExplicitQuit), keyEquivalent: "q")
+        quitItem.target = self
         quitItem.image = VIcon.power.nsImage
         menu.addItem(quitItem)
 
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 2), in: button)
+    }
+
+    /// Explicitly quit the app (status bar menu "Quit"). Bypasses the
+    /// Cmd+Q hide behavior by setting `isExplicitTermination`.
+    @objc func performExplicitQuit() {
+        isExplicitTermination = true
+        NSApp.terminate(nil)
     }
 
     @objc func markAllConversationsSeen() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -97,6 +97,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     #if !DEBUG
     var keychainBroker: KeychainBrokerServer?
     #endif
+
+    /// When true, `applicationShouldTerminate` allows the app to quit.
+    /// Set before calling `NSApp.terminate` in explicit flows (restart,
+    /// logout, uninstall, update). When false, Cmd+Q hides the window
+    /// instead of quitting so the dock icon keeps showing the avatar.
+    var isExplicitTermination = false
     var windowObserver: Any?
     /// Timestamp of the last `showMainWindow` call that performed work.
     /// Used by the debounce guard in `showMainWindow()`.
@@ -190,7 +196,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             if let existing = others.first {
                 log.info("[singleInstance] Another instance (pid \(existing.processIdentifier)) detected — activating it and terminating self")
                 existing.activate()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                    self?.isExplicitTermination = true
                     NSApp.terminate(nil)
                 }
                 return
@@ -433,6 +440,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     }
 
     // MARK: - Application Lifecycle
+
+    public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // Always allow termination for explicit flows (restart, logout,
+        // uninstall, update) — they set isExplicitTermination = true.
+        if isExplicitTermination {
+            return .terminateNow
+        }
+
+        // When a connected assistant exists, Cmd+Q hides the window
+        // instead of quitting so the dock icon keeps the avatar.
+        if UserDefaults.standard.string(forKey: "connectedAssistantId") != nil {
+            mainWindow?.hide()
+            return .terminateCancel
+        }
+
+        return .terminateNow
+    }
 
     public func applicationWillTerminate(_ notification: Notification) {
         // If Sparkle has a deferred update ready, install it now during

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -452,6 +452,7 @@ struct MainWindowView: View {
                     tooltip: updateManager.isDeferredUpdateReady ? "Restart to install the latest version" : "A new version is available"
                 ) {
                     if updateManager.isDeferredUpdateReady {
+                        AppDelegate.shared?.isExplicitTermination = true
                         NSApp.terminate(nil)
                     } else {
                         updateManager.checkForUpdates()


### PR DESCRIPTION
## Summary
- Add `applicationShouldTerminate` to intercept Cmd+Q: when a connected assistant exists, hides the main window and cancels termination so the dock icon keeps showing the avatar
- Explicit quit paths (restart, logout, uninstall, update restart, status-bar Quit menu) set `isExplicitTermination = true` to bypass the guard and terminate normally
- Status bar "Quit" menu item now routes through `performExplicitQuit` instead of directly calling `NSApp.terminate`

## Original prompt
If I don't explicitly log out / retire my assistant / switch assistants, I want the dock icon to continue to be my active assistant's avatar even after I close the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
