### PR TITLE
refactor: extract duplicated inlineMessage helper to shared component

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
@@ -25,7 +25,7 @@ struct ContactCreateView: View {
             formFields
             Spacer()
             if let errorMessage {
-                errorBanner(errorMessage)
+                VInlineMessage(errorMessage)
             }
             actionButtons
         }
@@ -87,23 +87,6 @@ struct ContactCreateView: View {
                 )
             }
         }
-    }
-
-    // MARK: - Error Banner
-
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            VIconView(.triangleAlert, size: 12)
-                .foregroundColor(VColor.systemNegativeStrong)
-            Text(message)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
-                .lineLimit(2)
-        }
-        .padding(VSpacing.sm)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(VColor.systemNegativeStrong.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 
     // MARK: - Action Buttons


### PR DESCRIPTION
## Summary
- Replace hand-rolled `errorBanner` in ContactCreateView with shared `VInlineMessage` component
- VInlineMessage already has `.fixedSize(horizontal: false, vertical: true)` built in to prevent text truncation
- All contact views now consistently use the shared VInlineMessage component

Part of plan: contacts-review-followups.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
