### PR TITLE
feat: accept and store source_path on attachment uploads

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -49,6 +49,7 @@ export interface VoiceBridgeDeps {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
   deriveDefaultStrictSideEffects: (conversationId: string) => boolean;
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -532,13 +532,20 @@ export async function runDaemon(): Promise<void> {
         getOrCreateConversation: (conversationId) =>
           server.getConversationForMessages(conversationId),
         assistantEventHub,
-        resolveAttachments: (attachmentIds) =>
-          attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
+        resolveAttachments: (attachmentIds) => {
+          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const sourcePaths =
+            attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+          return resolved.map((a) => ({
             id: a.id,
             filename: a.originalFilename,
             mimeType: a.mimeType,
             data: a.dataBase64,
-          })),
+            ...(sourcePaths.has(a.id)
+              ? { filePath: sourcePaths.get(a.id) }
+              : {}),
+          }));
+        },
       },
       findConversation: (conversationId) =>
         server.findConversation(conversationId),
@@ -623,13 +630,18 @@ export async function runDaemon(): Promise<void> {
     setVoiceBridgeDeps({
       getOrCreateConversation: (conversationId, _transport) =>
         server.getConversationForMessages(conversationId),
-      resolveAttachments: (attachmentIds) =>
-        attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
+      resolveAttachments: (attachmentIds) => {
+        const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+        const sourcePaths =
+          attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+        return resolved.map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
           data: a.dataBase64,
-        })),
+          ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
+        }));
+      },
       deriveDefaultStrictSideEffects: (conversationId) => {
         const conversationType = getConversationType(conversationId);
         return conversationType === "private";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -878,6 +878,7 @@ export class DaemonServer {
       filename: string;
       mimeType: string;
       data: string;
+      filePath?: string;
     }[];
   }> {
     const ingressCheck = checkIngressForSecrets(content);
@@ -960,12 +961,20 @@ export class DaemonServer {
     });
 
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          data: a.dataBase64,
-        }))
+      ? (() => {
+          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const sourcePaths =
+            attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+          return resolved.map((a) => ({
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            data: a.dataBase64,
+            ...(sourcePaths.has(a.id)
+              ? { filePath: sourcePaths.get(a.id) }
+              : {}),
+          }));
+        })()
       : [];
 
     return { conversation, attachments };

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -280,6 +280,37 @@ export function getFilePathForAttachment(attachmentId: string): string | null {
 }
 
 /**
+ * Returns the source_path (original file path on disk) for an attachment, or null if not set.
+ * Uses raw SQL since source_path is added via DB migration and is not in the Drizzle schema.
+ */
+export function getSourcePathForAttachment(
+  attachmentId: string,
+): string | null {
+  const row = rawGet<{ source_path: string | null }>(
+    "SELECT source_path FROM attachments WHERE id = ?",
+    attachmentId,
+  );
+  return row?.source_path ?? null;
+}
+
+/**
+ * Batch-fetch source_path values for multiple attachment IDs in a single query.
+ * Returns a Map of attachment ID → source_path for attachments that have a non-null source_path.
+ * Uses raw SQL since source_path is added via runtime migration and is not in the Drizzle schema.
+ */
+export function getSourcePathsForAttachments(
+  attachmentIds: string[],
+): Map<string, string> {
+  if (attachmentIds.length === 0) return new Map();
+  const placeholders = attachmentIds.map(() => "?").join(", ");
+  const rows = rawAll<{ id: string; source_path: string }>(
+    `SELECT id, source_path FROM attachments WHERE id IN (${placeholders}) AND source_path IS NOT NULL`,
+    ...attachmentIds,
+  );
+  return new Map(rows.map((r) => [r.id, r.source_path]));
+}
+
+/**
  * Batch-fetch file_path values for multiple attachment IDs in a single query.
  * Returns a Set of attachment IDs that are file-backed (have a non-null file_path).
  * Uses raw SQL since file_path is added via runtime migration and is not in the Drizzle schema.
@@ -334,6 +365,7 @@ export function uploadAttachment(
   filename: string,
   mimeType: string,
   dataBase64: string,
+  sourcePath?: string,
 ): StoredAttachment {
   if (!isValidBase64(dataBase64)) {
     throw new AttachmentUploadError("Invalid base64 encoding");
@@ -395,6 +427,14 @@ export function uploadAttachment(
   };
 
   db.insert(attachments).values(record).run();
+
+  if (sourcePath) {
+    rawRun(
+      `UPDATE attachments SET source_path = ? WHERE id = ?`,
+      sourcePath,
+      record.id,
+    );
+  }
 
   return {
     id: record.id,

--- a/assistant/src/memory/migrations/102-alter-table-columns.ts
+++ b/assistant/src/memory/migrations/102-alter-table-columns.ts
@@ -261,6 +261,11 @@ export function addCoreColumns(database: DrizzleDb): void {
   } catch {
     /* already exists */
   }
+  try {
+    database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN source_path TEXT`);
+  } catch {
+    /* already exists */
+  }
 
   // cron_jobs
   try {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -157,6 +157,7 @@ export interface SendMessageDeps {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
 }
 

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -29,9 +29,10 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
     filename?: string;
     mimeType?: string;
     data?: string;
+    filePath?: string;
   };
 
-  const { filename, mimeType, data } = body;
+  const { filename, mimeType, data, filePath } = body;
 
   if (!filename || typeof filename !== "string") {
     return httpError("BAD_REQUEST", "filename is required", 400);
@@ -52,7 +53,12 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
 
   let attachment: attachmentsStore.StoredAttachment;
   try {
-    attachment = attachmentsStore.uploadAttachment(filename, mimeType, data);
+    attachment = attachmentsStore.uploadAttachment(
+      filename,
+      mimeType,
+      data,
+      filePath ?? undefined,
+    );
   } catch (err) {
     if (err instanceof AttachmentUploadError) {
       const status = err.message.startsWith("Attachment too large") ? 413 : 400;


### PR DESCRIPTION
## Summary
- Add `source_path` column to the `attachments` table via idempotent migration
- Accept optional `filePath` in `POST /v1/attachments` and store as `source_path`
- Add `getSourcePathForAttachment()` and `getSourcePathsForAttachments()` accessors
- Include `filePath` in `resolveAttachments()` return and `prepareConversationForMessage()`

Part of plan: img-filepath-context.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
