### PR TITLE
fix: make trace hydration per-conversation and always backfill persisted events

### DIFF
--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -11,9 +11,13 @@ struct DebugPanelView: View {
     let conversationId: String?
     var onClose: () -> Void
 
-    @State private var isLoadingHistory = false
+    @State private var loadingConversationId: String?
     @State private var hydrationTask: Task<Void, Never>?
     private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
+
+    private var isLoadingHistory: Bool {
+        loadingConversationId != nil && loadingConversationId == conversationId
+    }
 
     private var hasEvents: Bool {
         guard let conversationId else { return false }
@@ -66,7 +70,7 @@ struct DebugPanelView: View {
         .onChange(of: conversationId) { _, _ in
             hydrationTask?.cancel()
             hydrationTask = nil
-            isLoadingHistory = false
+            loadingConversationId = nil
             hydrateIfNeeded()
         }
     }
@@ -75,12 +79,12 @@ struct DebugPanelView: View {
 
     private func hydrateIfNeeded() {
         guard let conversationId else { return }
-        guard !hasEvents, !isLoadingHistory else { return }
-        isLoadingHistory = true
+        guard loadingConversationId != conversationId else { return }
+        loadingConversationId = conversationId
         hydrationTask = Task {
             defer {
                 if !Task.isCancelled {
-                    isLoadingHistory = false
+                    loadingConversationId = nil
                     hydrationTask = nil
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -7,9 +7,13 @@ struct DebugPanel: View {
     let activeSessionId: String?
     var onClose: () -> Void
 
-    @State private var isLoadingHistory = false
+    @State private var loadingConversationId: String?
     @State private var hydrationTask: Task<Void, Never>?
     private let traceEventClient: any TraceEventClientProtocol = TraceEventClient()
+
+    private var isLoadingHistory: Bool {
+        loadingConversationId != nil && loadingConversationId == activeSessionId
+    }
 
     private var hasEvents: Bool {
         guard let conversationId = activeSessionId else { return false }
@@ -69,7 +73,7 @@ struct DebugPanel: View {
         .onChange(of: activeSessionId) { _, _ in
             hydrationTask?.cancel()
             hydrationTask = nil
-            isLoadingHistory = false
+            loadingConversationId = nil
             hydrateIfNeeded()
         }
     }
@@ -78,12 +82,12 @@ struct DebugPanel: View {
 
     private func hydrateIfNeeded() {
         guard let conversationId = activeSessionId else { return }
-        guard !hasEvents, !isLoadingHistory else { return }
-        isLoadingHistory = true
+        guard loadingConversationId != conversationId else { return }
+        loadingConversationId = conversationId
         hydrationTask = Task {
             defer {
                 guard !Task.isCancelled else { return }
-                isLoadingHistory = false
+                loadingConversationId = nil
                 hydrationTask = nil
             }
             do {


### PR DESCRIPTION
Addresses Codex feedback on #18638:

- Replace global `isLoadingHistory` bool with per-conversation `loadingConversationId` tracking, so the loading state is scoped to the conversation being hydrated rather than the whole panel. This builds on #18667's cancel+restart approach with defense-in-depth.
- Remove `!hasEvents` gate from `hydrateIfNeeded()` so persisted events are always backfilled even when recent live events are present (dedup handled by `ingest()` in `loadHistory`).

Applied to both macOS DebugPanel and iOS DebugPanelView.

Closes follow-up from #18638
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
