### PR TITLE
fix(macos): short-circuit auto-wake retry on task cancellation in connectImpl

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -82,6 +82,15 @@ extension DaemonClient {
             log.info("connect: transport connected successfully to \(baseURL, privacy: .public), SSE should be running")
         } catch {
             #if os(macOS)
+            // Short-circuit if the task was cancelled (e.g. external disconnect/reconfigure)
+            // to avoid entering the auto-wake path during an intentional teardown.
+            guard !Task.isCancelled else {
+                isConnecting = false
+                httpTransport = nil
+                log.info("connect: task cancelled — skipping auto-wake")
+                throw error
+            }
+
             // Auto-wake: if the gateway is unreachable and a wake handler is
             // configured, try waking the daemon and retrying the connection once.
             if let wakeHandler, config.transportMetadata.routeMode == .runtimeFlat {


### PR DESCRIPTION
Addresses Codex review feedback on #18708.

Adds a Task.isCancelled guard at the top of connectImpl's catch block so that when the auto-wake task is externally cancelled (via disconnect/reconfigure), the error handler short-circuits before entering the wake-retry path. Without this, a cancelled transport.connect() would fall through to the auto-wake logic and potentially restart the daemon during an intentional disconnect.