### PR TITLE
fix: sync canonical guardian request status on desktop /v1/confirm

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,6 +8,7 @@
  * header. Guardian decisions additionally verify that the actor is the
  * bound guardian.
  */
+import { resolveCanonicalGuardianRequest } from "../../memory/canonical-guardian-store.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { addRule } from "../../permissions/trust-store.js";
 import type { UserDecision } from "../../permissions/types.js";
@@ -139,6 +140,23 @@ export async function handleConfirm(
       source: "button",
     },
   );
+
+  // Sync the canonical guardian request status so stale "pending" DB
+  // records don't get matched by later guardian reply routing. Without
+  // this, the desktop /v1/confirm path consumes the in-memory pending
+  // interaction but leaves the canonical request "pending" in the DB,
+  // causing subsequent user messages to be falsely consumed as approvals.
+  const targetStatus =
+    decision === "deny" || decision === "always_deny" ? "denied" : "approved";
+  try {
+    resolveCanonicalGuardianRequest(requestId, "pending", {
+      status: targetStatus,
+    });
+  } catch {
+    // Best-effort — canonical request tracking should not break the
+    // primary approval flow.
+  }
+
   return Response.json({ accepted: true });
 }
 


### PR DESCRIPTION
## Summary
- The desktop `/v1/confirm` endpoint (approval buttons) consumed the in-memory pending interaction but did not update the canonical guardian request status in the DB
- This left stale "pending" canonical records that the guardian reply router could discover via the `guardianPrincipalId` fallback query
- When the user subsequently typed a common phrase like "yes" or "ok", the deterministic text matcher consumed it as an approval for the stale request, silently eating the user's message
- Added `resolveCanonicalGuardianRequest()` call after `handleConfirmationResponse()` to sync the canonical status, matching the pattern already used by cascaded approvals and auto-deny paths

## Original prompt
Fix 1: Sync canonical guardian request status when the desktop /v1/confirm endpoint resolves a pending interaction. Without this, the canonical request stays "pending" in the DB and can cause subsequent user messages to be falsely consumed as approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
