### PR TITLE
fix: improve disabled hosting card readability and chip layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -121,28 +121,34 @@ struct APIKeyStepView: View {
         }) {
             HStack(spacing: VSpacing.md) {
                 VIconView(icon, size: 18)
-                    .foregroundColor(isDisabled ? VColor.contentDisabled : (isSelected ? VColor.primaryBase : VColor.contentSecondary))
+                    .foregroundColor(isDisabled ? VColor.contentTertiary : (isSelected ? VColor.primaryBase : VColor.contentSecondary))
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentDefault)
+                    HStack(spacing: VSpacing.sm) {
+                        Text(title)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(isDisabled ? VColor.contentTertiary : VColor.contentDefault)
+
+                        Spacer()
+
+                        if let chipLabel {
+                            Text(chipLabel)
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.contentTertiary)
+                                .padding(.horizontal, VSpacing.sm)
+                                .padding(.vertical, VSpacing.xxs)
+                                .background(VColor.surfaceActive)
+                                .clipShape(Capsule())
+                        }
+                    }
                     Text(subtitle)
                         .font(.system(size: 12))
-                        .foregroundColor(isDisabled ? VColor.contentDisabled : VColor.contentSecondary)
+                        .foregroundColor(isDisabled ? VColor.contentTertiary : VColor.contentSecondary)
                 }
 
-                Spacer()
+                if chipLabel == nil {
+                    Spacer()
 
-                if let chipLabel {
-                    Text(chipLabel)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.contentTertiary)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xxs)
-                        .background(VColor.surfaceActive)
-                        .clipShape(Capsule())
-                } else {
                     Circle()
                         .fill(isSelected ? VColor.primaryBase : Color.clear)
                         .overlay(
@@ -171,7 +177,7 @@ struct APIKeyStepView: View {
                             )
                     )
             )
-            .opacity(isDisabled ? 0.7 : 1.0)
+            .opacity(isDisabled ? 0.85 : 1.0)
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)


### PR DESCRIPTION
## Summary
- Move the "Coming Soon" / "Requires Account" chip inline with the title row (right-aligned) instead of floating at the card's trailing edge
- Remove the trailing Spacer and radio circle from disabled cards so the chip sits flush right
- Use `contentTertiary` instead of `contentDisabled` for disabled text/icon colors and bump card opacity from 0.7 to 0.85 for better readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
