### PR TITLE
fix: seed TraceEmitter sequence from max persisted value

### DIFF
--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -1,6 +1,9 @@
 import { v4 as uuid } from "uuid";
 
-import { persistTraceEvent } from "../memory/trace-event-store.js";
+import {
+  getMaxSequence,
+  persistTraceEvent,
+} from "../memory/trace-event-store.js";
 import { getLogger } from "../util/logger.js";
 import type { ServerMessage, TraceEventKind } from "./message-protocol.js";
 import type { TraceEvent } from "./message-types/messages.js";
@@ -24,12 +27,21 @@ export interface TraceEmitOptions {
  * even if timestamps collide.
  */
 export class TraceEmitter {
-  private sequence = 0;
+  private sequence: number;
 
   constructor(
     private readonly conversationId: string,
     private sendToClient: (msg: ServerMessage) => void,
-  ) {}
+  ) {
+    // Seed from the highest persisted sequence so that new events always
+    // have strictly higher sequence numbers, even across daemon restarts.
+    try {
+      const maxPersisted = getMaxSequence(conversationId);
+      this.sequence = maxPersisted > 0 ? maxPersisted + 1 : 0;
+    } catch {
+      this.sequence = 0;
+    }
+  }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
     this.sendToClient = sendToClient;

--- a/assistant/src/memory/trace-event-store.ts
+++ b/assistant/src/memory/trace-event-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, eq, gt, lt, sql } from "drizzle-orm";
 
 import type {
   TraceEvent,
@@ -127,4 +127,22 @@ export function deleteOldTraceEvents(maxAgeDays: number): number {
   const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
   db.delete(traceEvents).where(lt(traceEvents.createdAt, cutoff)).run();
   return rawChanges();
+}
+
+// ---------------------------------------------------------------------------
+// Sequence
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the highest sequence number persisted for a conversation,
+ * or 0 if no events exist yet.
+ */
+export function getMaxSequence(conversationId: string): number {
+  const db = getDb();
+  const row = db
+    .select({ maxSeq: sql<number>`MAX(${traceEvents.sequence})` })
+    .from(traceEvents)
+    .where(eq(traceEvents.conversationId, conversationId))
+    .get();
+  return row?.maxSeq ?? 0;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for persist-trace-events.md.

**Gap:** Sequence counter reset across daemon restarts
**What was expected:** afterSequence incremental fetching works reliably across restarts
**What was found:** TraceEmitter.sequence starts at 0, colliding with persisted events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
