### PR TITLE
fix(macos): restart gateway when it dies between app launches

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -378,11 +378,10 @@ extension AppDelegate {
                 if lockfileExists && gatewayHealthy {
                     log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
                 } else {
-                    // On first launch post-onboarding, use daemonOnly: false so the CLI
-                    // creates a lockfile entry. On subsequent launches, daemonOnly: true
-                    // prevents duplicates.
+                    // Start the gateway when the lockfile needs creating (first launch)
+                    // OR when the gateway is unhealthy (crashed/died since last hatch).
                     let needsLockfileEntry = isFirstLaunch && !lockfileExists
-                    let daemonOnly = !needsLockfileEntry
+                    let daemonOnly = !needsLockfileEntry && gatewayHealthy
                     // Pass the selected assistant ID so the gateway starts
                     // with the correct default assistant (not a random name).
                     let assistantName = assistant?.assistantId


### PR DESCRIPTION
## Summary
- The macOS app's daemon setup logic detected an unhealthy gateway but always passed `--daemon-only` on non-first launches, preventing the gateway from restarting after a crash
- Changed `daemonOnly` to also be `false` when the gateway is unhealthy (`!needsLockfileEntry && gatewayHealthy` instead of `!needsLockfileEntry`), so the gateway recovers automatically on the next app launch

## Original prompt
Fix the gateway restart logic in AppDelegate+DaemonSetup.swift. The bug is on lines 384-385: `daemonOnly` should be false when the gateway is unhealthy, not just when the lockfile is missing. Currently `let daemonOnly = !needsLockfileEntry` means the gateway is only started on first launch. It should also restart the gateway when `gatewayHealthy` is false. Change the logic so that `daemonOnly` is false when either the lockfile entry is needed OR the gateway is not healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
