### PR TITLE
fix: resolve conversation key in cancel endpoint to prevent silent no-op

### DIFF
--- a/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
+++ b/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression test: POST /v1/conversations/:id/cancel must resolve the
+ * conversation key to the internal conversation ID before calling
+ * cancelGeneration(). Without resolveConversationId(), the cancel
+ * endpoint receives the client's local conversation key (which differs
+ * from the daemon's internal ID), fails to find the conversation, and
+ * silently ignores the cancel — leaving the stream running.
+ */
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "cancel-resolve-key-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+}));
+
+import { getOrCreateConversation } from "../memory/conversation-key-store.js";
+import { initializeDb, resetDb } from "../memory/db.js";
+import { conversationManagementRouteDefinitions } from "../runtime/routes/conversation-management-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("POST /v1/conversations/:id/cancel", () => {
+  test("resolves conversation key to internal ID before cancelling", () => {
+    // Create a conversation via key — this assigns an internal ID that
+    // differs from the key.
+    const conversationKey = "client-local-uuid-abc123";
+    const mapping = getOrCreateConversation(conversationKey);
+    const internalId = mapping.conversationId;
+
+    // Sanity: key and internal ID should differ.
+    expect(internalId).not.toBe(conversationKey);
+
+    // Track which ID cancelGeneration receives.
+    let cancelledId: string | undefined;
+    const routes = conversationManagementRouteDefinitions({
+      switchConversation: async () => null,
+      renameConversation: () => false,
+      clearAllConversations: () => 0,
+      cancelGeneration: (id) => {
+        cancelledId = id;
+        return true;
+      },
+      destroyConversation: () => {},
+      undoLastMessage: async () => null,
+      regenerateResponse: async () => null,
+    });
+
+    const cancelRoute = routes.find(
+      (r) => r.endpoint === "conversations/:id/cancel",
+    )!;
+
+    // Simulate the HTTP handler with the conversation KEY (what the
+    // macOS client sends — it uses the key, not the internal ID).
+    cancelRoute.handler({
+      params: { id: conversationKey },
+      req: new Request("http://localhost/v1/conversations/x/cancel", {
+        method: "POST",
+      }),
+      url: new URL("http://localhost/v1/conversations/x/cancel"),
+      server: undefined as never,
+      authContext: undefined as never,
+    });
+
+    // cancelGeneration must receive the INTERNAL ID, not the raw key.
+    expect(cancelledId).toBe(internalId);
+  });
+
+  test("falls back to raw ID when key is not in the mapping", () => {
+    let cancelledId: string | undefined;
+    const routes = conversationManagementRouteDefinitions({
+      switchConversation: async () => null,
+      renameConversation: () => false,
+      clearAllConversations: () => 0,
+      cancelGeneration: (id) => {
+        cancelledId = id;
+        return true;
+      },
+      destroyConversation: () => {},
+      undoLastMessage: async () => null,
+      regenerateResponse: async () => null,
+    });
+
+    const cancelRoute = routes.find(
+      (r) => r.endpoint === "conversations/:id/cancel",
+    )!;
+
+    // Use an ID that isn't a known key — should pass through as-is.
+    const directId = "direct-conversation-id";
+    cancelRoute.handler({
+      params: { id: directId },
+      req: new Request("http://localhost/v1/conversations/x/cancel", {
+        method: "POST",
+      }),
+      url: new URL("http://localhost/v1/conversations/x/cancel"),
+      server: undefined as never,
+      authContext: undefined as never,
+    });
+
+    expect(cancelledId).toBe(directId);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -216,7 +216,8 @@ export function conversationManagementRouteDefinitions(
       method: "POST",
       policyKey: "conversations/cancel",
       handler: ({ params }) => {
-        deps.cancelGeneration(params.id);
+        const resolvedId = resolveConversationId(params.id) ?? params.id;
+        deps.cancelGeneration(resolvedId);
         return new Response(null, { status: 202 });
       },
     },


### PR DESCRIPTION
## Summary
- The cancel endpoint (`POST /v1/conversations/:id/cancel`) was passing the raw URL param directly to `cancelGeneration()` without calling `resolveConversationId()` first
- The macOS client sends its local conversation key (which differs from the daemon's internal conversation ID), so `cancelGeneration()` couldn't find the conversation and silently returned `false` — the stream kept running despite the user clicking stop
- Every other conversation management endpoint (delete, undo, regenerate) already uses `resolveConversationId()`, but cancel was missed

## Test plan
- [x] Added `cancel-resolves-conversation-key.test.ts` that verifies the cancel handler resolves keys to internal IDs (fails without the fix)
- [ ] Manual: ask the assistant to read a long page, click stop while streaming — streaming should stop immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
