### PR TITLE
Fix VBadge build error: clipShape requires Shape conformance

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -88,35 +88,12 @@ public struct VBadge: View {
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, labelVerticalPadding)
             .background(labelBackgroundColor)
-            .overlay(labelBorderOverlay)
-            .clipShape(labelClipShape)
+            .modifier(LabelShapeModifier(shape: shape, borderColor: labelBorderColor, borderWidth: labelBorderWidth))
             .accessibilityLabel(text)
         }
     }
 
     // MARK: - Shape Helpers
-
-    @ViewBuilder
-    private var labelBorderOverlay: some View {
-        switch shape {
-        case .pill:
-            Capsule()
-                .stroke(labelBorderColor, lineWidth: labelBorderWidth)
-        case .rounded:
-            RoundedRectangle(cornerRadius: VRadius.sm)
-                .stroke(labelBorderColor, lineWidth: labelBorderWidth)
-        }
-    }
-
-    @ViewBuilder
-    private var labelClipShape: some View {
-        switch shape {
-        case .pill:
-            Capsule()
-        case .rounded:
-            RoundedRectangle(cornerRadius: VRadius.sm)
-        }
-    }
 
     private var labelVerticalPadding: CGFloat {
         shape == .rounded ? VSpacing.xs : VSpacing.xxs
@@ -199,5 +176,27 @@ public struct VBadge: View {
 
     private var labelBorderWidth: CGFloat {
         tone == nil ? 0 : 1
+    }
+}
+
+// MARK: - Shape Modifier
+
+/// Applies the correct clip shape and border overlay based on VBadge.Shape.
+private struct LabelShapeModifier: ViewModifier {
+    let shape: VBadge.Shape
+    let borderColor: Color
+    let borderWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        switch shape {
+        case .pill:
+            content
+                .overlay(Capsule().stroke(borderColor, lineWidth: borderWidth))
+                .clipShape(Capsule())
+        case .rounded:
+            content
+                .overlay(RoundedRectangle(cornerRadius: VRadius.sm).stroke(borderColor, lineWidth: borderWidth))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fix build error where `labelClipShape` returned `some View` but `clipShape()` requires `some Shape`
- Replace the `@ViewBuilder` clip/overlay properties with a `LabelShapeModifier` that applies the correct shape inline

## Original prompt
Fix the VBadge build error introduced in #18809 where labelClipShape returned some View but clipShape() requires some Shape conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)