### PR TITLE
fix: restore contentView method broken by usage skeleton PR

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -17,13 +17,7 @@ struct UsageDashboardPanel: View {
             timeRangeStrip(store: store)
         }) {
             if !allFailed {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    totalsSection(store: store)
-                    dailySection(store: store)
-                    breakdownSection(store: store)
-                }
-                .frame(maxWidth: 900)
-                .frame(maxWidth: .infinity)
+                contentView(store: store)
             }
         }
         .overlay {
@@ -91,6 +85,19 @@ struct UsageDashboardPanel: View {
         .frame(maxWidth: 900)
         .frame(maxWidth: .infinity)
         .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    func contentView(store: UsageDashboardStore) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            totalsSection(store: store)
+            dailySection(store: store)
+            breakdownSection(store: store)
+        }
+        .frame(maxWidth: 900)
+        .frame(maxWidth: .infinity)
     }
 
 


### PR DESCRIPTION
## Summary
- Restore `contentView(store:)` method on `UsageDashboardPanel` that was removed during the skeleton loading refactor
- Tests at `UsageDashboardPanelTests.swift:230` reference this method to inspect panel content

## Original prompt
--safe fix https://github.com/vellum-ai/vellum-assistant/actions/runs/23224106338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
