### PR TITLE
fix: replace guard-return with if-check in defer block

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -86,9 +86,10 @@ struct DebugPanel: View {
         loadingConversationId = conversationId
         hydrationTask = Task {
             defer {
-                guard !Task.isCancelled else { return }
-                loadingConversationId = nil
-                hydrationTask = nil
+                if !Task.isCancelled {
+                    loadingConversationId = nil
+                    hydrationTask = nil
+                }
             }
             do {
                 let events = try await traceEventClient.fetchHistory(conversationId: conversationId)


### PR DESCRIPTION
## Summary
- Replace `guard !Task.isCancelled else { return }` with `if !Task.isCancelled { ... }` inside the `defer` block in `DebugPanel.hydrateIfNeeded()` — Swift does not allow `return` to transfer control out of a `defer` statement.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23221739520/job/67495689767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
