### PR TITLE
Fix inline video previews in chat

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -237,6 +237,14 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain("browser automation as last resort");
   });
 
+  test("includes inline media attachment guidance", () => {
+    const result = buildSystemPrompt();
+    expect(result).toContain(
+      "Image and video attachments can render inline in chat.",
+    );
+    expect(result).toContain("attach it instead of only printing its path");
+  });
+
   test("does not include removed sections", () => {
     const result = buildSystemPrompt();
     expect(result).not.toContain("## External Communications Identity");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -206,6 +206,8 @@ function buildAttachmentSection(): string {
     "",
     'Use `source="host"` with an absolute path for host filesystem files. Optional attributes: `filename` (display name override), `mime_type` (override auto-detection).',
     "",
+    "Image and video attachments can render inline in chat. If the user asks to preview a media file here, attach it instead of only printing its path.",
+    "",
     "Embed images/GIFs inline using markdown: `![description](URL)`.",
   ].join("\n");
 }

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -191,8 +191,12 @@ private struct VideoEmbedWebView: UIViewRepresentable {
         webView.scrollView.isScrollEnabled = false
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
-        webView.load(URLRequest(url: url))
+        webView.load(Self.makeRequest(url: url, provider: provider))
         return webView
+    }
+
+    static func makeRequest(url: URL, provider: String) -> URLRequest {
+        VideoEmbedRequestBuilder.buildRequest(url: url, provider: provider)
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoWebView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 @preconcurrency import WebKit
+import VellumAssistantShared
 
 /// WKWebView subclass that forwards scroll-wheel events to the enclosing
 /// NSScrollView instead of consuming them internally.
@@ -61,7 +62,7 @@ struct InlineVideoWebView: NSViewRepresentable {
         let webView = Self.makeConfiguredWebView()
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
-        let request = URLRequest(url: url)
+        let request = Self.makeRequest(url: url, provider: provider)
         webView.load(request)
         return webView
     }
@@ -98,6 +99,11 @@ struct InlineVideoWebView: NSViewRepresentable {
         webView.allowsLinkPreview = false
 
         return webView
+    }
+
+    /// Build the initial request so tests can verify provider-specific headers.
+    static func makeRequest(url: URL, provider: String) -> URLRequest {
+        VideoEmbedRequestBuilder.buildRequest(url: url, provider: provider)
     }
 
     /// Check whether `host` matches any of the allowed patterns for `provider`.

--- a/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoPlayerIntegrationTests.swift
@@ -12,7 +12,7 @@ final class InlineVideoPlayerIntegrationTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertEqual(
             url?.absoluteString,
-            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0"
+            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0&playsinline=1"
         )
     }
 
@@ -137,7 +137,7 @@ final class InlineVideoPlayerIntegrationTests: XCTestCase {
         // Verify the URL the card would use for playback matches what
         // VideoEmbedURLBuilder produces for each provider.
         let providers: [(String, String, String)] = [
-            ("youtube", "testVid1", "https://www.youtube.com/embed/testVid1?autoplay=1&rel=0"),
+            ("youtube", "testVid1", "https://www.youtube.com/embed/testVid1?autoplay=1&rel=0&playsinline=1"),
             ("vimeo", "12345", "https://player.vimeo.com/video/12345?autoplay=1"),
             ("loom", "aaaabbbb", "https://www.loom.com/embed/aaaabbbb?autoplay=1"),
         ]

--- a/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/InlineVideoWebViewNavigationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import WebKit
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class InlineVideoWebViewNavigationTests: XCTestCase {
@@ -35,6 +36,29 @@ final class InlineVideoWebViewNavigationTests: XCTestCase {
         )
 
         XCTAssertNil(result, "Popup windows should be blocked by returning nil")
+    }
+
+    // MARK: - Initial request
+
+    func testYouTubeInitialRequestIncludesReferer() {
+        let request = InlineVideoWebView.makeRequest(
+            url: URL(string: "https://www.youtube.com/embed/abc123")!,
+            provider: "youtube"
+        )
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Referer"),
+            VideoEmbedRequestBuilder.defaultReferer
+        )
+    }
+
+    func testVimeoInitialRequestOmitsReferer() {
+        let request = InlineVideoWebView.makeRequest(
+            url: URL(string: "https://player.vimeo.com/video/123")!,
+            provider: "vimeo"
+        )
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
     }
 
     // MARK: - Host allowlist (static helper)

--- a/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
@@ -288,7 +288,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
 
     func testVideoEmbedURLBuilderYouTube() {
         let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "abc123")
-        XCTAssertEqual(url?.absoluteString, "https://www.youtube.com/embed/abc123?autoplay=1&rel=0")
+        XCTAssertEqual(url?.absoluteString, "https://www.youtube.com/embed/abc123?autoplay=1&rel=0&playsinline=1")
     }
 
     func testVideoEmbedURLBuilderVimeo() {

--- a/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
+++ b/clients/macos/vellum-assistantTests/VideoEmbedURLBuilderTests.swift
@@ -12,7 +12,7 @@ final class VideoEmbedURLBuilderTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertEqual(
             url?.absoluteString,
-            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0"
+            "https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0&playsinline=1"
         )
     }
 
