### PR TITLE
fix(macos): clean up notification service continuations when daemon resolves confirmations

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1900,6 +1900,13 @@ extension ChatViewModel {
                         break
                     }
                 }
+
+                // Clean up the native notification path when the daemon resolves
+                // the confirmation independently (timeout, new-message auto-deny,
+                // inline from another path). Without this, the notification
+                // service continuation leaks until app quit.
+                let decisionString = msg.state == "approved" ? "allow" : "deny"
+                onInlineConfirmationResponse?(msg.requestId, decisionString)
             }
 
         case .assistantActivityState(let msg):


### PR DESCRIPTION
## Summary
- Call `onInlineConfirmationResponse` from the `confirmationStateChanged` handler for terminal states to clean up notification continuations
- Route notification cleanup through the existing callback chain (AppDelegate handles `removeDeliveredNotifications`)

Part of plan: fix-notif-confirm-auto-deny.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
