### PR TITLE
feat: include image file path in LLM context for desktop attachments

### DIFF
--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { attachmentsToContentBlocks } from "../agent/attachments.js";
+import {
+  attachmentsToContentBlocks,
+  enrichMessageWithSourcePaths,
+} from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 
 // ---------------------------------------------------------------------------
@@ -139,5 +142,116 @@ describe("createUserMessage with image attachments", () => {
     expect(imageBlock.source.data).toBe(base64);
     expect(imageBlock.source.media_type).toBe("image/jpeg");
     expect(imageBlock.source.type).toBe("base64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrichMessageWithSourcePaths
+// ---------------------------------------------------------------------------
+
+describe("enrichMessageWithSourcePaths", () => {
+  test("appends a source path annotation for images with filePath", () => {
+    const attachments = [
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "base64img",
+        filePath: "/Users/me/Desktop/photo.jpg",
+      },
+    ];
+    const original = createUserMessage("what is this?", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // Original has text + image = 2 blocks; enriched adds 1 annotation = 3
+    expect(enriched.content).toHaveLength(3);
+    const annotation = enriched.content[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("returns the original message (same reference) when no images have filePath", () => {
+    const attachments = [
+      {
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "base64img",
+      },
+    ];
+    const original = createUserMessage("what is this?", attachments);
+    const result = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(result).toBe(original);
+  });
+
+  test("skips non-image attachments with filePath", () => {
+    const attachments = [
+      {
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        data: "pdfdata",
+        filePath: "/Users/me/Documents/doc.pdf",
+      },
+    ];
+    const original = createUserMessage("review this", attachments);
+    const result = enrichMessageWithSourcePaths(original, attachments);
+
+    // Non-image attachments are not annotated, so we get back the same ref
+    expect(result).toBe(original);
+  });
+
+  test("handles multiple images with file paths", () => {
+    const attachments = [
+      {
+        filename: "a.jpg",
+        mimeType: "image/jpeg",
+        data: "img1",
+        filePath: "/path/to/a.jpg",
+      },
+      {
+        filename: "b.png",
+        mimeType: "image/png",
+        data: "img2",
+        filePath: "/path/to/b.png",
+      },
+    ];
+    const original = createUserMessage("compare", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // text + 2 images + 1 annotation = 4
+    expect(enriched.content).toHaveLength(4);
+    const annotation = enriched.content[3] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /path/to/a.jpg]\n[Attached image source: /path/to/b.png]",
+    );
+  });
+
+  test("only annotates images that have filePath, skips those without", () => {
+    const attachments = [
+      {
+        filename: "a.jpg",
+        mimeType: "image/jpeg",
+        data: "img1",
+        filePath: "/path/to/a.jpg",
+      },
+      {
+        filename: "b.png",
+        mimeType: "image/png",
+        data: "img2",
+        // no filePath — e.g. pasted screenshot
+      },
+    ];
+    const original = createUserMessage("compare", attachments);
+    const enriched = enrichMessageWithSourcePaths(original, attachments);
+
+    expect(enriched).not.toBe(original);
+    // text + 2 images + 1 annotation (only for a.jpg) = 4
+    expect(enriched.content).toHaveLength(4);
+    const annotation = enriched.content[3] as { type: "text"; text: string };
+    expect(annotation.text).toBe("[Attached image source: /path/to/a.jpg]");
   });
 });

--- a/assistant/src/__tests__/image-source-path-reinject.test.ts
+++ b/assistant/src/__tests__/image-source-path-reinject.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { reinjectImageSourcePaths } from "../daemon/conversation-lifecycle.js";
+import type { ContentBlock } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// reinjectImageSourcePaths — re-inject [Attached image source: /path]
+// annotations when loading conversation history from DB
+// ---------------------------------------------------------------------------
+
+describe("reinjectImageSourcePaths", () => {
+  const baseContent: ContentBlock[] = [
+    { type: "text", text: "what is this?" },
+    {
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: "base64img" },
+    },
+  ];
+
+  test("adds annotation when user message has imageSourcePaths in metadata", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("does NOT annotate assistant messages even if metadata has imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/Users/me/Desktop/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "assistant", metadata);
+
+    // Should return the original content unchanged
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when metadata is null", () => {
+    const result = reinjectImageSourcePaths(baseContent, "user", null);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when metadata has no imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      userMessageChannel: "desktop",
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns content unchanged when imageSourcePaths is empty object", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {},
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles multiple image source paths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "a.jpg": "/path/to/a.jpg",
+        "b.png": "/path/to/b.png",
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.type).toBe("text");
+    expect(annotation.text).toBe(
+      "[Attached image source: /path/to/a.jpg]\n[Attached image source: /path/to/b.png]",
+    );
+  });
+
+  test("gracefully handles malformed metadata JSON", () => {
+    const result = reinjectImageSourcePaths(
+      baseContent,
+      "user",
+      "not-valid-json{{{",
+    );
+    // Should return original content, not throw
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("filters out non-string values in imageSourcePaths", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "photo.jpg": "/Users/me/Desktop/photo.jpg",
+        "bad.jpg": 42,
+        "also_bad.jpg": null,
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    expect(result).toHaveLength(3);
+    const annotation = result[2] as { type: "text"; text: string };
+    expect(annotation.text).toBe(
+      "[Attached image source: /Users/me/Desktop/photo.jpg]",
+    );
+  });
+
+  test("returns content unchanged when imageSourcePaths has only non-string values", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: {
+        "bad.jpg": 42,
+        "also_bad.jpg": null,
+      },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+    expect(result).toBe(baseContent);
+    expect(result).toHaveLength(2);
+  });
+
+  test("preserves original content blocks in returned array", () => {
+    const metadata = JSON.stringify({
+      imageSourcePaths: { "photo.jpg": "/path/photo.jpg" },
+    });
+    const result = reinjectImageSourcePaths(baseContent, "user", metadata);
+
+    // First two blocks should be identical to the originals
+    expect(result[0]).toEqual(baseContent[0]);
+    expect(result[1]).toEqual(baseContent[1]);
+  });
+});

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 export interface MessageAttachmentInput {
   id?: string;
@@ -6,6 +6,7 @@ export interface MessageAttachmentInput {
   mimeType: string;
   data: string;
   extractedText?: string;
+  filePath?: string;
 }
 
 export function attachmentsToContentBlocks(
@@ -34,4 +35,29 @@ export function attachmentsToContentBlocks(
       extracted_text: attachment.extractedText,
     } as ContentBlock;
   });
+}
+
+/**
+ * Return a copy of the message with text annotations for image source paths.
+ * The annotations are appended as a text content block so the LLM knows where
+ * the images came from on disk. The caller should persist the ORIGINAL message
+ * (without annotations) so the UI stays clean.
+ */
+export function enrichMessageWithSourcePaths(
+  message: Message,
+  attachments: MessageAttachmentInput[],
+): Message {
+  const imageAttachments = attachments.filter(
+    (a) => a.mimeType.toLowerCase().startsWith("image/") && a.filePath,
+  );
+  if (imageAttachments.length === 0) return message;
+
+  const annotation = imageAttachments
+    .map((a) => `[Attached image source: ${a.filePath}]`)
+    .join("\n");
+
+  return {
+    ...message,
+    content: [...message.content, { type: "text" as const, text: annotation }],
+  };
 }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -49,6 +49,7 @@ export interface VoiceBridgeDeps {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
   deriveDefaultStrictSideEffects: (conversationId: string) => boolean;
 }

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -68,6 +68,39 @@ function filterMessagesForUntrustedActor(messages: MessageRow[]): MessageRow[] {
   });
 }
 
