### PR TITLE
fix: add missing oauth-store mock exports in credentials-cli test

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -148,6 +148,9 @@ mock.module("../oauth/oauth-store.js", () => ({
   getConnectionByProvider: (): undefined => undefined,
   listConnections: (): never[] => [],
   deleteConnection: (): boolean => false,
+  upsertApp: async () => ({ id: "mock-app-id" }),
+  createConnection: () => ({ id: "mock-conn-id" }),
+  updateConnection: (): boolean => true,
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The `credentials-cli.test.ts` mock for `oauth-store.js` was missing `upsertApp`, `createConnection`, and `updateConnection` exports
- These are needed by `manual-token-connection.ts` (transitively imported via `credentials.ts`)
- Added the missing stub exports to the mock to fix the `SyntaxError: Export named 'upsertApp' not found` CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23210764778/job/67458601562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
