### PR TITLE
feat: skeleton loading for usage page (LUM-268)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -24,6 +24,8 @@ struct UsageDashboardPanel: View {
                     dailySection(store: store)
                     breakdownSection(store: store)
                 }
+                .frame(maxWidth: 900)
+                .frame(maxWidth: .infinity)
             }
         }
         .overlay {
@@ -88,6 +90,8 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
+        .frame(maxWidth: 900)
+        .frame(maxWidth: .infinity)
         .padding(.vertical, VSpacing.lg)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -88,8 +88,7 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
-        .padding(.top, VSpacing.lg)
-        .padding(.bottom, VSpacing.xs)
+        .padding(.vertical, VSpacing.sm)
     }
 
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -88,7 +88,8 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
-        .padding(.vertical, VSpacing.lg)
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.xs)
     }
 
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -13,7 +13,7 @@ struct UsageDashboardPanel: View {
     }
 
     var body: some View {
-        VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: VSpacing.lg, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
+        VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: 0, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
             if !allFailed {
                 timeRangeStrip(store: store)
             }
@@ -88,7 +88,7 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
-        .padding(.vertical, VSpacing.sm)
+        .padding(.vertical, VSpacing.lg)
     }
 
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -77,7 +77,20 @@ struct UsageDashboardPanel: View {
         SettingsCard(title: "Totals") {
             switch store.totalsState {
             case .idle, .loading:
-                loadingRow()
+                // Skeleton matching 2x3 stat card grid
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
+                    ForEach(0..<6, id: \.self) { _ in
+                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                            VSkeletonBone(width: 50, height: 14)
+                            VSkeletonBone(width: 90, height: 12)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(VSpacing.sm)
+                        .background(VColor.borderBase.opacity(0.15))
+                        .cornerRadius(8)
+                    }
+                }
+                .accessibilityHidden(true)
             case .loaded(let totals):
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
                     statCard(label: "Estimated Cost", value: formatCost(totals.totalEstimatedCostUsd))
@@ -88,7 +101,7 @@ struct UsageDashboardPanel: View {
                     statCard(label: "Cache Read", value: formatTokenCount(totals.totalCacheReadTokens))
                 }
             case .failed(let message):
-                errorRow(message)
+                errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
             }
         }
     }
