### PR TITLE
fix: remove dead hasManagedServices computed property

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -206,11 +206,6 @@ public final class SettingsStore: ObservableObject {
     /// Current Google OAuth mode. Values: "managed" or "your-own".
     @Published var googleOAuthMode: String = "your-own"
 
-    /// True when any service is configured to use managed mode.
-    var hasManagedServices: Bool {
-        inferenceMode == "managed" || webSearchMode == "managed" || imageGenMode == "managed" || googleOAuthMode == "managed"
-    }
-
     static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
 
     static let webSearchProviderDisplayNames: [String: String] = [


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for revoke-assistant-api-key.md.

**Gap:** hasManagedServices is now dead code
**What was expected:** No dead code left behind
**What was found:** hasManagedServices had zero callers after removing the logout warning modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
