### PR TITLE
feat: add `trace_events` SQLite table for persistent trace storage

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -54,6 +54,7 @@ import {
   migrateCreateThreadStartersTable,
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
+  migrateCreateTraceEventsTable,
   migrateDropCapabilityCardState,
   migrateDropConflicts,
   migrateDropContactInteractionColumns,
@@ -451,6 +452,9 @@ export function initializeDb(): void {
 
   // 79. Remove deleted capability-card state while keeping conversation starter chips
   migrateDropCapabilityCardState(database);
+
+  // 80. Trace events table for persistent trace/activity storage across sessions
+  migrateCreateTraceEventsTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/177-create-trace-events-table.ts
+++ b/assistant/src/memory/migrations/177-create-trace-events-table.ts
@@ -1,0 +1,40 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_create_trace_events_table_v1";
+
+/**
+ * Create the trace_events table for persisting trace/activity events
+ * so the Logs panel has data across sessions.
+ */
+export function migrateCreateTraceEventsTable(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS trace_events (
+        event_id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        request_id TEXT,
+        timestamp_ms INTEGER NOT NULL,
+        sequence INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        status TEXT,
+        summary TEXT NOT NULL,
+        attributes_json TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_trace_events_conversation_id
+      ON trace_events (conversation_id)
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_trace_events_conversation_timestamp
+      ON trace_events (conversation_id, timestamp_ms)
+    `);
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -118,6 +118,7 @@ export { migrateRenameSourceSessionIdColumn } from "./173-rename-source-session-
 export { migrateRenameThreadStartersTable } from "./174-rename-thread-starters-table.js";
 export { createLifecycleEventsTable } from "./175-create-lifecycle-events.js";
 export { migrateDropCapabilityCardState } from "./176-drop-capability-card-state.js";
+export { migrateCreateTraceEventsTable } from "./177-create-trace-events-table.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -157,6 +157,29 @@ export const actorTokenRecords = sqliteTable("actor_token_records", {
   updatedAt: integer("updated_at").notNull(),
 });
 
+export const traceEvents = sqliteTable(
+  "trace_events",
+  {
+    eventId: text("event_id").primaryKey(),
+    conversationId: text("conversation_id").notNull(),
+    requestId: text("request_id"),
+    timestampMs: integer("timestamp_ms").notNull(),
+    sequence: integer("sequence").notNull(),
+    kind: text("kind").notNull(),
+    status: text("status"),
+    summary: text("summary").notNull(),
+    attributesJson: text("attributes_json"), // JSON-serialized attributes
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_trace_events_conversation_id").on(table.conversationId),
+    index("idx_trace_events_conversation_timestamp").on(
+      table.conversationId,
+      table.timestampMs,
+    ),
+  ],
+);
+
 export const actorRefreshTokenRecords = sqliteTable(
   "actor_refresh_token_records",
   {


### PR DESCRIPTION
## Summary
- Add `trace_events` Drizzle schema table in `infrastructure.ts` with indexes on `conversation_id` and `(conversation_id, timestamp_ms)`
- Add idempotent migration `177-create-trace-events-table.ts` using `withCrashRecovery` pattern
- Register migration in `db-init.ts`

Part of plan: persist-trace-events.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
