### PR TITLE
feat: gate Notion setup behind feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -218,6 +218,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "integration-notion",
+      "scope": "assistant",
+      "key": "feature_flags.integration-notion.enabled",
+      "label": "Notion Integration",
+      "description": "Enable the Notion setup skill for connecting to Notion",
+      "defaultEnabled": false
+    },
+    {
       "id": "conversation-starters",
       "scope": "assistant",
       "key": "feature_flags.conversation-starters.enabled",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -358,6 +358,7 @@
         "emoji": "🔑",
         "vellum": {
           "display-name": "Notion Setup",
+          "feature-flag": "integration-notion",
           "includes": [
             "collaborative-oauth-flow"
           ]

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔑"
   vellum:
     display-name: "Notion Setup"
+    feature-flag: "integration-notion"
     includes: ["collaborative-oauth-flow"]
 ---
 


### PR DESCRIPTION
## Summary
- Adds `integration-notion` feature flag to the registry (disabled by default), matching the pattern used by all other integration OAuth setup skills
- Adds `feature-flag: "integration-notion"` to the Notion OAuth setup skill frontmatter so it is gated like GitHub, Linear, Spotify, etc.

## Test plan
- [ ] Verify Notion setup skill is hidden when `integration-notion` flag is not enabled
- [ ] Verify Notion setup skill appears when `integration-notion` flag is explicitly enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
