### PR TITLE
feat: add Docker hosting option, update subtitles, increase onboarding window height

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -69,16 +69,22 @@ struct APIKeyStepView: View {
     // MARK: - Hosting Cards
 
     private var availableHostingModes: [OnboardingState.HostingMode] {
-        var modes: [OnboardingState.HostingMode] = [.local, .vellumCloud]
+        var modes: [OnboardingState.HostingMode] = [.local, .docker, .vellumCloud]
         if userHostedEnabled {
-            modes.append(contentsOf: [.docker, .aws, .gcp, .customHardware])
+            modes.append(contentsOf: [.aws, .gcp, .customHardware])
         }
         return modes
     }
 
     private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
-        guard mode == .vellumCloud else { return nil }
-        return state.skippedAuth ? "Requires Account" : "Coming Soon"
+        switch mode {
+        case .vellumCloud:
+            return state.skippedAuth ? "Requires Account" : "Coming Soon"
+        case .docker:
+            return "Coming Soon"
+        default:
+            return nil
+        }
     }
 
     private var hostingCards: some View {
@@ -164,6 +170,7 @@ struct APIKeyStepView: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
+            .frame(minHeight: 64)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -57,9 +57,9 @@ final class OnboardingState {
 
         var displayName: String {
             switch self {
-            case .vellumCloud: return "Vellum\u{2019}s Cloud"
+            case .vellumCloud: return "Vellum Cloud"
             case .local: return "Local"
-            case .docker: return "Docker"
+            case .docker: return "Local (Docker)"
             case .gcp: return "GCP"
             case .aws: return "AWS"
             case .customHardware: return "Custom"
@@ -68,9 +68,9 @@ final class OnboardingState {
 
         var subtitle: String {
             switch self {
-            case .vellumCloud: return "Ready out of the box. Runs entirely on Vellum\u{2019}s secure infrastructure."
-            case .local: return "Run on your machine"
-            case .docker: return "Run in a Docker container"
+            case .vellumCloud: return "Ready out of the box. Runs entirely on Vellum's secure infrastructure."
+            case .local: return "Your machine, your data. Nothing leaves your Mac."
+            case .docker: return "Same privacy as local, but sandboxed in a container."
             case .gcp: return "Host on your GCP account"
             case .aws: return "Host on your AWS account"
             case .customHardware: return "Run on your own hardware"

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingWindow.swift
@@ -47,7 +47,7 @@ final class OnboardingWindow {
         let hostingController = NSHostingController(rootView: flowView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 740),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -60,10 +60,10 @@ final class OnboardingWindow {
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false
 
-        window.contentMinSize = NSSize(width: 420, height: 580)
+        window.contentMinSize = NSSize(width: 420, height: 700)
 
         let startWidth: CGFloat = 460
-        let startHeight: CGFloat = 620
+        let startHeight: CGFloat = 740
         if let visibleFrame = Self.visibleScreenFrame() {
             let x = visibleFrame.midX - startWidth / 2
             let y = visibleFrame.midY - startHeight / 2


### PR DESCRIPTION
## Summary
- Add "Local (Docker)" hosting option between Local and Vellum Cloud with a "Coming Soon" chip (not gated behind feature flag)
- Update hosting card subtitles: Local → "Your machine, your data. Nothing leaves your Mac.", Docker → "Same privacy as local, but sandboxed in a container.", rename "Vellum's Cloud" → "Vellum Cloud"
- Increase onboarding window height from 620 → 740 to eliminate scrollbars on taller steps, and set uniform minHeight on hosting cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
