### PR TITLE
fix(macos): preserve external cancellation handle for auto-wake task

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -12,8 +12,20 @@ extension DaemonClient {
     /// Connect to the daemon via HTTP transport. If already connected, disconnects first.
     /// SSE is managed separately via `startSSE()` / `stopSSE()`.
     public func connect() async throws {
+        try await connectImpl(cancelAutoWake: true)
+    }
+
+    /// Internal connect implementation.
+    ///
+    /// - Parameter cancelAutoWake: When `false`, the initial `disconnectInternal()`
+    ///   call preserves the `autoWakeTask` handle so that an *external*
+    ///   `disconnect()` / `reconfigure()` arriving while `connect()` is in-flight
+    ///   can still cancel the auto-wake task. The auto-wake reconnect path passes
+    ///   `false` here to avoid cancelling itself (the running task) while keeping
+    ///   the handle reachable by external callers.
+    private func connectImpl(cancelAutoWake: Bool) async throws {
         // Disconnect any existing connection without triggering reconnect.
-        disconnectInternal(triggerReconnect: false)
+        disconnectInternal(triggerReconnect: false, cancelAutoWake: cancelAutoWake)
 
         isConnecting = true
 
@@ -168,11 +180,7 @@ extension DaemonClient {
                     return
                 }
                 log.info("auto-wake: wake succeeded, reconnecting")
-                // Nil out autoWakeTask before connect() so that
-                // disconnectInternal() (called inside connect()) doesn't
-                // cancel this running task via cooperative cancellation.
-                self.autoWakeTask = nil
-                try await self.connect()
+                try await self.connectImpl(cancelAutoWake: false)
                 guard !Task.isCancelled else {
                     log.info("auto-wake: cancelled after connect — abandoning")
                     return
@@ -181,16 +189,21 @@ extension DaemonClient {
             } catch {
                 log.error("auto-wake: failed: \(error)")
             }
+            // Clear the handle now that the task has finished so stale
+            // references don't accumulate.
+            self.autoWakeTask = nil
         }
     }
     #endif
 
-    func disconnectInternal(triggerReconnect: Bool) {
+    func disconnectInternal(triggerReconnect: Bool, cancelAutoWake: Bool = true) {
         isAuthenticated = false
 
         #if os(macOS)
-        autoWakeTask?.cancel()
-        autoWakeTask = nil
+        if cancelAutoWake {
+            autoWakeTask?.cancel()
+            autoWakeTask = nil
+        }
         #endif
 
         httpTransport?.disconnect()


### PR DESCRIPTION
Addresses Codex review feedback on #18700.

## Summary
- Extracted connect logic into private `connectImpl(cancelAutoWake:)` to preserve the protocol-required `connect()` signature
- Added `cancelAutoWake` parameter to `disconnectInternal()` (defaults to `true`)
- Auto-wake reconnect path calls `connectImpl(cancelAutoWake: false)` — prevents self-cancellation while keeping the task handle reachable by external callers
- Added cleanup of `autoWakeTask` handle on natural task completion

## Test plan
- [ ] Verify auto-wake reconnect still works (kill daemon, confirm client reconnects)
- [ ] Verify external disconnect during auto-wake connect cancels the task
- [ ] Verify normal connect/disconnect flow unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