+/**
+ * Re-inject image source path annotations into message content blocks.
+ *
+ * When the desktop client attaches images from local files, the source paths
+ * are stored in `metadata.imageSourcePaths` (keyed by filename). The LLM-facing
+ * content omits these paths at persistence time, so we re-inject them when
+ * loading history from the DB. Only user messages are annotated.
+ */
+export function reinjectImageSourcePaths(
+  content: ContentBlock[],
+  role: string,
+  metadataJson: string | null,
+): ContentBlock[] {
+  if (role !== "user" || !metadataJson) return content;
+  try {
+    const meta = JSON.parse(metadataJson);
+    if (!meta.imageSourcePaths || typeof meta.imageSourcePaths !== "object") {
+      return content;
+    }
+    const paths = Object.values(meta.imageSourcePaths).filter(
+      (v): v is string => typeof v === "string",
+    );
+    if (paths.length === 0) return content;
+    const annotation = paths
+      .map((p) => `[Attached image source: ${p}]`)
+      .join("\n");
+    return [...content, { type: "text" as const, text: annotation }];
+  } catch {
+    // metadata parse failure — skip annotation, not critical
+    return content;
+  }
+}
+
 // ── Context Interfaces ───────────────────────────────────────────────
 
 export interface LoadFromDbContext {
@@ -151,6 +184,9 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
         );
         content = [{ type: "text", text: m.content }];
       }
