### PR TITLE
fix: fast-fail oversized images when sips is unavailable

### DIFF
--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -140,6 +140,14 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
         buffer = readFileSync(tmpPath) as Buffer;
         optimized = true;
       } else {
+        // sips unavailable — fast-fail if original file exceeds the transport limit
+        if (stat.size > MAX_SIZE_BYTES) {
+          const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
+          return {
+            content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB. Image optimization (sips) is unavailable on this platform.`,
+            isError: true,
+          };
+        }
         buffer = readFileSync(resolvedPath) as Buffer;
       }
     } else {
@@ -160,8 +168,11 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
 
   if (buffer.length > MAX_SIZE_BYTES) {
     const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
+    const msg = optimized
+      ? `Error: image too large after optimization (${sizeMB} MB). Maximum is 20 MB.`
+      : `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`;
     return {
-      content: `Error: image too large after optimization (${sizeMB} MB). Maximum is 20 MB.`,
+      content: msg,
       isError: true,
     };
   }


### PR DESCRIPTION
Addresses feedback from PR #18588: (1) fast-fail when sips is unavailable and file exceeds 20MB to avoid loading large files into memory, (2) differentiate error message based on whether optimization actually occurred.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
