### PR TITLE
feat: add "Need help deciding?" link to hosting step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -41,6 +41,10 @@ struct APIKeyStepView: View {
                     handleContinue()
                 }
 
+                OnboardingButton(title: "Need help deciding?", style: .secondary) {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
+                }
+
                 if !isAuthenticated {
                     OnboardingButton(title: "Back", style: .ghost) {
                         goBack()


### PR DESCRIPTION
## Summary
- Add a "Need help deciding?" secondary button to the Hosting onboarding step
- Positioned between Continue and Back buttons, styled as a green outlined button
- Opens https://vellum.ai/docs/environments to help users choose their hosting option

## Original prompt
Add "Need help deciding?" button to hosting step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
