### PR TITLE
fix: stringify conversation timeout before broadcasting to client

### DIFF
--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -132,12 +132,14 @@ export async function run(
   const meta = VOICE_SETTINGS[setting as VoiceSettingName];
   const friendlyName = FRIENDLY_NAMES[setting as VoiceSettingName];
 
-  // Send client_settings_update message to write to UserDefaults
+  // Send client_settings_update message to write to UserDefaults.
+  // Always stringify the value — Swift's ClientSettingsUpdate.value is typed
+  // as String, so a bare JSON number would fail to decode.
   if (context.sendToClient) {
     context.sendToClient({
       type: "client_settings_update",
       key: meta.userDefaultsKey,
-      value: validation.coerced,
+      value: String(validation.coerced),
     });
   }
 


### PR DESCRIPTION
## Summary
Wraps the conversation_timeout value in String() before sending via sendToClient so the Swift client can decode it (ClientSettingsUpdate.value is typed as String).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
