### PR TITLE
fix(macos): prevent avatar flicker during step expansion pinning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -822,6 +822,8 @@ struct MessageListView: View {
                         try? await Task.sleep(nanoseconds: 250_000_000)
                         guard !Task.isCancelled else { return }
                         scrollTracking.isPinningDuringExpansion = false
+                        // Refresh avatar position now that layout has settled.
+                        updateAvatarFollower(anchorY: scrollTracking.lastTailAnchorY)
                     }
                 } else {
                     // When scrolled away from bottom, suppress auto-scroll so the
@@ -890,6 +892,11 @@ struct MessageListView: View {
                 // reducing layout invalidation cascades during rapid scroll.
                 guard abs(anchorY - scrollTracking.lastTailAnchorY) > 2 else { return }
                 scrollTracking.lastTailAnchorY = anchorY
+                // Skip avatar updates during expansion pinning — the rapid scrollTo
+                // calls cause the tail anchor to momentarily leave the viewport,
+                // which would hide the avatar for a frame. Position is refreshed
+                // when the pinning flag clears.
+                guard !scrollTracking.isPinningDuringExpansion else { return }
                 updateAvatarFollower(anchorY: anchorY)
             }
             .transaction { $0.disablesAnimations = true }


### PR DESCRIPTION
## Summary
- Skip `updateAvatarFollower` calls during `isPinningDuringExpansion` to prevent the avatar from flickering out when the tail anchor momentarily leaves the viewport between scrollTo frames
- Refresh avatar position via `updateAvatarFollower` after the 250ms pinning window ends and layout has settled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
