### PR TITLE
fix(ngrok): handle daemon-only+keep-alive and robust stdio detachment

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -701,32 +701,36 @@ async function hatchLocal(
 
   await startLocalDaemon(watch, resources);
 
-  let runtimeUrl: string;
-  try {
-    runtimeUrl = await startGateway(watch, resources);
-  } catch (error) {
-    // Gateway failed — stop the daemon we just started so we don't leave
-    // orphaned processes with no lock file entry.
-    console.error(
-      `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
-    );
-    await stopLocalProcesses(resources);
-    throw error;
-  }
+  // When daemonOnly is set, skip gateway and ngrok — the caller only wants
+  // the daemon restarted (e.g. macOS app bootstrap retry).
+  let runtimeUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+  if (!daemonOnly) {
+    try {
+      runtimeUrl = await startGateway(watch, resources);
+    } catch (error) {
+      // Gateway failed — stop the daemon we just started so we don't leave
+      // orphaned processes with no lock file entry.
+      console.error(
+        `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
+      );
+      await stopLocalProcesses(resources);
+      throw error;
+    }
 
-  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
-  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
-  const prevBaseDataDir = process.env.BASE_DATA_DIR;
-  process.env.BASE_DATA_DIR = resources.instanceDir;
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
-  if (ngrokChild?.pid) {
-    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
-    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
-  }
-  if (prevBaseDataDir !== undefined) {
-    process.env.BASE_DATA_DIR = prevBaseDataDir;
-  } else {
-    delete process.env.BASE_DATA_DIR;
+    // Auto-start ngrok if webhook integrations (e.g. Telegram, Twilio) are configured.
+    // Set BASE_DATA_DIR so ngrok reads the correct instance config.
+    const prevBaseDataDir = process.env.BASE_DATA_DIR;
+    process.env.BASE_DATA_DIR = resources.instanceDir;
+    const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+    if (ngrokChild?.pid) {
+      const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+      writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+    }
+    if (prevBaseDataDir !== undefined) {
+      process.env.BASE_DATA_DIR = prevBaseDataDir;
+    } else {
+      delete process.env.BASE_DATA_DIR;
+    }
   }
 
   const localEntry: AssistantEntry = {
@@ -757,7 +761,12 @@ async function hatchLocal(
   }
 
   if (keepAlive) {
-    const gatewayHealthUrl = `http://127.0.0.1:${resources.gatewayPort}/healthz`;
+    // When --daemon-only is set, no gateway is running — poll the daemon
+    // health endpoint instead of the gateway to avoid self-termination.
+    const healthUrl = daemonOnly
+      ? `http://127.0.0.1:${resources.daemonPort}/healthz`
+      : `http://127.0.0.1:${resources.gatewayPort}/healthz`;
+    const healthTarget = daemonOnly ? "Assistant" : "Gateway";
     const POLL_INTERVAL_MS = 5000;
     const MAX_FAILURES = 3;
     let consecutiveFailures = 0;
@@ -771,11 +780,11 @@ async function hatchLocal(
     process.on("SIGTERM", () => void shutdown());
     process.on("SIGINT", () => void shutdown());
 
-    // Poll the gateway health endpoint until it stops responding.
+    // Poll the health endpoint until it stops responding.
     while (true) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
       try {
-        const res = await fetch(gatewayHealthUrl, {
+        const res = await fetch(healthUrl, {
           signal: AbortSignal.timeout(3000),
         });
         if (res.ok) {
@@ -787,7 +796,9 @@ async function hatchLocal(
         consecutiveFailures++;
       }
       if (consecutiveFailures >= MAX_FAILURES) {
-        console.log("\n⚠️  Gateway stopped responding — shutting down.");
+        console.log(
+          `\n⚠️  ${healthTarget} stopped responding — shutting down.`,
+        );
         await stopLocalProcesses(resources);
         process.exit(1);
       }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -1,5 +1,11 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -111,12 +117,29 @@ export async function findExistingTunnel(
 
 /**
  * Start an ngrok process tunneling HTTP traffic to the given local port.
+ *
+ * When `logFilePath` is provided, stdout/stderr are redirected to that file
+ * instead of being piped. This avoids keeping pipe handles open in the
+ * parent process — which would either prevent the CLI from exiting (if
+ * handles are left open) or send SIGPIPE to ngrok (if destroyed).
+ *
  * Returns the spawned child process.
  */
-export function startNgrokProcess(targetPort: number): ChildProcess {
+export function startNgrokProcess(
+  targetPort: number,
+  logFilePath?: string,
+): ChildProcess {
+  let stdio: ("ignore" | "pipe" | number)[] = ["ignore", "pipe", "pipe"];
+  if (logFilePath) {
+    const dir = dirname(logFilePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const fd = openSync(logFilePath, "a");
+    stdio = ["ignore", fd, fd];
+  }
+
   const child = spawn("ngrok", ["http", String(targetPort), "--log=stdout"], {
     detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio,
   });
   return child;
 }
@@ -170,14 +193,16 @@ function clearIngressUrl(): void {
 }
 
 /**
- * Check whether any webhook-based integrations (e.g. Telegram) are configured
- * that require a public ingress URL.
+ * Check whether any webhook-based integrations (e.g. Telegram, Twilio) are
+ * configured that require a public ingress URL.
  */
 function hasWebhookIntegrationsConfigured(): boolean {
   try {
     const config = loadRawConfig();
     const telegram = config.telegram as Record<string, unknown> | undefined;
     if (telegram?.botUsername) return true;
+    const twilio = config.twilio as Record<string, unknown> | undefined;
+    if (twilio?.accountSid || twilio?.phoneNumber) return true;
     return false;
   } catch {
     return false;
@@ -225,30 +250,22 @@ export async function maybeStartNgrokTunnel(
   }
 
   console.log(`   Starting ngrok tunnel for webhook integrations...`);
-  const ngrokProcess = startNgrokProcess(targetPort);
 
-  // Pipe output for debugging but don't block on it
-  ngrokProcess.stdout?.on("data", (data: Buffer) => {
-    const line = data.toString().trim();
-    if (line) console.log(`[ngrok] ${line}`);
-  });
-  ngrokProcess.stderr?.on("data", (data: Buffer) => {
-    const line = data.toString().trim();
-    if (line) console.error(`[ngrok] ${line}`);
-  });
+  // Spawn ngrok with stdout/stderr redirected to a log file instead of pipes.
+  // This avoids two problems that occur with piped stdio:
+  //   1. If pipe handles are left open, the CLI process hangs after hatch/wake.
+  //   2. If pipe handles are destroyed, SIGPIPE kills ngrok on its next write.
+  // Writing to a log file sidesteps both issues — the file descriptor is
+  // inherited by the detached ngrok process and remains valid after CLI exit.
+  const root = join(process.env.BASE_DATA_DIR?.trim() || homedir(), ".vellum");
+  const ngrokLogPath = join(root, "workspace", "data", "logs", "ngrok.log");
+  const ngrokProcess = startNgrokProcess(targetPort, ngrokLogPath);
+  ngrokProcess.unref();
 
   try {
     const publicUrl = await waitForNgrokUrl();
     saveIngressUrl(publicUrl);
     console.log(`   Tunnel established: ${publicUrl}`);
-
-    // Detach the ngrok process so the CLI (hatch/wake) can exit without
-    // keeping it alive. Remove stdout/stderr listeners and unref all handles.
-    ngrokProcess.stdout?.removeAllListeners("data");
-    ngrokProcess.stderr?.removeAllListeners("data");
-    ngrokProcess.stdout?.destroy();
-    ngrokProcess.stderr?.destroy();
-    ngrokProcess.unref();
 
     return ngrokProcess;
   } catch {


### PR DESCRIPTION
## Summary
- Fixes `--daemon-only` + `--keep-alive` flag interaction: when `--daemon-only` is set, the keep-alive loop now polls the daemon health endpoint instead of the gateway, preventing self-termination
- Improves ngrok stdio handle detachment by spawning ngrok with stdout/stderr redirected to a log file (`ngrok.log`) instead of pipes, avoiding both CLI hangs and SIGPIPE kills
- Includes original PR #15920 changes: skip gateway/ngrok when `--daemon-only`, detect Twilio webhooks for auto-ngrok

## Test plan
- [ ] Verify `vellum hatch --daemon-only --keep-alive` starts the daemon and stays alive (polls daemon health)
- [ ] Verify `vellum hatch --keep-alive` starts both daemon+gateway and polls gateway health
- [ ] Verify ngrok auto-start with Telegram/Twilio config: CLI exits cleanly, ngrok stays running
- [ ] Verify ngrok logs are written to `~/.vellum/workspace/data/logs/ngrok.log`
- [ ] Verify `vellum tunnel` interactive mode still works (uses piped stdio)

Addresses review feedback from #15920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
