### PR TITLE
fix: add concurrency guard and error feedback to contact creation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -32,10 +32,17 @@ struct ContactsContainerView: View {
     var body: some View {
         HStack(alignment: .top, spacing: VSpacing.lg) {
             // Left pane: contacts list (full height, internal scrolling)
-            ContactsListView(
-                viewModel: viewModel,
-                selection: $selection
-            )
+            VStack(spacing: VSpacing.sm) {
+                ContactsListView(
+                    viewModel: viewModel,
+                    selection: $selection
+                )
+                .frame(maxHeight: .infinity, alignment: .top)
+
+                if let createContactError {
+                    VInlineMessage(createContactError)
+                }
+            }
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             // Right pane: detail, loading, or placeholder
@@ -217,6 +224,8 @@ struct ContactsContainerView: View {
     @State private var guardianEditedName: String = ""
     @State private var guardianEditedNotes: String = ""
     @State private var guardianIsSaving: Bool = false
+    @State private var isCreatingContact: Bool = false
+    @State private var createContactError: String?
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 
@@ -241,6 +250,9 @@ struct ContactsContainerView: View {
     /// list, and shows the detail pane so the user can edit inline.
     private func createPlaceholderContact() async {
         viewModel.isCreatingContact = false
+        guard !isCreatingContact else { return }
+        isCreatingContact = true
+        createContactError = nil
         do {
             let contact = try await contactClient.createContact(
                 displayName: "New Contact",
@@ -254,7 +266,8 @@ struct ContactsContainerView: View {
                 selection = .contact(contact.id)
             }
         } catch {
-            // Silently fail — user can retry via the + button
+            createContactError = "Failed to create contact: \(error.localizedDescription)"
         }
+        isCreatingContact = false
     }
 }


### PR DESCRIPTION
## Summary
- Add concurrency guard to prevent multiple simultaneous contact creations
- Surface contact creation errors to the user instead of silently failing

Part of plan: contacts-review-followups.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
