### PR TITLE
Default split approval button to 'Allow for 10 minutes'

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -19,7 +19,7 @@ public struct ToolConfirmationBubble: View {
     @State private var showTechnicalDetails = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
-    @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_once"
+    @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_10m"
     #if os(macOS)
     @State private var keyMonitor: Any?
     #endif

--- a/meta/bun.lock
+++ b/meta/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "vellum",
       "dependencies": {
-        "@vellumai/assistant": "0.4.56",
-        "@vellumai/cli": "0.4.56",
-        "@vellumai/credential-executor": "0.4.56",
-        "@vellumai/vellum-gateway": "0.4.56",
+        "@vellumai/assistant": "0.5.1",
+        "@vellumai/cli": "0.5.1",
+        "@vellumai/credential-executor": "0.5.1",
+        "@vellumai/vellum-gateway": "0.5.1",
       },
       "devDependencies": {
         "@types/bun": "^1.2.4",
@@ -218,13 +218,13 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
-    "@vellumai/assistant": ["@vellumai/assistant@0.4.56", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@anthropic-ai/claude-agent-sdk": "^0.2.42", "@anthropic-ai/sdk": "^0.78.0", "@google/genai": "^1.40.0", "@modelcontextprotocol/sdk": "^1.15.1", "@qdrant/js-client-rest": "^1.16.2", "@resvg/resvg-js": "^2.6.2", "@sentry/node": "^10.38.0", "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "agentmail": "^0.1.0", "archiver": "^7.0.1", "commander": "^13.1.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "drizzle-orm": "^0.38.4", "jszip": "^3.10.1", "minimatch": "^10.2.4", "openai": "^6.18.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "playwright": "^1.58.2", "postgres": "^3.4.8", "qrcode": "^1.5.4", "react": "^19.2.4", "rrule": "^2.8.1", "tldts": "^7.0.23", "tree-sitter-bash": "0.25.1", "uuid": "^11.1.0", "web-tree-sitter": "0.26.5", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-+JZ1Udw5yGWgKDeKIo6iSRpL4MIGCQOsPX1Kh9on7TgpdVO1vMMWRQQMevBJMe5Yubj4OrpAjWnsbC2gXc616w=="],
+    "@vellumai/assistant": ["@vellumai/assistant@0.5.1", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@anthropic-ai/claude-agent-sdk": "^0.2.42", "@anthropic-ai/sdk": "^0.78.0", "@google/genai": "^1.40.0", "@modelcontextprotocol/sdk": "^1.15.1", "@qdrant/js-client-rest": "^1.16.2", "@resvg/resvg-js": "^2.6.2", "@sentry/node": "^10.38.0", "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "agentmail": "^0.1.0", "archiver": "^7.0.1", "commander": "^13.1.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "drizzle-orm": "^0.38.4", "jszip": "^3.10.1", "minimatch": "^10.2.4", "openai": "^6.18.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "playwright": "^1.58.2", "postgres": "^3.4.8", "qrcode": "^1.5.4", "react": "^19.2.4", "rrule": "^2.8.1", "tldts": "^7.0.23", "tree-sitter-bash": "0.25.1", "uuid": "^11.1.0", "web-tree-sitter": "0.26.5", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-S1G6jyapeViS2/oQkbikslRhBsZAamqsu4zkdonf6RNqQIG0j5N2LAfQVeiKCRSVUVNRKiKSdiTRZBJ+N+J4Cw=="],
 
-    "@vellumai/cli": ["@vellumai/cli@0.4.56", "", { "dependencies": { "chalk": "^5.6.0", "ink": "^6.7.0", "jsqr": "^1.4.0", "nanoid": "^5.1.7", "pngjs": "^7.0.0", "qrcode-terminal": "^0.12.0", "react": "^19.2.4", "react-devtools-core": "^6.1.2" }, "bin": { "vellum": "src/index.ts" } }, "sha512-OXtggLnsoLy0boaC+XkkS3eS63xFy9vMtMOi3pwyJt7fSxpTWq38WMC4cHbtsFfG8dbc5rtYqPHySquXiSPW8Q=="],
+    "@vellumai/cli": ["@vellumai/cli@0.5.1", "", { "dependencies": { "chalk": "^5.6.0", "ink": "^6.7.0", "jsqr": "^1.4.0", "nanoid": "^5.1.7", "pngjs": "^7.0.0", "qrcode-terminal": "^0.12.0", "react": "^19.2.4", "react-devtools-core": "^6.1.2" }, "bin": { "vellum": "src/index.ts" } }, "sha512-UaPbyhd1S8Jxc8pQdKLfMXF0Kk1hCEBQyFQLuTsKGwBmiEU/kg+eiUBU3ooGLRcSzkgD2dFxkOKOE38Hi5Ja4Q=="],
 
-    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.4.56", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-507JnMqjtocTPf0Ob0chpDs6YJ5m4DI/1kj06NnDXysz55Qyixj7DimAMdf1Sb3MNogV3rWBSpReVQAKYQdGhA=="],
+    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.5.1", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-J1vOTBEbBoR8mLFn/a63T0pTIFmG2CRzzO6eZfKM1QHT3qBEvIXOrQ8AQiLgN8s9j8T0cv9AjJGFRNKnUKePbg=="],
 
-    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.4.56", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3" } }, "sha512-/D9XFINSQBdQIQ4N+cMHr1A5+2MZX/M/IKCFDo9Np0+uoC/7mlS1wDsYb9RjSdbP6oRbO+ijtLG+RbhQ8y2AoA=="],
+    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.5.1", "", { "dependencies": { "file-type": "^21.3.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3" } }, "sha512-qdoJyr7zeFxnyPjOFs1paUgAipRKv8xKXxs3yKJO1snGQ/uqJT2p4j+WOBhRc4YpKEKGZzbrqRDrpLz4JGJ9nQ=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 


### PR DESCRIPTION
## Summary
- Change the default `preferredAllowAction` from `allow_once` to `allow_10m` so the split approval button defaults to "Allow for 10 minutes" instead of "Allow once"

## Original prompt
update the default value of the split approval button to be allow for 10 mins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
