### PR TITLE
feat: validate platform prerequisites in PlatformOAuthConnection constructor

### DIFF
--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -42,6 +42,17 @@ export class PlatformOAuthConnection implements OAuthConnection {
   private readonly apiKey: string;
 
   constructor(options: PlatformOAuthConnectionOptions) {
+    const missing: string[] = [];
+    if (!options.platformBaseUrl) missing.push("platform base URL");
+    if (!options.apiKey) missing.push("assistant API key");
+    if (!options.assistantId) missing.push("assistant ID");
+    if (missing.length > 0) {
+      throw new BackendError(
+        `Platform-managed connection for "${options.providerKey}" cannot be created: missing ${missing.join(", ")}. ` +
+          `Log in to the Vellum platform or switch to using your own OAuth app.`,
+      );
+    }
+
     this.id = options.id;
     this.providerKey = options.providerKey;
     this.externalId = options.externalId;


### PR DESCRIPTION
## Summary
- Adds constructor validation in `PlatformOAuthConnection` that checks for required platform prerequisites (platform base URL, API key, assistant ID)
- Throws a clear `BackendError` with actionable message when prerequisites are missing, telling users to log in to the platform or switch to their own OAuth app
- Updates tests to cover the new validation and managed-mode behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)