### PR TITLE
refactor: consolidate OAuth connection lookups and remove unused grantedScopes

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -46,6 +46,7 @@ import {
   deleteApp,
   deleteConnection,
   disconnectOAuthProvider,
+  getActiveConnection,
   getApp,
   getAppByProviderAndClientId,
   getConnection,
@@ -628,6 +629,120 @@ describe("connection operations", () => {
 
     test("returns undefined for unknown id", () => {
       expect(getConnection("nonexistent-id")).toBeUndefined();
+    });
+  });
+
+  describe("getActiveConnection", () => {
+    test("returns the most recent active connection with no filters", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 1000,
+      });
+
+      const conn2 = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo", "user"],
+        hasRefreshToken: true,
+        createdAt: 2000,
+      });
+
+      const result = getActiveConnection("github");
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(conn2.id);
+    });
+
+    test("narrows by account when provided", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      const conn1 = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user1@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 1000,
+      });
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user2@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 2000,
+      });
+
+      const result = getActiveConnection("github", {
+        account: "user1@example.com",
+      });
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(conn1.id);
+    });
+
+    test("narrows by clientId when provided", async () => {
+      const app1 = await createTestApp("github", "client-a");
+      const app2 = await createTestApp("github", "client-b");
+
+      const conn1 = createConnection({
+        oauthAppId: app1.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 1000,
+      });
+
+      createConnection({
+        oauthAppId: app2.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 2000,
+      });
+
+      const result = getActiveConnection("github", { clientId: "client-a" });
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(conn1.id);
+    });
+
+    test("returns undefined when clientId has no matching app", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      const result = getActiveConnection("github", {
+        clientId: "nonexistent",
+      });
+      expect(result).toBeUndefined();
+    });
+
+    test("skips revoked connections", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+      updateConnection(conn.id, { status: "revoked" });
+
+      const result = getActiveConnection("github");
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when no connections exist", () => {
+      expect(getActiveConnection("github")).toBeUndefined();
     });
   });
 

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -236,7 +236,6 @@ function createConnection(service = "integration:google"): BYOOAuthConnection {
     providerKey: service,
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     accountInfo: null,
-    grantedScopes: ["read", "write"],
   });
 }
 
