### PR TITLE
fix: remove dead code and empty MARK sections in contacts views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -903,8 +903,6 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Formatting Helpers
-
     // MARK: - Helpers
 
     private func channelIcon(for type: String) -> VIcon {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -94,18 +94,6 @@ struct ContactsListView: View {
                 }
             }
 
-            if viewModel.contacts.isEmpty {
-                Spacer()
-                VEmptyState(
-                    title: "No contacts yet",
-                    icon: VIcon.users.rawValue,
-                    actionLabel: "Add Contact",
-                    actionIcon: VIcon.plus.rawValue,
-                    action: { viewModel.isCreatingContact = true }
-                )
-                .frame(maxWidth: .infinity)
-                Spacer()
-            }
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## Summary
- Remove empty MARK: Formatting Helpers section in ContactDetailView
- Remove unreachable empty state block in ContactsListView.contactsCard

Part of plan: contacts-review-followups.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
