### PR TITLE
fix(macos): fix system permission rows not responding to clicks

### DIFF
--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -88,6 +88,11 @@ enum PermissionManager {
     private static let hasRequestedScreenRecordingFlag = "hasRequestedScreenRecording"
 
     static func requestScreenRecordingAccess() {
+        if CGPreflightScreenCaptureAccess() {
+            openScreenRecordingSettings()
+            return
+        }
+
         let hasRequestedBefore = UserDefaults.standard.bool(forKey: hasRequestedScreenRecordingFlag)
 
         // CGRequestScreenCaptureAccess() only shows the native OS prompt on
@@ -100,7 +105,7 @@ enum PermissionManager {
 
         if !hasRequestedBefore {
             UserDefaults.standard.set(true, forKey: hasRequestedScreenRecordingFlag)
-        } else if !CGPreflightScreenCaptureAccess() {
+        } else {
             openScreenRecordingSettings()
         }
     }
@@ -108,7 +113,7 @@ enum PermissionManager {
     static func requestMicrophoneAccess() {
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
-            return
+            openMicrophoneSettings()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .audio) { _ in }
         case .denied, .restricted:
@@ -121,7 +126,7 @@ enum PermissionManager {
     static func requestSpeechRecognitionAccess() {
         switch SFSpeechRecognizer.authorizationStatus() {
         case .authorized:
-            return
+            openSpeechRecognitionSettings()
         case .notDetermined:
             SFSpeechRecognizer.requestAuthorization { _ in }
         case .denied, .restricted:
@@ -138,7 +143,7 @@ enum PermissionManager {
             case .notDetermined:
                 _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
-                return
+                _ = openNotificationSettings()
             case .denied:
                 _ = openNotificationSettings()
             @unknown default:
@@ -154,15 +159,17 @@ enum PermissionManager {
             case .notDetermined:
                 _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
             case .authorized, .provisional, .ephemeral:
-                if settings.badgeSetting != .enabled {
-                    _ = openNotificationSettings()
-                }
+                _ = openNotificationSettings()
             case .denied:
                 _ = openNotificationSettings()
             @unknown default:
                 _ = openNotificationSettings()
             }
         }
+    }
+
+    static func openAccessibilitySettings() {
+        _ = openPrivacySettingsPane("Privacy_Accessibility")
     }
 
     static func openScreenRecordingSettings() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -453,7 +453,11 @@ struct SettingsPanel: View {
                     subtitle: "Allows your assistant to click, type, and control apps on your behalf.",
                     granted: accessibilityGranted
                 ) {
-                    _ = PermissionManager.accessibilityStatus(prompt: true)
+                    if accessibilityGranted {
+                        PermissionManager.openAccessibilitySettings()
+                    } else {
+                        _ = PermissionManager.accessibilityStatus(prompt: true)
+                    }
                     startPermissionPolling()
                 }
 
@@ -538,12 +542,10 @@ struct SettingsPanel: View {
     // MARK: - Permission Row
 
     private func permissionRow(label: String, subtitle: String, granted: Bool, action: @escaping () -> Void) -> some View {
-        VToggle(isOn: .constant(granted), label: label, helperText: subtitle)
-            .allowsHitTesting(false)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                action()
-            }
+        Button(action: action) {
+            VToggle(isOn: .constant(granted), label: label, helperText: subtitle, interactive: false)
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Permission Helpers

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -538,11 +538,12 @@ struct SettingsPanel: View {
     // MARK: - Permission Row
 
     private func permissionRow(label: String, subtitle: String, granted: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VToggle(isOn: .constant(granted), label: label, helperText: subtitle)
-                .allowsHitTesting(false)
-        }
-        .buttonStyle(.plain)
+        VToggle(isOn: .constant(granted), label: label, helperText: subtitle)
+            .allowsHitTesting(false)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                action()
+            }
     }
 
     // MARK: - Permission Helpers

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -21,8 +21,8 @@ public struct VToggle: View {
 
     public var body: some View {
         content
-            .accessibilityElement(children: .combine)
-            .accessibilityAddTraits(.isButton)
+            .accessibilityElement(children: interactive ? .combine : .ignore)
+            .accessibilityAddTraits(interactive ? .isButton : [])
             .accessibilityValue(isOn ? "On" : "Off")
             .accessibilityLabel(label ?? "Toggle")
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -4,6 +4,7 @@ public struct VToggle: View {
     @Binding public var isOn: Bool
     public var label: String? = nil
     public var helperText: String? = nil
+    public var interactive: Bool
     @Environment(\.isEnabled) private var isEnabled
 
     private let trackWidth: CGFloat = 36
@@ -11,13 +12,40 @@ public struct VToggle: View {
     private let knobSize: CGFloat = 20
     private let knobPadding: CGFloat = 2
 
-    public init(isOn: Binding<Bool>, label: String? = nil, helperText: String? = nil) {
+    public init(isOn: Binding<Bool>, label: String? = nil, helperText: String? = nil, interactive: Bool = true) {
         self._isOn = isOn
         self.label = label
         self.helperText = helperText
+        self.interactive = interactive
     }
 
     public var body: some View {
+        content
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityValue(isOn ? "On" : "Off")
+            .accessibilityLabel(label ?? "Toggle")
+    }
+
+    private var content: some View {
+        Group {
+            if interactive {
+                rowContent
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        guard isEnabled else { return }
+                        withAnimation(VAnimation.fast) {
+                            isOn.toggle()
+                        }
+                    }
+                    .pointerCursor()
+            } else {
+                rowContent
+            }
+        }
+    }
+
+    private var rowContent: some View {
         HStack(alignment: helperText != nil ? .top : .center, spacing: 10) {
             toggleTrack
                 .padding(.top, helperText != nil ? 2 : 0)
@@ -37,18 +65,6 @@ public struct VToggle: View {
                 }
             }
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            guard isEnabled else { return }
-            withAnimation(VAnimation.fast) {
-                isOn.toggle()
-            }
-        }
-        .pointerCursor()
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityValue(isOn ? "On" : "Off")
-        .accessibilityLabel(label ?? "Toggle")
     }
 
     // MARK: - Track

--- a/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -166,6 +166,11 @@ struct InputsGallerySection: View {
                         Text("Without label").font(VFont.caption).foregroundColor(VColor.contentTertiary)
                         VToggle(isOn: $toggleB)
                     }
+
+                    VStack(alignment: .leading, spacing: VSpacing.md) {
+                        Text("Non-interactive").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VToggle(isOn: .constant(true), label: "Read-only toggle", interactive: false)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Fix system permission rows in Settings not opening System Preferences when clicked

## Implementation
The `permissionRow` helper wrapped a read-only `VToggle` inside a `Button`. The VToggle's internal `.contentShape(Rectangle()).onTapGesture` was swallowing clicks before the Button's action could fire, even with `.allowsHitTesting(false)` applied.

Replaced the `Button` wrapper with a direct `.onTapGesture` on the row. `.allowsHitTesting(false)` disables the VToggle's own gesture handling, and a new `.contentShape(Rectangle()).onTapGesture` on the outer layer captures clicks and calls the permission request action.

## Testing
1. Open Settings → Permissions & Privacy
2. Click any system permission row (e.g., Accessibility, Screen Recording)
3. Verify System Preferences opens to the correct pane
4. Verify toggle still reflects the current permission status (read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
