### PR TITLE
Fix CI type check and test failures

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -624,6 +624,17 @@ describe("access-request-helper unit tests", () => {
   });
 
   test("notifyGuardianOfAccessRequest skips vellum fallback for same-channel-only routing (telegram)", async () => {
+    // Set up a telegram guardian binding with the anchor principal so
+    // guardianResolutionSource resolves to "source-channel-contact" and
+    // sameChannelOnly is true.
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "guardian-user-456",
+      guardianDeliveryChatId: "guardian-chat-456",
+      guardianPrincipalId: anchorPrincipalId,
+      verifiedVia: "test",
+    });
+
     mockEmitResult = {
       signalId: "sig-no-vellum",
       deduplicated: false,

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -220,7 +220,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       sourceChannel: params.sourceChannel,
       sourceContextId: params.sourceContextId,
       attentionHints: params.attentionHints,
-      payload: params.contextPayload ?? {},
+      payload: (params.contextPayload ?? {}) as Record<string, unknown>,
       dedupeKey: params.dedupeKey,
     });
 

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -234,7 +234,7 @@ export function notifyGuardianOfAccessRequest(
     },
     contextPayload: {
       requestId,
-      requestCode: canonicalRequest.requestCode,
+      requestCode: canonicalRequest.requestCode ?? "",
       sourceChannel,
       conversationExternalId,
       actorExternalId,


### PR DESCRIPTION
## Summary
- Cast `contextPayload` to `Record<string, unknown>` in `emit-signal.ts` to fix TS2322 (interface not assignable to index signature type)
- Add `?? ""` fallback for nullable `requestCode` in `access-request-helper.ts` to fix TS2322 (`string | null` → `string`)
- Add missing telegram guardian binding in `non-member-access-request.test.ts` so `sameChannelOnly` resolves correctly and the vellum fallback test passes

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/non-member-access-request.test.ts` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
