### PR TITLE
fix: default googleOAuthMode to your-own to prevent spurious logout warnings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -10,7 +10,7 @@ struct GoogleOAuthServiceCard: View {
     @ObservedObject var store: SettingsStore
 
     /// Local draft of the mode selection — only persisted on Save.
-    @State private var draftMode: String = "managed"
+    @State private var draftMode: String = "your-own"
 
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -201,7 +201,7 @@ public final class SettingsStore: ObservableObject {
     @Published var webSearchMode: String = "your-own"
 
     /// Current Google OAuth mode. Values: "managed" or "your-own".
-    @Published var googleOAuthMode: String = "managed"
+    @Published var googleOAuthMode: String = "your-own"
 
     /// True when any service is configured to use managed mode.
     var hasManagedServices: Bool {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-google-oauth.md.

**Gap:** googleOAuthMode in-memory default causes spurious logout warnings for BYOK users
**What was expected:** Safe default so hasManagedServices doesn't return true for users without google-oauth config
**What was found:** Default of "managed" causes hasManagedServices to be true for all existing users

Changes the in-memory default from "managed" to "your-own" in both SettingsStore and GoogleOAuthServiceCard. The correct mode is set during onboarding via initializeServiceDefaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
