### PR TITLE
Add `customInferenceProvider` assistant feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,6 +26,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "custom-inference-provider",
+      "scope": "assistant",
+      "key": "feature_flags.custom-inference-provider.enabled",
+      "label": "Custom Inference Provider",
+      "description": "Allow selecting a specific LLM provider and model for inference in Your Own mode",
+      "defaultEnabled": false
+    },
+    {
       "id": "email-channel",
       "scope": "assistant",
       "key": "feature_flags.email-channel.enabled",


### PR DESCRIPTION
## Summary
- Adds `custom-inference-provider` feature flag to the registry with scope `assistant` and `defaultEnabled: false`
- Syncs bundled copies across gateway, assistant, and client directories

Part of plan: custom-inference-provider.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
