### PR TITLE
fix: deliver Slack DM from daemon process during guardian verification

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -551,9 +551,14 @@ export async function handleChannelVerificationSession(
           rebind: msg.rebind,
           originConversationId: msg.originConversationId,
         });
+        if (result._pendingSlackDm) {
+          const { userId, text, assistantId: aid } = result._pendingSlackDm;
+          deliverVerificationSlack(userId, text, aid);
+        }
+        const { _pendingSlackDm: _, ...publicResult } = result;
         ctx.send({
           type: "channel_verification_session_response",
-          ...result,
+          ...publicResult,
         });
       } else {
         const result = createInboundChallenge(
@@ -591,9 +596,14 @@ export async function handleChannelVerificationSession(
         channel,
         originConversationId: msg.originConversationId,
       });
+      if (result._pendingSlackDm) {
+        const { userId, text, assistantId: aid } = result._pendingSlackDm;
+        deliverVerificationSlack(userId, text, aid);
+      }
+      const { _pendingSlackDm: _, ...publicResult } = result;
       ctx.send({
         type: "channel_verification_session_response",
-        ...result,
+        ...publicResult,
       });
     } else {
       ctx.send({

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
+import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
@@ -225,6 +226,38 @@ registerHook(
     } as unknown as ServerMessage);
   },
 );
+
+// Dispatch pending Slack DM delivery when a CLI verification command
+// completes.  The CLI subprocess is sandboxed and cannot reach the
+// gateway, so it includes a `_pendingSlackDm` field in its JSON output.
+// This hook runs in the unsandboxed daemon process and delivers the DM.
+registerHook("bash", (_name, input, result) => {
+  const command = (input.command ?? "") as string;
+  if (!command.includes("channel-verification-sessions")) return;
+  if (!result.content.includes("_pendingSlackDm")) return;
+  // Output may contain multiple JSON objects (e.g. cancel + create).
+  // Try each line as JSON to find the one with _pendingSlackDm.
+  for (const line of result.content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as {
+        _pendingSlackDm?: {
+          userId: string;
+          text: string;
+          assistantId: string;
+        };
+      };
+      if (parsed._pendingSlackDm) {
+        const { userId, text, assistantId } = parsed._pendingSlackDm;
+        deliverVerificationSlack(userId, text, assistantId);
+        return;
+      }
+    } catch {
+      continue;
+    }
+  }
+});
 
 // ── Runner ───────────────────────────────────────────────────────────
 

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -235,24 +235,31 @@ registerHook("bash", (_name, input, result) => {
   const command = (input.command ?? "") as string;
   if (!command.includes("channel-verification-sessions")) return;
   if (!result.content.includes("_pendingSlackDm")) return;
-  // Output may contain multiple JSON objects (e.g. cancel + create).
-  // Try each line as JSON to find the one with _pendingSlackDm.
+
+  type PendingDm = { userId: string; text: string; assistantId: string };
+  type Parsed = { _pendingSlackDm?: PendingDm };
+
+  const dispatch = (parsed: Parsed) => {
+    if (parsed._pendingSlackDm) {
+      const { userId, text, assistantId } = parsed._pendingSlackDm;
+      deliverVerificationSlack(userId, text, assistantId);
+      return true;
+    }
+    return false;
+  };
+
+  // Try full content first (handles pretty-printed single-object JSON)
+  try {
+    if (dispatch(JSON.parse(result.content.trim()) as Parsed)) return;
+  } catch {
+    // Not a single JSON object — fall back to line-by-line for
+    // multi-object output (e.g. cancel + create chained with &&).
+  }
   for (const line of result.content.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("{")) continue;
     try {
-      const parsed = JSON.parse(trimmed) as {
-        _pendingSlackDm?: {
-          userId: string;
-          text: string;
-          assistantId: string;
-        };
-      };
-      if (parsed._pendingSlackDm) {
-        const { userId, text, assistantId } = parsed._pendingSlackDm;
-        deliverVerificationSlack(userId, text, assistantId);
-        return;
-      }
+      if (dispatch(JSON.parse(trimmed) as Parsed)) return;
     } catch {
       continue;
     }

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -21,6 +21,7 @@ import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import {
   cancelOutbound,
+  deliverVerificationSlack,
   normalizeTelegramDestination,
   resendOutbound,
   startOutbound,
@@ -118,12 +119,20 @@ export async function handleCreateVerificationSession(
       verificationRateLimiter.recordFailure(rateLimitKey);
     }
 
+    // Dispatch Slack DM delivery from the daemon process (not sandboxed).
+    if (result._pendingSlackDm) {
+      const { userId, text, assistantId: aid } = result._pendingSlackDm;
+      deliverVerificationSlack(userId, text, aid);
+    }
+
     const status = result.success
       ? 200
       : result.error === "rate_limited"
         ? 429
         : 400;
-    return Response.json(result, { status });
+    // Strip internal field from the response
+    const { _pendingSlackDm: _, ...publicResult } = result;
+    return Response.json(publicResult, { status });
   }
 
   // Inbound challenge path
@@ -167,12 +176,20 @@ export async function handleResendVerificationSession(
     channel: body.channel,
     originConversationId: body.originConversationId,
   });
+
+  // Dispatch Slack DM delivery from the daemon process (not sandboxed).
+  if (result._pendingSlackDm) {
+    const { userId, text, assistantId: aid } = result._pendingSlackDm;
+    deliverVerificationSlack(userId, text, aid);
+  }
+
   const status = result.success
     ? 200
     : result.error === "rate_limited"
       ? 429
       : 400;
-  return Response.json(result, { status });
+  const { _pendingSlackDm: _, ...publicResult } = result;
+  return Response.json(publicResult, { status });
 }
 
 /**

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -116,6 +116,12 @@ export interface OutboundActionResult {
   pendingBootstrap?: boolean;
   /** Echoed back so consumers know which conversation to target for pointers. */
   originConversationId?: string;
