### PR TITLE
fix: consistent contact type pills with classification icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -216,7 +216,7 @@ struct ContactDetailView: View {
     }
 
     private var contactTypeBadge: some View {
-        VBadge(label: formatContactType(displayContact.role), tone: .neutral)
+        ContactTypeBadge(role: displayContact.role)
     }
 
     // MARK: - Channels Section
@@ -898,17 +898,6 @@ struct ContactDetailView: View {
     }
 
     // MARK: - Formatting Helpers
-
-    private func formatContactType(_ contactType: String?) -> String {
-        switch contactType {
-        case "assistant":
-            return "Assistant"
-        case "guardian":
-            return "Guardian"
-        default:
-            return "Human"
-        }
-    }
 
     // MARK: - Helpers
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A badge pill showing a contact's classification (Guardian, Assistant, Human)
+/// with a distinguishing icon. Styled to match VBadge neutral/subtle appearance.
+struct ContactTypeBadge: View {
+    let role: String?
+
+    var body: some View {
+        HStack(spacing: VSpacing.xxs) {
+            VIconView(icon, size: 12)
+                .foregroundColor(VColor.primaryBase)
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xxs)
+        .background(VColor.surfaceBase)
+        .overlay(
+            Capsule()
+                .stroke(VColor.borderBase.opacity(0.55), lineWidth: 1)
+        )
+        .clipShape(Capsule())
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        switch role {
+        case "guardian": return "Guardian"
+        case "assistant": return "Assistant"
+        default: return "Human"
+        }
+    }
+
+    private var icon: VIcon {
+        switch role {
+        case "guardian": return .shieldCheck
+        case "assistant": return .sparkles
+        default: return .user
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -2,27 +2,12 @@ import SwiftUI
 import VellumAssistantShared
 
 /// A badge pill showing a contact's classification (Guardian, Assistant, Human)
-/// with a distinguishing icon. Styled to match VBadge neutral/subtle appearance.
+/// with a distinguishing icon. Thin wrapper around VBadge.
 struct ContactTypeBadge: View {
     let role: String?
 
     var body: some View {
-        HStack(spacing: VSpacing.xxs) {
-            VIconView(icon, size: 12)
-                .foregroundColor(VColor.primaryBase)
-            Text(label)
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xxs)
-        .background(VColor.surfaceBase)
-        .overlay(
-            Capsule()
-                .stroke(VColor.borderBase.opacity(0.55), lineWidth: 1)
-        )
-        .clipShape(Capsule())
-        .accessibilityLabel(label)
+        VBadge(label: label, icon: icon, iconColor: VColor.primaryBase, tone: .neutral)
     }
 
     private var label: String {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -120,7 +120,7 @@ struct ContactsContainerView: View {
                             Text("\(contact.displayName) (You)")
                                 .font(VFont.display)
                                 .foregroundColor(VColor.contentDefault)
-                            VBadge(label: "Guardian", tone: .neutral)
+                            ContactTypeBadge(role: "guardian")
                         }
                         Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
                             .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -58,7 +58,7 @@ struct ContactsListView: View {
                     if matchesSearch(cachedAssistantDisplayName) {
                         contactListRow(
                             name: cachedAssistantDisplayName,
-                            tag: "Assistant",
+                            role: "assistant",
                             isSelected: selection == .assistant,
                             isHovered: isAssistantHovered,
                             onTap: { selection = .assistant },
@@ -71,7 +71,7 @@ struct ContactsListView: View {
                         let isGuardian = contact.role == "guardian"
                         contactListRow(
                             name: isGuardian ? "\(contact.displayName) (You)" : contact.displayName,
-                            tag: formatContactType(contact.role),
+                            role: contact.role,
                             isSelected: selection == .contact(contact.id),
                             isHovered: hoveredContactId == contact.id,
                             onTap: { selection = .contact(contact.id) },
@@ -123,7 +123,7 @@ struct ContactsListView: View {
 
     private func contactListRow(
         name: String,
-        tag: String,
+        role: String?,
         isSelected: Bool,
         isHovered: Bool,
         onTap: @escaping () -> Void,
@@ -138,9 +138,7 @@ struct ContactsListView: View {
 
                 Spacer()
 
-                Text(tag)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
+                ContactTypeBadge(role: role)
             }
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.md)
@@ -192,14 +190,6 @@ struct ContactsListView: View {
     }
 
     // MARK: - Helpers
-
-    private func formatContactType(_ role: String?) -> String {
-        switch role {
-        case "guardian": return "Guardian"
-        case "assistant": return "Assistant"
-        default: return "Human"
-        }
-    }
 
     private func rowBackground(isSelected: Bool, isHovered: Bool) -> some View {
         RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -24,17 +24,21 @@ public struct VBadge: View {
     public var color: Color = VColor.primaryBase
     public var tone: Tone?
     public var emphasis: Emphasis = .solid
+    public var icon: VIcon?
+    public var iconColor: Color?
 
     public init(style: Style, color: Color = VColor.primaryBase) {
         self.style = style
         self.color = color
     }
 
-    public init(label: String, tone: Tone = .accent, emphasis: Emphasis = .subtle) {
+    public init(label: String, icon: VIcon? = nil, iconColor: Color? = nil, tone: Tone = .accent, emphasis: Emphasis = .subtle) {
         self.style = .label(label)
         self.color = VColor.primaryBase
         self.tone = tone
         self.emphasis = emphasis
+        self.icon = icon
+        self.iconColor = iconColor
     }
 
     public var body: some View {
@@ -55,18 +59,24 @@ public struct VBadge: View {
                 .frame(width: 8, height: 8)
 
         case .label(let text):
-            Text(text)
-                .font(VFont.caption)
-                .foregroundColor(labelForegroundColor)
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xxs)
-                .background(labelBackgroundColor)
-                .overlay(
-                    Capsule()
-                        .stroke(labelBorderColor, lineWidth: labelBorderWidth)
-                )
-                .clipShape(Capsule())
-                .accessibilityLabel(text)
+            HStack(spacing: VSpacing.xxs) {
+                if let icon {
+                    VIconView(icon, size: 12)
+                        .foregroundColor(iconColor ?? labelForegroundColor)
+                }
+                Text(text)
+                    .font(VFont.caption)
+                    .foregroundColor(labelForegroundColor)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xxs)
+            .background(labelBackgroundColor)
+            .overlay(
+                Capsule()
+                    .stroke(labelBorderColor, lineWidth: labelBorderWidth)
+            )
+            .clipShape(Capsule())
+            .accessibilityLabel(text)
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace plain text classification tags in the contact list with `ContactTypeBadge` pill component matching the right-side detail view styling
- Add distinguishing icons for each classification: shield-check for Guardian, sparkles for Assistant, user for Human — icons use primary green color
- Use the same `ContactTypeBadge` component across contact list, contact detail, and guardian detail views for consistency

## Original prompt
pills/tags for user, assistant and humans arent consistent between contact list and right side, should look like they are on a right side plus let's add icons for each classification to differentiate contact visually with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
