### PR TITLE
fix: fail early when managed OAuth prerequisites are missing

### DIFF
--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -133,7 +133,7 @@ describe("resolveOAuthConnection", () => {
     expect(result.grantedScopes).toEqual(["scope-a", "scope-b"]);
   });
 
-  test("falls through to BYOOAuthConnection when managed mode but proxy prerequisites not met", async () => {
+  test("throws when managed mode but proxy prerequisites not met", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
     mockManagedProxyCtx = {
       enabled: false,
@@ -141,9 +141,9 @@ describe("resolveOAuthConnection", () => {
       assistantApiKey: "",
     };
 
-    const result = await resolveOAuthConnection("integration:google");
-    expect(result).toBeInstanceOf(BYOOAuthConnection);
-    expect(result.id).toBe("conn-1");
+    await expect(resolveOAuthConnection("integration:google")).rejects.toThrow(
+      /configured in managed mode but platform prerequisites/,
+    );
   });
 
   test("returns BYOOAuthConnection when service config mode is your-own", async () => {
@@ -157,11 +157,12 @@ describe("resolveOAuthConnection", () => {
     expect(result.id).toBe("conn-1");
   });
 
-  test("falls through to BYO when managed mode but no assistantId", async () => {
+  test("throws when managed mode but no assistantId", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
     mockAssistantId = "";
 
-    const result = await resolveOAuthConnection("integration:google");
-    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    await expect(resolveOAuthConnection("integration:google")).rejects.toThrow(
+      /missing: assistant ID/,
+    );
   });
 });

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -77,18 +77,26 @@ export async function resolveOAuthConnection(
     ) {
       const ctx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
-      if (ctx.enabled && assistantId) {
-        return new PlatformOAuthConnection({
-          id: conn.id,
-          providerKey: conn.providerKey,
-          externalId: conn.id,
-          accountInfo: conn.accountInfo,
-          grantedScopes,
-          assistantId,
-          platformBaseUrl: ctx.platformBaseUrl,
-          apiKey: ctx.assistantApiKey,
-        });
+      if (!ctx.enabled || !assistantId) {
+        const missing: string[] = [];
+        if (!ctx.platformBaseUrl) missing.push("platform base URL");
+        if (!ctx.assistantApiKey) missing.push("assistant API key");
+        if (!assistantId) missing.push("assistant ID");
+        throw new Error(
+          `"${credentialService}" is configured in managed mode but platform prerequisites are not met (missing: ${missing.join(", ")}). ` +
+            `Set up your platform connection or switch to "your-own" mode in your assistant config.`,
+        );
       }
+      return new PlatformOAuthConnection({
+        id: conn.id,
+        providerKey: conn.providerKey,
+        externalId: conn.id,
+        accountInfo: conn.accountInfo,
+        grantedScopes,
+        assistantId,
+        platformBaseUrl: ctx.platformBaseUrl,
+        apiKey: ctx.assistantApiKey,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- When `resolveOAuthConnection` detects managed mode but platform prerequisites (base URL, API key, assistant ID) are missing, throw a clear error instead of silently falling back to BYO
- Error message tells the user exactly what's missing and suggests either setting up the platform connection or switching to "your-own" mode
- Updated tests to expect throws instead of BYO fallback for these cases

## Original prompt
In `connection-resolver.ts`, when the service mode is "managed" but managed proxy prerequisites are not met, throw a clear error instead of silently falling through to BYO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
