### PR TITLE
fix: require write scope for conversation wipe endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -340,6 +340,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "model/image-gen", scopes: ["settings.write"] },
 
   // Conversation management
+  { endpoint: "conversations/wipe", scopes: ["chat.write"] },
   { endpoint: "conversations/reorder", scopes: ["chat.write"] },
 
   // Conversation search

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -126,7 +126,7 @@ export function conversationManagementRouteDefinitions(
     {
       endpoint: "conversations/:id/wipe",
       method: "POST",
-      policyKey: "conversations",
+      policyKey: "conversations/wipe",
       handler: async ({ params }) => {
         const resolvedId = resolveConversationId(params.id);
         if (!resolvedId) {


### PR DESCRIPTION
## Summary
- Set write-scoped policy key on the POST /v1/conversations/:id/wipe route
- Prevents read-only tokens from calling the destructive wipe endpoint

Addresses feedback from PR #18429
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
