### PR TITLE
fix: suppress activity notifications when conversation window is visible

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -285,6 +285,9 @@ public final class MainWindow {
         self.usageDashboardStore = UsageDashboardStore()
         self.conversationManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient
+        services.activityNotificationService.isConversationWindowVisible = { [weak self] in
+            self?.isVisible ?? false
+        }
         services.daemonClient.onTraceEvent = { [weak self] msg in
             Task { @MainActor in
                 self?.traceStore.ingest(msg)

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -11,6 +11,11 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 public final class ActivityNotificationService {
     private let settingsStore: SettingsStore
 
+    /// Returns true when the conversation window is visible on screen.
+    /// Injected by the window owner — defaults to false so notifications
+    /// fire when no window has been created yet.
+    public var isConversationWindowVisible: () -> Bool = { false }
+
     public init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
     }
@@ -33,11 +38,14 @@ public final class ActivityNotificationService {
             return
         }
 
-        // Check if app is in background
+        // Check if the user can already see the conversation — either the app
+        // is focused or the main window is visible (common for menu-bar apps where
+        // the window stays on screen after the user clicks another app).
         let isActive = NSApp.isActive
-        log.info("App isActive: \(isActive)")
-        guard !isActive else {
-            log.info("App is in foreground, skipping notification")
+        let windowVisible = isConversationWindowVisible()
+        log.info("App isActive: \(isActive), windowVisible: \(windowVisible)")
+        guard !isActive && !windowVisible else {
+            log.info("App is in foreground or window visible, skipping notification")
             return
         }
 
@@ -79,8 +87,8 @@ public final class ActivityNotificationService {
     /// Sends a notification when a quick input response completes.
     /// Only sends if the app is not active and notification permissions are granted.
     public func notifyQuickInputComplete(summary: String) async {
-        // Check if app is in background
-        guard !NSApp.isActive else { return }
+        // Check if app is in background or window is visible
+        guard !NSApp.isActive && !isConversationWindowVisible() else { return }
 
         // Check notification permissions
         let center = UNUserNotificationCenter.current()


### PR DESCRIPTION
## Summary
- `NSApp.isActive` is unreliable for LSUIElement (menu-bar) apps — it goes false when the user clicks another window, even if the Vellum window is still visible
- Added `isConversationWindowVisible` closure to `ActivityNotificationService` that checks `MainWindow.isVisible`
- Notifications are now suppressed when either the app is focused OR the main window is on screen

## Original prompt
Suppress "Completed N actions" notifications when the conversation window is visible, not just when the app is active — fixes false notifications for menu-bar apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
