### PR TITLE
fix: prevent desktop guardian reply router from bypassing in-memory staleness filter

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -139,8 +139,12 @@ async function tryConsumeCanonicalGuardianReply(params: {
     sourceChannel,
     conversation,
   );
-  const pendingRequestIds =
-    pendingRequestHintIds.length > 0 ? pendingRequestHintIds : undefined;
+  // Always pass the hints array (even when empty) so
+  // findPendingCanonicalRequests respects the in-memory staleness filter
+  // applied by collectCanonicalGuardianRequestHintIds. Converting empty
+  // hints to `undefined` caused the router to fall through to raw DB
+  // queries that rediscovered stale canonical requests.
+  const pendingRequestIds = pendingRequestHintIds;
 
   const routerResult = await routeGuardianReply({
     messageText: trimmedContent,


### PR DESCRIPTION
## Summary
- `collectCanonicalGuardianRequestHintIds` correctly filters `tool_approval` canonical requests to only those with a live in-memory pending interaction
- When the result was empty, the code converted `[]` to `undefined`, telling `findPendingCanonicalRequests` "no hints available — do your own DB lookup"
- The fallback DB query by `guardianPrincipalId` rediscovered stale canonical requests, and the deterministic text matcher consumed common user phrases ("yes", "ok") as approvals for those stale requests
- Fixed by passing the empty array through so the router returns `[]` immediately, respecting the hint collection's filtering

## Original prompt
Fix 2: Stop converting empty pendingRequestHintIds to undefined in tryConsumeCanonicalGuardianReply. This caused the guardian reply router to bypass the in-memory staleness filter and rediscover stale canonical requests via raw DB queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
