### PR TITLE
fix(macos): fix Escape handling, selectedRanges crash, and stale parent in editor

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -91,6 +91,14 @@ struct HighlightedTextView: View {
                 .background(Self.editorBackground)
             }
         }
+        .onKeyPress(.escape) {
+            if isSearchVisible {
+                dismissSearch()
+                return .handled
+            }
+            isActivelyEditing = false
+            return .handled
+        }
         .onChange(of: text) { _, _ in
             let count = searchMatchCount
             if count == 0 {
@@ -412,11 +420,21 @@ private struct CodeTextView: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: HorizontalOnlyScrollView, context: Context) {
+        context.coordinator.parent = self
         guard let textView = scrollView.documentView as? CodeNSTextView else { return }
         if textView.string != text {
             let selectedRanges = textView.selectedRanges
             textView.string = text
-            textView.selectedRanges = selectedRanges
+            let length = (text as NSString).length
+            let clampedRanges = selectedRanges.compactMap { rangeValue -> NSValue? in
+                let range = rangeValue.rangeValue
+                let clampedLocation = min(range.location, length)
+                let clampedLength = min(range.length, length - clampedLocation)
+                return NSValue(range: NSRange(location: clampedLocation, length: clampedLength))
+            }
+            textView.selectedRanges = clampedRanges.isEmpty
+                ? [NSValue(range: NSRange(location: length, length: 0))]
+                : clampedRanges
         }
         textView.onEscape = onEscape
         textView.onCommandF = onCommandF


### PR DESCRIPTION
## Summary
- Add container-level Escape handling so it works when search bar is focused
- Clamp selectedRanges to string length in updateNSView to prevent crash
- Update Coordinator.parent in updateNSView to prevent stale callbacks

Addresses feedback from PR #18472
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
