### PR TITLE
feat(macOS): auto-restart daemon on mid-session process death

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -471,6 +471,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Set by the app layer — `DaemonClient` never imports platform-specific types.
     public var wakeHandler: (@MainActor @Sendable () async throws -> Void)?
 
+    #if os(macOS)
+    /// Timestamp of the last auto-wake attempt from the health-check disconnect path.
+    /// Used to prevent crash loops: if the daemon dies again within the cooldown window
+    /// after a wake, we stop retrying. Reset on successful reconnection or reconfigure.
+    var lastAutoWakeAttempt: Date?
+    #endif
+
     // MARK: - Broadcast Subscribers
 
     /// Creates a new message stream for the caller. Each subscriber receives all messages
@@ -530,6 +537,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
+        #if os(macOS)
+        lastAutoWakeAttempt = nil
+        #endif
     }
 
     deinit {

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -45,6 +45,11 @@ extension DaemonClient {
             if connected {
                 NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
             }
+            #if os(macOS)
+            if !connected {
+                self.autoWakeIfDaemonDied()
+            }
+            #endif
         }
 
         // Persist refreshed bearer tokens so the client survives app restarts.
@@ -117,6 +122,47 @@ extension DaemonClient {
     public func disconnect() {
         disconnectInternal(triggerReconnect: false)
     }
+
+    // MARK: - Auto-Wake on Health Check Disconnect
+
+    #if os(macOS)
+    /// Minimum interval between auto-wake attempts to prevent crash loops.
+    private static let autoWakeCooldown: TimeInterval = 60.0
+
+    /// Check whether the daemon process has died and, if so, attempt to wake it
+    /// and reconnect. Called from the `onConnectionStateChanged` callback when
+    /// the health check reports disconnection.
+    private func autoWakeIfDaemonDied() {
+        guard let wakeHandler,
+              config.transportMetadata.routeMode == .runtimeFlat,
+              !DaemonClient.isDaemonProcessAlive(environment: config.instanceDir.map { ["BASE_DATA_DIR": $0] })
+        else { return }
+
+        // Crash loop protection: if we already tried recently and the daemon
+        // died again, don't keep restarting a broken process.
+        if let last = lastAutoWakeAttempt,
+           Date().timeIntervalSince(last) < Self.autoWakeCooldown {
+            log.warning("auto-wake: skipping — last attempt was within \(Self.autoWakeCooldown)s cooldown")
+            return
+        }
+
+        lastAutoWakeAttempt = Date()
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            log.info("auto-wake: daemon process died during session — attempting wake")
+            do {
+                try await wakeHandler()
+                log.info("auto-wake: wake succeeded, reconnecting")
+                try await self.connect()
+                log.info("auto-wake: reconnect succeeded")
+                self.lastAutoWakeAttempt = nil
+            } catch {
+                log.error("auto-wake: failed: \(error)")
+            }
+        }
+    }
+    #endif
 
     func disconnectInternal(triggerReconnect: Bool) {
         isAuthenticated = false


### PR DESCRIPTION
## Summary
- Extend the macOS client to auto-wake the daemon when periodic health checks detect the process has died mid-session, rather than showing a permanent disconnect
- Add `autoWakeIfDaemonDied()` to `DaemonConnection.swift` — checks PID liveness, respects a 60s cooldown to prevent crash loops, then wakes + reconnects
- Add `lastAutoWakeAttempt` timestamp to `DaemonClient.swift` for cooldown tracking, reset on successful reconnect or reconfigure

## Test plan
- [x] macOS target builds clean (`swift build`)
- [x] All 37 existing DaemonClient tests pass
- [ ] Manual: kill daemon process while client is connected → verify auto-wake fires within 15s and reconnects
- [ ] Manual: kill daemon repeatedly → verify cooldown prevents wake spam (only one attempt per 60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