+
+      content = reinjectImageSourcePaths(content, role, m.metadata);
+
       return { role, content };
     });
 

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -299,9 +299,10 @@ export async function persistUserMessage(
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
     const imageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
       if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        imageSourcePaths[a.filename] = a.filePath;
+        imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
 

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -7,6 +7,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -276,17 +277,20 @@ export async function persistUserMessage(
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
-  const userMessage = createUserMessage(
-    content,
-    attachments.map((attachment) => ({
-      id: attachment.id,
-      filename: attachment.filename,
-      mimeType: attachment.mimeType,
-      data: attachment.data,
-      extractedText: attachment.extractedText,
-    })),
+  const attachmentInputs = attachments.map((attachment) => ({
+    id: attachment.id,
+    filename: attachment.filename,
+    mimeType: attachment.mimeType,
+    data: attachment.data,
+    extractedText: attachment.extractedText,
+    filePath: attachment.filePath,
+  }));
+  const cleanMessage = createUserMessage(content, attachmentInputs);
+  const llmMessage = enrichMessageWithSourcePaths(
+    cleanMessage,
+    attachmentInputs,
   );
-  ctx.messages.push(userMessage);
+  ctx.messages.push(llmMessage);
 
   try {
     const turnCtx =
@@ -294,6 +298,13 @@ export async function persistUserMessage(
     const turnIfCtx =
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
+    const imageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        imageSourcePaths[a.filename] = a.filePath;
+      }
+    }
+
     const mergedMetadata = {
       ...(metadata ?? {}),
       ...provenance,
@@ -309,6 +320,7 @@ export async function persistUserMessage(
             assistantMessageInterface: turnIfCtx.assistantMessageInterface,
           }
         : {}),
+      ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
     };
 
     // When displayContent is provided (e.g. original text before recording
@@ -317,18 +329,9 @@ export async function persistUserMessage(
     // the stripped content.
     const contentToPersist = displayContent
       ? JSON.stringify(
-          createUserMessage(
-            displayContent,
-            attachments.map((a) => ({
-              id: a.id,
-              filename: a.filename,
-              mimeType: a.mimeType,
-              data: a.data,
-              extractedText: a.extractedText,
-            })),
-          ).content,
+          createUserMessage(displayContent, attachmentInputs).content,
         )
-      : JSON.stringify(userMessage.content);
+      : JSON.stringify(cleanMessage.content);
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -310,9 +310,10 @@ export async function drainQueue(
         conversation.trustContext,
       );
       const drainImageSourcePaths: Record<string, string> = {};
-      for (const a of next.attachments) {
+      for (let i = 0; i < next.attachments.length; i++) {
+        const a = next.attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          drainImageSourcePaths[a.filename] = a.filePath;
+          drainImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const drainChannelMeta = {
@@ -617,9 +618,10 @@ export async function processMessage(
     if (routerResult.consumed) {
       const guardianIfCtx = conversation.getTurnInterfaceContext();
       const guardianImageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          guardianImageSourcePaths[a.filename] = a.filePath;
+          guardianImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const routerChannelMeta = {
@@ -694,9 +696,10 @@ export async function processMessage(
     const pmInterfaceCtx = conversation.getTurnInterfaceContext();
     const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
     const pmImageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
       if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        pmImageSourcePaths[a.filename] = a.filePath;
+        pmImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
     const pmChannelMeta = {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -6,6 +6,7 @@
  * used by conversation-history.ts.
  */
 
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -308,6 +309,12 @@ export async function drainQueue(
       const drainProvenance = provenanceFromTrustContext(
         conversation.trustContext,
       );
+      const drainImageSourcePaths: Record<string, string> = {};
+      for (const a of next.attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          drainImageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const drainChannelMeta = {
         ...drainProvenance,
         ...(queuedTurnCtx
@@ -324,8 +331,15 @@ export async function drainQueue(
             }
           : {}),
         ...(next.metadata?.automated ? { automated: true } : {}),
+        ...(Object.keys(drainImageSourcePaths).length > 0
+          ? { imageSourcePaths: drainImageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(next.content, next.attachments);
+      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      const llmUserMsg = enrichMessageWithSourcePaths(
+        cleanUserMsg,
+        next.attachments,
+      );
       // When displayContent is provided (e.g. original text before recording
       // intent stripping), persist that to DB so users see the full message.
       // The in-memory userMessage (sent to the LLM) still uses the stripped content.
@@ -333,14 +347,14 @@ export async function drainQueue(
         ? JSON.stringify(
             createUserMessage(next.displayContent, next.attachments).content,
           )
-        : JSON.stringify(userMsg.content);
+        : JSON.stringify(cleanUserMsg.content);
       await addMessage(
         conversation.conversationId,
         "user",
         contentToPersist,
         drainChannelMeta,
       );
-      conversation.messages.push(userMsg);
+      conversation.messages.push(llmUserMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(
@@ -602,6 +616,12 @@ export async function processMessage(
 
     if (routerResult.consumed) {
       const guardianIfCtx = conversation.getTurnInterfaceContext();
+      const guardianImageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          guardianImageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const routerChannelMeta = {
         userMessageChannel: "vellum" as const,
         assistantMessageChannel: "vellum" as const,
@@ -609,16 +629,23 @@ export async function processMessage(
         assistantMessageInterface:
           guardianIfCtx?.assistantMessageInterface ?? "vellum",
         provenanceTrustClass: "guardian" as const,
+        ...(Object.keys(guardianImageSourcePaths).length > 0
+          ? { imageSourcePaths: guardianImageSourcePaths }
+          : {}),
       };
 
-      const userMsg = createUserMessage(content, attachments);
+      const cleanUserMsg = createUserMessage(content, attachments);
+      const llmUserMsg = enrichMessageWithSourcePaths(
+        cleanUserMsg,
+        attachments,
+      );
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanUserMsg.content),
         routerChannelMeta,
       );
-      conversation.messages.push(userMsg);
+      conversation.messages.push(llmUserMsg);
 
       const replyText =
         routerResult.replyText ??
@@ -666,6 +693,12 @@ export async function processMessage(
     const pmTurnCtx = conversation.getTurnChannelContext();
     const pmInterfaceCtx = conversation.getTurnInterfaceContext();
     const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
+    const pmImageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        pmImageSourcePaths[a.filename] = a.filePath;
+      }
+    }
     const pmChannelMeta = {
       ...pmProvenance,
       ...(pmTurnCtx
@@ -680,21 +713,25 @@ export async function processMessage(
             assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface,
           }
         : {}),
+      ...(Object.keys(pmImageSourcePaths).length > 0
+        ? { imageSourcePaths: pmImageSourcePaths }
+        : {}),
     };
-    const userMsg = createUserMessage(content, attachments);
+    const cleanUserMsg = createUserMessage(content, attachments);
+    const llmUserMsg = enrichMessageWithSourcePaths(cleanUserMsg, attachments);
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message.
     // The in-memory userMessage (sent to the LLM) still uses the stripped content.
     const contentToPersist = displayContent
       ? JSON.stringify(createUserMessage(displayContent, attachments).content)
-      : JSON.stringify(userMsg.content);
+      : JSON.stringify(cleanUserMsg.content);
     const persisted = await addMessage(
       conversation.conversationId,
       "user",
       contentToPersist,
       pmChannelMeta,
     );
-    conversation.messages.push(userMsg);
+    conversation.messages.push(llmUserMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
     await addMessage(

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -532,13 +532,20 @@ export async function runDaemon(): Promise<void> {
         getOrCreateConversation: (conversationId) =>
           server.getConversationForMessages(conversationId),
         assistantEventHub,
-        resolveAttachments: (attachmentIds) =>
-          attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
+        resolveAttachments: (attachmentIds) => {
+          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const sourcePaths =
+            attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+          return resolved.map((a) => ({
             id: a.id,
             filename: a.originalFilename,
             mimeType: a.mimeType,
             data: a.dataBase64,
-          })),
+            ...(sourcePaths.has(a.id)
+              ? { filePath: sourcePaths.get(a.id) }
+              : {}),
+          }));
+        },
       },
       findConversation: (conversationId) =>
         server.findConversation(conversationId),
@@ -623,13 +630,18 @@ export async function runDaemon(): Promise<void> {
     setVoiceBridgeDeps({
       getOrCreateConversation: (conversationId, _transport) =>
         server.getConversationForMessages(conversationId),
-      resolveAttachments: (attachmentIds) =>
-        attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
+      resolveAttachments: (attachmentIds) => {
+        const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+        const sourcePaths =
+          attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+        return resolved.map((a) => ({
           id: a.id,
           filename: a.originalFilename,
           mimeType: a.mimeType,
           data: a.dataBase64,
-        })),
+          ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
+        }));
+      },
       deriveDefaultStrictSideEffects: (conversationId) => {
         const conversationType = getConversationType(conversationId);
         return conversationType === "private";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -878,6 +878,7 @@ export class DaemonServer {
       filename: string;
       mimeType: string;
       data: string;
+      filePath?: string;
     }[];
   }> {
     const ingressCheck = checkIngressForSecrets(content);
@@ -960,12 +961,20 @@ export class DaemonServer {
     });
 
     const attachments = attachmentIds
-      ? attachmentsStore.getAttachmentsByIds(attachmentIds).map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          data: a.dataBase64,
-        }))
+      ? (() => {
+          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const sourcePaths =
+            attachmentsStore.getSourcePathsForAttachments(attachmentIds);
+          return resolved.map((a) => ({
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            data: a.dataBase64,
+            ...(sourcePaths.has(a.id)
+              ? { filePath: sourcePaths.get(a.id) }
+              : {}),
+          }));
+        })()
       : [];
 
     return { conversation, attachments };

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1076,9 +1076,10 @@ export class DaemonServer {
         conversation.trustContext,
       );
       const imageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          imageSourcePaths[a.filename] = a.filePath;
+          imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const serverChannelMeta = {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,6 +6,7 @@ import {
   getAcpSessionManager,
   setBroadcastToAllClients,
 } from "../acp/index.js";
+import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -1074,6 +1075,12 @@ export class DaemonServer {
       const serverProvenance = provenanceFromTrustContext(
         conversation.trustContext,
       );
+      const imageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          imageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const serverChannelMeta = {
         ...serverProvenance,
         ...(serverTurnCtx
@@ -1089,15 +1096,19 @@ export class DaemonServer {
                 serverInterfaceCtx.assistantMessageInterface,
             }
           : {}),
+        ...(Object.keys(imageSourcePaths).length > 0
+          ? { imageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(content, attachments);
+      const cleanMsg = createUserMessage(content, attachments);
+      const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
         conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanMsg.content),
         serverChannelMeta,
       );
-      conversation.getMessages().push(userMsg);
+      conversation.getMessages().push(llmMsg);
 
       if (serverTurnCtx) {
         try {

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -280,6 +280,37 @@ export function getFilePathForAttachment(attachmentId: string): string | null {
 }
 
 /**
+ * Returns the source_path (original file path on disk) for an attachment, or null if not set.
+ * Uses raw SQL since source_path is added via DB migration and is not in the Drizzle schema.
+ */
+export function getSourcePathForAttachment(
+  attachmentId: string,
+): string | null {
+  const row = rawGet<{ source_path: string | null }>(
+    "SELECT source_path FROM attachments WHERE id = ?",
+    attachmentId,
+  );
+  return row?.source_path ?? null;
+}
+
+/**
+ * Batch-fetch source_path values for multiple attachment IDs in a single query.
+ * Returns a Map of attachment ID → source_path for attachments that have a non-null source_path.
+ * Uses raw SQL since source_path is added via runtime migration and is not in the Drizzle schema.
+ */
+export function getSourcePathsForAttachments(
+  attachmentIds: string[],
+): Map<string, string> {
+  if (attachmentIds.length === 0) return new Map();
+  const placeholders = attachmentIds.map(() => "?").join(", ");
+  const rows = rawAll<{ id: string; source_path: string }>(
+    `SELECT id, source_path FROM attachments WHERE id IN (${placeholders}) AND source_path IS NOT NULL`,
+    ...attachmentIds,
+  );
+  return new Map(rows.map((r) => [r.id, r.source_path]));
+}
+
+/**
  * Batch-fetch file_path values for multiple attachment IDs in a single query.
  * Returns a Set of attachment IDs that are file-backed (have a non-null file_path).
  * Uses raw SQL since file_path is added via runtime migration and is not in the Drizzle schema.
@@ -334,6 +365,7 @@ export function uploadAttachment(
   filename: string,
   mimeType: string,
   dataBase64: string,
+  sourcePath?: string,
 ): StoredAttachment {
   if (!isValidBase64(dataBase64)) {
     throw new AttachmentUploadError("Invalid base64 encoding");
@@ -395,6 +427,14 @@ export function uploadAttachment(
   };
 
   db.insert(attachments).values(record).run();
+
+  if (sourcePath) {
+    rawRun(
+      `UPDATE attachments SET source_path = ? WHERE id = ?`,
+      sourcePath,
+      record.id,
+    );
+  }
 
   return {
     id: record.id,

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -409,6 +409,13 @@ export function uploadAttachment(
     .get();
 
   if (existing) {
+    if (sourcePath) {
+      rawRun(
+        `UPDATE attachments SET source_path = ? WHERE id = ?`,
+        sourcePath,
+        existing.id,
+      );
+    }
     return existing;
   }
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -67,6 +67,8 @@ export const messageMetadataSchema = z
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
     automated: z.boolean().optional(),
+    /** Image source paths from desktop attachments, keyed by filename. */
+    imageSourcePaths: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();
 

--- a/assistant/src/memory/migrations/102-alter-table-columns.ts
+++ b/assistant/src/memory/migrations/102-alter-table-columns.ts
@@ -261,6 +261,11 @@ export function addCoreColumns(database: DrizzleDb): void {
   } catch {
     /* already exists */
   }
+  try {
+    database.run(/*sql*/ `ALTER TABLE attachments ADD COLUMN source_path TEXT`);
+  } catch {
+    /* already exists */
+  }
 
   // cron_jobs
   try {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -157,6 +157,7 @@ export interface SendMessageDeps {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
 }
 

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -29,9 +29,10 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
     filename?: string;
     mimeType?: string;
     data?: string;
+    filePath?: string;
   };
 
-  const { filename, mimeType, data } = body;
+  const { filename, mimeType, data, filePath } = body;
 
   if (!filename || typeof filename !== "string") {
     return httpError("BAD_REQUEST", "filename is required", 400);
@@ -52,7 +53,12 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
 
   let attachment: attachmentsStore.StoredAttachment;
   try {
-    attachment = attachmentsStore.uploadAttachment(filename, mimeType, data);
+    attachment = attachmentsStore.uploadAttachment(
+      filename,
+      mimeType,
+      data,
+      filePath ?? undefined,
+    );
   } catch (err) {
     if (err instanceof AttachmentUploadError) {
       const status = err.message.startsWith("Attachment too large") ? 413 : 400;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -4,6 +4,7 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import { enrichMessageWithSourcePaths } from "../../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
@@ -923,6 +924,12 @@ export async function handleSendMessage(
     let cleanupDeferred = false;
     try {
       const provenance = provenanceFromTrustContext(conversation.trustContext);
+      const imageSourcePaths: Record<string, string> = {};
+      for (const a of attachments) {
+        if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+          imageSourcePaths[a.filename] = a.filePath;
+        }
+      }
       const channelMeta = {
         ...provenance,
         userMessageChannel: sourceChannel,
@@ -930,15 +937,19 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
         ...(body.automated === true ? { automated: true } : {}),
+        ...(Object.keys(imageSourcePaths).length > 0
+          ? { imageSourcePaths }
+          : {}),
       };
-      const userMsg = createUserMessage(rawContent, attachments);
+      const cleanMsg = createUserMessage(rawContent, attachments);
+      const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
       const persisted = await addMessage(
         mapping.conversationId,
         "user",
-        JSON.stringify(userMsg.content),
+        JSON.stringify(cleanMsg.content),
         channelMeta,
       );
-      conversation.getMessages().push(userMsg);
+      conversation.getMessages().push(llmMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
       await addMessage(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -108,6 +108,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     filename: string;
     mimeType: string;
     data: string;
+    filePath?: string;
   }>;
   conversation: import("../../daemon/conversation.js").Conversation;
   onEvent: (msg: ServerMessage) => void;
@@ -185,13 +186,10 @@ async function tryConsumeCanonicalGuardianReply(params: {
   let messageId: string | undefined;
   try {
     const guardianImageSourcePaths: Record<string, string> = {};
-    for (const a of attachments) {
-      const filePath = (a as Record<string, unknown>).filePath;
-      if (
-        typeof filePath === "string" &&
-        a.mimeType.toLowerCase().startsWith("image/")
-      ) {
-        guardianImageSourcePaths[a.filename] = filePath;
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        guardianImageSourcePaths[`${i}:${a.filename}`] = a.filePath;
       }
     }
     const channelMeta = {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -925,9 +925,10 @@ export async function handleSendMessage(
     try {
       const provenance = provenanceFromTrustContext(conversation.trustContext);
       const imageSourcePaths: Record<string, string> = {};
-      for (const a of attachments) {
+      for (let i = 0; i < attachments.length; i++) {
+        const a = attachments[i];
         if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-          imageSourcePaths[a.filename] = a.filePath;
+          imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
         }
       }
       const channelMeta = {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -184,19 +184,36 @@ async function tryConsumeCanonicalGuardianReply(params: {
   // is not re-processed as a new user turn.
   let messageId: string | undefined;
   try {
+    const guardianImageSourcePaths: Record<string, string> = {};
+    for (const a of attachments) {
+      const filePath = (a as Record<string, unknown>).filePath;
+      if (
+        typeof filePath === "string" &&
+        a.mimeType.toLowerCase().startsWith("image/")
+      ) {
+        guardianImageSourcePaths[a.filename] = filePath;
+      }
+    }
     const channelMeta = {
       userMessageChannel: sourceChannel,
       assistantMessageChannel: sourceChannel,
       userMessageInterface: sourceInterface,
       assistantMessageInterface: sourceInterface,
       provenanceTrustClass: "guardian" as const,
+      ...(Object.keys(guardianImageSourcePaths).length > 0
+        ? { imageSourcePaths: guardianImageSourcePaths }
+        : {}),
     };
 
-    const userMessage = createUserMessage(content, attachments);
+    const cleanUserMessage = createUserMessage(content, attachments);
+    const llmUserMessage = enrichMessageWithSourcePaths(
+      cleanUserMessage,
+      attachments,
+    );
     const persistedUser = await addMessage(
       conversationId,
       "user",
-      JSON.stringify(userMessage.content),
+      JSON.stringify(cleanUserMessage.content),
       channelMeta,
     );
     messageId = persistedUser.id;
@@ -216,7 +233,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
 
     // Avoid mutating in-memory history / emitting stream deltas while a run is active.
     if (!conversation.isProcessing()) {
-      conversation.getMessages().push(userMessage, assistantMessage);
+      conversation.getMessages().push(llmUserMessage, assistantMessage);
       onEvent({
         type: "assistant_text_delta",
         text: replyText,

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -236,7 +236,8 @@ public final class ChatAttachmentManager: ObservableObject {
                 data: base64,
                 thumbnailData: thumbnail,
                 dataLength: base64.count,
-                thumbnailImage: thumbnailImage
+                thumbnailImage: thumbnailImage,
+                filePath: url.path
             )
             return .success(attachment)
         }.value

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1154,7 +1154,7 @@ public final class ChatViewModel: ObservableObject {
                 pendingUserMessageDisplayText = rawText
                 pendingUserMessageAutomated = hidden
                 pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
-                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
                 }
                 isThinking = true
                 var userMsg = ChatMessage(role: .user, text: rawText, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments)
@@ -1235,7 +1235,7 @@ public final class ChatViewModel: ObservableObject {
         flushCoalescedPublish()
 
         let messageAttachments: [UserMessageAttachment]? = attachments.isEmpty ? nil : attachments.map {
-            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil, filePath: $0.filePath)
         }
 
         // Track the user text for this turn so assistantTextDelta can tag the

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1012,11 +1012,14 @@ public final class HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "filename": attachment.filename,
             "mimeType": attachment.mimeType,
             "data": attachment.data
         ]
+        if let filePath = attachment.filePath {
+            body["filePath"] = filePath
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)


### PR DESCRIPTION
## Summary
When users attach images from the desktop (macOS) app, the original file path is now included as context for the LLM so it knows where the image came from on disk (e.g., "screenshot from Desktop" vs "file from a project directory"). The file path does NOT appear in the chat UI — it is injected only into the LLM-facing content blocks and excluded from the persisted message content.

Source paths survive daemon restarts: they are persisted in message metadata and re-injected when conversation history is loaded.

## PRs merged into feature branch
- #18706: feat: preserve image file path on ChatAttachment and send to daemon
- #18707: feat: accept and store source_path on attachment uploads
- #18711: feat: inject image source path as context for LLM, exclude from persisted content
- #18714: feat: re-inject image source path annotations when loading conversation history for LLM

## Self-review result
Round 1 found 4 gaps, all fixed:
- #18719: fix: update source_path on dedup'd attachment uploads
- #18720: fix: use indexed keys for imageSourcePaths to prevent duplicate filename collision
- #18722: fix: enrich source path annotations in remaining message creation paths

Round 2 found 2 gaps, both fixed:
- #18723: fix: use indexed keys in remaining imageSourcePaths sites and add filePath to guardian reply type

Round 2 re-review: PASS

Part of plan: img-filepath-context.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
