### PR TITLE
fix: prefix unused args variable in skill-memory test

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -50,7 +50,7 @@ let mockResolveCatalog: () => Promise<import("../skills/catalog-install.js").Cat
   async () => [];
 
 mock.module("../skills/catalog-install.js", () => ({
-  resolveCatalog: (...args: unknown[]) => mockResolveCatalog(),
+  resolveCatalog: (..._args: unknown[]) => mockResolveCatalog(),
 }));
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";


### PR DESCRIPTION
## Summary
- Renamed `args` → `_args` in the `resolveCatalog` mock in `skill-memory.test.ts` to fix the `@typescript-eslint/no-unused-vars` lint error that was failing CI.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23219752229/job/67489411270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
