### PR TITLE
Add feature flag to auto-expand completed step groups

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -39,7 +39,7 @@ struct AssistantProgressView: View {
     var activeConfirmationRequestId: String? = nil  // For keyboard focus
 
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
     @State private var startDate: Date = Date()
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -256,6 +256,14 @@
       "label": "Quick Input",
       "description": "Enable the Quick Input popover on right-click of the menu bar icon",
       "defaultEnabled": false
+    },
+    {
+      "id": "expand-completed-steps",
+      "scope": "macos",
+      "key": "expand_completed_steps",
+      "label": "Expand Completed Steps",
+      "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `expand-completed-steps` macOS feature flag (`defaultEnabled: false`) to the registry
- `AssistantProgressView.isExpanded` initial value reads from the flag, so completed step groups can start expanded when enabled in Developer settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
