### PR TITLE
fix: scope Step F subject-match restore to wiped conversation's items

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -232,6 +232,75 @@ describe("wipeConversation", () => {
     expect(itemOldRow!.status).toBe("active");
   });
 
+  test("does not restore superseded items from unrelated conversations", async () => {
+    // convA has an item that superseded an older item — convA was previously
+    // deleted via regular deleteConversation, leaving the old item superseded
+    // with superseded_by = NULL. When we later wipe convB, Step F should NOT
+    // restore that unrelated item.
+    const convA = createConversation("conversation A");
+    const msgA = await addMessage(convA.id, "user", "I use dark theme");
+
+    const convB = createConversation("conversation B");
+    const msgB = await addMessage(convB.id, "user", "I use vim");
+
+    const db = getDb();
+    const now = Date.now();
+
+    // unrelatedOld: superseded item from an old conversation (e.g. "uses light theme")
+    // Its superseder was deleted in a prior deleteConversation, leaving
+    // superseded_by = NULL.
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('unrelatedOld', 'superseded', 'preference', 'theme', 'uses light theme', 0.7, 'fp-unrelated', 'default', ${now}, ${now})`,
+    );
+
+    // convA's active item that superseded unrelatedOld — we simulate the
+    // case where convA was already deleted, leaving unrelatedOld with
+    // superseded_by = NULL and no active replacement.
+    // (We don't actually insert the superseder — just leave unrelatedOld
+    // as a superseded item with no superseded_by and no active match.)
+
+    // convB's items — itemOld is superseded by itemNew (subject: editor)
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('editorOld', 'superseded', 'preference', 'editor', 'uses emacs', 0.7, 'fp-editor-old', 'default', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+       VALUES ('editorNew', 'active', 'preference', 'editor', 'uses vim', 0.9, 'fp-editor-new', 'default', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('editorNew', '${msgB.id}', ${now})`,
+    );
+
+    const result = wipeConversation(convB.id);
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // editorOld SHOULD be restored (its kind+subject matches an orphaned item from convB)
+    const editorOldRow = raw
+      .query("SELECT status FROM memory_items WHERE id = 'editorOld'")
+      .get() as { status: string } | null;
+    expect(editorOldRow).not.toBeNull();
+    expect(editorOldRow!.status).toBe("active");
+
+    // unrelatedOld should NOT be restored — it was superseded by a different
+    // conversation's item (theme, not editor) and has nothing to do with convB
+    const unrelatedOldRow = raw
+      .query("SELECT status FROM memory_items WHERE id = 'unrelatedOld'")
+      .get() as { status: string } | null;
+    expect(unrelatedOldRow).not.toBeNull();
+    expect(unrelatedOldRow!.status).toBe("superseded");
+
+    // Only editorOld should be in the unsuperseded list, not unrelatedOld
+    expect(result.unsupersededItemIds).toContain("editorOld");
+    expect(result.unsupersededItemIds).not.toContain("unrelatedOld");
+  });
+
   test("deletes conversation summaries", async () => {
     const conv = createConversation("test");
     await addMessage(conv.id, "user", "hello");

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -441,6 +441,28 @@ export function wipeConversation(id: string): WipeConversationResult {
   // Step D — Get the conversation's memoryScopeId before deletion.
   const scopeId = getConversationMemoryScopeId(id);
 
+  // Step D.5 — Collect kind + subject pairs of items that will be orphaned
+  // by deleteConversation. These are items sourced from this conversation's
+  // messages that have NO sources from any other conversation. We need this
+  // before deletion so we can scope Step F to only restore superseded items
+  // matching the specific kind + subject pairs that just lost their active
+  // replacement.
+  const orphanedKindSubjects = rawAll<{ kind: string; subject: string }>(
+    `SELECT DISTINCT mi.kind, mi.subject
+     FROM memory_items mi
+     JOIN memory_item_sources mis ON mis.memory_item_id = mi.id
+     JOIN messages m ON m.id = mis.message_id
+     WHERE m.conversation_id = ?
+       AND NOT EXISTS (
+         SELECT 1 FROM memory_item_sources mis2
+         JOIN messages m2 ON m2.id = mis2.message_id
+         WHERE mis2.memory_item_id = mi.id
+           AND m2.conversation_id != ?
+       )`,
+    id,
+    id,
+  );
+
   // Step E — Delegate to deleteConversation which handles messages (cascade
   // segments, item_sources, attachments), llmRequestLogs, toolInvocations,
   // orphaned memory items + embeddings, and the conversation row.
@@ -449,22 +471,35 @@ export function wipeConversation(id: string): WipeConversationResult {
   // Step F — Restore orphaned subject-match superseded items. After
   // deleteConversation removes superseding items, find superseded items
   // with no supersededBy link where no active item with the same
-  // kind + subject + scope_id exists.
-  const orphanedSuperseded = rawAll<{ id: string }>(
-    `SELECT id FROM memory_items
-     WHERE status = 'superseded'
-       AND superseded_by IS NULL
-       AND scope_id = ?
-       AND NOT EXISTS (
-         SELECT 1 FROM memory_items mi2
-         WHERE mi2.kind = memory_items.kind
-           AND mi2.subject = memory_items.subject
-           AND mi2.scope_id = memory_items.scope_id
-           AND mi2.status = 'active'
-           AND mi2.id != memory_items.id
-       )`,
-    scopeId,
-  );
+  // kind + subject + scope_id exists. Scoped to only the kind + subject
+  // pairs of items that were just orphaned by deleteConversation, so we
+  // don't accidentally restore items superseded by unrelated conversations.
+  let orphanedSuperseded: Array<{ id: string }> = [];
+  if (orphanedKindSubjects.length > 0) {
+    const placeholders = orphanedKindSubjects
+      .map(() => "(?, ?)")
+      .join(", ");
+    const params: Array<string> = [scopeId];
+    for (const { kind, subject } of orphanedKindSubjects) {
+      params.push(kind, subject);
+    }
+    orphanedSuperseded = rawAll<{ id: string }>(
+      `SELECT id FROM memory_items
+       WHERE status = 'superseded'
+         AND superseded_by IS NULL
+         AND scope_id = ?
+         AND (kind, subject) IN (VALUES ${placeholders})
+         AND NOT EXISTS (
+           SELECT 1 FROM memory_items mi2
+           WHERE mi2.kind = memory_items.kind
+             AND mi2.subject = memory_items.subject
+             AND mi2.scope_id = memory_items.scope_id
+             AND mi2.status = 'active'
+             AND mi2.id != memory_items.id
+         )`,
+      ...params,
+    );
+  }
   for (const { id: itemId } of orphanedSuperseded) {
     rawRun("UPDATE memory_items SET status = 'active' WHERE id = ?", itemId);
     enqueueMemoryJob("embed_item", { itemId });


### PR DESCRIPTION
## Summary
Fixes integration review gap: Step F in wipeConversation was over-broad.

**Gap:** Step F restored ALL superseded items with no active replacement in the scope, not just items superseded by the wiped conversation.
**Fix:** Collect kind+subject pairs of orphaned items before deletion, then scope the restore query to only those pairs.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
