### PR TITLE
refactor: extract BaseServiceSchema and default GoogleOAuth to your-own

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -20,15 +20,18 @@ export const VALID_WEB_SEARCH_PROVIDERS = [
   "inference-provider-native",
 ] as const;
 
-export const InferenceServiceSchema = z.object({
+export const BaseServiceSchema = z.object({
   mode: ServiceModeSchema.default("your-own"),
+});
+export type BaseService = z.infer<typeof BaseServiceSchema>;
+
+export const InferenceServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_INFERENCE_PROVIDERS).default("anthropic"),
   model: z.string().default("claude-opus-4-6"),
 });
 export type InferenceService = z.infer<typeof InferenceServiceSchema>;
 
-export const ImageGenerationServiceSchema = z.object({
-  mode: ServiceModeSchema.default("your-own"),
+export const ImageGenerationServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_IMAGE_GEN_PROVIDERS).default("gemini"),
   model: z.string().default("gemini-3.1-flash-image-preview"),
 });
@@ -36,17 +39,14 @@ export type ImageGenerationService = z.infer<
   typeof ImageGenerationServiceSchema
 >;
 
-export const WebSearchServiceSchema = z.object({
-  mode: ServiceModeSchema.default("your-own"),
+export const WebSearchServiceSchema = BaseServiceSchema.extend({
   provider: z
     .enum(VALID_WEB_SEARCH_PROVIDERS)
     .default("inference-provider-native"),
 });
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 
-export const GoogleOAuthServiceSchema = z.object({
-  mode: ServiceModeSchema.default("managed"),
-});
+export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({});
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
 export const ServicesSchema = z.object({


### PR DESCRIPTION
## Summary
- Extract `BaseServiceSchema` with `mode: ServiceModeSchema.default("your-own")` that all service schemas extend via `.extend()`
- Change `GoogleOAuthServiceSchema` to inherit the default `"your-own"` mode from the base instead of overriding to `"managed"`
- Removes duplicated `mode` field definitions from `InferenceServiceSchema`, `ImageGenerationServiceSchema`, and `WebSearchServiceSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
