### PR TITLE
fix: add route policy for trace-events endpoint to require chat.read scope

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -157,6 +157,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Events (SSE)
   { endpoint: "events", scopes: ["chat.read"] },
 
+  // Trace events
+  { endpoint: "trace-events", scopes: ["chat.read"] },
+
   // Attachments
   { endpoint: "attachments:POST", scopes: ["attachments.write"] },
   { endpoint: "attachments:DELETE", scopes: ["attachments.write"] },


### PR DESCRIPTION
## Summary
- Add route policy entry for trace-events endpoint requiring chat.read scope
- Prevents authorization bypass where any authenticated principal could query trace events
- Follows same pattern as the events SSE endpoint

Addresses feedback from PR #18634.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
