### PR TITLE
feat: add Google OAuth card to Models & Services settings page

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -119,6 +119,7 @@ struct SettingsPanel: View {
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
+    @State private var isGoogleOAuthEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
@@ -128,6 +129,7 @@ struct SettingsPanel: View {
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
+    private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -250,6 +252,8 @@ struct SettingsPanel: View {
                     isBillingEnabled = enabled
                 } else if key == Self.emailFeatureFlagKey {
                     isEmailEnabled = enabled
+                } else if key == Self.googleOAuthFeatureFlagKey {
+                    isGoogleOAuthEnabled = enabled
                 }
             }
         }
@@ -421,6 +425,15 @@ struct SettingsPanel: View {
                 apiKeyText: $imageGenKeyText,
                 showToast: showToast
             )
+
+            // GOOGLE OAUTH (feature-flagged)
+            if isGoogleOAuthEnabled {
+                Divider()
+                    .background(VColor.borderBase)
+                    .padding(.vertical, VSpacing.sm)
+
+                GoogleOAuthServiceCard(store: store)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -558,6 +571,9 @@ struct SettingsPanel: View {
                 if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
                     isEmailEnabled = emailFlag.enabled
                 }
+                if let googleOAuthFlag = flags.first(where: { $0.key == Self.googleOAuthFeatureFlagKey }) {
+                    isGoogleOAuthEnabled = googleOAuthFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -581,6 +597,9 @@ struct SettingsPanel: View {
         }
         if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
             isEmailEnabled = emailEnabled
+        }
+        if let googleOAuthEnabled = resolved[Self.googleOAuthFeatureFlagKey] {
+            isGoogleOAuthEnabled = googleOAuthEnabled
         }
 
         consumeDeferredDeepLinkIfVisible()

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Card for the Google OAuth service with Managed/Your Own mode toggle.
+///
+/// Both modes currently show a "Coming Soon" empty state.
+/// The mode selection is persisted so user preference is retained.
+@MainActor
+struct GoogleOAuthServiceCard: View {
+    @ObservedObject var store: SettingsStore
+
+    /// Local draft of the mode selection — only persisted on Save.
+    @State private var draftMode: String = "managed"
+
+    /// True when the user has made changes worth saving.
+    private var hasChanges: Bool {
+        draftMode != store.googleOAuthMode
+    }
+
+    var body: some View {
+        ServiceModeCard(
+            title: "Google OAuth",
+            subtitle: "Configure Google OAuth for Gmail and Calendar access",
+            draftMode: $draftMode,
+            hasChanges: hasChanges,
+            isSaving: false,
+            onSave: { save() },
+            onReset: nil,
+            showReset: false,
+            managedContent: {
+                comingSoonState
+            },
+            yourOwnContent: {
+                comingSoonState
+            }
+        )
+        .onAppear {
+            draftMode = store.googleOAuthMode
+        }
+        .onChange(of: store.googleOAuthMode) { _, newValue in
+            draftMode = newValue
+        }
+    }
+
+    // MARK: - Coming Soon
+
+    private var comingSoonState: some View {
+        VStack(spacing: VSpacing.md) {
+            Text("Coming Soon")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        if draftMode != store.googleOAuthMode {
+            store.setGoogleOAuthMode(draftMode)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -94,6 +94,10 @@ public enum WorkspaceConfigIO {
         }
     }
 
+    /// All known service keys. Add new services here to automatically include
+    /// them in `initializeServiceDefaults`.
+    static let serviceKeys = ["inference", "image-generation", "web-search", "google-oauth"]
+
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").
     /// Existing user-chosen modes are preserved so that app restarts don't reset preferences.
@@ -109,32 +113,13 @@ public enum WorkspaceConfigIO {
         var services = existingConfig["services"] as? [String: Any] ?? [:]
         var changed = false
 
-        var inference = services["inference"] as? [String: Any] ?? [:]
-        if force || inference["mode"] == nil {
-            inference["mode"] = mode
-            services["inference"] = inference
-            changed = true
-        }
-
-        var imageGen = services["image-generation"] as? [String: Any] ?? [:]
-        if force || imageGen["mode"] == nil {
-            imageGen["mode"] = mode
-            services["image-generation"] = imageGen
-            changed = true
-        }
-
-        var webSearch = services["web-search"] as? [String: Any] ?? [:]
-        if force || webSearch["mode"] == nil {
-            webSearch["mode"] = mode
-            services["web-search"] = webSearch
-            changed = true
-        }
-
-        var googleOAuth = services["google-oauth"] as? [String: Any] ?? [:]
-        if googleOAuth["mode"] == nil {
-            googleOAuth["mode"] = mode
-            services["google-oauth"] = googleOAuth
-            changed = true
+        for key in serviceKeys {
+            var service = services[key] as? [String: Any] ?? [:]
+            if force || service["mode"] == nil {
+                service["mode"] = mode
+                services[key] = service
+                changed = true
+            }
         }
 
         if changed {


### PR DESCRIPTION
## Summary
- Add GoogleOAuthServiceCard with Coming Soon states for both Managed and Your Own modes
- Wire into SettingsPanel behind managed-google-oauth feature flag with divider separator
- Refactor WorkspaceConfigIO.initializeServiceDefaults to loop over serviceKeys array
- Fix missing force check on google-oauth service initialization

Part of plan: managed-google-oauth.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
