### PR TITLE
fix: enforce image size limit on post-optimization bytes

### DIFF
--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -14,7 +14,8 @@ export const IMAGE_EXTENSIONS = new Set([
   ".webp",
 ]);
 
-const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB — LLM API transport limit (post-optimization)
+const MAX_SOURCE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB — pre-optimization guard
 
 // Images above this threshold get auto-optimized via sips (macOS) to avoid
 // sending multi-MB base64 payloads to the LLM API.
@@ -120,10 +121,10 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
     return { content: `Error: ${resolvedPath} is not a file`, isError: true };
   }
 
-  if (stat.size > MAX_SIZE_BYTES) {
+  if (stat.size > MAX_SOURCE_SIZE_BYTES) {
     const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
     return {
-      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
+      content: `Error: image too large (${sizeMB} MB). Maximum source file size is 100 MB.`,
       isError: true,
     };
   }
@@ -155,6 +156,14 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
         /* ignore cleanup errors */
       }
     }
+  }
+
+  if (buffer.length > MAX_SIZE_BYTES) {
+    const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
+    return {
+      content: `Error: image too large after optimization (${sizeMB} MB). Maximum is 20 MB.`,
+      isError: true,
+    };
   }
 
   // Detect actual format from magic bytes - never trust the file extension


### PR DESCRIPTION
## Summary
- Move the 20 MB LLM API limit check to after sips optimization runs
- Keep a higher pre-optimization guard (100 MB) for source files
- Images in 20-100 MB range can now be optimized down and sent successfully

Addresses feedback from PR #18502
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
