### PR TITLE
fix: skip feature-flag-disabled skills during capability memory seeding

### DIFF
--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -1,6 +1,8 @@
 import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import { getDb } from "../memory/db.js";
 import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
@@ -171,9 +173,19 @@ export function deleteSkillCapabilityMemory(skillId: string): void {
 export async function seedCatalogSkillMemories(): Promise<void> {
   try {
     const catalog = await resolveCatalog();
+    const config = getConfig();
     const catalogIds = new Set<string>();
 
     for (const entry of catalog) {
+      // Skip skills whose feature flag is disabled
+      const flagId = entry.metadata?.vellum?.["feature-flag"];
+      if (flagId) {
+        const flagKey = `feature_flags.${flagId}.enabled`;
+        if (!isAssistantFeatureFlagEnabled(flagKey, config)) {
+          continue;
+        }
+      }
+
       catalogIds.add(entry.id);
       upsertSkillCapabilityMemory(entry.id, entry);
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-capability-memories.md.

**Gap:** seedCatalogSkillMemories does not respect per-skill feature flags
**What was expected:** Skills with disabled feature flags should not have capability memories seeded
**What was found:** All catalog skills had memories seeded regardless of feature flag state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
