### PR TITLE
feat: persist trace events to SQLite as they are emitted

### DIFF
--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -1,8 +1,13 @@
 import { v4 as uuid } from "uuid";
 
+import type { TraceEvent } from "./message-types/messages.js";
 import type { ServerMessage, TraceEventKind } from "./message-protocol.js";
+import { persistTraceEvent } from "../memory/trace-event-store.js";
+import { getLogger } from "../util/logger.js";
 
 export type TraceEventStatus = "info" | "success" | "warning" | "error";
+
+const log = getLogger("trace-emitter");
 
 const SUMMARY_MAX_LENGTH = 200;
 const ATTRIBUTE_VALUE_MAX_LENGTH = 500;
@@ -49,6 +54,12 @@ export class TraceEmitter {
       summary: truncatedSummary,
       attributes,
     };
+
+    try {
+      persistTraceEvent(event as TraceEvent);
+    } catch (err) {
+      log.warn({ err, eventId }, "Failed to persist trace event");
+    }
 
     this.sendToClient(event);
   }


### PR DESCRIPTION
## Summary
- Import `persistTraceEvent` in `trace-emitter.ts`
- Write each trace event to SQLite before sending via SSE
- Wrap DB write in try-catch so failures don't break the real-time stream

Part of plan: persist-trace-events.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)