### PR TITLE
fix: guard against duplicate reactivation in wipeConversation Steps B and F

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -398,6 +398,14 @@ export function wipeConversation(id: string): WipeConversationResult {
          JOIN messages m2 ON m2.id = mis2.message_id
          WHERE mis2.memory_item_id = mi_new.id
            AND m2.conversation_id != ?
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM memory_items mi_active
+         WHERE mi_active.kind = mi_old.kind
+           AND mi_active.subject = mi_old.subject
+           AND mi_active.scope_id = mi_old.scope_id
+           AND mi_active.status = 'active'
+           AND mi_active.id != mi_old.id
        )`,
     id,
     id,
@@ -482,19 +490,25 @@ export function wipeConversation(id: string): WipeConversationResult {
       params.push(kind, subject);
     }
     orphanedSuperseded = rawAll<{ id: string }>(
-      `SELECT id FROM memory_items
-       WHERE status = 'superseded'
-         AND superseded_by IS NULL
-         AND scope_id = ?
-         AND (kind, subject) IN (VALUES ${placeholders})
-         AND NOT EXISTS (
-           SELECT 1 FROM memory_items mi2
-           WHERE mi2.kind = memory_items.kind
-             AND mi2.subject = memory_items.subject
-             AND mi2.scope_id = memory_items.scope_id
-             AND mi2.status = 'active'
-             AND mi2.id != memory_items.id
-         )`,
+      `SELECT id FROM (
+         SELECT id, ROW_NUMBER() OVER (
+           PARTITION BY kind, subject, scope_id
+           ORDER BY last_seen_at DESC
+         ) AS rn
+         FROM memory_items
+         WHERE status = 'superseded'
+           AND superseded_by IS NULL
+           AND scope_id = ?
+           AND (kind, subject) IN (VALUES ${placeholders})
+           AND NOT EXISTS (
+             SELECT 1 FROM memory_items mi2
+             WHERE mi2.kind = memory_items.kind
+               AND mi2.subject = memory_items.subject
+               AND mi2.scope_id = memory_items.scope_id
+               AND mi2.status = 'active'
+               AND mi2.id != memory_items.id
+           )
+       ) WHERE rn = 1`,
       ...params,
     );
   }


### PR DESCRIPTION
## Summary
- Step B: skip reactivation when a surviving active replacement exists for the same kind+subject+scope_id
- Step F: use ROW_NUMBER to only restore the most recent superseded item per kind+subject group

Addresses feedback from PR #18426
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
