### PR TITLE
feat: add ghostPrimary onboarding button style for external links

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -39,7 +39,7 @@ struct APIKeyEntryStepView: View {
                     saveAndHatch()
                 }
 
-                OnboardingButton(title: "Get an API key", style: .primary) {
+                OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
                     NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -41,7 +41,7 @@ struct APIKeyStepView: View {
                     handleContinue()
                 }
 
-                OnboardingButton(title: "Need help deciding?", style: .secondary) {
+                OnboardingButton(title: "Need help deciding?", style: .ghostPrimary) {
                     NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -6,6 +6,8 @@ enum OnboardingButtonStyle {
     case secondary
     case tertiary
     case ghost
+    /// Ghost layout (compact, borderless) with primary/green text color.
+    case ghostPrimary
 }
 
 struct OnboardingButton: View {
@@ -19,7 +21,7 @@ struct OnboardingButton: View {
     @State private var visible = false
     @State private var isHovered = false
 
-    private var isGhost: Bool { style == .ghost }
+    private var isGhost: Bool { style == .ghost || style == .ghostPrimary }
 
     var body: some View {
         Button(action: action) {
@@ -79,6 +81,8 @@ struct OnboardingButton: View {
             return disabled ? VColor.contentDefault.opacity(0.3) : VColor.contentDefault.opacity(0.85)
         case .ghost:
             return disabled ? VColor.contentSecondary.opacity(0.3) : VColor.contentSecondary
+        case .ghostPrimary:
+            return disabled ? VColor.primaryBase.opacity(0.3) : VColor.primaryBase
         }
     }
 
@@ -90,7 +94,7 @@ struct OnboardingButton: View {
             return AnyShapeStyle(Color.clear)
         case .tertiary:
             return AnyShapeStyle(Color.clear)
-        case .ghost:
+        case .ghost, .ghostPrimary:
             return AnyShapeStyle(Color.clear)
         }
     }
@@ -103,7 +107,7 @@ struct OnboardingButton: View {
             return VColor.primaryBase.opacity(disabled ? 0.2 : 0.5)
         case .tertiary:
             return VColor.contentDefault.opacity(disabled ? 0.1 : 0.25)
-        case .ghost:
+        case .ghost, .ghostPrimary:
             return .clear
         }
     }


### PR DESCRIPTION
## Summary
- Add `ghostPrimary` case to `OnboardingButtonStyle` — ghost layout (compact, borderless) with `VColor.primaryBase` text color
- Switch "Get an API key" and "Need help deciding?" onboarding buttons to `ghostPrimary` so they look like helpful links rather than competing CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
