### PR TITLE
feat: bump non-Telegram attachment limits to 100 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The assistant creates attachments from two sources:
 1. **Directives**: `<vellum-attachment source="sandbox|host" path="..." />` tags in response text. Sandbox paths are relative to the working directory; host paths require user approval.
 2. **Tool output**: Image and file content blocks from tool results are automatically converted into attachments.
 
-Limits: 20 MB per attachment.
+Limits: 100 MB per attachment (20 MB for Telegram).
 
 </details>
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -542,7 +542,7 @@ sequenceDiagram
     Materialize->>DB: load attachment (including base64 data)
     Materialize->>Visibility: isAttachmentVisible(attachmentCtx, currentCtx)
     Note over Visibility: Second visibility check at materialize time<br/>prevents TOCTOU between search and materialize
-    Materialize->>Materialize: size check (max 50 MB)
+    Materialize->>Materialize: size check (max 100 MB)
     Materialize->>Sandbox: write decoded bytes to destination
     Materialize-->>Model: "Materialized 'photo.jpg' to /workspace/media/photo.jpg"
 ```
@@ -586,7 +586,7 @@ graph TB
 ### Materialize Safeguards
 
 - **Sandbox path enforcement**: Destination path must resolve inside the sandbox working directory
-- **Size limit**: 50 MB ceiling prevents materializing excessively large attachments
+- **Size limit**: 100 MB ceiling prevents materializing excessively large attachments
 - **Double visibility check**: Both `asset_search` and `asset_materialize` independently verify visibility, preventing TOCTOU races between search and use
 - **Risk level**: Both tools are `RiskLevel.Low` since they read existing data and write only within the sandbox
 

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -263,7 +263,7 @@ describe("AssetMaterializeTool materialization", () => {
 describe("AssetMaterializeTool size limit", () => {
   beforeEach(resetTables);
 
-  test("rejects attachment exceeding 50MB limit", async () => {
+  test("rejects attachment exceeding 100MB limit", async () => {
     // Simulate a large attachment by inserting directly into the DB
     // with a sizeBytes value over the limit
     const db = getDb();
@@ -271,7 +271,7 @@ describe("AssetMaterializeTool size limit", () => {
     db.run(
       `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
        VALUES ('${fakeId}', 'huge.bin', 'application/octet-stream', ${
-         51 * 1024 * 1024
+         101 * 1024 * 1024
        }, 'document', 'AAAA', ${Date.now()})`,
     );
 

--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -193,11 +193,11 @@ describe("validateDrafts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  test("accepts a 25 MB attachment (under 50 MB limit)", () => {
+  test("accepts a 75 MB attachment (under 100 MB limit)", () => {
     const drafts = [
       makeDraft({
         filename: "video.mov",
-        sizeBytes: 25 * 1024 * 1024,
+        sizeBytes: 75 * 1024 * 1024,
       }),
     ];
     const result = validateDrafts(drafts);
@@ -205,18 +205,18 @@ describe("validateDrafts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  test("rejects a 51 MB attachment with warning mentioning 50.0 MB limit", () => {
+  test("rejects a 101 MB attachment with warning mentioning 100.0 MB limit", () => {
     const drafts = [
       makeDraft({
         filename: "huge.mov",
-        sizeBytes: 51 * 1024 * 1024,
+        sizeBytes: 101 * 1024 * 1024,
       }),
     ];
     const result = validateDrafts(drafts);
     expect(result.accepted).toHaveLength(0);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("huge.mov");
-    expect(result.warnings[0]).toContain("50.0 MB");
+    expect(result.warnings[0]).toContain("100.0 MB");
     expect(result.warnings[0]).toContain("limit");
   });
 });

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -167,7 +167,7 @@ describe("uploadAttachment", () => {
   });
 
   test("accepts payload exactly at MAX_UPLOAD_BYTES", () => {
-    // MAX_UPLOAD_BYTES (50 MB) is divisible by 3, so (MAX/3)*4 base64 chars
+    // MAX_UPLOAD_BYTES (100 MB) is divisible by 3, so (MAX/3)*4 base64 chars
     // decodes to exactly MAX bytes with no padding.
     const exactLength = (MAX_UPLOAD_BYTES / 3) * 4;
     const exactData = "A".repeat(exactLength);

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -17,8 +17,8 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Maximum size in bytes for a single assistant attachment (50 MB). */
-export const MAX_ASSISTANT_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+/** Maximum size in bytes for a single assistant attachment (100 MB). */
+export const MAX_ASSISTANT_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -48,8 +48,8 @@ function formatBytes(bytes: number): string {
 // Size and encoding limits
 // ---------------------------------------------------------------------------
 
-/** Hard ceiling on a single uploaded attachment (50 MB, matching assistant limits). */
-export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+/** Hard ceiling on a single uploaded attachment (100 MB, matching assistant limits). */
+export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 /** Attachments larger than this are stored on disk instead of inline in SQLite. */
 export const FILE_BACKED_THRESHOLD_BYTES = 5 * 1024 * 1024;
@@ -226,7 +226,7 @@ function computeContentHash(dataBase64: string): string {
 /**
  * Store a file-backed attachment by path reference, without reading the file
  * into memory. This avoids OOM risk for large recordings that exceed the
- * normal 50 MB upload limit.
+ * normal 100 MB upload limit.
  *
  * The file stays on disk; the attachment row stores an empty dataBase64 and
  * records the on-disk path in a `file_path` column (added via DB migration

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -199,8 +199,8 @@ const log = getLogger("runtime-http");
 const DEFAULT_PORT = 7821;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 
-/** Global hard cap on request body size (50 MB). */
-const MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
+/** Global hard cap on request body size (150 MB — accommodates base64-encoded 100 MB attachments). */
+const MAX_REQUEST_BODY_BYTES = 150 * 1024 * 1024;
 
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -12,8 +12,8 @@ import {
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
-/** 75 MB — base64-encoded 50 MB attachment ≈ 67 MB plus JSON wrapper overhead. */
-const MAX_UPLOAD_BODY_BYTES = 75 * 1024 * 1024;
+/** 150 MB — base64-encoded 100 MB attachment ≈ 134 MB plus JSON wrapper overhead. */
+const MAX_UPLOAD_BODY_BYTES = 150 * 1024 * 1024;
 
 export async function handleUploadAttachment(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -34,8 +34,8 @@ import { getAttachmentSourceConversations } from "./search.js";
 // Size limit - prevent materializing excessively large attachments
 // ---------------------------------------------------------------------------
 
-/** 50 MB ceiling for materialized files. */
-export const MAX_MATERIALIZE_BYTES = 50 * 1024 * 1024;
+/** 100 MB ceiling for materialized files. */
+export const MAX_MATERIALIZE_BYTES = 100 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -14,7 +14,7 @@ export const IMAGE_EXTENSIONS = new Set([
   ".webp",
 ]);
 
-const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+const MAX_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
 
 // Images above this threshold get auto-optimized via sips (macOS) to avoid
 // sending multi-MB base64 payloads to the LLM API.
@@ -123,7 +123,7 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
   if (stat.size > MAX_SIZE_BYTES) {
     const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
     return {
-      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
+      content: `Error: image too large (${sizeMB} MB). Maximum is 100 MB.`,
       isError: true,
     };
   }

--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -32,7 +32,7 @@ final class AttachmentFlowIOSTests: XCTestCase {
     // MARK: - Attachment Constants
 
     func testMaxFileSizeConstant() {
-        XCTAssertEqual(ChatViewModel.maxFileSize, 20 * 1024 * 1024, "Max file size should be 20 MB")
+        XCTAssertEqual(ChatViewModel.maxFileSize, 100 * 1024 * 1024, "Max file size should be 100 MB")
     }
 
     func testMaxImageSizeConstant() {

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -54,14 +54,14 @@ public final class ChatAttachmentManager: ObservableObject {
     }
 
     /// Limits concurrent attachment I/O to avoid unbounded memory spikes when
-    /// many files are selected at once (each can read up to 20 MB).
+    /// many files are selected at once (each can read up to 100 MB).
     private static let maxConcurrentLoads = 4
     private let loadSemaphore = AsyncSemaphore(value: maxConcurrentLoads)
 
     // MARK: - Limits
 
-    /// Maximum file size per attachment (20 MB).
-    nonisolated static let maxFileSize = 20 * 1024 * 1024
+    /// Maximum file size per attachment (100 MB).
+    nonisolated static let maxFileSize = 100 * 1024 * 1024
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5 MB limit per image; base64 encoding adds ~33% overhead.
     nonisolated static let maxImageSize = 4 * 1024 * 1024
@@ -86,7 +86,7 @@ public final class ChatAttachmentManager: ObservableObject {
     public func addAttachment(url: URL) {
         // Move file reading, compression, and thumbnail generation off the main
         // thread — Data(contentsOf:) is a blocking syscall that can stall the UI
-        // for up to 20 MB worth of I/O before we even begin image processing.
+        // for up to 100 MB worth of I/O before we even begin image processing.
         loadingCount += 1
         Task {
             defer { self.loadingCount -= 1 }
@@ -173,7 +173,7 @@ public final class ChatAttachmentManager: ObservableObject {
 
             // Belt-and-suspenders: validate the actual byte count after reading.
             guard data.count <= Self.maxFileSize else {
-                return .failure(.message("File exceeds 20 MB limit."))
+                return .failure(.message("File exceeds 100 MB limit."))
             }
 
             let filename = url.lastPathComponent
@@ -283,7 +283,7 @@ public final class ChatAttachmentManager: ObservableObject {
             #endif
 
             guard pngData.count <= Self.maxFileSize else {
-                return .failure(.message("Image exceeds 20 MB limit."))
+                return .failure(.message("Image exceeds 100 MB limit."))
             }
 
             // Compress image if needed

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -350,7 +350,7 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - Static size limits (forwarded to attachment manager for use in extensions)
 
-    /// Maximum file size per attachment (20 MB).
+    /// Maximum file size per attachment (100 MB).
     static let maxFileSize = ChatAttachmentManager.maxFileSize
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5MB limit per image; base64 encoding adds ~33% overhead.

--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -357,7 +357,7 @@ private struct SelectedFile: Identifiable {
             prompt: "Please share the design file you'd like me to review.",
             acceptedTypes: ["image/*", "application/pdf"],
             maxFiles: 3,
-            maxSizeBytes: 50 * 1024 * 1024
+            maxSizeBytes: 100 * 1024 * 1024
         ),
         onSubmit: { _ in },
         onCancel: {}

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -1041,7 +1041,7 @@ public extension Surface {
         guard let prompt = dict["prompt"] as? String else { return nil }
         let acceptedTypes = dict["acceptedTypes"] as? [String]
         let maxFiles = dict["maxFiles"] as? Int ?? 1
-        let maxSizeBytes = dict["maxSizeBytes"] as? Int ?? (50 * 1024 * 1024)
+        let maxSizeBytes = dict["maxSizeBytes"] as? Int ?? (100 * 1024 * 1024)
         return FileUploadSurfaceData(
             prompt: prompt,
             acceptedTypes: acceptedTypes,

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -13,7 +13,7 @@ describe("config: hardcoded defaults", () => {
       telegram: 20 * 1024 * 1024,
       slack: 100 * 1024 * 1024,
       whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
+      default: 100 * 1024 * 1024,
     });
     expect(config.maxAttachmentConcurrency).toBe(3);
     expect(config.runtimeProxyEnabled).toBe(false);

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -138,7 +138,7 @@ export function loadConfig(): GatewayConfig {
       telegram: 20 * 1024 * 1024, // Telegram Bot API getFile limit
       slack: 100 * 1024 * 1024, // Slack standard plan
       whatsapp: 16 * 1024 * 1024, // WhatsApp Business API limit
-      default: 50 * 1024 * 1024, // Fallback; capped by runtime MAX_UPLOAD_BYTES (50 MB)
+      default: 100 * 1024 * 1024, // Fallback; capped by runtime MAX_UPLOAD_BYTES (100 MB)
     },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,


### PR DESCRIPTION
## Summary
- Bumps all non-Telegram attachment size limits from 20/50 MB to 100 MB across daemon, gateway, and clients
- Increases HTTP request body caps to 150 MB to accommodate base64-encoded 100 MB payloads
- Telegram remains at 20 MB (Bot API hard limit), WhatsApp at 16 MB, Slack at 100 MB
- Updates all related tests, error messages, and documentation

## Original prompt
Let's bump everything except telegram to 100MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
