### PR TITLE
fix: use deduplicated contacts for detail view lookup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -56,7 +56,7 @@ struct ContactsContainerView: View {
                     assistantDetailView
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 case .contact(let contactId):
-                    if let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
+                    if let contact = viewModel.deduplicatedContacts.first(where: { $0.id == contactId }) {
                         if contact.role == "guardian" {
                             guardianDetailView(contact: contact)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -57,7 +57,7 @@ final class ContactsViewModel: ObservableObject {
                     notes: existing.notes ?? contact.notes,
                     contactType: existing.contactType ?? contact.contactType,
                     lastInteraction: existing.lastInteraction ?? contact.lastInteraction,
-                    interactionCount: existing.interactionCount + contact.interactionCount,
+                    interactionCount: max(existing.interactionCount, contact.interactionCount),
                     channels: mergedChannels
                 )
             } else {


### PR DESCRIPTION
## Summary
- Use deduplicated contacts for detail view lookup instead of raw contacts array
- Fix interactionCount double-counting in deduplication by using max() instead of sum
- Ensures contact list and detail pane show consistent data

Part of plan: contacts-review-followups.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
