### PR TITLE
fix(macos): constrain line height so emoji don't misalign gutter

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -384,6 +384,18 @@ private struct CodeTextView: NSViewRepresentable {
         // Match gutter's .padding(.top, VSpacing.sm) exactly
         textView.textContainerInset = NSSize(width: 0, height: VSpacing.sm)
 
+        // Fix line height so emoji/tall glyphs don't expand individual lines
+        let fixedLineHeight = layoutManager.defaultLineHeight(for: textView.font!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = fixedLineHeight
+        paragraphStyle.maximumLineHeight = fixedLineHeight
+        textView.defaultParagraphStyle = paragraphStyle
+        textView.typingAttributes = [
+            .font: textView.font!,
+            .foregroundColor: textView.textColor!,
+            .paragraphStyle: paragraphStyle,
+        ]
+
         textView.onEscape = onEscape
         textView.onCommandF = onCommandF
         textView.string = text


### PR DESCRIPTION
## Summary
- Set \`minimumLineHeight\` and \`maximumLineHeight\` on the CodeTextView's NSParagraphStyle to the font's default line height
- Also set \`typingAttributes\` with the paragraph style so newly typed text maintains the fixed line height
- Prevents emoji (like ❤️) from expanding their line and pushing subsequent lines out of alignment with the gutter

## Original prompt
When I go into edit mode the lines become misaligned with the line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
