### PR TITLE
fix: deduplicate deleteSkillCapabilityMemory call in uninstallSkill

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -604,10 +604,10 @@ export async function uninstallSkill(
       } catch {
         /* best effort */
       }
+      // Best-effort cleanup of capability memory for uninstalled skill
+      // (managed path handles this internally via deleteManagedSkill)
+      deleteSkillCapabilityMemory(skillId);
     }
-
-    // Best-effort cleanup of capability memory for uninstalled skill
-    deleteSkillCapabilityMemory(skillId);
 
     // Clean config entry
     const raw = loadRawConfig();


### PR DESCRIPTION
Move deleteSkillCapabilityMemory from unconditional post-uninstall to the non-managed else branch only. The managed path already handles cleanup internally via deleteManagedSkill.

Closes #18599
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
