### PR TITLE
refactor: use kwargs for resolveOAuthConnection, add clientId support, clean up naming

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -44,10 +44,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     switch (action) {
       case "list": {
         const pageSize = (input.page_size as number) ?? 50;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -35,10 +35,9 @@ export async function run(
     }
 
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
       let truncated = false;
@@ -107,10 +106,9 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
       return ok("Message archived.");
     } catch (e) {
@@ -128,10 +126,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     if (messageIds.length === 1) {
       await modifyMessage(connection, messageIds[0], {
         removeLabelIds: ["INBOX"],

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -57,10 +57,9 @@ export async function run(
 
   if (action === "list") {
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       const message = await getMessage(connection, messageId, "full");
       const attachments = collectAttachments(message.payload?.parts);
 
@@ -82,10 +81,9 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       const attachment = await getAttachment(
         connection,
         messageId,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -23,10 +23,9 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     const draft = await createDraft(
       connection,
       to,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -26,10 +26,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     switch (action) {
       case "list": {
         const filters = await listFilters(connection);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -38,10 +38,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     switch (action) {
       case "track": {
         const messageId = input.message_id as string;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -76,10 +76,9 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     const message = await getMessage(connection, messageId, "full");
     const headers = message.payload?.headers ?? [];
     const originalFrom = extractHeader(headers, "From");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -21,10 +21,9 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       await batchModifyMessages(connection, messageIds, {
         addLabelIds,
         removeLabelIds,
@@ -37,10 +36,9 @@ export async function run(
 
   if (messageId) {
     try {
-      const connection = await resolveOAuthConnection(
-        "integration:google",
+      const connection = await resolveOAuthConnection("integration:google", {
         account,
-      );
+      });
       await modifyMessage(connection, messageId, {
         addLabelIds,
         removeLabelIds,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -56,10 +56,9 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive
     const allMessageIds: string[] = [];
     const fetchPromises: Promise<GmailMessage[]>[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -15,10 +15,9 @@ export async function run(
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     const msg = await sendDraft(connection, draftId);
     return ok(`Draft sent (Message ID: ${msg.id}).`);
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -58,10 +58,9 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive,
     // overlapping fetch latency with pagination latency
     const allMessageIds: string[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -18,10 +18,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     await trashMessage(connection, messageId);
     return ok("Message moved to trash.");
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -32,10 +32,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     const message = await getMessage(connection, messageId, "metadata", [
       "List-Unsubscribe",
       "List-Unsubscribe-Post",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -22,10 +22,9 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection(
-      "integration:google",
+    const connection = await resolveOAuthConnection("integration:google", {
       account,
-    );
+    });
     switch (action) {
       case "get": {
         const settings = await getVacation(connection);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -13,5 +13,5 @@ export function ok(content: string): ToolExecutionResult {
 export async function getCalendarConnection(
   account?: string,
 ): Promise<OAuthConnection> {
-  return resolveOAuthConnection("integration:google", account);
+  return resolveOAuthConnection("integration:google", { account });
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -137,5 +137,5 @@ export async function getProviderConnection(
   account?: string,
 ): Promise<OAuthConnection | string> {
   if (await provider.isConnected?.()) return "";
-  return resolveOAuthConnection(provider.credentialService, account);
+  return resolveOAuthConnection(provider.credentialService, { account });
 }

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -237,7 +237,6 @@ function createConnection(service = "integration:google"): BYOOAuthConnection {
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     accountInfo: null,
     grantedScopes: ["read", "write"],
-    credentialService: service,
   });
 }
 
@@ -516,46 +515,5 @@ describe("resolveOAuthConnection", () => {
     ).rejects.toThrow(
       /No base URL configured for "integration:custom-service"/,
     );
-  });
-
-  test("resolves base URL via app's canonical providerKey for custom credential_service", async () => {
-    // Set up a well-known provider with a baseUrl
-    mockProviders.set("github", {
-      key: "github",
-      tokenUrl: "https://github.com/login/oauth/access_token",
-      baseUrl: "https://api.github.com",
-    });
-    // The custom credential service has no provider entry of its own
-    // (getProvider("integration:github-work") returns undefined)
-
-    // App points to the canonical "github" provider
-    const appId = "app-github-work";
-    mockApps.set(appId, {
-      id: appId,
-      providerKey: "github",
-      clientId: "test-client-id",
-      clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
-    });
-
-    // Connection uses the custom credential service as its providerKey
-    const connId = "conn-github-work";
-    mockConnections.set("integration:github-work", {
-      id: connId,
-      providerKey: "integration:github-work",
-      oauthAppId: appId,
-      expiresAt: Date.now() + 3600 * 1000,
-      grantedScopes: JSON.stringify(["repo"]),
-      accountInfo: null,
-    });
-    await setSecureKeyAsync(
-      `oauth_connection/${connId}/access_token`,
-      "ghp-test-token",
-    );
-
-    const conn = await resolveOAuthConnection("integration:github-work");
-
-    expect(conn).toBeInstanceOf(BYOOAuthConnection);
-    expect(conn.providerKey).toBe("integration:github-work");
-    expect(conn.grantedScopes).toEqual(["repo"]);
   });
 });

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -26,7 +26,6 @@ export interface BYOOAuthConnectionOptions {
   baseUrl: string;
   accountInfo: string | null;
   grantedScopes: string[];
-  credentialService: string;
 }
 
 export class BYOOAuthConnection implements OAuthConnection {
@@ -36,7 +35,6 @@ export class BYOOAuthConnection implements OAuthConnection {
   readonly grantedScopes: string[];
 
   private readonly baseUrl: string;
-  private readonly credentialService: string;
 
   constructor(opts: BYOOAuthConnectionOptions) {
     this.id = opts.id;
@@ -44,12 +42,11 @@ export class BYOOAuthConnection implements OAuthConnection {
     this.baseUrl = opts.baseUrl;
     this.accountInfo = opts.accountInfo;
     this.grantedScopes = opts.grantedScopes;
-    this.credentialService = opts.credentialService;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
     return withValidToken(
-      this.credentialService,
+      this.providerKey,
       async (token) => {
         const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
         let fullUrl = `${effectiveBaseUrl}${req.path}`;
@@ -106,7 +103,7 @@ export class BYOOAuthConnection implements OAuthConnection {
   }
 
   async withToken<T>(fn: (token: string) => Promise<T>): Promise<T> {
-    return withValidToken(this.credentialService, fn, {
+    return withValidToken(this.providerKey, fn, {
       connectionId: this.id,
     });
   }

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -252,12 +252,13 @@ export async function orchestrateOAuthConnect(
       prepared.completion
         .then(async (result) => {
           try {
-            let accountInfo: string | undefined;
+            let parsedAccountIdentifier: string | undefined;
 
-            // Run identity verifier if available (code-side behavior)
+            // Parse account identifier from the provider's identity endpoint.
+            // Best-effort — format varies by provider and may fail.
             if (behavior.identityVerifier) {
               try {
-                accountInfo = await behavior.identityVerifier(
+                parsedAccountIdentifier = await behavior.identityVerifier(
                   result.tokens.accessToken,
                 );
               } catch {
@@ -270,19 +271,19 @@ export async function orchestrateOAuthConnect(
               tokens: result.tokens,
               grantedScopes: result.grantedScopes,
               rawTokenResponse: result.rawTokenResponse,
-              identityAccountInfo: accountInfo,
+              parsedAccountIdentifier,
             });
             log.info(
               {
                 service: resolvedService,
-                accountInfo: stored.accountInfo ?? accountInfo,
+                accountInfo: stored.accountInfo ?? parsedAccountIdentifier,
               },
               "Deferred OAuth2 flow completed — tokens stored",
             );
             options.onDeferredComplete?.({
               success: true,
               service: resolvedService,
-              accountInfo: stored.accountInfo ?? accountInfo,
+              accountInfo: stored.accountInfo ?? parsedAccountIdentifier,
             });
           } catch (err) {
             log.error(
@@ -353,11 +354,14 @@ export async function orchestrateOAuthConnect(
           : undefined,
     );
 
-    // Run identity verifier if available (code-side behavior)
-    let verifiedIdentity: string | undefined;
+    // Parse account identifier from the provider's identity endpoint.
+    // Best-effort — format varies by provider and may fail.
+    let parsedAccountIdentifier: string | undefined;
     if (behavior.identityVerifier) {
       try {
-        verifiedIdentity = await behavior.identityVerifier(tokens.accessToken);
+        parsedAccountIdentifier = await behavior.identityVerifier(
+          tokens.accessToken,
+        );
       } catch {
         // Non-fatal
       }
@@ -368,14 +372,14 @@ export async function orchestrateOAuthConnect(
       tokens,
       grantedScopes,
       rawTokenResponse,
-      identityAccountInfo: verifiedIdentity,
+      parsedAccountIdentifier,
     });
 
     return {
       success: true,
       deferred: false,
       grantedScopes,
-      accountInfo: accountInfo ?? verifiedIdentity,
+      accountInfo: accountInfo ?? parsedAccountIdentifier,
     };
   } catch (err: unknown) {
     const message =

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockProvider: Record<string, unknown> | undefined;
 let mockConnection: Record<string, unknown> | undefined;
-let mockApp: Record<string, unknown> | undefined;
 let mockAccessToken: string | undefined;
 let mockConfig: Record<string, unknown> = {};
 let mockManagedProxyCtx = {
@@ -29,9 +28,19 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("./oauth-store.js", () => ({
   getProvider: () => mockProvider,
-  getConnectionByProvider: () => mockConnection,
-  getConnectionByProviderAndAccount: () => mockConnection,
-  getApp: () => mockApp,
+  getConnectionByProvider: (_pk: string, clientId?: string) => {
+    if (clientId && mockConnection?.clientId !== clientId) return undefined;
+    return mockConnection;
+  },
+  getConnectionByProviderAndAccount: (
+    _pk: string,
+    account?: string,
+    clientId?: string,
+  ) => {
+    if (clientId && mockConnection?.clientId !== clientId) return undefined;
+    if (account && mockConnection?.accountInfo !== account) return undefined;
+    return mockConnection;
+  },
 }));
 
 mock.module("../security/secure-keys.js", () => ({
@@ -75,10 +84,7 @@ function setupDefaults(): void {
     accountInfo: "user@example.com",
     grantedScopes: JSON.stringify(["scope-a", "scope-b"]),
     status: "active",
-  };
-  mockApp = {
-    id: "app-1",
-    providerKey: "integration:google",
+    clientId: "client-1",
   };
   mockAccessToken = "tok-valid";
   mockConfig = {
@@ -132,13 +138,12 @@ describe("resolveOAuthConnection", () => {
     expect(result.grantedScopes).toEqual([]);
   });
 
-  test("passes accountInfo through to PlatformOAuthConnection", async () => {
+  test("passes account through to PlatformOAuthConnection", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection(
-      "integration:google",
-      "user@example.com",
-    );
+    const result = await resolveOAuthConnection("integration:google", {
+      account: "user@example.com",
+    });
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
     expect(result.accountInfo).toBe("user@example.com");
   });
@@ -161,5 +166,30 @@ describe("resolveOAuthConnection", () => {
 
     const result = await resolveOAuthConnection("integration:google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("managed path ignores clientId option", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+
+    const result = await resolveOAuthConnection("integration:google", {
+      clientId: "some-client-id",
+    });
+    expect(result).toBeInstanceOf(PlatformOAuthConnection);
+  });
+
+  test("BYO path narrows by clientId when provided", async () => {
+    const result = await resolveOAuthConnection("integration:google", {
+      clientId: "client-1",
+    });
+    expect(result).toBeInstanceOf(BYOOAuthConnection);
+    expect(result.id).toBe("conn-1");
+  });
+
+  test("BYO path returns no credential when clientId does not match", async () => {
+    await expect(
+      resolveOAuthConnection("integration:google", {
+        clientId: "wrong-client",
+      }),
+    ).rejects.toThrow(/No credential found/);
   });
 });

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -6,27 +6,45 @@ import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
 import {
-  getApp,
   getConnectionByProvider,
   getConnectionByProviderAndAccount,
   getProvider,
 } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
+export interface ResolveOAuthConnectionOptions {
+  /** OAuth app client ID — narrows to a specific app when multiple BYO apps
+   *  exist for the same provider. */
+  clientId?: string;
+  /** Account identifier (e.g. email, username) — disambiguates when multiple
+   *  accounts are connected for the same provider. Best-effort: not guaranteed
+   *  to be present on all connections. */
+  account?: string;
+}
+
 /**
- * Resolve an OAuthConnection for a given credential service.
+ * Resolve an OAuthConnection for a given provider.
  *
  * Managed providers (where the service config `mode` is `"managed"`) are
  * routed through the platform proxy with no local state required.
  *
  * BYO providers resolve from the local SQLite oauth-store and require an
  * active connection row and a stored access token.
+ *
+ * @param providerKey - Provider identifier (e.g. "integration:google").
+ *   Maps to the `provider_key` primary key in the `oauth_providers` table.
+ * @param options.clientId - Optional OAuth app client ID. When multiple BYO
+ *   apps exist for the same provider, narrows the connection lookup to the
+ *   app matching this client ID. Ignored for managed providers.
+ * @param options.account - Optional account identifier to disambiguate
+ *   multi-account connections.
  */
 export async function resolveOAuthConnection(
-  credentialService: string,
-  accountInfo?: string,
+  providerKey: string,
+  options?: ResolveOAuthConnectionOptions,
 ): Promise<OAuthConnection> {
-  const provider = getProvider(credentialService);
+  const { clientId, account } = options ?? {};
+  const provider = getProvider(providerKey);
   const managedKey = provider?.managedServiceConfigKey;
 
   if (managedKey && managedKey in ServicesSchema.shape) {
@@ -35,10 +53,10 @@ export async function resolveOAuthConnection(
       const ctx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
       return new PlatformOAuthConnection({
-        id: credentialService,
-        providerKey: credentialService,
-        externalId: credentialService,
-        accountInfo: accountInfo ?? null,
+        id: providerKey,
+        providerKey,
+        externalId: providerKey,
+        accountInfo: account ?? null,
         grantedScopes: [],
         assistantId,
         platformBaseUrl: ctx.platformBaseUrl,
@@ -48,12 +66,12 @@ export async function resolveOAuthConnection(
   }
 
   // BYO path — requires a local connection row, access token, and base URL.
-  const conn = accountInfo
-    ? getConnectionByProviderAndAccount(credentialService, accountInfo)
-    : getConnectionByProvider(credentialService);
+  const conn = account
+    ? getConnectionByProviderAndAccount(providerKey, account, clientId)
+    : getConnectionByProvider(providerKey, clientId);
   if (!conn) {
     throw new Error(
-      `No credential found for "${credentialService}". Authorization required.`,
+      `No credential found for "${providerKey}". Authorization required.`,
     );
   }
 
@@ -62,17 +80,13 @@ export async function resolveOAuthConnection(
   );
   if (!accessToken) {
     throw new Error(
-      `No access token found for "${credentialService}". Authorization required.`,
+      `No access token found for "${providerKey}". Authorization required.`,
     );
   }
 
-  // When credentialService is a custom override (e.g. "integration:github-work")
-  // with no provider row, fall back to the app's canonical providerKey for baseUrl.
-  const byoProvider =
-    provider ?? getProvider(getApp(conn.oauthAppId)?.providerKey ?? "");
-  const baseUrl = byoProvider?.baseUrl;
+  const baseUrl = provider?.baseUrl;
   if (!baseUrl) {
-    throw new Error(`No base URL configured for "${credentialService}".`);
+    throw new Error(`No base URL configured for "${providerKey}".`);
   }
 
   const grantedScopes: string[] = conn.grantedScopes
@@ -85,6 +99,5 @@ export async function resolveOAuthConnection(
     baseUrl,
     accountInfo: conn.accountInfo,
     grantedScopes,
-    credentialService,
   });
 }

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -456,15 +456,37 @@ export function getConnectionByProvider(
 
 /**
  * Get the active connection for a provider matching a specific account.
+ * When `clientId` is provided, only connections linked to the matching app are considered.
  * Falls back to getConnectionByProvider when accountInfo is undefined.
  */
 export function getConnectionByProviderAndAccount(
   providerKey: string,
   accountInfo?: string,
+  clientId?: string,
 ): OAuthConnectionRow | undefined {
-  if (!accountInfo) return getConnectionByProvider(providerKey);
+  if (!accountInfo) return getConnectionByProvider(providerKey, clientId);
 
   const db = getDb();
+
+  if (clientId) {
+    const app = getAppByProviderAndClientId(providerKey, clientId);
+    if (!app) return undefined;
+    return db
+      .select()
+      .from(oauthConnections)
+      .where(
+        and(
+          eq(oauthConnections.providerKey, providerKey),
+          eq(oauthConnections.accountInfo, accountInfo),
+          eq(oauthConnections.oauthAppId, app.id),
+          eq(oauthConnections.status, "active"),
+        ),
+      )
+      .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
+      .limit(1)
+      .get();
+  }
+
   return db
     .select()
     .from(oauthConnections)

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -59,8 +59,12 @@ export interface StoreOAuth2TokensParams {
   clientId: string;
   clientSecret?: string;
   userinfoUrl?: string;
-  /** Fallback account info from an identity verifier (e.g. @username, email). */
-  identityAccountInfo?: string;
+  /**
+   * Best-effort account identifier parsed from the provider's identity
+   * endpoint (e.g. email, @username, display name). The format varies by
+   * provider and may be undefined if the API call fails.
+   */
+  parsedAccountIdentifier?: string;
   /** Pre-resolved oauth_app ID — skips the upsertApp() call if provided. */
   oauthAppId?: string;
 }
@@ -94,6 +98,10 @@ export async function storeOAuth2Tokens(
     ? Date.now() + tokens.expiresIn * 1000
     : null;
 
+  // Account identifier parsing is best-effort. The format varies by provider
+  // (email for Google, username for GitHub, display name for Spotify, etc.)
+  // and may be undefined if the userinfo/identity API call fails or the
+  // required scope wasn't granted.
   let accountInfo: string | undefined;
   if (userinfoUrl && grantedScopes.some((s) => s.includes("userinfo"))) {
     try {
@@ -109,7 +117,7 @@ export async function storeOAuth2Tokens(
     }
   }
 
-  const resolvedAccountInfo = accountInfo ?? params.identityAccountInfo;
+  const resolvedAccountInfo = accountInfo ?? params.parsedAccountIdentifier;
 
   // -------------------------------------------------------------------
   // SQLite oauth_app + oauth_connection + new-format secure keys


### PR DESCRIPTION
## Summary
- Change `resolveOAuthConnection` signature from positional args `(credentialService, accountInfo?)` to kwargs `(providerKey, { clientId?, account? }?)` for clarity and extensibility
- Add `clientId` support to narrow BYO connection lookups when multiple OAuth apps exist for the same provider
- Remove redundant `credentialService` field from `BYOOAuthConnection` (was always identical to `providerKey`), remove dead baseUrl fallback through `getApp`, and rename `identityAccountInfo` → `parsedAccountIdentifier` with best-effort documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
