### PR TITLE
refactor: centralize canonical guardian request sync in handleConfirmationResponse

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -608,6 +608,18 @@ export class Conversation {
       "Resuming after approval",
     );
 
+    // Sync the canonical guardian request status so stale "pending" DB
+    // records don't get matched by later guardian reply routing. Best-effort:
+    // CAS may harmlessly fail if the canonical decision primitive already
+    // resolved the request (e.g. channel approval path).
+    try {
+      resolveCanonicalGuardianRequest(requestId, "pending", {
+        status: resolvedState,
+      });
+    } catch {
+      // Canonical request tracking should not break the primary approval flow.
+    }
+
     // Cascade to other pending confirmations that match this decision
     this.cascadePendingApprovals(requestId, decision, selectedPattern);
   }
@@ -650,10 +662,11 @@ export class Conversation {
       // Consume from pending-interactions tracker
       pendingInteractions.resolve(candidateId);
 
-      // Resolve via handleConfirmationResponse which emits events.
-      // Use simple "allow"/"deny" so the permission-checker won't save
-      // duplicate rules or re-activate temporary modes. Recursion
-      // terminates because allow/deny exit cascadePendingApprovals early.
+      // Resolve via handleConfirmationResponse which emits events and
+      // syncs canonical status. Use simple "allow"/"deny" so the
+      // permission-checker won't save duplicate rules or re-activate
+      // temporary modes. Recursion terminates because allow/deny exit
+      // cascadePendingApprovals early.
       this.handleConfirmationResponse(
         candidateId,
         cascadeResult.allow ? "allow" : "deny",
@@ -665,17 +678,6 @@ export class Conversation {
           causedByRequestId: primaryRequestId,
         },
       );
-
-      // Sync the canonical guardian request status for the cascaded request.
-      // Best-effort: canonical request tracking should not break the cascade flow.
-      try {
-        const targetStatus = cascadeResult.allow ? "approved" : "denied";
-        resolveCanonicalGuardianRequest(candidateId, "pending", {
-          status: targetStatus,
-        });
-      } catch {
-        // Ignore — canonical request tracking is best-effort
-      }
     }
   }
 

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -9,7 +9,6 @@ import { getConfig } from "../../config/loader.js";
 import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
-  resolveCanonicalGuardianRequest,
 } from "../../memory/canonical-guardian-store.js";
 import {
   batchSetDisplayOrders,
@@ -49,27 +48,6 @@ import {
   log,
   pendingStandaloneSecrets,
 } from "./shared.js";
-
-export function syncCanonicalStatusFromConfirmationDecision(
-  requestId: string,
-  decision: ConfirmationResponse["decision"],
-): void {
-  const targetStatus =
-    decision === "deny" || decision === "always_deny"
-      ? ("denied" as const)
-      : ("approved" as const);
-
-  try {
-    resolveCanonicalGuardianRequest(requestId, "pending", {
-      status: targetStatus,
-    });
-  } catch (err) {
-    log.debug(
-      { err, requestId, targetStatus },
-      "Failed to resolve canonical request from local confirmation response",
-    );
-  }
-}
 
 export function makeEventSender(params: {
   ctx: HandlerContext;
@@ -165,7 +143,6 @@ export function handleConfirmationResponse(
         undefined,
         { source: "button" },
       );
-      syncCanonicalStatusFromConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,7 +8,6 @@
  * header. Guardian decisions additionally verify that the actor is the
  * bound guardian.
  */
-import { resolveCanonicalGuardianRequest } from "../../memory/canonical-guardian-store.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { addRule } from "../../permissions/trust-store.js";
 import type { UserDecision } from "../../permissions/types.js";
@@ -140,22 +139,6 @@ export async function handleConfirm(
       source: "button",
     },
   );
-
-  // Sync the canonical guardian request status so stale "pending" DB
-  // records don't get matched by later guardian reply routing. Without
-  // this, the desktop /v1/confirm path consumes the in-memory pending
-  // interaction but leaves the canonical request "pending" in the DB,
-  // causing subsequent user messages to be falsely consumed as approvals.
-  const targetStatus =
-    decision === "deny" || decision === "always_deny" ? "denied" : "approved";
-  try {
-    resolveCanonicalGuardianRequest(requestId, "pending", {
-      status: targetStatus,
-    });
-  } catch {
-    // Best-effort — canonical request tracking should not break the
-    // primary approval flow.
-  }
 
   return Response.json({ accepted: true });
 }


### PR DESCRIPTION
## Summary
- Moved the canonical guardian request status sync (`resolveCanonicalGuardianRequest`) into `handleConfirmationResponse` itself, so all 7+ callers automatically get the sync without per-call-site logic
- Removed duplicate sync code from `approval-routes.ts` (PR #18843), the legacy `conversations.ts` handler, and `cascadePendingApprovals`
- Deleted the now-unused `syncCanonicalStatusFromConfirmationDecision` helper function
- This also closes gaps in callers that previously lacked canonical sync: `voice-session-bridge.ts` (3 callers), `channel-approvals.ts` (2 callers), and `signals/confirm.ts` (1 caller)

## Original prompt
Move the canonical status sync into handleConfirmationResponse itself so all callers get it automatically, then remove the duplicate syncs from the individual call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
