### PR TITLE
fix: enable runtime proxy for docker hatch gateway

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -362,6 +362,8 @@ function serviceDockerRunArgs(opts: {
       `ASSISTANT_HOST=${res.assistantContainer}`,
       "-e",
       `RUNTIME_HTTP_PORT=${ASSISTANT_INTERNAL_PORT}`,
+      "-e",
+      "RUNTIME_PROXY_ENABLED=true",
       imageTags.gateway,
     ],
     "credential-executor": () => [

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -98,7 +98,9 @@ export function loadConfig(): GatewayConfig {
   const gw = (wsConfig.gateway ?? {}) as Record<string, unknown>;
 
   const runtimeProxyEnabled =
-    gw.runtimeProxyEnabled === true || gw.runtimeProxyEnabled === "true";
+    gw.runtimeProxyEnabled === true ||
+    gw.runtimeProxyEnabled === "true" ||
+    process.env.RUNTIME_PROXY_ENABLED === "true";
   const runtimeProxyRequireAuth =
     gw.runtimeProxyRequireAuth !== false &&
     gw.runtimeProxyRequireAuth !== "false";


### PR DESCRIPTION
## Summary
- Docker hatch gateway wasn't enabling the runtime proxy, causing 404s on `/v1/events` (SSE) and other daemon endpoints the macOS client routes through the gateway
- Local hatch writes `runtimeProxyEnabled: true` to workspace config, but docker containers can't read the host's config file
- Added `RUNTIME_PROXY_ENABLED` env var fallback to gateway config loading
- Pass `RUNTIME_PROXY_ENABLED=true` in docker hatch container startup

## Test plan
- [ ] Run `vellum hatch --docker` and verify SSE connection succeeds (no more 404 on `/v1/events`)
- [ ] Verify macOS client connects and receives events through the gateway
- [ ] Verify local (non-docker) hatch still works via workspace config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
