### PR TITLE
fix: include elevenlabs in APIKeyManager migration list

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -40,6 +40,7 @@ enum APIKeyManager {
     static let allSyncableProviders = [
         "anthropic",
         "brave",
+        "elevenlabs",
         "fireworks",
         "gemini",
         "openai",


### PR DESCRIPTION
## Summary
Adds "elevenlabs" to allSyncableProviders so the UserDefaults-to-CredentialStorage migration picks up ElevenLabs API keys for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
