### PR TITLE
feat: GA multifile app builder

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -63,7 +63,21 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 
 const mockStore = makeMockStore();
 
-mock.module("../memory/app-store.js", () => mockStore);
+mock.module("../memory/app-store.js", () => ({
+  ...mockStore,
+  getAppsDir: () => "/tmp/test-apps",
+  isMultifileApp: (app: AppDefinition) => app.formatVersion === 2,
+}));
+
+// Mock compileApp for multifile scaffold path
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: async () => ({
+    ok: true,
+    errors: [],
+    warnings: [],
+    durationMs: 0,
+  }),
+}));
 
 // ---------------------------------------------------------------------------
 // Import skill scripts (after mocking)

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -39,7 +39,7 @@
       "key": "feature_flags.app-builder-multifile.enabled",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "sentry-testing",


### PR DESCRIPTION
## Summary
- Defaults the `app-builder-multifile` feature flag to `true`, making multi-file TSX app creation the default for all users.

## Test plan
- [ ] Verify new apps are created as multifile (formatVersion 2) by default
- [ ] Verify the flag can still be toggled off to fall back to single-file HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
