### PR TITLE
[apps] Surface multifile build failures before GA

### DIFF
--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-import { compileApp } from "../bundler/app-compiler.js";
+import { compileApp, readCompileStatus } from "../bundler/app-compiler.js";
 import {
   ALLOWED_PACKAGES,
   getCacheDir,
@@ -143,6 +143,40 @@ console.log("styled");`,
     expect(result.ok).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0].text).toBeTruthy();
+
+    const status = readCompileStatus(appDir);
+    expect(status?.ok).toBe(false);
+    expect(status?.errors.length).toBeGreaterThan(0);
+  });
+
+  test("preserves the last successful dist output when a later build fails", async () => {
+    const appDir = await scaffold("stale-dist-guard", {
+      "main.tsx": `console.log("version one");`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    const initialResult = await compileApp(appDir);
+    expect(initialResult.ok).toBe(true);
+
+    const originalJs = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+
+    await writeFile(
+      join(appDir, "src", "main.tsx"),
+      `const broken = <<<INVALID>>>;`,
+    );
+
+    const failedResult = await compileApp(appDir);
+    expect(failedResult.ok).toBe(false);
+
+    const preservedJs = await readFile(
+      join(appDir, "dist", "main.js"),
+      "utf-8",
+    );
+    expect(preservedJs).toBe(originalJs);
+
+    const status = readCompileStatus(appDir);
+    expect(status?.ok).toBe(false);
+    expect(status?.errors[0]?.text).toBeTruthy();
   });
 
   test("dist/index.html has script tag injected", async () => {

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -24,6 +24,29 @@ import type { ToolExecutionResult } from "../tools/types.js";
 
 const refreshSpy = mock(() => {});
 const updatePublishedSpy = mock(() => Promise.resolve());
+const generateAppIconMock = mock(() => Promise.resolve());
+const compileAppMock = mock(
+  async (): Promise<{
+    ok: boolean;
+    errors: Array<{ text: string }>;
+    warnings: Array<{ text: string }>;
+    durationMs: number;
+    builtAt: number;
+  }> => ({
+    ok: true,
+    errors: [],
+    warnings: [],
+    durationMs: 12,
+    builtAt: Date.now(),
+  }),
+);
+const getAppMock = mock(
+  (): { id: string; formatVersion?: number } | null => null,
+);
+const isMultifileAppMock = mock((app: { formatVersion?: number } | null) => {
+  return app?.formatVersion === 2;
+});
+const getAppsDirMock = mock(() => "/fake/apps");
 
 // Mock session-surfaces so refreshSurfacesForApp is captured
 mock.module("../daemon/conversation-surfaces.js", () => ({
@@ -36,6 +59,28 @@ mock.module("../daemon/conversation-surfaces.js", () => ({
 // Mock published-app-updater to prevent real deployment calls
 mock.module("../services/published-app-updater.js", () => ({
   updatePublishedAppDeployment: updatePublishedSpy,
+}));
+
+mock.module("../media/app-icon-generator.js", () => ({
+  generateAppIcon: generateAppIconMock,
+}));
+
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: compileAppMock,
+  formatCompileStatusMessage: (result: {
+    ok: boolean;
+    errors: Array<{ text: string }>;
+  }) => {
+    if (result.ok) return undefined;
+    const firstError = result.errors[0]?.text ?? "Build failed";
+    return `Build failed: ${firstError}`;
+  },
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: getAppMock,
+  getAppsDir: getAppsDirMock,
+  isMultifileApp: isMultifileAppMock,
 }));
 
 // Mock browser-screencast registration (no-op)
@@ -99,6 +144,11 @@ const noopSecretPrompter = {
 } as unknown as SecretPrompter;
 const noopLifecycleHandler = mock(() => {});
 
+async function flushAsyncSideEffects(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -107,6 +157,23 @@ describe("session-tool-setup app refresh side effects", () => {
   beforeEach(() => {
     refreshSpy.mockClear();
     updatePublishedSpy.mockClear();
+    generateAppIconMock.mockClear();
+    compileAppMock.mockClear();
+    compileAppMock.mockImplementation(async () => ({
+      ok: true,
+      errors: [],
+      warnings: [],
+      durationMs: 12,
+      builtAt: Date.now(),
+    }));
+    getAppMock.mockClear();
+    getAppMock.mockReturnValue(null);
+    isMultifileAppMock.mockClear();
+    isMultifileAppMock.mockImplementation(
+      (app: { formatVersion?: number } | null) => app?.formatVersion === 2,
+    );
+    getAppsDirMock.mockClear();
+    getAppsDirMock.mockReturnValue("/fake/apps");
   });
 
   // ── app_update ──────────────────────────────────────────────────────
@@ -348,6 +415,50 @@ describe("session-tool-setup app refresh side effects", () => {
       );
     });
 
+    test("surfaces multifile compile failures instead of treating them as success", async () => {
+      getAppMock.mockReturnValue({ id: "multi-edit", formatVersion: 2 });
+      compileAppMock.mockImplementation(async () => ({
+        ok: false,
+        errors: [{ text: "Unexpected end of file" }],
+        warnings: [],
+        durationMs: 18,
+        builtAt: Date.now(),
+      }));
+
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_file_edit", {
+        app_id: "multi-edit",
+        path: "src/main.tsx",
+        old_string: "old",
+        new_string: "new",
+      });
+      await flushAsyncSideEffects();
+
+      expect(compileAppMock).toHaveBeenCalledTimes(1);
+      expect((compileAppMock.mock.calls as unknown[][])[0][0]).toBe(
+        "/fake/apps/multi-edit",
+      );
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][2]).toEqual({
+        fileChange: true,
+        status: "Build failed: Unexpected end of file",
+      });
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
     test("skips side effects when result is an error", async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({ content: "Error", isError: true });
@@ -488,6 +599,41 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
       expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
         "app-pub-write",
+      );
+    });
+
+    test("clears prior multifile failure state after a successful rebuild", async () => {
+      getAppMock.mockReturnValue({ id: "multi-write", formatVersion: 2 });
+
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_file_write", {
+        app_id: "multi-write",
+        path: "src/styles.css",
+        content: "body { color: green; }",
+      });
+      await flushAsyncSideEffects();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][2]).toEqual({
+        fileChange: true,
+        status: null,
+      });
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+        "multi-write",
       );
     });
 

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -9,9 +9,17 @@
  * path at module load time and breaks inside bun --compile's /$bunfs/).
  */
 
-import { existsSync, rmSync } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { ensureCompilerTools } from "./compiler-tools.js";
@@ -34,6 +42,56 @@ export interface CompileResult {
   errors: CompileDiagnostic[];
   warnings: CompileDiagnostic[];
   durationMs: number;
+  builtAt: number;
+}
+
+const COMPILE_STATUS_FILENAME = ".vellum-compile-status.json";
+
+function getCompileStatusPath(appDir: string): string {
+  return join(appDir, "dist", COMPILE_STATUS_FILENAME);
+}
+
+async function writeCompileStatus(
+  appDir: string,
+  result: CompileResult,
+): Promise<void> {
+  await mkdir(join(appDir, "dist"), { recursive: true });
+  await writeFile(
+    getCompileStatusPath(appDir),
+    JSON.stringify(result, null, 2),
+    "utf-8",
+  );
+}
+
+export function readCompileStatus(appDir: string): CompileResult | null {
+  const statusPath = getCompileStatusPath(appDir);
+  if (!existsSync(statusPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(statusPath, "utf-8")) as CompileResult;
+  } catch (err) {
+    log.warn({ appDir, err }, "Failed to read compile status artifact");
+    return null;
+  }
+}
+
+export function formatCompileStatusMessage(
+  result: Pick<CompileResult, "ok" | "errors">,
+): string | undefined {
+  if (result.ok) return undefined;
+
+  if (result.errors.length === 0) {
+    return "Build failed";
+  }
+
+  const firstError = result.errors[0];
+  const location = firstError.location
+    ? ` (${basename(firstError.location.file)}:${firstError.location.line}:${firstError.location.column})`
+    : "";
+  const remainingCount = result.errors.length - 1;
+  const suffix = remainingCount > 0 ? ` (+${remainingCount} more)` : "";
+
+  return `Build failed: ${firstError.text}${location}${suffix}`;
 }
 
 /**
@@ -114,110 +172,139 @@ export async function compileApp(appDir: string): Promise<CompileResult> {
   const srcDir = join(appDir, "src");
   const distDir = join(appDir, "dist");
   const entryPoint = join(srcDir, "main.tsx");
+  const tempDistDir = await mkdtemp(join(appDir, ".dist-tmp-"));
 
-  // Clear stale dist/ output so removed assets (e.g. CSS) don't persist
-  if (existsSync(distDir)) {
-    rmSync(distDir, { recursive: true, force: true });
-  }
-  await mkdir(distDir, { recursive: true });
+  const finish = async (
+    payload: Omit<CompileResult, "builtAt">,
+  ): Promise<CompileResult> => {
+    const result: CompileResult = {
+      ...payload,
+      builtAt: Date.now(),
+    };
+    await writeCompileStatus(appDir, result);
+    return result;
+  };
 
-  // JIT download esbuild binary + preact on first use
-  let tools;
-  try {
-    tools = await ensureCompilerTools();
-  } catch (err) {
+  const finishUnexpectedError = async (
+    err: unknown,
+  ): Promise<CompileResult> => {
     const durationMs = Math.round(performance.now() - start);
     const text = err instanceof Error ? err.message : String(err);
-    log.error({ err, durationMs }, "Failed to ensure compiler tools");
-    return {
+    log.error({ err, durationMs }, "Build threw unexpectedly");
+    return finish({
       ok: false,
-      errors: [{ text: `Compiler setup failed: ${text}` }],
+      errors: [{ text }],
       warnings: [],
       durationMs,
-    };
-  }
+    });
+  };
 
-  // Scan source files for bare imports and JIT-install allowed packages
-  await resolveAppImports(srcDir);
+  try {
+    // JIT download esbuild binary + preact on first use
+    let tools;
+    try {
+      tools = await ensureCompilerTools();
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      const text = err instanceof Error ? err.message : String(err);
+      log.error({ err, durationMs }, "Failed to ensure compiler tools");
+      return finish({
+        ok: false,
+        errors: [{ text: `Compiler setup failed: ${text}` }],
+        warnings: [],
+        durationMs,
+      });
+    }
 
-  // Build NODE_PATH: preact parent dir + shared package cache
-  const preactParent = dirname(tools.preactDir);
-  const cacheNodeModules = join(getCacheDir(), "node_modules");
-  const nodePath = [preactParent, cacheNodeModules]
-    .filter((p) => existsSync(p))
-    .join(":");
+    // Scan source files for bare imports and JIT-install allowed packages
+    await resolveAppImports(srcDir);
 
-  // Shell out to esbuild CLI
-  const args = [
-    entryPoint,
-    "--bundle",
-    "--minify",
-    `--outdir=${distDir}`,
-    "--format=esm",
-    "--target=es2022",
-    "--jsx=automatic",
-    "--jsx-import-source=preact",
-    "--alias:react=preact/compat",
-    "--alias:react-dom=preact/compat",
-    "--loader:.tsx=tsx",
-    "--loader:.ts=ts",
-    "--loader:.jsx=jsx",
-    "--loader:.js=js",
-    "--loader:.css=css",
-    "--log-level=warning",
-  ];
+    // Build NODE_PATH: preact parent dir + shared package cache
+    const preactParent = dirname(tools.preactDir);
+    const cacheNodeModules = join(getCacheDir(), "node_modules");
+    const nodePath = [preactParent, cacheNodeModules]
+      .filter((p) => existsSync(p))
+      .join(":");
 
-  const proc = Bun.spawn({
-    cmd: [tools.esbuildBin, ...args],
-    cwd: appDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: { ...process.env, NODE_PATH: nodePath },
-  });
+    // Shell out to esbuild CLI
+    const args = [
+      entryPoint,
+      "--bundle",
+      "--minify",
+      `--outdir=${tempDistDir}`,
+      "--format=esm",
+      "--target=es2022",
+      "--jsx=automatic",
+      "--jsx-import-source=preact",
+      "--alias:react=preact/compat",
+      "--alias:react-dom=preact/compat",
+      "--loader:.tsx=tsx",
+      "--loader:.ts=ts",
+      "--loader:.jsx=jsx",
+      "--loader:.js=js",
+      "--loader:.css=css",
+      "--log-level=warning",
+    ];
 
-  await proc.exited;
-  const stderr = await new Response(proc.stderr).text();
+    const proc = Bun.spawn({
+      cmd: [tools.esbuildBin, ...args],
+      cwd: appDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, NODE_PATH: nodePath },
+    });
 
-  if (proc.exitCode !== 0) {
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    if (proc.exitCode !== 0) {
+      const durationMs = Math.round(performance.now() - start);
+      const { errors, warnings } = parseEsbuildStderr(stderr);
+      // If parsing found nothing, use raw stderr as the error
+      if (errors.length === 0 && stderr.trim()) {
+        errors.push({ text: stderr.trim() });
+      }
+      log.info({ durationMs, errorCount: errors.length }, "Build failed");
+      return finish({ ok: false, errors, warnings, durationMs });
+    }
+
+    // Copy index.html and inject script/style tags
+    const htmlSrc = join(srcDir, "index.html");
+    if (existsSync(htmlSrc)) {
+      let html = await readFile(htmlSrc, "utf-8");
+
+      // Check if CSS output was produced
+      const distFiles = await readdir(tempDistDir);
+      const hasCss = distFiles.some((f) => f.endsWith(".css"));
+
+      // Inject stylesheet link into <head> if CSS exists and not already present
+      if (hasCss && !html.includes('href="main.css"')) {
+        html = html.replace(
+          "</head>",
+          '  <link rel="stylesheet" href="main.css">\n  </head>',
+        );
+      }
+
+      // Inject script tag before </body> if not already present
+      if (!html.includes('src="main.js"')) {
+        html = html.replace(
+          "</body>",
+          '  <script type="module" src="main.js"></script>\n  </body>',
+        );
+      }
+
+      await writeFile(join(tempDistDir, "index.html"), html);
+    }
+
+    await rm(distDir, { recursive: true, force: true });
+    await rename(tempDistDir, distDir);
+
     const durationMs = Math.round(performance.now() - start);
-    const { errors, warnings } = parseEsbuildStderr(stderr);
-    // If parsing found nothing, use raw stderr as the error
-    if (errors.length === 0 && stderr.trim()) {
-      errors.push({ text: stderr.trim() });
-    }
-    log.info({ durationMs, errorCount: errors.length }, "Build failed");
-    return { ok: false, errors, warnings, durationMs };
+    log.info({ durationMs }, "Build succeeded");
+    return finish({ ok: true, errors: [], warnings: [], durationMs });
+  } catch (err) {
+    return finishUnexpectedError(err);
+  } finally {
+    await rm(tempDistDir, { recursive: true, force: true });
   }
-
-  // Copy index.html and inject script/style tags
-  const htmlSrc = join(srcDir, "index.html");
-  if (existsSync(htmlSrc)) {
-    let html = await readFile(htmlSrc, "utf-8");
-
-    // Check if CSS output was produced
-    const distFiles = await readdir(distDir);
-    const hasCss = distFiles.some((f) => f.endsWith(".css"));
-
-    // Inject stylesheet link into <head> if CSS exists and not already present
-    if (hasCss && !html.includes('href="main.css"')) {
-      html = html.replace(
-        "</head>",
-        '  <link rel="stylesheet" href="main.css">\n  </head>',
-      );
-    }
-
-    // Inject script tag before </body> if not already present
-    if (!html.includes('src="main.js"')) {
-      html = html.replace(
-        "</body>",
-        '  <script type="module" src="main.js"></script>\n  </body>',
-      );
-    }
-
-    await writeFile(join(distDir, "index.html"), html);
-  }
-
-  const durationMs = Math.round(performance.now() - start);
-  log.info({ durationMs }, "Build succeeded");
-  return { ok: true, errors: [], warnings: [], durationMs };
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1,6 +1,18 @@
+import { join } from "node:path";
+
 import { v4 as uuid } from "uuid";
 
-import { getApp, getAppPreview, updateApp } from "../memory/app-store.js";
+import {
+  formatCompileStatusMessage,
+  readCompileStatus,
+} from "../bundler/app-compiler.js";
+import {
+  getApp,
+  getAppPreview,
+  getAppsDir,
+  isMultifileApp,
+  updateApp,
+} from "../memory/app-store.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
@@ -816,7 +828,7 @@ export function handleSurfaceAction(
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
   appId: string,
-  opts?: { fileChange?: boolean; status?: string },
+  opts?: { fileChange?: boolean; status?: string | null },
 ): boolean {
   const app = getApp(appId);
   if (!app) return false;
@@ -837,7 +849,7 @@ export function refreshSurfacesForApp(
       ...(opts?.fileChange
         ? { reloadGeneration: (data.reloadGeneration ?? 0) + 1 }
         : {}),
-      ...(opts?.status !== undefined ? { status: opts.status } : {}),
+      ...(opts && "status" in opts ? { status: opts.status ?? undefined } : {}),
     };
     stored.data = updatedData;
 
@@ -1219,9 +1231,17 @@ export async function surfaceProxyResolver(
     const defaultPreview = { title: app.name, subtitle: app.description };
 
     const storedPreview = getAppPreview(app.id);
+    const compileStatus = isMultifileApp(app)
+      ? readCompileStatus(join(getAppsDir(), app.id))
+      : null;
     const surfaceData: DynamicPageSurfaceData = {
       html: app.htmlDefinition,
       appId: app.id,
+      ...(compileStatus && !compileStatus.ok
+        ? {
+            status: formatCompileStatusMessage(compileStatus) ?? "Build failed",
+          }
+        : {}),
       preview: {
         ...defaultPreview,
         ...preview,

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,7 +9,10 @@
 
 import { join } from "node:path";
 
-import { compileApp } from "../bundler/app-compiler.js";
+import {
+  compileApp,
+  formatCompileStatusMessage,
+} from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
@@ -44,7 +47,7 @@ function handleAppChange(
   ctx: ToolSetupContext,
   appId: string,
   broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
-  opts?: { fileChange?: boolean; status?: string },
+  opts?: { fileChange?: boolean; status?: string | null },
 ): void {
   const app = getApp(appId);
 
@@ -54,22 +57,32 @@ function handleAppChange(
     const appDir = join(getAppsDir(), appId);
     void compileApp(appDir)
       .then((result) => {
+        const status = result.ok
+          ? (opts?.status ?? null)
+          : (formatCompileStatusMessage(result) ?? "Build failed");
         if (!result.ok) {
           log.warn(
             { appId, errors: result.errors },
-            "Recompile failed on app change, serving stale dist/",
+            "Recompile failed on app change; preserving last successful dist/",
           );
         }
-        refreshSurfacesForApp(ctx, appId, opts);
+        refreshSurfacesForApp(ctx, appId, {
+          ...opts,
+          status,
+        });
         broadcastToAllClients?.({ type: "app_files_changed", appId });
-        void updatePublishedAppDeployment(appId);
+        if (result.ok) {
+          void updatePublishedAppDeployment(appId);
+        }
       })
       .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
         log.warn({ appId, err }, "Recompile threw on app change");
-        // Still refresh surfaces with stale output
-        refreshSurfacesForApp(ctx, appId, opts);
+        refreshSurfacesForApp(ctx, appId, {
+          ...opts,
+          status: `Build failed: ${message}`,
+        });
         broadcastToAllClients?.({ type: "app_files_changed", appId });
-        void updatePublishedAppDeployment(appId);
       });
     return;
   }


### PR DESCRIPTION
## Summary
- preserve the last successful multifile dist output when a rebuild fails and persist compile status metadata
- surface multifile build failures in workspace refresh/open flows instead of making broken edits look successful
- add regression coverage for stale-dist preservation and failure status propagation

## Verification
- bun test assistant/src/__tests__/app-compiler.test.ts assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
- cd assistant && bunx tsc --noEmit

🤖 Generated with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
