### PR TITLE
Add elevenlabs.conversationTimeoutSeconds and maxStepsPerSession to config schema

### DIFF
--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -150,6 +150,19 @@ export async function run(
     invalidateConfigCache();
   }
 
+  // For conversation_timeout, persist to the config file
+  // (elevenlabs.conversationTimeoutSeconds).
+  if (setting === "conversation_timeout") {
+    const raw = loadRawConfig();
+    setNestedValue(
+      raw,
+      "elevenlabs.conversationTimeoutSeconds",
+      validation.coerced,
+    );
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
   return {
     content: `${friendlyName} updated to ${JSON.stringify(
       validation.coerced,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -321,6 +321,13 @@ export const AssistantConfigSchema = z
       .boolean()
       .default(true)
       .describe("Whether to send diagnostic/crash reports"),
+    maxStepsPerSession: z
+      .number({ error: "maxStepsPerSession must be a number" })
+      .int("maxStepsPerSession must be an integer")
+      .min(1, "maxStepsPerSession must be >= 1")
+      .max(200, "maxStepsPerSession must be <= 200")
+      .default(50)
+      .describe("Maximum number of computer-use steps per session"),
   })
   .superRefine((config, ctx) => {
     if (

--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -42,6 +42,16 @@ export const ElevenLabsConfigSchema = z
       .describe(
         "How closely the output matches the original voice — higher values increase similarity",
       ),
+    conversationTimeoutSeconds: z
+      .number({
+        error: "elevenlabs.conversationTimeoutSeconds must be a number",
+      })
+      .refine((v) => [5, 10, 15, 30, 60].includes(v), {
+        message:
+          "elevenlabs.conversationTimeoutSeconds must be one of: 5, 10, 15, 30, 60",
+      })
+      .default(30)
+      .describe("Seconds of silence before voice conversation auto-ends"),
   })
   .describe("ElevenLabs text-to-speech configuration");
 

--- a/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
+++ b/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
@@ -1,0 +1,12 @@
+import type { WorkspaceMigration } from "./types.js";
+
+export const voiceTimeoutAndMaxStepsMigration: WorkspaceMigration = {
+  id: "008-voice-timeout-and-max-steps",
+  description:
+    "Add elevenlabs.conversationTimeoutSeconds and maxStepsPerSession to config schema (defaults handle new installs; macOS client syncs existing UserDefaults values on startup)",
+  run(_workspaceDir: string): void {
+    // No-op — schema defaults handle new installs.
+    // Existing users: macOS client will sync UserDefaults values
+    // to config on next startup via settings sync endpoints.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -5,6 +5,7 @@ import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-da
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
 import { servicesConfigMigration } from "./006-services-config.js";
 import { webSearchProviderRenameMigration } from "./007-web-search-provider-rename.js";
+import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-steps.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -19,4 +20,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   addSendDiagnosticsMigration,
   servicesConfigMigration,
   webSearchProviderRenameMigration,
+  voiceTimeoutAndMaxStepsMigration,
 ];


### PR DESCRIPTION
## Summary
- Add conversationTimeoutSeconds field to ElevenLabsConfigSchema (default 30)
- Add maxStepsPerSession field to AssistantConfigSchema (default 50)
- Persist conversation_timeout changes to config in voice-config-update tool
- Add no-op migration 008 as checkpoint

Part of plan: userdefaults-cleanup.md (PR 4 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
