### PR TITLE
fix(lint): sort imports in trace-emitter.ts

### DIFF
--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -1,9 +1,9 @@
 import { v4 as uuid } from "uuid";
 
-import type { TraceEvent } from "./message-types/messages.js";
-import type { ServerMessage, TraceEventKind } from "./message-protocol.js";
 import { persistTraceEvent } from "../memory/trace-event-store.js";
 import { getLogger } from "../util/logger.js";
+import type { ServerMessage, TraceEventKind } from "./message-protocol.js";
+import type { TraceEvent } from "./message-types/messages.js";
 
 export type TraceEventStatus = "info" | "success" | "warning" | "error";
 


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/daemon/trace-emitter.ts` by sorting imports alphabetically

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23220720047/job/67492475842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
