### PR TITLE
fix: defer trace event pruning to avoid blocking daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -833,18 +833,20 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Prune trace events older than 7 days to keep the database lean.
-    // Fire-and-forget — cleanup failure must not prevent startup.
-    try {
-      const deletedTraceEvents = deleteOldTraceEvents(7);
-      if (deletedTraceEvents > 0) {
-        log.debug(
-          { deletedTraceEvents },
-          `Pruned ${deletedTraceEvents} trace event(s) older than 7 days`,
-        );
+    // Deferred so synchronous cleanup doesn't block the startup path.
+    setTimeout(() => {
+      try {
+        const deletedTraceEvents = deleteOldTraceEvents(7);
+        if (deletedTraceEvents > 0) {
+          log.debug(
+            { deletedTraceEvents },
+            `Pruned ${deletedTraceEvents} trace event(s) older than 7 days`,
+          );
+        }
+      } catch (err) {
+        log.warn({ err }, "Trace event cleanup failed");
       }
-    } catch (err) {
-      log.warn({ err }, "Trace event cleanup failed — continuing startup");
-    }
+    }, 0);
 
     const workspaceHeartbeat = new WorkspaceHeartbeatService();
     workspaceHeartbeat.start();


### PR DESCRIPTION
## Summary
- Wrap `deleteOldTraceEvents` call in `setTimeout(..., 0)` so it runs after the synchronous startup path completes
- Prevents trace event cleanup from blocking daemon boot in high-volume environments
- Preserves error handling and logging

Addresses feedback from PR #18633.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
