### PR TITLE
fix: lint errors in lifecycle.ts and skill-memory.test.ts

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -175,8 +175,6 @@ describe("upsertSkillCapabilityMemory", () => {
     expect(before).toHaveLength(1);
     const originalLastSeen = before[0].lastSeenAt;
 
-    // Small delay to ensure timestamps differ
-    const now = Date.now() + 100;
     // Upsert again
     upsertSkillCapabilityMemory("test-skill", entry);
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -61,6 +61,7 @@ import {
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
@@ -105,7 +106,6 @@ import {
   registerWatcherProviders,
 } from "./providers-setup.js";
 import { seedInterfaceFiles } from "./seed-files.js";
-import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { handleWatchObservation } from "./watch-handler.js";


### PR DESCRIPTION
## Summary
- Sort imports in `lifecycle.ts` — moved `seedCatalogSkillMemories` import to correct alphabetical position among `../` imports
- Remove unused `now` variable in `skill-memory.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23219393574/job/67488254365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
