### PR TITLE
fix: remove Home path from IDENTITY.md template

### DIFF
--- a/assistant/src/prompts/templates/IDENTITY.md
+++ b/assistant/src/prompts/templates/IDENTITY.md
@@ -2,13 +2,12 @@ _ Lines starting with _ are comments - they won't appear in the system prompt
 
 # IDENTITY.md
 
-This file is yours. Add sections, restructure it, make it reflect who you are. Name, Emoji, Role, Personality, and Home are parsed by the app - keep their `- **Label:**` format. Everything else is freeform.
+This file is yours. Add sections, restructure it, make it reflect who you are. Name, Emoji, Role, Personality are parsed by the app - keep their `- **Label:**` format. Everything else is freeform.
 
 - **Name:** _(not yet chosen)_
 - **Emoji:** _(not yet chosen)_
 - **Nature:** _(not yet established)_
 - **Personality:** _(not yet established)_
 - **Role:** _(not yet established)_
-- **Home:** Local (~/.vellum/workspace)
 
 ## Avatar


### PR DESCRIPTION
## Summary
- Remove the `- **Home:** Local (~/.vellum/workspace)` line from the IDENTITY.md template
- This line leaked an absolute workspace path into the system prompt, causing the model to use full absolute paths in bash commands (e.g. `rm /Users/.../BOOTSTRAP.md`), which triggered HIGH risk classification and unnecessary permission prompts
- The Home field was never parsed by any code — the multi-environment routing it was designed for was never implemented

## Original prompt
Remove the `Home: Local (~/.vellum/workspace)` line from the IDENTITY.md template. This line leaks an absolute path into the system prompt, which causes the model to use full absolute paths in bash commands (like `rm /Users/.../BOOTSTRAP.md`), triggering unnecessary permission prompts in the risk classifier. The Home field isn't parsed by any code despite the header comment claiming it is. The change has already been made to `assistant/src/prompts/templates/IDENTITY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
