### PR TITLE
Read voiceConversationTimeoutSeconds from daemon config and remove UserDefaults storage

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -314,11 +314,13 @@ extension AppDelegate {
             self.handleRecordingResume(msg)
         }
 
-        // Handle client_settings_update from daemon: route ttsVoiceId to the voice service
-        // override property; write all other keys to UserDefaults as before.
+        // Handle client_settings_update from daemon: route specific keys to their
+        // override properties; write all other keys to UserDefaults as before.
         daemonClient.onClientSettingsUpdate = { msg in
             if msg.key == "ttsVoiceId" {
                 OpenAIVoiceService.overrideVoiceId = msg.value as? String
+            } else if msg.key == "voiceConversationTimeoutSeconds" {
+                VoiceModeManager.conversationTimeoutOverride = msg.value as? Int
             } else {
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -7,6 +7,10 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Vo
 
 @MainActor
 final class VoiceModeManager: ObservableObject {
+    /// Override set via `client_settings_update` from the daemon.
+    /// When non-nil, used instead of the default 30-second conversation timeout.
+    static var conversationTimeoutOverride: Int?
+
     enum State: Equatable {
         case off, idle, listening, processing, speaking
     }
@@ -595,9 +599,13 @@ final class VoiceModeManager: ObservableObject {
 
     private func startConversationTimeout() {
         cancelConversationTimeout()
-        // Read the user's preference each time so changes take effect immediately
-        let storedTimeout = UserDefaults.standard.integer(forKey: "voiceConversationTimeoutSeconds")
-        let interval = storedTimeout > 0 ? TimeInterval(storedTimeout) : conversationTimeoutInterval
+        // Read the override each time so daemon broadcasts take effect immediately
+        let interval: TimeInterval
+        if let override = Self.conversationTimeoutOverride, override > 0 {
+            interval = TimeInterval(override)
+        } else {
+            interval = conversationTimeoutInterval
+        }
         let clampedInterval = max(1.0, interval.isFinite ? interval : 30.0)
         conversationTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(clampedInterval * 1_000_000_000))


### PR DESCRIPTION
## Summary
- Replace UserDefaults read for voiceConversationTimeoutSeconds with static override property on VoiceModeManager
- Route client_settings_update for voiceConversationTimeoutSeconds to the override instead of UserDefaults
- Remove from LogExporter snapshot (not present, no change needed)

Part of plan: userdefaults-cleanup.md (PR 8 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
