### PR TITLE
revert: undo Cmd+Q hide behavior

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -156,7 +156,6 @@ extension AppDelegate {
             }
             DispatchQueue.main.async {
                 self?.assistantCli.stop()
-                self?.isExplicitTermination = true
                 NSApp.terminate(nil)
             }
         }
@@ -725,7 +724,6 @@ extension AppDelegate {
                 failAlert.runModal()
             }
 
-            self.isExplicitTermination = true
             NSApp.terminate(nil)
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -265,19 +265,11 @@ extension AppDelegate {
         restartItem.image = VIcon.refreshCw.nsImage
         menu.addItem(restartItem)
 
-        let quitItem = NSMenuItem(title: "Quit", action: #selector(performExplicitQuit), keyEquivalent: "q")
-        quitItem.target = self
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         quitItem.image = VIcon.power.nsImage
         menu.addItem(quitItem)
 
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 2), in: button)
-    }
-
-    /// Explicitly quit the app (status bar menu "Quit"). Bypasses the
-    /// Cmd+Q hide behavior by setting `isExplicitTermination`.
-    @objc func performExplicitQuit() {
-        isExplicitTermination = true
-        NSApp.terminate(nil)
     }
 
     @objc func markAllConversationsSeen() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -97,12 +97,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     #if !DEBUG
     var keychainBroker: KeychainBrokerServer?
     #endif
-
-    /// When true, `applicationShouldTerminate` allows the app to quit.
-    /// Set before calling `NSApp.terminate` in explicit flows (restart,
-    /// logout, uninstall, update). When false, Cmd+Q hides the window
-    /// instead of quitting so the dock icon keeps showing the avatar.
-    var isExplicitTermination = false
     var windowObserver: Any?
     /// Timestamp of the last `showMainWindow` call that performed work.
     /// Used by the debounce guard in `showMainWindow()`.
@@ -196,8 +190,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             if let existing = others.first {
                 log.info("[singleInstance] Another instance (pid \(existing.processIdentifier)) detected — activating it and terminating self")
                 existing.activate()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                    self?.isExplicitTermination = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     NSApp.terminate(nil)
                 }
                 return
@@ -440,23 +433,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     }
 
     // MARK: - Application Lifecycle
-
-    public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        // Always allow termination for explicit flows (restart, logout,
-        // uninstall, update) — they set isExplicitTermination = true.
-        if isExplicitTermination {
-            return .terminateNow
-        }
-
-        // When a connected assistant exists, Cmd+Q hides the window
-        // instead of quitting so the dock icon keeps the avatar.
-        if UserDefaults.standard.string(forKey: "connectedAssistantId") != nil {
-            mainWindow?.hide()
-            return .terminateCancel
-        }
-
-        return .terminateNow
-    }
 
     public func applicationWillTerminate(_ notification: Notification) {
         // If Sparkle has a deferred update ready, install it now during

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -456,7 +456,6 @@ struct MainWindowView: View {
                     tooltip: updateManager.isDeferredUpdateReady ? "Restart to install the latest version" : "A new version is available"
                 ) {
                     if updateManager.isDeferredUpdateReady {
-                        AppDelegate.shared?.isExplicitTermination = true
                         NSApp.terminate(nil)
                     } else {
                         updateManager.checkForUpdates()


### PR DESCRIPTION
## Summary
- Reverts #18457 which made Cmd+Q hide the window instead of quitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
