### PR TITLE
fix: cancel in-flight trace hydration on conversation switch

### DIFF
--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -13,6 +13,7 @@ struct DebugPanelView: View {
     var onClose: () -> Void
 
     @State private var isLoadingHistory = false
+    @State private var hydrationTask: Task<Void, Never>?
     private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
 
     private var hasEvents: Bool {
@@ -63,6 +64,12 @@ struct DebugPanelView: View {
             hydrateIfNeeded()
         }
         .onDisappear { traceStore.isObserved = false }
+        .onChange(of: conversationId) { _, _ in
+            hydrationTask?.cancel()
+            hydrationTask = nil
+            isLoadingHistory = false
+            hydrateIfNeeded()
+        }
     }
 
     // MARK: - History Hydration
@@ -71,10 +78,15 @@ struct DebugPanelView: View {
         guard let conversationId else { return }
         guard !hasEvents, !isLoadingHistory else { return }
         isLoadingHistory = true
-        Task {
-            defer { isLoadingHistory = false }
+        hydrationTask = Task {
+            defer {
+                guard !Task.isCancelled else { return }
+                isLoadingHistory = false
+                hydrationTask = nil
+            }
             do {
                 let events = try await traceEventClient.fetchHistory(conversationId: conversationId)
+                guard !Task.isCancelled else { return }
                 traceStore.loadHistory(events)
             } catch {
                 // Fetch failed — fall back to the existing "No trace events yet" empty state.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -8,6 +8,7 @@ struct DebugPanel: View {
     var onClose: () -> Void
 
     @State private var isLoadingHistory = false
+    @State private var hydrationTask: Task<Void, Never>?
     private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
 
     private var hasEvents: Bool {
@@ -66,6 +67,9 @@ struct DebugPanel: View {
         }
         .onDisappear { traceStore.isObserved = false }
         .onChange(of: activeSessionId) { _, _ in
+            hydrationTask?.cancel()
+            hydrationTask = nil
+            isLoadingHistory = false
             hydrateIfNeeded()
         }
     }
@@ -76,10 +80,15 @@ struct DebugPanel: View {
         guard let conversationId = activeSessionId else { return }
         guard !hasEvents, !isLoadingHistory else { return }
         isLoadingHistory = true
-        Task {
-            defer { isLoadingHistory = false }
+        hydrationTask = Task {
+            defer {
+                guard !Task.isCancelled else { return }
+                isLoadingHistory = false
+                hydrationTask = nil
+            }
             do {
                 let events = try await traceEventClient.fetchHistory(conversationId: conversationId)
+                guard !Task.isCancelled else { return }
                 traceStore.loadHistory(events)
             } catch {
                 // Fetch failed — fall back to the existing "No trace events yet" empty state.


### PR DESCRIPTION
## Summary
- Cancel in-flight trace history fetch when the user switches conversations
- Use tracked `Task` to prevent stale fetches from blocking hydration of the new conversation
- Applied to both macOS DebugPanel and iOS DebugPanelView

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
