### PR TITLE
feat: persist identity intro in SOUL.md instead of LLM-generating on every view

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -196,6 +196,8 @@ Do it quietly. Don't tell the user which files you're editing or mention tool na
 
 When saving to `IDENTITY.md`, be specific about the tone, energy, and conversational style you discovered during onboarding. This file persists after onboarding, so everything about how you should come across needs to be captured there. Not just your name, but the full vibe: how you talk, how much energy you bring, whether you're blunt or gentle, funny or serious.
 
+When saving to `SOUL.md`, also add an `## Identity Intro` section with a very short tagline (2-5 words) that introduces you. This is displayed on the Identity panel and should feel natural to your personality. Examples: "It's [name].", "[name] here.", "[name], at your service." Write it as a single line under the heading (not a bullet list). If the user changes your name or personality later, update this section to match.
+
 ## Wrapping Up
 
 Once you've completed Phase 1 and made reasonable progress through Phase 2, you're done with onboarding. Use your best judgment on when the conversation has naturally moved past the bootstrap stage. There's no hard checklist. The goal is that the user feels set up and ready to work, not that every box is ticked.

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -12,6 +12,8 @@
  * No messages are persisted. `conversation.processing` is never set or checked.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+
 import { buildToolDefinitions } from "../../daemon/conversation-tool-setup.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../../prompts/system-prompt.js";
@@ -21,6 +23,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspacePromptPath } from "../../util/platform.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -31,6 +34,33 @@ const log = getLogger("btw-routes");
 
 /** Conversation key used by the client for identity intro generation. */
 const IDENTITY_INTRO_KEY = "identity-intro";
+
+/**
+ * Parse the `## Identity Intro` section from SOUL.md.
+ * Returns the first non-empty line under that heading, or null.
+ */
+function readSoulIdentityIntro(): string | null {
+  try {
+    const soulPath = getWorkspacePromptPath("SOUL.md");
+    if (!existsSync(soulPath)) return null;
+    const content = readFileSync(soulPath, "utf-8");
+
+    let inSection = false;
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (/^#+\s/.test(trimmed)) {
+        inSection = trimmed.toLowerCase().includes("identity intro");
+        continue;
+      }
+      if (inSection && trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  } catch {
+    // Fall through — no SOUL.md intro available
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -81,20 +111,25 @@ async function handleBtw(
     );
   }
 
-  // ----- Identity intro cache fast-path -----
-  // When the client requests the identity intro, check the cache first.
-  // If the cached text is still fresh and the identity files haven't changed,
-  // return it immediately as an SSE stream without making an LLM call.
+  // ----- Identity intro fast-path -----
+  // When the client requests the identity intro, check SOUL.md first (persisted
+  // during onboarding), then the LLM-generated cache. Only fall through to a
+  // live LLM call when neither source has a value.
   if (conversationKey === IDENTITY_INTRO_KEY) {
-    const cached = getCachedIntro();
-    if (cached) {
-      log.debug("Returning cached identity intro");
+    const soulIntro = readSoulIdentityIntro();
+    const fastText = soulIntro ?? getCachedIntro()?.text;
+    if (fastText) {
+      log.debug(
+        soulIntro
+          ? "Returning SOUL.md identity intro"
+          : "Returning cached identity intro",
+      );
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
           controller.enqueue(
             encoder.encode(
-              `event: btw_text_delta\ndata: ${JSON.stringify({ text: cached.text })}\n\n`,
+              `event: btw_text_delta\ndata: ${JSON.stringify({ text: fastText })}\n\n`,
             ),
           );
           controller.enqueue(

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -1,7 +1,7 @@
 /**
  * Caching layer for the LLM-generated identity intro text.
  *
- * The intro (a short tagline like "Velissa, your girl.") is generated via the
+ * The intro (a short identity tagline) is generated via the
  * /v1/btw endpoint and displayed on the Identity panel. To avoid redundant LLM
  * calls, we cache the result for 4 hours with content-hash-based invalidation:
  * when USER.md, IDENTITY.md, or SOUL.md change, the cache is busted.

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -238,7 +238,40 @@ export function handleGetIdentity(): Response {
 // Identity intro cache
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse the `## Identity Intro` section from SOUL.md.
+ * Returns the first non-empty line under that heading, or null.
+ */
+function readSoulIdentityIntro(): string | null {
+  try {
+    const soulPath = getWorkspacePromptPath("SOUL.md");
+    if (!existsSync(soulPath)) return null;
+    const content = readFileSync(soulPath, "utf-8");
+
+    let inSection = false;
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (/^#+\s/.test(trimmed)) {
+        inSection = trimmed.toLowerCase().includes("identity intro");
+        continue;
+      }
+      if (inSection && trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  } catch {
+    // Fall through to cache/fallback
+  }
+  return null;
+}
+
 export function handleGetIdentityIntro(): Response {
+  // Prefer SOUL.md persisted intro over LLM-generated cache
+  const soulIntro = readSoulIdentityIntro();
+  if (soulIntro) {
+    return Response.json({ text: soulIntro });
+  }
+
   const cached = getCachedIntro();
   if (!cached) {
     return httpError("NOT_FOUND", "No cached identity intro available", 404);

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -161,6 +161,30 @@ struct IdentityInfo {
         return IdentityInfo(name: name, role: role, personality: personality, emoji: emoji, home: home)
     }
 
+    /// Parses an optional `## Identity Intro` section from SOUL.md.
+    /// Returns a single short tagline or nil.
+    static func loadIdentityIntro() -> String? {
+        let path = NSHomeDirectory() + "/.vellum/workspace/SOUL.md"
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+
+        var inSection = false
+
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#") && trimmed.drop(while: { $0 == "#" }).first == " " {
+                inSection = trimmed.lowercased().contains("identity intro")
+                continue
+            }
+            if inSection {
+                // The intro is the first non-empty line in the section
+                if !trimmed.isEmpty {
+                    return trimmed
+                }
+            }
+        }
+        return nil
+    }
+
     /// Parses an optional `## Greetings` section from SOUL.md.
     /// The assistant is expected to maintain this section as part of its personality.
     static func loadGreetings() -> [String] {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -175,7 +175,12 @@ struct IdentityPanel: View {
                 }
 
                 if !isBootstrapActive && introText == nil {
-                    generateIntro()
+                    // Prefer SOUL.md intro; fall back to daemon generation
+                    if let soulIntro = IdentityInfo.loadIdentityIntro() {
+                        introText = soulIntro
+                    } else {
+                        generateIntro()
+                    }
                 }
             }
             .onDisappear { introTask?.cancel() }


### PR DESCRIPTION
## Summary

- Add `## Identity Intro` section parsing to SOUL.md (matching the existing `## Greetings` pattern) on both macOS client (`IdentityInfo.loadIdentityIntro()`) and daemon (`readSoulIdentityIntro()`)
- Update BOOTSTRAP.md to instruct the assistant to generate and save the identity intro tagline to SOUL.md during onboarding Phase 2
- Both the `/v1/btw` endpoint and `/v1/identity/intro` endpoint now check SOUL.md first, then the LLM-generated cache, then fall through to a live LLM call — so existing assistants without the section still work

## Original prompt

Generate the identity intro text during onboarding/personality setup and persist it in SOUL.md, similar to how greetings work. Then read it from SOUL.md at display time instead of making an LLM call via /v1/btw every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
