### PR TITLE
feat: delete capability memories when skills are uninstalled

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -38,6 +38,7 @@ import {
   removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
+import { deleteSkillCapabilityMemory } from "../../skills/skill-memory.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -604,6 +605,9 @@ export async function uninstallSkill(
         /* best effort */
       }
     }
+
+    // Best-effort cleanup of capability memory for uninstalled skill
+    deleteSkillCapabilityMemory(skillId);
 
     // Clean config entry
     const raw = loadRawConfig();

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -19,6 +19,7 @@ import {
   getWorkspaceSkillsDir,
   readPlatformToken,
 } from "../util/platform.js";
+import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("catalog-install");
 
@@ -288,6 +289,7 @@ export function uninstallSkillLocally(skillId: string): void {
 
   rmSync(skillDir, { recursive: true, force: true });
   removeSkillsIndexEntry(skillId);
+  deleteSkillCapabilityMemory(skillId);
 }
 
 export async function installSkillLocally(

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -13,6 +13,7 @@ import { stringify as stringifyYaml } from "yaml";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("managed-store");
 
@@ -307,6 +308,7 @@ export function deleteManagedSkill(
   }
 
   rmSync(skillDir, { recursive: true });
+  deleteSkillCapabilityMemory(id);
   log.info({ id, path: skillDir }, "Deleted managed skill");
 
   let indexUpdated = false;


### PR DESCRIPTION
## Summary
- Hook `deleteSkillCapabilityMemory()` into all three uninstall paths: `uninstallSkillLocally`, `deleteManagedSkill`, and the handler-layer `uninstallSkill`
- Best-effort cleanup: memory deletion never blocks or fails the uninstall operation
- Ensures capability memories don't go stale when skills are removed

Part of plan: skill-capability-memories.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
