### PR TITLE
Enable contacts feature flag by default

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -228,7 +228,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     expect(result).not.toContain(`**${DECLARED_SKILL_ID}**`);
   });
 
-  test("declared skills hidden when no flag overrides set (registry defaults to false)", () => {
+  test("contacts visible but email-channel hidden when no flag overrides set (contacts defaults true, email-channel defaults false)", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Contacts",
@@ -263,8 +263,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    // Both skills declare feature flags with registry defaultEnabled: false
-    expect(result).not.toContain(`**${DECLARED_SKILL_ID}**`);
+    // contacts defaults to true, email-channel defaults to false
+    expect(result).toContain(`**${DECLARED_SKILL_ID}**`);
     expect(result).not.toContain("**email-channel**");
   });
 
@@ -466,12 +466,10 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: false for contacts
+    // which has defaultEnabled: true for contacts
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
-      false,
-    );
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
   test("unknown flag defaults to true when no persisted override", () => {
@@ -510,7 +508,7 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     ).toBe(false);
   });
 
-  test("disabled when no override set (registry default is false)", () => {
+  test("enabled when no override set (registry default is true)", () => {
     const config = {} as any;
 
     expect(
@@ -518,6 +516,6 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -154,16 +154,16 @@ describe("CES flags do not affect unrelated flags", () => {
     ).toBe(true);
   });
 
-  test("enabling all CES flags does not change contacts flag (defaultEnabled: false)", () => {
+  test("enabling all CES flags does not change contacts flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
     }
     const config = makeConfig(overrides);
 
-    // contacts defaults to false in the registry and should stay false
+    // contacts defaults to true in the registry and should stay true
     expect(
       isAssistantFeatureFlagEnabled("feature_flags.contacts.enabled", config),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -138,14 +138,15 @@ describe("frontmatter feature-flag integration", () => {
     expect(key).toBeUndefined();
   });
 
-  test("resolveSkillStates gates skill with featureFlag when flag is OFF", () => {
+  test("resolveSkillStates includes skill with featureFlag when flag defaults to ON", () => {
     const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
-    // "contacts" is in the registry with defaultEnabled: false
+    // "contacts" is in the registry with defaultEnabled: true
     const config = makeConfig();
 
     const resolved = resolveSkillStates([skill], config);
-    // Flag defaults to false → skill is filtered out
-    expect(resolved.length).toBe(0);
+    // Flag defaults to true → skill passes through
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].summary.id).toBe("contacts");
   });
 
   test("resolveSkillStates includes skill with featureFlag when flag is ON", () => {
@@ -192,22 +193,22 @@ describe("frontmatter feature-flag integration", () => {
     const key = skillFlagKey(skill);
     expect(key).toBe("feature_flags.contacts.enabled");
 
-    // Step 4: Check flag state — "contacts" has defaultEnabled: false in registry
-    const configOff = makeConfig();
+    // Step 4: Check flag state — "contacts" has defaultEnabled: true in registry
+    const configDefault = makeConfig();
+    expect(isAssistantFeatureFlagEnabled(key!, configDefault)).toBe(true);
+
+    // Step 5: resolveSkillStates includes it by default
+    const resolvedDefault = resolveSkillStates([skill], configDefault);
+    expect(resolvedDefault.length).toBe(1);
+    expect(resolvedDefault[0].summary.id).toBe("contacts");
+
+    // Step 6: With override disabled, skill is filtered out
+    const configOff = makeConfig({
+      assistantFeatureFlagValues: { [key!]: false },
+    });
     expect(isAssistantFeatureFlagEnabled(key!, configOff)).toBe(false);
 
-    // Step 5: resolveSkillStates correctly filters it out
     const resolvedOff = resolveSkillStates([skill], configOff);
     expect(resolvedOff.length).toBe(0);
-
-    // Step 6: With override enabled, skill passes through
-    const configOn = makeConfig({
-      assistantFeatureFlagValues: { [key!]: true },
-    });
-    expect(isAssistantFeatureFlagEnabled(key!, configOn)).toBe(true);
-
-    const resolvedOn = resolveSkillStates([skill], configOn);
-    expect(resolvedOn.length).toBe(1);
-    expect(resolvedOn[0].summary.id).toBe("contacts");
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -81,14 +81,14 @@ describe("skillFlagKey", () => {
 // ---------------------------------------------------------------------------
 
 describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
-  test("returns false when no flag overrides (registry default is false)", () => {
+  test("returns true when no flag overrides (registry default is true)", () => {
     const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled(
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("returns true when skill key is explicitly true", () => {
@@ -140,10 +140,8 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // contacts defaults to false in the registry
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
-      false,
-    );
+    // contacts defaults to true in the registry
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
   test("respects persisted overrides for undeclared keys", () => {
@@ -207,13 +205,14 @@ describe("resolveSkillStates with feature flags", () => {
     expect(ids).toContain("browser");
   });
 
-  test("declared flag key defaults to registry value (false)", () => {
+  test("declared flag key defaults to registry value (true)", () => {
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // contacts registry default is false, so it's filtered out
-    expect(resolved.length).toBe(0);
+    // contacts registry default is true, so it passes through
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
   });
 
   test("skill without featureFlag is never flag-gated", () => {
@@ -280,14 +279,15 @@ describe("resolveSkillStates with feature flags", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveSkillStates with frontmatter featureFlag", () => {
-  test("skill with featureFlag (defaultEnabled: false) is filtered when no config override", () => {
-    // contacts has defaultEnabled: false in the registry
+  test("skill with featureFlag (defaultEnabled: true) is included when no config override", () => {
+    // contacts has defaultEnabled: true in the registry
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // No override, registry default is false → filtered out
-    expect(resolved.length).toBe(0);
+    // No override, registry default is true → passes through
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
   });
 
   test("skill with featureFlag is included when config override enables it", () => {

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -166,7 +166,7 @@ describe("skill_load feature flag enforcement", () => {
     expect(result.content).toContain("Skill: Contacts");
   });
 
-  test("rejects skill when flag key is absent (registry defaults to disabled)", async () => {
+  test("loads skill when flag key is absent (registry defaults to enabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
       "Contacts",
@@ -184,8 +184,8 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    // contacts is declared in the registry with defaultEnabled: false
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("disabled by feature flag");
+    // contacts is declared in the registry with defaultEnabled: true
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Skill: Contacts");
   });
 });

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -23,7 +23,7 @@
       "key": "feature_flags.contacts.enabled",
       "label": "Contacts",
       "description": "Show the Contacts tab in Settings for viewing and managing contacts",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "email-channel",


### PR DESCRIPTION
## Summary
- Set `defaultEnabled: true` for the contacts feature flag in the registry
- Updated 5 test files to reflect the new default

## Test plan
- [ ] Verify contacts tab appears in Settings without explicit flag override
- [ ] Verify contacts can still be disabled via explicit `false` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
