### PR TITLE
fix: auto-format assistant/ files to pass pre-commit hooks

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -116,7 +116,9 @@ describe("wipeConversation", () => {
       }
     ).$client;
     const itemARow = raw
-      .query("SELECT status, superseded_by FROM memory_items WHERE id = 'itemA'")
+      .query(
+        "SELECT status, superseded_by FROM memory_items WHERE id = 'itemA'",
+      )
       .get() as { status: string; superseded_by: string | null } | null;
     expect(itemARow).not.toBeNull();
     expect(itemARow!.status).toBe("active");

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -476,9 +476,7 @@ export function wipeConversation(id: string): WipeConversationResult {
   // don't accidentally restore items superseded by unrelated conversations.
   let orphanedSuperseded: Array<{ id: string }> = [];
   if (orphanedKindSubjects.length > 0) {
-    const placeholders = orphanedKindSubjects
-      .map(() => "(?, ?)")
-      .join(", ");
+    const placeholders = orphanedKindSubjects.map(() => "(?, ?)").join(", ");
     const params: Array<string> = [scopeId];
     for (const { kind, subject } of orphanedKindSubjects) {
       params.push(kind, subject);


### PR DESCRIPTION
## Summary

Formatting-only changes to two assistant/ files — no logic changes.

- **`assistant/src/__tests__/conversation-wipe.test.ts`** — Prettier reformats a long `.query()` call to wrap the string argument across lines (trailing comma style).
- **`assistant/src/memory/conversation-crud.ts`** — Prettier collapses a multi-line `.map().join()` chain into a single line.

## Why

The `fix/retina-icon-rendering` branch touches these files and currently carries unrelated formatting diffs. Merging this first keeps that PR focused on its actual changes.

## Test plan

- [ ] Pre-commit hooks (prettier + eslint) pass
- [ ] No functional changes — only whitespace / line-break differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
