### PR TITLE
fix: remove dead featureFlagToken from DaemonClient/DaemonConfig

### DIFF
--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -407,7 +407,6 @@ struct QRPairingSheet: View {
                 return
             }
             let localLanUrl = response["localLanUrl"] as? String
-            let featureFlagToken = response["featureFlagToken"] as? String
             let refreshToken = response["refreshToken"] as? String
             // Accept "accessTokenExpiresAt" (new) or legacy "actorTokenExpiresAt"
             let accessTokenExpiresAt = (response["accessTokenExpiresAt"] as? Int) ?? (response["actorTokenExpiresAt"] as? Int)
@@ -418,7 +417,6 @@ struct QRPairingSheet: View {
                 gatewayUrl: gatewayUrl,
                 hostId: payload.hostId,
                 localLanUrl: localLanUrl,
-                featureFlagToken: featureFlagToken,
                 actorToken: accessToken,
                 refreshToken: refreshToken,
                 actorTokenExpiresAt: accessTokenExpiresAt,
@@ -505,7 +503,6 @@ struct QRPairingSheet: View {
                         return
                     }
                     let localLanUrl = json["localLanUrl"] as? String
-                    let featureFlagToken = json["featureFlagToken"] as? String
                     let refreshToken = json["refreshToken"] as? String
                     // Accept "accessTokenExpiresAt" (new) or legacy "actorTokenExpiresAt"
                     let pollAccessTokenExpiresAt = (json["accessTokenExpiresAt"] as? Int) ?? (json["actorTokenExpiresAt"] as? Int)
@@ -516,7 +513,6 @@ struct QRPairingSheet: View {
                         gatewayUrl: gatewayUrl,
                         hostId: payload.hostId,
                         localLanUrl: localLanUrl,
-                        featureFlagToken: featureFlagToken,
                         actorToken: pollAccessToken,
                         refreshToken: refreshToken,
                         actorTokenExpiresAt: pollAccessTokenExpiresAt,
@@ -546,17 +542,12 @@ struct QRPairingSheet: View {
 
     // MARK: - Config Persistence
 
-    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, featureFlagToken: String? = nil, actorToken: String? = nil, refreshToken: String? = nil, actorTokenExpiresAt: Int? = nil, refreshTokenExpiresAt: Int? = nil, refreshAfter: Int? = nil) {
+    private func savePairingConfig(bearerToken: String, gatewayUrl: String, hostId: String, localLanUrl: String?, actorToken: String? = nil, refreshToken: String? = nil, actorTokenExpiresAt: Int? = nil, refreshTokenExpiresAt: Int? = nil, refreshAfter: Int? = nil) {
         UserDefaults.standard.set(gatewayUrl, forKey: UserDefaultsKeys.gatewayBaseURL)
         _ = APIKeyManager.shared.setAPIKey(bearerToken, provider: "runtime-bearer-token")
         if !hostId.isEmpty {
             UserDefaults.standard.set(hostId, forKey: "gateway_host_id")
         }
-        if let ffToken = featureFlagToken, !ffToken.isEmpty {
-            _ = APIKeyManager.shared.setAPIKey(ffToken, provider: "feature-flag-token")
-        }
-        // Don't delete on absence — the server may not send featureFlagToken yet,
-        // so a missing field shouldn't wipe a previously stored token.
 
         // Persist the JWT access token and refresh credentials received during pairing
         // so subsequent HTTP requests include the Authorization: Bearer header immediately.

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -101,12 +101,11 @@ extension AppDelegate {
             let baseURL = "http://localhost:\(port)"
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
             let instanceDir = assistant?.instanceDir
-            let featureFlagToken = instanceDir.map { readFeatureFlagToken(environment: ["BASE_DATA_DIR": $0]) } ?? readFeatureFlagToken()
             let config = DaemonConfig(transport: .http(
                 baseURL: baseURL,
                 bearerToken: nil,
                 conversationKey: conversationKey
-            ), instanceDir: instanceDir, featureFlagToken: featureFlagToken)
+            ), instanceDir: instanceDir)
             services.reconfigureDaemonClient(config: config)
             log.info("Configured local HTTP transport on port \(port)")
             return

--- a/clients/macos/vellum-assistantTests/TransportMetadataTests.swift
+++ b/clients/macos/vellum-assistantTests/TransportMetadataTests.swift
@@ -77,7 +77,7 @@ final class TransportMetadataTests: XCTestCase {
         let config = DaemonConfig(
             transport: .http(baseURL: "https://example.com", bearerToken: nil, conversationKey: "test"),
             transportMetadata: .defaultLocal,
-            featureFlagToken: nil
+
         )
         XCTAssertEqual(config.transportMetadata.routeMode, .runtimeFlat)
         XCTAssertEqual(config.transportMetadata.authMode, .bearerToken)
@@ -93,7 +93,7 @@ final class TransportMetadataTests: XCTestCase {
         let config = DaemonConfig(
             transport: .http(baseURL: "https://platform.vellum.ai", bearerToken: nil, conversationKey: "key"),
             transportMetadata: managedMetadata,
-            featureFlagToken: nil
+
         )
         XCTAssertEqual(config.transportMetadata.routeMode, .platformAssistantProxy)
         XCTAssertEqual(config.transportMetadata.authMode, .sessionToken)

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -45,34 +45,9 @@ private func resolveInstanceDirFromLockfile() -> String? {
     return instanceDir
 }
 
-/// Resolve the feature-flag bearer token path.
-/// Uses BASE_DATA_DIR when set to match daemon root resolution.
-public func resolveFeatureFlagTokenPath(environment: [String: String]? = nil) -> String {
-    return resolveVellumDir(environment: environment) + "/feature-flag-token"
-}
-
 /// Resolve the daemon PID file path, honoring `BASE_DATA_DIR`.
 public func resolvePidPath(environment: [String: String]? = nil) -> String {
     return resolveVellumDir(environment: environment) + "/vellum.pid"
-}
-
-/// Read the feature-flag bearer token from disk.
-/// Used to authenticate PATCH /v1/feature-flags/:flagKey requests.
-public func readFeatureFlagToken(environment: [String: String]? = nil) -> String? {
-    let tokenPath = resolveFeatureFlagTokenPath(environment: environment)
-    let data: Data
-    do {
-        data = try Data(contentsOf: URL(fileURLWithPath: tokenPath))
-    } catch {
-        log.error("Failed to read feature-flag token from \(tokenPath, privacy: .public): \(error)")
-        return nil
-    }
-    guard let token = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty else {
-        return nil
-    }
-    return token
 }
 
 /// Protocol for daemon client communication, enabling dependency injection and testing.
@@ -1197,7 +1172,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Build an authenticated URLRequest for a local HTTP endpoint.
     ///
     /// Token resolution order:
-    /// 1. `tokenOverride` (for callers that need a specific token, e.g. feature-flag token)
+    /// 1. `tokenOverride` (for callers that need a specific token)
     /// 2. JWT from `ActorTokenManager.getToken()` — persisted in Keychain, so available
     ///    across app restarts once the initial bootstrap has completed. On first-ever
     ///    launch the bootstrap endpoint is unprotected (pre-auth), so the lack of a

--- a/clients/shared/Network/DaemonConfig.swift
+++ b/clients/shared/Network/DaemonConfig.swift
@@ -96,11 +96,6 @@ public struct DaemonConfig {
     /// When set, token resolution uses this directory instead of the lockfile's latest entry.
     public let instanceDir: String?
 
-    /// Feature-flag bearer token for authenticating PATCH /v1/feature-flags/:flagKey requests.
-    /// On macOS this is read from `~/.vellum/feature-flag-token`.
-    /// On iOS this is received during QR pairing and stored in the Keychain.
-    public let featureFlagToken: String?
-
     #if os(macOS)
     public static var `default`: DaemonConfig {
         let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
@@ -114,15 +109,10 @@ public struct DaemonConfig {
     }
     #endif
 
-    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, instanceDir: String? = nil, featureFlagToken: String? = nil) {
+    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, instanceDir: String? = nil) {
         self.transport = transport
         self.transportMetadata = transportMetadata
         self.instanceDir = instanceDir
-        #if os(macOS)
-        self.featureFlagToken = featureFlagToken ?? readFeatureFlagToken()
-        #else
-        self.featureFlagToken = featureFlagToken
-        #endif
     }
 
     #if os(iOS)
@@ -136,8 +126,6 @@ public struct DaemonConfig {
 
     /// Create a `DaemonConfig` populated from UserDefaults / Keychain.
     public static func fromUserDefaults() -> DaemonConfig {
-        let featureFlagToken = APIKeyManager.shared.getAPIKey(provider: "feature-flag-token")
-
         // Managed assistant: cloud-hosted via platform proxy with session token auth.
         // Set after Vellum login + managed bootstrap completes.
         if let managedAssistantId = UserDefaults.standard.string(forKey: "managed_assistant_id"),
@@ -155,8 +143,7 @@ public struct DaemonConfig {
                     bearerToken: nil,
                     conversationKey: managedAssistantId
                 ),
-                transportMetadata: metadata,
-                featureFlagToken: featureFlagToken
+                transportMetadata: metadata
             )
         }
 
@@ -171,12 +158,12 @@ public struct DaemonConfig {
                 conversationKey = UUID().uuidString
                 UserDefaults.standard.set(conversationKey, forKey: "conversation_key")
             }
-            return DaemonConfig(transport: .http(baseURL: baseURL, bearerToken: bearerToken, conversationKey: conversationKey), featureFlagToken: featureFlagToken)
+            return DaemonConfig(transport: .http(baseURL: baseURL, bearerToken: bearerToken, conversationKey: conversationKey))
         }
 
         // No gateway URL configured — return a placeholder HTTP config that won't connect.
         // The user needs to pair via QR code (which sets gateway_base_url) before connecting.
-        return DaemonConfig(transport: .http(baseURL: "", bearerToken: nil, conversationKey: ""), featureFlagToken: featureFlagToken)
+        return DaemonConfig(transport: .http(baseURL: "", bearerToken: nil, conversationKey: ""))
     }
     #endif
 }


### PR DESCRIPTION
## Summary
- `featureFlagToken` on `DaemonConfig` was stored but never read — feature flags already go through `FeatureFlagClient` via `GatewayHTTPClient`
- `readFeatureFlagToken()` logged noisy errors on every startup when `~/.vellum/feature-flag-token` didn't exist
- Removed the dead property, init parameter, token reader, and iOS QR pairing Keychain storage

## Test plan
- [ ] Verify macOS build succeeds (`swift build`)
- [ ] Verify no more `Failed to read feature-flag token` log spam on startup
- [ ] Verify feature flags still work in Settings (they use `FeatureFlagClient` → gateway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
