### PR TITLE
fix: revert image-read limit to 20 MB and reduce concurrent attachment loads

### DIFF
--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -14,7 +14,7 @@ export const IMAGE_EXTENSIONS = new Set([
   ".webp",
 ]);
 
-const MAX_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
+const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
 
 // Images above this threshold get auto-optimized via sips (macOS) to avoid
 // sending multi-MB base64 payloads to the LLM API.
@@ -123,7 +123,7 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
   if (stat.size > MAX_SIZE_BYTES) {
     const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
     return {
-      content: `Error: image too large (${sizeMB} MB). Maximum is 100 MB.`,
+      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
       isError: true,
     };
   }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -54,7 +54,7 @@ public final class ChatAttachmentManager: ObservableObject {
     }
 
     /// Limits concurrent attachment I/O to keep memory usage reasonable.
-    private static let maxConcurrentLoads = 4
+    private static let maxConcurrentLoads = 2
     private let loadSemaphore = AsyncSemaphore(value: maxConcurrentLoads)
 
     /// Memory safety limit to avoid OOM from loading extremely large files.


### PR DESCRIPTION
## Summary
- Revert image-read.ts MAX_SIZE_BYTES to 20 MB (LLM API limit, not attachment storage)
- Reduce maxConcurrentLoads from 4 to 2 to limit peak memory with 100 MB attachments

Addresses feedback from PR #18477
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
