### PR TITLE
fix: center multiline subtitles in onboarding steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -22,6 +22,7 @@ struct APIKeyEntryStepView: View {
 
         Text("Vellum needs an Anthropic API key to work.\nEnter yours to connect.")
             .font(.system(size: 16))
+            .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -24,6 +24,7 @@ struct ImproveExperienceStepView: View {
 
         Text("Here\u{2019}s how Vellum handles your data.\nYou can change these anytime in Settings.")
             .font(.system(size: 16))
+            .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)


### PR DESCRIPTION
## Summary
- Add `.multilineTextAlignment(.center)` to the API Key Entry and Before You Start step subtitles so they match the centered layout of other onboarding steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
