### PR TITLE
fix: use indexed keys in remaining imageSourcePaths sites and add filePath to guardian reply type

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -310,9 +310,10 @@ export async function drainQueue(
         conversation.trustContext,
       );
       const drainImageSourcePaths: Record<string, string> = {};
-      for (const a of next.attachments) {
+      for (let i = 0; i < next.attachments.length; i++) {
+        const a = next.attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          drainImageSourcePaths[a.filename] = a.filePath;
+          drainImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const drainChannelMeta = {
@@ -617,9 +618,10 @@ export async function processMessage(
     if (routerResult.consumed) {
       const guardianIfCtx = conversation.getTurnInterfaceContext();
       const guardianImageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          guardianImageSourcePaths[a.filename] = a.filePath;
+          guardianImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const routerChannelMeta = {
@@ -694,9 +696,10 @@ export async function processMessage(
     const pmInterfaceCtx = conversation.getTurnInterfaceContext();
     const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
     const pmImageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
       if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        pmImageSourcePaths[a.filename] = a.filePath;
+        pmImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
     const pmChannelMeta = {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -108,6 +108,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
   conversation: import("../../daemon/conversation.js").Conversation;
   onEvent: (msg: ServerMessage) => void;
@@ -185,13 +186,10 @@ async function tryConsumeCanonicalGuardianReply(params: {
   let messageId: string | undefined;
   try {
     const guardianImageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
-      const filePath = (a as Record<string, unknown>).filePath;
-      if (
-        typeof filePath === "string" &&
-        a.mimeType.toLowerCase().startsWith("image/")
-      ) {
-        guardianImageSourcePaths[a.filename] = filePath;
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        guardianImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
     const channelMeta = {


### PR DESCRIPTION
## Summary
- Apply indexed key format (`${i}:${filename}`) to 4 remaining imageSourcePaths collection sites in conversation-process.ts and conversation-routes.ts
- Add `filePath?: string` to tryConsumeCanonicalGuardianReply attachments parameter type, removing unsafe cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
