### PR TITLE
fix(macos): prevent auto-wake task self-cancellation during reconnect

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -168,6 +168,10 @@ extension DaemonClient {
                     return
                 }
                 log.info("auto-wake: wake succeeded, reconnecting")
+                // Nil out autoWakeTask before connect() so that
+                // disconnectInternal() (called inside connect()) doesn't
+                // cancel this running task via cooperative cancellation.
+                self.autoWakeTask = nil
                 try await self.connect()
                 guard !Task.isCancelled else {
                     log.info("auto-wake: cancelled after connect — abandoning")


### PR DESCRIPTION
## Summary
- Auto-wake task cancels itself when `connect()` calls `disconnectInternal()` which cancels the in-flight `autoWakeTask`
- Fix nils out `autoWakeTask` before calling `connect()` so `disconnectInternal()` doesn't cancel the running task

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/18676

## Test plan
- [ ] Verify auto-wake reconnect succeeds reliably (no race-dependent failures)
- [ ] Verify intentional disconnect still cancels auto-wake task
- [ ] Verify reconfigure still cancels auto-wake task
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
