### PR TITLE
fix: update formatEditDiff test to match no-truncation implementation

### DIFF
--- a/assistant/src/__tests__/filesystem-tools.test.ts
+++ b/assistant/src/__tests__/filesystem-tools.test.ts
@@ -325,12 +325,14 @@ describe("formatEditDiff", () => {
     expect(result).not.toContain("+ ");
   });
 
-  test("truncates long diffs beyond 8 lines", () => {
+  test("shows all diff lines without truncation", () => {
     const longOld = Array.from({ length: 12 }, (_, i) => `old-line-${i}`).join(
       "\n",
     );
     const result = formatEditDiff(longOld, "short");
-    expect(result).toContain("more lines");
+    expect(result).not.toContain("more lines");
+    expect(result).toContain("old-line-11");
+    expect(result).toContain("+ short");
   });
 });
 


### PR DESCRIPTION
## Summary
- The `formatEditDiff` function no longer truncates long diffs (truncation was removed in #18745), but the test still asserted truncation behavior
- Updated the test to verify all diff lines are shown without truncation

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23227979037/job/67514842630

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
