### PR TITLE
feat: gate Docker hosting option behind user_hosted_enabled flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -81,7 +81,7 @@ struct APIKeyStepView: View {
         case .vellumCloud:
             return state.skippedAuth ? "Requires Account" : "Coming Soon"
         case .docker:
-            return "Coming Soon"
+            return userHostedEnabled ? nil : "Coming Soon"
         default:
             return nil
         }


### PR DESCRIPTION
## Summary
- Docker hosting card was unconditionally disabled with "Coming Soon"
- Now gated behind the existing `user_hosted_enabled` feature flag, matching the other self-hosted options (AWS, GCP, Custom Hardware)

## Test plan
- [ ] With `user_hosted_enabled` off: Docker card shows "Coming Soon" and is not selectable
- [ ] With `user_hosted_enabled` on: Docker card is selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
