### PR TITLE
feat: add `capability` memory kind to staleness, formatting, and retriever

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -25,6 +25,7 @@ import {
 } from "./schema.js";
 import {
   buildTwoLayerInjection,
+  CAPABILITY_KINDS,
   IDENTITY_KINDS,
   PREFERENCE_KINDS,
 } from "./search/formatting.js";
@@ -465,11 +466,15 @@ export async function buildMemoryRecall(
   const preferences = afterDemotion.filter(
     (c) => c.tier === 1 && PREFERENCE_KINDS.has(c.kind),
   );
+  const capabilities = afterDemotion.filter(
+    (c) => c.tier === 1 && CAPABILITY_KINDS.has(c.kind),
+  );
   const tier1Candidates = afterDemotion.filter(
     (c) =>
       c.tier === 1 &&
       !IDENTITY_KINDS.has(c.kind) &&
-      !PREFERENCE_KINDS.has(c.kind),
+      !PREFERENCE_KINDS.has(c.kind) &&
+      !CAPABILITY_KINDS.has(c.kind),
   );
   const tier2Candidates = afterDemotion.filter((c) => c.tier === 2);
 
@@ -478,6 +483,7 @@ export async function buildMemoryRecall(
     tier1Candidates,
     tier2Candidates,
     preferences,
+    capabilities,
     totalBudgetTokens: maxInjectTokens,
   });
 
@@ -486,7 +492,8 @@ export async function buildMemoryRecall(
     identityItems.length +
     tier1Candidates.length +
     tier2Candidates.length +
-    preferences.length;
+    preferences.length +
+    capabilities.length;
 
   const tier1Count = afterDemotion.filter((c) => c.tier === 1).length;
   const tier2Count = afterDemotion.filter((c) => c.tier === 2).length;

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -77,6 +77,9 @@ export const IDENTITY_KINDS = new Set(["identity"]);
 /** Kinds classified as preferences for the <applicable_preferences> section. */
 export const PREFERENCE_KINDS = new Set(["preference", "constraint"]);
 
+/** Kinds classified as capabilities for the <available_capabilities> section. */
+export const CAPABILITY_KINDS = new Set(["capability"]);
+
 /** Per-item token budget for tier 1 items. */
 const TIER1_PER_ITEM_TOKENS = 150;
 
@@ -102,6 +105,7 @@ export function buildTwoLayerInjection(params: {
   tier1Candidates: TieredCandidate[];
   tier2Candidates: TieredCandidate[];
   preferences: TieredCandidate[];
+  capabilities: TieredCandidate[];
   totalBudgetTokens?: number;
 }): string {
   const {
@@ -109,6 +113,7 @@ export function buildTwoLayerInjection(params: {
     tier1Candidates,
     tier2Candidates,
     preferences,
+    capabilities,
     totalBudgetTokens,
   } = params;
 
@@ -117,7 +122,8 @@ export function buildTwoLayerInjection(params: {
     identityItems.length === 0 &&
     tier1Candidates.length === 0 &&
     tier2Candidates.length === 0 &&
-    preferences.length === 0
+    preferences.length === 0 &&
+    capabilities.length === 0
   ) {
     return "";
   }
@@ -136,6 +142,7 @@ export function buildTwoLayerInjection(params: {
     tier1Candidates.length,
     tier2Candidates.length,
     preferences.length,
+    capabilities.length,
   ].filter((n) => n > 0).length;
   const structuralOverhead =
     WRAPPER_OVERHEAD_TOKENS + sectionCount * SECTION_TAG_TOKENS;
@@ -165,6 +172,13 @@ export function buildTwoLayerInjection(params: {
   );
   remainingTokens -= estimateTextTokens(preferenceLines.join("\n"));
 
+  const capabilityLines = renderPlainStatements(
+    capabilities,
+    TIER1_PER_ITEM_TOKENS,
+    remainingTokens,
+  );
+  remainingTokens -= estimateTextTokens(capabilityLines.join("\n"));
+
   // Tier 2 uses remaining budget
   const possiblyRelevantEpisodes = renderEpisodesWithStaleness(
     tier2Candidates,
@@ -190,6 +204,12 @@ export function buildTwoLayerInjection(params: {
   if (preferenceLines.length > 0) {
     sections.push(
       `<applicable_preferences>\n${preferenceLines.join("\n")}\n</applicable_preferences>`,
+    );
+  }
+
+  if (capabilityLines.length > 0) {
+    sections.push(
+      `<available_capabilities>\n${capabilityLines.join("\n")}\n</available_capabilities>`,
     );
   }
 

--- a/assistant/src/memory/search/staleness.ts
+++ b/assistant/src/memory/search/staleness.ts
@@ -8,6 +8,7 @@ const BASE_LIFETIME_MS: Record<string, number> = {
   project: 14 * 86_400_000, // 2 weeks
   decision: 14 * 86_400_000, // 2 weeks
   event: 3 * 86_400_000, // 3 days
+  capability: Infinity,
 };
 
 const DEFAULT_LIFETIME_MS = 30 * 86_400_000;


### PR DESCRIPTION
## Summary
- Add `capability` to `BASE_LIFETIME_MS` with `Infinity` lifetime (never stale)
- Add `CAPABILITY_KINDS` set and `<available_capabilities>` section to memory formatting
- Route capability items to plain statement rendering in the retriever

Part of plan: skill-capability-memories.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
