### PR TITLE
feat: use claude-opus-4-6 for Anthropic vision-optimized intent

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -62,7 +62,7 @@ describe("model intents", () => {
       "claude-opus-4-6",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
-      "claude-sonnet-4-6",
+      "claude-opus-4-6",
     );
     expect(resolveModelIntent("openai", "latency-optimized")).toBe(
       "gpt-4o-mini",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -18,7 +18,7 @@ const PROVIDER_MODEL_INTENTS: Record<
   anthropic: {
     "latency-optimized": "claude-haiku-4-5-20251001",
     "quality-optimized": "claude-opus-4-6",
-    "vision-optimized": "claude-sonnet-4-6",
+    "vision-optimized": "claude-opus-4-6",
   },
   openai: {
     "latency-optimized": "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- Change the Anthropic `vision-optimized` model intent from `claude-sonnet-4-6` to `claude-opus-4-6` for improved vision capabilities.
- Update the corresponding test assertion.

## Test plan
- [x] `bun test src/__tests__/model-intents.test.ts` — all 5 tests pass
- [x] Pre-commit hooks (lint, formatting, secrets check) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
