### PR TITLE
fix: rename `ok` to `success` in simulate-permission response to match client schema

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -522,7 +522,7 @@ async function handleToolPermissionSimulate(body: {
     }
 
     return Response.json({
-      ok: true,
+      success: true,
       decision: result.decision,
       riskLevel,
       reason: result.reason,


### PR DESCRIPTION
## Summary
- Fix Permission Simulator decode error by renaming `ok: true` to `success: true` in the daemon's simulate-permission response to match the Swift `ToolPermissionSimulateResponse` schema

Part of plan: fix-permission-sim-decode.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
