### PR TITLE
fix: expire orphaned canonical tool_approval requests on new message

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -97,6 +97,32 @@ function collectCanonicalGuardianRequestHintIds(
     .map((req) => req.id);
 }
 
+/**
+ * Expire orphaned canonical guardian requests for a conversation.
+ *
+ * After the in-memory auto-deny loop runs, there may still be "pending"
+ * canonical requests in the DB that have no corresponding in-memory
+ * pending interaction (e.g. the prompter timed out and resolved the
+ * confirmation directly without syncing canonical status). This sweep
+ * catches those stragglers so they don't get falsely matched by the
+ * guardian reply router on subsequent messages.
+ */
+function expireOrphanedCanonicalRequests(
+  conversationId: string,
+  sourceChannel: string,
+): void {
+  const orphaned = listPendingRequestsByConversationScope(
+    conversationId,
+    sourceChannel,
+  ).filter((r) => r.kind === "tool_approval");
+
+  for (const req of orphaned) {
+    resolveCanonicalGuardianRequest(req.id, "pending", {
+      status: "expired",
+    });
+  }
+}
+
 async function tryConsumeCanonicalGuardianReply(params: {
   conversationId: string;
   sourceChannel: string;
@@ -860,6 +886,10 @@ export async function handleSendMessage(
       pendingInteractions.removeByConversation(conversation);
     }
 
+    // Expire any orphaned canonical requests that survived without a
+    // matching in-memory pending interaction (e.g. prompter timeouts).
+    expireOrphanedCanonicalRequests(mapping.conversationId, sourceChannel);
+
     return Response.json(
       { accepted: true, queued: true, conversationId: mapping.conversationId },
       { status: 202 },
@@ -895,6 +925,10 @@ export async function handleSendMessage(
     conversation.denyAllPendingConfirmations();
     pendingInteractions.removeByConversation(conversation);
   }
+
+  // Expire any orphaned canonical requests that survived without a
+  // matching in-memory pending interaction (e.g. prompter timeouts).
+  expireOrphanedCanonicalRequests(mapping.conversationId, sourceChannel);
 
   // Conversation is idle — persist and fire agent loop immediately
   conversation.setTurnChannelContext({


### PR DESCRIPTION
## Summary
- After the in-memory auto-deny loop runs on new message arrival, stale "pending" canonical `tool_approval` requests could remain in the DB (e.g. from prompter timeouts that resolve the confirmation without syncing canonical status)
- Added `expireOrphanedCanonicalRequests()` helper that queries remaining pending `tool_approval` canonical requests for the conversation and expires them via CAS
- Called in both the busy-queue and idle-conversation paths in `handleSendMessage`, complementing the existing in-memory auto-deny logic

## Original prompt
Expire orphaned canonical guardian requests that survived without a matching in-memory pending interaction when a new message arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
