### PR TITLE
fix: add vertical separator between contacts list and detail pane

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -32,7 +32,7 @@ struct ContactsContainerView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: VSpacing.lg) {
+        HStack(alignment: .top, spacing: 0) {
             // Left pane: contacts list (full height, internal scrolling)
             VStack(spacing: VSpacing.sm) {
                 ContactsListView(
@@ -47,6 +47,12 @@ struct ContactsContainerView: View {
             }
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
+
+            // Vertical separator
+            VColor.borderDisabled
+                .frame(width: 1)
+                .frame(maxHeight: .infinity)
+
             // Right pane: detail, loading, or placeholder
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 // Skeleton loading state for detail pane


### PR DESCRIPTION
## Summary
- Add light vertical separator (VColor.borderDisabled) between contacts list and detail pane
- Remove HStack spacing, let the divider provide visual separation

Part of plan: contacts-layout-redesign.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
