### PR TITLE
fix: update CES backend docstring for v2 store.key format

### DIFF
--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -12,16 +12,22 @@
  * encrypted store so subsequent reads (by both CES and the assistant)
  * see the updated value.
  *
- * The encrypted store uses AES-256-GCM with a key derived from machine-
- * specific entropy via PBKDF2. The derivation includes `userInfo().username`
- * and `userInfo().homedir`, so the key is only correct when CES runs as the
- * same OS user as the assistant.
+ * Two store formats are supported:
  *
- * **This backend must NOT be used in managed mode.** In managed (sidecar)
- * deployments, the assistant container runs as `root` while the CES
- * container runs as `ces` (uid 1001). The different user identity produces
- * a different PBKDF2-derived key, causing silent decryption failures.
- * Managed deployments must use `platform_oauth` handles exclusively.
+ * - **v2 (primary):** AES-256-GCM with a random 32-byte key stored at
+ *   `<vellumRoot>/protected/store.key`. The key is machine-independent —
+ *   any process that can read the key file can decrypt the store.
+ *
+ * - **v1 (legacy):** AES-256-GCM with a key derived from machine-specific
+ *   entropy via PBKDF2. The derivation includes `userInfo().username` and
+ *   `userInfo().homedir`, so the key is only correct when CES runs as the
+ *   same OS user as the assistant.
+ *
+ * **Managed-mode restriction:** This backend must not be used in managed
+ * (sidecar) deployments. For legacy v1 stores, the different container user
+ * identity produces a different PBKDF2-derived key, causing silent
+ * decryption failures. Managed deployments must use `platform_oauth`
+ * handles exclusively.
  */
 
 import {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for random-store-key.md.

**Gap:** Stale CES module docstring
**What was expected:** Docstring should reflect dual v1/v2 store format support
**What was found:** Docstring only described v1 PBKDF2 model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
