### PR TITLE
fix(macos): use NSLayoutManager line height to fix gutter drift in editor

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -261,12 +261,14 @@ struct HighlightedTextView: View {
         .background(Self.gutterBackground)
     }
 
-    /// Line height for the text content font, computed from actual NSFont metrics
-    /// so the gutter stays aligned even if the font or size changes.
+    /// Line height for the text content font, derived from NSLayoutManager so the
+    /// gutter matches the actual line spacing NSTextView uses (which rounds each
+    /// metric component individually rather than ceiling the sum).
     private static let lineHeight: CGFloat = {
         let nsFont = NSFont(name: "DMMono-Regular", size: 13)
             ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        return ceil(nsFont.ascender - nsFont.descender + nsFont.leading)
+        let layoutManager = NSLayoutManager()
+        return layoutManager.defaultLineHeight(for: nsFont)
     }()
 
     /// Width of a single monospace character, used to calculate the minimum editor


### PR DESCRIPTION
## Summary
- Replaced manual `ceil(ascender - descender + leading)` line height computation with `NSLayoutManager.defaultLineHeight(for:)` which matches the actual line spacing used by NSTextView
- The previous `ceil()` of the sum differed from how the text system rounds each metric component individually, causing a fractional-pixel-per-line error that accumulated into visible vertical drift between line numbers and text content

## Original prompt
When I go into edit mode the lines become misaligned with the line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
