### PR TITLE
M1: Improve unverified user reply message on Slack

### DIFF
--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -163,11 +163,11 @@ describe("Slack inbound trusted contact verification", () => {
     // Verification code is NOT sent to the requester — only the guardian
     // receives it via the access request notification flow
 
-    // Channel reply tells user the owner has been notified
+    // Channel reply tells user they're not recognized yet
     expect(deliverReplyCalls.length).toBe(1);
     expect(
       (deliverReplyCalls[0].payload as Record<string, unknown>).text,
-    ).toContain("notified the owner");
+    ).toContain("I don't recognize you yet");
   });
 
   test("verification session is identity-bound to the Slack user", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -334,7 +334,7 @@ export async function enforceIngressAcl(
                   dmCallbackUrl,
                   {
                     chatId: senderUserId,
-                    text: "I've notified the owner that you'd like to chat with me. If they approve your request, they'll share a 6-digit verification code with you. You can reply with the code here.",
+                    text: "I don't recognize you yet! I've let my owner know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.",
                     assistantId,
                   },
                   mintBearerToken(),
@@ -588,7 +588,7 @@ export async function enforceIngressAcl(
                     dmCallbackUrl,
                     {
                       chatId: senderUserId,
-                      text: "I've notified the owner that you'd like to chat with me. If they approve your request, they'll share a 6-digit verification code with you. You can reply with the code here.",
+                      text: "I don't recognize you yet! I've let my owner know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.",
                       assistantId,
                     },
                     mintBearerToken(),


### PR DESCRIPTION
Part of #18755. Updates the DM sent to unverified Slack users from a passive notification to a more actionable message that tells them to ask the owner directly for the verification code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
