### PR TITLE
fix(macos): use lsregister CLI for dock label update

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -1,5 +1,4 @@
 import AppKit
-import CoreServices
 import Foundation
 import VellumAssistantShared
 import os
@@ -525,9 +524,18 @@ final class AvatarAppearanceManager {
             return
         }
 
-        // Tell LaunchServices to re-read the bundle so the Dock picks up
-        // the new display name.
-        LSRegisterURL(bundleURL as CFURL, true)
+        // Force LaunchServices to re-read the bundle so the Dock picks up
+        // the new display name. The deprecated LSRegisterURL API is
+        // unreliable on modern macOS; use the lsregister CLI tool instead.
+        let lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+        if FileManager.default.fileExists(atPath: lsregister) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: lsregister)
+            process.arguments = ["-f", bundleURL.path]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try? process.run()
+        }
     }
 
     // MARK: - Image Utilities


### PR DESCRIPTION
## Summary
- Replace deprecated `LSRegisterURL` API call with `lsregister -f` CLI tool which reliably force-updates the LaunchServices database on modern macOS
- Remove unused `CoreServices` import

## Original prompt
If I don't explicitly log out / retire my assistant / switch assistants, I want the dock icon to continue to be my active assistant's avatar even after I close the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