+  /** Internal: Slack DM delivery payload for the caller to dispatch.
+   *  The shared startOutbound/resendOutbound functions no longer fire the
+   *  delivery themselves because CLI subprocesses are sandboxed and cannot
+   *  reach the gateway.  The daemon HTTP route handler calls
+   *  deliverVerificationSlack() after receiving this payload. */
+  _pendingSlackDm?: { userId: string; text: string; assistantId: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -486,42 +492,52 @@ function startOutboundVoice(
 
 /**
  * Deliver a verification Slack DM via the gateway's /deliver/slack endpoint.
- * Fire-and-forget with error logging.
+ * Returns a promise that resolves when the delivery attempt completes.
+ */
+export async function deliverVerificationSlackAsync(
+  userId: string,
+  text: string,
+  assistantId: string,
+): Promise<void> {
+  try {
+    const gatewayUrl = getGatewayInternalBaseUrl();
+    const bearerToken = mintDaemonDeliveryToken();
+    const url = `${gatewayUrl}/deliver/slack`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${bearerToken}`,
+      },
+      body: JSON.stringify({ chatId: userId, text, assistantId }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "<unreadable>");
+      log.error(
+        { userId, assistantId, status: resp.status, body },
+        "Gateway /deliver/slack failed for verification",
+      );
+    } else {
+      log.info({ userId, assistantId }, "Verification Slack DM delivered");
+    }
+  } catch (err) {
+    log.error(
+      { err, userId, assistantId },
+      "Failed to deliver verification Slack DM",
+    );
+  }
+}
+
+/**
+ * Deliver a verification Slack DM via the gateway's /deliver/slack endpoint.
+ * Fire-and-forget wrapper for use in the daemon process (HTTP route handlers).
  */
 export function deliverVerificationSlack(
   userId: string,
   text: string,
   assistantId: string,
 ): void {
-  (async () => {
-    try {
-      const gatewayUrl = getGatewayInternalBaseUrl();
-      const bearerToken = mintDaemonDeliveryToken();
-      const url = `${gatewayUrl}/deliver/slack`;
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${bearerToken}`,
-        },
-        body: JSON.stringify({ chatId: userId, text, assistantId }),
-      });
-      if (!resp.ok) {
-        const body = await resp.text().catch(() => "<unreadable>");
-        log.error(
-          { userId, assistantId, status: resp.status, body },
-          "Gateway /deliver/slack failed for verification",
-        );
-      } else {
-        log.info({ userId, assistantId }, "Verification Slack DM delivered");
-      }
-    } catch (err) {
-      log.error(
-        { err, userId, assistantId },
-        "Failed to deliver verification Slack DM",
-      );
-    }
-  })();
+  deliverVerificationSlackAsync(userId, text, assistantId);
 }
 
 function startOutboundSlack(
@@ -588,7 +604,6 @@ function startOutboundSlack(
   const sendCount = 1;
 
   updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
-  deliverVerificationSlack(destination, slackBody, assistantId);
 
   return {
     success: true,
@@ -599,6 +614,7 @@ function startOutboundSlack(
     sendCount,
     channel,
     originConversationId,
+    _pendingSlackDm: { userId: destination, text: slackBody, assistantId },
   };
 }
 
@@ -788,7 +804,6 @@ export function resendOutbound(
       newSendCount,
       nextResendAt,
     );
-    deliverVerificationSlack(destination, slackBody, assistantId);
 
     return {
       success: true,
@@ -798,6 +813,7 @@ export function resendOutbound(
       sendCount: newSendCount,
       channel,
       originConversationId,
+      _pendingSlackDm: { userId: destination, text: slackBody, assistantId },
     };
   }
 


### PR DESCRIPTION
## Summary

- Slack DM delivery during guardian verification fails from chat because the CLI subprocess runs in a macOS sandbox that blocks network access to the gateway
- Moved delivery responsibility out of the shared `startOutboundSlack`/`resendOutbound` functions and into two daemon-process callers:
  - **HTTP route handlers** (settings page path): dispatch `_pendingSlackDm` after create/resend, strip from response
  - **Post-execution bash hook** (chat path): daemon-side side-effect detects `_pendingSlackDm` in CLI output and delivers from the unsandboxed daemon process
- Split `deliverVerificationSlack` into async (`deliverVerificationSlackAsync`) + fire-and-forget wrapper

## Test plan

- [x] Trigger Slack guardian verification from chat — DM arrives in Slack
- [ ] Trigger Slack guardian verification from settings page — DM arrives in Slack
- [ ] Resend flow works from both paths
- [ ] Non-Slack verification channels (Telegram, phone) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
