### PR TITLE
fix: update stale managed proxy comments to platform identity

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -177,13 +177,13 @@ extension AppDelegate {
                 await authManager.logout()
             }
 
-            // Clear managed proxy credentials from the running daemon (local assistants only).
+            // Clear platform identity credentials from the running daemon (local assistants only).
             // Skip when the daemon was never set up (e.g. logout during onboarding) —
             // there are no credentials to clear and no daemon to stop.
             if !isCurrentAssistantManaged && !isCurrentAssistantRemote && hasSetupDaemon {
                 let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials()
                 if !cleared {
-                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed proxy state")
+                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale platform identity state")
                     daemonClient.disconnect()
                     assistantCli.stop(name: connectedAssistantId)
                 }
@@ -205,7 +205,7 @@ extension AppDelegate {
                 _ = credStorage.delete(account: credentialAccount)
             }
 
-            // Stop all non-current local daemons to clear in-memory managed proxy
+            // Stop all non-current local daemons to clear in-memory platform identity
             // credentials. Assistant switches intentionally leave old daemons running
             // for fast switching, but on full logout there's no reason to keep them
             // alive with potentially stale state.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for revoke-assistant-api-key.md.

**Gap:** Stale comments reference managed proxy credentials after scope change
**What was expected:** Comments should match updated doc comment on clearDaemonCredentials()
**What was found:** Three comments in performLogout() still said managed proxy credentials

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
