### PR TITLE
Update onboarding step copy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -13,14 +13,14 @@ struct APIKeyEntryStepView: View {
     @FocusState private var keyFieldFocused: Bool
 
     var body: some View {
-        Text("Add your API key")
+        Text("Anthropic API Key")
             .font(.system(size: 32, weight: .regular, design: .serif))
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Vellum needs an Anthropic API key to work.\nEnter yours to connect.")
+        Text("Since you skipped creating an account,\nwe\u{2019}ll need your Anthropic API key.")
             .font(.system(size: 16))
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -22,7 +22,7 @@ struct ImproveExperienceStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Here\u{2019}s how Vellum handles your data.\nYou can change these anytime in Settings.")
+        Text("Choose your privacy preferences.\nYou can update these anytime in Settings.")
             .font(.system(size: 16))
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
@@ -83,7 +83,7 @@ struct ImproveExperienceStepView: View {
                 )
 
                 OnboardingButton(
-                    title: "Accept and Hatch",
+                    title: "Accept and Start",
                     style: .primary,
                     disabled: !tosAccepted
                 ) {


### PR DESCRIPTION
## Summary
- API key entry step: title changed to "Anthropic API Key", subtitle updated to explain why the step appears ("Since you skipped creating an account...")
- Consent step: subtitle changed to "Choose your privacy preferences", button changed from "Accept and Hatch" to "Accept and Start"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
