### PR TITLE
fix: reduce composer action button gap to VSpacing.sm

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -452,9 +452,9 @@ struct ComposerView: View {
         }
     }
 
-    /// Gap between a ghost button and a filled (primary/contrast) button — larger to visually
-    /// match the ghost-ghost gap, compensating for the filled button having no internal padding.
-    private let composerFilledGap: CGFloat = 12
+    /// Gap between a ghost button and a filled (primary/contrast) button — uses the standard
+    /// small spacing token for consistent spacing across the composer action bar.
+    private let composerFilledGap: CGFloat = VSpacing.sm
 
     /// Bottom action bar: paperclip on the left, send/mic/stop on the right.
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Reduce the gap between ghost and filled buttons in the composer action bar from 12pt to 8pt (`VSpacing.sm`)
- Replace hardcoded `CGFloat = 12` with the standard design token `VSpacing.sm` for consistency with the design system

## Test plan
- [ ] Open the composer and verify spacing between ghost and filled action buttons looks correct
- [ ] Verify no visual regression in the action bar layout across light and dark modes
- [ ] Confirm the Swift target builds successfully (`./clients/macos/build.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
