### PR TITLE
fix: coordinate conversation teardown before CLI wipe

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -1,8 +1,9 @@
 import type { Command } from "commander";
 
-import { getQdrantUrlEnv } from "../../config/env.js";
+import { getQdrantUrlEnv, getRuntimeHttpPort } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
+import { isHttpHealthy } from "../../daemon/daemon-control.js";
 import { ensureDaemonRunning } from "../../daemon/lifecycle.js";
 import { formatJson, formatMarkdown } from "../../export/formatter.js";
 import {
@@ -309,6 +310,35 @@ Examples:
         }
       }
 
+      // When the assistant is running, delegate to its HTTP wipe endpoint
+      // so it tears down in-memory conversation state before deleting DB
+      // rows — preventing FK constraint failures from follow-up writes.
+      if (await isHttpHealthy()) {
+        const port = getRuntimeHttpPort();
+        const res = await fetch(
+          `http://127.0.0.1:${port}/v1/conversations/${conversation.id}/wipe`,
+          { method: "POST" },
+        );
+        if (!res.ok) {
+          const body = await res.text();
+          log.error(`Assistant wipe failed (${res.status}): ${body}`);
+          process.exit(1);
+        }
+        const json = (await res.json()) as {
+          unsupersededItems: number;
+          deletedSummaries: number;
+          cancelledJobs: number;
+        };
+        log.info(
+          `Wiped conversation "${conversation.title ?? "Untitled"}". ` +
+            `Restored ${json.unsupersededItems} memory items, ` +
+            `deleted ${json.deletedSummaries} summaries, ` +
+            `cancelled ${json.cancelledJobs} jobs.`,
+        );
+        return;
+      }
+
+      // Daemon not running — safe to wipe directly (no in-memory state).
       const result = wipeConversation(conversation.id);
 
       // Enqueue Qdrant cleanup


### PR DESCRIPTION
## Summary
- When the assistant is running, the CLI `conversations wipe` command now delegates to the daemon's HTTP wipe endpoint instead of directly wiping the DB
- This ensures in-memory conversation state is torn down before DB rows are deleted, preventing FK constraint failures from follow-up writes
- Falls back to direct DB wipe when the assistant is not running (no in-memory state to worry about)

Addresses feedback from PR #18431
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
