### PR TITLE
M2: Reframe guardian verification as test-your-connection

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -135,13 +135,15 @@ Use the most recent `credential_store` result as the source of truth:
 
 Guardian verification depends on Socket Mode being live, so only proceed once the connection is confirmed.
 
-## Step 5: Guardian Verification (Optional)
+## Step 5: Test Your Connection
 
-Link the user's Slack account as the trusted guardian. Load the **guardian-verify-setup** skill:
+Now let's test the connection by verifying the user can receive messages from the bot. This also sets them up as the trusted guardian for this Slack workspace.
+
+Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user declines, skip and continue.
+If the user explicitly wants to skip this step, proceed to Step 6, but let them know they can always verify later by saying "verify me on slack".
 
 ## Step 6: Report Success
 


### PR DESCRIPTION
Part of #18755. Changes Step 5 of slack-app-setup from 'Guardian Verification (Optional)' to 'Test Your Connection', making it feel like a natural completion step rather than an optional extra.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
