### PR TITLE
feat: add managed-google-oauth feature flag to registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -232,6 +232,14 @@
       "label": "Deploy to Vercel",
       "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
       "defaultEnabled": false
+    },
+    {
+      "id": "managed-google-oauth",
+      "scope": "assistant",
+      "key": "feature_flags.managed-google-oauth.enabled",
+      "label": "Managed Google OAuth",
+      "description": "Show the Google OAuth service card in Models & Services settings",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add managed-google-oauth feature flag to the feature flag registry
- Scoped to assistant, disabled by default

Part of plan: managed-google-oauth.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
