### PR TITLE
Add OpenAI and Gemini API key validation in secret-routes

### DIFF
--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -3,6 +3,7 @@ import { ApiError, GoogleGenAI } from "@google/genai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { ProviderError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
   ContentBlock,
@@ -12,6 +13,47 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../types.js";
+
+const log = getLogger("gemini-client");
+
+/**
+ * Validate a Gemini API key by making a lightweight models.list() call.
+ * Returns `{ valid: true }` on success or `{ valid: false, reason: string }` on failure.
+ */
+export async function validateGeminiApiKey(
+  apiKey: string,
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+  try {
+    const client = new GoogleGenAI({ apiKey });
+    await client.models.list({ config: { pageSize: 1 } });
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (error.status === 401) {
+        return { valid: false, reason: "API key is invalid or expired." };
+      }
+      if (error.status === 403) {
+        return {
+          valid: false,
+          reason: `Gemini API error (${error.status}): ${error.message}`,
+        };
+      }
+      // Transient errors (429, 5xx, etc.) — validation is inconclusive,
+      // allow the key to be stored rather than blocking the user.
+      log.warn(
+        { status: error.status },
+        "Gemini API returned a transient error during key validation — allowing key storage",
+      );
+      return { valid: true };
+    }
+    // Network errors — validation is inconclusive, allow key storage.
+    log.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      "Network error during Gemini key validation — allowing key storage",
+    );
+    return { valid: true };
+  }
+}
 
 export interface GeminiProviderOptions {
   streamTimeoutMs?: number;

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { ProviderError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { createStreamTimeout } from "../stream-timeout.js";
@@ -13,6 +14,47 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../types.js";
+
+const log = getLogger("openai-client");
+
+/**
+ * Validate an OpenAI API key by making a lightweight GET /v1/models call.
+ * Returns `{ valid: true }` on success or `{ valid: false, reason: string }` on failure.
+ */
+export async function validateOpenAIApiKey(
+  apiKey: string,
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+  try {
+    const client = new OpenAI({ apiKey });
+    await client.models.list();
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof OpenAI.APIError) {
+      if (error.status === 401) {
+        return { valid: false, reason: "API key is invalid or expired." };
+      }
+      if (error.status === 403) {
+        return {
+          valid: false,
+          reason: `OpenAI API error (${error.status}): ${error.message}`,
+        };
+      }
+      // Transient errors (429, 5xx, etc.) — validation is inconclusive,
+      // allow the key to be stored rather than blocking the user.
+      log.warn(
+        { status: error.status },
+        "OpenAI API returned a transient error during key validation — allowing key storage",
+      );
+      return { valid: true };
+    }
+    // Network errors — validation is inconclusive, allow key storage.
+    log.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      "Network error during OpenAI key validation — allowing key storage",
+    );
+    return { valid: true };
+  }
+}
 
 export interface OpenAICompatibleProviderOptions {
   baseURL?: string;

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -13,6 +13,8 @@ import type { CesClient } from "../../credential-execution/client.js";
 import { setSentryOrganizationId } from "../../instrument.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
+import { validateGeminiApiKey } from "../../providers/gemini/client.js";
+import { validateOpenAIApiKey } from "../../providers/openai/client.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -131,7 +133,7 @@ export async function handleAddSecret(
           400,
         );
       }
-      // Validate Anthropic API keys before storing
+      // Validate API keys before storing (Anthropic, OpenAI, Gemini)
       if (name === "anthropic") {
         const validation = await validateAnthropicApiKey(value);
         if (!validation.valid) {
@@ -144,7 +146,32 @@ export async function handleAddSecret(
             { status: 422 },
           );
         }
+      } else if (name === "openai") {
+        const validation = await validateOpenAIApiKey(value);
+        if (!validation.valid) {
+          log.warn(
+            { provider: name, reason: validation.reason },
+            "API key validation failed",
+          );
+          return Response.json(
+            { success: false, error: validation.reason },
+            { status: 422 },
+          );
+        }
+      } else if (name === "gemini") {
+        const validation = await validateGeminiApiKey(value);
+        if (!validation.valid) {
+          log.warn(
+            { provider: name, reason: validation.reason },
+            "API key validation failed",
+          );
+          return Response.json(
+            { success: false, error: validation.reason },
+            { status: 422 },
+          );
+        }
       }
+      // fireworks, openrouter, ollama — no validation (allow storage)
 
       const stored = await setSecureKeyAsync(name, value);
       if (!stored) {


### PR DESCRIPTION
## Summary
- Adds `validateOpenAIApiKey` function following the existing Anthropic validation pattern
- Adds `validateGeminiApiKey` function using the Google GenAI SDK
- Extends `secret-routes.ts` to validate OpenAI and Gemini keys before storage
- Transient/network errors allow storage; only definitive auth failures (401/403) reject

Part of plan: custom-inference-provider.md (PR 4 of 7)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
