### PR TITLE
feat(macos): show assistant name as dock label instead of "Vellum"

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 import Foundation
 import VellumAssistantShared
 import os
@@ -122,6 +123,7 @@ final class AvatarAppearanceManager {
         loadAvatarComponents()
         watchAvatarFile()
         watchTraitsFile()
+        updateDockLabel()
 
         // Fire-and-forget: fetch character component definitions from the
         // daemon and populate AvatarComponentStore.shared so downstream
@@ -150,6 +152,7 @@ final class AvatarAppearanceManager {
                 self.cachedFallbackName = nil
                 self.cachedFullFallbackAvatar = nil
                 self.cachedFullFallbackName = nil
+                self.updateDockLabel()
             }
         }
     }
@@ -256,7 +259,9 @@ final class AvatarAppearanceManager {
         cachedFallbackName = nil
         cachedFullFallbackAvatar = nil
         cachedFullFallbackName = nil
+        assistantName = "V"
         updateDockIcon()
+        updateDockLabel()
     }
 
     func clearCustomAvatar() {
@@ -479,6 +484,50 @@ final class AvatarAppearanceManager {
 
         NSApplication.shared.applicationIconImage = icon
         NSApp.dockTile.display()
+    }
+
+    // MARK: - Dock Label
+
+    /// Default app name used for the dock label when no assistant is connected.
+    private static let defaultDockLabel = "Vellum"
+
+    /// Updates the dock label (text under the icon) to the assistant's name.
+    /// Writes `CFBundleDisplayName` into the running app bundle's Info.plist
+    /// and re-registers with LaunchServices so the Dock picks up the change.
+    private func updateDockLabel() {
+        // Use the assistant's name if it's a real name (not the single-letter
+        // avatar fallback "V"); otherwise revert to the default app name.
+        let label = assistantName.count > 1 ? assistantName : Self.defaultDockLabel
+
+        guard let bundleURL = Bundle.main.bundleURL as URL?,
+              bundleURL.pathExtension == "app" else { return }
+
+        let plistURL = bundleURL.appendingPathComponent("Contents/Info.plist")
+        guard FileManager.default.isWritableFile(atPath: plistURL.path),
+              let data = FileManager.default.contents(atPath: plistURL.path),
+              var plist = try? PropertyListSerialization.propertyList(
+                  from: data, format: nil
+              ) as? [String: Any] else { return }
+
+        // Skip the write if the label is already correct.
+        if plist["CFBundleDisplayName"] as? String == label { return }
+
+        plist["CFBundleDisplayName"] = label
+
+        guard let updated = try? PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0
+        ) else { return }
+
+        do {
+            try updated.write(to: plistURL)
+        } catch {
+            log.warning("Failed to update dock label: \(error.localizedDescription)")
+            return
+        }
+
+        // Tell LaunchServices to re-read the bundle so the Dock picks up
+        // the new display name.
+        LSRegisterURL(bundleURL as CFURL, true)
     }
 
     // MARK: - Image Utilities


### PR DESCRIPTION
## Summary
- Add `updateDockLabel()` to `AvatarAppearanceManager` that writes the assistant's name as `CFBundleDisplayName` in the app bundle's Info.plist and calls `LSRegisterURL` to refresh LaunchServices
- Called on startup, identity change, and disconnect (reverts to "Vellum")
- Falls back to "Vellum" when no real assistant name is set (single-letter avatar fallback)

## Original prompt
Can we change the name of the app in the doc to be the name of the assistant?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
