### PR TITLE
fix: auto-delete BOOTSTRAP.md after first-run inclusion

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, readFileSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -166,6 +166,16 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
+
+    // Auto-delete BOOTSTRAP.md after inclusion so the onboarding ritual
+    // only fires for the very first conversation.  Without this, every new
+    // thread would re-trigger the "Who am I? Who are you?" intro.
+    try {
+      unlinkSync(bootstrapPath);
+      log.info("Deleted BOOTSTRAP.md after first-run inclusion");
+    } catch (err) {
+      log.warn({ err }, "Failed to delete BOOTSTRAP.md after inclusion");
+    }
   }
   if (updates) {
     dynamicParts.push(


### PR DESCRIPTION
## Summary
- BOOTSTRAP.md (first-run onboarding ritual) was never deleted after onboarding completed, causing every new thread to re-trigger the "Who am I? Who are you?" intro
- `buildSystemPrompt()` now auto-deletes BOOTSTRAP.md immediately after including it in the prompt, ensuring the onboarding ritual only fires for the very first conversation

## Original prompt
fix: auto-delete BOOTSTRAP.md after first inclusion in system prompt

The BOOTSTRAP.md file (first-run onboarding ritual) was never deleted after onboarding completed, causing every new thread to re-trigger the "Who am I? Who are you?" intro.

The fix: in buildSystemPrompt(), after BOOTSTRAP.md content is included in the prompt, immediately delete the file. This ensures the onboarding ritual only fires for the very first conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