@@ -499,12 +498,11 @@ describe("resolveOAuthConnection", () => {
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
     expect(conn.providerKey).toBe("integration:google");
-    expect(conn.grantedScopes).toEqual(["read", "write"]);
   });
 
   test("throws when no credential metadata exists", async () => {
     await expect(resolveOAuthConnection("integration:unknown")).rejects.toThrow(
-      /No credential found for "integration:unknown"/,
+      /No active OAuth connection found for "integration:unknown"/,
     );
   });
 

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -25,14 +25,12 @@ export interface BYOOAuthConnectionOptions {
   providerKey: string;
   baseUrl: string;
   accountInfo: string | null;
-  grantedScopes: string[];
 }
 
 export class BYOOAuthConnection implements OAuthConnection {
   readonly id: string;
   readonly providerKey: string;
   readonly accountInfo: string | null;
-  readonly grantedScopes: string[];
 
   private readonly baseUrl: string;
 
@@ -41,7 +39,6 @@ export class BYOOAuthConnection implements OAuthConnection {
     this.providerKey = opts.providerKey;
     this.baseUrl = opts.baseUrl;
     this.accountInfo = opts.accountInfo;
-    this.grantedScopes = opts.grantedScopes;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -28,17 +28,14 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("./oauth-store.js", () => ({
   getProvider: () => mockProvider,
-  getConnectionByProvider: (_pk: string, clientId?: string) => {
-    if (clientId && mockConnection?.clientId !== clientId) return undefined;
-    return mockConnection;
-  },
-  getConnectionByProviderAndAccount: (
+  getActiveConnection: (
     _pk: string,
-    account?: string,
-    clientId?: string,
+    opts?: { clientId?: string; account?: string },
   ) => {
-    if (clientId && mockConnection?.clientId !== clientId) return undefined;
-    if (account && mockConnection?.accountInfo !== account) return undefined;
+    if (opts?.clientId && mockConnection?.clientId !== opts.clientId)
+      return undefined;
+    if (opts?.account && mockConnection?.accountInfo !== opts.account)
+      return undefined;
     return mockConnection;
   },
 }));
@@ -135,7 +132,6 @@ describe("resolveOAuthConnection", () => {
     expect(result.id).toBe("integration:google");
     expect(result.providerKey).toBe("integration:google");
     expect(result.accountInfo).toBeNull();
-    expect(result.grantedScopes).toEqual([]);
   });
 
   test("passes account through to PlatformOAuthConnection", async () => {
@@ -190,6 +186,6 @@ describe("resolveOAuthConnection", () => {
       resolveOAuthConnection("integration:google", {
         clientId: "wrong-client",
       }),
-    ).rejects.toThrow(/No credential found/);
+    ).rejects.toThrow(/No active OAuth connection found/);
   });
 });

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -5,11 +5,7 @@ import { resolveManagedProxyContext } from "../providers/managed-proxy/context.j
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
-import {
-  getConnectionByProvider,
-  getConnectionByProviderAndAccount,
-  getProvider,
-} from "./oauth-store.js";
+import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
 export interface ResolveOAuthConnectionOptions {
@@ -57,7 +53,6 @@ export async function resolveOAuthConnection(
         providerKey,
         externalId: providerKey,
         accountInfo: account ?? null,
-        grantedScopes: [],
         assistantId,
         platformBaseUrl: ctx.platformBaseUrl,
         apiKey: ctx.assistantApiKey,
@@ -66,12 +61,17 @@ export async function resolveOAuthConnection(
   }
 
   // BYO path — requires a local connection row, access token, and base URL.
-  const conn = account
-    ? getConnectionByProviderAndAccount(providerKey, account, clientId)
-    : getConnectionByProvider(providerKey, clientId);
+  const conn = getActiveConnection(providerKey, { clientId, account });
   if (!conn) {
+    const filters = [
+      account && `account "${account}"`,
+      clientId && `client ID "${clientId}"`,
+    ].filter(Boolean);
+    const qualifier = filters.length
+      ? ` matching ${filters.join(" and ")}`
+      : "";
     throw new Error(
-      `No credential found for "${providerKey}". Authorization required.`,
+      `No active OAuth connection found for "${providerKey}"${qualifier}. Connect the service first with oauth2_connect.`,
     );
   }
 
@@ -80,24 +80,21 @@ export async function resolveOAuthConnection(
   );
   if (!accessToken) {
     throw new Error(
-      `No access token found for "${providerKey}". Authorization required.`,
+      `OAuth connection for "${providerKey}" exists but has no access token. Re-authorize with oauth2_connect.`,
     );
   }
 
   const baseUrl = provider?.baseUrl;
   if (!baseUrl) {
-    throw new Error(`No base URL configured for "${providerKey}".`);
+    throw new Error(
+      `OAuth provider "${providerKey}" has no base URL configured. Check provider setup.`,
+    );
   }
-
-  const grantedScopes: string[] = conn.grantedScopes
-    ? JSON.parse(conn.grantedScopes)
-    : [];
 
   return new BYOOAuthConnection({
     id: conn.id,
     providerKey: conn.providerKey,
     baseUrl,
     accountInfo: conn.accountInfo,
-    grantedScopes,
   });
 }

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -34,5 +34,4 @@ export interface OAuthConnection {
   readonly id: string;
   readonly providerKey: string;
   readonly accountInfo: string | null;
-  readonly grantedScopes: string[];
 }

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -413,93 +413,59 @@ export function getConnection(id: string): OAuthConnectionRow | undefined {
 
 /**
  * Get the most recent active connection for a provider.
- * When `clientId` is provided, only connections linked to the matching app are considered.
- * Returns undefined if no active connection exists.
+ *
+ * Optional filters narrow the result:
+ * - `account` — match a specific account identifier (e.g. email).
+ * - `clientId` — restrict to connections linked to a specific OAuth app.
+ *
+ * Returns `undefined` when no matching active connection exists.
  */
-export function getConnectionByProvider(
+export function getActiveConnection(
   providerKey: string,
-  clientId?: string,
+  options?: { clientId?: string; account?: string },
 ): OAuthConnectionRow | undefined {
+  const { clientId, account } = options ?? {};
   const db = getDb();
+
+  const conditions = [
+    eq(oauthConnections.providerKey, providerKey),
+    eq(oauthConnections.status, "active"),
+  ];
+
+  if (account) {
+    conditions.push(eq(oauthConnections.accountInfo, account));
+  }
 
   if (clientId) {
     const app = getAppByProviderAndClientId(providerKey, clientId);
     if (!app) return undefined;
-    return db
-      .select()
-      .from(oauthConnections)
-      .where(
-        and(
-          eq(oauthConnections.providerKey, providerKey),
-          eq(oauthConnections.oauthAppId, app.id),
-          eq(oauthConnections.status, "active"),
-        ),
-      )
-      .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
-      .limit(1)
-      .get();
+    conditions.push(eq(oauthConnections.oauthAppId, app.id));
   }
 
   return db
     .select()
     .from(oauthConnections)
-    .where(
-      and(
-        eq(oauthConnections.providerKey, providerKey),
-        eq(oauthConnections.status, "active"),
-      ),
-    )
+    .where(and(...conditions))
     .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
     .limit(1)
     .get();
 }
 
-/**
- * Get the active connection for a provider matching a specific account.
- * When `clientId` is provided, only connections linked to the matching app are considered.
- * Falls back to getConnectionByProvider when accountInfo is undefined.
- */
+/** @deprecated Use {@link getActiveConnection} instead. */
+export function getConnectionByProvider(
+  providerKey: string,
+  clientId?: string,
+): OAuthConnectionRow | undefined {
+  return getActiveConnection(providerKey, { clientId });
+}
+
+/** @deprecated Use {@link getActiveConnection} instead. */
 export function getConnectionByProviderAndAccount(
   providerKey: string,
   accountInfo?: string,
   clientId?: string,
 ): OAuthConnectionRow | undefined {
-  if (!accountInfo) return getConnectionByProvider(providerKey, clientId);
-
-  const db = getDb();
-
-  if (clientId) {
-    const app = getAppByProviderAndClientId(providerKey, clientId);
-    if (!app) return undefined;
-    return db
-      .select()
-      .from(oauthConnections)
-      .where(
-        and(
-          eq(oauthConnections.providerKey, providerKey),
-          eq(oauthConnections.accountInfo, accountInfo),
-          eq(oauthConnections.oauthAppId, app.id),
-          eq(oauthConnections.status, "active"),
-        ),
-      )
-      .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
-      .limit(1)
-      .get();
-  }
-
-  return db
-    .select()
-    .from(oauthConnections)
-    .where(
-      and(
-        eq(oauthConnections.providerKey, providerKey),
-        eq(oauthConnections.accountInfo, accountInfo),
-        eq(oauthConnections.status, "active"),
-      ),
-    )
-    .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
-    .limit(1)
-    .get();
+  return getActiveConnection(providerKey, { clientId, account: accountInfo });
 }
 
 /**
@@ -533,7 +499,7 @@ export function listActiveConnectionsByProvider(
 export async function isProviderConnected(
   providerKey: string,
 ): Promise<boolean> {
-  const conn = getConnectionByProvider(providerKey);
+  const conn = getActiveConnection(providerKey);
   if (!conn || conn.status !== "active") return false;
   return (
     (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
@@ -651,7 +617,7 @@ export async function disconnectOAuthProvider(
 ): Promise<"disconnected" | "not-found" | "error"> {
   const conn = connectionId
     ? getConnection(connectionId)
-    : getConnectionByProvider(providerKey, clientId);
+    : getActiveConnection(providerKey, { clientId });
   if (!conn) return "not-found";
 
   // Wrap the assistant's secure-key functions into the SecureKeyBackend

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -12,7 +12,6 @@ const DEFAULT_OPTIONS = {
   providerKey: "integration:google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
-  grantedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
   assistantId: "asst-abc",
   platformBaseUrl: "https://platform.example.com",
   apiKey: "test-api-key",

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -24,7 +24,6 @@ export interface PlatformOAuthConnectionOptions {
   providerKey: string;
   externalId: string;
   accountInfo: string | null;
-  grantedScopes: string[];
   assistantId: string;
   platformBaseUrl: string;
   apiKey: string;
@@ -35,7 +34,6 @@ export class PlatformOAuthConnection implements OAuthConnection {
   readonly providerKey: string;
   readonly externalId: string;
   readonly accountInfo: string | null;
-  readonly grantedScopes: string[];
 
   private readonly assistantId: string;
   private readonly platformBaseUrl: string;
@@ -57,7 +55,6 @@ export class PlatformOAuthConnection implements OAuthConnection {
     this.providerKey = options.providerKey;
     this.externalId = options.externalId;
     this.accountInfo = options.accountInfo;
-    this.grantedScopes = options.grantedScopes;
     this.assistantId = options.assistantId;
     this.platformBaseUrl = options.platformBaseUrl.replace(/\/+$/, "");
     this.apiKey = options.apiKey;

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -28,9 +28,8 @@ import {
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
 import {
   createConnection,
+  getActiveConnection,
   getApp,
-  getConnectionByProvider,
-  getConnectionByProviderAndAccount,
   listActiveConnectionsByProvider,
   updateConnection,
   upsertApp,
@@ -152,12 +151,11 @@ export async function storeOAuth2Tokens(
   //    lookup so that re-auth without userinfo still updates the right row.
   //    However, treat provider-only matches as ambiguous when multiple active
   //    connections exist to avoid overwriting the wrong account's tokens.
-  let existingConn: ReturnType<typeof getConnectionByProvider>;
+  let existingConn: ReturnType<typeof getActiveConnection>;
   if (resolvedAccountInfo) {
-    existingConn = getConnectionByProviderAndAccount(
-      service,
-      resolvedAccountInfo,
-    );
+    existingConn = getActiveConnection(service, {
+      account: resolvedAccountInfo,
+    });
   } else {
     const activeConns = listActiveConnectionsByProvider(service);
     // Only reuse the provider-only match when it's unambiguous (single connection).

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -7,8 +7,8 @@ import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import {
   disconnectOAuthProvider,
+  getActiveConnection,
   getAppByProviderAndClientId,
-  getConnectionByProviderAndAccount,
   getMostRecentAppByProvider,
   getProvider,
 } from "../../oauth/oauth-store.js";
@@ -66,9 +66,7 @@ async function storeSlackChannelCredential(
     : setSlackChannelConfig(undefined, value);
 }
 
-function formatSlackChannelStatus(
-  result: SlackChannelConfigResult,
-): string {
+function formatSlackChannelStatus(result: SlackChannelConfigResult): string {
   if (result.connected) {
     const teamLabel = result.teamName ?? "Slack";
     const botLabel = result.botUsername ? ` (@${result.botUsername})` : "";
@@ -366,8 +364,7 @@ class CredentialStoreTool implements Tool {
           if (!slackChannelResult.success) {
             return {
               content: `Error: ${
-                slackChannelResult.error ??
-                "failed to configure Slack channel"
+                slackChannelResult.error ?? "failed to configure Slack channel"
               }`,
               isError: true,
             };
@@ -523,10 +520,9 @@ class CredentialStoreTool implements Tool {
           const accountHint = input.account as string | undefined;
           let oauthResult: "disconnected" | "not-found" | "error";
           if (accountHint) {
-            const targetConn = getConnectionByProviderAndAccount(
-              service,
-              accountHint,
-            );
+            const targetConn = getActiveConnection(service, {
+              account: accountHint,
+            });
             oauthResult = targetConn
               ? await disconnectOAuthProvider(service, undefined, targetConn.id)
               : "not-found";
@@ -778,8 +774,7 @@ class CredentialStoreTool implements Tool {
           if (!slackChannelResult.success) {
             return {
               content: `Error: ${
-                slackChannelResult.error ??
-                "failed to configure Slack channel"
+                slackChannelResult.error ?? "failed to configure Slack channel"
               }`,
               isError: true,
             };


### PR DESCRIPTION
## Summary
- Consolidate `getConnectionByProvider` and `getConnectionByProviderAndAccount` into a single `getActiveConnection(providerKey, { clientId?, account? }?)` function with dynamic WHERE clause composition. Old functions kept as `@deprecated` wrappers.
- Remove `grantedScopes` from the `OAuthConnection` interface and both implementations — it was never consumed at runtime, only displayed from DB rows directly.
- Improve error messages in `resolveOAuthConnection` to be more specific (e.g. "No active OAuth connection found... Connect the service first with oauth2_connect").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
