### PR TITLE
fix: disable runtime proxy auth for docker hatch

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -103,7 +103,8 @@ export function loadConfig(): GatewayConfig {
     process.env.RUNTIME_PROXY_ENABLED === "true";
   const runtimeProxyRequireAuth =
     gw.runtimeProxyRequireAuth !== false &&
-    gw.runtimeProxyRequireAuth !== "false";
+    gw.runtimeProxyRequireAuth !== "false" &&
+    process.env.RUNTIME_PROXY_REQUIRE_AUTH !== "false";
   const unmappedPolicy = gw.unmappedPolicy === "default" ? "default" : "reject";
   const defaultAssistantId =
     typeof gw.defaultAssistantId === "string" && gw.defaultAssistantId


### PR DESCRIPTION
## Summary
- Runtime proxy validates edge JWTs (`aud=vellum-gateway`), but the macOS client sends daemon JWTs (`aud=vellum-daemon`) — causing 401s on SSE and all proxied endpoints
- Docker gateway runs on localhost only, so proxy-level client auth is unnecessary
- Added `RUNTIME_PROXY_REQUIRE_AUTH` env var support to gateway config
- Docker hatch passes `RUNTIME_PROXY_REQUIRE_AUTH=false` — the gateway still authenticates itself to the daemon via service tokens

## Test plan
- [ ] Run `vellum hatch --docker` and verify SSE connects without 401
- [ ] Verify chat messages work through the gateway proxy
- [ ] Verify local (non-docker) hatch still requires auth on the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
