### PR TITLE
fix: lint errors in encrypted-store.test.ts

### DIFF
--- a/assistant/src/__tests__/encrypted-store.test.ts
+++ b/assistant/src/__tests__/encrypted-store.test.ts
@@ -14,7 +14,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { hostname, tmpdir, userInfo } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   afterAll,
@@ -42,8 +42,8 @@ import {
   _setStoreKeyPath,
   _setStorePath,
   deleteKey,
-  getMachineEntropy,
   getKey,
+  getMachineEntropy,
   listKeys,
   setKey,
 } from "../security/encrypted-store.js";


### PR DESCRIPTION
## Summary
- Remove unused `hostname` and `userInfo` imports from `node:os`
- Fix import sort order for `getKey`/`getMachineEntropy` in encrypted-store imports

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23219586857/job/67488885350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
