### PR TITLE
Remove ttsVoiceId UserDefaults cache and read voice ID from daemon config

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -314,9 +314,14 @@ extension AppDelegate {
             self.handleRecordingResume(msg)
         }
 
-        // Handle client_settings_update from daemon: write to UserDefaults and post notification
+        // Handle client_settings_update from daemon: route ttsVoiceId to the voice service
+        // override property; write all other keys to UserDefaults as before.
         daemonClient.onClientSettingsUpdate = { msg in
-            UserDefaults.standard.set(msg.value, forKey: msg.key)
+            if msg.key == "ttsVoiceId" {
+                OpenAIVoiceService.overrideVoiceId = msg.value as? String
+            } else {
+                UserDefaults.standard.set(msg.value, forKey: msg.key)
+            }
             if msg.key == "activationKey" {
                 NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
             }

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -82,9 +82,12 @@ final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
     /// Mirrored from: assistant/src/config/elevenlabs-schema.ts (DEFAULT_ELEVENLABS_VOICE_ID)
     private static let defaultVoiceId = "ZF6FPAbjXT4488VcRRnw"
 
-    /// ElevenLabs voice ID — reads from UserDefaults (set via daemon HTTP), falls back to Amelia.
+    /// Override voice ID set by daemon broadcasts (client_settings_update).
+    static var overrideVoiceId: String?
+
+    /// ElevenLabs voice ID — reads from daemon-provided override, falls back to Amelia.
     private static var elevenLabsVoiceId: String {
-        UserDefaults.standard.string(forKey: "ttsVoiceId").flatMap { $0.isEmpty ? nil : $0 }
+        overrideVoiceId.flatMap { $0.isEmpty ? nil : $0 }
             ?? Self.defaultVoiceId
     }
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -896,7 +896,6 @@ enum LogExporter {
             "conversationTextZoomLevel",
             "collectUsageData",
             "sendDiagnostics",
-            "ttsVoiceId",
             "selectedImageGenModel",
             "activityNotificationsEnabled",
         ]


### PR DESCRIPTION
## Summary
- Replace UserDefaults read for ttsVoiceId with static override property on OpenAIVoiceService
- Route client_settings_update for ttsVoiceId to the override property instead of UserDefaults
- Remove ttsVoiceId from LogExporter snapshot

Part of plan: userdefaults-cleanup.md (PR 5 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
