### PR TITLE
feat: migrate fetchMessageContent to ConversationClient

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -668,15 +668,6 @@ class IOSConversationStore: ObservableObject {
         }
     }
 
-    private func handleMessageContentResponse(_ response: MessageContentResponse) {
-        for (_, vm) in viewModels {
-            if vm.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
-                vm.handleMessageContentResponse(response)
-                return
-            }
-        }
-    }
-
     /// Load history for a daemon-backed conversation when first selected.
     func loadHistoryIfNeeded(for conversationLocalId: UUID) {
         guard let conversation = conversations.first(where: { $0.id == conversationLocalId }),

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -305,9 +305,6 @@ class IOSConversationStore: ObservableObject {
         daemon.onHistoryResponse = { [weak self] response in
             self?.handleHistoryResponse(response)
         }
-        daemon.onMessageContentResponse = { [weak self] response in
-            self?.handleMessageContentResponse(response)
-        }
         daemon.onScheduleConversationCreated = { [weak self] msg in
             guard let self else { return }
             // Avoid duplicates
@@ -407,7 +404,6 @@ class IOSConversationStore: ObservableObject {
         if let oldDaemon = daemonClient as? DaemonClient {
             oldDaemon.onConversationListResponse = nil
             oldDaemon.onHistoryResponse = nil
-            oldDaemon.onMessageContentResponse = nil
             oldDaemon.onScheduleConversationCreated = nil
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -66,10 +66,6 @@ final class ConversationRestorer {
         daemonClient.onConversationTitleUpdated = { [weak self] response in
             self?.handleConversationTitleUpdated(response)
         }
-        daemonClient.onMessageContentResponse = { [weak self] response in
-            self?.handleMessageContentResponse(response)
-        }
-
         // On first launch after onboarding, skip the initial conversation list fetch
         // so the conversation restorer doesn't override the wake-up conversation.
         // The handlers above are still registered for later use (e.g. history loading).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -299,19 +299,6 @@ final class ConversationRestorer {
         delegate.conversations[index].title = response.title
     }
 
-    func handleMessageContentResponse(_ response: MessageContentResponse) {
-        guard let delegate else { return }
-        // Route the full content back to the ChatViewModel that owns this message.
-        // We check all conversations with existing VMs for a matching daemonMessageId.
-        for conversation in delegate.conversations {
-            guard let viewModel = delegate.existingChatViewModel(for: conversation.id) else { continue }
-            if viewModel.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
-                viewModel.handleMessageContentResponse(response)
-                return
-            }
-        }
-    }
-
     // MARK: - Private
 
     private func fetchConversationList() {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -734,10 +734,10 @@ public final class ChatViewModel: ObservableObject {
               messages[idx].wasTruncated || messages[idx].isContentStripped,
               let conversationId = conversationId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
-        do {
-            try daemonClient.send(MessageContentRequest(type: "message_content_request", conversationId: conversationId, messageId: daemonMessageId))
-        } catch {
-            log.error("Failed to send message_content_request: \(error)")
+        Task {
+            if let response = await ConversationClient().fetchMessageContent(conversationId: conversationId, messageId: daemonMessageId) {
+                self.handleMessageContentResponse(response)
+            }
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -734,7 +734,9 @@ public final class ChatViewModel: ObservableObject {
               messages[idx].wasTruncated || messages[idx].isContentStripped,
               let conversationId = conversationId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
-        Task {
+        guard daemonClient.isConnected else { return }
+        Task { [weak self] in
+            guard let self else { return }
             if let response = await ConversationClient().fetchMessageContent(conversationId: conversationId, messageId: daemonMessageId) {
                 self.handleMessageContentResponse(response)
             }

--- a/clients/shared/Network/ConversationClient.swift
+++ b/clients/shared/Network/ConversationClient.swift
@@ -1,0 +1,46 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationClient")
+
+/// Focused client for conversation-related operations routed through the gateway.
+@MainActor
+public protocol ConversationClientProtocol {
+    func fetchMessageContent(conversationId: String, messageId: String) async -> MessageContentResponse?
+}
+
+/// Gateway-backed implementation of ``ConversationClientProtocol``.
+@MainActor
+public struct ConversationClient: ConversationClientProtocol {
+    nonisolated public init() {}
+
+    public func fetchMessageContent(conversationId: String, messageId: String) async -> MessageContentResponse? {
+        do {
+            let encoded = messageId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? messageId
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/messages/\(encoded)/content",
+                params: ["conversationId": conversationId],
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("fetchMessageContent failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            let patched = injectType("message_content_response", into: response.data)
+            return try JSONDecoder().decode(MessageContentResponse.self, from: patched)
+        } catch {
+            log.error("fetchMessageContent error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func injectType(_ type: String, into data: Data) -> Data {
+        guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return data
+        }
+        json["type"] = type
+        return (try? JSONSerialization.data(withJSONObject: json)) ?? data
+    }
+}

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -359,9 +359,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `history_response` message.
     public var onHistoryResponse: ((HistoryResponse) -> Void)?
 
-    /// Called when the daemon sends a `message_content_response` with full (untruncated) content.
-    public var onMessageContentResponse: ((MessageContentResponse) -> Void)?
-
     /// Called when the daemon sends a `slack_webhook_config_response` message.
     public var onSlackWebhookConfigResponse: ((SlackWebhookConfigResponseMessage) -> Void)?
 
@@ -813,12 +810,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     ///   - maxToolResultChars: When set, truncates tool result content to this many characters.
     public func sendHistoryRequest(conversationId: String, limit: Int? = nil, beforeTimestamp: Double? = nil, mode: String? = nil, maxTextChars: Int? = nil, maxToolResultChars: Int? = nil) throws {
         try send(HistoryRequestMessage(conversationId: conversationId, limit: limit, beforeTimestamp: beforeTimestamp, mode: mode, maxTextChars: maxTextChars, maxToolResultChars: maxToolResultChars))
-    }
-
-    /// Request full (untruncated) content for a specific message.
-    /// Used to rehydrate messages that were loaded with truncated text/tool results.
-    public func sendMessageContentRequest(conversationId: String, messageId: String) throws {
-        try send(MessageContentRequest(type: "message_content_request", conversationId: conversationId, messageId: messageId))
     }
 
     /// Get, set, or delete the Vercel API token configuration.

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -116,8 +116,8 @@ extension DaemonClient {
             onConversationTitleUpdated?(msg)
         case .historyResponse(let msg):
             onHistoryResponse?(msg)
-        case .messageContentResponse(let msg):
-            onMessageContentResponse?(msg)
+        case .messageContentResponse:
+            break // Handled by ConversationClient via GatewayHTTPClient.
         case .shareAppCloudResponse:
             break // Handled by AppsClient via GatewayHTTPClient.
         case .slackWebhookConfigResponse(let msg):

--- a/clients/shared/Network/HTTPDaemonClient+Conversations.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Conversations.swift
@@ -49,8 +49,8 @@ extension HTTPTransport {
                     )
                 }
                 return true
-            } else if let msg = message as? MessageContentRequest {
-                Task { await self.fetchMessageContent(conversationId: msg.conversationId, messageId: msg.messageId) }
+            } else if message is MessageContentRequest {
+                // Handled by ConversationClient via GatewayHTTPClient.
                 return true
             } else if let msg = message as? DeleteQueuedMessageMessage {
                 Task { await self.deleteQueuedMessage(conversationId: msg.conversationId, requestId: msg.requestId) }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -289,7 +289,6 @@ public final class HTTPTransport {
         case conversationRegenerate(id: String)
         case model
         case conversationSearch(query: String, limit: Int?, maxMessagesPerConversation: Int?)
-        case messageContent(id: String, conversationId: String?)
         case deleteQueuedMessage(id: String, conversationId: String)
         case conversationsReorder
         // Computer Use
@@ -448,13 +447,6 @@ public final class HTTPTransport {
             if let limit { qs += "&limit=\(limit)" }
             if let maxMessages { qs += "&maxMessagesPerConversation=\(maxMessages)" }
             return ("/v1/conversations/search", qs)
-        case .messageContent(let id, let conversationId):
-            let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
-            if let conversationId {
-                let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
-                return ("/v1/messages/\(idEncoded)/content", "conversationId=\(sEncoded)")
-            }
-            return ("/v1/messages/\(idEncoded)/content", nil)
         case .deleteQueuedMessage(let id, let conversationId):
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
@@ -607,13 +599,6 @@ public final class HTTPTransport {
             if let limit { qs += "&limit=\(limit)" }
             if let maxMessages { qs += "&maxMessagesPerConversation=\(maxMessages)" }
             return ("\(prefix)/conversations/search/", qs)
-        case .messageContent(let id, let conversationId):
-            let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
-            if let conversationId {
-                let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
-                return ("\(prefix)/messages/\(idEncoded)/content/", "conversationId=\(sEncoded)")
-            }
-            return ("\(prefix)/messages/\(idEncoded)/content/", nil)
         case .deleteQueuedMessage(let id, let conversationId):
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = conversationId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? conversationId
@@ -1922,34 +1907,6 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Conversation search error: \(error.localizedDescription)")
-        }
-    }
-
-    func fetchMessageContent(conversationId: String, messageId: String, isRetry: Bool = false) async {
-        guard let url = buildURL(for: .messageContent(id: messageId, conversationId: conversationId)) else { return }
-
-        var request = URLRequest(url: url)
-        applyAuth(&request)
-
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-
-            guard let http = response as? HTTPURLResponse else { return }
-
-            if http.statusCode == 200 {
-                let patched = injectType("message_content_response", into: data)
-                let decoded = try decoder.decode(MessageContentResponse.self, from: patched)
-                onMessage?(.messageContentResponse(decoded))
-            } else if http.statusCode == 401 && !isRetry {
-                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
-                if case .success = refreshResult {
-                    await fetchMessageContent(conversationId: conversationId, messageId: messageId, isRetry: true)
-                }
-            } else {
-                log.error("Message content fetch failed (HTTP \(http.statusCode))")
-            }
-        } catch {
-            log.error("Message content fetch error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Split out from batch 7 PR (#18694)
- Creates `ConversationClient` with `fetchMessageContent` method that calls the gateway directly via `GatewayHTTPClient`
- `ChatViewModel.rehydrateMessage` now calls `ConversationClient` inline and handles the response directly, replacing the old callback chain (DaemonClient → HTTPDaemonClient → onMessage → DaemonMessageRouter → onMessageContentResponse → ChatViewModel)
- Removes `sendMessageContentRequest`, `onMessageContentResponse`, `.messageContent` enum case, and related URL builders from the old DaemonClient infrastructure

## Test plan
- [ ] Open a conversation with truncated messages, scroll to trigger rehydration — verify full content loads
- [ ] Verify on both macOS and iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
