### PR TITLE
feat: inject identity context into conversation starters

### DIFF
--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -9,6 +9,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { loadSkillCatalog } from "../../config/skills.js";
+import { buildCoreIdentityContext } from "../../prompts/system-prompt.js";
 import {
   createTimeout,
   extractToolUse,
@@ -168,13 +169,15 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   const now = new Date();
   const timeContext = `Current time: ${now.toLocaleString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit", hour12: true })}`;
 
+  const identityContext = buildCoreIdentityContext();
+
   const systemPrompt = `You are generating 4 conversation starters for a personal assistant app. These appear as clickable chips on the empty conversation page — the first thing the user sees when they open the app.
 
 ${timeContext}
 
 Your goal: look at what's going on in this person's life right now and suggest the 4 most useful things they could ask you to do. Think about what a thoughtful chief of staff would proactively bring up in a 30-second check-in.
 
-## What you know
+${identityContext ? `## Assistant identity & user profile\n\n${identityContext}\n\n` : ""}## What you know
 
 ${rollup}
 ${diff}


### PR DESCRIPTION
## Summary
- Route conversation starters generation through `buildCoreIdentityContext` so the LLM has access to IDENTITY.md, SOUL.md, and USER.md when crafting suggestions
- Makes starters more contextually aware and aligned with the assistant's voice and user profile

## Test plan
- [ ] Verify conversation starters still generate successfully
- [ ] Confirm starters reflect identity/personality context when present
- [ ] Verify no regression when prompt files are absent (buildCoreIdentityContext returns null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
