### PR TITLE
Revert "fix: auto-delete BOOTSTRAP.md after first inclusion in system prompt (#18824)"

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -166,16 +166,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
-
-    // Auto-delete BOOTSTRAP.md after inclusion so the onboarding ritual
-    // only fires for the very first conversation.  Without this, every new
-    // thread would re-trigger the "Who am I? Who are you?" intro.
-    try {
-      unlinkSync(bootstrapPath);
-      log.info("Deleted BOOTSTRAP.md after first-run inclusion");
-    } catch (err) {
-      log.warn({ err }, "Failed to delete BOOTSTRAP.md after inclusion");
-    }
   }
   if (updates) {
     dynamicParts.push(


### PR DESCRIPTION
## Summary
- Reverts #18824 per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
