### PR TITLE
feat: add image file support to host_file_read tool

### DIFF
--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -8,6 +8,12 @@ import type { ToolContext } from "../tools/types.js";
 
 const testDirs: string[] = [];
 
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "host-file-read-test-"));
+  testDirs.push(dir);
+  return dir;
+}
+
 function makeContext(): ToolContext {
   return {
     workingDir: "/tmp",
@@ -21,6 +27,18 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// Minimal valid JPEG: FF D8 FF E0 header
+const JPEG_HEADER = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01,
+  0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+]);
+
+// Minimal PNG header
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52,
+]);
 
 describe("host_file_read tool", () => {
   test("rejects relative paths", async () => {
@@ -143,5 +161,74 @@ describe("host_file_read tool", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("symlink-content");
+  });
+});
+
+describe("host_file_read image support", () => {
+  test("returns image content block for .png file", async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "screenshot.png");
+    writeFileSync(filePath, PNG_HEADER);
+
+    const result = await hostFileReadTool.execute(
+      { path: filePath },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Image loaded");
+    expect(result.content).toContain("image/png");
+    expect((result as any).contentBlocks).toBeDefined();
+    expect((result as any).contentBlocks[0].type).toBe("image");
+    expect((result as any).contentBlocks[0].source.media_type).toBe(
+      "image/png",
+    );
+  });
+
+  test("returns correct media type for .jpg file", async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "photo.jpg");
+    writeFileSync(filePath, JPEG_HEADER);
+
+    const result = await hostFileReadTool.execute(
+      { path: filePath },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Image loaded");
+    expect(result.content).toContain("image/jpeg");
+    expect((result as any).contentBlocks).toBeDefined();
+    expect((result as any).contentBlocks[0].type).toBe("image");
+    expect((result as any).contentBlocks[0].source.media_type).toBe(
+      "image/jpeg",
+    );
+  });
+
+  test("returns error for non-existent image path", async () => {
+    const filePath = join(tmpdir(), `host-file-read-missing-${Date.now()}.png`);
+    const result = await hostFileReadTool.execute(
+      { path: filePath },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("file not found");
+  });
+
+  test("text file still works as before (regression)", async () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "notes.txt");
+    writeFileSync(filePath, "hello world\nsecond line\n");
+
+    const result = await hostFileReadTool.execute(
+      { path: filePath },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("1  hello world");
+    expect(result.content).toContain("2  second line");
+    expect((result as any).contentBlocks).toBeUndefined();
   });
 });

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,13 +1,19 @@
+import { extname } from "node:path";
+
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
+import {
+  IMAGE_EXTENSIONS,
+  readImageFile,
+} from "../shared/filesystem/image-read.js";
 import { hostPolicy } from "../shared/filesystem/path-policy.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 class HostFileReadTool implements Tool {
   name = "host_file_read";
   description =
-    "Read the contents of a file on the host filesystem. Not for workspace files under .vellum (use file_read instead).";
+    "Read the contents of a file on the host filesystem, including images (JPEG, PNG, GIF, WebP). Not for workspace files under .vellum (use file_read instead).";
   category = "host-filesystem";
   defaultRiskLevel = RiskLevel.Medium;
 
@@ -61,6 +67,16 @@ class HostFileReadTool implements Tool {
         context.conversationId,
         context.signal,
       );
+    }
+
+    // For image files, delegate to the shared image reader.
+    const ext = extname(rawPath).toLowerCase();
+    if (IMAGE_EXTENSIONS.has(ext)) {
+      const pathCheck = hostPolicy(rawPath);
+      if (!pathCheck.ok) {
+        return { content: `Error: ${pathCheck.error}`, isError: true };
+      }
+      return readImageFile(pathCheck.resolved);
     }
 
     const ops = new FileSystemOps(hostPolicy);


### PR DESCRIPTION
## Summary
- Add image detection (PNG, JPEG, GIF, WebP) to host_file_read tool using shared readImageFile helper
- Update tool description to mention image support so the LLM knows to use it
- Add tests for image reading, non-existent image paths, and text file regression

Part of plan: smooth-image-access.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
