### PR TITLE
fix(macos): only force-initialize managed service modes on first bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -331,6 +331,7 @@ extension AppDelegate {
 
                 hasSetupApp = false
                 hasSetupDaemon = false
+                UserDefaults.standard.removeObject(forKey: "managedServiceModesInitialized")
                 showAuthWindow(reusingWindow: detachedWindow)
                 authManager.errorMessage = nil
             }
@@ -416,11 +417,16 @@ extension AppDelegate {
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
 
-                // Set service modes to "managed", forcing overwrite so that daemon-
-                // materialized schema defaults ("your-own") are replaced on first
-                // authenticated startup. On subsequent restarts the user's explicit
-                // choices are preserved because authentication is already established.
-                WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "managed", force: true)
+                // Set service modes to "managed" on the first authenticated
+                // bootstrap so daemon-materialized schema defaults ("your-own")
+                // are replaced. On subsequent launches, pass force: false so
+                // user-chosen service modes (e.g. "your-own") are preserved.
+                let flagKey = "managedServiceModesInitialized"
+                let alreadyInitialized = UserDefaults.standard.bool(forKey: flagKey)
+                WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "managed", force: !alreadyInitialized)
+                if !alreadyInitialized {
+                    UserDefaults.standard.set(true, forKey: flagKey)
+                }
 
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
@@ -632,6 +638,7 @@ extension AppDelegate {
         SentryDeviceInfo.updateOrganizationTag(nil)
         SentryDeviceInfo.updateUserTag(nil)
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+        UserDefaults.standard.removeObject(forKey: "managedServiceModesInitialized")
 
         daemonClient.disconnect()
         actorTokenBootstrapTask?.cancel()


### PR DESCRIPTION
## Summary
- Track whether initial managed bootstrap has already run via `managedServiceModesInitialized` UserDefaults flag
- Only pass `force: true` to `initializeServiceDefaults` on the first authenticated bootstrap
- Subsequent app launches preserve user-chosen service modes (e.g., `your-own`)
- Flag is cleared on managed logout and retire/uninstall so re-authentication bootstraps fresh

Addresses feedback from PR #18499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
