### PR TITLE
fix: surface guardian save errors instead of silently swallowing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -164,6 +164,10 @@ struct ContactsContainerView: View {
                                 .controlSize(.small)
                         }
                     }
+
+                    if let guardianErrorMessage {
+                        VInlineMessage(guardianErrorMessage)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
@@ -198,6 +202,7 @@ struct ContactsContainerView: View {
         let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guardianIsSaving = true
+        guardianErrorMessage = nil
         do {
             if let updated = try await contactClient.updateContact(
                 contactId: contact.id,
@@ -209,7 +214,7 @@ struct ContactsContainerView: View {
                 viewModel.loadContacts()
             }
         } catch {
-            // Silently fail — user can retry
+            guardianErrorMessage = "Failed to save changes. Please try again."
         }
         guardianIsSaving = false
     }
@@ -217,6 +222,7 @@ struct ContactsContainerView: View {
     @State private var guardianEditedName: String = ""
     @State private var guardianEditedNotes: String = ""
     @State private var guardianIsSaving: Bool = false
+    @State private var guardianErrorMessage: String?
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 


### PR DESCRIPTION
## Summary
- Surface guardian save errors via VInlineMessage instead of silently swallowing
- Clear error on next successful save

Part of plan: contacts-review-followups.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
