### PR TITLE
fix(macos): align composer cursor with paperclip icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -451,6 +451,7 @@ struct ComposerView: View {
         standardComposerShell {
             VStack(spacing: 0) {
                 composerTextField
+                    .padding(.leading, VSpacing.xs)
                     .frame(minHeight: composerActionButtonSize)
                 composerActionBar
             }


### PR DESCRIPTION
## Summary
- Adds leading padding (`VSpacing.xs`) to the composer text field so the cursor horizontally aligns with the paperclip attachment icon in the action bar below.

## Test plan
- [ ] Open the main chat window and verify the text cursor aligns with the paperclip icon below
- [ ] Type text and confirm the input area still looks correct
- [ ] Check dictation inline mode still renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
