### PR TITLE
feat(security): replace machine entropy with random store.key for credential encryption

### DIFF
--- a/assistant/src/__tests__/encrypted-store.test.ts
+++ b/assistant/src/__tests__/encrypted-store.test.ts
@@ -1,4 +1,8 @@
-import { randomBytes } from "node:crypto";
+import {
+  createCipheriv,
+  pbkdf2Sync,
+  randomBytes,
+} from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -7,9 +11,10 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
 import {
   afterAll,
@@ -23,7 +28,7 @@ import {
 } from "bun:test";
 
 // ---------------------------------------------------------------------------
-// Mock only the logger (not platform — we use _setStorePath instead)
+// Mock only the logger (not platform -- we use _setStorePath instead)
 // ---------------------------------------------------------------------------
 
 mock.module("../util/logger.js", () => ({
@@ -34,8 +39,10 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import {
+  _setStoreKeyPath,
   _setStorePath,
   deleteKey,
+  getMachineEntropy,
   getKey,
   listKeys,
   setKey,
@@ -50,6 +57,57 @@ const TEST_DIR = join(
   `vellum-enc-test-${randomBytes(4).toString("hex")}`,
 );
 const STORE_PATH = join(TEST_DIR, "keys.enc");
+const STORE_KEY_PATH = join(TEST_DIR, "store.key");
+
+// ---------------------------------------------------------------------------
+// Legacy v1 helpers (for migration tests)
+// ---------------------------------------------------------------------------
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const PBKDF2_ITERATIONS = process.env.BUN_TEST === "1" ? 1 : 100_000;
+const SALT_LENGTH = 32;
+
+function legacyDeriveKey(salt: Buffer): Buffer {
+  const entropy = getMachineEntropy();
+  return pbkdf2Sync(entropy, salt, PBKDF2_ITERATIONS, KEY_LENGTH, "sha512");
+}
+
+function legacyEncrypt(
+  plaintext: string,
+  key: Buffer,
+): { iv: string; tag: string; data: string } {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf-8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return {
+    iv: iv.toString("hex"),
+    tag: tag.toString("hex"),
+    data: encrypted.toString("hex"),
+  };
+}
+
+/** Write a v1 store file directly (bypassing the module's writeStore). */
+function writeV1Store(
+  path: string,
+  salt: Buffer,
+  entries: Record<string, { iv: string; tag: string; data: string }>,
+): void {
+  const store = {
+    version: 1,
+    salt: salt.toString("hex"),
+    entries,
+  };
+  writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -66,10 +124,12 @@ describe("encrypted-store", () => {
       rmSync(join(TEST_DIR, entry), { recursive: true, force: true });
     }
     _setStorePath(STORE_PATH);
+    _setStoreKeyPath(STORE_KEY_PATH);
   });
 
   afterEach(() => {
     _setStorePath(null);
+    _setStoreKeyPath(null);
   });
 
   afterAll(() => {
@@ -173,16 +233,15 @@ describe("encrypted-store", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Store format
+  // Store format (v2)
   // -----------------------------------------------------------------------
   describe("store format", () => {
-    test("store file is valid JSON with version, salt, and entries", () => {
+    test("store file is valid JSON with version 2 and entries (no salt)", () => {
       setKey("test", "value");
       const raw = readFileSync(STORE_PATH, "utf-8");
       const parsed = JSON.parse(raw);
-      expect(parsed.version).toBe(1);
-      expect(typeof parsed.salt).toBe("string");
-      expect(parsed.salt.length).toBe(64); // 32 bytes = 64 hex chars
+      expect(parsed.version).toBe(2);
+      expect(parsed.salt).toBeUndefined();
       expect(typeof parsed.entries).toBe("object");
       expect(parsed.entries.test).toBeDefined();
     });
@@ -220,6 +279,159 @@ describe("encrypted-store", () => {
 
       // IVs should differ (random), so ciphertext should differ too
       expect(entry1.iv).not.toBe(entry2.iv);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // v2 format and store.key
+  // -----------------------------------------------------------------------
+  describe("v2 format and store.key", () => {
+    test("fresh store creates v2 format and store.key", () => {
+      setKey("test", "value");
+
+      // Verify keys.enc is v2 with no salt
+      const raw = readFileSync(STORE_PATH, "utf-8");
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(2);
+      expect(parsed.salt).toBeUndefined();
+
+      // Verify store.key exists with exactly 32 bytes and 0o600 perms
+      expect(existsSync(STORE_KEY_PATH)).toBe(true);
+      const keyBuf = readFileSync(STORE_KEY_PATH);
+      expect(keyBuf.length).toBe(32);
+      const mode = statSync(STORE_KEY_PATH).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    test("v2 round-trip", () => {
+      // Set multiple values and read them back
+      setKey("key-a", "value-a");
+      setKey("key-b", "value-b");
+      setKey("key-c", "value-c");
+
+      expect(getKey("key-a")).toBe("value-a");
+      expect(getKey("key-b")).toBe("value-b");
+      expect(getKey("key-c")).toBe("value-c");
+
+      // Delete one and verify others remain
+      deleteKey("key-b");
+      expect(getKey("key-b")).toBeUndefined();
+      expect(getKey("key-a")).toBe("value-a");
+      expect(getKey("key-c")).toBe("value-c");
+    });
+
+    test("v2 store without store.key returns undefined", () => {
+      setKey("test", "value");
+      // Delete store.key
+      unlinkSync(STORE_KEY_PATH);
+      expect(getKey("test")).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // v1 -> v2 migration
+  // -----------------------------------------------------------------------
+  describe("v1 to v2 migration", () => {
+    test("v1 to v2 migration preserves entries", () => {
+      // Create a v1 store using legacy encryption
+      const salt = randomBytes(SALT_LENGTH);
+      const legacyKey = legacyDeriveKey(salt);
+      const entries: Record<string, { iv: string; tag: string; data: string }> = {};
+      entries["api-key"] = legacyEncrypt("secret-123", legacyKey);
+      entries["other-key"] = legacyEncrypt("secret-456", legacyKey);
+      writeV1Store(STORE_PATH, salt, entries);
+
+      // Access via getKey -- should trigger migration
+      const val1 = getKey("api-key");
+      expect(val1).toBe("secret-123");
+
+      const val2 = getKey("other-key");
+      expect(val2).toBe("secret-456");
+
+      // Store should now be v2
+      const raw = readFileSync(STORE_PATH, "utf-8");
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(2);
+      expect(parsed.salt).toBeUndefined();
+
+      // store.key should exist
+      expect(existsSync(STORE_KEY_PATH)).toBe(true);
+    });
+
+    test("migration is idempotent", () => {
+      // Create a v1 store
+      const salt = randomBytes(SALT_LENGTH);
+      const legacyKey = legacyDeriveKey(salt);
+      const entries: Record<string, { iv: string; tag: string; data: string }> = {};
+      entries["my-key"] = legacyEncrypt("my-value", legacyKey);
+      writeV1Store(STORE_PATH, salt, entries);
+
+      // First access triggers migration
+      const val1 = getKey("my-key");
+      expect(val1).toBe("my-value");
+
+      // Second access should work the same (already migrated)
+      const val2 = getKey("my-key");
+      expect(val2).toBe("my-value");
+
+      // Should still be v2
+      const raw = readFileSync(STORE_PATH, "utf-8");
+      expect(JSON.parse(raw).version).toBe(2);
+    });
+
+    test("migration skips corrupt entries", () => {
+      // Create a v1 store with one good entry and one tampered entry
+      const salt = randomBytes(SALT_LENGTH);
+      const legacyKey = legacyDeriveKey(salt);
+      const entries: Record<string, { iv: string; tag: string; data: string }> = {};
+      entries["good"] = legacyEncrypt("good-value", legacyKey);
+      entries["bad"] = legacyEncrypt("bad-value", legacyKey);
+      // Tamper with the bad entry
+      const badData = entries["bad"].data;
+      entries["bad"].data =
+        badData[0] === "0" ? "1" + badData.slice(1) : "0" + badData.slice(1);
+      writeV1Store(STORE_PATH, salt, entries);
+
+      // Trigger migration via getKey
+      const goodVal = getKey("good");
+      expect(goodVal).toBe("good-value");
+
+      // Bad entry should be gone (not migrated)
+      const badVal = getKey("bad");
+      expect(badVal).toBeUndefined();
+
+      // Store should be v2
+      const raw = readFileSync(STORE_PATH, "utf-8");
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(2);
+      expect(parsed.entries["good"]).toBeDefined();
+      expect(parsed.entries["bad"]).toBeUndefined();
+    });
+
+    test("partial migration recovery", () => {
+      // Simulate crash between store.key write and store rewrite:
+      // write v1 store + store.key but leave store as v1
+      const salt = randomBytes(SALT_LENGTH);
+      const legacyKey = legacyDeriveKey(salt);
+      const entries: Record<string, { iv: string; tag: string; data: string }> = {};
+      entries["test-key"] = legacyEncrypt("test-value", legacyKey);
+      writeV1Store(STORE_PATH, salt, entries);
+
+      // Pre-write store.key (simulating partial migration)
+      const preKey = randomBytes(32);
+      writeFileSync(STORE_KEY_PATH, preKey, { mode: 0o600 });
+
+      // Migration should complete using the existing store.key
+      const val = getKey("test-key");
+      expect(val).toBe("test-value");
+
+      // Verify the store.key was reused (not regenerated)
+      const afterKey = readFileSync(STORE_KEY_PATH);
+      expect(afterKey.equals(preKey)).toBe(true);
+
+      // Store should now be v2
+      const raw = readFileSync(STORE_PATH, "utf-8");
+      expect(JSON.parse(raw).version).toBe(2);
     });
   });
 
@@ -273,7 +485,9 @@ describe("encrypted-store", () => {
     test("setKey creates directory if missing", () => {
       // Point to a path in a non-existent subdirectory
       const nestedPath = join(TEST_DIR, "sub", "dir", "keys.enc");
+      const nestedKeyPath = join(TEST_DIR, "sub", "dir", "store.key");
       _setStorePath(nestedPath);
+      _setStoreKeyPath(nestedKeyPath);
       const result = setKey("test", "value");
       expect(result).toBe(true);
       expect(getKey("test")).toBe("value");
@@ -311,7 +525,7 @@ describe("encrypted-store", () => {
       setKey("test", "value");
       // Loosen permissions
       chmodSync(STORE_PATH, 0o644);
-      // Write again — should re-enforce 0600
+      // Write again -- should re-enforce 0600
       setKey("test2", "value2");
       const mode = statSync(STORE_PATH).mode & 0o777;
       expect(mode).toBe(0o600);
@@ -352,16 +566,14 @@ describe("encrypted-store", () => {
       expect(getKey("__proto__")).toBeUndefined();
     });
 
-    test("salt is preserved across set operations", () => {
+    test("store.key is reused across set operations", () => {
       setKey("key1", "val1");
-      const raw1 = readFileSync(STORE_PATH, "utf-8");
-      const salt1 = JSON.parse(raw1).salt;
+      const key1 = readFileSync(STORE_KEY_PATH);
 
       setKey("key2", "val2");
-      const raw2 = readFileSync(STORE_PATH, "utf-8");
-      const salt2 = JSON.parse(raw2).salt;
+      const key2 = readFileSync(STORE_KEY_PATH);
 
-      expect(salt1).toBe(salt2);
+      expect(key1.equals(key2)).toBe(true);
     });
   });
 });

--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -1,12 +1,12 @@
 /**
- * Encrypted-at-rest key storage — fallback for systems without OS keychain.
+ * Encrypted-at-rest key storage -- fallback for systems without OS keychain.
  *
- * Uses AES-256-GCM with a key derived from machine-specific entropy:
- *   - hostname, username, platform, arch, homedir
- *   - PBKDF2 with 100k iterations + a persisted random salt
+ * v2 stores use a cryptographically random 32-byte `store.key` file as the
+ * AES-256-GCM key directly (no key derivation). The key file lives alongside
+ * `keys.enc` in `~/.vellum/protected/`.
  *
- * Secrets are stored in `~/.vellum/keys.enc` as a JSON blob encrypted
- * with the derived key. Each entry has its own IV for authenticated encryption.
+ * v1 stores (legacy) derived the AES key from machine-specific entropy via
+ * PBKDF2. Existing v1 stores are automatically migrated to v2 on first access.
  *
  * Provides the same get/set/delete interface as `keychain.ts`.
  */
@@ -17,7 +17,13 @@ import {
   pbkdf2Sync,
   randomBytes,
 } from "node:crypto";
-import { chmodSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { hostname, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -36,17 +42,26 @@ const PBKDF2_ITERATIONS =
   // In tests, PBKDF2 key derivation dominates runtime (~1-2s per file).
   // 1 iteration is sufficient for correctness; 100k is for brute-force resistance.
   process.env.BUN_TEST === "1" ? 1 : 100_000;
-const SALT_LENGTH = 32; // bytes
 
-/** On-disk format for the encrypted store. */
-interface StoreFile {
-  /** Version for future format changes. */
+// ---------------------------------------------------------------------------
+// On-disk formats
+// ---------------------------------------------------------------------------
+
+/** v1 on-disk format (legacy): PBKDF2-derived key from machine entropy. */
+interface StoreFileV1 {
   version: 1;
   /** Hex-encoded salt for PBKDF2 key derivation. */
   salt: string;
-  /** Individual encrypted entries keyed by account name. */
   entries: Record<string, EncryptedEntry>;
 }
+
+/** v2 on-disk format: random store.key used directly as AES key. */
+interface StoreFileV2 {
+  version: 2;
+  entries: Record<string, EncryptedEntry>;
+}
+
+type StoreFile = StoreFileV1 | StoreFileV2;
 
 /** A single encrypted value. */
 interface EncryptedEntry {
@@ -74,9 +89,74 @@ export function _setStorePath(path: string | null): void {
 }
 
 // ---------------------------------------------------------------------------
-// Machine entropy for key derivation
+// Store key file (v2)
 // ---------------------------------------------------------------------------
 
+const STORE_KEY_FILENAME = "store.key";
+const STORE_KEY_LENGTH = 32; // bytes
+
+let storeKeyPathOverride: string | null = null;
+
+/** @internal Test-only: override the store key file path. Pass `null` to reset. */
+export function _setStoreKeyPath(path: string | null): void {
+  storeKeyPathOverride = path;
+}
+
+function getStoreKeyPath(): string {
+  return (
+    storeKeyPathOverride ??
+    join(dirname(getStorePath()), STORE_KEY_FILENAME)
+  );
+}
+
+/**
+ * Read the store.key file. Returns the raw 32-byte key buffer, or null
+ * if the file is missing, wrong size, or unreadable.
+ */
+function readStoreKey(): Buffer | null {
+  const keyPath = getStoreKeyPath();
+  if (!pathExists(keyPath)) return null;
+  try {
+    const buf = readFileSync(keyPath);
+    if (buf.length !== STORE_KEY_LENGTH) return null;
+    return buf;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate a cryptographically random store key and write it atomically
+ * to `<dir>/store.key` with 0o600 permissions. Returns the key buffer.
+ */
+function generateAndWriteStoreKey(dir: string): Buffer {
+  ensureDir(dir);
+  const key = randomBytes(STORE_KEY_LENGTH);
+  const keyPath = join(dir, STORE_KEY_FILENAME);
+  const tmpPath = keyPath + `.tmp.${process.pid}`;
+  writeFileSync(tmpPath, key, { mode: 0o600 });
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, keyPath);
+  return key;
+}
+
+/**
+ * Read the existing store key, or generate and write a new one if missing.
+ */
+function getOrReadStoreKey(dir: string): Buffer {
+  const existing = readStoreKey();
+  if (existing) return existing;
+  return generateAndWriteStoreKey(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Machine entropy for key derivation (legacy v1 only)
+// ---------------------------------------------------------------------------
+
+/**
+ * @deprecated @internal Kept only for v1->v2 migration path.
+ * Derives entropy from publicly-knowable machine properties.
+ */
 export function getMachineEntropy(): string {
   const parts: string[] = [];
   try {
@@ -99,9 +179,73 @@ export function getMachineEntropy(): string {
   return parts.join(":");
 }
 
+/**
+ * @deprecated @internal Kept only for v1->v2 migration path.
+ * Derives an AES key from machine entropy via PBKDF2.
+ */
 function deriveKey(salt: Buffer): Buffer {
   const entropy = getMachineEntropy();
   return pbkdf2Sync(entropy, salt, PBKDF2_ITERATIONS, KEY_LENGTH, "sha512");
+}
+
+// ---------------------------------------------------------------------------
+// Key resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the AES key for a given store format.
+ * - v2: reads store.key file (returns null if missing)
+ * - v1: derives key from machine entropy via PBKDF2
+ */
+function getKeyForStore(store: StoreFile): Buffer | null {
+  if (store.version === 2) {
+    return readStoreKey();
+  }
+  return deriveKey(Buffer.from(store.salt, "hex"));
+}
+
+// ---------------------------------------------------------------------------
+// v1 -> v2 migration
+// ---------------------------------------------------------------------------
+
+/**
+ * Migrate a v1 store to v2 format:
+ * 1. Get or generate a random store.key
+ * 2. Decrypt each entry with the legacy PBKDF2-derived key
+ * 3. Re-encrypt each entry with the random store key
+ *
+ * Entries that fail to decrypt (corrupt/tampered) are logged and skipped.
+ * Returns null if a fatal error occurs (e.g. can't write store.key).
+ */
+function migrateV1ToV2(store: StoreFileV1): StoreFileV2 | null {
+  const protectedDir = dirname(getStorePath());
+
+  let storeKey: Buffer;
+  try {
+    storeKey = getOrReadStoreKey(protectedDir);
+  } catch (err) {
+    log.error({ err }, "Failed to create store.key during v1->v2 migration");
+    return null;
+  }
+
+  // Derive the legacy key for decryption
+  const legacyKey = deriveKey(Buffer.from(store.salt, "hex"));
+
+  const newEntries: Record<string, EncryptedEntry> = Object.create(null);
+
+  for (const [account, entry] of Object.entries(store.entries)) {
+    try {
+      const plaintext = decrypt(entry, legacyKey);
+      newEntries[account] = encrypt(plaintext, storeKey);
+    } catch (err) {
+      log.warn(
+        { err, account },
+        "Skipping corrupt entry during v1->v2 migration",
+      );
+    }
+  }
+
+  return { version: 2, entries: newEntries };
 }
 
 // ---------------------------------------------------------------------------
@@ -124,25 +268,34 @@ function readStore(): StoreFile | null {
 
   try {
     const parsed = JSON.parse(raw);
-    if (
-      parsed.version !== 1 ||
-      typeof parsed.salt !== "string" ||
-      typeof parsed.entries !== "object"
-    ) {
+
+    if (typeof parsed.entries !== "object") {
       throw new Error("Encrypted store has invalid format");
     }
-    // Use null-prototype object for entries to prevent prototype pollution
-    const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
-    Object.assign(safeEntries, parsed.entries);
-    parsed.entries = safeEntries;
-    return parsed as StoreFile;
+
+    // Accept v2 (no salt required) or v1 (salt required)
+    if (parsed.version === 2) {
+      const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
+      Object.assign(safeEntries, parsed.entries);
+      parsed.entries = safeEntries;
+      return parsed as StoreFileV2;
+    }
+
+    if (parsed.version === 1 && typeof parsed.salt === "string") {
+      const safeEntries: Record<string, EncryptedEntry> = Object.create(null);
+      Object.assign(safeEntries, parsed.entries);
+      parsed.entries = safeEntries;
+      return parsed as StoreFileV1;
+    }
+
+    throw new Error("Encrypted store has invalid format");
   } catch (err) {
-    // Corrupted or invalid store file — back it up and start fresh so the
+    // Corrupted or invalid store file -- back it up and start fresh so the
     // daemon doesn't crash on every credential access.
     const backupPath = `${path}.corrupt.${Date.now()}`;
     log.error(
       { err, backupPath },
-      "Encrypted store is corrupt — backing up and resetting",
+      "Encrypted store is corrupt -- backing up and resetting",
     );
     try {
       renameSync(path, backupPath);
@@ -154,48 +307,37 @@ function readStore(): StoreFile | null {
 }
 
 /**
- * Well-known filename for the persisted machine entropy.
- * Written alongside `keys.enc` so the CES sidecar (which mounts the
- * assistant data volume read-only) can derive the same AES key.
+ * Well-known filename for the persisted machine entropy (legacy).
+ * Written alongside `keys.enc` so the CES sidecar could derive the same AES key.
+ * Superseded by `store.key` in v2 format.
  */
 const ENTROPY_FILENAME = "entropy.key";
 
 /**
- * Persist the current machine entropy next to the key store so the managed
- * CES sidecar can read it and derive the same decryption key.
- *
- * Only writes in containerized (managed) mode — in local mode, CES runs on
- * the same machine and derives the same entropy natively, so the file is
- * unnecessary and would weaken offline security by persisting entropy to disk.
+ * Ensure the `store.key` file exists and is accessible on the shared mount
+ * (containerized/managed mode). Best-effort delete the old `entropy.key` file
+ * since v2 stores no longer need it.
  */
-function persistEntropy(protectedDir: string): void {
+function persistStoreKey(protectedDir: string): void {
   if (!getIsContainerized()) return;
   try {
-    const entropyPath = join(protectedDir, ENTROPY_FILENAME);
-    const tmpPath = entropyPath + `.tmp.${process.pid}`;
-    writeFileSync(tmpPath, getMachineEntropy(), { mode: 0o600 });
-    chmodSync(tmpPath, 0o600);
-    renameSync(tmpPath, entropyPath);
-  } catch {
-    // Best-effort — managed mode will log a clear error if it's missing.
-  }
-}
-
-/**
- * Backfill `entropy.key` for existing encrypted stores that predate the
- * entropy persistence feature. If the store file exists but `entropy.key`
- * does not, write it now so the managed CES sidecar can derive the key.
- */
-function backfillEntropyIfMissing(): void {
-  if (!getIsContainerized()) return;
-  try {
-    const protectedDir = dirname(getStorePath());
-    const entropyPath = join(protectedDir, ENTROPY_FILENAME);
-    if (!pathExists(entropyPath)) {
-      persistEntropy(protectedDir);
+    const storeKeyPath = join(protectedDir, STORE_KEY_FILENAME);
+    if (!pathExists(storeKeyPath)) {
+      // store.key should already exist from normal creation, but ensure it
+      getOrReadStoreKey(protectedDir);
     }
   } catch {
-    // Best-effort — don't break reads if backfill fails.
+    // Best-effort
+  }
+
+  // Best-effort cleanup of legacy entropy.key
+  try {
+    const entropyPath = join(protectedDir, ENTROPY_FILENAME);
+    if (pathExists(entropyPath)) {
+      unlinkSync(entropyPath);
+    }
+  } catch {
+    // Best-effort -- don't fail if cleanup of old file doesn't work.
   }
 }
 
@@ -211,23 +353,36 @@ function writeStore(store: StoreFile): void {
   chmodSync(tmpPath, 0o600);
   renameSync(tmpPath, path);
 
-  // Keep entropy.key in sync so the managed CES sidecar can decrypt.
-  persistEntropy(protectedDir);
+  // Keep store.key in sync so the managed CES sidecar can decrypt.
+  persistStoreKey(protectedDir);
 }
 
-function getOrCreateStore(): StoreFile {
+function getOrCreateStore(): StoreFileV2 {
   const existing = readStore();
-  if (existing) return existing;
 
-  const salt = randomBytes(SALT_LENGTH);
-  const entries: Record<string, EncryptedEntry> = Object.create(null);
-  const store: StoreFile = {
-    version: 1,
-    salt: salt.toString("hex"),
-    entries,
-  };
-  writeStore(store);
-  return store;
+  if (!existing) {
+    // Fresh store: generate store.key and create v2 format
+    const protectedDir = dirname(getStorePath());
+    getOrReadStoreKey(protectedDir);
+    const entries: Record<string, EncryptedEntry> = Object.create(null);
+    const store: StoreFileV2 = { version: 2, entries };
+    writeStore(store);
+    return store;
+  }
+
+  if (existing.version === 1) {
+    // Migrate v1 -> v2
+    const migrated = migrateV1ToV2(existing);
+    if (migrated) {
+      writeStore(migrated);
+      return migrated;
+    }
+    // Migration failed fatally -- fall through and use v1 as-is won't work
+    // because we can't get the key. Throw so callers handle the error.
+    throw new Error("Failed to migrate encrypted store from v1 to v2");
+  }
+
+  return existing;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +419,7 @@ function decrypt(entry: EncryptedEntry, key: Buffer): string {
 }
 
 // ---------------------------------------------------------------------------
-// Public API — matches keychain.ts interface
+// Public API -- matches keychain.ts interface
 // ---------------------------------------------------------------------------
 
 /**
@@ -276,15 +431,30 @@ export function getKey(account: string): string | undefined {
     const store = readStore();
     if (!store) return undefined;
 
-    // Backfill entropy.key for existing stores that were created before
-    // entropy persistence was added. Only needed in managed mode.
-    backfillEntropyIfMissing();
+    // If v1, trigger migration
+    if (store.version === 1) {
+      const migrated = migrateV1ToV2(store);
+      if (migrated) {
+        writeStore(migrated);
+        const entry = migrated.entries[account];
+        if (!entry) return undefined;
+        const key = getKeyForStore(migrated);
+        if (!key) return undefined;
+        return decrypt(entry, key);
+      }
+      // Migration failed -- try reading with legacy key
+      const entry = store.entries[account];
+      if (!entry) return undefined;
+      const key = getKeyForStore(store);
+      if (!key) return undefined;
+      return decrypt(entry, key);
+    }
 
     const entry = store.entries[account];
     if (!entry) return undefined;
 
-    const salt = Buffer.from(store.salt, "hex");
-    const key = deriveKey(salt);
+    const key = getKeyForStore(store);
+    if (!key) return undefined;
     return decrypt(entry, key);
   } catch (err) {
     log.debug({ err, account }, "Failed to read from encrypted store");
@@ -299,8 +469,8 @@ export function getKey(account: string): string | undefined {
 export function setKey(account: string, value: string): boolean {
   try {
     const store = getOrCreateStore();
-    const salt = Buffer.from(store.salt, "hex");
-    const key = deriveKey(salt);
+    const key = getKeyForStore(store);
+    if (!key) return false;
     store.entries[account] = encrypt(value, key);
     writeStore(store);
     return true;
@@ -310,7 +480,7 @@ export function setKey(account: string, value: string): boolean {
   }
 }
 
-/** Result of a delete operation — distinguishes success, not-found, and error. */
+/** Result of a delete operation -- distinguishes success, not-found, and error. */
 export type DeleteKeyResult = "deleted" | "not-found" | "error";
 
 /**


### PR DESCRIPTION
## Summary
- Replace `getMachineEntropy()` with a cryptographically random 32-byte `store.key` file
- v2 stores use `store.key` directly as the AES-256-GCM key (no PBKDF2 needed)
- Automatic in-place migration: v1 entries decrypted with legacy key, re-encrypted with random key
- Migration is idempotent and handles partial failures gracefully
- `getMachineEntropy()` and `deriveKey()` retained only for v1->v2 migration path

Part of plan: random-store-key.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
