### PR TITLE
feat: add Google OAuth mode state to SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -200,9 +200,12 @@ public final class SettingsStore: ObservableObject {
     /// Current web search mode. Values: "managed" or "your-own".
     @Published var webSearchMode: String = "your-own"
 
+    /// Current Google OAuth mode. Values: "managed" or "your-own".
+    @Published var googleOAuthMode: String = "managed"
+
     /// True when any service is configured to use managed mode.
     var hasManagedServices: Bool {
-        inferenceMode == "managed" || webSearchMode == "managed" || imageGenMode == "managed"
+        inferenceMode == "managed" || webSearchMode == "managed" || imageGenMode == "managed" || googleOAuthMode == "managed"
     }
 
     static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
@@ -1965,6 +1968,10 @@ public final class SettingsStore: ObservableObject {
            let mode = webSearch["mode"] as? String {
             self.webSearchMode = mode
         }
+        if let googleOAuth = services["google-oauth"] as? [String: Any],
+           let mode = googleOAuth["mode"] as? String {
+            self.googleOAuthMode = mode
+        }
     }
 
     func setInferenceMode(_ mode: String) {
@@ -2013,6 +2020,21 @@ public final class SettingsStore: ObservableObject {
             log.error("Failed to merge workspace config for web search mode: \(error)")
         }
         scheduleRoutingSourceRefresh()
+    }
+
+    func setGoogleOAuthMode(_ mode: String) {
+        googleOAuthMode = mode
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var googleOAuth = services["google-oauth"] as? [String: Any] ?? [:]
+        googleOAuth["mode"] = mode
+        services["google-oauth"] = googleOAuth
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+        } catch {
+            log.error("Failed to merge workspace config for google-oauth mode: \(error)")
+        }
     }
 
     func setWebSearchProvider(_ provider: String) {

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -123,6 +123,13 @@ public enum WorkspaceConfigIO {
             changed = true
         }
 
+        var googleOAuth = services["google-oauth"] as? [String: Any] ?? [:]
+        if googleOAuth["mode"] == nil {
+            googleOAuth["mode"] = mode
+            services["google-oauth"] = googleOAuth
+            changed = true
+        }
+
         if changed {
             try? merge(["services": services], into: path)
         }


### PR DESCRIPTION
## Summary
- Add googleOAuthMode published property to SettingsStore (defaults to managed)
- Add setGoogleOAuthMode() for persisting mode to workspace config
- Update loadServiceModes() to load google-oauth mode
- Update hasManagedServices to include googleOAuthMode
- Add google-oauth to WorkspaceConfigIO.initializeServiceDefaults

Part of plan: managed-google-oauth.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
