### PR TITLE
fix(macos): hide ghost suggestion when image attachments are pending

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -84,8 +84,10 @@ struct ComposerView: View {
     @State private var isComposerDropTargeted = false
 
     /// The portion of the suggestion that extends beyond the current input.
+    /// Hidden when the user has pending attachments so the composer looks empty
+    /// and they aren't confused about what will be sent.
     private var ghostSuffix: String? {
-        guard let suggestion else { return nil }
+        guard let suggestion, pendingAttachments.isEmpty else { return nil }
         if suggestion.hasPrefix(inputText) {
             let suffix = String(suggestion.dropFirst(inputText.count))
             return suffix.isEmpty ? nil : suffix


### PR DESCRIPTION
## Summary
- Suppress ghost suggestion text in the composer when the user has pending image attachments
- Prevents confusion about what text will be sent alongside images — the composer now appears empty when only images are queued
- The suggestion is preserved internally and reappears if attachments are removed

## Original prompt
Suppress ghost suggestion text in ComposerView when the user has pending image attachments. The ghost text (auto-suggested prompt) should not appear when pendingAttachments is non-empty, so users aren't confused about what will be sent alongside their images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
