### PR TITLE
fix: remove unused daemonClient capture in snapshot closure

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -931,7 +931,7 @@ struct DynamicWorkspaceWrapper: View {
                         onPageChanged: { [weak viewModel] page in
                             viewModel?.currentPage = page
                         },
-                        onSnapshotCaptured: data.appId != nil ? { [weak daemonClient] base64 in
+                        onSnapshotCaptured: data.appId != nil ? { base64 in
                             guard let appId = data.appId else { return }
                             Task { await AppsClient().updateAppPreview(appId: appId, preview: base64) }
                             NotificationCenter.default.post(


### PR DESCRIPTION
## Summary
- Remove unused `[weak daemonClient]` capture list from the `onSnapshotCaptured` closure in `PanelCoordinator.swift`, eliminating the "variable was written to, but never read" build warning

## Original prompt
Fix build warning: `variable 'daemonClient' was written to, but never read` at PanelCoordinator.swift:934

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
