### PR TITLE
feat: add Vellum's Cloud hosting option to onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -65,15 +65,16 @@ struct APIKeyStepView: View {
     // MARK: - Hosting Cards
 
     private var availableHostingModes: [OnboardingState.HostingMode] {
-        var modes: [OnboardingState.HostingMode] = []
-        if !state.skippedAuth {
-            modes.append(.vellumCloud)
-        }
-        modes.append(.local)
+        var modes: [OnboardingState.HostingMode] = [.local, .vellumCloud]
         if userHostedEnabled {
             modes.append(contentsOf: [.docker, .aws, .gcp, .customHardware])
         }
         return modes
+    }
+
+    private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
+        guard mode == .vellumCloud else { return nil }
+        return state.skippedAuth ? "Requires Account" : "Coming Soon"
     }
 
     private var hostingCards: some View {
@@ -84,7 +85,7 @@ struct APIKeyStepView: View {
                     title: mode.displayName,
                     subtitle: mode.subtitle,
                     mode: mode,
-                    comingSoon: mode == .vellumCloud
+                    chipLabel: chipLabel(for: mode)
                 )
             }
         }
@@ -105,31 +106,32 @@ struct APIKeyStepView: View {
         title: String,
         subtitle: String,
         mode: OnboardingState.HostingMode,
-        comingSoon: Bool
+        chipLabel: String?
     ) -> some View {
-        let isSelected = state.selectedHostingMode == mode && !comingSoon
+        let isDisabled = chipLabel != nil
+        let isSelected = state.selectedHostingMode == mode && !isDisabled
 
         return Button(action: {
-            guard !comingSoon else { return }
+            guard !isDisabled else { return }
             state.selectedHostingMode = mode
         }) {
             HStack(spacing: VSpacing.md) {
                 VIconView(icon, size: 18)
-                    .foregroundColor(comingSoon ? VColor.contentDisabled : (isSelected ? VColor.primaryBase : VColor.contentSecondary))
+                    .foregroundColor(isDisabled ? VColor.contentDisabled : (isSelected ? VColor.primaryBase : VColor.contentSecondary))
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(comingSoon ? VColor.contentDisabled : VColor.contentDefault)
+                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentDefault)
                     Text(subtitle)
                         .font(.system(size: 12))
-                        .foregroundColor(comingSoon ? VColor.contentDisabled : VColor.contentSecondary)
+                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentSecondary)
                 }
 
                 Spacer()
 
-                if comingSoon {
-                    Text("Coming Soon")
+                if let chipLabel {
+                    Text(chipLabel)
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.contentTertiary)
                         .padding(.horizontal, VSpacing.sm)
@@ -160,15 +162,15 @@ struct APIKeyStepView: View {
                         RoundedRectangle(cornerRadius: VRadius.lg)
                             .stroke(
                                 isSelected ? VColor.primaryBase.opacity(0.5)
-                                    : (comingSoon ? VColor.borderDisabled : VColor.borderBase),
+                                    : (isDisabled ? VColor.borderDisabled : VColor.borderBase),
                                 lineWidth: 1
                             )
                     )
             )
-            .opacity(comingSoon ? 0.7 : 1.0)
+            .opacity(isDisabled ? 0.7 : 1.0)
         }
         .buttonStyle(.plain)
-        .disabled(comingSoon)
+        .disabled(isDisabled)
         .pointerCursor()
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -57,7 +57,7 @@ final class OnboardingState {
 
         var displayName: String {
             switch self {
-            case .vellumCloud: return "Vellum Cloud"
+            case .vellumCloud: return "Vellum\u{2019}s Cloud"
             case .local: return "Local"
             case .docker: return "Docker"
             case .gcp: return "GCP"
@@ -68,7 +68,7 @@ final class OnboardingState {
 
         var subtitle: String {
             switch self {
-            case .vellumCloud: return "Hosted and managed by Vellum"
+            case .vellumCloud: return "Ready out of the box. Runs entirely on Vellum\u{2019}s secure infrastructure."
             case .local: return "Run on your machine"
             case .docker: return "Run in a Docker container"
             case .gcp: return "Host on your GCP account"


### PR DESCRIPTION
## Summary
- Add "Vellum's Cloud" as a visible (but disabled) hosting option below "Local" on the Hosting step
- Subtitle: "Ready out of the box. Runs entirely on Vellum's secure infrastructure."
- Shows "Coming Soon" chip for logged-in users, "Requires Account" chip for users who skipped login
- Refactored `comingSoon: Bool` to `chipLabel: String?` pattern for dynamic chip text

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
