### PR TITLE
fix: trigger v1-to-v2 migration on deleteKey access path

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -490,8 +490,8 @@ export type DeleteKeyResult = "deleted" | "not-found" | "error";
  */
 export function deleteKey(account: string): DeleteKeyResult {
   try {
-    const store = readStore();
-    if (!store || !Object.prototype.hasOwnProperty.call(store.entries, account))
+    const store = getOrCreateStore();
+    if (!Object.prototype.hasOwnProperty.call(store.entries, account))
       return "not-found";
 
     delete store.entries[account];


### PR DESCRIPTION
## Summary
deleteKey() used readStore() directly, bypassing v1→v2 migration. Changed to use getOrCreateStore() so all access paths consistently migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)