### PR TITLE
feat: inject image source path as context for LLM, exclude from persisted content

### DIFF
--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { attachmentsToContentBlocks } from "../agent/attachments.js";
+import {
+  attachmentsToContentBlocks,
+  enrichMessageWithSourcePaths,
+} from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 
 // ---------------------------------------------------------------------------
@@ -139,5 +142,116 @@ describe("createUserMessage with image attachments", () => {
     expect(imageBlock.source.data).toBe(base64);
     expect(imageBlock.source.media_type).toBe("image/jpeg");
     expect(imageBlock.source.type).toBe("base64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrichMessageWithSourcePaths
+// ---------------------------------------------------------------------------
+
+describe("enrichMessageWithSourcePaths", () => {
+  test("appends a source path annotation for images with filePath", () => {
+    const attachments = [
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "base64img",
+        filePath: "/Users/me/Desktop/photo.jpg",
+      },
+    ];
+    const original = createUserMessage("what is this?", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // Original has text + image = 2 blocks; enriched adds 1 annotation = 3
+    expect(enriched.content).toHaveLength(3);
+    const annotation = enriched.content[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("returns the original message (same reference) when no images have filePath", () => {
+    const attachments = [
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "base64img",
+      },
+    ];
+    const original = createUserMessage("what is this?", attachments);
+    const result = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(result).toBe(original);
+  });
+
+  test("skips non-image attachments with filePath", () => {
+    const attachments = [
+      {
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        data: "pdfdata",
+        filePath: "/Users/me/Documents/doc.pdf",
+      },
+    ];
+    const original = createUserMessage("review this", attachments);
+    const result = enrichMessageWithSourcePaths(original, attachments);
+
+    // Non-image attachments are not annotated, so we get back the same ref
+    expect(result).toBe(original);
+  });
+
+  test("handles multiple images with file paths", () => {
+    const attachments = [
+      {
+        filename: "a.jpg",
+        mimeType: "image/jpeg",
+        data: "img1",
+        filePath: "/path/to/a.jpg",
+      },
+      {
+        filename: "b.png",
+        mimeType: "image/png",
+        data: "img2",
+        filePath: "/path/to/b.png",
+      },
+    ];
+    const original = createUserMessage("compare", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // text + 2 images + 1 annotation = 4
+    expect(enriched.content).toHaveLength(4);
+    const annotation = enriched.content[3] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /path/to/a.jpg]\n[Attached image source: /path/to/b.png]",
+    );
+  });
+
+  test("only annotates images that have filePath, skips those without", () => {
+    const attachments = [
+      {
+        filename: "a.jpg",
+        mimeType: "image/jpeg",
+        data: "img1",
+        filePath: "/path/to/a.jpg",
+      },
+      {
+        filename: "b.png",
+        mimeType: "image/png",
+        data: "img2",
+        // no filePath — e.g. pasted screenshot
+      },
+    ];
+    const original = createUserMessage("compare", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // text + 2 images + 1 annotation (only for a.jpg) = 4
+    expect(enriched.content).toHaveLength(4);
+    const annotation = enriched.content[3] as { type: "text"; text: string };
+    expect(annotation.text).toBe("[Attached image source: /path/to/a.jpg]");
   });
 });

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 export interface MessageAttachmentInput {
   id?: string;
@@ -6,6 +6,7 @@ export interface MessageAttachmentInput {
   mimeType: string;
   data: string;
   extractedText?: string;
+  filePath?: string;
 }
 
 export function attachmentsToContentBlocks(
@@ -34,4 +35,29 @@ export function attachmentsToContentBlocks(
       extracted_text: attachment.extractedText,
     } as ContentBlock;
   });
+}
+
+/**
+ * Return a copy of the message with text annotations for image source paths.
+ * The annotations are appended as a text content block so the LLM knows where
+ * the images came from on disk. The caller should persist the ORIGINAL message
+ * (without annotations) so the UI stays clean.
+ */
+export function enrichMessageWithSourcePaths(
+  message: Message,
+  attachments: MessageAttachmentInput[],
+): Message {
+  const imageAttachments = attachments.filter(
+    (a) => a.mimeType.toLowerCase().startsWith("image/") && a.filePath,
+  );
+  if (imageAttachments.length === 0) return message;
+
+  const annotation = imageAttachments
+    .map((a) => `[Attached image source: ${a.filePath}]`)
+    .join("\n");
+
+  return {
+    ...message,
+    content: [...message.content, { type: "text" as const, text: annotation }],
+  };
 }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -7,6 +7,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -276,17 +277,20 @@ export async function persistUserMessage(
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
-  const userMessage = createUserMessage(
-    content,
-    attachments.map((attachment) => ({
-      id: attachment.id,
-      filename: attachment.filename,
-      mimeType: attachment.mimeType,
-      data: attachment.data,
-      extractedText: attachment.extractedText,
-    })),
+  const attachmentInputs = attachments.map((attachment) => ({
+    id: attachment.id,
+    filename: attachment.filename,
+    mimeType: attachment.mimeType,
+    data: attachment.data,
+    extractedText: attachment.extractedText,
+    filePath: attachment.filePath,
+  }));
+  const cleanMessage = createUserMessage(content, attachmentInputs);
+  const llmMessage = enrichMessageWithSourcePaths(
+    cleanMessage,
+    attachmentInputs,
   );
-  ctx.messages.push(userMessage);
+  ctx.messages.push(llmMessage);
 
   try {
     const turnCtx =
@@ -294,6 +298,13 @@ export async function persistUserMessage(
     const turnIfCtx =
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
+    const imageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        imageSourcePaths[a.filename] = a.filePath;
+      }
+    }
+
     const mergedMetadata = {
       ...(metadata ?? {}),
       ...provenance,
@@ -309,6 +320,7 @@ export async function persistUserMessage(
             assistantMessageInterface: turnIfCtx.assistantMessageInterface,
           }
         : {}),
+      ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
     };
 
     // When displayContent is provided (e.g. original text before recording
@@ -317,18 +329,9 @@ export async function persistUserMessage(
     // the stripped content.
     const contentToPersist = displayContent
       ? JSON.stringify(
-          createUserMessage(
-            displayContent,
-            attachments.map((a) => ({
-              id: a.id,
-              filename: a.filename,
-              mimeType: a.mimeType,
-              data: a.data,
-              extractedText: a.extractedText,
-            })),
-          ).content,
+          createUserMessage(displayContent, attachmentInputs).content,
         )
-      : JSON.stringify(userMessage.content);
+      : JSON.stringify(cleanMessage.content);
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,6 +6,7 @@ import {
   getAcpSessionManager,
   setBroadcastToAllClients,
 } from "../acp/index.js";
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -1074,6 +1075,12 @@ export class DaemonServer {
       const serverProvenance = provenanceFromTrustContext(
         conversation.trustContext,
       );
+      const imageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          imageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const serverChannelMeta = {
         ...serverProvenance,
         ...(serverTurnCtx
@@ -1089,15 +1096,19 @@ export class DaemonServer {
                 serverInterfaceCtx.assistantMessageInterface,
             }
           : {}),
+        ...(Object.keys(imageSourcePaths).length > 0
+          ? { imageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(content, attachments);
+      const cleanMsg = createUserMessage(content, attachments);
+      const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
         conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanMsg.content),
         serverChannelMeta,
       );
-      conversation.getMessages().push(userMsg);
+      conversation.getMessages().push(llmMsg);
 
       if (serverTurnCtx) {
         try {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -4,6 +4,7 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import { enrichMessageWithSourcePaths } from "../../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -923,6 +924,12 @@ export async function handleSendMessage(
     let cleanupDeferred = false;
     try {
       const provenance = provenanceFromTrustContext(conversation.trustContext);
+      const imageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          imageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const channelMeta = {
         ...provenance,
         userMessageChannel: sourceChannel,
@@ -930,15 +937,19 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
         ...(body.automated === true ? { automated: true } : {}),
+        ...(Object.keys(imageSourcePaths).length > 0
+          ? { imageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(rawContent, attachments);
+      const cleanMsg = createUserMessage(rawContent, attachments);
+      const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
         mapping.conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanMsg.content),
         channelMeta,
       );
-      conversation.getMessages().push(userMsg);
+      conversation.getMessages().push(llmMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(


### PR DESCRIPTION
## Summary
- Add `enrichMessageWithSourcePaths()` function that appends `[Attached image source: /path]` text blocks to messages
- Split message creation in `persistUserMessage()`, `handleSendMessage()`, and `processMessage()` into clean (DB) and enriched (LLM) versions
- Persist `imageSourcePaths` in message metadata for daemon restart survival
- Add `filePath` to `MessageAttachmentInput` interface
- Add unit tests for `enrichMessageWithSourcePaths()`

Part of plan: img-filepath-context.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
