### PR TITLE
fix: sync manual channel connection state after credential writes

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -70,6 +70,29 @@ mock.module("../oauth/oauth-store.js", () => {
   };
 });
 
+let manualConnectionStore: Record<string, string> = {};
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  syncManualTokenConnection: async (providerKey: string) => {
+    const { credentialKey } = await import("../security/credential-key.js");
+    const { getSecureKeyAsync } = await import("../security/secure-keys.js");
+
+    if (providerKey === "slack_channel") {
+      const hasBotToken = !!(await getSecureKeyAsync(
+        credentialKey("slack_channel", "bot_token"),
+      ));
+      const hasAppToken = !!(await getSecureKeyAsync(
+        credentialKey("slack_channel", "app_token"),
+      ));
+      if (hasBotToken && hasAppToken) {
+        manualConnectionStore[providerKey] = "active";
+      } else {
+        delete manualConnectionStore[providerKey];
+      }
+    }
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Mock public ingress URL — not available in unit tests. The connect
 // orchestrator dynamically imports this for non-interactive flows.
@@ -122,6 +145,10 @@ const _ctx: ToolContext = {
   conversationId: "test-conv",
   trustClass: "guardian",
 };
+
+beforeEach(() => {
+  manualConnectionStore = {};
+});
 
 afterAll(() => {
   mock.restore();
@@ -504,6 +531,41 @@ describe("credential_store tool — prompt action", () => {
     expect(meta!.allowedTools).toEqual(["browser_fill_credential"]);
     expect(meta!.allowedDomains).toEqual(["github.com"]);
     expect(meta!.usageDescription).toBe("GitHub login");
+  });
+
+  test("chat-style slack_channel prompts create the manual connection once both tokens exist", async () => {
+    const promptValues = ["xapp-test-token", "xoxb-test-token"];
+    const ctxWithPrompt: ToolContext = {
+      ..._ctx,
+      requestSecret: async () => ({
+        value: promptValues.shift() ?? "",
+        delivery: "store" as const,
+      }),
+    };
+
+    const appResult = await credentialStoreTool.execute(
+      {
+        action: "prompt",
+        service: "slack_channel",
+        field: "app_token",
+        label: "App-Level Token",
+      },
+      ctxWithPrompt,
+    );
+    expect(appResult.isError).toBe(false);
+    expect(manualConnectionStore["slack_channel"]).toBeUndefined();
+
+    const botResult = await credentialStoreTool.execute(
+      {
+        action: "prompt",
+        service: "slack_channel",
+        field: "bot_token",
+        label: "Bot User OAuth Token",
+      },
+      ctxWithPrompt,
+    );
+    expect(botResult.isError).toBe(false);
+    expect(manualConnectionStore["slack_channel"]).toBe("active");
   });
 
   test("prompt rejects invalid policy input", async () => {

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -148,6 +148,23 @@ mock.module("../oauth/manual-token-connection.js", () => ({
   removeManualTokenConnection: (providerKey: string) => {
     delete oauthConnectionStore[providerKey];
   },
+  syncManualTokenConnection: async (
+    providerKey: string,
+    accountInfo?: string,
+  ) => {
+    if (providerKey !== "slack_channel") return;
+    const hasBotToken = !!secureKeyStore[credentialKey("slack_channel", "bot_token")];
+    const hasAppToken = !!secureKeyStore[credentialKey("slack_channel", "app_token")];
+    if (hasBotToken && hasAppToken) {
+      oauthConnectionStore[providerKey] = {
+        id: `conn-${providerKey}`,
+        status: "active",
+        accountInfo: accountInfo ?? null,
+      };
+      return;
+    }
+    delete oauthConnectionStore[providerKey];
+  },
 }));
 
 // Mock credential metadata store
@@ -247,6 +264,17 @@ describe("Slack channel config handler", () => {
     expect(result.hasBotToken).toBe(true);
     expect(result.hasAppToken).toBe(true);
     expect(result.connected).toBe(true);
+  });
+
+  test("GET backfills the slack_channel connection row when chat setup stored both credentials", async () => {
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
+
+    const result = await getSlackChannelConfig();
+
+    expect(result.success).toBe(true);
+    expect(result.connected).toBe(true);
+    expect(oauthConnectionStore["slack_channel"]).toBeDefined();
   });
 
   test("GET reports per-field token presence independently of connection row", async () => {

--- a/assistant/src/__tests__/telegram-config.test.ts
+++ b/assistant/src/__tests__/telegram-config.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+let secureKeyStore: Record<string, string> = {};
+let oauthConnectionStore: Record<
+  string,
+  { id: string; status: string; accountInfo?: string | null }
+> = {};
+const syncCalls: Array<{ providerKey: string; accountInfo?: string }> = [];
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ telegram: {}, ui: {} }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  setNestedValue: () => {},
+}));
+
+mock.module("../inbound/platform-callback-registration.js", () => ({
+  registerCallbackRoute: async () => {},
+  shouldUsePlatformCallbacks: () => false,
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  log: {
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) =>
+    secureKeyStore[account] ?? undefined,
+  setSecureKeyAsync: async (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKeyAsync: async (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return "deleted" as const;
+    }
+    return "not-found" as const;
+  },
+}));
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (providerKey: string) =>
+    oauthConnectionStore[providerKey] ?? undefined,
+}));
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  ensureManualTokenConnection: async () => {},
+  removeManualTokenConnection: () => {},
+  syncManualTokenConnection: async (
+    providerKey: string,
+    accountInfo?: string,
+  ) => {
+    syncCalls.push({ providerKey, accountInfo });
+    if (providerKey !== "telegram") return;
+    const hasBotToken =
+      !!secureKeyStore[credentialKey("telegram", "bot_token")];
+    const hasWebhookSecret =
+      !!secureKeyStore[credentialKey("telegram", "webhook_secret")];
+    if (hasBotToken && hasWebhookSecret) {
+      oauthConnectionStore[providerKey] = {
+        id: `conn-${providerKey}`,
+        status: "active",
+        accountInfo: accountInfo ?? null,
+      };
+      return;
+    }
+    delete oauthConnectionStore[providerKey];
+  },
+}));
+
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotId: () => "123456",
+  getTelegramBotUsername: () => "testbot",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  deleteCredentialMetadata: () => true,
+  upsertCredentialMetadata: () => ({}),
+}));
+
+const originalFetch = globalThis.fetch;
+
+import { getTelegramConfig } from "../daemon/handlers/config-telegram.js";
+
+describe("Telegram config handler", () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    oauthConnectionStore = {};
+    syncCalls.length = 0;
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("GET backfills telegram connection metadata with @botUsername", async () => {
+    secureKeyStore[credentialKey("telegram", "bot_token")] = "123:abc";
+    secureKeyStore[credentialKey("telegram", "webhook_secret")] = "secret";
+
+    const result = await getTelegramConfig();
+
+    expect(result.success).toBe(true);
+    expect(result.botUsername).toBe("testbot");
+    expect(result.connected).toBe(true);
+    expect(syncCalls).toEqual([
+      { providerKey: "telegram", accountInfo: "@testbot" },
+    ]);
+    expect(oauthConnectionStore["telegram"]?.accountInfo).toBe("@testbot");
+  });
+});

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -5,6 +5,9 @@ import {
   type ManagedCredentialDescriptor,
 } from "../../credential-execution/managed-catalog.js";
 import {
+  syncManualTokenConnection,
+} from "../../oauth/manual-token-connection.js";
+import {
   disconnectOAuthProvider,
   getConnectionByProvider,
   listConnections,
@@ -439,6 +442,7 @@ Examples:
             usageDescription: opts.description,
             allowedTools,
           });
