### PR TITLE
fix: clear local credential storage when revoking assistant API key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -778,6 +778,16 @@ struct SettingsDeveloperTab: View {
                 path: "assistants/{assistantId}/secrets", json: body, timeout: 10
             )
             if response.isSuccess || response.statusCode == 404 {
+                // Clear the locally-cached credential so the key is not
+                // re-injected on the next daemon restart or bootstrap.
+                #if DEBUG
+                let credStorage = FileCredentialStorage()
+                #else
+                let credStorage = KeychainCredentialStorage()
+                #endif
+                let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: selectedAssistantId)
+                _ = credStorage.delete(account: credentialAccount)
+
                 showRevokeStatus("Assistant API key revoked", isError: false)
             } else {
                 showRevokeStatus("Failed to revoke (HTTP \(response.statusCode))", isError: true)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for revoke-assistant-api-key.md.

**Gap:** Revoked API key is re-injected from local credential storage on next bootstrap
**What was expected:** Revoke should durably remove the key until next login
**What was found:** Only daemon-side DELETE was issued; local Keychain copy survived and was re-injected on next bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
