### PR TITLE
feat: preserve image file path on ChatAttachment and send to daemon

### DIFF
--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -236,7 +236,8 @@ public final class ChatAttachmentManager: ObservableObject {
                 data: base64,
                 thumbnailData: thumbnail,
                 dataLength: base64.count,
-                thumbnailImage: thumbnailImage
+                thumbnailImage: thumbnailImage,
+                filePath: url.path
             )
             return .success(attachment)
         }.value

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1154,7 +1154,7 @@ public final class ChatViewModel: ObservableObject {
                 pendingUserMessageDisplayText = rawText
                 pendingUserMessageAutomated = hidden
                 pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
-                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
                 }
                 isThinking = true
                 var userMsg = ChatMessage(role: .user, text: rawText, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments)
@@ -1235,7 +1235,7 @@ public final class ChatViewModel: ObservableObject {
         flushCoalescedPublish()
 
         let messageAttachments: [UserMessageAttachment]? = attachments.isEmpty ? nil : attachments.map {
-            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
         }
 
         // Track the user text for this turn so assistantTextDelta can tag the

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1012,11 +1012,14 @@ public final class HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "filename": attachment.filename,
             "mimeType": attachment.mimeType,
             "data": attachment.data
         ]
+        if let filePath = attachment.filePath {
+            body["filePath"] = filePath
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)


### PR DESCRIPTION
## Summary
- Preserve `filePath` on `ChatAttachment` when created from a file URL in `ChatAttachmentManager.loadAttachment(url:)`
- Include `filePath` in all `ChatAttachment` → `UserMessageAttachment` conversion sites in `ChatViewModel`
- Send `filePath` in the `POST /v1/attachments` upload request body when available

Part of plan: img-filepath-context.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
