### PR TITLE
fix(macos): re-establish broadcast subscribers after auto-wake reconnect

### DIFF
--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -33,6 +33,7 @@ public final class ContactsStore: ObservableObject {
     private let contactClient: ContactClientProtocol
     private var contactsChangedTask: Task<Void, Never>?
     private var subscriptionTask: Task<Void, Never>?
+    private var reconnectObserver: NSObjectProtocol?
 
     // MARK: - Init
 
@@ -40,11 +41,23 @@ public final class ContactsStore: ObservableObject {
         self.daemonClient = daemonClient
         self.contactClient = contactClient
         subscribeToContactsChanged()
+        reconnectObserver = NotificationCenter.default.addObserver(
+            forName: .daemonDidReconnect,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.subscribeToContactsChanged()
+            }
+        }
     }
 
     deinit {
         subscriptionTask?.cancel()
         contactsChangedTask?.cancel()
+        if let reconnectObserver {
+            NotificationCenter.default.removeObserver(reconnectObserver)
+        }
     }
 
     // MARK: - Actions
@@ -108,6 +121,7 @@ public final class ContactsStore: ObservableObject {
 
     /// Subscribe to contactsChanged broadcasts with 500ms debounce.
     private func subscribeToContactsChanged() {
+        subscriptionTask?.cancel()
         subscriptionTask = Task { [weak self] in
             guard let daemonClient = self?.daemonClient else { return }
             let stream = daemonClient.subscribe()

--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -26,6 +26,7 @@ public final class DirectoryStore: ObservableObject {
     private weak var daemonClient: DaemonClient?
     private var appFilesChangedTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
+    private var reconnectObserver: NSObjectProtocol?
 
     // MARK: - Init
 
@@ -34,11 +35,23 @@ public final class DirectoryStore: ObservableObject {
         self.documentClient = documentClient
         self.daemonClient = daemonClient
         subscribeToAppFilesChanged()
+        reconnectObserver = NotificationCenter.default.addObserver(
+            forName: .daemonDidReconnect,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.subscribeToAppFilesChanged()
+            }
+        }
     }
 
     deinit {
         appFilesChangedTask?.cancel()
         debounceTask?.cancel()
+        if let reconnectObserver {
+            NotificationCenter.default.removeObserver(reconnectObserver)
+        }
     }
 
     // MARK: - Local Apps
@@ -160,6 +173,7 @@ public final class DirectoryStore: ObservableObject {
 
     /// Subscribe to appFilesChanged broadcasts with debounce, then refresh local apps.
     private func subscribeToAppFilesChanged() {
+        appFilesChangedTask?.cancel()
         appFilesChangedTask = Task { [weak self] in
             guard let daemonClient = self?.daemonClient else { return }
             let stream = daemonClient.subscribe()


### PR DESCRIPTION
## Summary
- After auto-wake reconnect, background broadcast subscribers (ContactsStore, DirectoryStore) silently die because `connect()` calls `disconnectInternal()` which finishes and clears all subscriber continuations
- Fix adds `daemonDidReconnect` observers to both stores so they re-subscribe after reconnect
- Cancels old subscription tasks before creating new ones to prevent duplicates

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/18655

## Test plan
- [ ] Verify ContactsStore re-subscribes after daemon crash + auto-wake
- [ ] Verify DirectoryStore re-subscribes after daemon crash + auto-wake
- [ ] Verify no duplicate subscriptions are created
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
