### PR TITLE
fix: update stale ghost-text comment in ComposerBridge.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -125,7 +125,7 @@ struct ComposerFocusBridge: NSViewRepresentable {
                 // Cmd+Enter send when the preference is enabled.
                 // Plain Enter flows through to SwiftUI's .onSubmit which
                 // calls performSendAction() — the canonical send path that
-                // handles slash-menu, ghost-text, and pending-confirmation.
+                // handles slash-menu selection and pending-confirmation.
                 let isReturn = event.keyCode == 36 || event.keyCode == 76
                 if isReturn {
                     let action = ComposerReturnKeyRouting.resolve(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-send-autosuggestion.md.

**Gap:** Stale ghost-text comment in ComposerBridge.swift
**What was expected:** Comment should not mention ghost-text since that behavior was removed from performSendAction()
**What was found:** Line 128 still says 'handles slash-menu, ghost-text, and pending-confirmation'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
