### PR TITLE
fix: remove unused `status` variable in voiceRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -268,7 +268,6 @@ struct AssistantChannelsDetailView: View {
     }
 
     private var voiceRow: some View {
-        let status = store.channelSetupStatus["phone"]
         let isConnected = store.twilioHasCredentials
         let value: String? = {
             if isConnected, let phone = store.twilioPhoneNumber {


### PR DESCRIPTION
## Summary
- Removed unused `let status = store.channelSetupStatus["phone"]` in `voiceRow` computed property to fix Swift compiler warning

## Original prompt
Fix Swift build warning: initialization of immutable value 'status' was never used in `AssistantChannelsDetailView.swift:271`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
