### PR TITLE
Add logout confirmation alert to DrawerMenuView when managed services are active

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -569,6 +569,7 @@ struct MainWindowView: View {
                         let drawerY = bottomPad + SidebarLayoutMetrics.rowMinHeight + dividerHeight + VSpacing.xs
                         DrawerMenuView(
                             authManager: authManager,
+                            settingsStore: settingsStore,
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.settings)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 
 struct DrawerMenuView: View {
     let authManager: AuthManager
+    let settingsStore: SettingsStore
     let onSettings: () -> Void
     let onUsage: () -> Void
     let onDebug: () -> Void
@@ -14,6 +15,7 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
     @State private var bootstrapGeneration: Int = 0
+    @State private var showLogoutAlert = false
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
 
     private var isBillingVisible: Bool {
@@ -71,7 +73,13 @@ struct DrawerMenuView: View {
                 SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
                 if authManager.isAuthenticated {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
+                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out")) {
+                        if settingsStore.hasManagedServices {
+                            showLogoutAlert = true
+                        } else {
+                            onLogOut()
+                        }
+                    }
                 } else {
                     SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
                 }
@@ -82,6 +90,17 @@ struct DrawerMenuView: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+        .alert("Heads up", isPresented: $showLogoutAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Log Out", role: .destructive) {
+                onLogOut()
+            }
+        } message: {
+            Text(
+                "Some of your services rely on being logged in."
+                    + " They won't work until you log back in or switch them to use your own API keys."
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }


### PR DESCRIPTION
## Summary
- Show a confirmation alert when logging out from the drawer menu while any services are in managed mode
- Pass settingsStore to DrawerMenuView from MainWindowView to check managed service state
- Alert copy matches the General tab alert exactly for consistency

Part of plan: logout-managed-service-warning.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
