### PR TITLE
fix: move trace persist after SSE send and use monotonic DB sequence

### DIFF
--- a/assistant/src/daemon/trace-emitter.ts
+++ b/assistant/src/daemon/trace-emitter.ts
@@ -67,13 +67,14 @@ export class TraceEmitter {
       attributes,
     };
 
+    // Send to client first so synchronous DB writes don't block SSE delivery.
+    this.sendToClient(event);
+
     try {
       persistTraceEvent(event as TraceEvent);
     } catch (err) {
       log.warn({ err, eventId }, "Failed to persist trace event");
     }
-
-    this.sendToClient(event);
   }
 }
 


### PR DESCRIPTION
Addresses Codex feedback on #18635:

- Move persistTraceEvent after sendToClient so synchronous SQLite writes don't block real-time SSE delivery (P1)
- P2 (monotonic sequence across restarts) was already addressed in the merged PR — the constructor seeds from `getMaxSequence(conversationId)`

Closes follow-up from #18635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
