### PR TITLE
fix: add force parameter to initializeServiceDefaults for managed bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -398,10 +398,11 @@ extension AppDelegate {
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
 
-                // Set service modes to "managed" for any services that don't already have a
-                // mode configured. On first bootstrap this sets all three; on subsequent app
-                // restarts the user's existing choices are preserved.
-                WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "managed")
+                // Set service modes to "managed", forcing overwrite so that daemon-
+                // materialized schema defaults ("your-own") are replaced on first
+                // authenticated startup. On subsequent restarts the user's explicit
+                // choices are preserved because authentication is already established.
+                WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "managed", force: true)
 
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -97,27 +97,34 @@ public enum WorkspaceConfigIO {
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").
     /// Existing user-chosen modes are preserved so that app restarts don't reset preferences.
-    public static func initializeServiceDefaults(defaultMode mode: String, into path: String? = nil) {
+    ///
+    /// - Parameters:
+    ///   - mode: The service mode to set (e.g. "managed", "your-own").
+    ///   - force: When `true`, overwrites existing modes unconditionally. Use this
+    ///     for the managed bootstrap path where daemon-materialized schema defaults
+    ///     ("your-own") must be replaced with the correct managed mode.
+    ///   - path: Override the file path (useful for testing).
+    public static func initializeServiceDefaults(defaultMode mode: String, force: Bool = false, into path: String? = nil) {
         let existingConfig = read(from: path)
         var services = existingConfig["services"] as? [String: Any] ?? [:]
         var changed = false
 
         var inference = services["inference"] as? [String: Any] ?? [:]
-        if inference["mode"] == nil {
+        if force || inference["mode"] == nil {
             inference["mode"] = mode
             services["inference"] = inference
             changed = true
         }
 
         var imageGen = services["image-generation"] as? [String: Any] ?? [:]
-        if imageGen["mode"] == nil {
+        if force || imageGen["mode"] == nil {
             imageGen["mode"] = mode
             services["image-generation"] = imageGen
             changed = true
         }
 
         var webSearch = services["web-search"] as? [String: Any] ?? [:]
-        if webSearch["mode"] == nil {
+        if force || webSearch["mode"] == nil {
             webSearch["mode"] = mode
             services["web-search"] = webSearch
             changed = true


### PR DESCRIPTION
## Summary
- Add `force: Bool` parameter to `initializeServiceDefaults` (default `false`)
- Managed bootstrap caller passes `force: true` to overwrite daemon-materialized schema defaults
- BYOK onboarding and restart paths preserve existing user choices via `force: false`

Addresses feedback from PR #18428
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
