### PR TITLE
feat(macos): open attachment images on double-click

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -70,9 +70,10 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             .frame(width: 60, height: 60)
                             .clipped()
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                            .onTapGesture {
+                            .onTapGesture(count: 2) {
                                 onTap(attachment)
                             }
+                            .pointerCursor()
                     } else if failedIds.contains(attachment.id) {
                         // All decode paths failed — show a file chip so the user still has the
                         // filename and a download affordance for corrupt/unsupported payloads.


### PR DESCRIPTION
## Summary
- Changed image attachment thumbnails from single-click to double-click to open in Preview, preventing accidental opens
- Added pointer cursor on hover for visual affordance, consistent with tool call images in `ToolCallChip`

## Original prompt
Double clicking on these images in the message should open them in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)