### PR TITLE
feat: use design system sidebar and app header in component gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -37,53 +37,135 @@ struct ComponentGalleryView: View {
     @State private var selectedCategory: ComponentGalleryCategory? = .buttons
 
     var body: some View {
-        NavigationSplitView {
-            VStack(spacing: 0) {
-                List(selection: $selectedCategory) {
-                    ForEach(ComponentGalleryCategory.allCases) { category in
-                        Label { Text(category.rawValue) } icon: { VIconView(category.vIcon, size: 14) }
-                            .tag(category)
-                    }
-                }
-                .listStyle(.sidebar)
+        VStack(spacing: 0) {
+            // Header bar (similar to main app top bar)
+            galleryHeaderBar
 
-                Divider()
-
-                VThemeToggle()
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.sm)
+            // Sidebar + detail content
+            HStack(spacing: 0) {
+                gallerySidebar
+                detailContent
             }
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 240)
-        } detail: {
-            ScrollView {
-                VStack(alignment: .leading, spacing: VSpacing.xxl) {
-                    if let category = selectedCategory {
-                        switch category {
-                        case .appIcons: AppIconGallerySection()
-                        case .buttons: ButtonsGallerySection()
-                        case .chat: ChatGallerySection()
-                        case .display: DisplayGallerySection()
-                        case .feedback: FeedbackGallerySection()
-                        case .icons: IconsGallerySection()
-                        case .inputs: InputsGallerySection()
-                        case .layout: LayoutGallerySection()
-                        case .navigation: NavigationGallerySection()
-                        case .modifiers: ModifiersGallerySection()
-                        case .tokens: TokensGallerySection()
-                        }
-                    } else {
-                        VEmptyState(
-                            title: "Select a category",
-                            subtitle: "Choose a component category from the sidebar",
-                            icon: VIcon.panelLeft.rawValue
-                        )
-                    }
-                }
-                .padding(VSpacing.xxl)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.surfaceOverlay)
         }
+        .background(VColor.surfaceBase)
+    }
+
+    // MARK: - Header Bar
+
+    private var galleryHeaderBar: some View {
+        HStack(spacing: VSpacing.sm) {
+            Text("Component Gallery")
+                .font(VFont.headline)
+                .foregroundColor(VColor.contentDefault)
+
+            Spacer()
+
+            VThemeToggle()
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .frame(height: 48)
+        .background(VColor.surfaceOverlay)
+    }
+
+    // MARK: - Sidebar
+
+    private var gallerySidebar: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: VSpacing.xs) {
+                    ForEach(ComponentGalleryCategory.allCases) { category in
+                        GallerySidebarRow(
+                            icon: category.vIcon,
+                            label: category.rawValue,
+                            isActive: selectedCategory == category
+                        ) {
+                            selectedCategory = category
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+                .padding(.horizontal, VSpacing.md)
+            }
+        }
+        .frame(width: 200)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .padding(VSpacing.md)
+    }
+
+    // MARK: - Detail Content
+
+    private var detailContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.xxl) {
+                if let category = selectedCategory {
+                    switch category {
+                    case .appIcons: AppIconGallerySection()
+                    case .buttons: ButtonsGallerySection()
+                    case .chat: ChatGallerySection()
+                    case .display: DisplayGallerySection()
+                    case .feedback: FeedbackGallerySection()
+                    case .icons: IconsGallerySection()
+                    case .inputs: InputsGallerySection()
+                    case .layout: LayoutGallerySection()
+                    case .navigation: NavigationGallerySection()
+                    case .modifiers: ModifiersGallerySection()
+                    case .tokens: TokensGallerySection()
+                    }
+                } else {
+                    VEmptyState(
+                        title: "Select a category",
+                        subtitle: "Choose a component category from the sidebar",
+                        icon: VIcon.panelLeft.rawValue
+                    )
+                }
+            }
+            .padding(VSpacing.xxl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .padding(.vertical, VSpacing.md)
+        .padding(.trailing, VSpacing.md)
+    }
+}
+
+// MARK: - Sidebar Row
+
+private struct GallerySidebarRow: View {
+    let icon: VIcon
+    let label: String
+    var isActive: Bool = false
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(icon, size: 13)
+                .foregroundColor(isActive ? VColor.primaryActive : VColor.primaryBase)
+                .frame(width: 20, height: 20)
+            Text(label)
+                .font(VFont.body)
+                .foregroundColor(isActive ? VColor.contentEmphasized : VColor.contentSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer()
+        }
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .frame(minHeight: 32)
+        .background(
+            isActive ? VColor.surfaceActive :
+            isHovered ? VColor.surfaceBase :
+            Color.clear
+        )
+        .animation(VAnimation.fast, value: isHovered)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .contentShape(Rectangle())
+        .onTapGesture { action() }
+        .onHover { isHovered = $0 }
+        .pointerCursor()
     }
 }
 

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -52,6 +52,9 @@ struct ComponentGalleryView: View {
 
     // MARK: - Header Bar
 
+    /// Leading padding to clear macOS traffic-light buttons when using fullSizeContentView.
+    private let trafficLightPadding: CGFloat = 78
+
     private var galleryHeaderBar: some View {
         HStack(spacing: VSpacing.sm) {
             Text("Component Gallery")
@@ -62,7 +65,8 @@ struct ComponentGalleryView: View {
 
             VThemeToggle()
         }
-        .padding(.horizontal, VSpacing.lg)
+        .padding(.leading, trafficLightPadding)
+        .padding(.trailing, VSpacing.lg)
         .frame(height: 48)
         .background(VColor.surfaceOverlay)
     }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -140,30 +140,31 @@ private struct GallerySidebarRow: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: VSpacing.xs) {
-            VIconView(icon, size: 13)
-                .foregroundColor(isActive ? VColor.primaryActive : VColor.primaryBase)
-                .frame(width: 20, height: 20)
-            Text(label)
-                .font(VFont.body)
-                .foregroundColor(isActive ? VColor.contentEmphasized : VColor.contentSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer()
+        Button(action: action) {
+            HStack(spacing: VSpacing.xs) {
+                VIconView(icon, size: 13)
+                    .foregroundColor(isActive ? VColor.primaryActive : VColor.primaryBase)
+                    .frame(width: 20, height: 20)
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(isActive ? VColor.contentEmphasized : VColor.contentSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+            }
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .frame(minHeight: 32)
+            .background(
+                isActive ? VColor.surfaceActive :
+                isHovered ? VColor.surfaceBase :
+                Color.clear
+            )
+            .animation(VAnimation.fast, value: isHovered)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
-        .padding(.leading, VSpacing.xs)
-        .padding(.trailing, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
-        .frame(minHeight: 32)
-        .background(
-            isActive ? VColor.surfaceActive :
-            isHovered ? VColor.surfaceBase :
-            Color.clear
-        )
-        .animation(VAnimation.fast, value: isHovered)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .contentShape(Rectangle())
-        .onTapGesture { action() }
+        .buttonStyle(.plain)
         .onHover { isHovered = $0 }
         .pointerCursor()
     }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryWindow.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryWindow.swift
@@ -26,8 +26,9 @@ public final class ComponentGalleryWindow {
 
         window.contentViewController = hostingController
         window.title = "Component Gallery"
+        window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
-        window.backgroundColor = NSColor(VColor.surfaceOverlay)
+        window.backgroundColor = NSColor(VColor.surfaceBase)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 500)
 


### PR DESCRIPTION
## Summary
- Replaced native `NavigationSplitView` with a custom sidebar using design system primitives (matching the main app sidebar pattern with hover states, active highlights, rounded corners)
- Added a top header bar similar to the main app's `topBarView` with title and theme toggle
- Sidebar and detail content use `VColor.surfaceOverlay` backgrounds with `VRadius.xl` rounded corners, consistent with the main app's panel styling

## Original prompt
--safe in component gallery use our design system side bar instead of whatever is currently used, and use app header similar to main app header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
