### PR TITLE
fix: stabilize CI - scheduler flake, wipe regression, gateway guard

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -22,6 +22,7 @@ const ALLOWLIST = new Set([
   // Matched by prefix check below: gateway/
 
   // --- Intentional local daemon-control paths ---
+  "assistant/src/cli/commands/conversations.ts", // CLI wipe talks to runtime directly
   "clients/shared/Network/DaemonClient.swift",
   "clients/macos/vellum-assistant/App/AppDelegate.swift",
   "clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift",

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -108,7 +108,9 @@ describe("scheduler RRULE execution", () => {
     ) => {
       // Use a small real delay so fire-and-forget async ticks have time to
       // settle, while still cutting the 500ms waits down dramatically.
-      return origSetTimeout(fn, 50, ...args);
+      // 200ms gives headroom for the run_task path which does a dynamic
+      // import of task-runner.js on first invocation.
+      return origSetTimeout(fn, 200, ...args);
     }) as typeof setTimeout;
   });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -406,6 +406,7 @@ export function wipeConversation(id: string): WipeConversationResult {
            AND mi_active.scope_id = mi_old.scope_id
            AND mi_active.status = 'active'
            AND mi_active.id != mi_old.id
+           AND mi_active.id != mi_new.id
        )`,
     id,
     id,


### PR DESCRIPTION
## Summary
- **scheduler-recurrence**: increase patched `setTimeout` from 50ms to 200ms so the `run_task` dynamic import of `task-runner.js` has time to complete on loaded CI runners
- **conversation-wipe**: exclude the superseding item (`mi_new`) from Step B's active-item existence check, since it will be deleted later in the wipe flow — fixes regression from #18500
- **gateway-only-guard**: add `conversations.ts` CLI command to allowlist (intentional direct daemon-control path for `wipe`)

## Test plan
- [x] All three tests pass locally (verified 3x for scheduler)
- [x] Addresses flaky CI failures on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
