### PR TITLE
fix: insert synthetic web_search_tool_result adjacent to its server_tool_use

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -588,6 +588,77 @@ describe("repairHistory", () => {
     });
   });
 
+  test("synthetic web_search_tool_result is placed immediately after its server_tool_use, not at end", () => {
+    // Regression: synthetic results appended to the end of the content array
+    // get separated from their server_tool_use by ensureToolPairing's split
+    // at tool_use boundaries, causing the API to reject with "web_search
+    // tool use without a corresponding web_search_tool_result block".
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Search and act" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me search" },
+          {
+            type: "server_tool_use",
+            id: "stu_1",
+            name: "web_search",
+            input: { query: "openai" },
+          },
+          {
+            type: "server_tool_use",
+            id: "stu_2",
+            name: "web_search",
+            input: { query: "anthropic" },
+          },
+          { type: "text", text: "Based on my research" },
+          {
+            type: "tool_use",
+            id: "tu_1",
+            name: "skill_load",
+            input: { skill: "app-builder" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_1",
+            content: "Skill loaded",
+          },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.missingToolResultsInserted).toBe(2);
+
+    const assistantMsg = repaired[1];
+    // Synthetic results must appear immediately after their server_tool_use,
+    // NOT after the tool_use block at the end
+    const blockTypes = assistantMsg.content.map((b) => b.type);
+    expect(blockTypes).toEqual([
+      "text",
+      "server_tool_use",
+      "web_search_tool_result", // right after stu_1
+      "server_tool_use",
+      "web_search_tool_result", // right after stu_2
+      "text",
+      "tool_use",
+    ]);
+
+    // Verify the pairings are correct
+    expect(
+      (assistantMsg.content[2] as { tool_use_id: string }).tool_use_id,
+    ).toBe("stu_1");
+    expect(
+      (assistantMsg.content[4] as { tool_use_id: string }).tool_use_id,
+    ).toBe("stu_2");
+  });
+
   test("downgrades type-mismatched tool_result for server_tool_use", () => {
     // A tool_result in the user message for a server_tool_use ID is orphaned —
     // server-side results belong in the assistant message

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -69,7 +69,10 @@ export function repairHistory(messages: Message[]): RepairResult {
       }
 
       // Ensure every server_tool_use has a paired web_search_tool_result
-      // in the same assistant message (handles interrupted streams)
+      // in the same assistant message (handles interrupted streams).
+      // Synthetic results are inserted IMMEDIATELY AFTER their corresponding
+      // server_tool_use block — not appended to the end — so that
+      // ensureToolPairing's split at tool_use boundaries cannot separate them.
       const serverToolIds = new Set(
         cleanedContent
           .filter(
@@ -82,18 +85,35 @@ export function repairHistory(messages: Message[]): RepairResult {
           .filter((b) => b.type === "web_search_tool_result")
           .map((b) => (b as { tool_use_id: string }).tool_use_id),
       );
+      const orphanedServerIds = new Set<string>();
       for (const id of serverToolIds) {
         if (!matchedServerIds.has(id)) {
-          cleanedContent.push({
-            type: "web_search_tool_result",
-            tool_use_id: id,
-            content: SYNTHETIC_WEB_SEARCH_ERROR,
-          });
-          stats.missingToolResultsInserted++;
+          orphanedServerIds.add(id);
         }
       }
 
-      result.push({ role: "assistant", content: cleanedContent });
+      let repairedContent: ContentBlock[];
+      if (orphanedServerIds.size > 0) {
+        repairedContent = [];
+        for (const block of cleanedContent) {
+          repairedContent.push(block);
+          if (
+            block.type === "server_tool_use" &&
+            orphanedServerIds.has(block.id)
+          ) {
+            repairedContent.push({
+              type: "web_search_tool_result",
+              tool_use_id: block.id,
+              content: SYNTHETIC_WEB_SEARCH_ERROR,
+            });
+            stats.missingToolResultsInserted++;
+          }
+        }
+      } else {
+        repairedContent = cleanedContent;
+      }
+
+      result.push({ role: "assistant", content: repairedContent });
 
       // Only track client-side tool_use IDs as pending (not server_tool_use)
       pendingToolUseIds = new Set(


### PR DESCRIPTION
## Summary
- **Bug**: `repairHistory` appended synthetic `web_search_tool_result` blocks to the end of assistant message content. When a `tool_use` block existed in the same message, `ensureToolPairing` split the message at the `tool_use` boundary, separating `server_tool_use` from its synthetic result. The API rejected with "web_search tool use without a corresponding web_search_tool_result block" — an unrecoverable error that bricked the conversation.
- **Fix**: Insert synthetic `web_search_tool_result` blocks immediately after each orphaned `server_tool_use` block (matching what `repairOrphanedServerToolUse` in the Anthropic client already does correctly), so they stay together through `ensureToolPairing`'s split.
- **Test**: Added regression test verifying synthetic results are placed adjacent to their `server_tool_use`, not at the end of the content array.

## Original prompt
Fix the web search repair ordering bug identified from user logs: `repairHistory` pushes synthetic `web_search_tool_result` to the end of the content array, but `ensureToolPairing` splits the message at `tool_use` boundaries, separating `server_tool_use` from its synthetic result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)