### PR TITLE
fix: update test assertions for v3 bootstrap and ui_show default rule

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -16,8 +16,8 @@ describe("onboarding template contracts", () => {
     test("contains identity discovery prompts", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("your name");
-      expect(lower).toContain("your nature");
-      expect(lower).toContain("your emoji");
+      expect(lower).toContain("personality");
+      expect(lower).toContain("avatar");
     });
 
     test("infers personality organically instead of asking directly", () => {
@@ -34,11 +34,11 @@ describe("onboarding template contracts", () => {
     });
 
     test("asks about user after assistant identity", () => {
-      const nameIdx = bootstrap.indexOf("Your name.");
-      const whoIdx = bootstrap.indexOf("Who they are.");
+      const nameIdx = bootstrap.indexOf("Your name");
+      const guardianIdx = bootstrap.indexOf("Your guardian");
       expect(nameIdx).toBeGreaterThan(-1);
-      expect(whoIdx).toBeGreaterThan(-1);
-      expect(nameIdx).toBeLessThan(whoIdx);
+      expect(guardianIdx).toBeGreaterThan(-1);
+      expect(nameIdx).toBeLessThan(guardianIdx);
     });
 
     test("gathers user context: work role, hobbies, daily tools", () => {
@@ -60,7 +60,7 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("do not delete this file");
       expect(lower).toContain("you have a name");
       expect(lower).toContain("vibe");
-      expect(lower).toContain("2 suggestions");
+      expect(lower).toContain("two suggestions");
     });
 
     test("contains refusal policy", () => {
@@ -68,7 +68,7 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("hard-required");
       expect(lower).toContain("best-effort");
       expect(lower).toContain("declined");
-      expect(lower).toContain("do not push");
+      expect(lower).toContain("don't push");
     });
 
     test("defines resolved as provided, inferred, or declined", () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -790,6 +790,7 @@ describe("Trust Store", () => {
         "skill_execute",
         "skill_load",
         "ui_dismiss",
+        "ui_show",
         "ui_update",
       ]);
     });


### PR DESCRIPTION
## Summary
- Add `ui_show` to the expected default tools list in trust-store.test.ts (missed when #18498 added it as auto-approved)
- Update onboarding-template-contract.test.ts assertions to match v3 BOOTSTRAP.md content from #18524: "your nature"/"your emoji" → "personality"/"avatar", "Your name."/"Who they are." → "Your name"/"Your guardian", "2 suggestions" → "two suggestions", "do not push" → "don't push"

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23214097836/job/67470239830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
