### PR TITLE
fix: scroll-to-latest button on short conversations + opaque background

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -173,9 +173,9 @@ struct MessageListView: View {
     /// trigger re-renders.
     @StateObject private var anchorTracker = AnchorVisibilityTracker()
     /// Whether a physical scroll event (wheel/trackpad) has been received since
-    /// the current conversation loaded. Before any scroll event, `isNearBottom`
-    /// (which defaults to `true`) is not trusted; the button relies solely on
-    /// `anchorTracker.isVisible` to decide visibility.
+    /// the current conversation loaded. Used by `restoreScrollToBottom` to skip
+    /// retries once the user has interacted, and by the scroll-bottom-anchor's
+    /// `onAppear` to avoid premature re-tethering during LazyVStack prefetch.
     @State private var hasReceivedScrollEvent: Bool = false
     /// The scroll view's viewport height, captured via preference key. Used by
     /// the anchor GeometryReader to determine if the anchor is within bounds.
@@ -904,7 +904,9 @@ struct MessageListView: View {
                 conversationTailAvatar
             }
             .overlay(alignment: .bottom) {
-                if (!isNearBottom || !hasReceivedScrollEvent) && !anchorTracker.isVisible {
+                if !isNearBottom && !anchorTracker.isVisible
+                    && anchorTracker.lastMinY > scrollViewportHeight + 20
+                {
                     Button(action: {
                         hasReceivedScrollEvent = true
                         isNearBottom = true

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -921,7 +921,7 @@ struct MessageListView: View {
                         }
                         .padding(.horizontal, VSpacing.md)
                         .padding(.vertical, VSpacing.sm)
-                        .background(.ultraThinMaterial)
+                        .background(VColor.surfaceOverlay)
                         .clipShape(Capsule())
                         .shadow(color: VColor.auxBlack.opacity(0.15), radius: 4, y: 2)
                     }


### PR DESCRIPTION
## Summary
- **Prevent the "Scroll to latest" button from appearing on short conversations** where there's nothing to scroll to. The old condition relied on `anchorTracker.isVisible` via `|| !hasReceivedScrollEvent`, which was vulnerable to transient layout races. The new condition requires `!isNearBottom` (which has a built-in `docHeight > clipHeight` guard in `ScrollWheelDetector`) and a runtime cross-check that the anchor is genuinely past the viewport (`lastMinY > scrollViewportHeight + 20`).
- **Use opaque `VColor.surfaceOverlay` background** instead of `.ultraThinMaterial` so the button color stays consistent regardless of the content behind it.

## Test plan
- [ ] Open a short conversation (1-2 messages) — button should NOT appear
- [ ] Switch between conversations — button should NOT flash
- [ ] Scroll up in a long conversation — button SHOULD appear
- [ ] Click the button — should scroll to bottom and hide
- [ ] Verify button background is consistent color while scrolling over different content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
