### PR TITLE
Add spacing above onboarding welcome buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -54,6 +54,8 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
+        Color.clear.frame(height: VSpacing.xxl)
+
         // Buttons
         VStack(spacing: VSpacing.md) {
             if authManager?.isLoading == true {


### PR DESCRIPTION
## Summary
- Add 32pt vertical spacing above the Log In / Continue without account buttons on the welcome step to improve visual balance in the onboarding window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
