### PR TITLE
feat: cache identity intro tagline for 4 hours

### DIFF
--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the identity intro cache (identity-intro-cache.ts).
+ *
+ * Validates TTL-based expiration, content-hash-based invalidation when
+ * workspace identity files change, and round-trip get/set behavior.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be defined before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// In-memory checkpoint store
+const checkpointStore = new Map<string, string>();
+
+mock.module("../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    checkpointStore.set(key, value);
+  },
+}));
+
+// Simulated workspace file contents
+const workspaceFiles: Record<string, string> = {};
+
+mock.module("../util/platform.js", () => ({
+  getWorkspacePromptPath: (name: string) => `/mock/workspace/${name}`,
+}));
+
+mock.module("node:fs", () => ({
+  existsSync: (path: string) => {
+    const name = path.split("/").pop() ?? "";
+    return name in workspaceFiles;
+  },
+  readFileSync: (path: string, _encoding: string) => {
+    const name = path.split("/").pop() ?? "";
+    if (name in workspaceFiles) return workspaceFiles[name];
+    throw new Error(`ENOENT: ${path}`);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  computeIdentityContentHash,
+  getCachedIntro,
+  setCachedIntro,
+} from "../runtime/routes/identity-intro-cache.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  checkpointStore.clear();
+  for (const key of Object.keys(workspaceFiles)) {
+    delete workspaceFiles[key];
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("identity intro cache", () => {
+  test("returns null when cache is empty", () => {
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("round-trip: set then get returns cached text", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Velissa";
+    workspaceFiles["SOUL.md"] = "Be playful.";
+    workspaceFiles["USER.md"] = "The user likes coffee.";
+
+    setCachedIntro("Velissa, your girl.");
+    const cached = getCachedIntro();
+    expect(cached).not.toBeNull();
+    expect(cached!.text).toBe("Velissa, your girl.");
+  });
+
+  test("returns null when cache is expired (TTL exceeded)", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Velissa";
+
+    setCachedIntro("Hello!");
+
+    // Manually set the timestamp to 5 hours ago
+    const fiveHoursAgo = String(Date.now() - 5 * 60 * 60 * 1000);
+    checkpointStore.set("identity:intro:cached_at", fiveHoursAgo);
+
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("returns cached text when within TTL (3 hours ago)", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Velissa";
+
+    setCachedIntro("Hello!");
+
+    // Set timestamp to 3 hours ago (within 4-hour TTL)
+    const threeHoursAgo = String(Date.now() - 3 * 60 * 60 * 1000);
+    checkpointStore.set("identity:intro:cached_at", threeHoursAgo);
+
+    const cached = getCachedIntro();
+    expect(cached).not.toBeNull();
+    expect(cached!.text).toBe("Hello!");
+  });
+
+  test("busts cache when IDENTITY.md changes", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Velissa";
+    setCachedIntro("I'm Velissa!");
+
+    // Change IDENTITY.md
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Nova";
+
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("busts cache when SOUL.md changes", () => {
+    workspaceFiles["SOUL.md"] = "Be playful.";
+    setCachedIntro("Hey there!");
+
+    // Change SOUL.md
+    workspaceFiles["SOUL.md"] = "Be serious and formal.";
+
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("busts cache when USER.md changes", () => {
+    workspaceFiles["USER.md"] = "Likes coffee.";
+    setCachedIntro("Good morning!");
+
+    // Change USER.md
+    workspaceFiles["USER.md"] = "Likes tea.";
+
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("cache survives when files are unchanged", () => {
+    workspaceFiles["IDENTITY.md"] = "- **Name:** Velissa";
+    workspaceFiles["SOUL.md"] = "Be chill.";
+    workspaceFiles["USER.md"] = "Likes sunsets.";
+
+    setCachedIntro("Velissa here.");
+
+    // Read twice — both should return the cached value
+    expect(getCachedIntro()?.text).toBe("Velissa here.");
+    expect(getCachedIntro()?.text).toBe("Velissa here.");
+  });
+
+  test("computeIdentityContentHash is deterministic", () => {
+    workspaceFiles["IDENTITY.md"] = "test";
+    workspaceFiles["SOUL.md"] = "test2";
+    workspaceFiles["USER.md"] = "test3";
+
+    const hash1 = computeIdentityContentHash();
+    const hash2 = computeIdentityContentHash();
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex
+  });
+
+  test("computeIdentityContentHash changes when file content changes", () => {
+    workspaceFiles["IDENTITY.md"] = "v1";
+    const hash1 = computeIdentityContentHash();
+
+    workspaceFiles["IDENTITY.md"] = "v2";
+    const hash2 = computeIdentityContentHash();
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("handles missing workspace files gracefully", () => {
+    // No files exist — should still work (empty content hashed)
+    setCachedIntro("Hello!");
+    const cached = getCachedIntro();
+    expect(cached).not.toBeNull();
+    expect(cached!.text).toBe("Hello!");
+  });
+
+  test("returns null when text checkpoint is missing", () => {
+    checkpointStore.set("identity:intro:content_hash", "abc");
+    checkpointStore.set("identity:intro:cached_at", String(Date.now()));
+    // Missing text — should return null
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("returns null when hash checkpoint is missing", () => {
+    checkpointStore.set("identity:intro:text", "Hello");
+    checkpointStore.set("identity:intro:cached_at", String(Date.now()));
+    // Missing hash — should return null
+    expect(getCachedIntro()).toBeNull();
+  });
+
+  test("returns null when timestamp checkpoint is missing", () => {
+    checkpointStore.set("identity:intro:text", "Hello");
+    checkpointStore.set("identity:intro:content_hash", "abc");
+    // Missing timestamp — should return null
+    expect(getCachedIntro()).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -25,8 +25,12 @@ import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import type { SendMessageDeps } from "../http-types.js";
+import { getCachedIntro, setCachedIntro } from "./identity-intro-cache.js";
 
 const log = getLogger("btw-routes");
+
+/** Conversation key used by the client for identity intro generation. */
+const IDENTITY_INTRO_KEY = "identity-intro";
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -77,6 +81,38 @@ async function handleBtw(
     );
   }
 
+  // ----- Identity intro cache fast-path -----
+  // When the client requests the identity intro, check the cache first.
+  // If the cached text is still fresh and the identity files haven't changed,
+  // return it immediately as an SSE stream without making an LLM call.
+  if (conversationKey === IDENTITY_INTRO_KEY) {
+    const cached = getCachedIntro();
+    if (cached) {
+      log.debug("Returning cached identity intro");
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `event: btw_text_delta\ndata: ${JSON.stringify({ text: cached.text })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            encoder.encode(`event: btw_complete\ndata: {}\n\n`),
+          );
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+  }
+
   // Look up an existing conversation — never create one.  BTW is ephemeral
   // (the file header promises "No messages are persisted"), so we must not
   // call getOrCreateConversation which would insert a DB row.  When no
@@ -116,7 +152,9 @@ async function handleBtw(
             ? conversation.systemPrompt
             : buildSystemPrompt({ excludeBootstrap: true });
 
+          const isIntroRequest = conversationKey === IDENTITY_INTRO_KEY;
           let textDeltaCount = 0;
+          let collectedText = "";
           await conversation.provider.sendMessage(
             messages,
             tools,
@@ -130,6 +168,7 @@ async function handleBtw(
               onEvent: (event) => {
                 if (event.type === "text_delta") {
                   textDeltaCount++;
+                  if (isIntroRequest) collectedText += event.text;
                   controller.enqueue(
                     encoder.encode(
                       `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
@@ -146,6 +185,16 @@ async function handleBtw(
               { conversationKey, messageCount: messages.length },
               "btw side-chain completed with no text deltas",
             );
+          }
+
+          // Cache the generated identity intro for subsequent requests.
+          if (isIntroRequest && collectedText.trim()) {
+            try {
+              setCachedIntro(collectedText.trim());
+              log.debug("Cached identity intro text");
+            } catch {
+              // Non-fatal — next request will regenerate.
+            }
           }
 
           controller.enqueue(

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -1,0 +1,105 @@
+/**
+ * Caching layer for the LLM-generated identity intro text.
+ *
+ * The intro (a short tagline like "Velissa, your girl.") is generated via the
+ * /v1/btw endpoint and displayed on the Identity panel. To avoid redundant LLM
+ * calls, we cache the result for 4 hours with content-hash-based invalidation:
+ * when USER.md, IDENTITY.md, or SOUL.md change, the cache is busted.
+ *
+ * Storage uses the existing `memory_checkpoints` table (simple key-value store).
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../memory/checkpoints.js";
+import { getWorkspacePromptPath } from "../../util/platform.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const CHECKPOINT_KEY_TEXT = "identity:intro:text";
+const CHECKPOINT_KEY_HASH = "identity:intro:content_hash";
+const CHECKPOINT_KEY_TIMESTAMP = "identity:intro:cached_at";
+
+/** Workspace files whose content influences the identity intro. */
+const IDENTITY_FILES = ["USER.md", "IDENTITY.md", "SOUL.md"] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Read a workspace prompt file, returning empty string if missing. */
+function readWorkspaceFile(name: string): string {
+  try {
+    const path = getWorkspacePromptPath(name);
+    if (!existsSync(path)) return "";
+    return readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/** Compute a SHA-256 hex hash of the concatenated identity file contents. */
+export function computeIdentityContentHash(): string {
+  const combined = IDENTITY_FILES.map(readWorkspaceFile).join("\n---\n");
+  return createHash("sha256").update(combined).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface CachedIntro {
+  text: string;
+}
+
+/**
+ * Retrieve the cached identity intro if it exists, is within the TTL window,
+ * and the identity files have not changed since it was generated.
+ *
+ * Returns `null` when the cache is missing, expired, or invalidated.
+ */
+export function getCachedIntro(): CachedIntro | null {
+  try {
+    const text = getMemoryCheckpoint(CHECKPOINT_KEY_TEXT);
+    const hash = getMemoryCheckpoint(CHECKPOINT_KEY_HASH);
+    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
+
+    if (!text || !hash || !timestampStr) return null;
+
+    // TTL check
+    const cachedAt = Number(timestampStr);
+    if (isNaN(cachedAt) || Date.now() - cachedAt > CACHE_TTL_MS) return null;
+
+    // Content-hash check — bust cache when identity files change
+    const currentHash = computeIdentityContentHash();
+    if (currentHash !== hash) return null;
+
+    return { text };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store the generated identity intro text in the cache along with
+ * the current content hash and timestamp.
+ */
+export function setCachedIntro(text: string): void {
+  try {
+    const hash = computeIdentityContentHash();
+    const now = String(Date.now());
+    setMemoryCheckpoint(CHECKPOINT_KEY_TEXT, text);
+    setMemoryCheckpoint(CHECKPOINT_KEY_HASH, hash);
+    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, now);
+  } catch {
+    // Cache write failure is non-fatal — next request will regenerate.
+  }
+}

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -11,6 +11,7 @@ import { getBaseDataDir } from "../../config/env-registry.js";
 import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+import { getCachedIntro } from "./identity-intro-cache.js";
 
 interface DiskSpaceInfo {
   path: string;
@@ -234,6 +235,18 @@ export function handleGetIdentity(): Response {
 }
 
 // ---------------------------------------------------------------------------
+// Identity intro cache
+// ---------------------------------------------------------------------------
+
+export function handleGetIdentityIntro(): Response {
+  const cached = getCachedIntro();
+  if (!cached) {
+    return httpError("NOT_FOUND", "No cached identity intro available", 404);
+  }
+  return Response.json({ text: cached.text });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -248,6 +261,11 @@ export function identityRouteDefinitions(): RouteDefinition[] {
       endpoint: "identity",
       method: "GET",
       handler: () => handleGetIdentity(),
+    },
+    {
+      endpoint: "identity/intro",
+      method: "GET",
+      handler: () => handleGetIdentityIntro(),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Caches the LLM-generated identity intro text (shown on the Identity panel) for 4 hours using the existing `memory_checkpoints` table
- Cache invalidation is based on a SHA-256 hash of `USER.md`, `IDENTITY.md`, and `SOUL.md` contents — when any file changes, the cache is automatically busted
- Integrates transparently into the `/v1/btw` endpoint: cache hits skip the LLM call entirely and return cached text as SSE; cache misses proceed normally and store the result
- Adds a `GET /v1/identity/intro` endpoint for direct cache retrieval

## Test plan
- [x] 14 unit tests covering TTL expiration, content-hash invalidation for each file, round-trip caching, partial checkpoint states, and edge cases
- [x] Existing 12 btw-routes tests pass without modification
- [x] Type-check passes cleanly
- [x] Lint and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
