### PR TITLE
fix: restore UserDefaults fallback for voice settings on app restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -85,9 +85,11 @@ final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
     /// Override voice ID set by daemon broadcasts (client_settings_update).
     static var overrideVoiceId: String?
 
-    /// ElevenLabs voice ID — reads from daemon-provided override, falls back to Amelia.
+    /// ElevenLabs voice ID — reads from daemon-provided override, then UserDefaults
+    /// (so the user's last-configured value survives app restarts), falls back to Amelia.
     private static var elevenLabsVoiceId: String {
         overrideVoiceId.flatMap { $0.isEmpty ? nil : $0 }
+            ?? UserDefaults.standard.string(forKey: "ttsVoiceId").flatMap { $0.isEmpty ? nil : $0 }
             ?? Self.defaultVoiceId
     }
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -599,10 +599,14 @@ final class VoiceModeManager: ObservableObject {
 
     private func startConversationTimeout() {
         cancelConversationTimeout()
-        // Read the override each time so daemon broadcasts take effect immediately
+        // Read the override each time so daemon broadcasts take effect immediately.
+        // Fall back to UserDefaults so the user's last-configured value survives
+        // app restarts (before the daemon sends a client_settings_update).
         let interval: TimeInterval
         if let override = Self.conversationTimeoutOverride, override > 0 {
             interval = TimeInterval(override)
+        } else if let stored = UserDefaults.standard.object(forKey: "voiceConversationTimeoutSeconds") as? Int, stored > 0 {
+            interval = TimeInterval(stored)
         } else {
             interval = conversationTimeoutInterval
         }


### PR DESCRIPTION
## Summary
Restores UserDefaults as a fallback (not primary) source for voice settings so they persist across app restarts. The daemon override is still preferred when available.

- VoiceModeManager: falls back to UserDefaults for conversationTimeoutSeconds before using hardcoded 30s default
- OpenAIVoiceService: falls back to UserDefaults for ttsVoiceId before using hardcoded default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
