### PR TITLE
fix: use correct registry key for developer menu items feature flag

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -238,7 +238,7 @@ extension AppDelegate {
         updateItem.image = VIcon.circleArrowDown.nsImage
         menu.addItem(updateItem)
 
-        if MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items") {
+        if MacOSClientFeatureFlagManager.shared.isEnabled("developer_menu_items_enabled") {
             menu.addItem(NSMenuItem.separator())
 
             let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")


### PR DESCRIPTION
## Summary

Fixes a key mismatch that made the `developer_menu_items_enabled` feature flag dead code in the menu bar. The "Replay Onboarding" and "Component Gallery" menu items never appeared, even when the flag was toggled on in Developer settings.

## The Bug

The menu bar status menu called `MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items")`, but the flag is registered with the key `"developer_menu_items_enabled"`. The `normalize()` function strips underscores to produce a canonical comparison key, but it does not strip hyphens — so `"developer-menu-items"` and `"developer_menu_items_enabled"` never match.

## The Fix

Changed the `isEnabled` argument from `"developer-menu-items"` to `"developer_menu_items_enabled"` to match the registry key exactly.

## Files Changed

- `clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift` — one-line key string fix

## Testing

1. Launch the app
2. Open Settings > Developer and toggle the developer menu items flag on
3. Click the menu bar icon — "Replay Onboarding" (and "Component Gallery" in DEBUG builds) should now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