@@ -100,7 +113,17 @@ struct UsageDashboardPanel: View {
         SettingsCard(title: "Daily Trend") {
             switch store.dailyState {
             case .idle, .loading:
-                loadingRow()
+                // Skeleton matching bar chart layout
+                HStack(alignment: .bottom, spacing: VSpacing.xs) {
+                    ForEach(0..<7, id: \.self) { index in
+                        VStack(spacing: VSpacing.xxs) {
+                            Spacer(minLength: 0)
+                            VSkeletonBone(width: maxBarWidth, height: CGFloat([40, 80, 60, 100, 50, 70, 30][index]), radius: VRadius.xs)
+                        }
+                    }
+                }
+                .frame(height: barChartHeight)
+                .accessibilityHidden(true)
             case .loaded(let daily):
                 if daily.buckets.isEmpty {
                     VEmptyState(
@@ -112,7 +135,7 @@ struct UsageDashboardPanel: View {
                     dailyBarChart(daily.buckets)
                 }
             case .failed(let message):
-                errorRow(message)
+                errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
             }
         }
     }
@@ -192,7 +215,28 @@ struct UsageDashboardPanel: View {
 
             switch store.breakdownState {
             case .idle, .loading:
-                loadingRow()
+                // Skeleton matching breakdown table rows
+                VStack(spacing: 0) {
+                    HStack(spacing: VSpacing.sm) {
+                        VSkeletonBone(width: 50, height: 12)
+                        VSkeletonBone(height: 12)
+                        VSkeletonBone(width: 50, height: 12)
+                    }
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.sm)
+                    ForEach(0..<4, id: \.self) { _ in
+                        Divider().background(VColor.borderBase)
+                        HStack(spacing: VSpacing.sm) {
+                            VSkeletonBone(width: 100, height: 14)
+                            VSkeletonBone(height: 12)
+                            VSkeletonBone(width: 50, height: 14)
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                    }
+                }
+                .frame(maxWidth: breakdownTableWidth, alignment: .leading)
+                .accessibilityHidden(true)
             case .loaded(let breakdown):
                 if breakdown.breakdown.isEmpty {
                     VEmptyState(
@@ -204,7 +248,7 @@ struct UsageDashboardPanel: View {
                     breakdownTable(breakdown.breakdown)
                 }
             case .failed(let message):
-                errorRow(message)
+                errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
             }
         }
     }
@@ -298,26 +342,20 @@ struct UsageDashboardPanel: View {
     }
 
     @ViewBuilder
-    private func loadingRow() -> some View {
-        HStack {
-            ProgressView()
-                .controlSize(.small)
-            Text("Loading...")
-                .font(VFont.small)
-                .foregroundColor(VColor.contentTertiary)
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, VSpacing.md)
-    }
-
-    @ViewBuilder
-    private func errorRow(_ message: String) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            VIconView(.triangleAlert, size: 14)
-                .foregroundColor(VColor.systemNegativeHover)
-            Text(message)
-                .font(VFont.small)
-                .foregroundColor(VColor.contentTertiary)
+    private func errorRow(_ message: String, retryAction: (() -> Void)? = nil) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                VIconView(.triangleAlert, size: 14)
+                    .foregroundColor(VColor.systemNegativeHover)
+                Text(message)
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            if let retryAction {
+                VButton(label: "Try Again", style: .outlined) {
+                    retryAction()
+                }
+            }
         }
         .padding(.vertical, VSpacing.sm)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -73,22 +73,23 @@ struct UsageDashboardPanel: View {
     @ViewBuilder
     func contentView(store: UsageDashboardStore) -> some View {
         if allFailed {
-            VStack(spacing: VSpacing.lg) {
-                VIconView(.circleAlert, size: 32)
-                    .foregroundColor(VColor.systemNegativeHover)
-                Text("Unable to load usage data")
-                    .font(VFont.headline)
-                    .foregroundColor(VColor.contentDefault)
-                Text("Please check your connection and try again.")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
-                VButton(label: "Try Again", style: .outlined) {
-                    refreshTask?.cancel()
-                    refreshTask = Task { await store.refresh() }
+            GeometryReader { geo in
+                VStack(spacing: VSpacing.lg) {
+                    VIconView(.circleAlert, size: 32)
+                        .foregroundColor(VColor.systemNegativeHover)
+                    Text("Unable to load usage data")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Please check your connection and try again.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    VButton(label: "Try Again", style: .outlined) {
+                        refreshTask?.cancel()
+                        refreshTask = Task { await store.refresh() }
+                    }
                 }
+                .frame(width: geo.size.width, height: geo.size.height)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.vertical, VSpacing.xxxl)
         } else {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 totalsSection(store: store)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -8,9 +8,15 @@ struct UsageDashboardPanel: View {
     @State private var refreshTask: Task<Void, Never>?
     @State private var breakdownTask: Task<Void, Never>?
 
+    private var allFailed: Bool {
+        store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
+    }
+
     var body: some View {
         VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: VSpacing.lg, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
-            timeRangeStrip(store: store)
+            if !allFailed {
+                timeRangeStrip(store: store)
+            }
         }) {
             contentView(store: store)
         }
@@ -66,8 +72,6 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     func contentView(store: UsageDashboardStore) -> some View {
-        let allFailed = store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
-
         if allFailed {
             VStack(spacing: VSpacing.lg) {
                 VIconView(.circleAlert, size: 32)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -88,8 +88,7 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
-        .padding(.top, VSpacing.md)
-        .padding(.bottom, VSpacing.sm)
+        .padding(.vertical, VSpacing.lg)
     }
 
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -66,10 +66,31 @@ struct UsageDashboardPanel: View {
 
     @ViewBuilder
     func contentView(store: UsageDashboardStore) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            totalsSection(store: store)
-            dailySection(store: store)
-            breakdownSection(store: store)
+        let allFailed = store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
+
+        if allFailed {
+            VStack(spacing: VSpacing.lg) {
+                VIconView(.circleAlert, size: 32)
+                    .foregroundColor(VColor.systemNegativeHover)
+                Text("Unable to load usage data")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.contentDefault)
+                Text("Please check your connection and try again.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                VButton(label: "Try Again", style: .outlined) {
+                    refreshTask?.cancel()
+                    refreshTask = Task { await store.refresh() }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.vertical, VSpacing.xxxl)
+        } else {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                totalsSection(store: store)
+                dailySection(store: store)
+                breakdownSection(store: store)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -14,9 +14,7 @@ struct UsageDashboardPanel: View {
 
     var body: some View {
         VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: 0, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
-            if !allFailed {
-                timeRangeStrip(store: store)
-            }
+            timeRangeStrip(store: store)
         }) {
             if !allFailed {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -18,7 +18,31 @@ struct UsageDashboardPanel: View {
                 timeRangeStrip(store: store)
             }
         }) {
-            contentView(store: store)
+            if !allFailed {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    totalsSection(store: store)
+                    dailySection(store: store)
+                    breakdownSection(store: store)
+                }
+            }
+        }
+        .overlay {
+            if allFailed {
+                VStack(spacing: VSpacing.lg) {
+                    VIconView(.circleAlert, size: 32)
+                        .foregroundColor(VColor.systemNegativeHover)
+                    Text("Unable to load usage data")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Please check your connection and try again.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    VButton(label: "Try Again", style: .outlined) {
+                        refreshTask?.cancel()
+                        refreshTask = Task { await store.refresh() }
+                    }
+                }
+            }
         }
         .onAppear {
             refreshTask = Task {
@@ -68,36 +92,7 @@ struct UsageDashboardPanel: View {
         .padding(.bottom, VSpacing.sm)
     }
 
-    // MARK: - Content
 
-    @ViewBuilder
-    func contentView(store: UsageDashboardStore) -> some View {
-        if allFailed {
-            GeometryReader { geo in
-                VStack(spacing: VSpacing.lg) {
-                    VIconView(.circleAlert, size: 32)
-                        .foregroundColor(VColor.systemNegativeHover)
-                    Text("Unable to load usage data")
-                        .font(VFont.headline)
-                        .foregroundColor(VColor.contentDefault)
-                    Text("Please check your connection and try again.")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    VButton(label: "Try Again", style: .outlined) {
-                        refreshTask?.cancel()
-                        refreshTask = Task { await store.refresh() }
-                    }
-                }
-                .frame(width: geo.size.width, height: geo.size.height)
-            }
-        } else {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                totalsSection(store: store)
-                dailySection(store: store)
-                breakdownSection(store: store)
-            }
-        }
-    }
 
     // MARK: - Totals Section
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -20,7 +20,10 @@ struct UsageDashboardPanel: View {
             }
         }
         .onChange(of: store.needsRefresh) {
-            if store.needsRefresh {
+            // Only auto-refresh for idle states, not failed — failed states
+            // have retry buttons and shouldn't trigger an automatic retry loop.
+            let hasIdle = store.totalsState == .idle || store.dailyState == .idle || store.breakdownState == .idle
+            if hasIdle {
                 refreshTask?.cancel()
                 refreshTask = Task {
                     await store.refresh()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -64,8 +64,8 @@ struct UsageDashboardPanel: View {
             .frame(width: 160)
             Spacer()
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.sm)
+        .padding(.top, VSpacing.md)
+        .padding(.bottom, VSpacing.sm)
     }
 
     // MARK: - Content

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -17,7 +17,9 @@ struct SettingsBillingTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             balanceCard
-            if summary != nil {
+            if isLoading {
+                addFundsSkeleton
+            } else if summary != nil {
                 addFundsCard
             }
         }
@@ -39,13 +41,28 @@ struct SettingsBillingTab: View {
     private var balanceCard: some View {
         SettingsCard(title: "Balance") {
             if isLoading {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Loading billing info...")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    // Effective balance skeleton
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        VSkeletonBone(width: 110, height: 12)
+                        VSkeletonBone(width: 80, height: 24)
+                    }
+
+                    SettingsDivider()
+
+                    // Two-column breakdown skeleton
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            VSkeletonBone(width: 100, height: 12)
+                            VSkeletonBone(width: 60, height: 14)
+                        }
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            VSkeletonBone(width: 110, height: 12)
+                            VSkeletonBone(width: 60, height: 14)
+                        }
+                    }
                 }
+                .accessibilityHidden(true)
             } else if let summary {
                 balanceContent(summary)
             } else if let error {
@@ -111,6 +128,21 @@ struct SettingsBillingTab: View {
                         .foregroundColor(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
             }
+        }
+    }
+
+    // MARK: - Add Funds Skeleton
+
+    private var addFundsSkeleton: some View {
+        SettingsCard(title: "Add Funds") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VSkeletonBone(width: 90, height: 12)
+                    VSkeletonBone(height: 28, radius: VRadius.md)
+                }
+                VSkeletonBone(width: 80, height: 28, radius: VRadius.md)
+            }
+            .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -211,7 +211,10 @@ struct SettingsBillingTab: View {
     // MARK: - Actions
 
     private func loadSummary() async {
-        isLoading = true
+        // Only show skeleton on initial load — don't flash on background refreshes
+        if summary == nil {
+            isLoading = true
+        }
         error = nil
         do {
             var result = try await BillingService.shared.getBillingSummary()
@@ -220,7 +223,10 @@ struct SettingsBillingTab: View {
             }
             summary = result
         } catch {
-            self.error = "Unable to load billing information. Please try again."
+            // Only show error if we have no cached data to display
+            if summary == nil {
+                self.error = "Unable to load billing information. Please try again."
+            }
         }
         isLoading = false
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -66,12 +66,17 @@ struct SettingsBillingTab: View {
             } else if let summary {
                 balanceContent(summary)
             } else if let error {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.circleAlert, size: 14)
-                        .foregroundColor(VColor.systemNegativeStrong)
-                    Text(error)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.circleAlert, size: 14)
+                            .foregroundColor(VColor.systemNegativeStrong)
+                        Text(error)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.systemNegativeStrong)
+                    }
+                    VButton(label: "Try Again", style: .outlined) {
+                        Task { await loadSummary() }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replaced `ProgressView` spinner in the Balance card with `VSkeletonBone` placeholders that mirror the loaded layout (effective balance, divider, two-column breakdown)
- Added a skeleton state for the Add Funds card so the full page layout is visible during loading instead of only appearing after data arrives
- All skeleton containers have `.accessibilityHidden(true)`

## Test plan
- [ ] Open Settings > Billing while signed in — verify shimmer skeleton appears briefly then real content loads
- [ ] Simulate slow network — verify the skeleton layout matches the loaded content dimensions
- [ ] VoiceOver: confirm skeleton bones are hidden from accessibility tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
