### PR TITLE
fix(macos): guard onInlineConfirmationResponse against double-call on inline-initiated resolution

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1903,10 +1903,13 @@ extension ChatViewModel {
 
                 // Clean up the native notification path when the daemon resolves
                 // the confirmation independently (timeout, new-message auto-deny,
-                // inline from another path). Without this, the notification
-                // service continuation leaks until app quit.
-                let decisionString = msg.state == "approved" ? "allow" : "deny"
-                onInlineConfirmationResponse?(msg.requestId, decisionString)
+                // system cascade). Skip when source is "button" or "inline_nl"
+                // because respondToConfirmation / respondToAlwaysAllow already
+                // called onInlineConfirmationResponse for those paths.
+                if msg.source != "button" && msg.source != "inline_nl" {
+                    let decisionString = msg.state == "approved" ? "allow" : "deny"
+                    onInlineConfirmationResponse?(msg.requestId, decisionString)
+                }
             }
 
         case .assistantActivityState(let msg):


### PR DESCRIPTION
## Summary
- Guard `onInlineConfirmationResponse` call in `confirmationStateChanged` handler to only fire for non-inline sources (`timeout`, `auto_deny`, `system`)
- Prevents harmless but noisy "No pending request" warning when `respondToConfirmation` already called it for `button`/`inline_nl` sources

Fix for gap identified during plan review for fix-notif-confirm-auto-deny.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
