### PR TITLE
fix: remove unused daemonClient from iOS DebugPanelView

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -670,7 +670,6 @@ struct ConversationChatView: View {
             .sheet(isPresented: $showDebugPanel) {
                 DebugPanelView(
                     traceStore: clientProvider.traceStore,
-                    daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                     conversationId: viewModel.conversationId,
                     onClose: { showDebugPanel = false }
                 )

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -8,7 +8,6 @@ import VellumAssistantShared
 /// the developer toggle is enabled. Gated behind `UserDefaultsKeys.developerModeEnabled`.
 struct DebugPanelView: View {
     @ObservedObject var traceStore: TraceStore
-    let daemonClient: DaemonClient
     let conversationId: String?
     var onClose: () -> Void
 
@@ -461,6 +460,6 @@ struct TraceTimelineIOSView: View {
 }
 
 #Preview {
-    DebugPanelView(traceStore: TraceStore(), daemonClient: DaemonClient(), conversationId: nil, onClose: {})
+    DebugPanelView(traceStore: TraceStore(), conversationId: nil, onClose: {})
 }
 #endif

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -88,7 +88,6 @@ private struct DeveloperSettingsSectionContent: View {
         .sheet(isPresented: $showDebugPanel) {
             DebugPanelView(
                 traceStore: traceStore,
-                daemonClient: clientProvider.client as? DaemonClient ?? DaemonClient(),
                 conversationId: selectedConversationId,
                 onClose: { showDebugPanel = false }
             )


### PR DESCRIPTION
## Summary
Removes unused `daemonClient` property from iOS `DebugPanelView` and updates call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
