### PR TITLE
Remove subcommand risk escalation for assistant CLI

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -197,15 +197,6 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "reflog",
 ]);
 
-// Vellum/assistant CLI subcommands that are low-risk (read-only)
-const LOW_RISK_CLI_SUBCOMMANDS = new Set([
-  "ps",
-  "doctor",
-  "audit",
-  "completions",
-  "map",
-]);
-
 // Commands that wrap another program — the real program appears as the first
 // non-flag argument.  When one of these is the segment program we look through
 // its args to find the effective program (e.g. `env curl …` → curl).
@@ -667,17 +658,6 @@ async function classifyRiskUncached(
           continue;
         }
         // Non-read-only git commands are medium
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (prog === "vellum" || prog === "assistant") {
-        const subcommand = firstPositionalArg(seg.args);
-        if (subcommand && LOW_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
-          // Read-only subcommands stay at current risk
-          continue;
-        }
-        // Mutating subcommands are medium
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
## Summary
- Removed the `vellum`/`assistant` subcommand escalation block that bumped any non-allowlisted subcommand to Medium risk
- Removed the now-unused `LOW_RISK_CLI_SUBCOMMANDS` set
- `assistant` stays low-risk for all subcommands since it's already in `LOW_RISK_PROGRAMS`; `vellum` continues to be Medium via the generic unknown-program path

## Original prompt
let's get rid of that subcommand bullshit. anything in the `assistant` CLI is fair game. can we get rid of that entire code block?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
