### PR TITLE
fix(macos): store auto-wake task for cancellation and preserve crash-loop cooldown

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -474,8 +474,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     #if os(macOS)
     /// Timestamp of the last auto-wake attempt from the health-check disconnect path.
     /// Used to prevent crash loops: if the daemon dies again within the cooldown window
-    /// after a wake, we stop retrying. Reset on successful reconnection or reconfigure.
+    /// after a wake, we stop retrying. Expires naturally after the cooldown period.
     var lastAutoWakeAttempt: Date?
+
+    /// The in-flight auto-wake task, stored so it can be cancelled on intentional
+    /// disconnect or reconfigure to prevent reconnecting after teardown.
+    var autoWakeTask: Task<Void, Never>?
     #endif
 
     // MARK: - Broadcast Subscribers
@@ -528,6 +532,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// and resets connection-specific state. Callers must call `connect()`
     /// after reconfiguring to establish the new connection.
     public func reconfigure(config newConfig: DaemonConfig) {
+        #if os(macOS)
+        autoWakeTask?.cancel()
+        autoWakeTask = nil
+        #endif
         disconnect()
         self.config = newConfig
         // Reset connection-specific state
@@ -545,6 +553,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     deinit {
         // Swift 5.9+: deinit on @MainActor class is NOT guaranteed to run on main actor.
         // Only call thread-safe cancellation methods here — Task.cancel() is safe from any thread.
+        #if os(macOS)
+        autoWakeTask?.cancel()
+        #endif
         //
         // We must finish subscriber continuations to prevent hanging `for await` loops.
         // deinit guarantees exclusive access (no other strong references exist), so

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -148,15 +148,22 @@ extension DaemonClient {
 
         lastAutoWakeAttempt = Date()
 
-        Task { @MainActor [weak self] in
+        autoWakeTask = Task { @MainActor [weak self] in
             guard let self else { return }
             log.info("auto-wake: daemon process died during session — attempting wake")
             do {
                 try await wakeHandler()
+                guard !Task.isCancelled else {
+                    log.info("auto-wake: cancelled after wake — skipping reconnect")
+                    return
+                }
                 log.info("auto-wake: wake succeeded, reconnecting")
                 try await self.connect()
+                guard !Task.isCancelled else {
+                    log.info("auto-wake: cancelled after connect — abandoning")
+                    return
+                }
                 log.info("auto-wake: reconnect succeeded")
-                self.lastAutoWakeAttempt = nil
             } catch {
                 log.error("auto-wake: failed: \(error)")
             }
@@ -166,6 +173,11 @@ extension DaemonClient {
 
     func disconnectInternal(triggerReconnect: Bool) {
         isAuthenticated = false
+
+        #if os(macOS)
+        autoWakeTask?.cancel()
+        autoWakeTask = nil
+        #endif
 
         httpTransport?.disconnect()
         httpTransport = nil


### PR DESCRIPTION
Addresses Devin feedback on #18655:

- Store the auto-wake Task as a cancellable property, cancel it in disconnectInternal() and reconfigure() so intentional disconnects aren't overridden
- Don't clear lastAutoWakeAttempt on success — the 60s cooldown window expires naturally, preventing unbounded wake cycles for daemons that crash shortly after starting

Closes follow-up from #18655
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
