### PR TITLE
fix: repair two failing CI benchmark tests

### DIFF
--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -248,7 +248,7 @@ describe("Memory context benchmark", () => {
         ...DEFAULT_CONFIG.memory,
         embeddings: {
           ...DEFAULT_CONFIG.memory.embeddings,
-          provider: "openai" as const,
+          provider: "local" as const,
           required: false,
         },
         retrieval: {

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -64,6 +64,7 @@ mock.module("../config/loader.js", () => ({
     permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
     secretDetection: { enabled: true, entropyThreshold: 4.0, action: "warn" },
+    sandbox: { enabled: false },
     contextWindow: {},
     memory: {},
   }),


### PR DESCRIPTION
## Summary
- **tool-execution-pipeline.benchmark.test.ts**: Added missing `sandbox: { enabled: false }` to the mock `getConfig()` return value. The production `checker.ts` now accesses `getConfig().sandbox.enabled`, which threw `TypeError: undefined is not an object` with the incomplete mock.
- **memory-context-benchmark.benchmark.test.ts**: Changed embedding provider from `"openai"` to `"local"` in the recall config. CI has no OpenAI API key, so `selectEmbeddingBackend` returned no backend, semantic search was skipped entirely, and all recency-only candidates were filtered as "in context" — resulting in `selectedCount: 0`.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23217759467/job/67482874139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