+          await syncManualTokenConnection(service);
 
           writeOutput(cmd, {
             ok: true,

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -8,6 +8,7 @@ import {
 import {
   ensureManualTokenConnection,
   removeManualTokenConnection,
+  syncManualTokenConnection,
 } from "../../oauth/manual-token-connection.js";
 import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -40,6 +41,12 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult> {
+  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+  const accountInfo = teamName
+    ? `${teamName}${botUsername ? ` (@${botUsername})` : ""}`
+    : undefined;
+  await syncManualTokenConnection("slack_channel", accountInfo);
+
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
   ));
@@ -49,7 +56,6 @@ export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult>
   const conn = getConnectionByProvider("slack_channel");
   const connected =
     !!(conn && conn.status === "active") && hasBotToken && hasAppToken;
-  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
     hasBotToken,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -70,7 +70,11 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export async function getTelegramConfig(): Promise<TelegramConfigResult> {
-  await syncManualTokenConnection("telegram");
+  const botUsername = getTelegramBotUsername();
+  await syncManualTokenConnection(
+    "telegram",
+    botUsername ? `@${botUsername}` : undefined,
+  );
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("telegram", "bot_token"),
   ));
@@ -80,7 +84,6 @@ export async function getTelegramConfig(): Promise<TelegramConfigResult> {
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
   const botId = getTelegramBotId();
-  const botUsername = getTelegramBotUsername();
   return {
     success: true,
     hasBotToken,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -11,6 +11,7 @@ import {
 import {
   ensureManualTokenConnection,
   removeManualTokenConnection,
+  syncManualTokenConnection,
 } from "../../oauth/manual-token-connection.js";
 import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -69,6 +70,7 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export async function getTelegramConfig(): Promise<TelegramConfigResult> {
+  await syncManualTokenConnection("telegram");
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("telegram", "bot_token"),
   ));

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -66,6 +66,53 @@ export function removeManualTokenConnection(providerKey: string): void {
 }
 
 /**
+ * Reconcile the synthetic oauth_connection row for a manual-token provider
+ * with whatever credentials are currently present in secure storage.
+ *
+ * This lets generic credential entry paths (chat setup, CLI, secure prompt)
+ * keep connection status in sync without duplicating per-provider rules.
+ */
+export async function syncManualTokenConnection(
+  providerKey: string,
+  accountInfo?: string,
+): Promise<void> {
+  switch (providerKey) {
+    case "telegram": {
+      const hasBotToken = !!(await getSecureKeyAsync(
+        credentialKey("telegram", "bot_token"),
+      ));
+      const hasWebhookSecret = !!(await getSecureKeyAsync(
+        credentialKey("telegram", "webhook_secret"),
+      ));
+      if (hasBotToken && hasWebhookSecret) {
+        await ensureManualTokenConnection(providerKey, accountInfo);
+      } else {
+        removeManualTokenConnection(providerKey);
+      }
+      return;
+    }
+
+    case "slack_channel": {
+      const hasBotToken = !!(await getSecureKeyAsync(
+        credentialKey("slack_channel", "bot_token"),
+      ));
+      const hasAppToken = !!(await getSecureKeyAsync(
+        credentialKey("slack_channel", "app_token"),
+      ));
+      if (hasBotToken && hasAppToken) {
+        await ensureManualTokenConnection(providerKey, accountInfo);
+      } else {
+        removeManualTokenConnection(providerKey);
+      }
+      return;
+    }
+
+    default:
+      return;
+  }
+}
+
+/**
  * Backfill oauth_connection rows for manual-token providers that already
  * have valid keychain credentials but are missing connection records.
  *
@@ -78,29 +125,6 @@ export function removeManualTokenConnection(providerKey: string): void {
  * connection row.
  */
 export async function backfillManualTokenConnections(): Promise<void> {
-  // Telegram: requires both bot_token and webhook_secret
-  if (!getConnectionByProvider("telegram")) {
-    const hasBotToken = !!(await getSecureKeyAsync(
-      credentialKey("telegram", "bot_token"),
-    ));
-    const hasWebhookSecret = !!(await getSecureKeyAsync(
-      credentialKey("telegram", "webhook_secret"),
-    ));
-    if (hasBotToken && hasWebhookSecret) {
-      await ensureManualTokenConnection("telegram");
-    }
-  }
-
-  // Slack channel: requires both bot_token and app_token
-  if (!getConnectionByProvider("slack_channel")) {
-    const hasBotToken = !!(await getSecureKeyAsync(
-      credentialKey("slack_channel", "bot_token"),
-    ));
-    const hasAppToken = !!(await getSecureKeyAsync(
-      credentialKey("slack_channel", "app_token"),
-    ));
-    if (hasBotToken && hasAppToken) {
-      await ensureManualTokenConnection("slack_channel");
-    }
-  }
+  await syncManualTokenConnection("telegram");
+  await syncManualTokenConnection("slack_channel");
 }

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { setSentryOrganizationId } from "../../instrument.js";
+import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -217,6 +218,7 @@ export async function handleAddSecret(
           );
         }
         upsertCredentialMetadata(service, field, {});
+        await syncManualTokenConnection(service);
         if (service === "vellum" && field === "platform_base_url") {
           setPlatformBaseUrl(effectiveValue);
         }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,5 +1,6 @@
 import { getConfig } from "../../config/loader.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
+import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import {
   disconnectOAuthProvider,
   getAppByProviderAndClientId,
@@ -344,6 +345,7 @@ class CredentialStoreTool implements Tool {
             "metadata write failed after storing credential",
           );
         }
+        await syncManualTokenConnection(service);
         const metadata = getCredentialMetadata(service, field);
         const credIdSuffix = metadata
           ? ` (credential_id: ${metadata.credentialId})`
@@ -725,6 +727,7 @@ class CredentialStoreTool implements Tool {
             "metadata write failed after storing credential",
           );
         }
+        await syncManualTokenConnection(service);
         const promptMeta = getCredentialMetadata(service, field);
         const promptCredIdSuffix = promptMeta
           ? ` (credential_id: ${promptMeta.credentialId})`


### PR DESCRIPTION
## Summary
- reconcile manual-token oauth_connection rows after generic credential writes so chat-driven Slack setup creates the same connected state as the settings flow
- self-heal Slack and Telegram config reads by backfilling missing manual-token connections from stored credentials
- add regression coverage for chat-style slack_channel credential prompts and Slack config backfill behavior

## Testing
- cd assistant && bun test src/__tests__/slack-channel-config.test.ts
- cd assistant && bun test src/__tests__/credential-vault-unit.test.ts
- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
