### PR TITLE
Add provider-aware model setting, per-provider API key management, and key lifecycle to SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -57,6 +57,61 @@ public final class SettingsStore: ObservableObject {
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
     ]
 
+    // MARK: - Inference Provider Selection
+
+    @Published var selectedInferenceProvider: String = "anthropic"
+    @Published var inferenceAvailableModels: [CatalogModel] = []
+
+    static let inferenceProviders: [String] = [
+        "anthropic", "openai", "gemini", "ollama", "fireworks", "openrouter",
+    ]
+    static let inferenceProviderDisplayNames: [String: String] = [
+        "anthropic": "Anthropic",
+        "openai": "OpenAI",
+        "gemini": "Google Gemini",
+        "ollama": "Ollama",
+        "fireworks": "Fireworks",
+        "openrouter": "OpenRouter",
+    ]
+    /// Client-side model catalog for immediate UI updates on provider change.
+    /// Mirrors PROVIDER_MODEL_CATALOG on the daemon.
+    static let inferenceProviderModels: [String: [(id: String, displayName: String)]] = [
+        "anthropic": [
+            ("claude-opus-4-6", "Claude Opus 4.6"),
+            ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+            ("claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
+        ],
+        "openai": [
+            ("gpt-5.2", "GPT-5.2"),
+            ("gpt-5.4", "GPT-5.4"),
+            ("gpt-5.4-nano", "GPT-5.4 Nano"),
+        ],
+        "gemini": [
+            ("gemini-3-flash", "Gemini 3 Flash"),
+            ("gemini-3-pro", "Gemini 3 Pro"),
+        ],
+        "ollama": [
+            ("llama3.2", "Llama 3.2"),
+            ("mistral", "Mistral"),
+        ],
+        "fireworks": [
+            ("accounts/fireworks/models/kimi-k2p5", "Kimi K2.5"),
+        ],
+        "openrouter": [
+            ("x-ai/grok-4", "Grok 4"),
+            ("x-ai/grok-4.20-beta", "Grok 4.20 Beta"),
+        ],
+    ]
+    /// Default model per provider (first entry from the catalog).
+    static let inferenceProviderDefaultModel: [String: String] = [
+        "anthropic": "claude-opus-4-6",
+        "openai": "gpt-5.2",
+        "gemini": "gemini-3-flash",
+        "ollama": "llama3.2",
+        "fireworks": "accounts/fireworks/models/kimi-k2p5",
+        "openrouter": "x-ai/grok-4",
+    ]
+
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
@@ -288,6 +343,7 @@ public final class SettingsStore: ObservableObject {
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle conversations.
     private var lastDaemonModel: String?
+    private var lastDaemonProvider: String?
     private var pendingVerificationSessionChannel: String?
     private var verificationSessionTimeoutWorkItem: DispatchWorkItem?
     private var verificationStatusPollingWorkItems: [String: DispatchWorkItem] = [:]
@@ -754,6 +810,42 @@ public final class SettingsStore: ObservableObject {
         maskedElevenLabsKey = ""
     }
 
+    func clearAPIKeyForProvider(_ provider: String) {
+        APIKeyManager.deleteKey(for: provider)
+        addDeletionTombstone(type: "api_key", name: provider)
+        deleteKeyFromDaemon(provider: provider)
+        refreshAPIKeyState()
+        scheduleRoutingSourceRefresh()
+    }
+
+    func saveInferenceAPIKey(_ raw: String, provider: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        apiKeySaveError = nil
+        apiKeySaving = true
+
+        // Persist locally first
+        APIKeyManager.setKey(trimmed, for: provider)
+
+        // Remove any stale deletion tombstone
+        removeDeletionTombstone(type: "api_key", name: provider)
+
+        Task {
+            let result = await syncKeyToDaemonWithValidation(provider: provider, value: trimmed)
+            apiKeySaving = false
+            if result.success {
+                scheduleRoutingSourceRefresh()
+                onSuccess?()
+            } else if let error = result.error {
+                apiKeySaveError = error
+                if !result.isTransient {
+                    // Definitive validation failure — revert optimistic local state
+                    APIKeyManager.deleteKey(for: provider)
+                }
+            }
+        }
+    }
+
     func setImageGenModel(_ model: String) {
         selectedImageGenModel = model
         Task {
@@ -782,6 +874,14 @@ public final class SettingsStore: ObservableObject {
         hasElevenLabsKey = elevenLabsKey != nil
         maskedElevenLabsKey = Self.maskKey(elevenLabsKey)
 
+    }
+
+    func hasKeyForProvider(_ provider: String) -> Bool {
+        APIKeyManager.getKey(for: provider) != nil
+    }
+
+    func maskedKeyForProvider(_ provider: String) -> String {
+        Self.maskKey(APIKeyManager.getKey(for: provider))
     }
 
     /// Shows the first 10 and last 4 characters of a key, e.g. "sk-ant-api...Ab1x".
@@ -838,9 +938,14 @@ public final class SettingsStore: ObservableObject {
 
     private func applyModelInfoResponse(_ response: ModelInfoMessage) {
         self.lastDaemonModel = response.model
+        self.lastDaemonProvider = response.provider
         self.selectedModel = response.model
+        self.selectedInferenceProvider = response.provider
         if let providers = response.configuredProviders {
             self.configuredProviders = Set(providers)
+        }
+        if let models = response.availableModels {
+            self.inferenceAvailableModels = models
         }
     }
 
@@ -1973,9 +2078,9 @@ public final class SettingsStore: ObservableObject {
     func loadServiceModes() {
         let config = WorkspaceConfigIO.read(from: configPath)
         guard let services = config["services"] as? [String: Any] else { return }
-        if let inference = services["inference"] as? [String: Any],
-           let mode = inference["mode"] as? String {
-            self.inferenceMode = mode
+        if let inference = services["inference"] as? [String: Any] {
+            if let mode = inference["mode"] as? String { self.inferenceMode = mode }
+            if let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
         }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {
@@ -2073,6 +2178,21 @@ public final class SettingsStore: ObservableObject {
             log.error("Failed to merge workspace config for web search provider: \(error)")
         }
         scheduleRoutingSourceRefresh()
+    }
+
+    func setInferenceProvider(_ provider: String) {
+        selectedInferenceProvider = provider
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["provider"] = provider
+        services["inference"] = inference
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+        } catch {
+            log.error("Failed to persist inference provider: \(error.localizedDescription)")
+        }
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the
@@ -2244,16 +2364,21 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Model Actions
 
-    func setModel(_ model: String) {
-        guard model != lastDaemonModel else { return }
+    func setModel(_ model: String, provider: String? = nil) {
+        // Skip if neither model nor provider changed
+        let modelUnchanged = model == lastDaemonModel
+        let providerUnchanged = provider == nil || provider == lastDaemonProvider
+        guard !modelUnchanged || !providerUnchanged else { return }
         lastDaemonModel = model
+        if let provider { lastDaemonProvider = provider }
         Task {
-            let info = await settingsClient.setModel(model: model)
+            let info = await settingsClient.setModel(model: model, provider: provider)
             if let info {
                 applyModelInfoResponse(info)
             } else if lastDaemonModel == model {
                 // Request failed — revert only if no newer call overwrote lastDaemonModel
                 lastDaemonModel = nil
+                lastDaemonProvider = nil
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -38,7 +38,7 @@ final class MockSettingsClient: SettingsClientProtocol {
         return modelInfoResponse
     }
 
-    func setModel(model: String) async -> ModelInfoMessage? {
+    func setModel(model: String, provider: String? = nil) async -> ModelInfoMessage? {
         setModelCalls.append(model)
         return setModelResponse
     }

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -11,7 +11,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 public protocol SettingsClientProtocol {
     func fetchVercelConfig() async -> VercelApiConfigResponseMessage?
     func fetchModelInfo() async -> ModelInfoMessage?
-    func setModel(model: String) async -> ModelInfoMessage?
+    func setModel(model: String, provider: String?) async -> ModelInfoMessage?
     func setImageGenModel(modelId: String) async -> ModelInfoMessage?
     func fetchTelegramConfig() async -> TelegramConfigResponseMessage?
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage?
@@ -58,10 +58,12 @@ public struct SettingsClient: SettingsClientProtocol {
         }
     }
 
-    public func setModel(model: String) async -> ModelInfoMessage? {
+    public func setModel(model: String, provider: String? = nil) async -> ModelInfoMessage? {
         do {
+            var body: [String: Any] = ["modelId": model]
+            if let provider { body["provider"] = provider }
             let response = try await GatewayHTTPClient.put(
-                path: "model", json: ["modelId": model], timeout: 10
+                path: "model", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setModel failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
- Updates SettingsClient to send optional provider in setModel requests
- Adds provider selection state, client-side model catalog, and provider display names to SettingsStore
- Adds provider-aware API key save/clear with tombstone support and 422 error handling
- Adds per-provider key status helpers (hasKeyForProvider, maskedKeyForProvider)
- Updates applyModelInfoResponse to capture provider and availableModels from daemon
- Smart no-op guard prevents unnecessary provider reinit when neither model nor provider changes

Part of plan: custom-inference-provider.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
