### PR TITLE
fix: exclude to-be-deleted superseder from wipe Step B guard

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -406,8 +406,26 @@ export function wipeConversation(id: string): WipeConversationResult {
            AND mi_active.scope_id = mi_old.scope_id
            AND mi_active.status = 'active'
            AND mi_active.id != mi_old.id
-           AND mi_active.id != mi_new.id
+           -- Exclude items sourced exclusively from the conversation being
+           -- wiped — deleteConversation will remove them, so they should not
+           -- block restoration of mi_old.
+           AND NOT (
+             EXISTS (
+               SELECT 1 FROM memory_item_sources mis_a
+               JOIN messages m_a ON m_a.id = mis_a.message_id
+               WHERE mis_a.memory_item_id = mi_active.id
+                 AND m_a.conversation_id = ?
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM memory_item_sources mis_b
+               JOIN messages m_b ON m_b.id = mis_b.message_id
+               WHERE mis_b.memory_item_id = mi_active.id
+                 AND m_b.conversation_id != ?
+             )
+           )
        )`,
+    id,
+    id,
     id,
     id,
   );


### PR DESCRIPTION
## Summary
- Step B's NOT EXISTS guard now excludes active items sourced exclusively from the conversation being wiped, rather than only excluding `mi_new` by ID
- Prevents explicitly superseded items from getting stuck when their superseder (or any other active duplicate from the same conversation) is about to be deleted by `deleteConversation`

Addresses feedback from PR #18500
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
