### PR TITLE
fix(macos): restyle conversation starter chips to match app pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -224,37 +224,33 @@ struct ConversationStarterPill: View {
     @State private var isPressed = false
 
     private var fillColor: Color {
-        if isPressed {
-            return VColor.surfaceOverlay.opacity(0.9)
-        } else if isHovered {
-            return VColor.surfaceOverlay
-        } else {
-            return VColor.surfaceActive
-        }
+        if isPressed { return VColor.borderBase.opacity(0.5) }
+        if isHovered { return VColor.borderBase.opacity(0.4) }
+        return VColor.borderBase.opacity(0.3)
     }
 
     private var borderColor: Color {
-        isHovered ? VColor.borderHover : VColor.borderBase
+        isHovered ? VColor.borderHover.opacity(0.5) : VColor.borderBase.opacity(0.5)
     }
 
     var body: some View {
         Button(action: action) {
             Text(label)
-                .font(VFont.bodyMedium)
+                .font(VFont.body)
                 .foregroundColor(isHovered ? VColor.contentDefault : VColor.contentSecondary)
                 .lineLimit(1)
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.xs + 2)
+                .padding(.vertical, VSpacing.sm)
                 .background(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: VRadius.md)
                         .fill(fillColor)
                 )
                 .overlay(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(borderColor, lineWidth: 0.5)
                 )
-                .contentShape(Capsule())
+                .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
         .buttonStyle(PillButtonStyle(isPressed: $isPressed))
         .onHover { isHovered = $0 }


### PR DESCRIPTION
## Summary
- Replaced `Capsule()` shape with `RoundedRectangle(cornerRadius: VRadius.md)` to match ToolCallChip, SubagentStatusChip, and other chip patterns in the app
- Switched from heavy `VColor.surfaceActive` fill to translucent `VColor.borderBase.opacity(0.3)`
- Changed font from `VFont.bodyMedium` to `VFont.body` and padding from non-standard `VSpacing.xs + 2` to `VSpacing.sm`

## Test plan
- [ ] Open a new conversation and verify starter chips render with rounded rectangle shape
- [ ] Hover over chips and verify hover/press state transitions
- [ ] Click a chip and verify it triggers the conversation starter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
