### PR TITLE
Revert onboarding flow UI polish changes (#18559)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -10,13 +10,7 @@ struct APIKeyEntryStepView: View {
     @State private var isEditing = false
     @State private var showTitle = false
     @State private var showContent = false
-    @State private var showCharacters = false
     @FocusState private var keyFieldFocused: Bool
-
-    private static let welcomeCharacters: NSImage? = {
-        guard let url = ResourceBundle.bundle.url(forResource: "welcome-characters", withExtension: "png") else { return nil }
-        return NSImage(contentsOf: url)
-    }()
 
     var body: some View {
         Text("Anthropic API Key")
@@ -34,29 +28,9 @@ struct APIKeyEntryStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        Spacer()
-
         VStack(spacing: VSpacing.md) {
-            VStack(spacing: 0) {
+            VStack(spacing: VSpacing.md) {
                 apiKeyField
-
-                Button {
-                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
-                } label: {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.info, size: 14)
-                            .foregroundColor(VColor.contentSecondary)
-                        Text("Get an API key")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentSecondary)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .buttonStyle(.plain)
-                .pointerCursor()
-                .accessibilityLabel("Get an API key")
-                .padding(.top, VSpacing.sm)
-                .padding(.bottom, VSpacing.xl)
 
                 OnboardingButton(
                     title: "Continue",
@@ -66,10 +40,13 @@ struct APIKeyEntryStepView: View {
                     saveAndHatch()
                 }
 
+                OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
+                    NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
+                }
+
                 OnboardingButton(title: "Back", style: .ghost) {
                     goBack()
                 }
-                .padding(.top, VSpacing.md)
             }
         }
         .padding(.horizontal, VSpacing.xxl)
@@ -89,26 +66,6 @@ struct APIKeyEntryStepView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
                 keyFieldFocused = true
             }
-        }
-
-        Spacer()
-
-        if let characters = Self.welcomeCharacters {
-            Image(nsImage: characters)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity)
-                .clipShape(UnevenRoundedRectangle(
-                    topLeadingRadius: 0,
-                    bottomLeadingRadius: VRadius.window,
-                    bottomTrailingRadius: VRadius.window,
-                    topTrailingRadius: 0
-                ))
-                .opacity(showCharacters ? 1 : 0)
-                .offset(y: showCharacters ? 0 : 30)
-                .animation(.easeOut(duration: 0.6).delay(0.5), value: showCharacters)
-                .onAppear { showCharacters = true }
-                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -30,26 +30,8 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         VStack(spacing: VSpacing.md) {
-            VStack(spacing: 0) {
+            VStack(spacing: VSpacing.md) {
                 hostingCards
-
-                Button {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
-                } label: {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.info, size: 14)
-                            .foregroundColor(VColor.contentSecondary)
-                        Text("Need help deciding?")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentSecondary)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .buttonStyle(.plain)
-                .pointerCursor()
-                .accessibilityLabel("Need help deciding?")
-                .padding(.top, VSpacing.sm)
-                .padding(.bottom, VSpacing.xl)
 
                 OnboardingButton(
                     title: continueButtonTitle,
@@ -59,11 +41,15 @@ struct APIKeyStepView: View {
                     handleContinue()
                 }
 
+                OnboardingButton(title: "Need help deciding?", style: .ghostPrimary) {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
+                }
+
                 if !isAuthenticated {
                     OnboardingButton(title: "Back", style: .ghost) {
                         goBack()
                     }
-                    .padding(.top, VSpacing.md)
+                    .padding(.top, VSpacing.xs)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -83,13 +83,12 @@ struct ImproveExperienceStepView: View {
                 )
 
                 OnboardingButton(
-                    title: "Continue",
+                    title: "Accept and Start",
                     style: .primary,
                     disabled: !tosAccepted
                 ) {
                     saveAndContinue()
                 }
-                .padding(.top, VSpacing.lg)
 
                 OnboardingButton(title: "Back", style: .ghost) {
                     goBack()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -6,6 +6,8 @@ enum OnboardingButtonStyle {
     case secondary
     case tertiary
     case ghost
+    /// Ghost layout (compact, borderless) with primary/green text color.
+    case ghostPrimary
 }
 
 struct OnboardingButton: View {
@@ -19,7 +21,7 @@ struct OnboardingButton: View {
     @State private var visible = false
     @State private var isHovered = false
 
-    private var isGhost: Bool { style == .ghost }
+    private var isGhost: Bool { style == .ghost || style == .ghostPrimary }
 
     var body: some View {
         Button(action: action) {
@@ -79,6 +81,8 @@ struct OnboardingButton: View {
             return disabled ? VColor.contentDefault.opacity(0.3) : VColor.contentDefault.opacity(0.85)
         case .ghost:
             return disabled ? VColor.contentSecondary.opacity(0.3) : VColor.contentSecondary
+        case .ghostPrimary:
+            return disabled ? VColor.primaryBase.opacity(0.3) : VColor.primaryBase
         }
     }
 
@@ -90,7 +94,7 @@ struct OnboardingButton: View {
             return AnyShapeStyle(Color.clear)
         case .tertiary:
             return AnyShapeStyle(Color.clear)
-        case .ghost:
+        case .ghost, .ghostPrimary:
             return AnyShapeStyle(Color.clear)
         }
     }
@@ -103,7 +107,7 @@ struct OnboardingButton: View {
             return VColor.primaryBase.opacity(disabled ? 0.2 : 0.5)
         case .tertiary:
             return VColor.contentDefault.opacity(disabled ? 0.1 : 0.25)
-        case .ghost:
+        case .ghost, .ghostPrimary:
             return .clear
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: VSpacing.xxxl)
+                    Color.clear.frame(height: geometry.size.height * 0.08)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)
@@ -134,13 +134,13 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for steps with characters footer (0, 2) where the
+                    // Skip for step 0 (WakeUpStepView) where the characters
                     // graphic is designed to sit flush at the window bottom.
-                    if (state.currentStep != 0 && state.currentStep != 2) || isBootstrappingManaged {
+                    if state.currentStep != 0 || isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }
-                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height)
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -43,7 +43,7 @@ struct WakeUpStepView: View {
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.md)
+            .padding(.bottom, VSpacing.xs)
 
         // Subtitle
         Text("Your personal AI assistant,\nrunning on your terms.")
@@ -54,7 +54,7 @@ struct WakeUpStepView: View {
             .offset(y: showSubtext ? 0 : 8)
             .padding(.bottom, VSpacing.xxl)
 
-        Spacer()
+        Color.clear.frame(height: VSpacing.xxl)
 
         // Buttons
         VStack(spacing: VSpacing.md) {


### PR DESCRIPTION
## Summary
- Reverts PR #18559 which introduced layout regressions in the onboarding flow
- Back buttons were sometimes hidden due to `alignment: .top` + Spacer layout changes pushing content off screen
- The "Need help deciding?" and "Get an API key" buttons were changed from `ghostPrimary` OnboardingButtons to subtle info-icon links — reverting to original style
- The layout changes could produce a blank onboarding modal that persisted across app relaunches

## Original prompt
this revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
