### PR TITLE
fix(macos): update Revoke Assistant API Key subtitle text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -753,7 +753,7 @@ struct SettingsDeveloperTab: View {
     private var revokeAssistantApiKeySection: some View {
         SettingsCard(
             title: "Revoke Assistant API Key",
-            subtitle: "Removes the managed inference API key. Services set to \"managed\" mode will stop working until you log in again or switch them to use your own API keys."
+            subtitle: "Revokes the API key used by the assistant to interact with the Vellum platform."
         ) {
             VButton(label: "Revoke", style: .danger, isDisabled: isRevokingApiKey) {
                 showingRevokeApiKeyConfirmation = true


### PR DESCRIPTION
## Summary
- Update the subtitle text for the "Revoke Assistant API Key" SettingsCard to be more concise and accurate

## Original prompt
Update the subtitle text for the "Revoke Assistant API Key" SettingsCard in SettingsDeveloperTab.swift to "Revokes the API key used by the assistant to interact with the Vellum platform."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
