### PR TITLE
Add default-action hint to tool confirmation bubble

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -226,10 +226,6 @@ public struct ToolConfirmationBubble: View {
                 }
             }
 
-            if hasAllow10m || hasAllowConversation {
-                VInlineMessage("Your selection becomes the default action.", tone: .info)
-            }
-
             // First-time educational banner for command confirmations
             if isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner
@@ -492,6 +488,10 @@ public struct ToolConfirmationBubble: View {
                             }
                         }
                     }
+                }
+
+                Section {
+                    Text("Your selection becomes the default action.")
                 }
             }
         } else {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -490,8 +490,13 @@ public struct ToolConfirmationBubble: View {
                     }
                 }
 
-                Section {
-                    Text("Your selection becomes the default action.")
+                // Show hint when preference-changing options are available.
+                // Hidden when "Always allow" is the only secondary option
+                // since it creates a persistent rule, not a default preference.
+                if hasAllow10m || hasAllowConversation || primary != "allow_once" {
+                    Section {
+                        Text("Sets default for this button (except \u{201C}Always allow\u{201D})")
+                    }
                 }
             }
         } else {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -495,7 +495,7 @@ public struct ToolConfirmationBubble: View {
                 // since it creates a persistent rule, not a default preference.
                 if hasAllow10m || hasAllowConversation || primary != "allow_once" {
                     Section {
-                        Text("Sets default for this button (except \u{201C}Always allow\u{201D})")
+                        Text("Your selection becomes the default action (except \u{201C}Always allow\u{201D})")
                     }
                 }
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -226,6 +226,10 @@ public struct ToolConfirmationBubble: View {
                 }
             }
 
+            if hasAllow10m || hasAllowConversation {
+                VInlineMessage("Your selection becomes the default action.", tone: .info)
+            }
+
             // First-time educational banner for command confirmations
             if isCommandTool && !hasSeenCommandExplanation {
                 commandExplanationBanner


### PR DESCRIPTION
## Summary
Adds a subtle VInlineMessage hint ("Your selection becomes the default action.") below the approval buttons in the tool confirmation bubble. Only shown when temporal approval options (10-minute or conversation-scoped) are available, since those are the options that actually persist as the default via @AppStorage.

## Changes
- Add `VInlineMessage` with `.info` tone directly under the approval buttons in `ToolConfirmationBubble.pendingContent`
- Conditioned on `hasAllow10m || hasAllowConversation` to avoid showing when only "Always allow" (persistent allowlist rule) is the secondary option

## Milestone PRs (merged into feature branch)
- #18829: M1: Add VInlineMessage hint to tool confirmation bubble

## Project issue
Closes #18827

## Test plan
- [ ] Trigger a tool confirmation that has temporal options (allow_10m / allow_conversation)
- [ ] Verify the info message appears below the buttons and above "Show details"
- [ ] Verify the message does NOT appear for confirmations with only "Always allow" as the secondary option
- [ ] Verify the "Show details" accordion still expands/collapses without overlap

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