@@ -23,6 +23,7 @@ final class VideoEmbedURLBuilderTests: XCTestCase {
 
         XCTAssertTrue(queryItems.contains(where: { $0.name == "autoplay" && $0.value == "1" }))
         XCTAssertTrue(queryItems.contains(where: { $0.name == "rel" && $0.value == "0" }))
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "playsinline" && $0.value == "1" }))
     }
 
     // MARK: - Vimeo
@@ -77,7 +78,7 @@ final class VideoEmbedURLBuilderTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertEqual(
             url?.absoluteString,
-            "https://www.youtube.com/embed/testID?autoplay=1&rel=0"
+            "https://www.youtube.com/embed/testID?autoplay=1&rel=0&playsinline=1"
         )
     }
 
@@ -86,7 +87,7 @@ final class VideoEmbedURLBuilderTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertEqual(
             url?.absoluteString,
-            "https://www.youtube.com/embed/testID?autoplay=1&rel=0"
+            "https://www.youtube.com/embed/testID?autoplay=1&rel=0&playsinline=1"
         )
     }
 

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedRequestBuilder.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedRequestBuilder.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Builds the initial URLRequest for inline video embeds.
+///
+/// YouTube started rejecting embedded player loads without an identifying
+/// `Referer` header in July 2025 (`onError` code 153). Native app webviews
+/// don't naturally provide a page referrer, so we attach a stable HTTPS
+/// referer for YouTube requests to satisfy that requirement.
+public enum VideoEmbedRequestBuilder {
+    /// Stable HTTPS referer used to identify Vellum-hosted embeds.
+    public static let defaultReferer = "https://vellum.ai"
+
+    public static func buildRequest(
+        url: URL,
+        provider: String,
+        referer: String? = defaultReferer
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+
+        guard provider.caseInsensitiveCompare("youtube") == .orderedSame,
+              let normalizedReferer = normalizeReferer(referer) else {
+            return request
+        }
+
+        request.setValue(normalizedReferer, forHTTPHeaderField: "Referer")
+        return request
+    }
+
+    private static func normalizeReferer(_ referer: String?) -> String? {
+        guard let trimmed = referer?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        return trimmed
+    }
+}

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoEmbedURLBuilder.swift
@@ -10,7 +10,16 @@ public enum VideoEmbedURLBuilder {
     public static func buildEmbedURL(provider: String, videoID: String) -> URL? {
         switch provider.lowercased() {
         case "youtube":
-            return URL(string: "https://www.youtube.com/embed/\(videoID)?autoplay=1&rel=0")
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "www.youtube.com"
+            components.path = "/embed/\(videoID)"
+            components.queryItems = [
+                URLQueryItem(name: "autoplay", value: "1"),
+                URLQueryItem(name: "rel", value: "0"),
+                URLQueryItem(name: "playsinline", value: "1"),
+            ]
+            return components.url
         case "vimeo":
             return URL(string: "https://player.vimeo.com/video/\(videoID)?autoplay=1")
         case "loom":

--- a/clients/shared/Tests/MediaEmbedResolverTests.swift
+++ b/clients/shared/Tests/MediaEmbedResolverTests.swift
@@ -52,6 +52,39 @@ final class MediaEmbedResolverTests: XCTestCase {
         XCTAssertEqual(result?.videoID, "xyz789")
     }
 
+    // MARK: - VideoEmbedURLBuilder
+
+    func testYouTubeEmbedBuilderAddsPlaysinline() {
+        let url = VideoEmbedURLBuilder.buildEmbedURL(provider: "youtube", videoID: "abc123")
+        let components = URLComponents(url: url!, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems ?? []
+
+        XCTAssertTrue(queryItems.contains(where: { $0.name == "playsinline" && $0.value == "1" }))
+    }
+
+    // MARK: - VideoEmbedRequestBuilder
+
+    func testYouTubeEmbedRequestAddsRefererHeader() {
+        let request = VideoEmbedRequestBuilder.buildRequest(
+            url: URL(string: "https://www.youtube.com/embed/abc123")!,
+            provider: "youtube"
+        )
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Referer"),
+            VideoEmbedRequestBuilder.defaultReferer
+        )
+    }
+
+    func testNonYouTubeEmbedRequestOmitsRefererHeader() {
+        let request = VideoEmbedRequestBuilder.buildRequest(
+            url: URL(string: "https://player.vimeo.com/video/123")!,
+            provider: "vimeo"
+        )
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
+    }
+
     // MARK: - DomainAllowlistMatcher
 
     func testExactDomainMatch() {


### PR DESCRIPTION
## Summary
- add a YouTube embed request builder that sends a stable Referer so WKWebView embeds stop failing with Error 153
- add playsinline to YouTube embed URLs and keep macOS/iOS inline video loaders aligned
- clarify in the assistant system prompt that image and video attachments can render inline in chat so local media gets attached instead of only described by path

## Testing
- cd assistant && bun test src/__tests__/system-prompt.test.ts
- cd clients/macos && ./build.sh test --filter 'MediaEmbedResolverTests|VideoEmbedURLBuilderTests|InlineVideoWebViewNavigationTests|InlineVideoPlayerIntegrationTests|MediaEmbedFinalRegressionTests'

## Notes
- I could not run an iOS Xcode build locally because xcodebuild on this machine fails before project loading and asks for xcodebuild -runFirstLaunch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
