### PR TITLE
fix(ios): handle QR-mode empty assistantId in TraceEventClient and remove dead daemonClient property

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -670,7 +670,6 @@ struct ConversationChatView: View {
             .sheet(isPresented: $showDebugPanel) {
                 DebugPanelView(
                     traceStore: clientProvider.traceStore,
-                    daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                     conversationId: viewModel.conversationId,
                     onClose: { showDebugPanel = false }
                 )

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -8,7 +8,6 @@ import VellumAssistantShared
 /// the developer toggle is enabled. Gated behind `UserDefaultsKeys.developerModeEnabled`.
 struct DebugPanelView: View {
     @ObservedObject var traceStore: TraceStore
-    let daemonClient: DaemonClient
     let conversationId: String?
     var onClose: () -> Void
 
@@ -461,6 +460,6 @@ struct TraceTimelineIOSView: View {
 }
 
 #Preview {
-    DebugPanelView(traceStore: TraceStore(), daemonClient: DaemonClient(), conversationId: nil, onClose: {})
+    DebugPanelView(traceStore: TraceStore(), conversationId: nil, onClose: {})
 }
 #endif

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -88,7 +88,6 @@ private struct DeveloperSettingsSectionContent: View {
         .sheet(isPresented: $showDebugPanel) {
             DebugPanelView(
                 traceStore: traceStore,
-                daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                 conversationId: selectedConversationId,
                 onClose: { showDebugPanel = false }
             )

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -322,7 +322,12 @@ public enum GatewayHTTPClient {
         params: [String: String]?,
         connection: ConnectionInfo
     ) throws -> URL {
-        let resolvedPath = path.replacingOccurrences(of: "{assistantId}", with: connection.assistantId)
+        var resolvedPath = path.replacingOccurrences(of: "{assistantId}", with: connection.assistantId)
+        // QR-mode connections have an empty assistantId — collapse the empty scope
+        // prefix so e.g. "assistants//trace-events" falls back to "trace-events".
+        if connection.assistantId.isEmpty {
+            resolvedPath = resolvedPath.replacingOccurrences(of: "assistants//", with: "")
+        }
 
         let pathComponent: String
         let queryComponent: String


### PR DESCRIPTION
## Summary
- **QR-mode trace events fix**: `GatewayHTTPClient.constructURL` now collapses `assistants//` to the flat path when `assistantId` is empty (QR-paired connections), preventing 404s on the trace-events endpoint.
- **Dead code removal**: Removed unused `daemonClient: DaemonClient` property from iOS `DebugPanelView` and updated all callers (`DeveloperSettingsSection`, `ConversationListView`, `#Preview`).

Addresses feedback on PR #18648.

## Test plan
- [ ] QR-paired iOS connection: verify trace history loads without 404
- [ ] Direct/managed connection: verify trace history still loads with assistant-scoped path
- [ ] DebugPanelView compiles without `daemonClient` parameter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
