### PR TITLE
fix: enrich source path annotations in remaining message creation paths

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -6,6 +6,7 @@
  * used by conversation-history.ts.
  */
 
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -308,6 +309,12 @@ export async function drainQueue(
       const drainProvenance = provenanceFromTrustContext(
         conversation.trustContext,
       );
+      const drainImageSourcePaths: Record<string, string> = {};
+      for (const a of next.attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          drainImageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const drainChannelMeta = {
         ...drainProvenance,
         ...(queuedTurnCtx
@@ -324,8 +331,15 @@ export async function drainQueue(
             }
           : {}),
         ...(next.metadata?.automated ? { automated: true } : {}),
+        ...(Object.keys(drainImageSourcePaths).length > 0
+          ? { imageSourcePaths: drainImageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(next.content, next.attachments);
+      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      const llmUserMsg = enrichMessageWithSourcePaths(
+        cleanUserMsg,
+        next.attachments,
+      );
       // When displayContent is provided (e.g. original text before recording
       // intent stripping), persist that to DB so users see the full message.
       // The in-memory userMessage (sent to the LLM) still uses the stripped content.
@@ -333,14 +347,14 @@ export async function drainQueue(
         ? JSON.stringify(
             createUserMessage(next.displayContent, next.attachments).content,
           )
-        : JSON.stringify(userMsg.content);
+        : JSON.stringify(cleanUserMsg.content);
       await addMessage(
         conversation.conversationId,
         "user",
         contentToPersist,
         drainChannelMeta,
       );
-      conversation.messages.push(userMsg);
+      conversation.messages.push(llmUserMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(
@@ -602,6 +616,12 @@ export async function processMessage(
 
     if (routerResult.consumed) {
       const guardianIfCtx = conversation.getTurnInterfaceContext();
+      const guardianImageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          guardianImageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const routerChannelMeta = {
         userMessageChannel: "vellum" as const,
         assistantMessageChannel: "vellum" as const,
@@ -609,16 +629,23 @@ export async function processMessage(
         assistantMessageInterface:
           guardianIfCtx?.assistantMessageInterface ?? "vellum",
         provenanceTrustClass: "guardian" as const,
+        ...(Object.keys(guardianImageSourcePaths).length > 0
+          ? { imageSourcePaths: guardianImageSourcePaths }
+          : {}),
       };
 
-      const userMsg = createUserMessage(content, attachments);
+      const cleanUserMsg = createUserMessage(content, attachments);
+      const llmUserMsg = enrichMessageWithSourcePaths(
+        cleanUserMsg,
+        attachments,
+      );
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanUserMsg.content),
         routerChannelMeta,
       );
-      conversation.messages.push(userMsg);
+      conversation.messages.push(llmUserMsg);
 
       const replyText =
         routerResult.replyText ??
@@ -666,6 +693,12 @@ export async function processMessage(
     const pmTurnCtx = conversation.getTurnChannelContext();
     const pmInterfaceCtx = conversation.getTurnInterfaceContext();
     const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
+    const pmImageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        pmImageSourcePaths[a.filename] = a.filePath;
+      }
+    }
     const pmChannelMeta = {
       ...pmProvenance,
       ...(pmTurnCtx
@@ -680,21 +713,25 @@ export async function processMessage(
             assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface,
           }
         : {}),
+      ...(Object.keys(pmImageSourcePaths).length > 0
+        ? { imageSourcePaths: pmImageSourcePaths }
+        : {}),
     };
-    const userMsg = createUserMessage(content, attachments);
+    const cleanUserMsg = createUserMessage(content, attachments);
+    const llmUserMsg = enrichMessageWithSourcePaths(cleanUserMsg, attachments);
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message.
     // The in-memory userMessage (sent to the LLM) still uses the stripped content.
     const contentToPersist = displayContent
       ? JSON.stringify(createUserMessage(displayContent, attachments).content)
-      : JSON.stringify(userMsg.content);
+      : JSON.stringify(cleanUserMsg.content);
     const persisted = await addMessage(
       conversation.conversationId,
       "user",
       contentToPersist,
       pmChannelMeta,
     );
-    conversation.messages.push(userMsg);
+    conversation.messages.push(llmUserMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
     await addMessage(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -184,19 +184,36 @@ async function tryConsumeCanonicalGuardianReply(params: {
   // is not re-processed as a new user turn.
   let messageId: string | undefined;
   try {
+    const guardianImageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      const filePath = (a as Record<string, unknown>).filePath;
+      if (
+        typeof filePath === "string" &&
+        a.mimeType.toLowerCase().startsWith("image/")
+      ) {
+        guardianImageSourcePaths[a.filename] = filePath;
+      }
+    }
     const channelMeta = {
       userMessageChannel: sourceChannel,
       assistantMessageChannel: sourceChannel,
       userMessageInterface: sourceInterface,
       assistantMessageInterface: sourceInterface,
       provenanceTrustClass: "guardian" as const,
+      ...(Object.keys(guardianImageSourcePaths).length > 0
+        ? { imageSourcePaths: guardianImageSourcePaths }
+        : {}),
     };
 
-    const userMessage = createUserMessage(content, attachments);
+    const cleanUserMessage = createUserMessage(content, attachments);
+    const llmUserMessage = enrichMessageWithSourcePaths(
+      cleanUserMessage,
+      attachments,
+    );
     const persistedUser = await addMessage(
       conversationId,
       "user",
-      JSON.stringify(userMessage.content),
+      JSON.stringify(cleanUserMessage.content),
       channelMeta,
     );
     messageId = persistedUser.id;
@@ -216,7 +233,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
 
     // Avoid mutating in-memory history / emitting stream deltas while a run is active.
     if (!conversation.isProcessing()) {
-      conversation.getMessages().push(userMessage, assistantMessage);
+      conversation.getMessages().push(llmUserMessage, assistantMessage);
       onEvent({
         type: "assistant_text_delta",
         text: replyText,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for img-filepath-context.md.

**Gap:** Several message creation paths in conversation-process.ts and conversation-routes.ts were not updated with source path enrichment
**What was expected:** All paths that create user messages with attachments should use the clean/LLM split pattern
**What was found:** 4 call sites were missing the enrichment

- `drainQueue` slash-unknown path in `conversation-process.ts`
- `processMessage` guardian-reply path in `conversation-process.ts`
- `processMessage` slash-unknown path in `conversation-process.ts`
- `tryConsumeCanonicalGuardianReply` in `conversation-routes.ts`

Each site now:
1. Builds `cleanMsg` via `createUserMessage` (persisted to DB)
2. Builds `llmMsg` via `enrichMessageWithSourcePaths` (pushed to in-memory messages)
3. Collects `imageSourcePaths` from attachments and includes in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
