### PR TITLE
fix: lint error for unused variable in conversation-wipe test

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -238,7 +238,7 @@ describe("wipeConversation", () => {
     // with superseded_by = NULL. When we later wipe convB, Step F should NOT
     // restore that unrelated item.
     const convA = createConversation("conversation A");
-    const msgA = await addMessage(convA.id, "user", "I use dark theme");
+    const _msgA = await addMessage(convA.id, "user", "I use dark theme");
 
     const convB = createConversation("conversation B");
     const msgB = await addMessage(convB.id, "user", "I use vim");


### PR DESCRIPTION
## Summary
- Prefix unused `msgA` variable with `_` in `conversation-wipe.test.ts` to satisfy the `@typescript-eslint/no-unused-vars` lint rule

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23210042488/job/67456063481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
