### PR TITLE
fix: update contract tests to match BOOTSTRAP.md v5 and trace-emitter seeding

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -35,10 +35,10 @@ describe("onboarding template contracts", () => {
 
     test("asks about user after assistant identity", () => {
       const nameIdx = bootstrap.indexOf("Your name");
-      const guardianIdx = bootstrap.indexOf("Your guardian");
+      const theirNameIdx = bootstrap.indexOf("Their name");
       expect(nameIdx).toBeGreaterThan(-1);
-      expect(guardianIdx).toBeGreaterThan(-1);
-      expect(nameIdx).toBeLessThan(guardianIdx);
+      expect(theirNameIdx).toBeGreaterThan(-1);
+      expect(nameIdx).toBeLessThan(theirNameIdx);
     });
 
     test("gathers user context: work role, hobbies, daily tools", () => {
@@ -54,11 +54,10 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toContain("relay_prompt");
     });
 
-    test("contains completion gate with required conditions", () => {
+    test("contains wrapping-up criteria with required conditions", () => {
       const lower = bootstrap.toLowerCase();
-      expect(lower).toContain("completion gate");
-      expect(lower).toContain("do not delete this file");
-      expect(lower).toContain("you have a name");
+      expect(lower).toContain("wrapping up");
+      expect(lower).toContain("done with onboarding");
       expect(lower).toContain("vibe");
       expect(lower).toContain("two suggestions");
     });
@@ -68,7 +67,7 @@ describe("onboarding template contracts", () => {
       expect(lower).toContain("hard-required");
       expect(lower).toContain("best-effort");
       expect(lower).toContain("declined");
-      expect(lower).toContain("don't push");
+      expect(lower).toContain("not interrogation");
     });
 
     test("defines resolved as provided, inferred, or declined", () => {

--- a/assistant/src/__tests__/trace-emitter.test.ts
+++ b/assistant/src/__tests__/trace-emitter.test.ts
@@ -169,6 +169,6 @@ describe("TraceEmitter", () => {
     expect(newSent).toHaveLength(1);
     expect(newSent[0].summary).toBe("after");
     // Sequence continues from where it left off
-    expect(newSent[0].sequence).toBe(1);
+    expect(newSent[0].sequence).toBe(sent[0].sequence + 1);
   });
 });


### PR DESCRIPTION
## Summary
- Update onboarding template contract tests to match the rewritten BOOTSTRAP.md v5 content ("Your guardian" removed, "completion gate" replaced with "wrapping up", "don't push" replaced with "not interrogation")
- Fix trace-emitter `updateSender` test to use relative sequence assertion (`sent[0].sequence + 1`) instead of hardcoded `1`, since the constructor now seeds from persisted max sequence

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23221225940/job/67494088356

🤖 Generated with [Claude Code](https://claude.com/claude-code)