### PR TITLE
Migrate APIKeyManager from plaintext UserDefaults to CredentialStorage (Keychain/File)

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -20,10 +20,19 @@ extension Notification.Name {
     static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
 }
 
-/// Manages API keys using UserDefaults. The daemon owns the canonical encrypted
-/// store; the app syncs keys to the daemon via HTTP on save/clear/reconnect.
+/// Manages API keys using CredentialStorage (Keychain in Release, file-based
+/// in DEBUG). The daemon owns the canonical encrypted store; the app syncs
+/// keys to the daemon via HTTP on save/clear/reconnect.
 enum APIKeyManager {
     private static let udPrefix = "vellum_provider_"
+
+    private static let storage: CredentialStorage = {
+        #if DEBUG
+        return FileCredentialStorage()
+        #else
+        return KeychainCredentialStorage()
+        #endif
+    }()
 
     /// All provider identifiers whose API keys should be synced to the daemon.
     /// Every call site that iterates over syncable providers must use this list
@@ -45,19 +54,39 @@ enum APIKeyManager {
         return false
     }
 
+    // MARK: - Migration from UserDefaults
+
+    /// One-time migration: copies API keys from UserDefaults to credential
+    /// storage for existing users, then removes them from UserDefaults.
+    /// Safe to call multiple times — skips providers that already have a
+    /// value in credential storage.
+    static func migrateFromUserDefaults() {
+        for provider in allSyncableProviders {
+            let udKey = udPrefix + provider
+            if let udValue = UserDefaults.standard.string(forKey: udKey),
+               !udValue.isEmpty,
+               storage.get(account: udKey) == nil {
+                _ = storage.set(account: udKey, value: udValue)
+            }
+            // Always remove from UserDefaults regardless — keys should not
+            // remain in the plaintext plist after migration.
+            UserDefaults.standard.removeObject(forKey: udKey)
+        }
+    }
+
     // MARK: - Generic provider access
 
     static func getKey(for provider: String) -> String? {
-        UserDefaults.standard.string(forKey: udPrefix + provider)
+        storage.get(account: udPrefix + provider)
     }
 
     static func setKey(_ key: String, for provider: String) {
-        UserDefaults.standard.set(key, forKey: udPrefix + provider)
+        _ = storage.set(account: udPrefix + provider, value: key)
         notifyKeyDidChange()
     }
 
     static func deleteKey(for provider: String) {
-        UserDefaults.standard.removeObject(forKey: udPrefix + provider)
+        _ = storage.delete(account: udPrefix + provider)
         notifyKeyDidChange()
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -251,6 +251,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // renders EmptyView — we handle settings in the main window panel).
         UserDefaults.standard.removeObject(forKey: "NSWindow Frame com_apple_SwiftUI_Settings_window")
 
+        // Migrate API keys from plaintext UserDefaults to credential storage
+        // (Keychain in Release, file-based in DEBUG). Safe to call on every
+        // launch — skips providers already present in credential storage.
+        APIKeyManager.migrateFromUserDefaults()
 
         if let envPath = MacOSClientFeatureFlagManager.findRepoEnvFile() {
             MacOSClientFeatureFlagManager.shared.loadFromFile(at: envPath)

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -724,11 +724,11 @@ final class AssistantCli {
                let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
-            // Fall back to UserDefaults for the Anthropic API key when
-            // it's not in the process environment (e.g. app launched from
-            // Finder, not a terminal with ANTHROPIC_API_KEY set).
+            // Fall back to credential storage for the Anthropic API key
+            // when it's not in the process environment (e.g. app launched
+            // from Finder, not a terminal with ANTHROPIC_API_KEY set).
             if env["ANTHROPIC_API_KEY"] == nil,
-               let storedKey = UserDefaults.standard.string(forKey: "vellum_provider_anthropic"),
+               let storedKey = APIKeyManager.getKey(for: "anthropic"),
                !storedKey.isEmpty {
                 env["ANTHROPIC_API_KEY"] = storedKey
             }


### PR DESCRIPTION
## Summary
- Replace UserDefaults storage with CredentialStorage protocol (Keychain in Release, file-based in DEBUG)
- Add one-time migration from UserDefaults to credential store for existing users
- Update AssistantCli.swift to read API keys through APIKeyManager instead of direct UserDefaults access

Part of plan: userdefaults-cleanup.md (PR 9 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
