### PR TITLE
Remove collectUsageDataEnabled legacy UserDefaults fallback reads

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -208,11 +208,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Gated on sendDiagnostics: if the user has previously disabled diagnostics,
         // Sentry is never initialized. Otherwise, initialize eagerly so crashes
         // before the daemon connects are captured.
-        // Falls back through legacy keys so users who opted out via the old
-        // collectUsageDataEnabled master switch keep Sentry disabled.
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
             ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-            ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
             ?? true
         if sendDiagnostics {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -159,7 +159,6 @@ struct SettingsDeveloperTab: View {
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
                 ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-                ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
                 ?? true
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -255,13 +255,11 @@ public final class SettingsStore: ObservableObject {
     /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
     @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
         ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-        ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
         ?? true
 
     /// Whether the user has opted in to sharing anonymized usage analytics (e.g. token counts,
     /// feature adoption). Defaults to `true`. Independent from diagnostics.
     @Published var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-        ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
         ?? true
 
     // MARK: - Private

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -222,7 +222,6 @@ import os
         guard !SentrySDK.isEnabled else { return }
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
             ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-            ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
             ?? true
         guard sendDiagnostics else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
@@ -258,7 +257,6 @@ extension MetricKitManager: MXMetricManagerSubscriber {
             // Only send to Sentry if sendDiagnostics is enabled.
             let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
                 ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
-                ?? UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool
                 ?? true
             guard sendDiagnostics else { continue }
 


### PR DESCRIPTION
## Summary
- Remove collectUsageDataEnabled fallback from all read sites (SettingsStore, AppDelegate, SettingsDeveloperTab, MetricKitManager)
- Keep the migration/cleanup path in syncPrivacyConfig() for stragglers

Part of plan: userdefaults-cleanup.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
