### PR TITLE
fix: heal guardian binding drift after DB reset

### DIFF
--- a/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
+++ b/assistant/src/__tests__/guardian-binding-drift-heal.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(
+  join(tmpdir(), "guardian-binding-drift-heal-test-"),
+);
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { healGuardianBindingDrift } from "../runtime/guardian-vellum-migration.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+describe("healGuardianBindingDrift", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test("heals drift when both principals have vellum-principal- prefix", () => {
+    // Simulate DB reset: new guardian binding with a different UUID
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-new-uuid",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-new-uuid",
+      verifiedVia: "startup-migration",
+    });
+
+    // Client arrives with the old JWT principal
+    const healed = healGuardianBindingDrift("vellum-principal-old-uuid");
+    expect(healed).toBe(true);
+
+    // Guardian binding now matches the old JWT
+    const guardian = findGuardianForChannel("vellum");
+    expect(guardian).not.toBeNull();
+    expect(guardian!.contact.principalId).toBe("vellum-principal-old-uuid");
+    expect(guardian!.channel.externalUserId).toBe("vellum-principal-old-uuid");
+  });
+
+  test("no-op when principals already match", () => {
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-same",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-same",
+      verifiedVia: "startup-migration",
+    });
+
+    const healed = healGuardianBindingDrift("vellum-principal-same");
+    expect(healed).toBe(false);
+  });
+
+  test("refuses to heal when incoming principal lacks vellum-principal- prefix", () => {
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "vellum-principal-aaa",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "vellum-principal-aaa",
+      verifiedVia: "startup-migration",
+    });
+
+    // External/platform principal — should NOT be adopted
+    const healed = healGuardianBindingDrift("platform-user-12345");
+    expect(healed).toBe(false);
+
+    // Guardian unchanged
+    const guardian = findGuardianForChannel("vellum");
+    expect(guardian!.contact.principalId).toBe("vellum-principal-aaa");
+  });
+
+  test("refuses to heal when stored principal lacks vellum-principal- prefix", () => {
+    createGuardianBinding({
+      channel: "vellum",
+      guardianExternalUserId: "verified-phone-guardian",
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId: "verified-phone-guardian",
+      verifiedVia: "challenge",
+    });
+
+    // Even with a vellum-principal- incoming, don't overwrite a real binding
+    const healed = healGuardianBindingDrift("vellum-principal-attacker");
+    expect(healed).toBe(false);
+
+    const guardian = findGuardianForChannel("vellum");
+    expect(guardian!.contact.principalId).toBe("verified-phone-guardian");
+  });
+
+  test("returns false when no guardian binding exists", () => {
+    const healed = healGuardianBindingDrift("vellum-principal-orphan");
+    expect(healed).toBe(false);
+  });
+});

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -901,6 +901,39 @@ export function updateChannelLastSeenById(channelId: string): void {
 }
 
 /**
+ * Update a guardian contact's principalId and its channel's identity fields.
+ * Used for healing guardian binding drift when the JWT principal no longer
+ * matches the stored guardian binding after a DB reset.
+ */
+export function updateContactPrincipalAndChannel(
+  contactId: string,
+  channelId: string,
+  newPrincipalId: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  const normalizedAddress = newPrincipalId.toLowerCase();
+
+  db.transaction(() => {
+    db.update(contacts)
+      .set({ principalId: newPrincipalId, updatedAt: now })
+      .where(eq(contacts.id, contactId))
+      .run();
+
+    db.update(contactChannels)
+      .set({
+        externalUserId: newPrincipalId,
+        address: normalizedAddress,
+        updatedAt: now,
+      })
+      .where(eq(contactChannels.id, channelId))
+      .run();
+  });
+
+  emitContactChange();
+}
+
+/**
  * Atomically increment interactionCount and set lastInteraction on a contact channel.
  * Optimized for the hot path — single UPDATE with no prior SELECT.
  */

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -12,7 +12,10 @@
 
 import { v4 as uuid } from "uuid";
 
-import { findGuardianForChannel } from "../contacts/contact-store.js";
+import {
+  findGuardianForChannel,
+  updateContactPrincipalAndChannel,
+} from "../contacts/contact-store.js";
 import { createGuardianBinding } from "../contacts/contacts-write.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -69,4 +72,52 @@ export function ensureVellumGuardianBinding(
   );
 
   return guardianPrincipalId;
