### PR TITLE
M6: Channel-agnostic unverified-guardian detection in notification layer

### DIFF
--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -196,6 +196,14 @@ export function hasInviteFlowDirective(text: string | undefined): boolean {
  * Build the deterministic access-request contract text from payload fields.
  * This is the canonical baseline that enforcement can append when generated
  * copy is missing required elements.
+ *
+ * Channel-agnostic by design: this function reads from the generic
+ * `contextPayload` and works identically regardless of which channel
+ * (Slack, Telegram, desktop, etc.) the notification is delivered to.
+ * When `guardianResolutionSource` is present and not `"source-channel-contact"`,
+ * the guardian was resolved via fallback (e.g. vellum anchor) rather than
+ * a verified same-channel contact — downstream copy or routing can use
+ * this to append verification CTAs like "Was this you?".
  */
 export function buildAccessRequestContractText(
   payload: Record<string, unknown>,

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -118,8 +118,44 @@ export interface AttentionHints {
 
 export type RoutingIntent = "single_channel" | "multi_channel" | "all_channels";
 
+// ── Typed context payloads ──────────────────────────────────────────────
+
+/**
+ * How the guardian was resolved for an access request.
+ *
+ * - `"source-channel-contact"` — Guardian was found via the originating channel's
+ *   contact store and their principalId matches the assistant's anchor.
+ * - `"vellum-anchor"` — No same-channel guardian matched; fell back to the
+ *   assistant's vellum guardian principal.
+ * - `"none"` — No guardian binding could be resolved at all.
+ *
+ * Downstream consumers (notification copy, routing) use this to decide whether
+ * to append a "Was this you?" CTA or route notifications beyond the source channel.
+ * This is channel-agnostic by design — any channel's access request that
+ * resolves to a non-source-channel guardian gets the same treatment.
+ */
+export type GuardianResolutionSource =
+  | "source-channel-contact"
+  | "vellum-anchor"
+  | "none";
+
+export interface AccessRequestContextPayload {
+  requestId: string;
+  requestCode: string;
+  sourceChannel: string;
+  conversationExternalId: string;
+  actorExternalId: string;
+  actorDisplayName: string | null;
+  actorUsername: string | null;
+  senderIdentifier: string;
+  guardianBindingChannel: string | null;
+  guardianResolutionSource: GuardianResolutionSource;
+  previousMemberStatus: string | null;
+}
+
 export interface NotificationEventContextPayloadMap {
   "guardian.question": GuardianQuestionPayload;
+  "ingress.access_request": AccessRequestContextPayload;
 }
 
 export type NotificationContextPayload<TEventName extends string = string> =

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -21,7 +21,10 @@ import {
   updateCanonicalGuardianDelivery,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
-import type { NotificationSourceChannel } from "../notifications/signal.js";
+import type {
+  GuardianResolutionSource,
+  NotificationSourceChannel,
+} from "../notifications/signal.js";
 import type { NotificationDeliveryResult } from "../notifications/types.js";
 import { getLogger } from "../util/logger.js";
 import { ensureVellumGuardianBinding } from "./guardian-vellum-migration.js";
@@ -100,10 +103,7 @@ export function notifyGuardianOfAccessRequest(
   let guardianExternalUserId: string | null = null;
   let guardianPrincipalId: string | null = null;
   let guardianBindingChannel: string | null = null;
-  let guardianResolutionSource:
-    | "source-channel-contact"
-    | "vellum-anchor"
-    | "none" = "none";
+  let guardianResolutionSource: GuardianResolutionSource = "none";
 
   const assistantGuardianPrincipalId =
     ensureVellumGuardianBinding(canonicalAssistantId);
@@ -207,11 +207,19 @@ export function notifyGuardianOfAccessRequest(
   // because the desktop path lacks the channel delivery context needed
   // to deliver the verification code. Phone is excluded because it is
   // not a deliverable notification channel.
+  // When the guardian was resolved via a verified same-channel contact,
+  // route only to that channel — delivering on desktop as well is noisy
+  // and the desktop path lacks the channel delivery context for approval.
+  // When the guardian was NOT verified on the source channel (e.g. resolved
+  // via vellum anchor), route to all channels so the guardian can see
+  // the request on desktop/other channels where they ARE verified.
   const TEXT_CHANNELS_WITH_DELIVERY: ReadonlySet<string> = new Set([
     "slack",
     "telegram",
   ]);
-  const sameChannelOnly = TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel);
+  const sameChannelOnly =
+    TEXT_CHANNELS_WITH_DELIVERY.has(sourceChannel) &&
+    guardianResolutionSource === "source-channel-contact";
 
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",
@@ -234,6 +242,7 @@ export function notifyGuardianOfAccessRequest(
       actorUsername: actorUsername ?? null,
       senderIdentifier,
       guardianBindingChannel,
+      guardianResolutionSource,
       previousMemberStatus: previousMemberStatus ?? null,
     },
     dedupeKey: `access-request:${canonicalRequest.id}`,


### PR DESCRIPTION
Part of #18755. Formalizes the guardianResolutionSource field in notification signal type definitions and documents the channel-agnostic design of the 'Was this you?' CTA in copy-composer.

Changes:
- Add GuardianResolutionSource type and AccessRequestContextPayload interface to signal.ts, registered in NotificationEventContextPayloadMap
- Include guardianResolutionSource in the emitted contextPayload in access-request-helper.ts
- Use the canonical GuardianResolutionSource type instead of inline union in access-request-helper.ts
- Fix routing: sameChannelOnly is now false when guardian was not resolved via source-channel contact, so unverified-guardian requests route to all channels (including desktop)
- Add docstring in copy-composer.ts explaining channel-agnostic design
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
