### PR TITLE
feat(gateway): add v2 encrypted store read support with store.key

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -78,18 +78,10 @@ function getMachineEntropy(): string {
   return parts.join(":");
 }
 
-function writeEncryptedStore(entries: Record<string, string>): void {
-  const storePath = join(testDir, ".vellum", "protected", "keys.enc");
-  mkdirSync(join(testDir, ".vellum", "protected"), { recursive: true });
-
-  const salt = randomBytes(16);
-  const key = pbkdf2Sync(
-    getMachineEntropy(),
-    salt,
-    PBKDF2_ITERATIONS,
-    KEY_LENGTH,
-    "sha512",
-  );
+function encryptEntries(
+  entries: Record<string, string>,
+  key: Buffer,
+): Record<string, { iv: string; tag: string; data: string }> {
   const encryptedEntries: Record<
     string,
     { iv: string; tag: string; data: string }
@@ -110,13 +102,46 @@ function writeEncryptedStore(entries: Record<string, string>): void {
       data: encrypted.toString("hex"),
     };
   }
+  return encryptedEntries;
+}
+
+function writeEncryptedStore(entries: Record<string, string>): void {
+  const storePath = join(testDir, ".vellum", "protected", "keys.enc");
+  mkdirSync(join(testDir, ".vellum", "protected"), { recursive: true });
+
+  const salt = randomBytes(16);
+  const key = pbkdf2Sync(
+    getMachineEntropy(),
+    salt,
+    PBKDF2_ITERATIONS,
+    KEY_LENGTH,
+    "sha512",
+  );
 
   const store = {
     version: 1,
     salt: salt.toString("hex"),
-    entries: encryptedEntries,
+    entries: encryptEntries(entries, key),
   };
   writeFileSync(storePath, JSON.stringify(store));
+}
+
+/**
+ * Write a v2 encrypted store with a random store.key file.
+ * The store.key is used directly as the AES-256-GCM key (no PBKDF2).
+ */
+function writeEncryptedStoreV2(entries: Record<string, string>): void {
+  const protectedDir = join(testDir, ".vellum", "protected");
+  mkdirSync(protectedDir, { recursive: true });
+
+  const storeKey = randomBytes(KEY_LENGTH);
+  writeFileSync(join(protectedDir, "store.key"), storeKey);
+
+  const store = {
+    version: 2,
+    entries: encryptEntries(entries, storeKey),
+  };
+  writeFileSync(join(protectedDir, "keys.enc"), JSON.stringify(store));
 }
 
 // ---------------------------------------------------------------------------
