### PR TITLE
Add logout confirmation alert to SettingsGeneralTab when managed services are active

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -12,6 +12,7 @@ struct SettingsGeneralTab: View {
     var onSignIn: (() -> Void)?
 
     @State private var showingPairingQR: Bool = false
+    @State private var showLogoutAlert = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -92,7 +93,11 @@ struct SettingsGeneralTab: View {
                 }
             } else if authManager.currentUser != nil {
                 VButton(label: "Log Out", style: .danger) {
-                    AppDelegate.shared?.performLogout()
+                    if store.hasManagedServices {
+                        showLogoutAlert = true
+                    } else {
+                        AppDelegate.shared?.performLogout()
+                    }
                 }
             } else {
                 VButton(
@@ -110,6 +115,17 @@ struct SettingsGeneralTab: View {
                     }
                 }
             }
+        }
+        .alert("Heads up", isPresented: $showLogoutAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Log Out", role: .destructive) {
+                AppDelegate.shared?.performLogout()
+            }
+        } message: {
+            Text(
+                "Some of your services rely on being logged in."
+                    + " They won't work until you log back in or switch them to use your own API keys."
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Show a confirmation alert when logging out from the General tab while any services are in managed mode
- Alert warns that managed services won't work until user logs back in or switches to own API keys
- If no managed services, logout proceeds immediately without a modal

Part of plan: logout-managed-service-warning.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
