### PR TITLE
fix(build): externalize @resvg/resvg-js to prevent daemon startup crash

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -179,7 +179,11 @@ GATEWAY_SRC_DIR="$SCRIPT_DIR/../../gateway"
 # Packages that must stay external in compiled Bun binaries.
 # playwright-core has optional requires (electron, chromium-bidi) that cannot
 # be resolved at bundle time.  Mark them external so bun --compile skips them.
-BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*")
+# @resvg/resvg-js contains a platform-specific native .node addon; bun --compile
+# bundles and extracts it at runtime, but macOS rejects the dlopen because the
+# extracted binary's Team ID differs from the main process.  Externalising it
+# lets the lazy wrapper in avatar/resvg-lazy.ts handle the missing module.
+BUN_EXTERNAL_FLAGS=(--external electron --external "chromium-bidi/*" --external "@resvg/resvg-js" --external "@resvg/resvg-js-darwin-arm64" --external "@resvg/resvg-js-darwin-x64")
 
 # ---------------------------------------------------------------------------
 # build_bun_binary — compile a TypeScript project to a native binary via Bun.


### PR DESCRIPTION
## Summary

- Externalize `@resvg/resvg-js` and its platform-specific packages (`-darwin-arm64`, `-darwin-x64`) from `bun --compile` in the macOS build script
- The native `.node` addon was being bundled and eagerly evaluated at process startup, causing a `dlopen` failure due to macOS code signing Team ID mismatch — crashing the daemon before any user code could run
- This matches the existing pattern for `electron` and `chromium-bidi/*`; the lazy wrapper in `resvg-lazy.ts` handles the missing module gracefully, so avatar character rendering degrades without taking down the daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
