### PR TITLE
Shorten voice mode button tooltip

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -520,11 +520,8 @@ struct ComposerView: View {
                 )
                 .disabled(!hasAPIKey)
                 .popover(isPresented: $showVoiceModeHover, arrowEdge: .top) {
-                    Text("Start a live voice conversation with your assistant. Unlike the mic button, this is a real-time back-and-forth voice call.")
+                    Text("Live voice conversation (not dictation)")
                         .font(VFont.caption)
-                        .multilineTextAlignment(.leading)
-                        .frame(width: 200)
-                        .fixedSize(horizontal: false, vertical: true)
                         .padding(VSpacing.sm)
                 }
                 .onHover { hovering in


### PR DESCRIPTION
## Summary
- Replace verbose voice mode tooltip with concise "Live voice conversation (not dictation)"
- Remove unnecessary frame/multiline modifiers since the text now fits on one line

## Original prompt
replace the help description of the live voice conversation button in the composer with "Live voice conversation (not dictation)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
