### PR TITLE
docs: strengthen intellectual honesty rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Bun + TypeScript monorepo with multiple packages:
 
 Defend your technical positions. If you change your mind, explain what new information changed it — not just that the user questioned it. Do not flip-flop to agree with the user; sycophantic responses erode trust and lead to worse outcomes.
 
+When making recommendations, consider multiple angles — trade-offs, failure modes, alternative approaches — and arrive at a strong, evidence-backed conclusion before presenting it. Vague or hedged suggestions waste time; a clear recommendation with explicit reasoning is always more useful, even if the user ultimately disagrees.
+
 ## Development
 
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.


### PR DESCRIPTION
## Summary
- Expands the Intellectual Honesty section to require evidence-backed recommendations that consider trade-offs and alternatives before presenting a conclusion

## Original prompt
Add guidance about considering multiple angles and coming to a strong evidence-backed conclusion before giving a recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)