### PR TITLE
feat: prune old trace events on daemon startup (7-day retention)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -42,6 +42,7 @@ import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
 import { QdrantManager } from "../memory/qdrant-manager.js";
 import { rotateToolInvocations } from "../memory/tool-usage-store.js";
+import { deleteOldTraceEvents } from "../memory/trace-event-store.js";
 import {
   emitNotificationSignal,
   registerBroadcastFn,
@@ -829,6 +830,20 @@ export async function runDaemon(): Promise<void> {
       } catch (err) {
         log.warn({ err }, "Audit log rotation failed");
       }
+    }
+
+    // Prune trace events older than 7 days to keep the database lean.
+    // Fire-and-forget — cleanup failure must not prevent startup.
+    try {
+      const deletedTraceEvents = deleteOldTraceEvents(7);
+      if (deletedTraceEvents > 0) {
+        log.debug(
+          { deletedTraceEvents },
+          `Pruned ${deletedTraceEvents} trace event(s) older than 7 days`,
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "Trace event cleanup failed — continuing startup");
     }
 
     const workspaceHeartbeat = new WorkspaceHeartbeatService();


### PR DESCRIPTION
## Summary
- Import `deleteOldTraceEvents` in `lifecycle.ts`
- Call `deleteOldTraceEvents(7)` during daemon startup housekeeping
- Fire-and-forget with try-catch — cleanup failure does not block startup

Part of plan: persist-trace-events.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
