### PR TITLE
feat: seed skill capability memories from catalog at daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -105,6 +105,7 @@ import {
   registerWatcherProviders,
 } from "./providers-setup.js";
 import { seedInterfaceFiles } from "./seed-files.js";
+import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { handleWatchObservation } from "./watch-handler.js";
@@ -372,6 +373,12 @@ export async function runDaemon(): Promise<void> {
 
     log.info("Daemon startup: starting memory worker");
     const memoryWorker = startMemoryJobsWorker();
+
+    // Seed capability memories for first-party catalog skills so the memory
+    // pipeline can surface relevant skills via semantic search.
+    void seedCatalogSkillMemories().catch((err) =>
+      log.warn({ err }, "Catalog skill memory seeding failed — continuing"),
+    );
 
     registerWatcherProviders();
     registerMessagingProviders();


### PR DESCRIPTION
## Summary
- Call `seedCatalogSkillMemories()` as a fire-and-forget async operation after the memory worker starts
- Non-blocking: daemon continues startup while seeding runs in background
- Failures are logged as warnings and never block daemon startup

Part of plan: skill-capability-memories.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