@@ -261,6 +286,74 @@ describe("readTelegramCredentials", () => {
       botToken: "enc-bot-token",
       webhookSecret: "enc-webhook-secret",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: v2 encrypted store (store.key)
+// ---------------------------------------------------------------------------
+
+describe("v2 encrypted store with store.key", () => {
+  test("reads credential from v2 store when store.key exists", async () => {
+    writeEncryptedStoreV2({
+      [credentialKey("test", "key")]: "v2-secret-value",
+    });
+
+    const result = await readCredential(credentialKey("test", "key"));
+    expect(result).toBe("v2-secret-value");
+  });
+
+  test("returns undefined for v2 store when store.key is missing", async () => {
+    // Write a v2 store but without the store.key file
+    const protectedDir = join(testDir, ".vellum", "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    const storeKey = randomBytes(KEY_LENGTH);
+    const store = {
+      version: 2,
+      entries: encryptEntries(
+        { [credentialKey("test", "key")]: "v2-secret-value" },
+        storeKey,
+      ),
+    };
+    writeFileSync(join(protectedDir, "keys.enc"), JSON.stringify(store));
+    // Deliberately do NOT write store.key
+
+    const result = await readCredential(credentialKey("test", "key"));
+    expect(result).toBeUndefined();
+  });
+
+  test("returns Telegram credentials from v2 store", async () => {
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      { service: "telegram", field: "webhook_secret" },
+    ]);
+
+    writeEncryptedStoreV2({
+      [credentialKey("telegram", "bot_token")]: "v2-bot-token",
+      [credentialKey("telegram", "webhook_secret")]: "v2-webhook-secret",
+    });
+
+    const result = await readTelegramCredentials();
+    expect(result).toEqual({
+      botToken: "v2-bot-token",
+      webhookSecret: "v2-webhook-secret",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: v1 encrypted store backward compatibility
+// ---------------------------------------------------------------------------
+
+describe("v1 encrypted store backward compatibility", () => {
+  test("v1 store continues to work with entropy-based key derivation", async () => {
+    writeEncryptedStore({
+      [credentialKey("test", "key")]: "v1-secret-value",
+    });
+
+    const result = await readCredential(credentialKey("test", "key"));
+    expect(result).toBe("v1-secret-value");
   });
 });
 

--- a/gateway/src/__tests__/credential-watcher.test.ts
+++ b/gateway/src/__tests__/credential-watcher.test.ts
@@ -114,6 +114,31 @@ function writeEncryptedStore(botToken: string, webhookSecret: string): void {
   writeFileSync(storePath, JSON.stringify(store));
 }
 
+/**
+ * Write Telegram credentials into a v2 encrypted store using a random
+ * store.key file (no PBKDF2 derivation).
+ */
+function writeEncryptedStoreV2(
+  botToken: string,
+  webhookSecret: string,
+): void {
+  const protectedDir = join(testDir, ".vellum", "protected");
+  mkdirSync(protectedDir, { recursive: true });
+
+  const storeKey = cryptoRandomBytes(KEY_LENGTH);
+  writeFileSync(join(protectedDir, "store.key"), storeKey);
+
+  const store = {
+    version: 2,
+    entries: {
+      "credential/telegram/bot_token": encrypt(botToken, storeKey),
+      "credential/telegram/webhook_secret": encrypt(webhookSecret, storeKey),
+    },
+  };
+
+  writeFileSync(join(protectedDir, "keys.enc"), JSON.stringify(store));
+}
+
 function metadataRecord(
   credentialId: string,
   service: string,
@@ -284,6 +309,40 @@ describe("gateway telegram hot-reload (e2e)", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
+    const after = await fetch(`${base}/webhooks/telegram`, {
+      method: "POST",
+    });
+    expect(after.status).toBe(401);
+  }, 15_000);
+
+  test("gateway hot-reloads v2 encrypted store credentials written after startup", async () => {
+    // --- Setup: no credentials directory exists (fresh hatch) ---
+    mkdirSync(testDir, { recursive: true });
+
+    // Start the real gateway process
+    await startGateway();
+
+    const base = `http://localhost:${port}`;
+
+    // --- Step 1: confirm Telegram is NOT configured ---
+    const before = await fetch(`${base}/webhooks/telegram`, {
+      method: "POST",
+    });
+    expect(before.status).toBe(503);
+    const beforeBody = (await before.json()) as { error: string };
+    expect(beforeBody.error).toBe("Telegram integration not configured");
+
+    // --- Step 2: simulate daemon writing v2 credentials ---
+    writeEncryptedStoreV2("fake-v2-bot-token:XYZ", "fake-v2-webhook-secret");
+    writeCredentialMetadata();
+
+    // Wait for credential watcher debounce (500ms) + generous margin
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // --- Step 3: query again — gateway should now recognize Telegram is configured.
+    // We expect 401 (webhook secret verification failed) rather than 503
+    // (not configured). Getting past the 503 gate proves the gateway
+    // hot-reloaded the v2 credentials from the credential store.
     const after = await fetch(`${base}/webhooks/telegram`, {
       method: "POST",
     });

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -26,11 +26,20 @@ interface EncryptedEntry {
   data: string;
 }
 
-interface StoreFile {
+interface StoreFileV1 {
   version: 1;
   salt: string;
   entries: Record<string, EncryptedEntry>;
 }
+
+interface StoreFileV2 {
+  version: 2;
+  entries: Record<string, EncryptedEntry>;
+}
+
+type StoreFile = StoreFileV1 | StoreFileV2;
+
+const STORE_KEY_FILENAME = "store.key";
 
 function getPlatformName(): string {
   // Must match assistant/src/util/platform.ts#getPlatformName exactly.
@@ -66,6 +75,22 @@ function deriveKey(salt: Buffer): Buffer {
   return pbkdf2Sync(entropy, salt, PBKDF2_ITERATIONS, KEY_LENGTH, "sha512");
 }
 
+/**
+ * Read the v2 store key file (~/.vellum/protected/store.key).
+ * Returns null if the file doesn't exist or isn't exactly 32 bytes.
+ */
+function readStoreKey(): Buffer | null {
+  const keyPath = join(getRootDir(), "protected", STORE_KEY_FILENAME);
+  if (!existsSync(keyPath)) return null;
+  try {
+    const buf = readFileSync(keyPath);
+    if (buf.length !== KEY_LENGTH) return null;
+    return buf;
+  } catch {
+    return null;
+  }
+}
+
 function decrypt(entry: EncryptedEntry, key: Buffer): string {
   const iv = Buffer.from(entry.iv, "hex");
   const tag = Buffer.from(entry.tag, "hex");
@@ -83,17 +108,26 @@ function readStore(storePath: string): StoreFile | null {
 
   const raw = readFileSync(storePath, "utf-8");
   const parsed = JSON.parse(raw);
-  if (
-    parsed.version !== 1 ||
-    typeof parsed.salt !== "string" ||
-    typeof parsed.entries !== "object"
-  ) {
-    throw new Error("Encrypted store has invalid format");
+
+  if (parsed.version === 2 && typeof parsed.entries === "object") {
+    const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
+    Object.assign(safeEntries, parsed.entries);
+    parsed.entries = safeEntries;
+    return parsed as StoreFileV2;
   }
-  const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
-  Object.assign(safeEntries, parsed.entries);
-  parsed.entries = safeEntries;
-  return parsed as StoreFile;
+
+  if (
+    parsed.version === 1 &&
+    typeof parsed.salt === "string" &&
+    typeof parsed.entries === "object"
+  ) {
+    const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
+    Object.assign(safeEntries, parsed.entries);
+    parsed.entries = safeEntries;
+    return parsed as StoreFileV1;
+  }
+
+  throw new Error("Encrypted store has invalid format");
 }
 
 export function getRootDir(): string {
@@ -125,6 +159,9 @@ export function getMetadataPath(): string {
  * Read a single credential from the encrypted store.
  * Returns `undefined` if the store doesn't exist, the key is missing,
  * or decryption fails.
+ *
+ * For v2 stores, uses the store.key file directly as the AES key.
+ * For v1 stores, derives the key from machine entropy via PBKDF2.
  */
 function readEncryptedCredential(account: string): string | undefined {
   try {
@@ -134,8 +171,15 @@ function readEncryptedCredential(account: string): string | undefined {
     const entry = store.entries[account];
     if (!entry) return undefined;
 
-    const salt = Buffer.from(store.salt, "hex");
-    const key = deriveKey(salt);
+    let key: Buffer;
+    if (store.version === 2) {
+      const storeKey = readStoreKey();
+      if (!storeKey) return undefined;
+      key = storeKey;
+    } else {
+      const salt = Buffer.from(store.salt, "hex");
+      key = deriveKey(salt);
+    }
     return decrypt(entry, key);
   } catch (err) {
     log.debug({ err, account }, "Failed to read from encrypted store");


### PR DESCRIPTION
## Summary
- Add v2 store format support to gateway credential reader
- v2 stores use a random 32-byte `store.key` file directly as the AES-256-GCM key (no PBKDF2)
- Backward compatible: v1 stores continue using entropy-based PBKDF2 derivation
- Added tests for v2 store reading in credential-reader and credential-watcher tests

Part of plan: random-store-key.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
