### PR TITLE
refactor: add optional `metadata` field to `CatalogSkill` interface

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -31,6 +31,14 @@ export interface CatalogSkill {
   emoji?: string;
   includes?: string[];
   version?: string;
+  metadata?: {
+    vellum?: {
+      "display-name"?: string;
+      "activation-hints"?: string[];
+      "avoid-when"?: string[];
+      "feature-flag"?: string;
+    };
+  };
 }
 
 export interface CatalogManifest {


### PR DESCRIPTION
## Summary
- Extend `CatalogSkill` interface with optional `metadata` field
- Captures `display-name`, `activation-hints`, `avoid-when`, and `feature-flag` from catalog JSON
- Backwards-compatible additive change — existing code is unaffected

Part of plan: skill-capability-memories.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
