### PR TITLE
Fix onboarding flow UI polish issues

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -32,16 +32,27 @@ struct APIKeyEntryStepView: View {
             VStack(spacing: VSpacing.md) {
                 apiKeyField
 
+                Button {
+                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
+                } label: {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.info, size: 14)
+                            .foregroundColor(VColor.contentSecondary)
+                        Text("Get an API key")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Get an API key")
+                .padding(.top, VSpacing.xs)
+
                 OnboardingButton(
                     title: "Continue",
                     style: .primary,
                     disabled: apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ) {
                     saveAndHatch()
-                }
-
-                OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
-                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
                 }
 
                 OnboardingButton(title: "Back", style: .ghost) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -34,8 +34,10 @@ struct APIKeyEntryStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
+        Spacer()
+
         VStack(spacing: VSpacing.md) {
-            VStack(spacing: VSpacing.md) {
+            VStack(spacing: 0) {
                 apiKeyField
 
                 Button {
@@ -53,7 +55,8 @@ struct APIKeyEntryStepView: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Get an API key")
-                .padding(.top, VSpacing.xs)
+                .padding(.top, VSpacing.sm)
+                .padding(.bottom, VSpacing.xl)
 
                 OnboardingButton(
                     title: "Continue",
@@ -66,6 +69,7 @@ struct APIKeyEntryStepView: View {
                 OnboardingButton(title: "Back", style: .ghost) {
                     goBack()
                 }
+                .padding(.top, VSpacing.md)
             }
         }
         .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -42,8 +42,10 @@ struct APIKeyEntryStepView: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentSecondary)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .buttonStyle(.plain)
+                .pointerCursor()
                 .accessibilityLabel("Get an API key")
                 .padding(.top, VSpacing.xs)
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -10,7 +10,13 @@ struct APIKeyEntryStepView: View {
     @State private var isEditing = false
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var showCharacters = false
     @FocusState private var keyFieldFocused: Bool
+
+    private static let welcomeCharacters: NSImage? = {
+        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
+        return NSImage(contentsOf: url)
+    }()
 
     var body: some View {
         Text("Anthropic API Key")
@@ -79,6 +85,26 @@ struct APIKeyEntryStepView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 keyFieldFocused = true
             }
+        }
+
+        Spacer()
+
+        if let characters = Self.welcomeCharacters {
+            Image(nsImage: characters)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: VRadius.window,
+                    bottomTrailingRadius: VRadius.window,
+                    topTrailingRadius: 0
+                ))
+                .opacity(showCharacters ? 1 : 0)
+                .offset(y: showCharacters ? 0 : 30)
+                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
+                .onAppear { showCharacters = true }
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -33,16 +33,29 @@ struct APIKeyStepView: View {
             VStack(spacing: VSpacing.md) {
                 hostingCards
 
+                Button {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
+                } label: {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.info, size: 14)
+                            .foregroundColor(VColor.contentSecondary)
+                        Text("Need help deciding?")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .accessibilityLabel("Need help deciding?")
+                .padding(.top, VSpacing.xs)
+
                 OnboardingButton(
                     title: continueButtonTitle,
                     style: .primary,
                     disabled: !canContinue
                 ) {
                     handleContinue()
-                }
-
-                OnboardingButton(title: "Need help deciding?", style: .ghostPrimary) {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
                 }
 
                 if !isAuthenticated {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -30,7 +30,7 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         VStack(spacing: VSpacing.md) {
-            VStack(spacing: VSpacing.md) {
+            VStack(spacing: 0) {
                 hostingCards
 
                 Button {
@@ -48,7 +48,8 @@ struct APIKeyStepView: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Need help deciding?")
-                .padding(.top, VSpacing.xs)
+                .padding(.top, VSpacing.sm)
+                .padding(.bottom, VSpacing.xl)
 
                 OnboardingButton(
                     title: continueButtonTitle,
@@ -62,7 +63,7 @@ struct APIKeyStepView: View {
                     OnboardingButton(title: "Back", style: .ghost) {
                         goBack()
                     }
-                    .padding(.top, VSpacing.xs)
+                    .padding(.top, VSpacing.md)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -83,7 +83,7 @@ struct ImproveExperienceStepView: View {
                 )
 
                 OnboardingButton(
-                    title: "Accept and Start",
+                    title: "Continue",
                     style: .primary,
                     disabled: !tosAccepted
                 ) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -89,6 +89,7 @@ struct ImproveExperienceStepView: View {
                 ) {
                     saveAndContinue()
                 }
+                .padding(.top, VSpacing.lg)
 
                 OnboardingButton(title: "Back", style: .ghost) {
                     goBack()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -6,8 +6,6 @@ enum OnboardingButtonStyle {
     case secondary
     case tertiary
     case ghost
-    /// Ghost layout (compact, borderless) with primary/green text color.
-    case ghostPrimary
 }
 
 struct OnboardingButton: View {
@@ -21,7 +19,7 @@ struct OnboardingButton: View {
     @State private var visible = false
     @State private var isHovered = false
 
-    private var isGhost: Bool { style == .ghost || style == .ghostPrimary }
+    private var isGhost: Bool { style == .ghost }
 
     var body: some View {
         Button(action: action) {
@@ -81,8 +79,6 @@ struct OnboardingButton: View {
             return disabled ? VColor.contentDefault.opacity(0.3) : VColor.contentDefault.opacity(0.85)
         case .ghost:
             return disabled ? VColor.contentSecondary.opacity(0.3) : VColor.contentSecondary
-        case .ghostPrimary:
-            return disabled ? VColor.primaryBase.opacity(0.3) : VColor.primaryBase
         }
     }
 
@@ -94,7 +90,7 @@ struct OnboardingButton: View {
             return AnyShapeStyle(Color.clear)
         case .tertiary:
             return AnyShapeStyle(Color.clear)
-        case .ghost, .ghostPrimary:
+        case .ghost:
             return AnyShapeStyle(Color.clear)
         }
     }
@@ -107,7 +103,7 @@ struct OnboardingButton: View {
             return VColor.primaryBase.opacity(disabled ? 0.2 : 0.5)
         case .tertiary:
             return VColor.contentDefault.opacity(disabled ? 0.1 : 0.25)
-        case .ghost, .ghostPrimary:
+        case .ghost:
             return .clear
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: geometry.size.height * 0.15)
+                    Color.clear.frame(height: geometry.size.height * 0.04)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: geometry.size.height * 0.04)
+                    Color.clear.frame(height: VSpacing.xxxl)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)
@@ -134,13 +134,13 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for step 0 (WakeUpStepView) where the characters
+                    // Skip for steps with characters footer (0, 2) where the
                     // graphic is designed to sit flush at the window bottom.
-                    if state.currentStep != 0 || isBootstrappingManaged {
+                    if (state.currentStep != 0 && state.currentStep != 2) || isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }
-                .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: geometry.size.height * 0.08)
+                    Color.clear.frame(height: geometry.size.height * 0.15)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -54,8 +54,6 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        Color.clear.frame(height: VSpacing.xxl)
-
         // Buttons
         VStack(spacing: VSpacing.md) {
             if authManager?.isLoading == true {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -43,7 +43,7 @@ struct WakeUpStepView: View {
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.xs)
+            .padding(.bottom, VSpacing.md)
 
         // Subtitle
         Text("Your personal AI assistant,\nrunning on your terms.")

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -54,6 +54,8 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
+        Spacer()
+
         // Buttons
         VStack(spacing: VSpacing.md) {
             if authManager?.isLoading == true {


### PR DESCRIPTION
## Summary
Addresses design review feedback on the onboarding/setup flow to improve visual consistency and polish across all steps. Fixes logo positioning, spacing consistency, help link styling, and button text.

## Changes
- Increased top inset from 8% to 15% so content sits more centered vertically across all steps (fixes logo jumping and initial screen feeling too high)
- Standardized title-to-subtitle spacing to VSpacing.md (12pt) on the WakeUp step to match steps 1-3
- Replaced "Get an API key" primary button with a subtle info icon + accessible hyperlink directly under the API key field
- Changed diagnostic step button text from "Accept and Hatch" to "Continue"

## Milestone PRs (merged into feature branch)
- #18554: M1: Consistent layout and spacing across onboarding steps
- #18555: M2: Polish help links and button text

## Project issue
Closes #18551

## Test plan
- [ ] Launch app with fresh onboarding (delete preferences or use --skip-onboarding flag)
- [ ] Verify V logo stays at same position across all 4 steps
- [ ] Verify initial welcome screen content is vertically centered (not too high)
- [ ] Verify title-to-subtitle spacing is consistent across all steps
- [ ] Verify "Get an API key" shows as info icon + link under the API key field
- [ ] Verify the info icon + link is keyboard-focusable and VoiceOver-accessible
- [ ] Verify diagnostics step shows "Continue" as the primary button

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
