### PR TITLE
docs: update stale PBKDF2 comments in managed-main.ts and error.ts for v2 store.key

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -133,14 +133,16 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
 
   // -- Build handler registry ------------------------------------------------
   // NOTE: local_static credential handles are NOT supported in managed mode.
-  // The encrypted key store uses PBKDF2 key derivation from user identity
-  // (username, homedir), but the assistant container runs as root while CES
-  // runs as ces — different derived keys make decryption silently fail.
-  // Managed deployments must use platform_oauth handles exclusively.
+  // v2 stores use a UID-independent `store.key` file that removes the
+  // technical barrier (legacy v1 stores relied on PBKDF2 key derivation
+  // from user identity, which broke across container users). The managed-
+  // mode restriction is now a policy choice: managed deployments use
+  // platform_oauth handles exclusively for simpler lifecycle and
+  // centralized token management.
   //
   // We provide error-returning stubs for localMaterialiser/localSubjectDeps
   // so the HTTP handler compiles but any local_static request gets a clear
-  // error message rather than a silent decryption failure.
+  // rejection message.
 
   const localMaterialiserStub = {
     materialise: async () => ({

--- a/packages/ces-contracts/src/error.ts
+++ b/packages/ces-contracts/src/error.ts
@@ -15,10 +15,11 @@ export type RpcError = z.infer<typeof RpcErrorSchema>;
 
 /**
  * Error returned when a local_static credential handle is used in managed
- * mode. The encrypted key store uses PBKDF2 key derivation from user
- * identity (username, homedir), but the assistant container runs as root
- * while CES runs as ces — different derived keys make decryption silently
- * fail. Managed deployments must use platform_oauth handles exclusively.
+ * mode. v2 stores use a UID-independent `store.key` file that removes the
+ * technical barrier (legacy v1 relied on PBKDF2 key derivation from user
+ * identity, which broke across container users). The restriction is now a
+ * policy choice: managed deployments use platform_oauth handles exclusively
+ * for simpler lifecycle and centralized token management.
  */
 export const MANAGED_LOCAL_STATIC_REJECTION_ERROR =
   "local_static credential handles are not supported in managed mode. " +


### PR DESCRIPTION
## Summary
- Update comment in managed-main.ts to reflect v2 store.key makes local_static restriction a policy choice
- Update JSDoc in ces-contracts error.ts with same updated rationale
- Completes the doc update started in PR #18630

Addresses feedback from PR #18630.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
