### PR TITLE
Hide Quick Input behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -199,7 +199,8 @@ extension AppDelegate {
             showStatusMenu()
             return
         }
-        if event.type == .rightMouseUp || event.modifierFlags.contains(.control) {
+        if (event.type == .rightMouseUp || event.modifierFlags.contains(.control)),
+           MacOSClientFeatureFlagManager.shared.isEnabled("quick_input_enabled") {
             toggleQuickInput()
         } else {
             showStatusMenu()

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -240,6 +240,14 @@
       "label": "Managed Google OAuth",
       "description": "Show the Google OAuth service card in Models & Services settings",
       "defaultEnabled": false
+    },
+    {
+      "id": "quick-input",
+      "scope": "macos",
+      "key": "quick_input_enabled",
+      "label": "Quick Input",
+      "description": "Enable the Quick Input popover on right-click of the menu bar icon",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `quick-input` feature flag to the registry (scope: macos, defaultEnabled: false)
- Gate the right-click menu bar → Quick Input popover behind `MacOSClientFeatureFlagManager.shared.isEnabled("quick_input_enabled")`
- When the flag is off, right-clicking the menu bar icon falls through to `showStatusMenu()` (same as left-click)

## Original prompt
Hide the Quick Input feature (the component that activates when you right click the menu bar app icon) behind a feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
