### PR TITLE
Centralize logout managed-service warning in performLogout()

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -162,6 +162,22 @@ extension AppDelegate {
     }
 
     @objc public func performLogout() {
+        // Warn when managed services are active — they'll stop working after logout.
+        if services.settingsStore.hasManagedServices {
+            let alert = NSAlert()
+            alert.messageText = "Heads up"
+            alert.informativeText = "Some of your services rely on being logged in."
+                + " They won't work until you log back in or switch them to use your own API keys."
+            alert.addButton(withTitle: "Log Out")
+            alert.addButton(withTitle: "Cancel")
+            // Style the primary button as destructive (caution icon).
+            alert.alertStyle = .warning
+            let response = alert.runModal()
+            if response != .alertFirstButtonReturn {
+                return
+            }
+        }
+
         Task {
             // Capture assistant ID before logout clears it from UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -569,7 +569,6 @@ struct MainWindowView: View {
                         let drawerY = bottomPad + SidebarLayoutMetrics.rowMinHeight + dividerHeight + VSpacing.xs
                         DrawerMenuView(
                             authManager: authManager,
-                            settingsStore: settingsStore,
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.settings)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -3,7 +3,6 @@ import VellumAssistantShared
 
 struct DrawerMenuView: View {
     let authManager: AuthManager
-    let settingsStore: SettingsStore
     let onSettings: () -> Void
     let onUsage: () -> Void
     let onDebug: () -> Void
@@ -15,7 +14,6 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
     @State private var bootstrapGeneration: Int = 0
-    @State private var showLogoutAlert = false
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
 
     private var isBillingVisible: Bool {
@@ -73,13 +71,7 @@ struct DrawerMenuView: View {
                 SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
                 if authManager.isAuthenticated {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out")) {
-                        if settingsStore.hasManagedServices {
-                            showLogoutAlert = true
-                        } else {
-                            onLogOut()
-                        }
-                    }
+                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
                 } else {
                     SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
                 }
@@ -90,17 +82,6 @@ struct DrawerMenuView: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
-        .alert("Heads up", isPresented: $showLogoutAlert) {
-            Button("Cancel", role: .cancel) {}
-            Button("Log Out", role: .destructive) {
-                onLogOut()
-            }
-        } message: {
-            Text(
-                "Some of your services rely on being logged in."
-                    + " They won't work until you log back in or switch them to use your own API keys."
-            )
-        }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -12,7 +12,6 @@ struct SettingsGeneralTab: View {
     var onSignIn: (() -> Void)?
 
     @State private var showingPairingQR: Bool = false
-    @State private var showLogoutAlert = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -93,11 +92,7 @@ struct SettingsGeneralTab: View {
                 }
             } else if authManager.currentUser != nil {
                 VButton(label: "Log Out", style: .danger) {
-                    if store.hasManagedServices {
-                        showLogoutAlert = true
-                    } else {
-                        AppDelegate.shared?.performLogout()
-                    }
+                    AppDelegate.shared?.performLogout()
                 }
             } else {
                 VButton(
@@ -115,17 +110,6 @@ struct SettingsGeneralTab: View {
                     }
                 }
             }
-        }
-        .alert("Heads up", isPresented: $showLogoutAlert) {
-            Button("Cancel", role: .cancel) {}
-            Button("Log Out", role: .destructive) {
-                AppDelegate.shared?.performLogout()
-            }
-        } message: {
-            Text(
-                "Some of your services rely on being logged in."
-                    + " They won't work until you log back in or switch them to use your own API keys."
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move the managed-service logout warning from duplicated SwiftUI `.alert()` modifiers in SettingsGeneralTab and DrawerMenuView into a single `NSAlert` at the top of `performLogout()` in AppDelegate
- Every logout path now gets the warning for free — no need to add alert state to each new logout button
- Net reduction of ~20 lines: removed `showLogoutAlert` state, `.alert()` modifiers, and the `settingsStore` dependency from DrawerMenuView

## Original prompt
Refactor the logout managed-service warning to be centralized in `performLogout()` using `NSAlert` (AppKit native modal) instead of duplicated SwiftUI `.alert()` modifiers. This way every logout path gets the warning for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
