### PR TITLE
fix: don't auto-accept suggestion when pressing Enter to send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -383,14 +383,9 @@ struct ComposerView: View {
 
     /// Shared send logic used by `.onSubmit` (native Return-to-send) and the
     /// AppKit `ComposerFocusBridge` Cmd+Enter interception. Keeps slash-menu
-    /// selection, ghost-text acceptance, and pending-confirmation approval
-    /// all working regardless of how "send" is triggered.
+    /// selection and pending-confirmation approval working regardless of how
+    /// "send" is triggered.
     private func performSendAction() {
-        // Do not mutate inputText before onSend(). The ViewModel already trims
-        // whitespace, and mutating here races with the ViewModel's clearing of
-        // inputText — the TextField's internal buffer can write stale text back
-        // through the binding, preventing the composer from clearing.
-        if ghostSuffix != nil { onAcceptSuggestion() }
         if showSlashMenu {
             handleSlashNavigation(.select)
         } else if canSend {


### PR DESCRIPTION
## Summary
- Remove auto-accept of ghost suggestion text in `performSendAction()`
- Suggestions are now only accepted via explicit Tab press
- Fixes bug where sending an image with Enter would include unintended suggestion text

Part of plan: fix-send-autosuggestion.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
