### PR TITLE
fix: auto-approve ui_show tool for untrusted actors

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -259,10 +259,10 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     }),
   );
 
-  // ui_update and ui_dismiss are purely passive operations (modify/remove existing
-  // surfaces). ui_show is excluded because it can create forms that collect user
-  // input — it goes through normal permission checking instead.
-  const UI_SURFACE_TOOLS = ["ui_update", "ui_dismiss"] as const;
+  // All three UI surface tools are passive, user-visible operations. ui_show
+  // creates surfaces (cards, forms, tables) but user input is voluntary and
+  // user-controlled — safe to auto-approve like ui_update and ui_dismiss.
+  const UI_SURFACE_TOOLS = ["ui_show", "ui_update", "ui_dismiss"] as const;
   const uiSurfaceRules: DefaultRuleTemplate[] = UI_SURFACE_TOOLS.map(
     (tool) => ({
       id: `default:allow-${tool}-global`,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -130,11 +130,20 @@ export async function waitForInlineGrant(
   return { outcome: "timeout", requestId: escalationRequestId };
 }
 
+const UI_SURFACE_TOOLS = new Set(["ui_show", "ui_update", "ui_dismiss"]);
+
 function requiresGuardianApprovalForActor(
   toolName: string,
   input: Record<string, unknown>,
   executionTarget: ExecutionTarget,
 ): boolean {
+  // UI surface tools are passive, user-visible operations (cards, forms,
+  // tables). User input is voluntary and user-controlled — skip the guardian
+  // gate so they work during fresh onboarding before trust is established.
+  if (UI_SURFACE_TOOLS.has(toolName)) {
+    return false;
+  }
+
   // Side-effect tools always require guardian approval for untrusted actors.
   // Read-only host execution is also blocked because it can leak sensitive
   // local information (e.g. shell/file reads).


### PR DESCRIPTION
## Summary
- `ui_show` was blocked by the guardian approval gate during fresh onboarding (no trust grants, `trustClass: "unknown"`), causing the model to fall back to plain text lists instead of interactive cards/forms
- Added `ui_show` to default allow rules alongside `ui_update` and `ui_dismiss`
- Added UI surface tools exemption in the guardian approval gate since they are passive, user-visible operations

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/checker.test.ts` (367 pass)
- [x] `bun test src/__tests__/tool-approval-handler.test.ts` (14 pass)
- [x] Manual test: fresh onboarding now renders `ui_show` cards instead of falling back to bullet lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
