### PR TITLE
Unify slash-command and HTTP model switching through shared setModel with provider support

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -25,6 +25,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
+import { PROVIDER_MODEL_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
@@ -37,6 +38,7 @@ import {
   resolveSlash,
   type SlashContext,
 } from "./conversation-slash.js";
+import type { ModelSetContext } from "./handlers/config-model.js";
 import type {
   ServerMessage,
   UsageStats,
@@ -50,11 +52,13 @@ const log = getLogger("conversation-process");
 /** Build a model_info event with fresh config data. */
 export async function buildModelInfoEvent(): Promise<ServerMessage> {
   const config = getConfig();
+  const provider = config.services.inference.provider;
   return {
     type: "model_info",
     model: config.services.inference.model,
-    provider: config.services.inference.provider,
+    provider,
     configuredProviders: await getConfiguredProviders(),
+    availableModels: PROVIDER_MODEL_CATALOG[provider],
   };
 }
 
@@ -93,6 +97,8 @@ export interface ProcessConversationContext {
   addPreactivatedSkillId(id: string): void;
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
+  /** Model set context for delegating model/provider changes through shared setModel(). */
+  modelSetContext?: ModelSetContext;
   trustContext?: TrustContext;
   ensureActorScopedHistory(): Promise<void>;
   persistUserMessage(
@@ -204,6 +210,7 @@ function buildSlashContext(
     model: config.services.inference.model,
     provider: config.services.inference.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
+    modelSetContext: conversation.modelSetContext,
   };
 }
 

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -5,16 +5,16 @@ import { join } from "node:path";
 import QRCode from "qrcode";
 
 import { getGatewayPort, getIngressPublicBaseUrl } from "../config/env.js";
-import { getConfig, loadRawConfig, saveRawConfig } from "../config/loader.js";
-import { setServiceField } from "../config/raw-config-utils.js";
+import { getConfig } from "../config/loader.js";
 import {
   getConfiguredProviders,
   isProviderAvailable,
 } from "../providers/provider-availability.js";
-import { initializeProviders } from "../providers/registry.js";
 import { getLocalIPv4 } from "../util/network-info.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { silentlyWithLog } from "../util/silently.js";
+import type { ModelSetContext } from "./handlers/config-model.js";
+import { setModel } from "./handlers/config-model.js";
 import { getAssistantName } from "./identity-helpers.js";
 import type { PairingStore } from "./pairing-store.js";
 
@@ -45,6 +45,8 @@ export interface SlashContext {
   model: string;
   provider: string;
   estimatedCost: number;
+  /** Model set context for delegating model/provider changes to shared setModel(). */
+  modelSetContext?: ModelSetContext;
 }
 
 // ── /model command ───────────────────────────────────────────────────
@@ -120,6 +122,7 @@ function matchModel(input: string): string | undefined {
 
 async function resolveProviderModelCommand(
   content: string,
+  ctx?: ModelSetContext,
 ): Promise<SlashResolution | null> {
   const trimmed = content.trim();
   if (!trimmed.startsWith("/")) return null;
@@ -158,15 +161,10 @@ async function resolveProviderModelCommand(
     };
   }
 
-  // Update config with both provider and model
-  const raw = loadRawConfig();
-  setServiceField(raw, "inference", "provider", provider);
-  setServiceField(raw, "inference", "model", model);
-  saveRawConfig(raw);
-
-  // Re-initialize providers with new config
-  const newConfig = getConfig();
-  await initializeProviders(newConfig);
+  // Delegate to shared setModel for config write, provider reinit, and conversation eviction
+  if (ctx) {
+    await setModel(model, ctx, provider);
+  }
 
   const switchedMsg = name
     ? `Switched ${name} to **${displayName}**. New conversations will use this model.`
@@ -209,6 +207,7 @@ async function resolveModelList(): Promise<SlashResolution> {
 
 async function resolveModelCommand(
   content: string,
+  ctx?: ModelSetContext,
 ): Promise<SlashResolution | null> {
   const trimmed = content.trim();
   // Match /models → route to list
@@ -275,13 +274,10 @@ async function resolveModelCommand(
     };
   }
 
-  // Change model: save config and re-initialize providers
-  const raw = loadRawConfig();
-  setServiceField(raw, "inference", "provider", "anthropic"); // Ensure provider is set for Anthropic models
-  setServiceField(raw, "inference", "model", matched);
-  saveRawConfig(raw);
-  const config = getConfig();
-  await initializeProviders(config);
+  // Delegate to shared setModel for config write, provider reinit, and conversation eviction
+  if (ctx) {
+    await setModel(matched, ctx, "anthropic");
+  }
 
   const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
   const switchedMsg = name
@@ -334,12 +330,17 @@ export async function resolveSlash(
   content: string,
   context?: SlashContext,
 ): Promise<SlashResolution> {
+  const modelSetCtx = context?.modelSetContext;
+
   // Check provider shortcuts first (/gpt4, /opus, etc.)
-  const providerResult = await resolveProviderModelCommand(content);
+  const providerResult = await resolveProviderModelCommand(
+    content,
+    modelSetCtx,
+  );
   if (providerResult) return providerResult;
 
   // Handle /model command
-  const modelResult = await resolveModelCommand(content);
+  const modelResult = await resolveModelCommand(content, modelSetCtx);
   if (modelResult) return modelResult;
 
   // Handle /pair command

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -95,6 +95,7 @@ import {
   createToolExecutor,
 } from "./conversation-tool-setup.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
+import type { ModelSetContext } from "./handlers/config-model.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
 import type { CuObservationResult } from "./host-cu-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
@@ -177,6 +178,7 @@ export class Conversation {
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ trustContext?: TrustContext;
+  /** @internal */ modelSetContext?: ModelSetContext;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ voiceCallControlPrompt?: string;

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -4,6 +4,12 @@ import {
   saveRawConfig,
 } from "../../config/loader.js";
 import { setServiceField } from "../../config/raw-config-utils.js";
+import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
+import {
+  isModelInCatalog,
+  PROVIDER_MODEL_CATALOG,
+} from "../../providers/model-catalog.js";
+import { getProviderDefaultModel } from "../../providers/model-intents.js";
 import {
   getConfiguredProviders,
   isProviderAvailable,
@@ -28,15 +34,18 @@ export interface ModelInfo {
   model: string;
   provider: string;
   configuredProviders?: string[];
+  availableModels?: Array<{ id: string; displayName: string }>;
 }
 
 /** Return current model configuration. */
 export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
+  const provider = config.services.inference.provider;
   return {
     model: config.services.inference.model,
-    provider: config.services.inference.provider,
+    provider,
     configuredProviders: await getConfiguredProviders(),
+    availableModels: PROVIDER_MODEL_CATALOG[provider],
   };
 }
 
@@ -58,28 +67,52 @@ export interface ModelSetContext {
 /**
  * Set the active model. Returns the resulting ModelInfo, or throws on failure.
  * The caller is responsible for sending the response to the client.
+ *
+ * When `explicitProvider` is supplied, it takes precedence over automatic
+ * provider inference from the model ID. If the provider changes and the
+ * current model doesn't belong to the new provider's catalog, the model
+ * is auto-reset to the provider's default.
  */
 export async function setModel(
   modelId: string,
   ctx: ModelSetContext,
+  explicitProvider?: string,
 ): Promise<ModelInfo> {
-  // If the requested model is already the current model AND the provider
-  // is already aligned with what MODEL_TO_PROVIDER expects, skip expensive
-  // reinitialization but still return model_info so the client confirms.
-  {
-    const current = getConfig();
-    const expectedProvider = MODEL_TO_PROVIDER[modelId];
-    const providerAligned =
-      !expectedProvider ||
-      current.services.inference.provider === expectedProvider;
-    if (modelId === current.services.inference.model && providerAligned) {
-      return await getModelInfo();
-    }
+  const validProviders = new Set<string>(VALID_INFERENCE_PROVIDERS);
+
+  // Validate explicit provider against allowlist
+  if (explicitProvider && !validProviders.has(explicitProvider)) {
+    throw new Error(
+      `Invalid provider "${explicitProvider}". Valid providers: ${[...validProviders].join(", ")}`,
+    );
+  }
+
+  // Resolve provider: explicit > MODEL_TO_PROVIDER lookup > current
+  const current = getConfig();
+  const resolvedProvider =
+    explicitProvider ??
+    MODEL_TO_PROVIDER[modelId] ??
+    current.services.inference.provider;
+
+  // Auto-reset model when provider changes and current modelId doesn't
+  // belong to the new provider's catalog.
+  if (
+    resolvedProvider !== current.services.inference.provider &&
+    !isModelInCatalog(resolvedProvider, modelId)
+  ) {
+    modelId = getProviderDefaultModel(resolvedProvider);
+  }
+
+  // No-op guard: skip expensive reinitialization when nothing changed
+  if (
+    modelId === current.services.inference.model &&
+    resolvedProvider === current.services.inference.provider
+  ) {
+    return await getModelInfo();
   }
 
   // Validate provider availability (secure key, env var, or managed proxy) before switching
-  const provider = MODEL_TO_PROVIDER[modelId];
-  if (provider && !(await isProviderAvailable(provider))) {
+  if (!(await isProviderAvailable(resolvedProvider))) {
     // Return current model_info so the client resyncs its optimistic state
     return await getModelInfo();
   }
@@ -87,10 +120,7 @@ export async function setModel(
   // Use raw config to avoid persisting env-var API keys to disk
   const raw = loadRawConfig();
   setServiceField(raw, "inference", "model", modelId);
-  // Infer provider from model ID to keep provider and model in sync
-  if (provider) {
-    setServiceField(raw, "inference", "provider", provider);
-  }
+  setServiceField(raw, "inference", "provider", resolvedProvider);
 
   // Suppress the file watcher callback — setModel already does
   // the full reload sequence; a redundant watcher-triggered reload
@@ -128,10 +158,12 @@ export async function setModel(
 
   ctx.updateConfigFingerprint();
 
+  const newProvider = config.services.inference.provider;
   return {
     model: config.services.inference.model,
-    provider: config.services.inference.provider,
+    provider: newProvider,
     configuredProviders: await getConfiguredProviders(),
+    availableModels: PROVIDER_MODEL_CATALOG[newProvider],
   };
 }
 
@@ -179,7 +211,7 @@ export async function handleModelSet(
   ctx: HandlerContext,
 ): Promise<void> {
   try {
-    const info = await setModel(msg.model, ctx);
+    const info = await setModel(msg.model, ctx, msg.provider);
     ctx.send({ type: "model_info", ...info });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -80,6 +80,7 @@ export interface ModelGetRequest {
 export interface ModelSetRequest {
   type: "model_set";
   model: string;
+  provider?: string;
 }
 
 export interface ImageGenModelSetRequest {
@@ -240,6 +241,7 @@ export interface ModelInfo {
   model: string;
   provider: string;
   configuredProviders?: string[];
+  availableModels?: Array<{ id: string; displayName: string }>;
 }
 
 export interface HistoryResponseToolCall {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -806,6 +806,7 @@ export class DaemonServer {
           await newConversation.ensureActorScopedHistory();
         }
         this.applyTransportMetadata(newConversation, storedOptions);
+        newConversation.modelSetContext = this.handlerContext();
         this.conversations.set(conversationId, newConversation);
         return newConversation;
       })();

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -65,7 +65,10 @@ export function conversationQueryRouteDefinitions(
         if (!deps.getModelSetContext) {
           return httpError("INTERNAL_ERROR", "Model set not available", 500);
         }
-        const body = (await req.json()) as { modelId?: string };
+        const body = (await req.json()) as {
+          modelId?: string;
+          provider?: string;
+        };
         if (!body.modelId || typeof body.modelId !== "string") {
           return httpError(
             "BAD_REQUEST",
@@ -74,7 +77,11 @@ export function conversationQueryRouteDefinitions(
           );
         }
         try {
-          const info = await setModel(body.modelId, deps.getModelSetContext());
+          const info = await setModel(
+            body.modelId,
+            deps.getModelSetContext(),
+            body.provider,
+          );
           return Response.json(info);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Extends ModelSetRequest with optional `provider` field and ModelInfo with `availableModels`
- Updates `setModel()` to accept explicit provider with validation, auto-reset, and no-op guard
- Updates `PUT /v1/model` to parse optional provider field
- Refactors slash commands to delegate to shared `setModel()` instead of direct config writes
- Returns per-provider model catalog in `GET /v1/model` response

Part of plan: custom-inference-provider.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
