### PR TITLE
Add hasManagedServices computed property to SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -200,6 +200,11 @@ public final class SettingsStore: ObservableObject {
     /// Current web search mode. Values: "managed" or "your-own".
     @Published var webSearchMode: String = "your-own"
 
+    /// True when any service is configured to use managed mode.
+    var hasManagedServices: Bool {
+        inferenceMode == "managed" || webSearchMode == "managed" || imageGenMode == "managed"
+    }
+
     static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
 
     static let webSearchProviderDisplayNames: [String: String] = [


### PR DESCRIPTION
## Summary
- Add a `hasManagedServices` computed property to `SettingsStore` that returns `true` when any service (inference, web search, image generation) is in managed mode
- This will be used by the logout flow to show a confirmation alert when managed services are active

Part of plan: logout-managed-service-warning.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
