### PR TITLE
M4: Auto-deliver verification code to requester on Slack

### DIFF
--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -226,15 +226,10 @@ export async function notifyRequesterOfApproval(params: {
   bearerToken?: string;
   channel?: string;
   requesterExternalUserId?: string;
-  /** When true, the Slack-specific text references the auto-delivered code. */
-  codeDeliveredToRequester?: boolean;
 }): Promise<void> {
   const text =
-    params.channel === "slack" && params.codeDeliveredToRequester
-      ? "Your access request was approved! " +
-        "I've sent you the verification code — check your DMs and reply with it here."
-      : "Your access request has been approved! " +
-        "Please enter the 6-digit verification code you receive from the guardian.";
+    "Your access request has been approved! " +
+    "Please enter the 6-digit verification code you receive from the guardian.";
 
   const target = resolveRequesterTarget(params);
 

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -226,9 +226,11 @@ export async function notifyRequesterOfApproval(params: {
   bearerToken?: string;
   channel?: string;
   requesterExternalUserId?: string;
+  /** When true, the Slack-specific text references the auto-delivered code. */
+  codeDeliveredToRequester?: boolean;
 }): Promise<void> {
   const text =
-    params.channel === "slack"
+    params.channel === "slack" && params.codeDeliveredToRequester
       ? "Your access request was approved! " +
         "I've sent you the verification code — check your DMs and reply with it here."
       : "Your access request has been approved! " +

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -175,6 +175,47 @@ function resolveRequesterTarget(params: {
 }
 
 /**
+ * Deliver the verification code directly to the requester's DM on Slack,
+ * removing the need for the guardian to manually share it.
+ */
+export async function deliverVerificationCodeToRequester(params: {
+  replyCallbackUrl: string;
+  requesterChatId: string;
+  verificationCode: string;
+  assistantId: string;
+  bearerToken?: string;
+  channel?: string;
+  requesterExternalUserId?: string;
+}): Promise<DeliveryResult> {
+  const text =
+    `Great news — your access request was approved! ` +
+    `Your verification code is: ${params.verificationCode}. ` +
+    `Reply with it here to complete verification. The code expires in 10 minutes.`;
+
+  const target = resolveRequesterTarget(params);
+
+  try {
+    await deliverChannelReply(
+      target.callbackUrl,
+      {
+        chatId: target.chatId,
+        text,
+        assistantId: params.assistantId,
+      },
+      params.bearerToken,
+    );
+    return { ok: true };
+  } catch (err) {
+    log.error(
+      { err, requesterChatId: params.requesterChatId },
+      "Failed to deliver verification code to requester",
+    );
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason };
+  }
+}
+
+/**
  * Notify the requester that the guardian has approved their access request
  * and they should enter the verification code they receive from the guardian.
  */
@@ -187,8 +228,11 @@ export async function notifyRequesterOfApproval(params: {
   requesterExternalUserId?: string;
 }): Promise<void> {
   const text =
-    "Your access request has been approved! " +
-    "Please enter the 6-digit verification code you receive from the guardian.";
+    params.channel === "slack"
+      ? "Your access request was approved! " +
+        "I've sent you the verification code — check your DMs and reply with it here."
+      : "Your access request has been approved! " +
+        "Please enter the 6-digit verification code you receive from the guardian.";
 
   const target = resolveRequesterTarget(params);
 

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -692,6 +692,7 @@ async function handleAccessRequestApproval(
   // On Slack, auto-deliver the verification code directly to the requester's
   // DM so the guardian doesn't have to manually share it. The identity binding
   // still protects against abuse — only the bound user can consume the code.
+  let requesterCodeDelivered = false;
   if (
     codeDelivered &&
     approval.channel === "slack" &&
@@ -706,7 +707,9 @@ async function handleAccessRequestApproval(
       channel: approval.channel,
       requesterExternalUserId: approval.requesterExternalUserId,
     });
-    if (!requesterCodeResult.ok) {
+    if (requesterCodeResult.ok) {
+      requesterCodeDelivered = true;
+    } else {
       log.error(
         { reason: requesterCodeResult.reason, approvalId: approval.id },
         "Failed to auto-deliver verification code to requester on Slack",
@@ -714,7 +717,10 @@ async function handleAccessRequestApproval(
     }
   }
 
-  if (codeDelivered) {
+  // Skip the separate approval notification when the requester already
+  // received the verification code directly (on Slack both messages go
+  // to the same DM, so sending both is redundant).
+  if (codeDelivered && !requesterCodeDelivered) {
     await notifyRequesterOfApproval({
       replyCallbackUrl,
       requesterChatId: approval.requesterChatId,
@@ -723,7 +729,7 @@ async function handleAccessRequestApproval(
       channel: approval.channel,
       requesterExternalUserId: approval.requesterExternalUserId,
     });
-  } else {
+  } else if (!codeDelivered) {
     // Let the requester know something went wrong without revealing details
     await notifyRequesterOfDeliveryFailure({
       replyCallbackUrl,

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -27,6 +27,7 @@ import type {
 } from "../../http-types.js";
 import {
   deliverVerificationCodeToGuardian,
+  deliverVerificationCodeToRequester,
   type DeliveryResult,
   handleAccessRequestDecision,
   notifyRequesterOfApproval,
@@ -685,6 +686,31 @@ async function handleAccessRequestApproval(
         "Skipping requester notification — verification code was not delivered to guardian",
       );
       codeDelivered = false;
+    }
+  }
+
+  // On Slack, auto-deliver the verification code directly to the requester's
+  // DM so the guardian doesn't have to manually share it. The identity binding
+  // still protects against abuse — only the bound user can consume the code.
+  if (
+    codeDelivered &&
+    approval.channel === "slack" &&
+    decisionResult.verificationCode
+  ) {
+    const requesterCodeResult = await deliverVerificationCodeToRequester({
+      replyCallbackUrl,
+      requesterChatId: approval.requesterChatId,
+      verificationCode: decisionResult.verificationCode,
+      assistantId,
+      bearerToken,
+      channel: approval.channel,
+      requesterExternalUserId: approval.requesterExternalUserId,
+    });
+    if (!requesterCodeResult.ok) {
+      log.error(
+        { reason: requesterCodeResult.reason, approvalId: approval.id },
+        "Failed to auto-deliver verification code to requester on Slack",
+      );
     }
   }
 


### PR DESCRIPTION
Part of #18755. When a guardian approves a Slack access request, auto-DM the verification code to the requester instead of requiring manual handoff. The identity binding still protects against abuse.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
