### PR TITLE
fix(macos): migrate fetchTraceEventHistory from DaemonClient to GatewayHTTPClient pattern

### DIFF
--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -13,6 +13,7 @@ struct DebugPanelView: View {
     var onClose: () -> Void
 
     @State private var isLoadingHistory = false
+    private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
 
     private var hasEvents: Bool {
         guard let conversationId else { return false }
@@ -73,7 +74,7 @@ struct DebugPanelView: View {
         Task {
             defer { isLoadingHistory = false }
             do {
-                let events = try await daemonClient.fetchTraceEventHistory(conversationId: conversationId)
+                let events = try await traceEventClient.fetchHistory(conversationId: conversationId)
                 traceStore.loadHistory(events)
             } catch {
                 // Fetch failed — fall back to the existing "No trace events yet" empty state.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -8,6 +8,7 @@ struct DebugPanel: View {
     var onClose: () -> Void
 
     @State private var isLoadingHistory = false
+    private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
 
     private var hasEvents: Bool {
         guard let conversationId = activeSessionId else { return false }
@@ -78,7 +79,7 @@ struct DebugPanel: View {
         Task {
             defer { isLoadingHistory = false }
             do {
-                let events = try await daemonClient.fetchTraceEventHistory(conversationId: conversationId)
+                let events = try await traceEventClient.fetchHistory(conversationId: conversationId)
                 traceStore.loadHistory(events)
             } catch {
                 // Fetch failed — fall back to the existing "No trace events yet" empty state.

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1217,28 +1217,4 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
-    // MARK: - Trace Event History
-
-    /// Fetches persisted trace events for a conversation from the daemon.
-    public func fetchTraceEventHistory(conversationId: String) async throws -> [TraceEventMessage] {
-        let encodedId = conversationId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationId
-        let path = "v1/trace-events?conversationId=\(encodedId)"
-
-        if let httpTransport {
-            guard let url = URL(string: "\(httpTransport.baseURL)/\(path)") else { return [] }
-            var request = URLRequest(url: url)
-            request.timeoutInterval = 10
-            if let token = httpTransport.bearerToken, !token.isEmpty {
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            }
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return [] }
-            let decoded = try JSONDecoder().decode(TraceEventsHistoryResponse.self, from: data)
-            return decoded.events
-        }
-
-        let result: TraceEventsHistoryResponse? = await executeLocalRequest(path: path)
-        return result?.events ?? []
-    }
-
 }

--- a/clients/shared/Network/TraceEventClient.swift
+++ b/clients/shared/Network/TraceEventClient.swift
@@ -1,0 +1,30 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "TraceEventClient")
+
+/// Focused client for trace event history operations routed through the gateway.
+@MainActor
+public protocol TraceEventClientProtocol {
+    func fetchHistory(conversationId: String) async throws -> [TraceEventMessage]
+}
+
+/// Gateway-backed implementation of ``TraceEventClientProtocol``.
+@MainActor
+public struct TraceEventClient: TraceEventClientProtocol {
+    nonisolated public init() {}
+
+    public func fetchHistory(conversationId: String) async throws -> [TraceEventMessage] {
+        let response = try await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/trace-events",
+            params: ["conversationId": conversationId],
+            timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("fetchHistory failed (HTTP \(response.statusCode))")
+            return []
+        }
+        let decoded = try JSONDecoder().decode(TraceEventsHistoryResponse.self, from: response.data)
+        return decoded.events
+    }
+}


### PR DESCRIPTION
## Summary
- Move fetchTraceEventHistory from DaemonClient to a new TraceEventClient backed by GatewayHTTPClient per clients/AGENTS.md
- Fix URL encoding: GatewayHTTPClient.buildRequest() handles query param escaping automatically using the restricted queryValueAllowed charset
- Remove the method from DaemonClient.swift
- Update both macOS DebugPanel and iOS DebugPanelView callers

Addresses feedback from PR #18637.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
