### PR TITLE
fix: phone calling status and guardian save bugs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -378,7 +378,7 @@ struct AssistantChannelsDetailView: View {
 
                 // Right: status or action
                 if let status, status == .connected {
-                    VBadge(label: "Connected", tone: .positive)
+                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .outlined, isDisabled: true) {}
                 } else if let setupAction {
                     VButton(label: "Set up", style: .outlined) {
                         setupAction()

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -228,7 +228,7 @@ struct AssistantChannelsDetailView: View {
     private var voiceRow: some View {
         let status = store.channelSetupStatus["phone"]
         return Group {
-            if status == "ready" || (status == "incomplete" && store.twilioHasCredentials) {
+            if store.twilioHasCredentials {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     channelRowHeader(
                         name: "Phone Calling",
@@ -238,25 +238,22 @@ struct AssistantChannelsDetailView: View {
                         hasDisconnect: true,
                         isDisconnectDisabled: store.twilioSaveInProgress
                     )
-                    // Phone number dropdown in connected state
-                    if store.twilioHasCredentials {
-                        HStack(spacing: VSpacing.sm) {
-                            Text("Phone Number")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentSecondary)
-                            VDropdown(
-                                placeholder: "Not Set",
-                                selection: Binding(
-                                    get: { store.twilioPhoneNumber ?? "" },
-                                    set: { newValue in
-                                        store.assignTwilioNumber(phoneNumber: newValue)
-                                    }
-                                ),
-                                options: store.twilioNumbers.map { (label: $0.friendlyName, value: $0.phoneNumber) },
-                                emptyValue: ""
-                            )
-                            .frame(maxWidth: 280)
-                        }
+                    HStack(spacing: VSpacing.sm) {
+                        Text("Phone Number")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                        VDropdown(
+                            placeholder: "Not Set",
+                            selection: Binding(
+                                get: { store.twilioPhoneNumber ?? "" },
+                                set: { newValue in
+                                    store.assignTwilioNumber(phoneNumber: newValue)
+                                }
+                            ),
+                            options: store.twilioNumbers.map { (label: $0.friendlyName, value: $0.phoneNumber) },
+                            emptyValue: ""
+                        )
+                        .frame(maxWidth: 280)
                     }
                 }
                 .padding(.vertical, VSpacing.sm)
@@ -709,12 +706,11 @@ struct AssistantChannelsDetailView: View {
     private var voiceCard: some View {
         let status = store.channelSetupStatus["phone"]
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio", showBorder: showCardBorders) {
-            if status == "ready" || (status == "incomplete" && store.twilioHasCredentials) {
+            if store.twilioHasCredentials {
                 VBadge(label: "Connected", tone: .positive)
             }
         } content: {
-            // Phone number dropdown: show when credentials are configured
-            if (status == "ready" || status == "incomplete") && store.twilioHasCredentials {
+            if store.twilioHasCredentials {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Phone Number")
                         .font(VFont.inputLabel)

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -378,7 +378,7 @@ struct AssistantChannelsDetailView: View {
 
                 // Right: status or action
                 if let status, status == .connected {
-                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .outlined) {}
+                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .ghost) {}
                 } else if let setupAction {
                     VButton(label: "Set up", style: .outlined) {
                         setupAction()

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -228,28 +228,7 @@ struct AssistantChannelsDetailView: View {
     private var voiceRow: some View {
         let status = store.channelSetupStatus["phone"]
         return Group {
-            if voiceSetupExpanded || (status == "incomplete" && store.twilioHasCredentials) {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    channelRowHeader(name: "Phone Calling", value: nil, status: nil)
-                    // Phone number dropdown when credentials exist
-                    if store.twilioHasCredentials {
-                        VDropdown(
-                            placeholder: "Not Set",
-                            selection: Binding(
-                                get: { store.twilioPhoneNumber ?? "" },
-                                set: { newValue in
-                                    store.assignTwilioNumber(phoneNumber: newValue)
-                                }
-                            ),
-                            options: store.twilioNumbers.map { (label: $0.friendlyName, value: $0.phoneNumber) },
-                            emptyValue: ""
-                        )
-                        .frame(maxWidth: 360)
-                    }
-                    voiceCredentialEntry
-                }
-                .padding(.vertical, VSpacing.sm)
-            } else if status == "ready" {
+            if status == "ready" || (status == "incomplete" && store.twilioHasCredentials) {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     channelRowHeader(
                         name: "Phone Calling",
@@ -279,6 +258,12 @@ struct AssistantChannelsDetailView: View {
                             .frame(maxWidth: 280)
                         }
                     }
+                }
+                .padding(.vertical, VSpacing.sm)
+            } else if voiceSetupExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    channelRowHeader(name: "Phone Calling", value: nil, status: nil)
+                    voiceCredentialEntry
                 }
                 .padding(.vertical, VSpacing.sm)
             } else {

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -378,39 +378,34 @@ struct AssistantChannelsDetailView: View {
 
                 // Right: status or action
                 if let status, status == .connected {
-                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .outlined, isDisabled: true) {}
+                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .outlined) {}
                 } else if let setupAction {
                     VButton(label: "Set up", style: .outlined) {
                         setupAction()
                     }
                 }
 
-                // Trailing column — fixed width for alignment across all rows
-                Group {
-                    if hasDisconnect, let channelKey {
-                        Menu {
-                            Button(role: .destructive) {
-                                onDisconnect?(channelKey)
-                            } label: {
-                                Label("Disconnect", systemImage: "trash")
-                            }
-                            .disabled(isDisconnectDisabled)
+                // Trailing kebab menu — only takes space when disconnect is available
+                if hasDisconnect, let channelKey {
+                    Menu {
+                        Button(role: .destructive) {
+                            onDisconnect?(channelKey)
                         } label: {
-                            VIconView(.ellipsis, size: 14)
-                                .foregroundColor(VColor.contentTertiary)
-                                .frame(width: 24, height: 24)
-                                .contentShape(Rectangle())
+                            Label("Disconnect", systemImage: "trash")
                         }
-                        .menuStyle(.borderlessButton)
-                        .menuIndicator(.hidden)
-                        .fixedSize()
-                        .opacity(isHovered ? 1 : 0)
-                        .animation(VAnimation.fast, value: isHovered)
-                    } else {
-                        Color.clear
+                        .disabled(isDisconnectDisabled)
+                    } label: {
+                        VIconView(.ellipsis, size: 14)
+                            .foregroundColor(VColor.contentTertiary)
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
                     }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    .opacity(isHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHovered)
                 }
-                .frame(width: 24)
             }
             .frame(minHeight: 36)
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -709,7 +709,7 @@ struct AssistantChannelsDetailView: View {
     private var voiceCard: some View {
         let status = store.channelSetupStatus["phone"]
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio", showBorder: showCardBorders) {
-            if status == "ready" {
+            if status == "ready" || (status == "incomplete" && store.twilioHasCredentials) {
                 VBadge(label: "Connected", tone: .positive)
             }
         } content: {
@@ -732,14 +732,12 @@ struct AssistantChannelsDetailView: View {
                     )
                     .frame(maxWidth: 360)
                 }
-            }
 
-            if status == "ready" {
                 VButton(label: "Disconnect", style: .dangerGhost, isDisabled: store.twilioSaveInProgress) {
                     store.clearTwilioCredentials()
                     store.channelSetupStatus["phone"] = "not_configured"
                 }
-            } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
+            } else if voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .outlined) {

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -378,7 +378,7 @@ struct AssistantChannelsDetailView: View {
 
                 // Right: status or action
                 if let status, status == .connected {
-                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .ghost) {}
+                    VButton(label: "Connected", leftIcon: VIcon.check.rawValue, style: .primary) {}
                 } else if let setupAction {
                     VButton(label: "Set up", style: .outlined) {
                         setupAction()

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -13,6 +13,7 @@ struct ContactDetailView: View {
     var channelClient: ChannelClientProtocol = ChannelClient()
     var store: SettingsStore?
     var onDelete: (() -> Void)?
+    var onSelectAssistant: (() -> Void)?
     var guardianName: String?
 
     @State var currentContact: ContactPayload?
@@ -79,7 +80,7 @@ struct ContactDetailView: View {
                     contact: displayContact,
                     daemonClient: daemonClient,
                     store: store,
-                    onSelectAssistant: nil,
+                    onSelectAssistant: onSelectAssistant,
                     showCardBorders: false
                 )
                 .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -196,17 +196,12 @@ struct ContactsContainerView: View {
         guard !trimmedName.isEmpty else { return }
         let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let originalNotes = contact.notes ?? ""
-        if trimmedName == contact.displayName && trimmedNotes == originalNotes {
-            return
-        }
-
         guardianIsSaving = true
         do {
             if let updated = try await contactClient.updateContact(
                 contactId: contact.id,
                 displayName: trimmedName,
-                notes: trimmedNotes
+                notes: trimmedNotes.isEmpty ? nil : trimmedNotes
             ) {
                 guardianEditedName = updated.displayName
                 guardianEditedNotes = updated.notes ?? ""

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -69,6 +69,7 @@ struct ContactsContainerView: View {
                                     selection = .assistant
                                     viewModel.loadContacts()
                                 },
+                                onSelectAssistant: { selection = .assistant },
                                 guardianName: viewModel.guardianContact?.displayName
                             )
                             .id(contactId)

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -423,7 +423,7 @@ struct GuardianChannelsDetailView: View {
         case "telegram": return "Telegram"
         case "email": return "Email"
         case "whatsapp": return "WhatsApp"
-        case "phone": return "Phone"
+        case "phone": return "Phone Calling"
         case "slack": return "Slack"
         default: return type.capitalized
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -160,8 +160,13 @@ struct GuardianChannelsDetailView: View {
                 channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
             }
         } else {
+            let needsSetup = !isVerified
+                && store?.channelVerificationState(for: type).verified != true
+                && (existingChannels.isEmpty || dismissedChannels.contains(type))
+                && !setupExpanded.contains(type)
+
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                // Row header: icon + name + status
+                // Row header: icon + name + inline status/action
                 HStack(spacing: VSpacing.sm) {
                     VIconView(channelIcon(for: type), size: 16)
                         .foregroundColor(isVerified ? VColor.systemPositiveStrong : VColor.contentSecondary)
@@ -171,11 +176,19 @@ struct GuardianChannelsDetailView: View {
                     Spacer()
                     if isVerified {
                         VBadge(label: "Verified", tone: .positive)
+                    } else if needsSetup {
+                        VButton(label: "Set up", style: .outlined) {
+                            dismissedChannels.remove(type)
+                            setupExpanded.insert(type)
+                        }
                     }
                 }
                 .frame(minHeight: 36)
-                // Expandable content below the row
-                channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
+
+                // Expanded content below the row (verification flow or verified identity)
+                if !needsSetup {
+                    channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
+                }
             }
         }
     }
@@ -188,16 +201,10 @@ struct GuardianChannelsDetailView: View {
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
             verificationFlowContent(for: type)
-        } else {
-            VButton(label: "Set Up", style: .outlined) {
-                dismissedChannels.remove(type)
-                setupExpanded.insert(type)
-            }
         }
 
-            if errorChannelType == type, let errorMessage {
-                VInlineMessage(errorMessage)
-            }
+        if errorChannelType == type, let errorMessage {
+            VInlineMessage(errorMessage)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -69,7 +69,11 @@ struct GuardianChannelsDetailView: View {
     private var visibleTypes: [String] {
         Self.allChannelTypes.filter { type in
             let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
-            return hasExisting || channelReadiness[type]?.ready == true
+            let readiness = channelReadiness[type]
+            let isAvailable = readiness?.ready == true
+                || readiness?.setupStatus == "ready"
+                || readiness?.setupStatus == "incomplete"
+            return hasExisting || isAvailable
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -134,40 +134,66 @@ struct GuardianChannelsDetailView: View {
 
     // MARK: - Channel Card
 
+    private func channelIcon(for type: String) -> VIcon {
+        switch type {
+        case "slack": return .hash
+        case "telegram": return .send
+        case "phone": return .phone
+        default: return .messageCircle
+        }
+    }
+
     @ViewBuilder
     private func channelCard(for type: String) -> some View {
-        SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type), showBorder: showCardBorders) {
-            let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
-            let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
-                ?? existingChannels.first
-            if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
-                VBadge(label: "Verified", tone: .positive)
-            } else if store?.channelVerificationState(for: type).verified == true {
-                VBadge(label: "Verified", tone: .positive)
-            }
-        } content: {
-            let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
+        let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
+        let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
+            ?? existingChannels.first
+        let isVerified = (activeChannel?.status == "active" && activeChannel?.verifiedAt != nil)
+            || store?.channelVerificationState(for: type).verified == true
 
-            // Prefer the latest verified channel to avoid showing stale status when
-            // multiple non-revoked rows exist for the same channel type.
-            let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
-                ?? existingChannels.first
-
-            if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
-                // Verified channel — show rich identity + disconnect
-                verifiedChannelContent(channel: channel, type: type)
-            } else if store?.channelVerificationState(for: type).verified == true
-                || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
-                || setupExpanded.contains(type) {
-                // Existing unverified channel or user clicked "Set Up" — show verification flow
-                verificationFlowContent(for: type)
-            } else {
-                // Channel ready on assistant but not yet started — show "Set Up"
-                VButton(label: "Set Up", style: .outlined) {
-                    dismissedChannels.remove(type)
-                    setupExpanded.insert(type)
+        if showCardBorders {
+            SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type), showBorder: true) {
+                if isVerified {
+                    VBadge(label: "Verified", tone: .positive)
                 }
+            } content: {
+                channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
             }
+        } else {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Row header: icon + name + status
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(channelIcon(for: type), size: 16)
+                        .foregroundColor(isVerified ? VColor.systemPositiveStrong : VColor.contentSecondary)
+                    Text(channelLabel(for: type))
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentDefault)
+                    Spacer()
+                    if isVerified {
+                        VBadge(label: "Verified", tone: .positive)
+                    }
+                }
+                .frame(minHeight: 36)
+                // Expandable content below the row
+                channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func channelCardContent(type: String, existingChannels: [ContactChannelPayload], activeChannel: ContactChannelPayload?, isVerified: Bool) -> some View {
+        if let channel = activeChannel, isVerified {
+            verifiedChannelContent(channel: channel, type: type)
+        } else if store?.channelVerificationState(for: type).verified == true
+            || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
+            || setupExpanded.contains(type) {
+            verificationFlowContent(for: type)
+        } else {
+            VButton(label: "Set Up", style: .outlined) {
+                dismissedChannels.remove(type)
+                setupExpanded.insert(type)
+            }
+        }
 
             if errorChannelType == type, let errorMessage {
                 VInlineMessage(errorMessage)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1293,6 +1293,10 @@ public final class SettingsStore: ObservableObject {
             )
             twilioSaveInProgress = false
             self.fetchChannelSetupStatus()
+            // Fetch available phone numbers immediately after saving credentials
+            if twilioHasCredentials {
+                self.refreshTwilioNumbers()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1363,6 +1363,10 @@ public final class SettingsStore: ObservableObject {
                 applyNumbers: true
             )
             twilioListInProgress = false
+            // Auto-select the first available number if none is assigned
+            if twilioPhoneNumber == nil, let first = twilioNumbers.first {
+                assignTwilioNumber(phoneNumber: first.phoneNumber)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1305,6 +1305,10 @@ public final class SettingsStore: ObservableObject {
                 method: "DELETE",
                 path: "integrations/twilio/credentials"
             )
+            // Clear any warning/error set by the response — "credentials not
+            // configured" is obvious after the user just disconnected.
+            twilioWarning = nil
+            twilioError = nil
             twilioSaveInProgress = false
             self.fetchChannelSetupStatus()
         }


### PR DESCRIPTION
## Summary
- Fix phone calling flat row: show connected state when credentials exist (even if status is "incomplete"), hide credential form when already configured
- Auto-select first available phone number after refreshing Twilio numbers if none is assigned
- Fix guardian (You) save: remove overly aggressive no-change early return, pass nil for empty notes

## Original prompt
--safe fix bugs: when setting up phone calling, it doesn't show if it's connected, it doesn't pick any available phone numbers by default and it's still offering to enter credentials, even there are some set already; when I am trying to change name for User (You) and click save it doesn't do anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
