### PR TITLE
fix: use unauthenticated /healthz for gateway readiness probe

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -764,7 +764,15 @@ async function waitForGatewayAndLease(opts: {
         ready = true;
         break;
       }
-      log(`Readiness check: ${resp.status} (retrying...)`);
+      const body = await resp.text();
+      let detail = "";
+      try {
+        const json = JSON.parse(body);
+        const parts = [json.status];
+        if (json.upstream != null) parts.push(`upstream=${json.upstream}`);
+        detail = ` — ${parts.join(", ")}`;
+      } catch {}
+      log(`Readiness check: ${resp.status}${detail} (retrying...)`);
     } catch {
       // Connection refused / timeout — not up yet
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -840,7 +840,7 @@ async function main() {
         // know the full stack is ready, not just the gateway process.
         try {
           const upstream = await fetch(
-            `${config.assistantRuntimeBaseUrl}/v1/health`,
+            `${config.assistantRuntimeBaseUrl}/healthz`,
             { signal: AbortSignal.timeout(3000) },
           );
           if (!upstream.ok) {


### PR DESCRIPTION
## Summary
- Gateway's `/readyz` was calling `/v1/health` on the assistant, which requires JWT auth — causing a permanent 503 `upstream_unhealthy` loop during docker hatch since no token is sent
- Switched to `/healthz` which is the unauthenticated probe endpoint designed for this purpose
- Improved readiness check CLI logging to include failure reason and upstream status code

## Test plan
- [ ] Run `vellum hatch` and verify readiness check passes without 503 loop
- [ ] Verify `hatch.log` shows improved log messages if readiness is delayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
