### PR TITLE
fix: remove vellum from LOW_RISK_PROGRAMS, keep only assistant

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -144,7 +144,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "du",
   "df",
   "assistant",
-  "vellum",
 ]);
 
 // High-risk shell programs / patterns


### PR DESCRIPTION
## Summary
- Remove `vellum` from `LOW_RISK_PROGRAMS` in the permission checker
- Only `assistant` should be low-risk — `vellum` manages instance lifecycle and should go through normal permission checks

## Original prompt
Remove `vellum` from LOW_RISK_PROGRAMS in checker.ts — only `assistant` should be low-risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