+}
+
+/**
+ * Heal guardian binding drift for the vellum channel.
+ *
+ * After a DB reset, the daemon creates a new guardian binding with a fresh
+ * `vellum-principal-<uuid>`, but the client may still hold a valid JWT
+ * signed with the surviving signing key containing the old principal.
+ * The JWT passes signature validation but trust resolution returns
+ * `unknown` because the principals don't match.
+ *
+ * This function detects that scenario and updates the binding to match
+ * the JWT's principal. Only heals when both the stored and incoming
+ * principals have the `vellum-principal-` prefix (both auto-generated,
+ * no external identity meaning). The JWT's signature proves it was
+ * minted by this daemon's signing key.
+ *
+ * Returns true if healing occurred, false otherwise.
+ */
+export function healGuardianBindingDrift(
+  incomingPrincipalId: string,
+): boolean {
+  if (!incomingPrincipalId.startsWith("vellum-principal-")) {
+    return false;
+  }
+
+  const guardianResult = findGuardianForChannel("vellum");
+  if (!guardianResult) return false;
+
+  const currentPrincipalId = guardianResult.contact.principalId;
+  if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
+  if (currentPrincipalId === incomingPrincipalId) return false;
+
+  updateContactPrincipalAndChannel(
+    guardianResult.contact.id,
+    guardianResult.channel.id,
+    incomingPrincipalId,
+  );
+
+  log.info(
+    {
+      oldPrincipalId: currentPrincipalId,
+      newPrincipalId: incomingPrincipalId,
+    },
+    "Healed vellum guardian binding drift — updated principalId to match JWT actor",
+  );
+
+  return true;
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -58,6 +58,7 @@ import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import type { AuthContext } from "../auth/types.js";
 import { bridgeConfirmationRequestToGuardian } from "../confirmation-request-guardian-bridge.js";
+import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
 import { routeGuardianReply } from "../guardian-reply-router.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -647,22 +648,43 @@ export async function handleSendMessage(
   // the same trust resolution pipeline that channel ingress uses.
   if (authContext.actorPrincipalId) {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-    const trustCtx = resolveTrustContext({
+    let trustCtx = resolveTrustContext({
       assistantId,
       sourceChannel: "vellum",
       conversationExternalId: "local",
       actorExternalId: authContext.actorPrincipalId,
     });
     if (trustCtx.trustClass === "unknown") {
-      log.warn(
-        {
-          actorPrincipalId: authContext.actorPrincipalId,
-          sourceChannel,
-          trustClass: trustCtx.trustClass,
-          principalType: authContext.principalType,
-        },
-        "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
-      );
+      // Attempt to heal guardian binding drift: after a DB reset the
+      // guardian binding gets a new vellum-principal-* UUID while the
+      // client still holds a valid JWT with the old one. The signing
+      // key survives the reset, so the JWT is authentic — just stale.
+      const healed = healGuardianBindingDrift(authContext.actorPrincipalId);
+      if (healed) {
+        trustCtx = resolveTrustContext({
+          assistantId,
+          sourceChannel: "vellum",
+          conversationExternalId: "local",
+          actorExternalId: authContext.actorPrincipalId,
+        });
+        log.info(
+          {
+            actorPrincipalId: authContext.actorPrincipalId,
+            trustClass: trustCtx.trustClass,
+          },
+          "Trust re-resolved after guardian binding drift heal",
+        );
+      } else {
+        log.warn(
+          {
+            actorPrincipalId: authContext.actorPrincipalId,
+            sourceChannel,
+            trustClass: trustCtx.trustClass,
+            principalType: authContext.principalType,
+          },
+          "JWT-verified actor resolved to unknown trust class — possible guardian binding drift (e.g. DB reset without re-bootstrap)",
+        );
+      }
     }
     conversation.setTrustContext(withSourceChannel(sourceChannel, trustCtx));
   } else {


### PR DESCRIPTION
## Summary

- After a DB reset, the daemon's guardian binding gets a new `vellum-principal-*` UUID while the client holds a JWT with the old one. Trust resolves to `unknown`, blocking all host-target tools with "Permission denied... requires guardian approval."
- Added `healGuardianBindingDrift()` that detects this mismatch and atomically updates the binding to match the JWT's principal, then re-resolves trust. Only heals when both principals have the `vellum-principal-` prefix (auto-generated), ensuring real verified bindings are never overwritten.
- The two DB updates (contact `principalId` + channel `externalUserId`/`address`) are wrapped in a transaction to prevent partial state on crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
