### PR TITLE
feat: hydrate TraceStore with persisted events when Logs panel opens

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -670,6 +670,7 @@ struct ConversationChatView: View {
             .sheet(isPresented: $showDebugPanel) {
                 DebugPanelView(
                     traceStore: clientProvider.traceStore,
+                    daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                     conversationId: viewModel.conversationId,
                     onClose: { showDebugPanel = false }
                 )

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -8,8 +8,16 @@ import VellumAssistantShared
 /// the developer toggle is enabled. Gated behind `UserDefaultsKeys.developerModeEnabled`.
 struct DebugPanelView: View {
     @ObservedObject var traceStore: TraceStore
+    let daemonClient: DaemonClient
     let conversationId: String?
     var onClose: () -> Void
+
+    @State private var isLoadingHistory = false
+
+    private var hasEvents: Bool {
+        guard let conversationId else { return false }
+        return !(traceStore.eventsByConversation[conversationId] ?? []).isEmpty
+    }
 
     var body: some View {
         NavigationStack {
@@ -18,15 +26,20 @@ struct DebugPanelView: View {
                     metricsStrip(conversationId: conversationId)
                     Divider()
 
-                    let events = traceStore.eventsByConversation[conversationId] ?? []
-                    if events.isEmpty {
+                    if hasEvents {
+                        TraceTimelineIOSView(traceStore: traceStore, conversationId: conversationId)
+                    } else if isLoadingHistory {
+                        emptyState(
+                            title: "Loading trace history...",
+                            subtitle: "Fetching persisted events from the assistant",
+                            icon: .audioWaveform
+                        )
+                    } else {
                         emptyState(
                             title: "No trace events yet",
                             subtitle: "Events will appear as the conversation runs",
                             icon: .audioWaveform
                         )
-                    } else {
-                        TraceTimelineIOSView(traceStore: traceStore, conversationId: conversationId)
                     }
                 } else {
                     emptyState(
@@ -44,8 +57,28 @@ struct DebugPanelView: View {
                 }
             }
         }
-        .onAppear { traceStore.isObserved = true }
+        .onAppear {
+            traceStore.isObserved = true
+            hydrateIfNeeded()
+        }
         .onDisappear { traceStore.isObserved = false }
+    }
+
+    // MARK: - History Hydration
+
+    private func hydrateIfNeeded() {
+        guard let conversationId else { return }
+        guard !hasEvents, !isLoadingHistory else { return }
+        isLoadingHistory = true
+        Task {
+            defer { isLoadingHistory = false }
+            do {
+                let events = try await daemonClient.fetchTraceEventHistory(conversationId: conversationId)
+                traceStore.loadHistory(events)
+            } catch {
+                // Fetch failed — fall back to the existing "No trace events yet" empty state.
+            }
+        }
     }
 
     // MARK: - Metrics Strip
@@ -427,6 +460,6 @@ struct TraceTimelineIOSView: View {
 }
 
 #Preview {
-    DebugPanelView(traceStore: TraceStore(), conversationId: nil, onClose: {})
+    DebugPanelView(traceStore: TraceStore(), daemonClient: DaemonClient(), conversationId: nil, onClose: {})
 }
 #endif

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -88,6 +88,7 @@ private struct DeveloperSettingsSectionContent: View {
         .sheet(isPresented: $showDebugPanel) {
             DebugPanelView(
                 traceStore: traceStore,
+                daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                 conversationId: selectedConversationId,
                 onClose: { showDebugPanel = false }
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -7,6 +7,8 @@ struct DebugPanel: View {
     let activeSessionId: String?
     var onClose: () -> Void
 
+    @State private var isLoadingHistory = false
+
     private var hasEvents: Bool {
         guard let conversationId = activeSessionId else { return false }
         return !(traceStore.eventsByConversation[conversationId] ?? []).isEmpty
@@ -30,11 +32,19 @@ struct DebugPanel: View {
             if !hasEvents {
                 Spacer()
                 if activeSessionId != nil {
-                    VEmptyState(
-                        title: "No trace events yet",
-                        subtitle: "Events will appear as the session runs",
-                        icon: "waveform.path"
-                    )
+                    if isLoadingHistory {
+                        VEmptyState(
+                            title: "Loading trace history...",
+                            subtitle: "Fetching persisted events from the assistant",
+                            icon: "waveform.path"
+                        )
+                    } else {
+                        VEmptyState(
+                            title: "No trace events yet",
+                            subtitle: "Events will appear as the session runs",
+                            icon: "waveform.path"
+                        )
+                    }
                 } else {
                     VEmptyState(
                         title: "No session selected",
@@ -49,8 +59,31 @@ struct DebugPanel: View {
             // state is rendered in pinnedContent above to avoid scrolling.
             EmptyView()
         }
-        .onAppear { traceStore.isObserved = true }
+        .onAppear {
+            traceStore.isObserved = true
+            hydrateIfNeeded()
+        }
         .onDisappear { traceStore.isObserved = false }
+        .onChange(of: activeSessionId) { _, _ in
+            hydrateIfNeeded()
+        }
+    }
+
+    // MARK: - History Hydration
+
+    private func hydrateIfNeeded() {
+        guard let conversationId = activeSessionId else { return }
+        guard !hasEvents, !isLoadingHistory else { return }
+        isLoadingHistory = true
+        Task {
+            defer { isLoadingHistory = false }
+            do {
+                let events = try await daemonClient.fetchTraceEventHistory(conversationId: conversationId)
+                traceStore.loadHistory(events)
+            } catch {
+                // Fetch failed — fall back to the existing "No trace events yet" empty state.
+            }
+        }
     }
 
     // MARK: - Metrics Strip

--- a/clients/shared/Features/TraceStore.swift
+++ b/clients/shared/Features/TraceStore.swift
@@ -119,6 +119,16 @@ public final class TraceStore: ObservableObject {
         schedulePublish()
     }
 
+    // MARK: - History Loading
+
+    /// Load persisted trace events from the daemon, deduplicating against any
+    /// already-ingested real-time events.
+    public func loadHistory(_ events: [TraceEventMessage]) {
+        for event in events {
+            ingest(event) // ingest() already handles dedup via seenIds
+        }
+    }
+
     // MARK: - Queries
 
     /// Events for a conversation grouped by requestId. Events with nil requestId go under an empty-string key.


### PR DESCRIPTION
## Summary
- Add `loadHistory(_:)` method to `TraceStore` for bulk-loading persisted events
- On panel open (macOS + iOS), fetch trace event history from daemon and hydrate the store
- Show "Loading trace history..." during fetch, fall back to empty state on failure
- Deduplication handled by existing `ingest()` logic

Part of plan: persist-trace-events.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)