### PR TITLE
feat: VSplitButton + tool confirmation redesign

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -851,19 +851,11 @@ private struct StepDetailRow: View {
                     .stroke(VColor.borderBase, lineWidth: 0.5)
             )
 
-            Button {
+            VButton(label: copyLabel, iconOnly: VIcon.copy.rawValue, style: .ghost, iconSize: 24, iconColor: VColor.contentTertiary) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(copyText, forType: .string)
-            } label: {
-                VIconView(.copy, size: 10)
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(width: 24, height: 24)
-                    .background(VColor.surfaceBase)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
             }
-            .buttonStyle(.plain)
             .padding(VSpacing.xs)
-            .accessibilityLabel(copyLabel)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -843,6 +843,7 @@ private struct StepDetailRow: View {
                 }
             }
             .padding(VSpacing.sm)
+            .padding(.trailing, VSpacing.xl) // reserve space for copy button
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(VColor.surfaceOverlay.opacity(0.6))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))

--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/JITPermissionView.swift
@@ -154,7 +154,7 @@ struct JITPermissionView: View {
                 permissionButton("Allow", isPrimary: false) {
                     manager.grantActivePermission()
                 }
-                permissionButton("Don't Allow", isPrimary: false) {
+                permissionButton("Deny", isPrimary: false) {
                     dismiss()
                 }
                 permissionButton("Always Allow", isPrimary: true) {

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -16,12 +16,13 @@ public struct VButton: View {
     public var size: Size = .regular
     public var tooltip: String? = nil
     public var accessibilityID: String? = nil
+    public var iconColor: Color? = nil
     public let action: () -> Void
 
     @State private var isHovered = false
     @FocusState private var isFocused: Bool
 
-    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, size: Size = .regular, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, size: Size = .regular, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, iconColor: Color? = nil, action: @escaping () -> Void) {
         self.label = label
         self.leftIcon = leftIcon ?? icon
         self.rightIcon = rightIcon
@@ -34,6 +35,7 @@ public struct VButton: View {
         self.size = size
         self.tooltip = tooltip
         self.accessibilityID = accessibilityID
+        self.iconColor = iconColor
         self.action = action
     }
 
@@ -44,7 +46,7 @@ public struct VButton: View {
                     VIconView(.resolve(iconOnly), size: 13)
                         .frame(width: 20, height: 20)
                 }
-                .foregroundColor(iconOnlyForegroundColor)
+                .foregroundColor(iconColor ?? iconOnlyForegroundColor)
             } else {
                 HStack(spacing: VSpacing.sm) {
                     if let leftIcon {

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+public struct VSplitButton<MenuContent: View>: View {
+    public let label: String
+    public var icon: String?
+    public var style: VButton.Style
+    public var isDisabled: Bool
+    public var accessibilityID: String?
+    public let action: () -> Void
+    @ViewBuilder public let menuContent: () -> MenuContent
+
+    @State private var isPrimaryHovered = false
+    @State private var isDropdownHovered = false
+
+    public init(
+        label: String,
+        icon: String? = nil,
+        style: VButton.Style = .primary,
+        isDisabled: Bool = false,
+        accessibilityID: String? = nil,
+        action: @escaping () -> Void,
+        @ViewBuilder menuContent: @escaping () -> MenuContent
+    ) {
+        self.label = label
+        self.icon = icon
+        self.style = style
+        self.isDisabled = isDisabled
+        self.accessibilityID = accessibilityID
+        self.action = action
+        self.menuContent = menuContent
+    }
+
+    public var body: some View {
+        let cornerRadius = VRadius.md
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+
+        HStack(spacing: 0) {
+            // Primary action zone
+            Button(action: action) {
+                HStack(spacing: VSpacing.sm) {
+                    if let icon {
+                        VIconView(.resolve(icon), size: 13)
+                    }
+                    Text(label)
+                        .font(VFont.bodyMedium)
+                }
+                .foregroundColor(foregroundColor)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.buttonV)
+                .frame(height: 32)
+                .background(zoneBackgroundColor(isHovered: isPrimaryHovered))
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                isPrimaryHovered = isDisabled ? false : hovering
+            }
+            .pointerCursor()
+
+            // Divider
+            divider
+
+            // Dropdown zone — visual layer + invisible Menu overlay
+            ZStack(alignment: .center) {
+                // Visual layer: background + centered icon
+                zoneBackgroundColor(isHovered: isDropdownHovered)
+                    .frame(width: 32, height: 32)
+
+                VIconView(.chevronDown, size: 11)
+                    .foregroundColor(foregroundColor)
+                    .frame(width: 32, height: 32)
+                    .allowsHitTesting(false)
+
+                // Interactive layer: fills entire zone
+                Menu {
+                    menuContent()
+                } label: {
+                    Color.clear
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+            }
+            .frame(width: 32, height: 32)
+            .clipped()
+            .onHover { hovering in
+                isDropdownHovered = isDisabled ? false : hovering
+            }
+            .pointerCursor()
+        }
+        .fixedSize()
+        .clipShape(shape)
+        .overlay(
+            shape.strokeBorder(
+                borderColor,
+                lineWidth: borderLineWidth
+            )
+        )
+        .contentShape(shape)
+        .disabled(isDisabled)
+        .accessibilityElement(children: .contain)
+        .optionalSplitButtonAccessibilityID(accessibilityID)
+        .animation(VAnimation.fast, value: isPrimaryHovered)
+        .animation(VAnimation.fast, value: isDropdownHovered)
+    }
+
+    // MARK: - Divider
+
+    @ViewBuilder
+    private var divider: some View {
+        switch style {
+        case .primary, .danger:
+            // For filled styles, pad the divider and fill behind it with the base color
+            // so no transparency leaks through between the two zones
+            ZStack {
+                Rectangle()
+                    .fill(filledBaseColor)
+                    .frame(width: 1 + 2, height: 32) // 1px divider + 1px padding each side
+                Rectangle()
+                    .fill(VColor.auxWhite.opacity(0.3))
+                    .frame(width: 1, height: 32)
+            }
+        case .outlined, .dangerOutline:
+            Rectangle()
+                .fill(borderColor)
+                .frame(width: 1, height: 32)
+        case .ghost, .dangerGhost:
+            Rectangle()
+                .fill(VColor.borderBase)
+                .frame(width: 1, height: 32)
+        case .contrast:
+            Rectangle()
+                .fill(VColor.auxWhite.opacity(0.3))
+                .frame(width: 1, height: 32)
+        }
+    }
+
+    // MARK: - Colors
+
+    private var filledBaseColor: Color {
+        switch style {
+        case .primary: return VColor.primaryBase
+        case .danger: return VColor.systemNegativeStrong
+        default: return .clear
+        }
+    }
+
+    private func zoneBackgroundColor(isHovered: Bool) -> Color {
+        guard !isDisabled else {
+            switch style {
+            case .primary, .danger, .contrast:
+                return VColor.primaryDisabled
+            default:
+                return .clear
+            }
+        }
+
+        switch style {
+        case .primary:
+            return isHovered ? VColor.primaryHover : VColor.primaryBase
+        case .danger:
+            return isHovered ? VColor.systemNegativeHover : VColor.systemNegativeStrong
+        case .outlined, .dangerOutline:
+            return isHovered ? VColor.surfaceBase : .clear
+        case .ghost, .dangerGhost:
+            return isHovered ? VColor.surfaceBase : .clear
+        case .contrast:
+            return isHovered ? VColor.contentSecondary : VColor.contentDefault
+        }
+    }
+
+    private var foregroundColor: Color {
+        guard !isDisabled else { return VColor.contentDisabled }
+        switch style {
+        case .primary, .danger, .contrast:
+            return VColor.auxWhite
+        case .outlined, .ghost:
+            return VColor.primaryBase
+        case .dangerOutline, .dangerGhost:
+            return VColor.systemNegativeStrong
+        }
+    }
+
+    private var borderColor: Color {
+        guard !isDisabled else {
+            switch style {
+            case .outlined, .dangerOutline, .ghost, .dangerGhost:
+                return VColor.primaryDisabled
+            default:
+                return .clear
+            }
+        }
+        switch style {
+        case .outlined:
+            return VColor.primaryBase
+        case .dangerOutline:
+            return VColor.systemNegativeStrong
+        case .ghost:
+            return VColor.borderBase
+        case .dangerGhost:
+            return VColor.borderBase
+        default:
+            return .clear
+        }
+    }
+
+    private var borderLineWidth: CGFloat {
+        switch style {
+        case .outlined, .dangerOutline: return 2
+        case .ghost, .dangerGhost: return 1
+        default: return 0
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func optionalSplitButtonAccessibilityID(_ identifier: String?) -> some View {
+        if let identifier {
+            self.accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
+    }
+}

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -4,6 +4,7 @@ public struct VSplitButton<MenuContent: View>: View {
     public let label: String
     public var icon: String?
     public var style: VButton.Style
+    public var size: VButton.Size
     public var isDisabled: Bool
     public var accessibilityID: String?
     public let action: () -> Void
@@ -16,6 +17,7 @@ public struct VSplitButton<MenuContent: View>: View {
         label: String,
         icon: String? = nil,
         style: VButton.Style = .primary,
+        size: VButton.Size = .regular,
         isDisabled: Bool = false,
         accessibilityID: String? = nil,
         action: @escaping () -> Void,
@@ -24,11 +26,17 @@ public struct VSplitButton<MenuContent: View>: View {
         self.label = label
         self.icon = icon
         self.style = style
+        self.size = size
         self.isDisabled = isDisabled
         self.accessibilityID = accessibilityID
         self.action = action
         self.menuContent = menuContent
     }
+
+    /// Matches the height logic in VButton's ButtonLayoutModifier.
+    private var zoneHeight: CGFloat { size == .regular ? VSpacing.xxl : VSpacing.xl }
+    /// Dropdown zone is square (width == height).
+    private var dropdownWidth: CGFloat { zoneHeight }
 
     public var body: some View {
         let cornerRadius = VRadius.md
@@ -42,12 +50,11 @@ public struct VSplitButton<MenuContent: View>: View {
                         VIconView(.resolve(icon), size: 13)
                     }
                     Text(label)
-                        .font(VFont.bodyMedium)
+                        .font(size == .regular ? VFont.bodyMedium : VFont.captionMedium)
                 }
                 .foregroundColor(foregroundColor)
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.buttonV)
-                .frame(height: 32)
+                .padding(.horizontal, size == .regular ? VSpacing.md : VSpacing.sm)
+                .frame(height: zoneHeight)
                 .background(zoneBackgroundColor(isHovered: isPrimaryHovered))
             }
             .buttonStyle(.plain)
@@ -63,11 +70,11 @@ public struct VSplitButton<MenuContent: View>: View {
             ZStack(alignment: .center) {
                 // Visual layer: background + centered icon
                 zoneBackgroundColor(isHovered: isDropdownHovered)
-                    .frame(width: 32, height: 32)
+                    .frame(width: dropdownWidth, height: zoneHeight)
 
                 VIconView(.chevronDown, size: 11)
                     .foregroundColor(foregroundColor)
-                    .frame(width: 32, height: 32)
+                    .frame(width: dropdownWidth, height: zoneHeight)
                     .allowsHitTesting(false)
 
                 // Interactive layer: fills entire zone
@@ -75,13 +82,13 @@ public struct VSplitButton<MenuContent: View>: View {
                     menuContent()
                 } label: {
                     Color.clear
-                        .frame(width: 32, height: 32)
+                        .frame(width: dropdownWidth, height: zoneHeight)
                         .contentShape(Rectangle())
                 }
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
             }
-            .frame(width: 32, height: 32)
+            .frame(width: dropdownWidth, height: zoneHeight)
             .clipped()
             .onHover { hovering in
                 isDropdownHovered = isDisabled ? false : hovering
@@ -115,23 +122,23 @@ public struct VSplitButton<MenuContent: View>: View {
             ZStack {
                 Rectangle()
                     .fill(filledBaseColor)
-                    .frame(width: 1 + 2, height: 32) // 1px divider + 1px padding each side
+                    .frame(width: 1 + 2, height: zoneHeight) // 1px divider + 1px padding each side
                 Rectangle()
                     .fill(VColor.auxWhite.opacity(0.3))
-                    .frame(width: 1, height: 32)
+                    .frame(width: 1, height: zoneHeight)
             }
         case .outlined, .dangerOutline:
             Rectangle()
                 .fill(borderColor)
-                .frame(width: 1, height: 32)
+                .frame(width: 1, height: zoneHeight)
         case .ghost, .dangerGhost:
             Rectangle()
                 .fill(VColor.borderBase)
-                .frame(width: 1, height: 32)
+                .frame(width: 1, height: zoneHeight)
         case .contrast:
             Rectangle()
                 .fill(VColor.auxWhite.opacity(0.3))
-                .frame(width: 1, height: 32)
+                .frame(width: 1, height: zoneHeight)
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -33,8 +33,8 @@ public struct VSplitButton<MenuContent: View>: View {
         self.menuContent = menuContent
     }
 
-    /// Matches the height logic in VButton's ButtonLayoutModifier.
-    private var zoneHeight: CGFloat { size == .regular ? VSpacing.xxl : VSpacing.xl }
+    /// Matches VButton's ButtonLayoutModifier: regular=32, compact/pill=24.
+    private var zoneHeight: CGFloat { size == .regular ? 32 : 24 }
     /// Dropdown zone is square (width == height).
     private var dropdownWidth: CGFloat { zoneHeight }
 
@@ -87,6 +87,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 }
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
+                .accessibilityLabel("\(label) options")
             }
             .frame(width: dropdownWidth, height: zoneHeight)
             .clipped()

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -212,6 +212,63 @@ struct ButtonsGallerySection: View {
                     }
                 }
             }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSplitButton
+            GallerySectionHeader(
+                title: "VSplitButton",
+                description: "A split button with a primary action and a dropdown menu for secondary actions."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    Text("Styles")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.contentSecondary)
+
+                    HStack(spacing: VSpacing.lg) {
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Primary").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                Section("Duration") {
+                                    Button("Allow once") {}
+                                    Button("Allow for this session") {}
+                                }
+                                Section("Scope") {
+                                    Button("Allow for this project") {}
+                                    Button("Allow always") {}
+                                }
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Outlined").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VSplitButton(label: "Save", style: .outlined, action: {}) {
+                                Button("Save as draft") {}
+                                Button("Save and publish") {}
+                                Button("Save as template") {}
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Danger").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VSplitButton(label: "Delete", icon: VIcon.trash.rawValue, style: .danger, action: {}) {
+                                Button("Delete selected") {}
+                                Button("Delete all") {}
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Long Label").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VSplitButton(label: "Allow for this conversation", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                Button("Allow once") {}
+                                Button("Allow always") {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -386,7 +386,6 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": actions.append(.allow10m)
         case "allow_conversation": actions.append(.allowConversation)
-        case "always_allow": actions.append(.alwaysAllow)
         default: actions.append(.allowOnce)
         }
         actions.append(.dontAllow)
@@ -400,7 +399,6 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": return selected == .allow10m
         case "allow_conversation": return selected == .allowConversation
-        case "always_allow": return selected == .alwaysAllow
         default: return selected == .allowOnce
         }
     }
@@ -411,7 +409,6 @@ public struct ToolConfirmationBubble: View {
         switch preferredAllowAction {
         case "allow_10m" where hasAllow10m: return "allow_10m"
         case "allow_conversation" where hasAllowConversation: return "allow_conversation"
-        case "always_allow" where hasAlwaysAllow: return "always_allow"
         case "allow_once": return "allow_once"
         default:
             return "allow_once"
@@ -422,7 +419,6 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": return "Allow for 10 minutes"
         case "allow_conversation": return "Allow for this conversation"
-        case "always_allow": return "Always allow"
         default: return "Allow once"
         }
     }
@@ -434,14 +430,6 @@ public struct ToolConfirmationBubble: View {
             onTemporaryAllow?(confirmation.requestId, "allow_10m")
         case "allow_conversation":
             onTemporaryAllow?(confirmation.requestId, "allow_conversation")
-        case "always_allow":
-            let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-            let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-            if pattern.isEmpty {
-                onAllow()
-            } else {
-                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
-            }
         default:
             onAllow()
         }
@@ -456,7 +444,7 @@ public struct ToolConfirmationBubble: View {
         return (primary != "allow_once") ||
                (hasAllow10m && primary != "allow_10m") ||
                (hasAllowConversation && primary != "allow_conversation") ||
-               (hasAlwaysAllow && primary != "always_allow")
+               hasAlwaysAllow
     }
 
     @ViewBuilder
@@ -476,7 +464,7 @@ public struct ToolConfirmationBubble: View {
                         }
                     }
 
-                    if hasAlwaysAllow && primary != "always_allow" {
+                    if hasAlwaysAllow {
                         alwaysAllowMenuItems
                     }
                 }
@@ -530,7 +518,7 @@ public struct ToolConfirmationBubble: View {
                         if scopes.isEmpty {
                             Button(option.label) {
                                 markCommandExplanationSeen()
-                                preferredAllowAction = "always_allow"
+    
                                 onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
                             }
                         } else {
@@ -539,7 +527,7 @@ public struct ToolConfirmationBubble: View {
                                     ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
                                         Button(scopeOption.label) {
                                             markCommandExplanationSeen()
-                                            preferredAllowAction = "always_allow"
+                
                                             onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
                                         }
                                     }
@@ -568,7 +556,7 @@ public struct ToolConfirmationBubble: View {
                         ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
                             Button(scopeOption.label) {
                                 markCommandExplanationSeen()
-                                preferredAllowAction = "always_allow"
+    
                                 onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
                             }
                         }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -511,15 +511,55 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowMenuItems: some View {
-        Button("Always allow") {
-            markCommandExplanationSeen()
-            preferredAllowAction = "always_allow"
-            let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-            let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-            if pattern.isEmpty {
-                onAllow()
+        let options = confirmation.allowlistOptions
+        let scopes = confirmation.scopeOptions
+
+        if options.count > 1 {
+            // Multiple patterns — show each, with scope submenus if needed
+            Menu("Always allow") {
+                ForEach(Array(options.enumerated()), id: \.element.pattern) { _, option in
+                    if scopes.isEmpty {
+                        Button(option.label) {
+                            markCommandExplanationSeen()
+                            preferredAllowAction = "always_allow"
+                            onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
+                        }
+                    } else {
+                        Menu(option.label) {
+                            ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
+                                Button(scopeOption.label) {
+                                    markCommandExplanationSeen()
+                                    preferredAllowAction = "always_allow"
+                                    onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else if let option = options.first {
+            // Single pattern
+            if scopes.isEmpty {
+                Button("Always allow") {
+                    markCommandExplanationSeen()
+                    preferredAllowAction = "always_allow"
+                    if option.pattern.isEmpty {
+                        onAllow()
+                    } else {
+                        onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
+                    }
+                }
             } else {
-                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
+                // Single pattern with scope choice
+                Menu("Always allow") {
+                    ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
+                        Button(scopeOption.label) {
+                            markCommandExplanationSeen()
+                            preferredAllowAction = "always_allow"
+                            onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                        }
+                    }
+                }
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -247,14 +247,16 @@ public struct ToolConfirmationBubble: View {
                         showTechnicalDetails.toggle()
                     }
                 } label: {
-                    HStack(spacing: VSpacing.xs) {
+                    HStack(alignment: .firstTextBaseline, spacing: VSpacing.xxs) {
                         VIconView(.chevronRight, size: 9)
                             .foregroundColor(VColor.contentDefault)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
+                            .frame(width: 9, height: 9)
                         Text(showTechnicalDetails ? "Hide details" : "Show details")
                             .font(VFont.captionMedium)
                             .foregroundColor(VColor.contentDefault)
                     }
+                    .offset(x: -1)
                 }
                 .buttonStyle(.plain)
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -449,11 +449,16 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
+    private var hasAlwaysAllow: Bool {
+        hasRuleOptions && confirmation.persistentDecisionsAllowed
+    }
+
     private var hasSecondaryAllowOptions: Bool {
         let primary = effectivePrimaryAction
         return (primary != "allow_once") ||
                (hasAllow10m && primary != "allow_10m") ||
-               (hasAllowConversation && primary != "allow_conversation")
+               (hasAllowConversation && primary != "allow_conversation") ||
+               hasAlwaysAllow
     }
 
     @ViewBuilder
@@ -486,10 +491,63 @@ public struct ToolConfirmationBubble: View {
                         onTemporaryAllow?(confirmation.requestId, "allow_conversation")
                     }
                 }
+
+                if hasAlwaysAllow {
+                    Divider()
+                    alwaysAllowMenuItems
+                }
             }
         } else {
             VButton(label: primaryAllowLabel, style: .primary, size: .compact) {
                 firePrimaryAllow()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var alwaysAllowMenuItems: some View {
+        if confirmation.allowlistOptions.count > 1 {
+            // Multiple patterns — show each as a menu item or submenu
+            ForEach(Array(confirmation.allowlistOptions.enumerated()), id: \.element.pattern) { _, option in
+                if needsScopeChoice {
+                    Menu(option.label) {
+                        ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { _, scopeOption in
+                            Button(scopeOption.label) {
+                                markCommandExplanationSeen()
+                                onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                            }
+                        }
+                    }
+                } else {
+                    Button(option.label) {
+                        markCommandExplanationSeen()
+                        if option.pattern.isEmpty {
+                            onAllow()
+                        } else {
+                            onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
+                        }
+                    }
+                }
+            }
+        } else if let option = confirmation.allowlistOptions.first {
+            if needsScopeChoice {
+                Menu("Always allow") {
+                    ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { _, scopeOption in
+                        Button(scopeOption.label) {
+                            markCommandExplanationSeen()
+                            onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                        }
+                    }
+                }
+            } else {
+                Button("Always allow") {
+                    markCommandExplanationSeen()
+                    if option.pattern.isEmpty {
+                        onAllow()
+                    } else {
+                        onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
+                    }
+                }
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -24,7 +24,7 @@ public struct ToolConfirmationBubble: View {
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @State private var popoverKeyboardModel: ToolConfirmationPopoverKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
-    @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_10m"
+    @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_once"
     #if os(macOS)
     @State private var keyMonitor: Any?
     #endif
@@ -425,7 +425,6 @@ public struct ToolConfirmationBubble: View {
         case "allow_conversation" where hasAllowConversation: return "allow_conversation"
         case "allow_once": return "allow_once"
         default:
-            if hasAllow10m { return "allow_10m" }
             return "allow_once"
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -450,34 +450,47 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
+    private var hasSecondaryAllowOptions: Bool {
+        let primary = effectivePrimaryAction
+        return (primary != "allow_once") ||
+               (hasAllow10m && primary != "allow_10m") ||
+               (hasAllowConversation && primary != "allow_conversation")
+    }
+
     @ViewBuilder
     private var allowSplitButton: some View {
         let primary = effectivePrimaryAction
-        VSplitButton(label: primaryAllowLabel, style: .primary, size: .compact, action: {
-            firePrimaryAllow()
-        }) {
-            if primary != "allow_once" {
-                Button("Allow once") {
-                    markCommandExplanationSeen()
-                    preferredAllowAction = "allow_once"
-                    onAllow()
+        if hasSecondaryAllowOptions {
+            VSplitButton(label: primaryAllowLabel, style: .primary, size: .compact, action: {
+                firePrimaryAllow()
+            }) {
+                if primary != "allow_once" {
+                    Button("Allow once") {
+                        markCommandExplanationSeen()
+                        preferredAllowAction = "allow_once"
+                        onAllow()
+                    }
+                }
+
+                if hasAllow10m && primary != "allow_10m" {
+                    Button("Allow for 10 minutes") {
+                        markCommandExplanationSeen()
+                        preferredAllowAction = "allow_10m"
+                        onTemporaryAllow?(confirmation.requestId, "allow_10m")
+                    }
+                }
+
+                if hasAllowConversation && primary != "allow_conversation" {
+                    Button("Allow for this conversation") {
+                        markCommandExplanationSeen()
+                        preferredAllowAction = "allow_conversation"
+                        onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+                    }
                 }
             }
-
-            if hasAllow10m && primary != "allow_10m" {
-                Button("Allow for 10 minutes") {
-                    markCommandExplanationSeen()
-                    preferredAllowAction = "allow_10m"
-                    onTemporaryAllow?(confirmation.requestId, "allow_10m")
-                }
-            }
-
-            if hasAllowConversation && primary != "allow_conversation" {
-                Button("Allow for this conversation") {
-                    markCommandExplanationSeen()
-                    preferredAllowAction = "allow_conversation"
-                    onTemporaryAllow?(confirmation.requestId, "allow_conversation")
-                }
+        } else {
+            VButton(label: primaryAllowLabel, style: .primary, size: .compact) {
+                firePrimaryAllow()
             }
         }
     }
@@ -504,10 +517,6 @@ public struct ToolConfirmationBubble: View {
                 return event
             }
             let mods = event.modifierFlags.intersection(Self.intentionalModifiers)
-            // Nested popover is open — handle up/down/enter/escape within it
-            if showAlwaysAllowMenu || showScopePickerMenu {
-                return handlePopoverKey(event, mods: mods)
-            }
             // Top-level button row navigation
             switch event.keyCode {
             case 48 where mods == .shift:
@@ -531,109 +540,6 @@ public struct ToolConfirmationBubble: View {
             default:
                 return event
             }
-        }
-    }
-
-    /// Handle key events when a nested popover (Always Allow dropdown or
-    /// scope picker) is open.
-    private func handlePopoverKey(_ event: NSEvent, mods: NSEvent.ModifierFlags) -> NSEvent? {
-        switch event.keyCode {
-        case 126:
-            // Up arrow
-            popoverKeyboardModel?.moveUp()
-            return nil
-        case 125:
-            // Down arrow
-            popoverKeyboardModel?.moveDown()
-            return nil
-        case 36 where mods.isEmpty, 76 where mods.isEmpty:
-            // Plain Return / numpad Enter — activate selected row (modified Enter passes through)
-            activatePopoverSelection()
-            return nil
-        case 53 where mods.isEmpty:
-            // Plain Escape — back or close (modified Escape passes through)
-            handlePopoverEscape()
-            return nil
-        default:
-            return event
-        }
-    }
-
-    /// Activate the currently selected row in the nested popover.
-    private func activatePopoverSelection() {
-        markCommandExplanationSeen()
-        guard let model = popoverKeyboardModel else { return }
-        let index = model.selectedIndex
-
-        if showAlwaysAllowMenu {
-            if pendingPattern != nil && needsScopeChoice {
-                // We're in the scope step of the dropdown
-                guard index < confirmation.scopeOptions.count else { return }
-                let scopeOption = confirmation.scopeOptions[index]
-                showAlwaysAllowMenu = false
-                let pattern = pendingPattern!
-                pendingPattern = nil
-                popoverKeyboardModel = nil
-                onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
-            } else {
-                // We're in the pattern step of the dropdown
-                guard index < confirmation.allowlistOptions.count else { return }
-                let option = confirmation.allowlistOptions[index]
-                if option.pattern.isEmpty {
-                    showAlwaysAllowMenu = false
-                    popoverKeyboardModel = nil
-                    onAllow()
-                } else if needsScopeChoice {
-                    pendingPattern = option.pattern
-                    popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                        mode: .scopes,
-                        itemCount: confirmation.scopeOptions.count
-                    )
-                } else {
-                    // No scope options (non-scoped tool) — auto-use "everywhere"
-                    showAlwaysAllowMenu = false
-                    popoverKeyboardModel = nil
-                    onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
-                }
-            }
-        } else if showScopePickerMenu {
-            // Inline scope picker
-            guard index < confirmation.scopeOptions.count else { return }
-            let scopeOption = confirmation.scopeOptions[index]
-            showScopePickerMenu = false
-            popoverKeyboardModel = nil
-            if let pattern = pendingPattern {
-                onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
-                pendingPattern = nil
-            }
-        }
-    }
-
-    /// Handle Escape in a nested popover.
-    private func handlePopoverEscape() {
-        guard let model = popoverKeyboardModel else { return }
-        switch model.handleEscape() {
-        case .backToPatterns:
-            if showScopePickerMenu {
-                // Standalone scope picker has no pattern list to return to — just close.
-                showScopePickerMenu = false
-                popoverKeyboardModel = nil
-                pendingPattern = nil
-            } else {
-                pendingPattern = nil
-                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                    mode: .patterns,
-                    itemCount: confirmation.allowlistOptions.count
-                )
-            }
-        case .closePopover:
-            if showAlwaysAllowMenu {
-                showAlwaysAllowMenu = false
-            }
-            if showScopePickerMenu {
-                showScopePickerMenu = false
-            }
-            popoverKeyboardModel = nil
         }
     }
 
@@ -667,216 +573,10 @@ public struct ToolConfirmationBubble: View {
         case .allowConversation:
             onTemporaryAllow?(confirmation.requestId, "allow_conversation")
         case .alwaysAllow:
-            if confirmation.allowlistOptions.count > 1 {
-                withAnimation(VAnimation.fast) {
-                    pendingPattern = nil
-                    showAlwaysAllowMenu.toggle()
-                }
-                if showAlwaysAllowMenu {
-                    popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                        mode: .patterns,
-                        itemCount: confirmation.allowlistOptions.count
-                    )
-                } else {
-                    popoverKeyboardModel = nil
-                }
-            } else {
-                handleSingleOptionAlwaysAllow()
-            }
+            break // Always-allow is handled via the split button dropdown
         case .dontAllow:
             onDeny()
         }
-    }
-
-    /// Shared logic for the single-option Always Allow action, used by both the
-    /// inline button click handler and keyboard Enter activation.
-    private func handleSingleOptionAlwaysAllow() {
-        markCommandExplanationSeen()
-        let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
-        if pattern.isEmpty {
-            onAllow()
-            return
-        }
-        if needsScopeChoice {
-            pendingPattern = pattern
-            showScopePickerMenu = true
-            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                mode: .scopes,
-                itemCount: confirmation.scopeOptions.count
-            )
-        } else {
-            // No scope options (non-scoped tool) — auto-use "everywhere"
-            onAlwaysAllow(confirmation.requestId, pattern, "everywhere", alwaysAllowDecision)
-        }
-    }
-
-    /// Convenience wrapper that maps the legacy isPrimary/isDanger flags to a `VButton.Style`.
-    @ViewBuilder
-    private func confirmationButton(_ label: String, isPrimary: Bool, isDanger: Bool, isDangerOutline: Bool = false, isKeyboardSelected: Bool = false, action: @escaping () -> Void) -> some View {
-        let style: VButton.Style = isDanger ? .danger : isDangerOutline ? .dangerOutline : isPrimary ? .primary : .outlined
-        VButton(label: label, style: style, size: .compact, action: action)
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.primaryBase, lineWidth: isKeyboardSelected ? 2 : 0)
-            )
-            .accessibilityLabel(label)
-    }
-
-    // MARK: - Always Allow Button
-
-    @ViewBuilder
-    private var alwaysAllowInlineButton: some View {
-        if !confirmation.allowlistOptions.isEmpty && confirmation.allowlistOptions.count > 1 {
-            alwaysAllowDropdown
-        } else {
-            let patternDesc = confirmation.allowlistOptions.first?.description ?? ""
-            confirmationButton("Always Allow", isPrimary: false, isDanger: false, isKeyboardSelected: keyboardModel?.selectedAction == .alwaysAllow) {
-                handleSingleOptionAlwaysAllow()
-            }
-            .help(patternDesc.isEmpty ? "Always allow this action" : patternDesc)
-            .popover(isPresented: $showScopePickerMenu, arrowEdge: .bottom) {
-                scopePickerContent
-            }
-        }
-    }
-
-    // MARK: - Always Allow Dropdown
-
-    @ViewBuilder
-    private var alwaysAllowDropdown: some View {
-        confirmationButton("Always Allow", isPrimary: false, isDanger: false, isKeyboardSelected: keyboardModel?.selectedAction == .alwaysAllow) {
-            withAnimation(VAnimation.fast) {
-                pendingPattern = nil
-                showAlwaysAllowMenu.toggle()
-            }
-            if showAlwaysAllowMenu {
-                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                    mode: .patterns,
-                    itemCount: confirmation.allowlistOptions.count
-                )
-            } else {
-                popoverKeyboardModel = nil
-            }
-        }
-        .popover(isPresented: $showAlwaysAllowMenu, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                if let pending = pendingPattern, needsScopeChoice {
-                    // Scope selection step after pattern was chosen
-                    HStack(spacing: VSpacing.xs) {
-                        Button {
-                            pendingPattern = nil
-                            popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                                mode: .patterns,
-                                itemCount: confirmation.allowlistOptions.count
-                            )
-                        } label: {
-                            VIconView(.chevronLeft, size: 10)
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        .buttonStyle(.plain)
-
-                        Text("Choose scope")
-                            .font(VFont.captionMedium)
-                            .foregroundColor(VColor.contentTertiary)
-                    }
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xs)
-
-                    Divider()
-                        .background(VColor.borderBase)
-
-                    ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { index, scopeOption in
-                        ScopePickerRow(
-                            label: scopeOption.label,
-                            isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
-                        ) {
-                            markCommandExplanationSeen()
-                            showAlwaysAllowMenu = false
-                            pendingPattern = nil
-                            popoverKeyboardModel = nil
-                            onAlwaysAllow(confirmation.requestId, pending, scopeOption.scope, alwaysAllowDecision)
-                        }
-
-                        if index < confirmation.scopeOptions.count - 1 {
-                            Divider()
-                                .background(VColor.borderBase)
-                        }
-                    }
-                } else {
-                    // Pattern selection step
-                    ForEach(Array(confirmation.allowlistOptions.enumerated()), id: \.element.pattern) { index, option in
-                        AlwaysAllowRow(
-                            title: option.label,
-                            subtitle: option.description,
-                            isKeyboardSelected: popoverKeyboardModel?.mode == .patterns && popoverKeyboardModel?.selectedIndex == index
-                        ) {
-                            markCommandExplanationSeen()
-                            if option.pattern.isEmpty {
-                                showAlwaysAllowMenu = false
-                                popoverKeyboardModel = nil
-                                onAllow()
-                            } else if needsScopeChoice {
-                                pendingPattern = option.pattern
-                                popoverKeyboardModel = ToolConfirmationPopoverKeyboardModel(
-                                    mode: .scopes,
-                                    itemCount: confirmation.scopeOptions.count
-                                )
-                            } else {
-                                // No scope options (non-scoped tool) — auto-use "everywhere"
-                                showAlwaysAllowMenu = false
-                                popoverKeyboardModel = nil
-                                onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
-                            }
-                        }
-
-                        if index < confirmation.allowlistOptions.count - 1 {
-                            Divider()
-                                .background(VColor.borderBase)
-                        }
-                    }
-                }
-            }
-            .padding(VSpacing.xs)
-            .frame(minWidth: 200)
-        }
-    }
-
-    // MARK: - Scope Picker (inline button popover)
-
-    @ViewBuilder
-    private var scopePickerContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Choose scope")
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.contentTertiary)
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xs)
-
-            Divider()
-                .background(VColor.borderBase)
-
-            ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { index, scopeOption in
-                ScopePickerRow(
-                    label: scopeOption.label,
-                    isKeyboardSelected: popoverKeyboardModel?.mode == .scopes && popoverKeyboardModel?.selectedIndex == index
-                ) {
-                    markCommandExplanationSeen()
-                    showScopePickerMenu = false
-                    popoverKeyboardModel = nil
-                    if let pattern = pendingPattern {
-                        onAlwaysAllow(confirmation.requestId, pattern, scopeOption.scope, alwaysAllowDecision)
-                        pendingPattern = nil
-                    }
-                }
-
-                if index < confirmation.scopeOptions.count - 1 {
-                    Divider()
-                        .background(VColor.borderBase)
-                }
-            }
-        }
-        .padding(VSpacing.xs)
-        .frame(minWidth: 180)
     }
 
     // MARK: - Tool Permission (decided)
@@ -898,84 +598,6 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-}
-
-// MARK: - Always Allow Row
-
-private struct AlwaysAllowRow: View {
-    let title: String
-    let subtitle: String
-    var isKeyboardSelected: Bool = false
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(VFont.monoSmall)
-                    .foregroundColor(VColor.contentDefault)
-                if !subtitle.isEmpty {
-                    Text(subtitle)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, VSpacing.sm)
-            .padding(.horizontal, VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(isHovered || isKeyboardSelected ? VColor.borderBase.opacity(0.5) : .clear)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .stroke(isKeyboardSelected ? VColor.primaryBase : .clear, lineWidth: 2)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .pointerCursor()
-    }
-}
-
-// MARK: - Scope Picker Row
-
-private struct ScopePickerRow: View {
-    let label: String
-    var isKeyboardSelected: Bool = false
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(VFont.body)
-                .foregroundColor(VColor.contentDefault)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, VSpacing.sm)
-                .padding(.horizontal, VSpacing.sm)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .fill(isHovered || isKeyboardSelected ? VColor.borderBase.opacity(0.5) : .clear)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.sm)
-                        .stroke(isKeyboardSelected ? VColor.primaryBase : .clear, lineWidth: 2)
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .pointerCursor()
-    }
 }
 
 #if DEBUG

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -37,10 +37,6 @@ public struct ToolConfirmationBubble: View {
         !confirmation.allowlistOptions.isEmpty
     }
 
-    private var needsScopeChoice: Bool {
-        !confirmation.scopeOptions.isEmpty
-    }
-
     private var isCommandTool: Bool {
         confirmation.toolName == "bash" || confirmation.toolName == "host_bash"
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -390,6 +390,7 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": actions.append(.allow10m)
         case "allow_conversation": actions.append(.allowConversation)
+        case "always_allow": actions.append(.alwaysAllow)
         default: actions.append(.allowOnce)
         }
         actions.append(.dontAllow)
@@ -403,6 +404,7 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": return selected == .allow10m
         case "allow_conversation": return selected == .allowConversation
+        case "always_allow": return selected == .alwaysAllow
         default: return selected == .allowOnce
         }
     }
@@ -604,7 +606,13 @@ public struct ToolConfirmationBubble: View {
         case .allowConversation:
             onTemporaryAllow?(confirmation.requestId, "allow_conversation")
         case .alwaysAllow:
-            break // Always-allow is handled via the split button dropdown
+            let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+            let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+            if pattern.isEmpty {
+                onAllow()
+            } else {
+                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
+            }
         case .dontAllow:
             onDeny()
         }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -219,11 +219,19 @@ public struct ToolConfirmationBubble: View {
 
                 HStack(spacing: VSpacing.sm) {
                     allowSplitButton
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                        )
 
                     VButton(label: "Deny", style: .danger, size: .compact) {
                         markCommandExplanationSeen()
                         onDeny()
                     }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                    )
                 }
             }
 
@@ -397,6 +405,15 @@ public struct ToolConfirmationBubble: View {
     }
 
     // MARK: - Allow Split Button
+
+    private var isPrimaryAllowKeyboardSelected: Bool {
+        guard let selected = keyboardModel?.selectedAction else { return false }
+        switch effectivePrimaryAction {
+        case "allow_10m": return selected == .allow10m
+        case "allow_conversation": return selected == .allowConversation
+        default: return selected == .allowOnce
+        }
+    }
 
     /// The effective primary action, resolving the persisted preference against
     /// what this confirmation actually supports.

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -16,13 +16,8 @@ public struct ToolConfirmationBubble: View {
     public let isKeyboardActive: Bool
 
     @State private var showDiff = false
-    @State private var showAlwaysAllowMenu = false
     @State private var showTechnicalDetails = false
-    /// Tracks a selected pattern while waiting for the user to pick a scope.
-    @State private var pendingPattern: String?
-    @State private var showScopePickerMenu = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
-    @State private var popoverKeyboardModel: ToolConfirmationPopoverKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
     @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_once"
     #if os(macOS)
@@ -294,7 +289,6 @@ public struct ToolConfirmationBubble: View {
             }
         }
         .onDisappear {
-            popoverKeyboardModel = nil
             #if os(macOS)
             removeKeyMonitor()
             #endif
@@ -311,10 +305,6 @@ public struct ToolConfirmationBubble: View {
                 removeKeyMonitor()
                 #endif
                 keyboardModel = nil
-                popoverKeyboardModel = nil
-                showAlwaysAllowMenu = false
-                showScopePickerMenu = false
-                pendingPattern = nil
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -212,7 +212,7 @@ public struct ToolConfirmationBubble: View {
                     allowSplitButton
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.md)
-                                .stroke(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                                .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
                         )
 
                     VButton(label: "Deny", style: .danger, size: .compact) {
@@ -221,7 +221,7 @@ public struct ToolConfirmationBubble: View {
                     }
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                            .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
                     )
                 }
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -17,13 +17,14 @@ public struct ToolConfirmationBubble: View {
 
     @State private var showDiff = false
     @State private var showAlwaysAllowMenu = false
-    @State private var showTechnicalDetails = true
+    @State private var showTechnicalDetails = false
     /// Tracks a selected pattern while waiting for the user to pick a scope.
     @State private var pendingPattern: String?
     @State private var showScopePickerMenu = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @State private var popoverKeyboardModel: ToolConfirmationPopoverKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
+    @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_10m"
     #if os(macOS)
     @State private var keyMonitor: Any?
     #endif
@@ -205,23 +206,33 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var pendingContent: some View {
+        let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Bold non-technical question
-            Text(confirmation.humanDescription)
-                .font(VFont.bodyBold)
-                .foregroundColor(VColor.contentDefault)
+            // Title + action buttons inline
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                Text(confirmation.humanDescription)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.contentDefault)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: VSpacing.md)
+
+                HStack(spacing: VSpacing.sm) {
+                    allowSplitButton
+
+                    VButton(label: "Deny", style: .danger, size: .compact) {
+                        markCommandExplanationSeen()
+                        onDeny()
+                    }
+                }
+            }
 
             // First-time educational banner for command confirmations
             if isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner
             }
 
-            // Action buttons at top
-            buttonRow
-
-            Divider()
-
-            // More Details accordion (expanded by default)
+            // Show details accordion
             VStack(alignment: .leading, spacing: 0) {
                 Button {
                     withAnimation(VAnimation.fast) {
@@ -232,7 +243,7 @@ public struct ToolConfirmationBubble: View {
                         VIconView(.chevronRight, size: 9)
                             .foregroundColor(VColor.contentDefault)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
-                        Text(showTechnicalDetails ? "Hide" : "More details")
+                        Text(showTechnicalDetails ? "Hide details" : "Show details")
                             .font(VFont.captionMedium)
                             .foregroundColor(VColor.contentDefault)
                     }
@@ -263,6 +274,39 @@ public struct ToolConfirmationBubble: View {
                         .stroke(VColor.borderBase, lineWidth: 0.5)
                 )
         )
+        .onAppear {
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: actions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+                #endif
+            }
+        }
+        .onDisappear {
+            popoverKeyboardModel = nil
+            #if os(macOS)
+            removeKeyMonitor()
+            #endif
+        }
+        .onChange(of: isKeyboardActive) {
+            if isKeyboardActive {
+                #if os(macOS)
+                installKeyMonitor(actions: actions)
+                #else
+                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
+                #endif
+            } else {
+                #if os(macOS)
+                removeKeyMonitor()
+                #endif
+                keyboardModel = nil
+                popoverKeyboardModel = nil
+                showAlwaysAllowMenu = false
+                showScopePickerMenu = false
+                pendingPattern = nil
+            }
+        }
     }
 
 
@@ -341,125 +385,80 @@ public struct ToolConfirmationBubble: View {
 
     // MARK: - Button Row
 
-    /// Build the ordered list of top-level actions based on current confirmation state.
-    /// Order matches visual layout (top-to-bottom, left-to-right) so keyboard Tab
-    /// navigation follows the same sequence the user sees on screen.
     private var topLevelActions: [ToolConfirmationKeyboardModel.Action] {
         var actions: [ToolConfirmationKeyboardModel.Action] = []
-        // When allow10m is present, it and dontAllow share the top "Recommended" row
-        if hasAllow10m {
-            actions.append(.allow10m)
-            actions.append(.dontAllow)
+        switch effectivePrimaryAction {
+        case "allow_10m": actions.append(.allow10m)
+        case "allow_conversation": actions.append(.allowConversation)
+        default: actions.append(.allowOnce)
         }
-        // Bottom row (or only row): allowOnce, alwaysAllow?, allowConversation?
-        actions.append(.allowOnce)
-        if hasRuleOptions && confirmation.persistentDecisionsAllowed {
-            actions.append(.alwaysAllow)
-        }
-        if hasAllowConversation { actions.append(.allowConversation) }
-        // When allow10m is absent, dontAllow goes at the end (matching its rightmost
-        // visual position) so an allow action is always the default at index 0
-        if !hasAllow10m { actions.append(.dontAllow) }
+        actions.append(.dontAllow)
         return actions
     }
 
-    private var hasTemporaryOptions: Bool {
-        hasAllow10m || hasAllowConversation
+    // MARK: - Allow Split Button
+
+    /// The effective primary action, resolving the persisted preference against
+    /// what this confirmation actually supports.
+    private var effectivePrimaryAction: String {
+        switch preferredAllowAction {
+        case "allow_10m" where hasAllow10m: return "allow_10m"
+        case "allow_conversation" where hasAllowConversation: return "allow_conversation"
+        case "allow_once": return "allow_once"
+        default:
+            if hasAllow10m { return "allow_10m" }
+            return "allow_once"
+        }
+    }
+
+    private var primaryAllowLabel: String {
+        switch effectivePrimaryAction {
+        case "allow_10m": return "Allow for 10 minutes"
+        case "allow_conversation": return "Allow for this conversation"
+        default: return "Allow once"
+        }
+    }
+
+    private func firePrimaryAllow() {
+        markCommandExplanationSeen()
+        switch effectivePrimaryAction {
+        case "allow_10m":
+            onTemporaryAllow?(confirmation.requestId, "allow_10m")
+        case "allow_conversation":
+            onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+        default:
+            onAllow()
+        }
     }
 
     @ViewBuilder
-    private var buttonRow: some View {
-        let actions = topLevelActions
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Top group: recommended actions — only shown when allow10m is available
-            // (pairs "Allow for 10 minutes" with "Don't Allow" under "Recommended")
-            if hasAllow10m {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Recommended")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.contentDefault)
-                    HStack(spacing: VSpacing.xs) {
-                        confirmationButton(
-                            "Allow for 10 minutes",
-                            isPrimary: true,
-                            isDanger: false,
-                            isKeyboardSelected: keyboardModel?.selectedAction == .allow10m
-                        ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_10m") }
-                        confirmationButton(
-                            "Don\u{2019}t Allow",
-                            isPrimary: false,
-                            isDanger: true,
-                            isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
-                        ) { markCommandExplanationSeen(); onDeny() }
-                    }
+    private var allowSplitButton: some View {
+        let primary = effectivePrimaryAction
+        VSplitButton(label: primaryAllowLabel, style: .primary, size: .compact, action: {
+            firePrimaryAllow()
+        }) {
+            if primary != "allow_once" {
+                Button("Allow once") {
+                    markCommandExplanationSeen()
+                    preferredAllowAction = "allow_once"
+                    onAllow()
                 }
             }
-            // Bottom group: more options
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if hasAllow10m {
-                    Text("More Options")
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                HStack(spacing: VSpacing.xs) {
-                    confirmationButton(
-                        "Allow Once",
-                        isPrimary: !hasAllow10m,
-                        isDanger: false,
-                        isKeyboardSelected: keyboardModel?.selectedAction == .allowOnce
-                    ) { markCommandExplanationSeen(); onAllow() }
-                    if hasRuleOptions && confirmation.persistentDecisionsAllowed { alwaysAllowInlineButton }
-                    if hasAllowConversation {
-                        confirmationButton(
-                            "Allow for this conversation",
-                            isPrimary: false,
-                            isDanger: false,
-                            isKeyboardSelected: keyboardModel?.selectedAction == .allowConversation
-                        ) { markCommandExplanationSeen(); onTemporaryAllow?(confirmation.requestId, "allow_conversation") }
-                    }
-                    if !hasAllow10m {
-                        confirmationButton(
-                            "Don\u{2019}t Allow",
-                            isPrimary: false,
-                            isDanger: true,
-                            isKeyboardSelected: keyboardModel?.selectedAction == .dontAllow
-                        ) { markCommandExplanationSeen(); onDeny() }
-                    }
-                    Spacer()
+
+            if hasAllow10m && primary != "allow_10m" {
+                Button("Allow for 10 minutes") {
+                    markCommandExplanationSeen()
+                    preferredAllowAction = "allow_10m"
+                    onTemporaryAllow?(confirmation.requestId, "allow_10m")
                 }
             }
-        }
-        .onAppear {
-            if isKeyboardActive {
-                #if os(macOS)
-                installKeyMonitor(actions: actions)
-                #else
-                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
-                #endif
-            }
-        }
-        .onDisappear {
-            popoverKeyboardModel = nil
-            #if os(macOS)
-            removeKeyMonitor()
-            #endif
-        }
-        .onChange(of: isKeyboardActive) {
-            if isKeyboardActive {
-                #if os(macOS)
-                installKeyMonitor(actions: actions)
-                #else
-                keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
-                #endif
-            } else {
-                #if os(macOS)
-                removeKeyMonitor()
-                #endif
-                keyboardModel = nil
-                popoverKeyboardModel = nil
-                showAlwaysAllowMenu = false
-                showScopePickerMenu = false
-                pendingPattern = nil
+
+            if hasAllowConversation && primary != "allow_conversation" {
+                Button("Allow for this conversation") {
+                    markCommandExplanationSeen()
+                    preferredAllowAction = "allow_conversation"
+                    onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+                }
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -468,33 +468,40 @@ public struct ToolConfirmationBubble: View {
             VSplitButton(label: primaryAllowLabel, style: .primary, size: .compact, action: {
                 firePrimaryAllow()
             }) {
-                if primary != "allow_once" {
-                    Button("Allow once") {
-                        markCommandExplanationSeen()
-                        preferredAllowAction = "allow_once"
-                        onAllow()
+                // "This action" — scoped to this specific invocation or pattern
+                Section("This action") {
+                    if primary != "allow_once" {
+                        Button("Allow once") {
+                            markCommandExplanationSeen()
+                            preferredAllowAction = "allow_once"
+                            onAllow()
+                        }
+                    }
+
+                    if hasAlwaysAllow {
+                        alwaysAllowMenuItems
                     }
                 }
 
-                if hasAllow10m && primary != "allow_10m" {
-                    Button("Allow for 10 minutes") {
-                        markCommandExplanationSeen()
-                        preferredAllowAction = "allow_10m"
-                        onTemporaryAllow?(confirmation.requestId, "allow_10m")
-                    }
-                }
+                // "All actions" — blanket approval for a duration
+                if hasAllow10m || hasAllowConversation {
+                    Section("All actions") {
+                        if hasAllow10m && primary != "allow_10m" {
+                            Button("Allow for 10 minutes") {
+                                markCommandExplanationSeen()
+                                preferredAllowAction = "allow_10m"
+                                onTemporaryAllow?(confirmation.requestId, "allow_10m")
+                            }
+                        }
 
-                if hasAllowConversation && primary != "allow_conversation" {
-                    Button("Allow for this conversation") {
-                        markCommandExplanationSeen()
-                        preferredAllowAction = "allow_conversation"
-                        onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+                        if hasAllowConversation && primary != "allow_conversation" {
+                            Button("Allow for this conversation") {
+                                markCommandExplanationSeen()
+                                preferredAllowAction = "allow_conversation"
+                                onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+                            }
+                        }
                     }
-                }
-
-                if hasAlwaysAllow {
-                    Divider()
-                    alwaysAllowMenuItems
                 }
             }
         } else {
@@ -506,48 +513,14 @@ public struct ToolConfirmationBubble: View {
 
     @ViewBuilder
     private var alwaysAllowMenuItems: some View {
-        if confirmation.allowlistOptions.count > 1 {
-            // Multiple patterns — show each as a menu item or submenu
-            ForEach(Array(confirmation.allowlistOptions.enumerated()), id: \.element.pattern) { _, option in
-                if needsScopeChoice {
-                    Menu(option.label) {
-                        ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { _, scopeOption in
-                            Button(scopeOption.label) {
-                                markCommandExplanationSeen()
-                                onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
-                            }
-                        }
-                    }
-                } else {
-                    Button(option.label) {
-                        markCommandExplanationSeen()
-                        if option.pattern.isEmpty {
-                            onAllow()
-                        } else {
-                            onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
-                        }
-                    }
-                }
-            }
-        } else if let option = confirmation.allowlistOptions.first {
-            if needsScopeChoice {
-                Menu("Always allow") {
-                    ForEach(Array(confirmation.scopeOptions.enumerated()), id: \.element.scope) { _, scopeOption in
-                        Button(scopeOption.label) {
-                            markCommandExplanationSeen()
-                            onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
-                        }
-                    }
-                }
+        Button("Always allow") {
+            markCommandExplanationSeen()
+            let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+            let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+            if pattern.isEmpty {
+                onAllow()
             } else {
-                Button("Always allow") {
-                    markCommandExplanationSeen()
-                    if option.pattern.isEmpty {
-                        onAllow()
-                    } else {
-                        onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
-                    }
-                }
+                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -423,6 +423,7 @@ public struct ToolConfirmationBubble: View {
         switch preferredAllowAction {
         case "allow_10m" where hasAllow10m: return "allow_10m"
         case "allow_conversation" where hasAllowConversation: return "allow_conversation"
+        case "always_allow" where hasAlwaysAllow: return "always_allow"
         case "allow_once": return "allow_once"
         default:
             return "allow_once"
@@ -433,6 +434,7 @@ public struct ToolConfirmationBubble: View {
         switch effectivePrimaryAction {
         case "allow_10m": return "Allow for 10 minutes"
         case "allow_conversation": return "Allow for this conversation"
+        case "always_allow": return "Always allow"
         default: return "Allow once"
         }
     }
@@ -444,6 +446,14 @@ public struct ToolConfirmationBubble: View {
             onTemporaryAllow?(confirmation.requestId, "allow_10m")
         case "allow_conversation":
             onTemporaryAllow?(confirmation.requestId, "allow_conversation")
+        case "always_allow":
+            let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
+            let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+            if pattern.isEmpty {
+                onAllow()
+            } else {
+                onAlwaysAllow(confirmation.requestId, pattern, scope, alwaysAllowDecision)
+            }
         default:
             onAllow()
         }
@@ -458,7 +468,7 @@ public struct ToolConfirmationBubble: View {
         return (primary != "allow_once") ||
                (hasAllow10m && primary != "allow_10m") ||
                (hasAllowConversation && primary != "allow_conversation") ||
-               hasAlwaysAllow
+               (hasAlwaysAllow && primary != "always_allow")
     }
 
     @ViewBuilder
@@ -478,7 +488,7 @@ public struct ToolConfirmationBubble: View {
                         }
                     }
 
-                    if hasAlwaysAllow {
+                    if hasAlwaysAllow && primary != "always_allow" {
                         alwaysAllowMenuItems
                     }
                 }
@@ -515,6 +525,7 @@ public struct ToolConfirmationBubble: View {
     private var alwaysAllowMenuItems: some View {
         Button("Always allow") {
             markCommandExplanationSeen()
+            preferredAllowAction = "always_allow"
             let pattern = confirmation.allowlistOptions.first?.pattern ?? ""
             let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
             if pattern.isEmpty {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -509,6 +509,14 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
+    private var alwaysAllowPatternLabel: String {
+        let tool = confirmation.toolName
+        if tool == "bash" || tool == "host_bash" { return "Command" }
+        if tool.contains("file") { return "File" }
+        if tool == "web_fetch" || tool == "web_search" { return "URL" }
+        return "Pattern"
+    }
+
     @ViewBuilder
     private var alwaysAllowMenuItems: some View {
         let options = confirmation.allowlistOptions
@@ -517,20 +525,24 @@ public struct ToolConfirmationBubble: View {
         if options.count > 1 {
             // Multiple patterns — show each, with scope submenus if needed
             Menu("Always allow") {
-                ForEach(Array(options.enumerated()), id: \.element.pattern) { _, option in
-                    if scopes.isEmpty {
-                        Button(option.label) {
-                            markCommandExplanationSeen()
-                            preferredAllowAction = "always_allow"
-                            onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
-                        }
-                    } else {
-                        Menu(option.label) {
-                            ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
-                                Button(scopeOption.label) {
-                                    markCommandExplanationSeen()
-                                    preferredAllowAction = "always_allow"
-                                    onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                Section(alwaysAllowPatternLabel) {
+                    ForEach(Array(options.enumerated()), id: \.element.pattern) { _, option in
+                        if scopes.isEmpty {
+                            Button(option.label) {
+                                markCommandExplanationSeen()
+                                preferredAllowAction = "always_allow"
+                                onAlwaysAllow(confirmation.requestId, option.pattern, "everywhere", alwaysAllowDecision)
+                            }
+                        } else {
+                            Menu(option.label) {
+                                Section("Scope") {
+                                    ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
+                                        Button(scopeOption.label) {
+                                            markCommandExplanationSeen()
+                                            preferredAllowAction = "always_allow"
+                                            onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -552,11 +564,13 @@ public struct ToolConfirmationBubble: View {
             } else {
                 // Single pattern with scope choice
                 Menu("Always allow") {
-                    ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
-                        Button(scopeOption.label) {
-                            markCommandExplanationSeen()
-                            preferredAllowAction = "always_allow"
-                            onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                    Section("Scope") {
+                        ForEach(Array(scopes.enumerated()), id: \.element.scope) { _, scopeOption in
+                            Button(scopeOption.label) {
+                                markCommandExplanationSeen()
+                                preferredAllowAction = "always_allow"
+                                onAlwaysAllow(confirmation.requestId, option.pattern, scopeOption.scope, alwaysAllowDecision)
+                            }
                         }
                     }
                 }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -542,7 +542,6 @@ public struct ToolConfirmationBubble: View {
             if scopes.isEmpty {
                 Button("Always allow") {
                     markCommandExplanationSeen()
-                    preferredAllowAction = "always_allow"
                     if option.pattern.isEmpty {
                         onAllow()
                     } else {


### PR DESCRIPTION
## Summary
- **VSplitButton component**: New design system component — a button with two click zones: a primary action (left) and a dropdown chevron (right) that opens a native menu. Supports all `VButton.Style` variants and a new `size` parameter (`.regular` / `.compact`).
- **Tool confirmation redesign**: Title and action buttons are now inline on the same row. The Allow button is a `VSplitButton` whose dropdown contains alternative allow options. User's last selection is persisted as the default via `@AppStorage`. "Don't Allow" renamed to "Deny" with a filled danger button.
- **VButton `iconColor` parameter**: Optional color override for icon-only buttons, used by the output copy button.
- **Output copy button**: Changed to a ghost `VButton` with `contentTertiary` color to match the timestamp icon style.

## Test plan
- [ ] Open Component Gallery → Buttons → verify VSplitButton variants render correctly
- [ ] Trigger a tool confirmation → verify inline layout with Allow split button + Deny
- [ ] Click dropdown chevron → verify menu shows alternative allow options
- [ ] Select a dropdown option → verify it becomes the default next time
- [ ] Verify "Deny" button is filled danger style
- [ ] Verify "Show details" is collapsed by default
- [ ] Verify output copy button is muted grey and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
