### PR TITLE
fix: add VBadge icon variant to FeedbackGallerySection

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -65,6 +65,18 @@ struct FeedbackGallerySection: View {
                         VBadge(style: .label("Error"), color: VColor.systemNegativeStrong)
                         VBadge(style: .label("Warn"), color: VColor.systemNegativeHover)
                     }
+
+                    // Icon label row
+                    HStack(spacing: VSpacing.lg) {
+                        VStack(spacing: VSpacing.xs) {
+                            Text("With iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBadge(label: "Guardian", icon: .shieldCheck, iconColor: VColor.primaryBase, tone: .neutral)
+                        }
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Default iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBadge(label: "Status", icon: .sparkles, tone: .accent)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add VBadge icon variant examples to the design system gallery
- Showcase both with and without iconColor override

Part of plan: contacts-review-followups.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
