### PR TITLE
Add static per-provider model catalog for inference provider selection

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1,0 +1,48 @@
+export interface CatalogModel {
+  id: string;
+  displayName: string;
+}
+
+export const PROVIDER_MODEL_CATALOG: Record<string, CatalogModel[]> = {
+  anthropic: [
+    { id: "claude-opus-4-6", displayName: "Claude Opus 4.6" },
+    { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
+    { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
+  ],
+  openai: [
+    { id: "gpt-5.2", displayName: "GPT-5.2" },
+    { id: "gpt-5.4", displayName: "GPT-5.4" },
+    { id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano" },
+  ],
+  gemini: [
+    { id: "gemini-3-flash", displayName: "Gemini 3 Flash" },
+    { id: "gemini-3-pro", displayName: "Gemini 3 Pro" },
+  ],
+  ollama: [
+    { id: "llama3.2", displayName: "Llama 3.2" },
+    { id: "mistral", displayName: "Mistral" },
+  ],
+  fireworks: [
+    { id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5" },
+  ],
+  openrouter: [
+    { id: "x-ai/grok-4", displayName: "Grok 4" },
+    { id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta" },
+  ],
+};
+
+/** Display names for inference providers */
+export const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  gemini: "Google Gemini",
+  ollama: "Ollama",
+  fireworks: "Fireworks",
+  openrouter: "OpenRouter",
+};
+
+/** Check if a model ID is in the catalog for a given provider */
+export function isModelInCatalog(provider: string, modelId: string): boolean {
+  const catalog = PROVIDER_MODEL_CATALOG[provider];
+  return catalog?.some((m) => m.id === modelId) ?? false;
+}

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -1,6 +1,6 @@
 import type { ModelIntent } from "./types.js";
 
-const PROVIDER_DEFAULT_MODELS = {
+export const PROVIDER_DEFAULT_MODELS = {
   anthropic: "claude-opus-4-6",
   openai: "gpt-5.2",
   gemini: "gemini-3-flash",


### PR DESCRIPTION
## Summary
- Creates `model-catalog.ts` with per-provider model catalog (2-3 recommended models per provider)
- Exports `PROVIDER_DEFAULT_MODELS` from `model-intents.ts` for use by other modules
- Adds provider display names and `isModelInCatalog` utility

Part of plan: custom-inference-provider.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
