### PR TITLE
Add <no_response/> support for channel thread discretion

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -365,6 +365,41 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload.user).toBeUndefined();
   });
 
+  it("suppresses delivery when the only text segment is <no_response/>", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent",
+      textSegments: ["<no_response/>"],
+      fallbackText: "Fallback text",
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("suppresses delivery for <no_response/> with surrounding whitespace", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent-ws",
+      textSegments: ["  <no_response/>  "],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("delivers other segments when <no_response/> is mixed with real text", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-mixed",
+      textSegments: ["<no_response/>", "Real response."],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Real response.");
+  });
+
   it("passes startFromSegment through deliverReplyViaCallback options", async () => {
     conversationMessages.push(
       { id: "msg-u", role: "user", content: "hi" },

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -377,6 +377,26 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls).toHaveLength(0);
   });
 
+  it("suppresses attachment delivery when <no_response/> is present", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent-att",
+      textSegments: ["<no_response/>"],
+      attachments: [
+        {
+          id: "att-no-resp",
+          filename: "secret.txt",
+          mimeType: "text/plain",
+          sizeBytes: 10,
+          kind: "uploaded",
+        },
+      ],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
   it("suppresses delivery for <no_response/> with surrounding whitespace", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/slack",

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1065,9 +1065,10 @@ describe("buildTurnContextBlock (channel-only)", () => {
       },
       undefined,
     );
-    expect(block).toBe(
-      "<turn_context>\n" + "channel: telegram\n" + "</turn_context>",
-    );
+    expect(block).toContain("<turn_context>");
+    expect(block).toContain("channel: telegram");
+    expect(block).toContain("response_discretion:");
+    expect(block).toContain("</turn_context>");
   });
 
   test('uses "unknown" when conversationOriginChannel is null', () => {

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1071,6 +1071,20 @@ describe("buildTurnContextBlock (channel-only)", () => {
     expect(block).toContain("</turn_context>");
   });
 
+  test("omits response_discretion for vellum channel", () => {
+    const block = buildTurnContextBlock(
+      {
+        turnContext: {
+          userMessageChannel: "vellum",
+          assistantMessageChannel: "vellum",
+        },
+        conversationOriginChannel: "vellum",
+      },
+      undefined,
+    );
+    expect(block).not.toContain("response_discretion:");
+  });
+
   test('uses "unknown" when conversationOriginChannel is null', () => {
     const block = buildTurnContextBlock(
       {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -634,6 +634,9 @@ export function buildTurnContextBlock(
       lines.push(`assistant_message_channel: ${assistant}`);
       lines.push(`conversation_origin_channel: ${origin}`);
     }
+    lines.push(
+      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
+    );
   }
 
   lines.push("</turn_context>");

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -634,9 +634,15 @@ export function buildTurnContextBlock(
       lines.push(`assistant_message_channel: ${assistant}`);
       lines.push(`conversation_origin_channel: ${origin}`);
     }
-    lines.push(
-      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
-    );
+    // Only inject response discretion for external channels (Slack, Telegram,
+    // etc.) where the assistant may receive thread replies not directed at it.
+    // The "vellum" channel is the web/desktop interface where every message is
+    // intentionally directed at the assistant.
+    if (user !== "vellum") {
+      lines.push(
+        `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
+      );
+    }
   }
 
   lines.push("</turn_context>");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -121,9 +121,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // System Permissions section removed — guidance lives in request_system_permission tool description.
   // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
-  if (hasNoClient) {
-    staticParts.push(buildResponseDiscretionSection());
-  }
   // Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes
   // sections removed — guidance lives in memory_manage/memory_recall tool descriptions
   // and the Proactive Workspace Editing subsection in Configuration.
@@ -242,21 +239,6 @@ function buildAccessPreferenceSection(hasNoClient: boolean): string {
           "On macOS, prefer osascript/CLI via `host_bash` over computer use tools, which take over the user's cursor. Use foreground computer use only when no scripting alternative exists or the user explicitly asks.",
         ]
       : []),
-  ].join("\n");
-}
-
-function buildResponseDiscretionSection(): string {
-  return [
-    "## Response Discretion",
-    "",
-    "Not every message requires a response. In channel conversations (Slack, Telegram, etc.), you may receive messages in threads where you were previously tagged but the new message is not directed at you — for example, other people continuing a conversation among themselves, reactions, or follow-ups that don't need your input.",
-    "",
-    "When you determine a message does not warrant a response, output exactly `<no_response/>` as your entire reply. This suppresses delivery so nothing is posted to the channel. Use this when:",
-    "- The message is clearly between other people and not addressed to you",
-    "- Someone is acknowledging or reacting to a previous message without asking you anything",
-    "- The conversation has moved on to a topic where your input isn't needed",
-    "",
-    "When in doubt, respond — silence is only appropriate when you're confident the message isn't for you.",
   ].join("\n");
 }
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -121,7 +121,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // System Permissions section removed — guidance lives in request_system_permission tool description.
   // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
-  staticParts.push(buildResponseDiscretionSection());
+  if (hasNoClient) {
+    staticParts.push(buildResponseDiscretionSection());
+  }
   // Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes
   // sections removed — guidance lives in memory_manage/memory_recall tool descriptions
   // and the Proactive Workspace Editing subsection in Configuration.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -121,6 +121,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // System Permissions section removed — guidance lives in request_system_permission tool description.
   // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
   staticParts.push(buildAccessPreferenceSection(hasNoClient));
+  staticParts.push(buildResponseDiscretionSection());
   // Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes
   // sections removed — guidance lives in memory_manage/memory_recall tool descriptions
   // and the Proactive Workspace Editing subsection in Configuration.
@@ -239,6 +240,21 @@ function buildAccessPreferenceSection(hasNoClient: boolean): string {
           "On macOS, prefer osascript/CLI via `host_bash` over computer use tools, which take over the user's cursor. Use foreground computer use only when no scripting alternative exists or the user explicitly asks.",
         ]
       : []),
+  ].join("\n");
+}
+
+function buildResponseDiscretionSection(): string {
+  return [
+    "## Response Discretion",
+    "",
+    "Not every message requires a response. In channel conversations (Slack, Telegram, etc.), you may receive messages in threads where you were previously tagged but the new message is not directed at you — for example, other people continuing a conversation among themselves, reactions, or follow-ups that don't need your input.",
+    "",
+    "When you determine a message does not warrant a response, output exactly `<no_response/>` as your entire reply. This suppresses delivery so nothing is posted to the channel. Use this when:",
+    "- The message is clearly between other people and not addressed to you",
+    "- Someone is acknowledging or reacting to a previous message without asking you anything",
+    "- The conversation has moved on to a topic where your input isn't needed",
+    "",
+    "When in doubt, respond — silence is only appropriate when you're confident the message isn't for you.",
   ].join("\n");
 }
 

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -47,6 +47,11 @@ function sleep(ms: number): Promise<void> {
 
 const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/;
 
+/** Returns true when any segment is a `<no_response/>` sentinel. */
+function hasNoResponseMarker(textSegments: string[]): boolean {
+  return textSegments.some((s) => NO_RESPONSE_RE.test(s));
+}
+
 function toDeliverableTextSegments(
   textSegments: string[],
   fallbackText?: string,
@@ -57,8 +62,7 @@ function toDeliverableTextSegments(
   if (nonEmptySegments.length > 0) return nonEmptySegments;
   // If the only text was <no_response/>, treat as intentional silence —
   // do not fall back to fallbackText.
-  const hadNoResponseMarker = textSegments.some((s) => NO_RESPONSE_RE.test(s));
-  if (hadNoResponseMarker) return [];
+  if (hasNoResponseMarker(textSegments)) return [];
   if (typeof fallbackText === "string" && fallbackText.trim().length > 0) {
     return [fallbackText];
   }
@@ -91,6 +95,12 @@ export async function deliverRenderedReplyViaCallback(
   );
   const replyAttachments =
     attachments && attachments.length > 0 ? attachments : undefined;
+
+  // If the model output <no_response/> and no other deliverable text remains,
+  // suppress all delivery — including attachments — so nothing is posted.
+  if (deliverableSegments.length === 0 && hasNoResponseMarker(textSegments)) {
+    return;
+  }
 
   if (deliverableSegments.length === 0) {
     if (replyAttachments) {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -45,14 +45,20 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/;
+
 function toDeliverableTextSegments(
   textSegments: string[],
   fallbackText?: string,
 ): string[] {
   const nonEmptySegments = textSegments.filter(
-    (segment) => segment.trim().length > 0,
+    (segment) => segment.trim().length > 0 && !NO_RESPONSE_RE.test(segment),
   );
   if (nonEmptySegments.length > 0) return nonEmptySegments;
+  // If the only text was <no_response/>, treat as intentional silence —
+  // do not fall back to fallbackText.
+  const hadNoResponseMarker = textSegments.some((s) => NO_RESPONSE_RE.test(s));
+  if (hadNoResponseMarker) return [];
   if (typeof fallbackText === "string" && fallbackText.trim().length > 0) {
     return [fallbackText];
   }


### PR DESCRIPTION
## Summary
- Adds a `<no_response/>` text marker that the assistant can output to intentionally suppress delivery in channel conversations (Slack, Telegram, etc.)
- Filters the marker in the delivery layer (`toDeliverableTextSegments`) so nothing is posted to the channel
- Adds a "Response Discretion" section to the system prompt instructing the LLM when to use this (e.g., thread replies not directed at the bot)

## Motivation
When the bot is @mentioned in a Slack thread, all subsequent replies in that thread are auto-forwarded for 24 hours. This means the bot responds to every message even when people are just talking among themselves. With this change, the LLM can judge whether a message is directed at it and stay silent when appropriate.

## Test plan
- [x] Existing `channel-reply-delivery` tests pass
- [x] New tests: `<no_response/>` suppresses delivery, whitespace-wrapped variant works, mixed segments deliver only real text
- [ ] Manual: tag bot in Slack thread, send follow-up messages between humans, verify bot stays silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
