### PR TITLE
Read maxStepsPerSession from config in daemon and remove UserDefaults storage on client

### DIFF
--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -10,6 +10,7 @@
 import { v4 as uuid } from "uuid";
 
 import { escapeAxTreeContent } from "../agent/loop.js";
+import { loadConfig } from "../config/loader.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -23,7 +24,6 @@ const log = getLogger("host-cu-proxy");
 // ---------------------------------------------------------------------------
 
 const REQUEST_TIMEOUT_SEC = 60;
-const MAX_STEPS = 50;
 const MAX_HISTORY_ENTRIES = 10;
 const LOOP_DETECTION_WINDOW = 3;
 const CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD = 2;
@@ -79,7 +79,7 @@ export class HostCuProxy {
   constructor(
     sendToClient: (msg: ServerMessage) => void,
     onInternalResolve?: (requestId: string) => void,
-    maxSteps = MAX_STEPS,
+    maxSteps = loadConfig().maxStepsPerSession,
   ) {
     this.sendToClient = sendToClient;
     this.onInternalResolve = onInternalResolve;

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -69,7 +69,6 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Settings Values
 
-    @Published var maxSteps: Double
     @Published var globalHotkeyShortcut: String
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
@@ -352,9 +351,6 @@ public final class SettingsStore: ObservableObject {
         // selectedImageGenModel is initialized with a hardcoded default and
         // populated from the daemon's workspace config via loadServiceModes().
 
-        let storedMaxSteps = UserDefaults.standard.double(forKey: "maxStepsPerSession")
-        self.maxSteps = storedMaxSteps == 0 ? 50 : storedMaxSteps
-
         self.cmdEnterToSend = UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool ?? false
 
         if UserDefaults.standard.object(forKey: "globalHotkeyShortcut") == nil {
@@ -427,13 +423,6 @@ public final class SettingsStore: ObservableObject {
             .sink { [weak self] _ in
                 self?.loadProviderRoutingSources()
             }
-            .store(in: &cancellables)
-
-        // maxStepsPerSession is read at conversation startup, so it must be persisted synchronously
-        // to avoid a race where a new conversation reads a stale value before the debounced write fires.
-        $maxSteps
-            .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "maxStepsPerSession") }
             .store(in: &cancellables)
 
         // Debounce UserDefaults writes so rapid toggle changes don't thrash disk I/O.


### PR DESCRIPTION
## Summary
- Wire daemon HostCuProxy to read maxStepsPerSession from config instead of hardcoded constant
- Remove maxSteps @Published property and UserDefaults persistence from SettingsStore
- Keep client-side hardcoded fallback for overlay display

Part of plan: userdefaults-cleanup.md (PR 7 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
