### PR TITLE
fix(macos): persist dock label for build.sh so rebuilds keep assistant name

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -90,6 +90,13 @@ cd "$SCRIPT_DIR"
 
 BUNDLE_ID="com.vellum.vellum-assistant"
 APP_NAME="vellum-assistant"
+# Read the dock display name persisted by the running app (assistant name),
+# falling back to "Vellum" if not set. Can be overridden via env var.
+_DOCK_LABEL_FILE="$HOME/.vellum/.dock-display-name"
+if [ -z "${BUNDLE_DISPLAY_NAME:-}" ] && [ -f "$_DOCK_LABEL_FILE" ]; then
+    _SAVED_NAME="$(cat "$_DOCK_LABEL_FILE" 2>/dev/null | tr -d '\n')"
+    BUNDLE_DISPLAY_NAME="${_SAVED_NAME:-Vellum}"
+fi
 BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-Vellum}"
 APP_DIR="$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app"
 CONTENTS="$APP_DIR/Contents"

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -490,14 +490,27 @@ final class AvatarAppearanceManager {
     /// Default app name used for the dock label when no assistant is connected.
     private static let defaultDockLabel = "Vellum"
 
-    /// Updates the dock label (text under the icon) to the assistant's name.
-    /// Writes `CFBundleDisplayName` into the running app bundle's Info.plist
-    /// and re-registers with LaunchServices so the Dock picks up the change.
+    /// Sentinel file that `build.sh` reads at build time to set
+    /// `CFBundleDisplayName` so the Dock shows the assistant name from
+    /// the very first launch after a rebuild.
+    private static let dockDisplayNameURL: URL = {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".vellum/.dock-display-name")
+    }()
+
+    /// Persists the dock label so `build.sh` can embed it into
+    /// `CFBundleDisplayName` at build time.  Also updates the running
+    /// app bundle's Info.plist and re-registers with LaunchServices so
+    /// the change takes effect on the next launch without a rebuild.
     private func updateDockLabel() {
-        // Use the assistant's name if it's a real name (not the single-letter
-        // avatar fallback "V"); otherwise revert to the default app name.
         let label = assistantName.count > 1 ? assistantName : Self.defaultDockLabel
 
+        // 1. Persist for build.sh
+        let dir = Self.dockDisplayNameURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? label.write(to: Self.dockDisplayNameURL, atomically: true, encoding: .utf8)
+
+        // 2. Update the running bundle's Info.plist (takes effect next launch)
         guard let bundleURL = Bundle.main.bundleURL as URL?,
               bundleURL.pathExtension == "app" else { return }
 
@@ -508,7 +521,6 @@ final class AvatarAppearanceManager {
                   from: data, format: nil
               ) as? [String: Any] else { return }
 
-        // Skip the write if the label is already correct.
         if plist["CFBundleDisplayName"] as? String == label { return }
 
         plist["CFBundleDisplayName"] = label
@@ -524,9 +536,7 @@ final class AvatarAppearanceManager {
             return
         }
 
-        // Force LaunchServices to re-read the bundle so the Dock picks up
-        // the new display name. The deprecated LSRegisterURL API is
-        // unreliable on modern macOS; use the lsregister CLI tool instead.
+        // Force LaunchServices to re-read the bundle.
         let lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
         if FileManager.default.fileExists(atPath: lsregister) {
             let process = Process()


### PR DESCRIPTION
## Summary
- App persists the dock label to `~/.vellum/.dock-display-name` whenever the assistant name changes
- `build.sh` reads this file to set `CFBundleDisplayName` at build time, so the dock shows the assistant name from the first launch after a rebuild
- Still updates the running bundle's Info.plist + lsregister for release builds (no rebuild needed)
- Falls back to "Vellum" when no saved name exists

## Original prompt
Can we change the name of the app in the doc to be the name of the assistant?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
