### PR TITLE
chore: remove unused sentry_testing_enabled feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "sentry-testing",
-      "scope": "macos",
-      "key": "sentry_testing_enabled",
-      "label": "Sentry Testing",
-      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
-      "defaultEnabled": false
-    },
-    {
       "id": "mobile-pairing",
       "scope": "macos",
       "key": "mobile_pairing_enabled",


### PR DESCRIPTION
## Summary
- Remove the `sentry_testing_enabled` feature flag from `feature-flag-registry.json`
- The flag was originally added to gate the Sentry Testing tab in Settings, but the tab was moved into the Developer tab where it renders unconditionally — the flag is no longer checked anywhere

## Original prompt
Remove the unused sentry_testing_enabled feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
