### PR TITLE
fix: route access request notifications to source channel only

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -623,7 +623,7 @@ describe("access-request-helper unit tests", () => {
     expect(telegram!.status).toBe("sent");
   });
 
-  test("notifyGuardianOfAccessRequest records failed vellum fallback when pipeline has no vellum delivery", async () => {
+  test("notifyGuardianOfAccessRequest skips vellum fallback for same-channel-only routing (telegram)", async () => {
     mockEmitResult = {
       signalId: "sig-no-vellum",
       deduplicated: false,
@@ -657,8 +657,8 @@ describe("access-request-helper unit tests", () => {
       (d) => d.destinationChannel === "telegram",
     );
 
-    expect(vellum).toBeDefined();
-    expect(vellum!.status).toBe("failed");
+    // Same-channel routing skips vellum delivery entirely — no fallback record
+    expect(vellum).toBeUndefined();
     expect(telegram).toBeDefined();
     expect(telegram!.destinationChatId).toBe("guardian-chat-456");
     expect(telegram!.status).toBe("sent");

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -866,17 +866,28 @@ export function enforceRoutingIntent(
   }
 
   if (routingIntent === "single_channel") {
-    if (!decision.shouldNotify || decision.selectedChannels.length <= 1) {
+    if (!decision.shouldNotify) {
       return decision;
     }
 
-    // Prefer the source channel if it's among the selected channels;
-    // otherwise keep the first selected channel.
-    const preferred =
+    // Force delivery to the source channel only. If the source channel
+    // is among the connected channels, use it regardless of what the LLM
+    // picked (even if the LLM picked exactly one wrong channel).
+    // Otherwise fall back to capping at the first selected channel.
+    const sourceIsConnected =
       sourceChannel &&
-      decision.selectedChannels.includes(sourceChannel as NotificationChannel)
-        ? (sourceChannel as NotificationChannel)
-        : decision.selectedChannels[0];
+      connectedChannels.includes(sourceChannel as NotificationChannel);
+    const preferred = sourceIsConnected
+      ? (sourceChannel as NotificationChannel)
+      : decision.selectedChannels[0];
+
+    // No change needed if the decision already matches.
+    if (
+      decision.selectedChannels.length === 1 &&
+      decision.selectedChannels[0] === preferred
+    ) {
+      return decision;
+    }
 
     const enforced = { ...decision };
     enforced.selectedChannels = [preferred];

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -852,15 +852,45 @@ async function classifyWithLLM(
  *
  * - `all_channels`: force selected channels to all connected channels.
  * - `multi_channel`: ensure at least 2 channels when 2+ are connected.
- * - `single_channel`: no override (default behavior).
+ * - `single_channel`: cap to a single channel. When explicitly set, reduces
+ *   selected channels to one — preferring the source channel if present.
  */
 export function enforceRoutingIntent(
   decision: NotificationDecision,
   routingIntent: RoutingIntent | undefined,
   connectedChannels: NotificationChannel[],
+  sourceChannel?: string,
 ): NotificationDecision {
-  if (!routingIntent || routingIntent === "single_channel") {
+  if (!routingIntent) {
     return decision;
+  }
+
+  if (routingIntent === "single_channel") {
+    if (!decision.shouldNotify || decision.selectedChannels.length <= 1) {
+      return decision;
+    }
+
+    // Prefer the source channel if it's among the selected channels;
+    // otherwise keep the first selected channel.
+    const preferred =
+      sourceChannel &&
+      decision.selectedChannels.includes(sourceChannel as NotificationChannel)
+        ? (sourceChannel as NotificationChannel)
+        : decision.selectedChannels[0];
+
+    const enforced = { ...decision };
+    enforced.selectedChannels = [preferred];
+    enforced.reasoningSummary = `${decision.reasoningSummary} [routing_intent=single_channel enforced: capped to ${preferred}]`;
+    log.info(
+      {
+        routingIntent,
+        sourceChannel,
+        originalChannels: decision.selectedChannels,
+        enforcedChannel: preferred,
+      },
+      "Routing intent enforcement: single_channel → capped to one channel",
+    );
+    return enforced;
   }
 
   if (!decision.shouldNotify) {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -256,6 +256,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       decision,
       signal.routingIntent,
       connectedChannels,
+      signal.sourceChannel,
     );
 
     // Re-persist the decision if routing intent enforcement changed it,

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -200,12 +200,18 @@ export function notifyGuardianOfAccessRequest(
   });
 
   let vellumDeliveryId: string | null = null;
-  // When the access request originates from a specific channel (Slack,
-  // Telegram, etc.), route the guardian notification to that same channel
-  // only. Delivering on the macOS client as well is noisy and approving
-  // from there doesn't work because the desktop path lacks the channel
-  // delivery context needed to deliver the verification code.
-  const sameChannelOnly = sourceChannel !== "vellum";
+  // When the access request originates from a text channel with
+  // notification delivery support (Slack, Telegram), route the guardian
+  // notification to that same channel only. Delivering on the macOS
+  // client as well is noisy and approving from there doesn't work
+  // because the desktop path lacks the channel delivery context needed
+  // to deliver the verification code. Phone is excluded because it is
+  // not a deliverable notification channel.
+  const TEXT_CHANNELS_WITH_DELIVERY: ReadonlySet<string> = new Set([
+    "slack",
+    "telegram",
+  ]);
+  const sameChannelOnly = TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel);
 
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",
@@ -266,7 +272,7 @@ export function notifyGuardianOfAccessRequest(
         applyDeliveryStatus(delivery.id, result);
       }
 
-      if (!vellumDeliveryId) {
+      if (!vellumDeliveryId && !sameChannelOnly) {
         const fallback = createCanonicalGuardianDelivery({
           requestId: canonicalRequest.id,
           destinationChannel: "vellum",

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -200,10 +200,18 @@ export function notifyGuardianOfAccessRequest(
   });
 
   let vellumDeliveryId: string | null = null;
+  // When the access request originates from a specific channel (Slack,
+  // Telegram, etc.), route the guardian notification to that same channel
+  // only. Delivering on the macOS client as well is noisy and approving
+  // from there doesn't work because the desktop path lacks the channel
+  // delivery context needed to deliver the verification code.
+  const sameChannelOnly = sourceChannel !== "vellum";
+
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",
     sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceContextId: `access-req-${sourceChannel}-${actorExternalId}`,
+    ...(sameChannelOnly ? { routingIntent: "single_channel" as const } : {}),
     attentionHints: {
       requiresAction: true,
       urgency: "high",


### PR DESCRIPTION
## Summary
- When a trusted contact verification is initiated from Slack, the guardian notification now stays on Slack only instead of also appearing in the macOS client
- Adds enforcement for `single_channel` routing intent in the notification pipeline (previously was a no-op), capping to the source channel
- Fixes the issue where approving from macOS didn't work because the desktop path lacks channel delivery context for the verification code

## Test plan
- [x] Existing notification routing tests pass (`emit-signal-routing-intent`, `notification-decision-strategy`, `access-request-decision`, `trusted-contact-lifecycle-notifications`, `notification-broadcaster`, `notification-decision-fallback`)
- [x] TypeScript type check passes
- [ ] Manual: initiate a trusted contact verification from Slack → verify guardian notification only appears in Slack, not macOS client
- [ ] Manual: initiate access request from macOS desktop → verify notification still appears in macOS client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
