### PR TITLE
fix(ios): replace illegal return in defer block

### DIFF
--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -79,9 +79,10 @@ struct DebugPanelView: View {
         isLoadingHistory = true
         hydrationTask = Task {
             defer {
-                guard !Task.isCancelled else { return }
-                isLoadingHistory = false
-                hydrationTask = nil
+                if !Task.isCancelled {
+                    isLoadingHistory = false
+                    hydrationTask = nil
+                }
             }
             do {
                 let events = try await traceEventClient.fetchHistory(conversationId: conversationId)


### PR DESCRIPTION
## Summary
- Replace `guard !Task.isCancelled else { return }` inside a `defer` block in `DebugPanelView.swift` with `if !Task.isCancelled { ... }` — Swift forbids `return` inside `defer`.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23221586742/job/67495202770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
