### PR TITLE
fix: add JWT auth and dynamic host resolution for CLI wipe

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -1,9 +1,18 @@
 import type { Command } from "commander";
 
-import { getQdrantUrlEnv, getRuntimeHttpPort } from "../../config/env.js";
+import {
+  getQdrantUrlEnv,
+  getRuntimeHttpHost,
+  getRuntimeHttpPort,
+} from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
-import { isHttpHealthy } from "../../daemon/daemon-control.js";
+import { healthCheckHost, isHttpHealthy } from "../../daemon/daemon-control.js";
+import {
+  initAuthSigningKey,
+  loadOrCreateSigningKey,
+  mintDaemonDeliveryToken,
+} from "../../runtime/auth/token-service.js";
 import { ensureDaemonRunning } from "../../daemon/lifecycle.js";
 import { formatJson, formatMarkdown } from "../../export/formatter.js";
 import {
@@ -315,9 +324,15 @@ Examples:
       // rows — preventing FK constraint failures from follow-up writes.
       if (await isHttpHealthy()) {
         const port = getRuntimeHttpPort();
+        const host = healthCheckHost(getRuntimeHttpHost());
+        initAuthSigningKey(loadOrCreateSigningKey());
+        const token = mintDaemonDeliveryToken();
         const res = await fetch(
-          `http://127.0.0.1:${port}/v1/conversations/${conversation.id}/wipe`,
-          { method: "POST" },
+          `http://${host}:${port}/v1/conversations/${conversation.id}/wipe`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+          },
         );
         if (!res.ok) {
           const body = await res.text();

--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -133,7 +133,7 @@ function isVellumDaemonProcess(pid: number): boolean {
  *  Wildcard addresses (0.0.0.0, ::) bind all interfaces but aren't
  *  connectable on all platforms — substitute loopback. IPv6 literals
  *  need brackets in URLs. */
-function healthCheckHost(host: string): string {
+export function healthCheckHost(host: string): string {
   if (host === "0.0.0.0") return "127.0.0.1";
   if (host === "::") return "[::1]";
   if (host.includes(":")) return `[${host}]`;


### PR DESCRIPTION
## Summary
- Add JWT Authorization header when CLI delegates wipe to daemon HTTP endpoint
- Replace hardcoded 127.0.0.1 with healthCheckHost(getRuntimeHttpHost()) for proper host resolution
- Export healthCheckHost from daemon-control.ts for reuse
- Fixes 401 failures in auth-enabled environments and IPv6 host mismatches

Addresses feedback from PR #18504
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
