### PR TITLE
fix: use indexed keys for imageSourcePaths to prevent duplicate filename collision

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -299,9 +299,10 @@ export async function persistUserMessage(
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
     const imageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
       if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        imageSourcePaths[a.filename] = a.filePath;
+        imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1076,9 +1076,10 @@ export class DaemonServer {
         conversation.trustContext,
       );
       const imageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          imageSourcePaths[a.filename] = a.filePath;
+          imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const serverChannelMeta = {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -925,9 +925,10 @@ export async function handleSendMessage(
     try {
       const provenance = provenanceFromTrustContext(conversation.trustContext);
       const imageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          imageSourcePaths[a.filename] = a.filePath;
+          imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const channelMeta = {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-filepath-context.md.

**Gap:** imageSourcePaths keyed by filename loses paths when multiple images share the same filename
**What was expected:** All image source paths should survive in metadata
**What was found:** Duplicate filenames overwrite each other in the map

Changes all 3 sites that build `imageSourcePaths` to use indexed keys (`"0:photo.jpg"`, `"1:photo.jpg"`) instead of bare filenames. The consumer (`reinjectImageSourcePaths`) only uses `Object.values()`, so the key format change is transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
