### PR TITLE
feat(macos): add Revoke Assistant API Key button and simplify logout flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -162,22 +162,6 @@ extension AppDelegate {
     }
 
     @objc public func performLogout() {
-        // Warn when managed services are active — they'll stop working after logout.
-        if services.settingsStore.hasManagedServices {
-            let alert = NSAlert()
-            alert.messageText = "Heads up"
-            alert.informativeText = "Some of your services rely on being logged in."
-                + " They won't work until you log back in or switch them to use your own API keys."
-            alert.addButton(withTitle: "Log Out")
-            alert.addButton(withTitle: "Cancel")
-            // Style the primary button as destructive (caution icon).
-            alert.alertStyle = .warning
-            let response = alert.runModal()
-            if response != .alertFirstButtonReturn {
-                return
-            }
-        }
-
         Task {
             // Capture assistant ID before logout clears it from UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -52,6 +52,12 @@ struct SettingsDeveloperTab: View {
     @State private var inlineUpgradeError: String?
     @State private var inlineUpgradeSuccess: String?
 
+    // -- Revoke API key state --
+    @State private var showingRevokeApiKeyConfirmation: Bool = false
+    @State private var isRevokingApiKey: Bool = false
+    @State private var revokeApiKeyStatus: String?
+    @State private var revokeApiKeyDismissTask: Task<Void, Never>?
+
     // -- Sentry testing state --
     @State private var lastSentryStatus: String?
     @State private var sentryDismissTask: Task<Void, Never>?
@@ -106,6 +112,11 @@ struct SettingsDeveloperTab: View {
             hatchNewAssistantSection
             // Retire Assistant
             retireAssistantSection
+
+            // Revoke Assistant API Key (dev mode only)
+            if devModeManager.isDevMode {
+                revokeAssistantApiKeySection
+            }
 
             // Permission Simulator
             if let model = testerModel {
@@ -189,6 +200,14 @@ struct SettingsDeveloperTab: View {
         } message: {
             Text("Are you sure you want to restart the assistant? It will be briefly unavailable.")
         }
+        .alert("Revoke Assistant API Key", isPresented: $showingRevokeApiKeyConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Revoke", role: .destructive) {
+                Task { await revokeAssistantApiKey() }
+            }
+        } message: {
+            Text("This will disable managed inference. Services set to \"managed\" mode will stop working until you log in again or switch them to use your own API keys.")
+        }
         .sheet(isPresented: $isRestarting) {
             VStack(spacing: VSpacing.lg) {
                 ProgressView()
@@ -227,6 +246,7 @@ struct SettingsDeveloperTab: View {
         .onDisappear {
             daemonClient?.onEnvVarsResponse = nil
             sentryDismissTask?.cancel()
+            revokeApiKeyDismissTask?.cancel()
         }
     }
 
@@ -724,6 +744,57 @@ struct SettingsDeveloperTab: View {
         ) {
             VButton(label: "Retire", style: .danger) {
                 showingRetireConfirmation = true
+            }
+        }
+    }
+
+    // MARK: - Revoke Assistant API Key
+
+    private var revokeAssistantApiKeySection: some View {
+        SettingsCard(
+            title: "Revoke Assistant API Key",
+            subtitle: "Removes the managed inference API key. Services set to \"managed\" mode will stop working until you log in again or switch them to use your own API keys."
+        ) {
+            VButton(label: "Revoke", style: .danger, isDisabled: isRevokingApiKey) {
+                showingRevokeApiKeyConfirmation = true
+            }
+
+            if let status = revokeApiKeyStatus {
+                Text(status)
+                    .font(VFont.caption)
+                    .foregroundColor(status.starts(with: "Failed") ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private func revokeAssistantApiKey() async {
+        isRevokingApiKey = true
+        defer { isRevokingApiKey = false }
+
+        let body: [String: String] = ["type": "credential", "name": "vellum:assistant_api_key"]
+        do {
+            let response = try await GatewayHTTPClient.delete(
+                path: "assistants/{assistantId}/secrets", json: body, timeout: 10
+            )
+            if response.isSuccess || response.statusCode == 404 {
+                showRevokeStatus("Assistant API key revoked", isError: false)
+            } else {
+                showRevokeStatus("Failed to revoke (HTTP \(response.statusCode))", isError: true)
+            }
+        } catch {
+            showRevokeStatus("Failed to revoke: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    private func showRevokeStatus(_ message: String, isError: Bool) {
+        revokeApiKeyDismissTask?.cancel()
+        withAnimation { revokeApiKeyStatus = message }
+        revokeApiKeyDismissTask = Task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
+            withAnimation {
+                if revokeApiKeyStatus == message { revokeApiKeyStatus = nil }
             }
         }
     }

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -338,14 +338,13 @@ public final class LocalAssistantBootstrapService {
         }
     }
 
-    /// Clears all managed proxy credentials from the daemon's secret store
+    /// Clears platform identity credentials from the daemon's secret store
     /// by issuing `DELETE /v1/secrets` for each vellum-namespaced credential.
     ///
     /// Returns `true` if all credentials were successfully cleared (or didn't exist).
     @discardableResult
     public static func clearDaemonCredentials() async -> Bool {
         let credentialNames = [
-            "vellum:assistant_api_key",
             "vellum:platform_assistant_id",
             "vellum:platform_base_url",
             "vellum:platform_organization_id",
@@ -370,9 +369,9 @@ public final class LocalAssistantBootstrapService {
             }
         }
         if allCleared {
-            log.info("All managed proxy credentials cleared from daemon")
+            log.info("All platform identity credentials cleared from daemon")
         } else {
-            log.warning("Some managed proxy credentials could not be cleared from daemon")
+            log.warning("Some platform identity credentials could not be cleared from daemon")
         }
         return allCleared
     }


### PR DESCRIPTION
## Summary
- Add a "Revoke Assistant API Key" button to the Developer tab (dev mode) that explicitly deletes the managed inference API key
- Remove the managed-services warning modal from the logout flow — logout now proceeds immediately
- Stop clearing assistant_api_key during logout so managed inference survives re-login

Part of plan: revoke-assistant-api-key.md (PR 1 of 1, combined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
