### PR TITLE
M5: Detect unverified guardian and add Was-this-you CTA

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -623,7 +623,7 @@ describe("access-request-helper unit tests", () => {
     expect(telegram!.status).toBe("sent");
   });
 
-  test("notifyGuardianOfAccessRequest skips vellum fallback for same-channel-only routing (telegram)", async () => {
+  test("notifyGuardianOfAccessRequest creates vellum fallback when guardian not verified on source channel (telegram)", async () => {
     mockEmitResult = {
       signalId: "sig-no-vellum",
       deduplicated: false,
@@ -657,8 +657,9 @@ describe("access-request-helper unit tests", () => {
       (d) => d.destinationChannel === "telegram",
     );
 
-    // Same-channel routing skips vellum delivery entirely — no fallback record
-    expect(vellum).toBeUndefined();
+    // Guardian not verified on telegram → routes to vellum as fallback
+    expect(vellum).toBeDefined();
+    expect(vellum!.status).toBe("failed");
     expect(telegram).toBeDefined();
     expect(telegram!.destinationChatId).toBe("guardian-chat-456");
     expect(telegram!.status).toBe("sent");

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -235,7 +235,7 @@ export function buildAccessRequestContractText(
     sourceChannel
   ) {
     lines.push(
-      `Note: You haven't verified your identity on ${sourceChannel} yet. If this was you trying to message your assistant, say "verify me on ${sourceChannel}" to set up direct access.`,
+      `Note: You haven't verified your identity on ${sourceChannel} yet. If this was you trying to message your assistant, say "help me verify as guardian on ${sourceChannel}" to set up direct access.`,
     );
   }
   return lines.join("\n");

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -208,6 +208,15 @@ export function buildAccessRequestContractText(
       ? payload.previousMemberStatus
       : undefined;
 
+  const guardianResolutionSource =
+    typeof payload.guardianResolutionSource === "string"
+      ? payload.guardianResolutionSource
+      : undefined;
+  const sourceChannel =
+    typeof payload.sourceChannel === "string"
+      ? payload.sourceChannel
+      : undefined;
+
   const lines: string[] = [];
   lines.push(buildAccessRequestIdentityLine(payload));
   if (previousMemberStatus === "revoked") {
@@ -220,6 +229,15 @@ export function buildAccessRequestContractText(
     );
   }
   lines.push(buildAccessRequestInviteDirective());
+  if (
+    (guardianResolutionSource === "vellum-anchor" ||
+      guardianResolutionSource === "none") &&
+    sourceChannel
+  ) {
+    lines.push(
+      `Note: You haven't verified your identity on ${sourceChannel} yet. If this was you trying to message your assistant, say "verify me on ${sourceChannel}" to set up direct access.`,
+    );
+  }
   return lines.join("\n");
 }
 

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -211,7 +211,9 @@ export function notifyGuardianOfAccessRequest(
     "slack",
     "telegram",
   ]);
-  const sameChannelOnly = TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel);
+  const sameChannelOnly =
+    TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel) &&
+    guardianResolutionSource === "source-channel-contact";
 
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",
@@ -234,6 +236,7 @@ export function notifyGuardianOfAccessRequest(
       actorUsername: actorUsername ?? null,
       senderIdentifier,
       guardianBindingChannel,
+      guardianResolutionSource,
       previousMemberStatus: previousMemberStatus ?? null,
     },
     dedupeKey: `access-request:${canonicalRequest.id}`,


### PR DESCRIPTION
## Summary
- When the guardian hasn't verified on the source channel (`guardianResolutionSource !== "source-channel-contact"`), the `sameChannelOnly` flag is now set to `false` so the notification also routes to the desktop app (ensuring the guardian sees it somewhere)
- Added `guardianResolutionSource` to the notification signal's `contextPayload` so downstream copy composition can detect unverified guardians
- In `buildAccessRequestContractText`, when `guardianResolutionSource` is `"vellum-anchor"` or `"none"`, appends a "Was this you?" CTA telling the guardian how to verify on the source channel

## Test plan
- [ ] Verify existing tests pass (contract text tests don't include `guardianResolutionSource` in payload, so CTA is not appended — backward compatible)
- [ ] Test with a Slack access request where guardian IS verified on Slack — should route to Slack only (sameChannelOnly=true), no CTA
- [ ] Test with a Slack access request where guardian is NOT verified on Slack — should route to both Slack and desktop, CTA appended

Part of #18755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
