### PR TITLE
fix: avoid creating store on deleteKey miss path in encrypted-store

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -490,7 +490,22 @@ export type DeleteKeyResult = "deleted" | "not-found" | "error";
  */
 export function deleteKey(account: string): DeleteKeyResult {
   try {
-    const store = getOrCreateStore();
+    const existing = readStore();
+    if (!existing) return "not-found";
+
+    // Ensure v1→v2 migration happens when a store exists
+    let store: StoreFileV2;
+    if (existing.version === 1) {
+      const migrated = migrateV1ToV2(existing);
+      if (!migrated) {
+        throw new Error("Failed to migrate encrypted store from v1 to v2");
+      }
+      writeStore(migrated);
+      store = migrated;
+    } else {
+      store = existing;
+    }
+
     if (!Object.prototype.hasOwnProperty.call(store.entries, account))
       return "not-found";
 


### PR DESCRIPTION
Addresses Codex feedback on PR #18626.

Changed `deleteKey()` to call `readStore()` first and only proceed with migration/deletion when a store actually exists on disk. Previously it called `getOrCreateStore()` which would create `store.key` and `keys.enc` as a side effect even when deleting a non-existent key from a non-existent store.

Closes #18626 feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
