### PR TITLE
fix: reconnect voice timeout settings UI and fix Int cast

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -320,7 +320,7 @@ extension AppDelegate {
             if msg.key == "ttsVoiceId" {
                 OpenAIVoiceService.overrideVoiceId = msg.value as? String
             } else if msg.key == "voiceConversationTimeoutSeconds" {
-                VoiceModeManager.conversationTimeoutOverride = msg.value as? Int
+                VoiceModeManager.conversationTimeoutOverride = Int(msg.value)
             } else {
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -43,6 +43,9 @@ struct VoiceSettingsView: View {
         .onDisappear {
             stopRecordingCustomKey()
         }
+        .onChange(of: conversationTimeoutSeconds) { newValue in
+            VoiceModeManager.conversationTimeoutOverride = newValue
+        }
     }
 
     // MARK: - Push to Talk Card


### PR DESCRIPTION
## Summary
- Fix `as? Int` cast on String value in daemon broadcast handler (always nil) → use `Int(msg.value)`
- Add onChange handler in VoiceSettingsView to immediately update VoiceModeManager.conversationTimeoutOverride when user changes the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
