### PR TITLE
fix: always scroll to latest messages when opening threads (LUM-291)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -561,15 +561,6 @@ struct MessageListView: View {
                 log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
             }
 
-            // Stage 3: ~500ms total — final attempt for conversations with many
-            // messages where LazyVStack materialization is slow.
-            try? await Task.sleep(nanoseconds: 300_000_000)
-            guard !Task.isCancelled else { return }
-            let scrollLanded = hasFreshAnchorMeasurement && anchorTracker.isVisible
-            if anchorMessageId == nil && !hasReceivedScrollEvent && !scrollLanded {
-                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                log.debug("Scroll restore: stage 3 (500ms) — final scrollTo")
-            }
             if !Task.isCancelled { scrollRestoreTask = nil }
         }
     }
@@ -818,7 +809,6 @@ struct MessageListView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
-            .defaultScrollAnchor(.bottom)
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
             .environment(\.suppressAutoScroll, { [self] in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -816,6 +816,8 @@ struct MessageListView: View {
                 .padding(.bottom, VSpacing.md)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
+                // Push messages to the bottom when content is shorter than viewport
+                .frame(minHeight: scrollViewportHeight, alignment: .bottom)
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -818,6 +818,7 @@ struct MessageListView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
+            .defaultScrollAnchor(.bottom)
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
             .environment(\.suppressAutoScroll, { [self] in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -548,17 +548,27 @@ struct MessageListView: View {
             log.debug("Scroll restore: stage 1 (50ms)")
 
             // Stage 2: ~9 frames — catches slower layout/materialization.
-            // scrollLanded is computed after the full wait so it reflects
-            // the latest geometry, not a stale snapshot from before the delay.
+            // Always retry the scrollTo here regardless of anchorTracker state,
+            // because anchorTracker.isVisible may have been manually set to true
+            // during conversation switch (to suppress the "Scroll to latest"
+            // button flash) and does not reflect actual scroll position.
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard !Task.isCancelled else { return }
-            let scrollLanded = hasFreshAnchorMeasurement && anchorTracker.isVisible
-            log.debug("Scroll restore: stage 2 check — scrollLanded=\(scrollLanded) hasReceivedScrollEvent=\(hasReceivedScrollEvent)")
-            if anchorMessageId == nil && !hasReceivedScrollEvent && !scrollLanded {
+            if anchorMessageId == nil && !hasReceivedScrollEvent {
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 log.debug("Scroll restore: stage 2 (200ms) — retrying scrollTo")
             } else {
-                log.debug("Scroll restore: stage 2 skipped")
+                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
+            }
+
+            // Stage 3: ~500ms total — final attempt for conversations with many
+            // messages where LazyVStack materialization is slow.
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            let scrollLanded = hasFreshAnchorMeasurement && anchorTracker.isVisible
+            if anchorMessageId == nil && !hasReceivedScrollEvent && !scrollLanded {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                log.debug("Scroll restore: stage 3 (500ms) — final scrollTo")
             }
             if !Task.isCancelled { scrollRestoreTask = nil }
         }
@@ -1142,7 +1152,12 @@ struct MessageListView: View {
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
                 anchorTracker.isVisible = true
-                anchorTracker.lastMinY = 0
+                // Reset lastMinY to .infinity so the AnchorMinYKey preference
+                // handler's 2pt dead-zone doesn't filter out the first real
+                // measurement after a conversation switch. A value of 0 could
+                // collide with the actual anchor position and prevent
+                // hasFreshAnchorMeasurement from becoming true.
+                anchorTracker.lastMinY = .infinity
                 hasReceivedScrollEvent = false
                 lastHandledContainerWidth = containerWidth
                 hoverExitDebounceTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -816,8 +816,6 @@ struct MessageListView: View {
                 .padding(.bottom, VSpacing.md)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
-                // Push messages to the bottom when content is shorter than viewport
-                .frame(minHeight: scrollViewportHeight, alignment: .bottom)
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")


### PR DESCRIPTION
## Summary
- Fixed scroll-to-bottom not working reliably when opening or switching conversations
- Stage 2 of `restoreScrollToBottom` was prematurely skipping because `anchorTracker.isVisible` was manually set to `true` during conversation switch (to suppress button flash), making the "has scroll landed?" check pass before it actually landed
- Reset `anchorTracker.lastMinY` to `.infinity` instead of `0` on conversation switch so the 2pt dead-zone filter in the preference handler doesn't suppress the first real geometry measurement
- Added a stage 3 retry at 500ms for conversations with many messages where LazyVStack materialization is slow

## Test plan
- [ ] Open the app with multiple conversations that have many messages
- [ ] Switch between conversations and verify the scroll position is always at the bottom (latest messages)
- [ ] Open a conversation, scroll up to read history, then switch to another conversation — verify the new conversation scrolls to bottom
- [ ] While in a conversation, scroll up to read history — verify it does NOT force scroll to bottom
- [ ] Send a new message while scrolled to bottom — verify it stays at bottom as the response streams in
- [ ] Verify the "Scroll to latest" button does not flash briefly during conversation switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
