### PR TITLE
Remove all truncation and hiding of text in tool call UI

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -167,30 +167,6 @@ export function emitLlmCallStartedIfNeeded(
   );
 }
 
-// ── Client Payload Size Caps ─────────────────────────────────────────
-// The client truncates tool results anyway (20 000 chars in ChatViewModel),
-// but the full string can be megabytes (file_read, bash output). Capping
-// here avoids sending oversized payloads which get decoded on the
-// client's main thread.
-
-const TOOL_RESULT_MAX_CHARS = 20_000;
-const TOOL_RESULT_TRUNCATION_SUFFIX = "...[truncated]";
-
-// tool_input_delta streams accumulated JSON as tools run. For non-app
-// tools the client discards it (extractCodePreview only handles app tools),
-// so we cap it aggressively to avoid excessive client traffic.
-const TOOL_INPUT_DELTA_MAX_CHARS = 50_000;
-const APP_TOOL_NAMES = new Set(["app_create", "app_update"]);
-
-function truncateForClient(
-  value: string,
-  maxChars: number,
-  suffix: string,
-): string {
-  if (value.length <= maxChars) return value;
-  return value.slice(0, maxChars - suffix.length) + suffix;
-}
-
 // ── Friendly Tool Names ──────────────────────────────────────────────
 
 const TOOL_FRIENDLY_NAMES: Record<string, string> = {
@@ -409,19 +385,10 @@ export function handleInputJsonDelta(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "input_json_delta" }>,
 ): void {
-  // Cap non-app tool input deltas — the client only uses this data for
-  // app_create/app_update code previews; all other tools discard it.
-  const content = APP_TOOL_NAMES.has(event.toolName)
-    ? event.accumulatedJson
-    : truncateForClient(
-        event.accumulatedJson,
-        TOOL_INPUT_DELTA_MAX_CHARS,
-        TOOL_RESULT_TRUNCATION_SUFFIX,
-      );
   deps.onEvent({
     type: "tool_input_delta",
     toolName: event.toolName,
-    content,
+    content: event.accumulatedJson,
     conversationId: deps.ctx.conversationId,
     toolUseId: event.toolUseId,
   });
@@ -438,11 +405,7 @@ export function handleToolResult(
   deps.onEvent({
     type: "tool_result",
     toolName: "",
-    result: truncateForClient(
-      event.content,
-      TOOL_RESULT_MAX_CHARS,
-      TOOL_RESULT_TRUNCATION_SUFFIX,
-    ),
+    result: event.content,
     isError: event.isError,
     diff: event.diff,
     status: event.status,

--- a/assistant/src/tools/shared/filesystem/format-diff.ts
+++ b/assistant/src/tools/shared/filesystem/format-diff.ts
@@ -1,21 +1,15 @@
-const MAX_DIFF_LINES = 8;
-
 /**
- * Build a compact inline diff from an old→new string replacement.
- * Lines are prefixed with - / + and truncated if the change is large.
+ * Build an inline diff from an old→new string replacement.
+ * Lines are prefixed with - / +.
  */
 export function formatEditDiff(oldString: string, newString: string): string {
   const removed =
     oldString.length > 0
-      ? truncateLines(oldString.split("\n"), MAX_DIFF_LINES).map(
-          (l) => `- ${l}`,
-        )
+      ? oldString.split("\n").map((l) => `- ${l}`)
       : [];
   const added =
     newString.length > 0
-      ? truncateLines(newString.split("\n"), MAX_DIFF_LINES).map(
-          (l) => `+ ${l}`,
-        )
+      ? newString.split("\n").map((l) => `+ ${l}`)
       : [];
 
   return [...removed, ...added].join("\n");
@@ -37,9 +31,3 @@ export function formatWriteSummary(
   return `(${oldLineCount} → ${newLineCount} lines)`;
 }
 
-function truncateLines(lines: string[], max: number): string[] {
-  if (lines.length <= max) return lines;
-  const kept = lines.slice(0, max);
-  kept.push(`... (${lines.length - max} more lines)`);
-  return kept;
-}

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -502,9 +502,7 @@ private struct StepDetailRow: View {
     @State private var isHovered = false
     /// Cached formatted input — computed once on first expand.
     @State private var cachedInputFull: String?
-    /// Tracks which output sections (live output / final output) are expanded.
-    @State private var expandedOutputIds: Set<String> = []
-    @Environment(\.displayScale) private var displayScale
+@Environment(\.displayScale) private var displayScale
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
 
     /// Lazily resolved full input text.
@@ -512,12 +510,6 @@ private struct StepDetailRow: View {
         if let cached = cachedInputFull { return cached }
         if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
         return ""
-    }
-
-    /// Whether the tool result or input appears truncated.
-    private var isTruncated: Bool {
-        (toolCall.result?.hasSuffix("[truncated]") ?? false)
-            || toolCall.inputFull.hasSuffix("[truncated]")
     }
 
     /// Whether this tool has detail content to show (running or completed).
@@ -651,9 +643,6 @@ private struct StepDetailRow: View {
                                 cachedInputFull = ToolCallData.formatAllToolInput(dict)
                             }
                         }
-                        if isTruncated {
-                            onRehydrate?()
-                        }
                     }
             }
         }
@@ -681,22 +670,10 @@ private struct StepDetailRow: View {
 
             // Technical details
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack {
-                    Text("Technical details")
-                        .font(VFont.small)
-                        .foregroundColor(VColor.contentTertiary)
-                        .textCase(.uppercase)
-                    if isTruncated {
-                        Text("truncated")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.systemMidStrong)
-                            .padding(.horizontal, VSpacing.xs)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.xs)
-                                    .fill(VColor.systemMidStrong.opacity(0.12))
-                            )
-                    }
-                }
+                Text("Technical details")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
+                    .textCase(.uppercase)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     if let reason = toolCall.reasonDescription, !reason.isEmpty {
@@ -712,6 +689,7 @@ private struct StepDetailRow: View {
                             .font(VFont.monoSmall)
                             .foregroundColor(VColor.contentSecondary)
                             .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
             }
@@ -743,12 +721,10 @@ private struct StepDetailRow: View {
                         .textCase(.uppercase)
 
                     outputBlock(
-                        id: "live-\(toolCall.id.uuidString)",
                         text: toolCall.partialOutput,
                         attributedText: nil,
                         copyText: toolCall.partialOutput,
-                        copyLabel: "Copy live output",
-                        isLive: true
+                        copyLabel: "Copy live output"
                     )
                 }
                 .padding(.horizontal, VSpacing.lg)
@@ -766,7 +742,6 @@ private struct StepDetailRow: View {
                         .textCase(.uppercase)
 
                     outputBlock(
-                        id: "result-\(toolCall.id.uuidString)",
                         text: nil,
                         attributedText: coloredOutput(result, isError: toolCall.isError),
                         copyText: result,
@@ -781,65 +756,29 @@ private struct StepDetailRow: View {
 
     // MARK: - Output Block
 
-    /// Reusable output block that replaces nested ScrollView with truncated Text.
-    /// Default state shows 8 lines with a "Show more" toggle. Expanded state shows
-    /// full text; outputs exceeding 500 lines use a ScrollView capped at 400pt.
+    /// Reusable output block — shows full text with a copy button.
     @ViewBuilder
     private func outputBlock(
-        id: String,
         text: String?,
         attributedText: AttributedString?,
         copyText: String,
-        copyLabel: String,
-        isLive: Bool = false
+        copyLabel: String
     ) -> some View {
-        let isOutputExpanded = expandedOutputIds.contains(id)
-        let lineCount = copyText.components(separatedBy: "\n").count
-        let needsTruncation = lineCount > 8 || copyText.count > 400
-
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if isOutputExpanded && lineCount > 500 {
-                    // Expanded with ScrollView for extremely long outputs
-                    ScrollView {
-                        outputTextView(text: text, attributedText: attributedText, lineLimit: nil)
-                    }
-                    .if(isLive) { view in
-                        view.defaultScrollAnchor(.bottom)
-                    }
-                    .frame(maxHeight: 400)
-                } else if let attrText = attributedText {
+                if let attrText = attributedText {
                     Text(attrText)
                         .font(VFont.monoSmall)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
-                        .lineLimit(isOutputExpanded ? nil : 8)
-                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 } else if let plainText = text {
                     Text(plainText)
                         .font(VFont.monoSmall)
                         .foregroundColor(VColor.contentSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
-                        .lineLimit(isOutputExpanded ? nil : 8)
-                        .truncationMode(.tail)
-                }
-
-                if needsTruncation {
-                    Button {
-                        withAnimation(VAnimation.fast) {
-                            if isOutputExpanded {
-                                expandedOutputIds.remove(id)
-                            } else {
-                                expandedOutputIds.insert(id)
-                            }
-                        }
-                    } label: {
-                        Text(isOutputExpanded ? "Show less" : "Show more")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.primaryBase)
-                    }
-                    .buttonStyle(.plain)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(VSpacing.sm)
@@ -857,29 +796,6 @@ private struct StepDetailRow: View {
                 NSPasteboard.general.setString(copyText, forType: .string)
             }
             .padding(VSpacing.xs)
-        }
-    }
-
-    /// Text view used inside the expanded ScrollView for long outputs.
-    @ViewBuilder
-    private func outputTextView(
-        text: String?,
-        attributedText: AttributedString?,
-        lineLimit: Int?
-    ) -> some View {
-        if let attrText = attributedText {
-            Text(attrText)
-                .font(VFont.monoSmall)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
-                .lineLimit(lineLimit)
-        } else if let plainText = text {
-            Text(plainText)
-                .font(VFont.monoSmall)
-                .foregroundColor(VColor.contentSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
-                .lineLimit(lineLimit)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -870,12 +870,10 @@ public struct ToolCallData: Identifiable, Equatable {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
-        var fullInput = inputFull ?? inputSummary
-        if fullInput.count > 10_000 { fullInput = String(fullInput.prefix(10_000)) + "... [truncated]" }
+        let fullInput = inputFull ?? inputSummary
         self.inputFull = fullInput
         self.inputFullLength = fullInput.count
-        var rawValue = inputRawValue ?? inputSummary
-        if rawValue.count > 10_000 { rawValue = String(rawValue.prefix(10_000)) + "... [truncated]" }
+        let rawValue = inputRawValue ?? inputSummary
         self.inputRawValue = rawValue
         self.inputRawValueLength = rawValue.count
         self.result = result
@@ -1255,9 +1253,7 @@ public struct ToolCallData: Identifiable, Equatable {
             }
         }
 
-        var result = lines.joined(separator: "\n")
-        if result.count > 10_000 { result = String(result.prefix(10_000)) + "... [truncated]" }
-        return result
+        return lines.joined(separator: "\n")
     }
 
     private static func stringifyValue(_ value: AnyCodable) -> String {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -164,9 +164,7 @@ extension ChatViewModel {
             }
         }
 
-        var result = lines.joined(separator: "\n")
-        if result.count > 10_000 { result = String(result.prefix(10_000)) + "... [truncated]" }
-        return result
+        return lines.joined(separator: "\n")
     }
 
     private func stringifyValue(_ value: AnyCodable) -> String {
@@ -1527,8 +1525,7 @@ extension ChatViewModel {
                 }
             }
             if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
-                let truncatedResult = msg.result.count > 20000 ? String(msg.result.prefix(20000)) + "...[truncated]" : msg.result
-                messages[msgIndex].toolCalls[tcIndex].result = truncatedResult
+                messages[msgIndex].toolCalls[tcIndex].result = msg.result
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
                 messages[msgIndex].toolCalls[tcIndex].completedAt = Date()
@@ -1544,10 +1541,10 @@ extension ChatViewModel {
                 let toolErrored = msg.isError ?? false
                 downgradeAdjacentApprovedConfirmationForPermissionDeniedError(
                     assistantMessageIndex: msgIndex,
-                    toolResult: truncatedResult,
+                    toolResult: msg.result,
                     isError: toolErrored
                 )
-                if toolErrored, Self.isOSPermissionDeniedError(truncatedResult),
+                if toolErrored, Self.isOSPermissionDeniedError(msg.result),
                    messages[msgIndex].toolCalls[tcIndex].confirmationDecision == .approved {
                     messages[msgIndex].toolCalls[tcIndex].confirmationDecision = .denied
                 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2598,12 +2598,6 @@ public final class ChatViewModel: ObservableObject {
             let toolsBeforeText = item.toolCallsBeforeText ?? true
             if let historyToolCalls = item.toolCalls {
                 toolCalls = historyToolCalls.map { tc in
-                    // Truncate tool result for memory safety
-                    let truncatedResult: String? = {
-                        guard let result = tc.result else { return nil }
-                        return result.count > 20000 ? String(result.prefix(20000)) + "...[truncated]" : result
-                    }()
-
                     // Decode image once — pass decoded image directly to avoid double-decode
                     // (ToolCallData.init also decodes base64, so skip that by passing imageData: nil)
                     let decodedImage = ToolCallData.decodeImage(from: tc.imageData)
@@ -2613,7 +2607,7 @@ public final class ChatViewModel: ObservableObject {
                         inputSummary: summarizeToolInput(tc.input),
                         inputFull: "",
                         inputRawValue: extractToolInput(tc.input),
-                        result: truncatedResult,
+                        result: tc.result,
                         isError: tc.isError ?? false,
                         isComplete: true,
                         arrivedBeforeText: toolsBeforeText,

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -18,13 +18,7 @@ public struct ToolCallChip: View {
     /// `formatAllToolInput` on every SwiftUI render pass.
     @State private var cachedInputFull: String?
 
-    /// Whether the tool result or input appears to contain truncated content.
-    private var isTruncated: Bool {
-        (toolCall.result?.hasSuffix("[truncated]") ?? false)
-            || toolCall.inputFull.hasSuffix("[truncated]")
-    }
-
-    /// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
+/// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
     static func parseExitCode(from result: String) -> Int? {
         // Match <command_exit code="N" /> where N is an integer
         guard let codeRange = result.range(of: #"<command_exit code="(\d+)" />"#, options: .regularExpression) else {
@@ -115,22 +109,10 @@ public struct ToolCallChip: View {
 
                     // Technical details section
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        HStack {
-                            Text("Technical details")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                                .textCase(.uppercase)
-                            if isTruncated {
-                                Text("truncated")
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.systemMidStrong)
-                                    .padding(.horizontal, VSpacing.xs)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: VRadius.xs)
-                                            .fill(VColor.systemMidStrong.opacity(0.12))
-                                    )
-                            }
-                        }
+                        Text("Technical details")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                            .textCase(.uppercase)
 
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
@@ -141,6 +123,7 @@ public struct ToolCallChip: View {
                                     .font(VFont.monoSmall)
                                     .foregroundColor(VColor.contentSecondary)
                                     .textSelection(.enabled)
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                     }
@@ -223,14 +206,12 @@ public struct ToolCallChip: View {
                                         .foregroundColor(VColor.contentSecondary)
                                 }
                             } else {
-                                ScrollView {
-                                    Text(result)
-                                        .font(VFont.monoSmall)
-                                        .foregroundColor(VColor.contentSecondary)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .textSelection(.enabled)
-                                }
-                                .frame(maxHeight: 200)
+                                Text(result)
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.contentSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                         .padding(.horizontal, VSpacing.sm)
@@ -247,10 +228,6 @@ public struct ToolCallChip: View {
                         } else if let dict = toolCall.inputRawDict {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
-                    }
-                    // Trigger on-demand rehydration when expanding truncated content.
-                    if isTruncated {
-                        onRehydrate?()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Remove all character limits (10K/20K), line limits (8 lines), and "Show more" toggles from tool call input/output displays across daemon, shared client, and macOS client
- Remove `MAX_DIFF_LINES=8` truncation in `format-diff.ts` so edit diffs show full content
- Add `.fixedSize(horizontal: false, vertical: true)` to Text views to prevent SwiftUI layout clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
