### PR TITLE
fix: use -1 sentinel in getMaxSequence to prevent sequence collision at zero

### DIFF
--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -37,7 +37,7 @@ export class TraceEmitter {
     // have strictly higher sequence numbers, even across daemon restarts.
     try {
       const maxPersisted = getMaxSequence(conversationId);
-      this.sequence = maxPersisted > 0 ? maxPersisted + 1 : 0;
+      this.sequence = maxPersisted + 1;
     } catch {
       this.sequence = 0;
     }

--- a/assistant/src/memory/trace-event-store.ts
+++ b/assistant/src/memory/trace-event-store.ts
@@ -135,7 +135,7 @@ export function deleteOldTraceEvents(maxAgeDays: number): number {
 
 /**
  * Return the highest sequence number persisted for a conversation,
- * or 0 if no events exist yet.
+ * or -1 if no events exist yet.
  */
 export function getMaxSequence(conversationId: string): number {
   const db = getDb();
@@ -144,5 +144,5 @@ export function getMaxSequence(conversationId: string): number {
     .from(traceEvents)
     .where(eq(traceEvents.conversationId, conversationId))
     .get();
-  return row?.maxSeq ?? 0;
+  return row?.maxSeq ?? -1;
 }


### PR DESCRIPTION
## Summary

Addresses feedback on PR #18651 from both Codex and Devin.

- `getMaxSequence()` now returns `-1` (instead of `0`) when no events exist, disambiguating "no events" from "highest sequence is 0"
- `TraceEmitter` constructor simplified to `this.sequence = maxPersisted + 1`, which correctly handles all cases:
  - No events: `-1 + 1 = 0` (starts at 0)
  - Max is 0: `0 + 1 = 1` (no duplicate)
  - Max is N: `N + 1` (correct continuation)

## Test plan

- [x] Existing `trace-emitter.test.ts` tests pass (constructor throws in test env → catch sets 0)
- [x] No other callers of `getMaxSequence` need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
