### PR TITLE
feat: resolve OAuth connections to managed or BYO based on service config

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -83,6 +83,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateOAuthAppsClientSecretPath,
+  migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingUrl,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
@@ -455,6 +456,9 @@ export function initializeDb(): void {
 
   // 80. Trace events table for persistent trace/activity storage across sessions
   migrateCreateTraceEventsTable(database);
+
+  // 81. Add managed_service_config_key column to oauth_providers
+  migrateOAuthProvidersManagedServiceConfigKey(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/178-oauth-providers-managed-service-config-key.ts
+++ b/assistant/src/memory/migrations/178-oauth-providers-managed-service-config-key.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersManagedServiceConfigKey(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE oauth_providers ADD COLUMN managed_service_config_key TEXT`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -119,6 +119,7 @@ export { migrateRenameThreadStartersTable } from "./174-rename-thread-starters-t
 export { createLifecycleEventsTable } from "./175-create-lifecycle-events.js";
 export { migrateDropCapabilityCardState } from "./176-drop-capability-card-state.js";
 export { migrateCreateTraceEventsTable } from "./177-create-trace-events-table.js";
+export { migrateOAuthProvidersManagedServiceConfigKey } from "./178-oauth-providers-managed-service-config-key.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -18,6 +18,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   extraParams: text("extra_params"),
   callbackTransport: text("callback_transport"),
   pingUrl: text("ping_url"),
+  managedServiceConfigKey: text("managed_service_config_key"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let mockProvider: Record<string, unknown> | undefined;
+let mockConnection: Record<string, unknown> | undefined;
+let mockApp: Record<string, unknown> | undefined;
+let mockAccessToken: string | undefined;
+let mockConfig: Record<string, unknown> = {};
+let mockManagedProxyCtx = {
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+};
+let mockAssistantId = "";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede imports of the module under test)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("./oauth-store.js", () => ({
+  getProvider: () => mockProvider,
+  getConnectionByProvider: () => mockConnection,
+  getConnectionByProviderAndAccount: () => mockConnection,
+  getApp: () => mockApp,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => mockAccessToken,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformAssistantId: () => mockAssistantId,
+}));
+
+mock.module("../providers/managed-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => mockManagedProxyCtx,
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { BYOOAuthConnection } from "./byo-connection.js";
+import { resolveOAuthConnection } from "./connection-resolver.js";
+import { PlatformOAuthConnection } from "./platform-connection.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupDefaults(): void {
+  mockProvider = {
+    providerKey: "integration:google",
+    baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    managedServiceConfigKey: null,
+  };
+  mockConnection = {
+    id: "conn-1",
+    providerKey: "integration:google",
+    oauthAppId: "app-1",
+    accountInfo: "user@example.com",
+    grantedScopes: JSON.stringify(["scope-a", "scope-b"]),
+    status: "active",
+  };
+  mockApp = {
+    id: "app-1",
+    providerKey: "integration:google",
+  };
+  mockAccessToken = "tok-valid";
+  mockConfig = {
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+      "google-oauth": { mode: "managed" },
+    },
+  };
+  mockManagedProxyCtx = {
+    enabled: true,
+    platformBaseUrl: "https://platform.example.com",
+    assistantApiKey: "sk-test-key",
+  };
+  mockAssistantId = "asst-123";
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveOAuthConnection", () => {
+  beforeEach(() => {
+    setupDefaults();
+  });
+
+  test("returns BYOOAuthConnection when provider has no managedServiceConfigKey", async () => {
+    // managedServiceConfigKey is null — should take the BYO path
+    const result = await resolveOAuthConnection("integration:google");
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("conn-1");
+    expect(result.providerKey).toBe("integration:google");
+  });
+
+  test("returns PlatformOAuthConnection when managed mode is active and proxy prerequisites are met", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+
+    const result = await resolveOAuthConnection("integration:google");
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+    expect(result.id).toBe("conn-1");
+    expect(result.providerKey).toBe("integration:google");
+    expect(result.accountInfo).toBe("user@example.com");
+    expect(result.grantedScopes).toEqual(["scope-a", "scope-b"]);
+  });
+
+  test("falls through to BYOOAuthConnection when managed mode but proxy prerequisites not met", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockManagedProxyCtx = {
+      enabled: false,
+      platformBaseUrl: "",
+      assistantApiKey: "",
+    };
+
+    const result = await resolveOAuthConnection("integration:google");
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("conn-1");
+  });
+
+  test("returns BYOOAuthConnection when service config mode is your-own", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    (mockConfig.services as Record<string, unknown>)["google-oauth"] = {
+      mode: "your-own",
+    };
+
+    const result = await resolveOAuthConnection("integration:google");
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("conn-1");
+  });
+
+  test("falls through to BYO when managed mode but no assistantId", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockAssistantId = "";
+
+    const result = await resolveOAuthConnection("integration:google");
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+  });
+});

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,3 +1,7 @@
+import { getPlatformAssistantId } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
+import type { Services } from "../config/schemas/services.js";
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
@@ -7,6 +11,7 @@ import {
   getConnectionByProviderAndAccount,
   getProvider,
 } from "./oauth-store.js";
+import { PlatformOAuthConnection } from "./platform-connection.js";
 
 /**
  * Resolve an OAuthConnection for a given credential service.
@@ -60,6 +65,32 @@ export async function resolveOAuthConnection(
   const grantedScopes: string[] = conn.grantedScopes
     ? JSON.parse(conn.grantedScopes)
     : [];
+
+  const managedKey = provider?.managedServiceConfigKey;
+  if (managedKey) {
+    const services: Services = getConfig().services;
+    const serviceConfig = services[managedKey as keyof Services];
+    if (
+      serviceConfig &&
+      "mode" in serviceConfig &&
+      serviceConfig.mode === "managed"
+    ) {
+      const ctx = await resolveManagedProxyContext();
+      const assistantId = getPlatformAssistantId();
+      if (ctx.enabled && assistantId) {
+        return new PlatformOAuthConnection({
+          id: conn.id,
+          providerKey: conn.providerKey,
+          externalId: conn.id,
+          accountInfo: conn.accountInfo,
+          grantedScopes,
+          assistantId,
+          platformBaseUrl: ctx.platformBaseUrl,
+          apiKey: ctx.assistantApiKey,
+        });
+      }
+    }
+  }
 
   return new BYOOAuthConnection({
     id: conn.id,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -45,7 +45,7 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authUrl, tokenUrl,
  * tokenEndpointAuthMethod, userinfoUrl, extraParams, callbackTransport,
- * pingUrl) propagate to existing installations on every startup, while
+ * pingUrl, managedServiceConfigKey) propagate to existing installations on every startup, while
  * user-customizable fields (defaultScopes, scopePolicy, baseUrl) are
  * only written on the initial insert.
  */
@@ -62,6 +62,7 @@ export function seedProviders(
     scopePolicy: Record<string, unknown>;
     extraParams?: Record<string, string>;
     callbackTransport?: string;
+    managedServiceConfigKey?: string;
   }>,
 ): void {
   const db = getDb();
@@ -77,6 +78,7 @@ export function seedProviders(
     const scopePolicy = JSON.stringify(p.scopePolicy);
     const extraParams = p.extraParams ? JSON.stringify(p.extraParams) : null;
     const callbackTransport = p.callbackTransport ?? null;
+    const managedServiceConfigKey = p.managedServiceConfigKey ?? null;
 
     db.insert(oauthProviders)
       .values({
@@ -91,6 +93,7 @@ export function seedProviders(
         extraParams,
         callbackTransport,
         pingUrl,
+        managedServiceConfigKey,
         createdAt: now,
         updatedAt: now,
       })
@@ -104,6 +107,7 @@ export function seedProviders(
           extraParams,
           callbackTransport,
           pingUrl,
+          managedServiceConfigKey,
           updatedAt: now,
         },
       })
@@ -143,6 +147,7 @@ export function registerProvider(params: {
   scopePolicy: Record<string, unknown>;
   extraParams?: Record<string, string>;
   callbackTransport?: string;
+  managedServiceConfigKey?: string;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -164,6 +169,7 @@ export function registerProvider(params: {
     extraParams: params.extraParams ? JSON.stringify(params.extraParams) : null,
     callbackTransport: params.callbackTransport ?? null,
     pingUrl: params.pingUrl ?? null,
+    managedServiceConfigKey: params.managedServiceConfigKey ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -5,7 +5,8 @@ import { seedProviders } from "./oauth-store.js";
  *
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authUrl, tokenUrl,
- * tokenEndpointAuthMethod, extraParams, callbackTransport, pingUrl) are
+ * tokenEndpointAuthMethod, extraParams, callbackTransport, pingUrl,
+ * managedServiceConfigKey) are
  * overwritten on subsequent startups — user-customizable
  * fields (defaultScopes, scopePolicy, userinfoUrl, baseUrl) are only
  * written on initial insert and preserved across restarts.
@@ -32,6 +33,7 @@ const PROVIDER_SEED_DATA: Record<
     };
     extraParams?: Record<string, string>;
     callbackTransport?: string;
+    managedServiceConfigKey?: string;
   }
 > = {
   "integration:google": {
@@ -60,6 +62,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { access_type: "offline", prompt: "consent" },
     callbackTransport: "loopback",
+    managedServiceConfigKey: "google-oauth",
   },
 
   "integration:slack": {


### PR DESCRIPTION
## Summary
- Add `managed_service_config_key` nullable column to `oauth_providers` table with migration
- Seed Google OAuth provider with `managed_service_config_key = "google-oauth"`
- Update `resolveOAuthConnection` to check service config mode and return `PlatformOAuthConnection` (managed) or `BYOOAuthConnection` (your-own)
- Add tests for managed vs BYO resolution paths

Part of plan: managed-oauth-resolve.md (all PRs consolidated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
