### PR TITLE
feat: add `assistant auth info` command for platform identity and auth status

### DIFF
--- a/assistant/src/cli/commands/auth.ts
+++ b/assistant/src/cli/commands/auth.ts
@@ -1,0 +1,92 @@
+import type { Command } from "commander";
+
+import {
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+  getPlatformOrganizationId,
+  getPlatformUserId,
+} from "../../config/env.js";
+import { resolveManagedProxyContext } from "../../providers/managed-proxy/context.js";
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
+
+export function registerAuthCommand(program: Command): void {
+  const auth = program
+    .command("auth")
+    .description("Manage platform authentication and identity")
+    .option("--json", "Machine-readable compact JSON output");
+
+  auth.addHelpText(
+    "after",
+    `
+The auth namespace manages the assistant's authentication state with the
+Vellum platform. It provides commands to inspect identity and connection
+status, helping diagnose configuration issues.
+
+Examples:
+  $ assistant auth info
+  $ assistant auth info --json`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // info
+  // ---------------------------------------------------------------------------
+
+  auth
+    .command("info")
+    .description("Show platform identity and authentication status")
+    .addHelpText(
+      "after",
+      `
+Fields:
+  platformUrl         The Vellum platform base URL this assistant connects to
+  assistantId         This assistant's platform UUID (from PLATFORM_ASSISTANT_ID)
+  organizationId      The organization this assistant belongs to (from PLATFORM_ORGANIZATION_ID)
+  userId              The user who owns this assistant (from PLATFORM_USER_ID)
+  authenticated       Whether all prerequisites for platform authentication are met
+                      (platform URL and assistant API key both present)
+
+When not authenticated, a message field provides guidance on next steps.
+
+Examples:
+  $ assistant auth info
+  $ assistant auth info --json`,
+    )
+    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      const ctx = await resolveManagedProxyContext();
+
+      const platformUrl = getPlatformBaseUrl();
+      const assistantId = getPlatformAssistantId();
+      const organizationId = getPlatformOrganizationId();
+      const userId = getPlatformUserId();
+      const authenticated = ctx.enabled;
+
+      const result: Record<string, unknown> = {
+        platformUrl: platformUrl || null,
+        assistantId: assistantId || null,
+        organizationId: organizationId || null,
+        userId: userId || null,
+        authenticated,
+      };
+
+      if (!authenticated) {
+        result.message = !platformUrl
+          ? "Platform URL not configured. Run assistant config set platform.baseUrl <url>"
+          : "Assistant API key not found. Store one with: assistant keys set credential/vellum/assistant_api_key <key>";
+      }
+
+      writeOutput(cmd, result);
+
+      if (!shouldOutputJson(cmd)) {
+        log.info(`Platform URL:        ${platformUrl || "(not set)"}`);
+        log.info(`Assistant ID:        ${assistantId || "(not set)"}`);
+        log.info(`Organization ID:     ${organizationId || "(not set)"}`);
+        log.info(`User ID:             ${userId || "(not set)"}`);
+        log.info(`Authenticated:       ${authenticated ? "yes" : "no"}`);
+        if (!authenticated && result.message) {
+          log.info("");
+          log.info(result.message as string);
+        }
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -5,6 +5,7 @@ import { isEmailEnabled } from "../email/feature-gate.js";
 import { registerHooksCommand } from "../hooks/cli.js";
 import { APP_VERSION } from "../version.js";
 import { registerAuditCommand } from "./commands/audit.js";
+import { registerAuthCommand } from "./commands/auth.js";
 import { registerAutonomyCommand } from "./commands/autonomy.js";
 import { registerAvatarCommand } from "./commands/avatar.js";
 import { registerBashCommand } from "./commands/bash.js";
@@ -39,6 +40,16 @@ export function buildCliProgram(): Command {
     .description("Local AI assistant")
     .version(APP_VERSION);
 
+  program.addHelpText(
+    "after",
+    `
+Examples:
+  $ assistant auth info          Show platform identity and auth status
+  $ assistant config list        List all configuration values
+  $ assistant keys list          List stored API keys
+  $ assistant doctor             Run diagnostic checks`,
+  );
+
   registerDefaultAction(program);
   registerBashCommand(program);
   registerConversationsCommand(program);
@@ -49,6 +60,7 @@ export function buildCliProgram(): Command {
   registerTrustCommand(program);
   registerMemoryCommand(program);
   registerAuditCommand(program);
+  registerAuthCommand(program);
   registerAvatarCommand(program);
   registerDoctorCommand(program);
   registerHooksCommand(program);


### PR DESCRIPTION
## Summary
- Adds new `auth` CLI namespace with `info` subcommand
- Shows platform URL, assistant ID, organization ID, user ID, and authentication status
- Provides helpful guidance message when not authenticated
- Adds top-level help text examples to the root `assistant` command

Part of plan: auth-info-cmd.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
