### PR TITLE
M1: Add VInlineMessage hint to tool confirmation bubble

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -226,6 +226,10 @@ public struct ToolConfirmationBubble: View {
                 }
             }
 
+            if hasSecondaryAllowOptions {
+                VInlineMessage("Your selection becomes the default action.", tone: .info)
+            }
+
             // First-time educational banner for command confirmations
             if isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -226,7 +226,7 @@ public struct ToolConfirmationBubble: View {
                 }
             }
 
-            if hasSecondaryAllowOptions {
+            if hasAllow10m || hasAllowConversation {
                 VInlineMessage("Your selection becomes the default action.", tone: .info)
             }
 


### PR DESCRIPTION
Part of #18827. Fixes #18828.

- Add VInlineMessage with 'Your selection becomes the default action' hint below the approval buttons
- Only shown when split button has secondary options (no hint for single-option confirmations)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
