### PR TITLE
Add rounded shape variant to VBadge and use in Memories panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -371,17 +371,12 @@ struct MemoryItemDetailSheet: View {
         MemoryKind(rawValue: displayItem.kind)
     }
 
-    @ViewBuilder
     private var kindBadge: some View {
-        let color = memoryKind?.color ?? VColor.contentTertiary
-        let label = memoryKind?.label ?? displayItem.kind.capitalized
-        Text(label)
-            .font(VFont.caption)
-            .foregroundColor(VColor.contentEmphasized)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(color.opacity(0.2))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        VBadge(
+            label: memoryKind?.label ?? displayItem.kind.capitalized,
+            color: memoryKind?.color ?? VColor.contentTertiary,
+            shape: .rounded
+        )
     }
 
     private func metadataRow(label: String, value: String) -> some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -53,19 +53,12 @@ struct MemoryItemRow: View {
 
     // MARK: - Kind Tag
 
-    @ViewBuilder
     private var kindTag: some View {
         let memoryKind = MemoryKind(rawValue: item.kind)
-        let color = memoryKind?.color ?? VColor.contentTertiary
-        let label = memoryKind?.label ?? item.kind.capitalized
-
-        Text(label)
-            .font(VFont.caption)
-            .foregroundColor(VColor.contentEmphasized)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(color.opacity(0.2))
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .accessibilityLabel(label)
+        return VBadge(
+            label: memoryKind?.label ?? item.kind.capitalized,
+            color: memoryKind?.color ?? VColor.contentTertiary,
+            shape: .rounded
+        )
     }
 }

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -20,25 +20,42 @@ public struct VBadge: View {
         case subtle
     }
 
+    public enum Shape {
+        case pill
+        case rounded
+    }
+
     public let style: Style
     public var color: Color = VColor.primaryBase
     public var tone: Tone?
     public var emphasis: Emphasis = .solid
+    public var shape: Shape = .pill
     public var icon: VIcon?
     public var iconColor: Color?
 
-    public init(style: Style, color: Color = VColor.primaryBase) {
+    public init(style: Style, color: Color = VColor.primaryBase, shape: Shape = .pill) {
         self.style = style
         self.color = color
+        self.shape = shape
     }
 
-    public init(label: String, icon: VIcon? = nil, iconColor: Color? = nil, tone: Tone = .accent, emphasis: Emphasis = .subtle) {
+    public init(label: String, icon: VIcon? = nil, iconColor: Color? = nil, tone: Tone = .accent, emphasis: Emphasis = .subtle, shape: Shape = .pill) {
         self.style = .label(label)
         self.color = VColor.primaryBase
         self.tone = tone
         self.emphasis = emphasis
+        self.shape = shape
         self.icon = icon
         self.iconColor = iconColor
+    }
+
+    /// Custom-colored label badge. Uses the provided color at 20% opacity
+    /// as the background with `contentEmphasized` foreground text.
+    public init(label: String, color: Color, shape: Shape = .pill) {
+        self.style = .label(label)
+        self.color = color
+        self.emphasis = .subtle
+        self.shape = shape
     }
 
     public var body: some View {
@@ -69,19 +86,48 @@ public struct VBadge: View {
                     .foregroundColor(labelForegroundColor)
             }
             .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xxs)
+            .padding(.vertical, labelVerticalPadding)
             .background(labelBackgroundColor)
-            .overlay(
-                Capsule()
-                    .stroke(labelBorderColor, lineWidth: labelBorderWidth)
-            )
-            .clipShape(Capsule())
+            .overlay(labelBorderOverlay)
+            .clipShape(labelClipShape)
             .accessibilityLabel(text)
         }
     }
 
+    // MARK: - Shape Helpers
+
+    @ViewBuilder
+    private var labelBorderOverlay: some View {
+        switch shape {
+        case .pill:
+            Capsule()
+                .stroke(labelBorderColor, lineWidth: labelBorderWidth)
+        case .rounded:
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .stroke(labelBorderColor, lineWidth: labelBorderWidth)
+        }
+    }
+
+    @ViewBuilder
+    private var labelClipShape: some View {
+        switch shape {
+        case .pill:
+            Capsule()
+        case .rounded:
+            RoundedRectangle(cornerRadius: VRadius.sm)
+        }
+    }
+
+    private var labelVerticalPadding: CGFloat {
+        shape == .rounded ? VSpacing.xs : VSpacing.xxs
+    }
+
+    // MARK: - Color Resolution
+
     private var labelForegroundColor: Color {
-        guard let tone else { return VColor.auxWhite }
+        guard let tone else {
+            return emphasis == .subtle ? VColor.contentEmphasized : VColor.auxWhite
+        }
 
         switch (tone, emphasis) {
         case (.accent, .solid), (.positive, .solid), (.danger, .solid):
@@ -104,7 +150,9 @@ public struct VBadge: View {
     }
 
     private var labelBackgroundColor: Color {
-        guard let tone else { return color }
+        guard let tone else {
+            return emphasis == .subtle ? color.opacity(0.2) : color
+        }
 
         switch (tone, emphasis) {
         case (.accent, .solid):

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -77,6 +77,31 @@ struct FeedbackGallerySection: View {
                             VBadge(label: "Status", icon: .sparkles, tone: .accent)
                         }
                     }
+
+                    Divider().background(VColor.borderBase)
+
+                    // Rounded shape
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        Text("Rounded shape").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        HStack(spacing: VSpacing.lg) {
+                            VBadge(label: "Identity", color: VColor.funTeal, shape: .rounded)
+                            VBadge(label: "Preference", color: VColor.funPurple, shape: .rounded)
+                            VBadge(label: "Project", color: VColor.funGreen, shape: .rounded)
+                            VBadge(label: "Decision", color: VColor.funYellow, shape: .rounded)
+                            VBadge(label: "Constraint", color: VColor.funCoral, shape: .rounded)
+                            VBadge(label: "Event", color: VColor.funPink, shape: .rounded)
+                        }
+                    }
+
+                    // Pill shape with custom color
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        Text("Pill shape with custom color").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        HStack(spacing: VSpacing.lg) {
+                            VBadge(label: "Teal", color: VColor.funTeal)
+                            VBadge(label: "Purple", color: VColor.funPurple)
+                            VBadge(label: "Coral", color: VColor.funCoral)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add `Shape` enum (`.pill`, `.rounded`) to `VBadge` and a custom-color label init that uses `color.opacity(0.2)` background with `contentEmphasized` text — matching the existing hand-rolled memory kind tags exactly
- Replace the hand-built `kindTag` in `MemoryItemRow` and `kindBadge` in `MemoryItemDetailSheet` with `VBadge(label:color:shape:.rounded)`
- Update the component gallery with examples of rounded shape and custom-color badges

## Original prompt
help me update the VBadge to support a rectangular variant and custom color, update the component gallery, and use VBadge instead in the Memories page instead of the custom built component. Make sure it looks the same and also replace it in the memory item detail sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
