### PR TITLE
fix: use GROUP BY with MAX for deterministic conversation ordering in trace-event-store

### DIFF
--- a/assistant/src/memory/trace-event-store.ts
+++ b/assistant/src/memory/trace-event-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, sql } from "drizzle-orm";
 
 import type {
   TraceEvent,
@@ -140,9 +140,10 @@ export function deleteOldTraceEvents(maxAgeDays: number): number {
 export function getTraceEventConversationIds(): string[] {
   const db = getDb();
   const rows = db
-    .selectDistinct({ conversationId: traceEvents.conversationId })
+    .select({ conversationId: traceEvents.conversationId })
     .from(traceEvents)
-    .orderBy(desc(traceEvents.timestampMs))
+    .groupBy(traceEvents.conversationId)
+    .orderBy(desc(sql`MAX(${traceEvents.timestampMs})`))
     .all();
   return rows.map((r) => r.conversationId);
 }


### PR DESCRIPTION
## Summary
- Replace selectDistinct + orderBy with GROUP BY + ORDER BY MAX(timestamp_ms) DESC
- Ensures getTraceEventConversationIds returns conversations in correct most-recent-first order
- Previous approach produced non-deterministic ordering because timestamp_ms wasn't in the DISTINCT select list

Addresses feedback from PR #18629.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
