### PR TITLE
fix: update source_path on dedup'd attachment uploads

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -409,6 +409,13 @@ export function uploadAttachment(
     .get();
 
   if (existing) {
+    if (sourcePath) {
+      rawRun(
+        `UPDATE attachments SET source_path = ? WHERE id = ?`,
+        sourcePath,
+        existing.id,
+      );
+    }
     return existing;
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-filepath-context.md.

**Gap:** Dedup early return in uploadAttachment drops sourcePath
**What was expected:** source_path should be stored even for dedup'd attachments
**What was found:** Early return skipped the source_path UPDATE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
