### PR TITLE
fix: classify assistant/vellum CLI as low-risk shell programs

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -143,6 +143,8 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
+  "assistant",
+  "vellum",
 ]);
 
 // High-risk shell programs / patterns


### PR DESCRIPTION
## Summary
- Add `assistant` and `vellum` to `LOW_RISK_PROGRAMS` in the permission checker
- These are first-party CLIs — equivalent in risk to `git` or `bun` which are already low-risk
- Prevents unnecessary permission prompts when the assistant runs its own CLI commands

## Original prompt
yeah please make that change to make sure it's low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
