### PR TITLE
fix: combine contact header and channels into single card with separators

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -30,10 +30,11 @@ struct ContactDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
+            VStack(alignment: .leading, spacing: 0) {
                 headerSection
                     .padding(VSpacing.lg)
-                    .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
+
+                SettingsDivider()
 
                 GuardianChannelsDetailView(
                     contact: displayContact,
@@ -43,12 +44,14 @@ struct ContactDetailView: View {
                     showCardBorders: false
                 )
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                 if let errorMessage {
                     VInlineMessage(errorMessage)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.bottom, VSpacing.lg)
                 }
             }
+            .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
         }
         .confirmationDialog(
             "Delete \(displayContact.displayName)?",

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -164,7 +164,7 @@ struct ContactsContainerView: View {
     /// Guardian detail — editable name+notes header card, then existing channel content in a second card.
     private func guardianDetailView(contact: ContactPayload) -> some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
+            VStack(alignment: .leading, spacing: 0) {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
                     // Title row: display name + badge + interaction count
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -224,7 +224,8 @@ struct ContactsContainerView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
+
+                SettingsDivider()
 
                 GuardianChannelsDetailView(
                     contact: contact,
@@ -234,8 +235,8 @@ struct ContactsContainerView: View {
                     showCardBorders: false
                 )
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
+            .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
         }
         .id(contact.id)
         .onAppear {


### PR DESCRIPTION
## Summary
- Combine header and channels sections into a single card in ContactDetailView
- Same treatment for guardian detail in ContactsContainerView
- SettingsDivider separates the two parts within the unified card

Part of plan: contacts-layout-redesign.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
