### PR TITLE
fix: cancel embed_segment jobs by segmentId in conversation wipe

### DIFF
--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -99,8 +99,9 @@ export function invalidateAssistantInferredItemsForConversation(
 
 /**
  * Cancel all pending/running memory jobs referencing the given conversation.
- * Covers every job type: `extract_items`, `embed_segment`, `embed_attachment`
- * (keyed by messageId), `build_conversation_summary` (keyed by conversationId),
+ * Covers every job type: `extract_items`, `embed_attachment` (keyed by messageId),
+ * `embed_segment` (keyed by segmentId via memory_segments),
+ * `build_conversation_summary` (keyed by conversationId),
  * and `embed_item` (keyed by itemId sourced from the conversation's messages).
  */
 export function cancelPendingJobsForConversation(
@@ -110,7 +111,7 @@ export function cancelPendingJobsForConversation(
   const now = Date.now();
   let total = 0;
 
-  // Jobs keyed by messageId: extract_items, embed_segment, embed_attachment
+  // Jobs keyed by messageId: extract_items, embed_attachment
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
@@ -133,6 +134,21 @@ export function cancelPendingJobsForConversation(
             updated_at = ?
       WHERE status IN ('pending', 'running')
         AND json_extract(payload, '$.conversationId') = ?`,
+    reason,
+    now,
+    conversationId,
+  );
+
+  // Jobs keyed by segmentId: embed_segment (segments belong to the conversation)
+  total += rawRun(
+    `UPDATE memory_jobs
+        SET status = 'failed',
+            last_error = ?,
+            updated_at = ?
+      WHERE status IN ('pending', 'running')
+        AND json_extract(payload, '$.segmentId') IN (
+          SELECT id FROM memory_segments WHERE conversation_id = ?
+        )`,
     reason,
     now,
     conversationId,


### PR DESCRIPTION
## Summary
- Add a fourth query to `cancelPendingJobsForConversation` that matches `embed_segment` jobs via their `segmentId` payload key (joining through `memory_segments.conversation_id`)
- Update comments and JSDoc to accurately reflect which query handles which job types — `embed_segment` is no longer incorrectly listed under the messageId-keyed query

Addresses feedback from PR #18424
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
