### PR TITLE
fix: stabilize flaky run_task scheduler-recurrence test

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -186,8 +186,11 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
 
     const directCalls: { conversationId: string; message: string }[] = [];
+    let onMessage: (() => void) | undefined;
+    const messageReceived = new Promise<void>((r) => (onMessage = r));
     const processMessage = async (conversationId: string, message: string) => {
       directCalls.push({ conversationId, message });
+      onMessage?.();
     };
 
     const scheduler = startScheduler(
@@ -195,7 +198,17 @@ describe("scheduler RRULE execution", () => {
       () => {},
       () => {},
     );
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    // The run_task path involves a dynamic import which can take >50ms in CI,
+    // exceeding the patched setTimeout delay. Await the actual callback instead
+    // of relying on a fixed timeout.
+    await Promise.race([
+      messageReceived,
+      new Promise((r) => origSetTimeout(r, 2000)),
+    ]);
+    // Yield to the macrotask queue so all pending microtasks settle —
+    // the scheduler tick still needs to create the schedule run after
+    // processMessage returns.
+    await new Promise((r) => origSetTimeout(r, 0));
     scheduler.stop();
 
     // runTask renders the template, so processMessage gets the template text


### PR DESCRIPTION
## Summary
- Replace fixed-timeout wait in the `run_task` scheduler test with a deterministic callback-based approach
- The `run_task` path involves a dynamic `import()` that takes >50ms in CI, exceeding the 50ms patched setTimeout delay introduced by #18406
- Now awaits the `processMessage` callback directly, then yields to the macrotask queue so the scheduler tick can finish creating the schedule run

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23212762478/job/67465648366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
