### PR TITLE
fix(macos): use requestId set instead of source-based guard for confirmation cleanup

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1901,12 +1901,11 @@ extension ChatViewModel {
                     }
                 }
 
-                // Clean up the native notification path when the daemon resolves
-                // the confirmation independently (timeout, new-message auto-deny,
-                // system cascade). Skip when source is "button" or "inline_nl"
-                // because respondToConfirmation / respondToAlwaysAllow already
-                // called onInlineConfirmationResponse for those paths.
-                if msg.source != "button" && msg.source != "inline_nl" {
+                // Clean up the native notification path. If respondToConfirmation /
+                // respondToAlwaysAllow already called onInlineConfirmationResponse
+                // for this requestId, skip the duplicate call; otherwise forward
+                // so externally-resolved confirmations still dismiss notifications.
+                if inlineResponseHandledRequestIds.remove(msg.requestId) == nil {
                     let decisionString = msg.state == "approved" ? "allow" : "deny"
                     onInlineConfirmationResponse?(msg.requestId, decisionString)
                 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -538,6 +538,11 @@ public final class ChatViewModel: ObservableObject {
     /// Parameters: (requestId, decision)
     public var onInlineConfirmationResponse: ((String, String) -> Void)?
 
+    /// Tracks requestIds for which onInlineConfirmationResponse has already been called locally
+    /// (via respondToConfirmation / respondToAlwaysAllow). When the daemon's confirmationStateChanged
+    /// event arrives for the same requestId, we skip the duplicate callback.
+    var inlineResponseHandledRequestIds = Set<String>()
+
     /// Called to determine whether this ChatViewModel should accept a `confirmationRequest`.
     /// Set by ConversationManager to coordinate routing when multiple ChatViewModels are active.
     public var shouldAcceptConfirmation: (() -> Bool)?
@@ -2409,6 +2414,7 @@ public final class ChatViewModel: ObservableObject {
         clearPendingConfirmation(requestId: requestId)
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, decision)
+        inlineResponseHandledRequestIds.insert(requestId)
     }
 
     /// Respond to a tool confirmation with "always_allow", sending the selected pattern and scope
@@ -2443,6 +2449,7 @@ public final class ChatViewModel: ObservableObject {
         clearPendingConfirmation(requestId: requestId)
         // Dismiss the corresponding floating panel / native notification if one exists
         onInlineConfirmationResponse?(requestId, "allow")
+        inlineResponseHandledRequestIds.insert(requestId)
     }
 
     /// Update the inline confirmation message state without sending a response to the daemon.


### PR DESCRIPTION
## Summary
- Replace source-based guard (msg.source != button/inline_nl) with a requestId-based set to track which confirmations have already been handled inline
- Prevents notification continuation leaks when confirmations are resolved externally (signal files, HTTP API, voice bridge)
- Preserves double-call suppression for locally-initiated resolutions

Addresses feedback from PR #18617.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
