### PR TITLE
feat: re-inject image source path annotations when loading conversation history for LLM

### DIFF
--- a/assistant/src/__tests__/image-source-path-reinject.test.ts
+++ b/assistant/src/__tests__/image-source-path-reinject.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { reinjectImageSourcePaths } from "../daemon/conversation-lifecycle.js";
+import type { ContentBlock } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// reinjectImageSourcePaths — re-inject [Attached image source: /path]
+// annotations when loading conversation history from DB
+// ---------------------------------------------------------------------------
+
+describe("reinjectImageSourcePaths", () => {
+  const baseContent: ContentBlock[] = [
+    { type: "text", text: "what is this?" },
+    {
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: "base64img" },
+    },
+  ];
+
+  test("adds annotation when user message has imageSourcePaths in metadata", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("does NOT annotate assistant messages even if metadata has imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "assistant", metadata);
+
+    // Should return the original content unchanged
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when metadata is null", () => {
+    const result = reinjectImageSourcePaths(baseContent, "user", null);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when metadata has no imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      userMessageChannel: "desktop",
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when imageSourcePaths is empty object", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {},
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles multiple image source paths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "a.jpg": "/path/to/a.jpg",
+        "b.png": "/path/to/b.png",
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /path/to/a.jpg]\n[Attached image source: /path/to/b.png]",
+    );
+  });
+
+  test("gracefully handles malformed metadata JSON", () => {
+    const result = reinjectImageSourcePaths(
+      baseContent,
+      "user",
+      "not-valid-json{{{",
+    );
+    // Should return original content, not throw
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("filters out non-string values in imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "photo.jpg": "/Users/me/Desktop/photo.jpg",
+        "bad.jpg": 42,
+        "also_bad.jpg": null,
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("returns content unchanged when imageSourcePaths has only non-string values", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "bad.jpg": 42,
+        "also_bad.jpg": null,
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("preserves original content blocks in returned array", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/path/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    // First two blocks should be identical to the originals
+    expect(result[0]).toEqual(baseContent[0]);
+    expect(result[1]).toEqual(baseContent[1]);
+  });
+});

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -68,6 +68,39 @@ function filterMessagesForUntrustedActor(messages: MessageRow[]): MessageRow[] {
   });
 }
 
+/**
+ * Re-inject image source path annotations into message content blocks.
+ *
+ * When the desktop client attaches images from local files, the source paths
+ * are stored in `metadata.imageSourcePaths` (keyed by filename). The LLM-facing
+ * content omits these paths at persistence time, so we re-inject them when
+ * loading history from the DB. Only user messages are annotated.
+ */
+export function reinjectImageSourcePaths(
+  content: ContentBlock[],
+  role: string,
+  metadataJson: string | null,
+): ContentBlock[] {
+  if (role !== "user" || !metadataJson) return content;
+  try {
+    const meta = JSON.parse(metadataJson);
+    if (!meta.imageSourcePaths || typeof meta.imageSourcePaths !== "object") {
+      return content;
+    }
+    const paths = Object.values(meta.imageSourcePaths).filter(
+      (v): v is string => typeof v === "string",
+    );
+    if (paths.length === 0) return content;
+    const annotation = paths
+      .map((p) => `[Attached image source: ${p}]`)
+      .join("\n");
+    return [...content, { type: "text" as const, text: annotation }];
+  } catch {
+    // metadata parse failure — skip annotation, not critical
+    return content;
+  }
+}
+
 // ── Context Interfaces ───────────────────────────────────────────────
 
 export interface LoadFromDbContext {
@@ -151,6 +184,9 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
         );
         content = [{ type: "text", text: m.content }];
       }
+
+      content = reinjectImageSourcePaths(content, role, m.metadata);
+
       return { role, content };
     });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -67,6 +67,8 @@ export const messageMetadataSchema = z
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
     automated: z.boolean().optional(),
+    /** Image source paths from desktop attachments, keyed by filename. */
+    imageSourcePaths: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Add `imageSourcePaths` to `messageMetadataSchema` in `conversation-crud.ts`
- Re-inject source path annotations in `loadFromDb()` when loading messages with `imageSourcePaths` metadata
- Only annotates user messages; assistant messages and messages without paths are unchanged
- Add tests for the re-injection logic

Part of plan: img-filepath-context.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
