### PR TITLE
feat: add google-oauth service to assistant config schema

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -44,6 +44,11 @@ export const WebSearchServiceSchema = z.object({
 });
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 
+export const GoogleOAuthServiceSchema = z.object({
+  mode: ServiceModeSchema.default("managed"),
+});
+export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -51,6 +56,9 @@ export const ServicesSchema = z.object({
   ),
   "web-search": WebSearchServiceSchema.default(
     WebSearchServiceSchema.parse({}),
+  ),
+  "google-oauth": GoogleOAuthServiceSchema.default(
+    GoogleOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;


### PR DESCRIPTION
## Summary
- Add GoogleOAuthServiceSchema with mode field defaulting to managed
- Add google-oauth entry to ServicesSchema

Part of plan: managed-google-oauth.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
