### PR TITLE
fix: improve file_read error for out-of-bounds paths to suggest host_file_read

### DIFF
--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -177,3 +177,43 @@ describe("file_read image support", () => {
     expect(result.content).toContain("outside the working directory");
   });
 });
+
+// ── Out-of-bounds hint for host_file_read ─────────────────────────────
+
+describe("file_read out-of-bounds hint", () => {
+  test("suggests host_file_read for out-of-bounds text file path", async () => {
+    const dir = makeTempDir();
+
+    const result = await fileReadTool.execute(
+      { path: "/etc/passwd" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("host_file_read");
+  });
+
+  test("suggests host_file_read for out-of-bounds image file path", async () => {
+    const dir = makeTempDir();
+
+    const result = await fileReadTool.execute(
+      { path: "/Users/someone/Desktop/screenshot.png" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("host_file_read");
+  });
+
+  test("does not suggest host_file_read for missing file within sandbox", async () => {
+    const dir = makeTempDir();
+
+    const result = await fileReadTool.execute(
+      { path: "nonexistent.txt" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("host_file_read");
+  });
+});

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -61,7 +61,10 @@ class FileReadTool implements Tool {
     if (IMAGE_EXTENSIONS.has(ext)) {
       const pathCheck = sandboxPolicy(rawPath, context.workingDir);
       if (!pathCheck.ok) {
-        return { content: `Error: ${pathCheck.error}`, isError: true };
+        return {
+          content: `Error: ${pathCheck.error}. To read files outside the workspace, use the host_file_read tool instead.`,
+          isError: true,
+        };
       }
       return readImageFile(pathCheck.resolved);
     }
@@ -89,8 +92,16 @@ class FileReadTool implements Tool {
             content: `Error reading file "${rawPath}": ${error.message}`,
             isError: true,
           };
-        default:
-          return { content: `Error: ${error.message}`, isError: true };
+        default: {
+          const hint =
+            error.code === "PATH_OUT_OF_BOUNDS"
+              ? ". To read files outside the workspace, use the host_file_read tool instead."
+              : "";
+          return {
+            content: `Error: ${error.message}${hint}`,
+            isError: true,
+          };
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Add hint to file_read error messages for out-of-bounds paths suggesting host_file_read
- Applies to both image paths and text file paths that are outside the workspace
- Add test verifying the hint appears in the error message

Part of plan: smooth-image-access.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
