### PR TITLE
fix: mock persistence layer in trace-emitter tests for isolation

### DIFF
--- a/assistant/src/__tests__/trace-emitter.test.ts
+++ b/assistant/src/__tests__/trace-emitter.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, mock } from "bun:test";
 
+// Mock the persistence layer so tests are isolated from the database.
+// getMaxSequence returning -1 means "no persisted events" → sequence starts at 0.
+mock.module("../memory/trace-event-store.js", () => ({
+  getMaxSequence: () => -1,
+  persistTraceEvent: () => {},
+}));
+
 import type { ServerMessage, TraceEvent } from "../daemon/message-protocol.js";
 import { TraceEmitter } from "../daemon/trace-emitter.js";
 


### PR DESCRIPTION
## Summary
- Mock `getMaxSequence` and `persistTraceEvent` in `trace-emitter.test.ts` so tests don't leak database state between cases
- Fixes the "increments sequence monotonically" test that expected `[0, 1, 2]` but got `[1, 2, 3]` because a prior test persisted a sequence-0 event for the same conversation ID

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23221520928/job/67494998735

🤖 Generated with [Claude Code](https://claude.com/claude-code)