### PR TITLE
feat: add trace event history request/response to Swift message types

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1217,4 +1217,28 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
+    // MARK: - Trace Event History
+
+    /// Fetches persisted trace events for a conversation from the daemon.
+    public func fetchTraceEventHistory(conversationId: String) async throws -> [TraceEventMessage] {
+        let encodedId = conversationId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationId
+        let path = "v1/trace-events?conversationId=\(encodedId)"
+
+        if let httpTransport {
+            guard let url = URL(string: "\(httpTransport.baseURL)/\(path)") else { return [] }
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 10
+            if let token = httpTransport.bearerToken, !token.isEmpty {
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return [] }
+            let decoded = try JSONDecoder().decode(TraceEventsHistoryResponse.self, from: data)
+            return decoded.events
+        }
+
+        let result: TraceEventsHistoryResponse? = await executeLocalRequest(path: path)
+        return result?.events ?? []
+    }
+
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1237,6 +1237,11 @@ public struct TraceEventMessage: Decodable, Sendable {
     public let attributes: [String: AnyCodable]?
 }
 
+/// Response containing historical trace events for a conversation.
+public struct TraceEventsHistoryResponse: Decodable, Sendable {
+    public let events: [TraceEventMessage]
+}
+
 /// Structured error codes for conversation-level errors.
 public enum ConversationErrorCode: String, CaseIterable, Codable, Sendable {
     case providerNetwork = "PROVIDER_NETWORK"


### PR DESCRIPTION
## Summary
- Add `TraceEventsHistoryResponse` struct in `MessageTypes.swift`
- Add `fetchTraceEventHistory(conversationId:)` method to `DaemonClient` for HTTP GET to `/v1/trace-events`
- Uses existing authenticated HTTP request infrastructure

Part of plan: persist-trace-events.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
