### PR TITLE
fix: disable multi-file app builder by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -39,7 +39,7 @@
       "key": "feature_flags.app-builder-multifile.enabled",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "mobile-pairing",


### PR DESCRIPTION
## Summary
- Disables the `app-builder-multifile` feature flag by default (`defaultEnabled: true` → `false`)

## Test plan
- [ ] Verify new installs default to single-file app builder
- [ ] Verify the flag can still be manually enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
