### PR TITLE
fix: restore GoogleOAuthServiceSchema default mode to managed

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -46,7 +46,9 @@ export const WebSearchServiceSchema = BaseServiceSchema.extend({
 });
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 
-export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({});
+export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("managed"),
+});
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
 export const ServicesSchema = z.object({


### PR DESCRIPTION
## Summary
Restores the GoogleOAuthServiceSchema default mode to "managed" which was inadvertently changed to "your-own" when PR #18779 introduced BaseServiceSchema.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
