### PR TITLE
feat: add `GET /v1/trace-events` endpoint for historical event retrieval

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -162,6 +162,7 @@ import { subagentRouteDefinitions } from "./routes/subagents-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { telemetryRouteDefinitions } from "./routes/telemetry-routes.js";
+import { traceEventRouteDefinitions } from "./routes/trace-event-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
@@ -1196,6 +1197,7 @@ export class RuntimeHttpServer {
 
       ...brainGraphRouteDefinitions({ mintUiPageToken }),
       ...eventsRouteDefinitions(),
+      ...traceEventRouteDefinitions(),
       ...migrationRouteDefinitions(),
 
       // Internal OAuth callback (gateway -> runtime)

--- a/assistant/src/runtime/routes/trace-event-routes.ts
+++ b/assistant/src/runtime/routes/trace-event-routes.ts
@@ -1,0 +1,62 @@
+/**
+ * HTTP route handlers for trace event retrieval.
+ *
+ * GET /v1/trace-events — Returns persisted trace events for a conversation.
+ */
+
+import { getTraceEvents } from "../../memory/trace-event-store.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function traceEventRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "trace-events",
+      method: "GET",
+      handler: ({ url }) => {
+        const conversationId = url.searchParams.get("conversationId");
+        if (!conversationId) {
+          return httpError(
+            "BAD_REQUEST",
+            "conversationId query parameter is required",
+            400,
+          );
+        }
+
+        const limitParam = url.searchParams.get("limit");
+        const afterSequenceParam = url.searchParams.get("afterSequence");
+
+        const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+        if (limitParam && (isNaN(limit!) || limit! <= 0)) {
+          return httpError(
+            "BAD_REQUEST",
+            "limit must be a positive integer",
+            400,
+          );
+        }
+
+        const afterSequence = afterSequenceParam
+          ? parseInt(afterSequenceParam, 10)
+          : undefined;
+        if (afterSequenceParam && (isNaN(afterSequence!) || afterSequence! < 0)) {
+          return httpError(
+            "BAD_REQUEST",
+            "afterSequence must be a non-negative integer",
+            400,
+          );
+        }
+
+        const events = getTraceEvents(conversationId, {
+          limit,
+          afterSequence,
+        });
+
+        return Response.json({ events });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `trace-event-routes.ts` with `GET /v1/trace-events` endpoint
- Accepts `conversationId` (required), `limit`, and `afterSequence` query params
- Returns persisted trace events as JSON via `getTraceEvents()` from the store
- Register route in `http-server.ts`

Part of plan: persist-trace-events.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
