### PR TITLE
fix: guard contact channel update against unique-address collisions

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -904,15 +904,44 @@ export function updateChannelLastSeenById(channelId: string): void {
  * Update a guardian contact's principalId and its channel's identity fields.
  * Used for healing guardian binding drift when the JWT principal no longer
  * matches the stored guardian binding after a DB reset.
+ *
+ * Returns false if the update would violate the unique (type, address)
+ * constraint on contact_channels — e.g. when the incoming principal already
+ * exists on another channel record (a revoked former guardian entry).
+ * In that case the heal is skipped and trust stays `unknown`.
  */
 export function updateContactPrincipalAndChannel(
   contactId: string,
   channelId: string,
   newPrincipalId: string,
-): void {
+): boolean {
   const db = getDb();
   const now = Date.now();
   const normalizedAddress = newPrincipalId.toLowerCase();
+
+  // Look up the channel we're about to update so we know its type.
+  const channel = db
+    .select()
+    .from(contactChannels)
+    .where(eq(contactChannels.id, channelId))
+    .get();
+  if (!channel) return false;
+
+  // Guard: check if another channel row already holds this (type, address).
+  const conflicting = db
+    .select()
+    .from(contactChannels)
+    .where(
+      and(
+        eq(contactChannels.type, channel.type),
+        eq(contactChannels.address, normalizedAddress),
+      ),
+    )
+    .get();
+
+  if (conflicting && conflicting.id !== channelId) {
+    return false;
+  }
 
   db.transaction(() => {
     db.update(contacts)
@@ -931,6 +960,7 @@ export function updateContactPrincipalAndChannel(
   });
 
   emitContactChange();
+  return true;
 }
 
 /**

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -105,11 +105,22 @@ export function healGuardianBindingDrift(
   if (!currentPrincipalId?.startsWith("vellum-principal-")) return false;
   if (currentPrincipalId === incomingPrincipalId) return false;
 
-  updateContactPrincipalAndChannel(
+  const updated = updateContactPrincipalAndChannel(
     guardianResult.contact.id,
     guardianResult.channel.id,
     incomingPrincipalId,
   );
+
+  if (!updated) {
+    log.warn(
+      {
+        oldPrincipalId: currentPrincipalId,
+        newPrincipalId: incomingPrincipalId,
+      },
+      "Skipped guardian binding drift heal — address collision on contact_channels",
+    );
+    return false;
+  }
 
   log.info(
     {


### PR DESCRIPTION
## Summary
- Guard the contact channel address update during guardian drift healing against unique (type, address) index collisions
- Prevents heal attempt from aborting with a constraint error when the principal already exists on another channel record
- `updateContactPrincipalAndChannel` now checks for conflicting rows and returns `false` instead of throwing
- `healGuardianBindingDrift` handles the failure gracefully, leaving trust as `unknown`

Addresses feedback from PR #18486
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
