### PR TITLE
feat: add skill-memory module for capability memory CRUD

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -1,0 +1,314 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+const testDir = mkdtempSync(join(tmpdir(), "skill-memory-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getWorkspaceSkillsDir: () => join(testDir, "skills"),
+  getWorkspaceConfigPath: () => join(testDir, "config.json"),
+  readPlatformToken: () => undefined,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+const TEST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    enabled: true,
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => TEST_CONFIG,
+  getConfig: () => TEST_CONFIG,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { memoryItems, memoryJobs } from "../memory/schema.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+import {
+  buildCapabilityStatement,
+  deleteSkillCapabilityMemory,
+  upsertSkillCapabilityMemory,
+} from "../skills/skill-memory.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    // best effort cleanup
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM memory_item_sources");
+  db.run("DELETE FROM memory_embeddings");
+  db.run("DELETE FROM memory_items");
+  db.run("DELETE FROM memory_jobs");
+}
+
+function makeSkill(overrides: Partial<CatalogSkill> = {}): CatalogSkill {
+  return {
+    id: "test-skill",
+    name: "Test Skill",
+    description: "A skill for testing",
+    ...overrides,
+  };
+}
+
+// ─── buildCapabilityStatement ────────────────────────────────────────────────
+
+describe("buildCapabilityStatement", () => {
+  test("includes display name, id, and description", () => {
+    const entry = makeSkill({
+      metadata: { vellum: { "display-name": "My Skill" } },
+    });
+    const result = buildCapabilityStatement(entry);
+    expect(result).toContain('"My Skill"');
+    expect(result).toContain("(test-skill)");
+    expect(result).toContain("A skill for testing");
+  });
+
+  test("includes activation hints when present", () => {
+    const entry = makeSkill({
+      metadata: {
+        vellum: {
+          "display-name": "My Skill",
+          "activation-hints": ["user asks to search", "needs web data"],
+        },
+      },
+    });
+    const result = buildCapabilityStatement(entry);
+    expect(result).toContain("Use when:");
+    expect(result).toContain("user asks to search");
+    expect(result).toContain("needs web data");
+  });
+
+  test("works without metadata (falls back to name)", () => {
+    const entry = makeSkill({ metadata: undefined });
+    const result = buildCapabilityStatement(entry);
+    expect(result).toContain('"Test Skill"');
+    expect(result).toContain("(test-skill)");
+    expect(result).toContain("A skill for testing");
+  });
+
+  test("truncates long statements to 500 chars", () => {
+    const longDesc = "x".repeat(600);
+    const entry = makeSkill({ description: longDesc });
+    const result = buildCapabilityStatement(entry);
+    expect(result.length).toBe(500);
+  });
+});
+
+// ─── upsertSkillCapabilityMemory ─────────────────────────────────────────────
+
+describe("upsertSkillCapabilityMemory", () => {
+  beforeEach(resetTables);
+
+  test("inserts with correct kind, subject, confidence, importance", () => {
+    const entry = makeSkill();
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const db = getDb();
+    const items = db.select().from(memoryItems).all();
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("capability");
+    expect(items[0].subject).toBe("skill:test-skill");
+    expect(items[0].confidence).toBe(1.0);
+    expect(items[0].importance).toBe(0.7);
+    expect(items[0].status).toBe("active");
+    expect(items[0].scopeId).toBe("default");
+
+    // Should also enqueue an embed_item job
+    const jobs = db.select().from(memoryJobs).all();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].type).toBe("embed_item");
+  });
+
+  test("is idempotent (same entry only touches lastSeenAt)", () => {
+    const entry = makeSkill();
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const db = getDb();
+    const before = db.select().from(memoryItems).all();
+    expect(before).toHaveLength(1);
+    const originalLastSeen = before[0].lastSeenAt;
+
+    // Small delay to ensure timestamps differ
+    const now = Date.now() + 100;
+    // Upsert again
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const after = db.select().from(memoryItems).all();
+    expect(after).toHaveLength(1);
+    // Fingerprint should be the same, so only lastSeenAt changes
+    expect(after[0].fingerprint).toBe(before[0].fingerprint);
+    expect(after[0].lastSeenAt).toBeGreaterThanOrEqual(originalLastSeen);
+
+    // Should NOT enqueue a second embed job (only 1 from initial insert)
+    const jobs = db.select().from(memoryJobs).all();
+    expect(jobs).toHaveLength(1);
+  });
+
+  test("updates statement when description changes", () => {
+    const entry = makeSkill({ description: "Original description" });
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const db = getDb();
+    const before = db.select().from(memoryItems).all();
+    expect(before).toHaveLength(1);
+    expect(before[0].statement).toContain("Original description");
+
+    // Change description
+    const updatedEntry = makeSkill({ description: "Updated description" });
+    upsertSkillCapabilityMemory("test-skill", updatedEntry);
+
+    const after = db.select().from(memoryItems).all();
+    expect(after).toHaveLength(1);
+    expect(after[0].statement).toContain("Updated description");
+    expect(after[0].fingerprint).not.toBe(before[0].fingerprint);
+
+    // Should enqueue a second embed job
+    const jobs = db.select().from(memoryJobs).all();
+    expect(jobs).toHaveLength(2);
+  });
+
+  test("reactivates soft-deleted items", () => {
+    const entry = makeSkill();
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const db = getDb();
+    // Soft-delete the item
+    db.update(memoryItems)
+      .set({ status: "deleted" })
+      .where(eq(memoryItems.subject, "skill:test-skill"))
+      .run();
+
+    const deleted = db.select().from(memoryItems).all();
+    expect(deleted[0].status).toBe("deleted");
+
+    // Clear jobs from initial insert
+    db.run("DELETE FROM memory_jobs");
+
+    // Upsert again — should reactivate
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const reactivated = db.select().from(memoryItems).all();
+    expect(reactivated).toHaveLength(1);
+    expect(reactivated[0].status).toBe("active");
+
+    // Should enqueue embed job for reactivated item
+    const jobs = db.select().from(memoryJobs).all();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].type).toBe("embed_item");
+  });
+
+  test("does not throw on DB error", () => {
+    // Close the DB connection to force errors, then reinitialize
+    resetDb();
+    // getDb() will create a new connection, but we can force a DB error by
+    // dropping the table it reads from. Use a fresh DB without initialization.
+    // Instead, verify the try/catch by closing and reopening:
+    // resetDb closes the connection; getDb lazily reconnects.
+    // We drop the memory_items table to force an error on the next query.
+    const db = getDb();
+    db.run("DROP TABLE IF EXISTS memory_items");
+
+    expect(() => {
+      upsertSkillCapabilityMemory("test-skill", makeSkill());
+    }).not.toThrow();
+
+    // Restore DB state for subsequent tests
+    resetDb();
+    initializeDb();
+  });
+});
+
+// ─── deleteSkillCapabilityMemory ─────────────────────────────────────────────
+
+describe("deleteSkillCapabilityMemory", () => {
+  beforeEach(resetTables);
+
+  test("soft-deletes matching item", () => {
+    const entry = makeSkill();
+    upsertSkillCapabilityMemory("test-skill", entry);
+
+    const db = getDb();
+    const before = db.select().from(memoryItems).all();
+    expect(before).toHaveLength(1);
+    expect(before[0].status).toBe("active");
+
+    deleteSkillCapabilityMemory("test-skill");
+
+    const after = db.select().from(memoryItems).all();
+    expect(after).toHaveLength(1);
+    expect(after[0].status).toBe("deleted");
+  });
+
+  test("is no-op for missing item", () => {
+    // Should not throw when no matching item exists
+    expect(() => {
+      deleteSkillCapabilityMemory("nonexistent-skill");
+    }).not.toThrow();
+
+    const db = getDb();
+    const items = db.select().from(memoryItems).all();
+    expect(items).toHaveLength(0);
+  });
+
+  test("does not throw on DB error", () => {
+    // Close and reopen DB, then drop the table to force a query error
+    resetDb();
+    const db = getDb();
+    db.run("DROP TABLE IF EXISTS memory_items");
+
+    expect(() => {
+      deleteSkillCapabilityMemory("test-skill");
+    }).not.toThrow();
+
+    // Restore DB state for subsequent tests
+    resetDb();
+    initializeDb();
+  });
+});

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -1,0 +1,208 @@
+import { and, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../memory/db.js";
+import { computeMemoryFingerprint } from "../memory/fingerprint.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
+import { memoryItems } from "../memory/schema.js";
+import { getLogger } from "../util/logger.js";
+import { type CatalogSkill, resolveCatalog } from "./catalog-install.js";
+
+const log = getLogger("skill-memory");
+
+/**
+ * Build a semantically rich capability statement from a catalog skill entry.
+ * Truncated to 500 chars max (matching the limit used by memory item extraction).
+ */
+export function buildCapabilityStatement(entry: CatalogSkill): string {
+  const displayName =
+    entry.metadata?.vellum?.["display-name"] ?? entry.name;
+  const activationHints = entry.metadata?.vellum?.["activation-hints"];
+
+  let statement = `The "${displayName}" skill (${entry.id}) is available. ${entry.description}.`;
+  if (activationHints && activationHints.length > 0) {
+    statement += ` Use when: ${activationHints.join("; ")}.`;
+  }
+
+  // Truncate to 500 chars max
+  if (statement.length > 500) {
+    statement = statement.slice(0, 500);
+  }
+
+  return statement;
+}
+
+/**
+ * Upsert a capability memory item for a catalog skill.
+ * Best-effort: errors are logged but never thrown.
+ */
+export function upsertSkillCapabilityMemory(
+  skillId: string,
+  entry: CatalogSkill,
+): void {
+  try {
+    const db = getDb();
+    const subject = `skill:${skillId}`;
+    const statement = buildCapabilityStatement(entry);
+    const kind = "capability";
+    const scopeId = "default";
+    const confidence = 1.0;
+    const importance = 0.7;
+    const fingerprint = computeMemoryFingerprint(
+      scopeId,
+      kind,
+      subject,
+      statement,
+    );
+    const now = Date.now();
+
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(
+        and(
+          eq(memoryItems.kind, kind),
+          eq(memoryItems.subject, subject),
+          eq(memoryItems.scopeId, scopeId),
+        ),
+      )
+      .get();
+
+    if (existing) {
+      if (existing.status === "active" && existing.fingerprint === fingerprint) {
+        // Same content — just touch lastSeenAt
+        db.update(memoryItems)
+          .set({ lastSeenAt: now })
+          .where(eq(memoryItems.id, existing.id))
+          .run();
+        return;
+      }
+
+      if (existing.status === "active") {
+        // Content changed — update statement and fingerprint
+        db.update(memoryItems)
+          .set({
+            statement,
+            fingerprint,
+            lastSeenAt: now,
+          })
+          .where(eq(memoryItems.id, existing.id))
+          .run();
+        enqueueMemoryJob("embed_item", { itemId: existing.id });
+        return;
+      }
+
+      // status === "deleted" or other — reactivate
+      db.update(memoryItems)
+        .set({
+          status: "active",
+          statement,
+          fingerprint,
+          lastSeenAt: now,
+          firstSeenAt: now,
+        })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+      enqueueMemoryJob("embed_item", { itemId: existing.id });
+      return;
+    }
+
+    // No existing — insert new row
+    const id = uuid();
+    db.insert(memoryItems)
+      .values({
+        id,
+        kind,
+        subject,
+        statement,
+        status: "active",
+        confidence,
+        importance,
+        fingerprint,
+        scopeId,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      })
+      .run();
+    enqueueMemoryJob("embed_item", { itemId: id });
+  } catch (err) {
+    log.warn({ err, skillId }, "Failed to upsert skill capability memory");
+  }
+}
+
+/**
+ * Soft-delete the capability memory item for a skill.
+ * Best-effort: errors are logged but never thrown.
+ */
+export function deleteSkillCapabilityMemory(skillId: string): void {
+  try {
+    const db = getDb();
+    const subject = `skill:${skillId}`;
+    const now = Date.now();
+
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(
+        and(
+          eq(memoryItems.kind, "capability"),
+          eq(memoryItems.subject, subject),
+          eq(memoryItems.scopeId, "default"),
+        ),
+      )
+      .get();
+
+    if (existing && existing.status !== "deleted") {
+      db.update(memoryItems)
+        .set({ status: "deleted", lastSeenAt: now })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+    }
+  } catch (err) {
+    log.warn({ err, skillId }, "Failed to delete skill capability memory");
+  }
+}
+
+/**
+ * Seed capability memory items for all catalog skills.
+ * Prunes stale entries whose skills are no longer in the catalog.
+ * Best-effort: errors are logged but never thrown.
+ */
+export async function seedCatalogSkillMemories(): Promise<void> {
+  try {
+    const catalog = await resolveCatalog();
+    const catalogIds = new Set<string>();
+
+    for (const entry of catalog) {
+      catalogIds.add(entry.id);
+      upsertSkillCapabilityMemory(entry.id, entry);
+    }
+
+    // Prune stale capability memories for skills no longer in catalog
+    const db = getDb();
+    const allCapabilities = db
+      .select()
+      .from(memoryItems)
+      .where(
+        and(
+          eq(memoryItems.kind, "capability"),
+          eq(memoryItems.scopeId, "default"),
+          eq(memoryItems.status, "active"),
+        ),
+      )
+      .all();
+
+    const now = Date.now();
+    for (const item of allCapabilities) {
+      const itemSkillId = item.subject.replace("skill:", "");
+      if (!catalogIds.has(itemSkillId)) {
+        db.update(memoryItems)
+          .set({ status: "deleted", lastSeenAt: now })
+          .where(eq(memoryItems.id, item.id))
+          .run();
+      }
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to seed catalog skill memories");
+  }
+}


### PR DESCRIPTION
## Summary
- New `skill-memory.ts` module with `buildCapabilityStatement`, `upsertSkillCapabilityMemory`, `deleteSkillCapabilityMemory`, and `seedCatalogSkillMemories`
- Writes `capability`-kind memory items with deterministic subjects (`skill:{id}`) for reliable lookup/deletion
- All DB operations are best-effort (try/catch) to never block skill install/uninstall
- Unit tests covering statement building, upsert idempotency, reactivation, deletion, and error resilience

Part of plan: skill-capability-memories.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
