### PR TITLE
M2: Polish help links and button text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -32,16 +32,24 @@ struct APIKeyEntryStepView: View {
             VStack(spacing: VSpacing.md) {
                 apiKeyField
 
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.info, size: 14)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("Get an API key")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                        .onTapGesture {
+                            NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
+                        }
+                }
+                .padding(.top, VSpacing.xs)
+
                 OnboardingButton(
                     title: "Continue",
                     style: .primary,
                     disabled: apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ) {
                     saveAndHatch()
-                }
-
-                OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
-                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
                 }
 
                 OnboardingButton(title: "Back", style: .ghost) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -32,16 +32,19 @@ struct APIKeyEntryStepView: View {
             VStack(spacing: VSpacing.md) {
                 apiKeyField
 
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.info, size: 14)
-                        .foregroundColor(VColor.contentSecondary)
-                    Text("Get an API key")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentSecondary)
-                        .onTapGesture {
-                            NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
-                        }
+                Button {
+                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
+                } label: {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.info, size: 14)
+                            .foregroundColor(VColor.contentSecondary)
+                        Text("Get an API key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Get an API key")
                 .padding(.top, VSpacing.xs)
 
                 OnboardingButton(

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -83,7 +83,7 @@ struct ImproveExperienceStepView: View {
                 )
 
                 OnboardingButton(
-                    title: "Accept and Start",
+                    title: "Continue",
                     style: .primary,
                     disabled: !tosAccepted
                 ) {


### PR DESCRIPTION
Part of #18551. Fixes #18553.

- Replace 'Get an API key' primary button with a subtle info icon + hyperlink directly under the API key field
- Change diagnostic step button text from 'Accept and Hatch' to 'Continue'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
