### PR TITLE
Add provider field to ModelSetRequest and availableModels to ModelInfo in Swift types

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2661,27 +2661,41 @@ public struct ModelGetRequest: Codable, Sendable {
     }
 }
 
+public struct CatalogModel: Codable, Sendable {
+    public let id: String
+    public let displayName: String
+
+    public init(id: String, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
+}
+
 public struct ModelInfo: Codable, Sendable {
     public let type: String
     public let model: String
     public let provider: String
     public let configuredProviders: [String]?
+    public let availableModels: [CatalogModel]?
 
-    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil) {
+    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil, availableModels: [CatalogModel]? = nil) {
         self.type = type
         self.model = model
         self.provider = provider
         self.configuredProviders = configuredProviders
+        self.availableModels = availableModels
     }
 }
 
 public struct ModelSetRequest: Codable, Sendable {
     public let type: String
     public let model: String
+    public let provider: String?
 
-    public init(type: String, model: String) {
+    public init(type: String, model: String, provider: String? = nil) {
         self.type = type
         self.model = model
+        self.provider = provider
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `CatalogModel` struct with `id` and `displayName` fields
- Extends `ModelInfo` with optional `availableModels: [CatalogModel]?` field
- Extends `ModelSetRequest` with optional `provider: String?` field
- All new fields are optional with defaults for backward compatibility

Part of plan: custom-inference-provider.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
