### PR TITLE
fix: align gateway test IV length with production (16 bytes)

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -87,7 +87,7 @@ function encryptEntries(
     { iv: string; tag: string; data: string }
   > = {};
   for (const [account, value] of Object.entries(entries)) {
-    const iv = randomBytes(12);
+    const iv = randomBytes(16);
     const cipher = createCipheriv(ALGORITHM, key, iv, {
       authTagLength: AUTH_TAG_LENGTH,
     });

--- a/gateway/src/__tests__/credential-watcher.test.ts
+++ b/gateway/src/__tests__/credential-watcher.test.ts
@@ -68,7 +68,7 @@ function encrypt(
   value: string,
   key: Buffer,
 ): { iv: string; tag: string; data: string } {
-  const iv = cryptoRandomBytes(12);
+  const iv = cryptoRandomBytes(16);
   const cipher = createCipheriv(ALGORITHM, key, iv, {
     authTagLength: AUTH_TAG_LENGTH,
   });


### PR DESCRIPTION
## Summary
Gateway test fixtures used 12-byte IVs while production uses 16-byte. Updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
