### PR TITLE
fix(macos): stop tool confirmation notifications from auto-denying on banner click, dismiss, and post failure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -46,7 +46,7 @@ extension AppDelegate {
             identifier: "TOOL_CONFIRMATION",
             actions: [confirmAllowAction, confirmDenyAction],
             intentIdentifiers: [],
-            options: [.customDismissAction]
+            options: []
         )
 
         let viewResponseAction = UNNotificationAction(
@@ -485,15 +485,27 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 decision = "allow"
             case "CONFIRM_DENY":
                 decision = "deny"
-            case UNNotificationDismissActionIdentifier:
-                decision = "deny"
             default:
-                // Default action (clicked banner) — deny and bring app forward
-                decision = "deny"
+                // User clicked the notification banner — bring app forward to the
+                // confirmation's conversation and let the inline bubble handle it.
+                // Do NOT auto-deny.
                 await MainActor.run {
                     guard !self.isBootstrapping else { return }
-                    self.showMainWindow()
+                    let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
+                    if let conversationId {
+                        self.openConversation(conversationId: conversationId)
+                    } else {
+                        self.showMainWindow()
+                    }
                 }
+                await MainActor.run {
+                    self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)
+                }
+                // Remove the delivered notification since the user is now in the app
+                UNUserNotificationCenter.current().removeDeliveredNotifications(
+                    withIdentifiers: [response.notification.request.identifier]
+                )
+                return
             }
             await MainActor.run {
                 self.toolConfirmationNotificationService.handleResponse(requestId: requestId, decision: decision)

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -19,10 +19,14 @@ public final class ToolConfirmationNotificationService {
         content.body = formatBody(message)
         content.categoryIdentifier = "TOOL_CONFIRMATION"
         content.sound = .default
-        content.userInfo = [
+        var userInfo: [String: Any] = [
             "requestId": message.requestId,
             "type": "tool_confirmation"
         ]
+        if let conversationId = message.conversationId {
+            userInfo["conversationId"] = conversationId
+        }
+        content.userInfo = userInfo
 
         content.attachAppIcon()
 
@@ -37,7 +41,7 @@ public final class ToolConfirmationNotificationService {
             log.info("Posted tool confirmation notification: requestId=\(message.requestId, privacy: .public), tool=\(message.toolName, privacy: .public)")
         } catch {
             log.error("Failed to post notification: \(error.localizedDescription)")
-            return "deny"
+            return Self.inlineHandledSentinel
         }
 
         // If a continuation already exists for this requestId (e.g. daemon re-sent


### PR DESCRIPTION
## Summary
- Remove `.customDismissAction` from TOOL_CONFIRMATION category so dismiss no longer auto-denies
- Change default notification action (banner click) to navigate to conversation instead of denying
- Return `inlineHandledSentinel` on notification post failure instead of auto-denying

Part of plan: fix-notif-confirm-auto-deny.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
