### PR TITLE
fix: address contacts review followups

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
@@ -25,7 +25,7 @@ struct ContactCreateView: View {
             formFields
             Spacer()
             if let errorMessage {
-                errorBanner(errorMessage)
+                VInlineMessage(errorMessage)
             }
             actionButtons
         }
@@ -87,23 +87,6 @@ struct ContactCreateView: View {
                 )
             }
         }
-    }
-
-    // MARK: - Error Banner
-
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            VIconView(.triangleAlert, size: 12)
-                .foregroundColor(VColor.systemNegativeStrong)
-            Text(message)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
-                .lineLimit(2)
-        }
-        .padding(VSpacing.sm)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(VColor.systemNegativeStrong.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
     }
 
     // MARK: - Action Buttons

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -24,6 +24,7 @@ struct ContactDetailView: View {
     @State private var editedName = ""
     @State private var editedNotes = ""
     @FocusState private var isNameFocused: Bool
+    @State private var focusTask: Task<Void, Never>?
     @State private var isSaving = false
     @State private var verificationInProgress: String?
     @State private var verificationSuccessChannelId: String?
@@ -100,6 +101,8 @@ struct ContactDetailView: View {
             Text("This will permanently delete this contact and all their channels. This action cannot be undone.")
         }
         .onChange(of: contact.id) { _, _ in
+            focusTask?.cancel()
+            focusTask = nil
             currentContact = nil
             let name = contact.displayName
             editedName = (name == "New Contact") ? "" : name
@@ -118,6 +121,8 @@ struct ContactDetailView: View {
             editedNotes = contact.notes ?? ""
         }
         .onDisappear {
+            focusTask?.cancel()
+            focusTask = nil
             verificationTimeoutTask?.cancel()
             verificationTimeoutTask = nil
             verificationSuccessAnimationTask?.cancel()
@@ -148,7 +153,9 @@ struct ContactDetailView: View {
             editedName = isNewContact ? "" : name
             editedNotes = displayContact.notes ?? ""
             if isNewContact {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                focusTask?.cancel()
+                focusTask = Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 300_000_000)
                     isNameFocused = true
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -156,6 +156,7 @@ struct ContactDetailView: View {
                 focusTask?.cancel()
                 focusTask = Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 300_000_000)
+                    guard !Task.isCancelled else { return }
                     isNameFocused = true
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -903,8 +903,6 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Formatting Helpers
-
     // MARK: - Helpers
 
     private func channelIcon(for type: String) -> VIcon {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -171,6 +171,10 @@ struct ContactsContainerView: View {
                                 .controlSize(.small)
                         }
                     }
+
+                    if let guardianErrorMessage {
+                        VInlineMessage(guardianErrorMessage)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
@@ -205,6 +209,7 @@ struct ContactsContainerView: View {
         let trimmedNotes = guardianEditedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guardianIsSaving = true
+        guardianErrorMessage = nil
         do {
             if let updated = try await contactClient.updateContact(
                 contactId: contact.id,
@@ -216,7 +221,7 @@ struct ContactsContainerView: View {
                 viewModel.loadContacts()
             }
         } catch {
-            // Silently fail — user can retry
+            guardianErrorMessage = "Failed to save changes. Please try again."
         }
         guardianIsSaving = false
     }
@@ -224,6 +229,7 @@ struct ContactsContainerView: View {
     @State private var guardianEditedName: String = ""
     @State private var guardianEditedNotes: String = ""
     @State private var guardianIsSaving: Bool = false
+    @State private var guardianErrorMessage: String?
     @State private var isCreatingContact: Bool = false
     @State private var createContactError: String?
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -56,7 +56,7 @@ struct ContactsContainerView: View {
                     assistantDetailView
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 case .contact(let contactId):
-                    if let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
+                    if let contact = viewModel.deduplicatedContacts.first(where: { $0.id == contactId }) {
                         if contact.role == "guardian" {
                             guardianDetailView(contact: contact)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -32,10 +32,17 @@ struct ContactsContainerView: View {
     var body: some View {
         HStack(alignment: .top, spacing: VSpacing.lg) {
             // Left pane: contacts list (full height, internal scrolling)
-            ContactsListView(
-                viewModel: viewModel,
-                selection: $selection
-            )
+            VStack(spacing: VSpacing.sm) {
+                ContactsListView(
+                    viewModel: viewModel,
+                    selection: $selection
+                )
+                .frame(maxHeight: .infinity, alignment: .top)
+
+                if let createContactError {
+                    VInlineMessage(createContactError)
+                }
+            }
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
             // Right pane: detail, loading, or placeholder
@@ -217,6 +224,8 @@ struct ContactsContainerView: View {
     @State private var guardianEditedName: String = ""
     @State private var guardianEditedNotes: String = ""
     @State private var guardianIsSaving: Bool = false
+    @State private var isCreatingContact: Bool = false
+    @State private var createContactError: String?
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 
@@ -241,6 +250,9 @@ struct ContactsContainerView: View {
     /// list, and shows the detail pane so the user can edit inline.
     private func createPlaceholderContact() async {
         viewModel.isCreatingContact = false
+        guard !isCreatingContact else { return }
+        isCreatingContact = true
+        createContactError = nil
         do {
             let contact = try await contactClient.createContact(
                 displayName: "New Contact",
@@ -254,7 +266,8 @@ struct ContactsContainerView: View {
                 selection = .contact(contact.id)
             }
         } catch {
-            // Silently fail — user can retry via the + button
+            createContactError = "Failed to create contact: \(error.localizedDescription)"
         }
+        isCreatingContact = false
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -94,18 +94,6 @@ struct ContactsListView: View {
                 }
             }
 
-            if viewModel.contacts.isEmpty {
-                Spacer()
-                VEmptyState(
-                    title: "No contacts yet",
-                    icon: VIcon.users.rawValue,
-                    actionLabel: "Add Contact",
-                    actionIcon: VIcon.plus.rawValue,
-                    action: { viewModel.isCreatingContact = true }
-                )
-                .frame(maxWidth: .infinity)
-                Spacer()
-            }
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -57,7 +57,7 @@ final class ContactsViewModel: ObservableObject {
                     notes: existing.notes ?? contact.notes,
                     contactType: existing.contactType ?? contact.contactType,
                     lastInteraction: existing.lastInteraction ?? contact.lastInteraction,
-                    interactionCount: existing.interactionCount + contact.interactionCount,
+                    interactionCount: max(existing.interactionCount, contact.interactionCount),
                     channels: mergedChannels
                 )
             } else {

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -65,6 +65,18 @@ struct FeedbackGallerySection: View {
                         VBadge(style: .label("Error"), color: VColor.systemNegativeStrong)
                         VBadge(style: .label("Warn"), color: VColor.systemNegativeHover)
                     }
+
+                    // Icon label row
+                    HStack(spacing: VSpacing.lg) {
+                        VStack(spacing: VSpacing.xs) {
+                            Text("With iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBadge(label: "Guardian", icon: .shieldCheck, iconColor: VColor.primaryBase, tone: .neutral)
+                        }
+                        VStack(spacing: VSpacing.xs) {
+                            Text("Default iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBadge(label: "Status", icon: .sparkles, tone: .accent)
+                        }
+                    }
                 }
             }
 

--- a/clients/shared/Network/ContactClient.swift
+++ b/clients/shared/Network/ContactClient.swift
@@ -42,6 +42,26 @@ public protocol ContactClientProtocol {
 public struct ContactClient: ContactClientProtocol {
     nonisolated public init() {}
 
+    enum ContactClientError: LocalizedError {
+        case httpError(statusCode: Int, serverMessage: String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .httpError(let statusCode, let serverMessage):
+                if let serverMessage {
+                    return "Contact request failed (HTTP \(statusCode)): \(serverMessage)"
+                }
+                return "Contact request failed (HTTP \(statusCode))"
+            }
+        }
+    }
+
+    /// Attempt to extract a human-readable error message from a non-2xx response body.
+    private static func parseServerError(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json["message"] as? String ?? json["error"] as? String
+    }
+
     private struct UpsertResponse: Decodable {
         let ok: Bool
         let contact: ContactPayload
@@ -78,7 +98,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("updateContact failed (HTTP \(response.statusCode))")
-            return nil
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(UpsertResponse.self, from: response.data).contact
     }
@@ -101,7 +121,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("createContact failed (HTTP \(response.statusCode))")
-            return nil
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(UpsertResponse.self, from: response.data).contact
     }
@@ -130,7 +150,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("createInvite failed (HTTP \(response.statusCode))")
-            return nil
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         let decoded = try JSONDecoder().decode(CreateInviteResponse.self, from: response.data)
         guard let invite = decoded.invite else { return nil }
@@ -151,7 +171,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("triggerInviteCall failed (HTTP \(response.statusCode))")
-            return false
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return true
     }
@@ -177,7 +197,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("fetchContactsList failed (HTTP \(response.statusCode))")
-            return []
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(ContactsListResponse.self, from: response.data).contacts
     }
@@ -188,7 +208,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("fetchContact failed (HTTP \(response.statusCode))")
-            return nil
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(SingleContactResponse.self, from: response.data).contact
     }
@@ -199,7 +219,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess || response.statusCode == 204 else {
             log.error("deleteContact failed (HTTP \(response.statusCode))")
-            return false
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return true
     }
@@ -220,7 +240,7 @@ public struct ContactClient: ContactClientProtocol {
         )
         guard response.isSuccess else {
             log.error("updateContactChannel failed (HTTP \(response.statusCode))")
-            return nil
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(SingleContactResponse.self, from: response.data).contact
     }


### PR DESCRIPTION
## Summary
Address all reviewer feedback from today's contacts PRs — prioritized by severity from data-loss bugs to polish.

## PRs merged into feature branch
- #18572: fix: throw errors from ContactClient on non-2xx HTTP responses
- #18573: fix: use deduplicated contacts for detail view lookup
- #18574: fix: replace DispatchQueue.asyncAfter with cancellable Task in ContactDetailView
- #18579: fix: surface guardian save errors instead of silently swallowing
- #18569: fix: remove dead code and empty MARK sections in contacts views
- #18571: fix: add VBadge icon variant to FeedbackGallerySection
- #18576: refactor: extract duplicated inlineMessage helper to shared component
- #18575: fix: add concurrency guard and error feedback to contact creation

## Self-review result
PASS — both plan faithfulness and repo integration reviews found no gaps.

Part of plan: contacts-review-followups.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
