### PR TITLE
fix: add pricing catalog entries for gpt-5.x and gemini-3 models

### DIFF
--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -24,6 +24,9 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     "claude-haiku-4": { inputPer1M: 0.8, outputPer1M: 4 },
   },
   openai: {
+    "gpt-5.4": { inputPer1M: 2.5, outputPer1M: 15 },
+    "gpt-5.4-nano": { inputPer1M: 0.2, outputPer1M: 1.25 },
+    "gpt-5.2": { inputPer1M: 1.75, outputPer1M: 14 },
     "gpt-4o": { inputPer1M: 2.5, outputPer1M: 10 },
     "gpt-4o-mini": { inputPer1M: 0.15, outputPer1M: 0.6 },
     "gpt-4.1": { inputPer1M: 2.0, outputPer1M: 8.0 },
@@ -35,6 +38,7 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
     "o4-mini": { inputPer1M: 1.1, outputPer1M: 4.4 },
   },
   gemini: {
+    "gemini-3-flash": { inputPer1M: 0.5, outputPer1M: 3 },
     "gemini-2.5-pro": { inputPer1M: 1.25, outputPer1M: 10 },
     "gemini-2.5-flash": { inputPer1M: 0.15, outputPer1M: 0.6 },
     "gemini-2.0-flash": { inputPer1M: 0.1, outputPer1M: 0.4 },


### PR DESCRIPTION
## Summary
- Add pricing entries for gpt-5.4 ($2.50/$15 per 1M tokens), gpt-5.4-nano ($0.20/$1.25), gpt-5.2 ($1.75/$14)
- Add pricing entry for gemini-3-flash ($0.50/$3.00 per 1M tokens)
- These models were missing from PROVIDER_PRICING, causing them to resolve as 'unpriced'

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/18671

## Test plan
- [ ] Verify gpt-5.4, gpt-5.4-nano, gpt-5.2 resolve to correct pricing
- [ ] Verify gemini-3-flash resolves to correct pricing
- [ ] Verify existing model pricing is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
