### PR TITLE
fix: restore BaseServiceSchema for service config schemas

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -20,15 +20,18 @@ export const VALID_WEB_SEARCH_PROVIDERS = [
   "inference-provider-native",
 ] as const;
 
-export const InferenceServiceSchema = z.object({
+export const BaseServiceSchema = z.object({
   mode: ServiceModeSchema.default("your-own"),
+});
+export type BaseService = z.infer<typeof BaseServiceSchema>;
+
+export const InferenceServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_INFERENCE_PROVIDERS).default("anthropic"),
   model: z.string().default("claude-opus-4-6"),
 });
 export type InferenceService = z.infer<typeof InferenceServiceSchema>;
 
-export const ImageGenerationServiceSchema = z.object({
-  mode: ServiceModeSchema.default("your-own"),
+export const ImageGenerationServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_IMAGE_GEN_PROVIDERS).default("gemini"),
   model: z.string().default("gemini-3.1-flash-image-preview"),
 });
@@ -36,15 +39,14 @@ export type ImageGenerationService = z.infer<
   typeof ImageGenerationServiceSchema
 >;
 
-export const WebSearchServiceSchema = z.object({
-  mode: ServiceModeSchema.default("your-own"),
+export const WebSearchServiceSchema = BaseServiceSchema.extend({
   provider: z
     .enum(VALID_WEB_SEARCH_PROVIDERS)
     .default("inference-provider-native"),
 });
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 
-export const GoogleOAuthServiceSchema = z.object({
+export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("managed"),
 });
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;


### PR DESCRIPTION
## Summary
- Restore `BaseServiceSchema` that was accidentally reverted in #18794 — it was originally introduced in #18776 to DRY up the `mode` field across service schemas
- `GoogleOAuthServiceSchema` overrides the default `mode` to `"managed"` via `.extend()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
