### PR TITLE
feat: sticky system contacts and empty state in contacts sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct AssistantChannelsDetailView: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
+    var conversationManager: ConversationManager?
     var assistantName: String = "your assistant"
     var isEmailEnabled: Bool = false
     var showCardBorders: Bool = true
@@ -209,8 +210,10 @@ struct AssistantChannelsDetailView: View {
                     isConnected: isConnected,
                     isExpanded: $telegramRowExpanded,
                     setupAction: !isConnected && !telegramSetupExpanded && !(status == "incomplete" && store.telegramHasBotToken) ? {
-                        telegramRowExpanded = true
-                        telegramSetupExpanded = true
+                        conversationManager?.openConversation(
+                            message: "I want to reach you on Telegram. Let's set it up.",
+                            forceNew: true
+                        )
                     } : nil,
                     isDisconnectDisabled: store.telegramSaveInProgress
                 )
@@ -247,8 +250,10 @@ struct AssistantChannelsDetailView: View {
                     isConnected: isConnected,
                     isExpanded: $slackRowExpanded,
                     setupAction: !isConnected && !slackChannelSetupExpanded && !(status == "incomplete" && (store.slackChannelHasBotToken || store.slackChannelHasAppToken)) ? {
-                        slackRowExpanded = true
-                        slackChannelSetupExpanded = true
+                        conversationManager?.openConversation(
+                            message: "I want to reach you on Slack. Let's set it up.",
+                            forceNew: true
+                        )
                     } : nil,
                     isDisconnectDisabled: store.slackChannelSaveInProgress
                 )
@@ -288,8 +293,10 @@ struct AssistantChannelsDetailView: View {
                     isConnected: isConnected,
                     isExpanded: $voiceRowExpanded,
                     setupAction: !isConnected && !voiceSetupExpanded ? {
-                        voiceRowExpanded = true
-                        voiceSetupExpanded = true
+                        conversationManager?.openConversation(
+                            message: "I want to be able to call you. Let's set you up with a phone number.",
+                            forceNew: true
+                        )
                     } : nil,
                     isDisconnectDisabled: store.twilioSaveInProgress
                 )
@@ -570,7 +577,10 @@ struct AssistantChannelsDetailView: View {
                 telegramCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .outlined) {
-                    telegramSetupExpanded = true
+                    conversationManager?.openConversation(
+                        message: "I want to reach you on Telegram. Let's set it up.",
+                        forceNew: true
+                    )
                 }
             }
 
@@ -671,7 +681,10 @@ struct AssistantChannelsDetailView: View {
                 slackChannelCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .outlined) {
-                    slackChannelSetupExpanded = true
+                    conversationManager?.openConversation(
+                        message: "I want to reach you on Slack. Let's set it up.",
+                        forceNew: true
+                    )
                 }
             }
 
@@ -775,7 +788,10 @@ struct AssistantChannelsDetailView: View {
                 voiceCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .outlined) {
-                    voiceSetupExpanded = true
+                    conversationManager?.openConversation(
+                        message: "I want to be able to call you. Let's set you up with a phone number.",
+                        forceNew: true
+                    )
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -15,6 +15,7 @@ enum ContactSelection: Hashable {
 struct ContactsContainerView: View {
     var daemonClient: DaemonClient?
     var store: SettingsStore?
+    var conversationManager: ConversationManager?
     var isEmailEnabled: Bool = false
     var showToast: ((String, ToastInfo.Style) -> Void)?
 
@@ -23,9 +24,10 @@ struct ContactsContainerView: View {
 
     private let contactClient: ContactClientProtocol = ContactClient()
 
-    init(daemonClient: DaemonClient?, store: SettingsStore? = nil, isEmailEnabled: Bool = false, showToast: ((String, ToastInfo.Style) -> Void)? = nil) {
+    init(daemonClient: DaemonClient?, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, isEmailEnabled: Bool = false, showToast: ((String, ToastInfo.Style) -> Void)? = nil) {
         self.daemonClient = daemonClient
         self.store = store
+        self.conversationManager = conversationManager
         self.isEmailEnabled = isEmailEnabled
         self.showToast = showToast
         _viewModel = StateObject(wrappedValue: ContactsViewModel(daemonClient: daemonClient))
@@ -295,7 +297,7 @@ struct ContactsContainerView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 if let store {
-                    AssistantChannelsDetailView(store: store, daemonClient: daemonClient, assistantName: cachedAssistantName, isEmailEnabled: isEmailEnabled, showCardBorders: false)
+                    AssistantChannelsDetailView(store: store, daemonClient: daemonClient, conversationManager: conversationManager, assistantName: cachedAssistantName, isEmailEnabled: isEmailEnabled, showCardBorders: false)
                         .padding(VSpacing.lg)
                         .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
                 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -16,9 +16,6 @@ struct ContactsListView: View {
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 loadingState
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if viewModel.contacts.isEmpty {
-                emptyState
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 contactsCard
             }
@@ -50,50 +47,64 @@ struct ContactsListView: View {
                 .accessibilityLabel("Add contact")
             }
 
-            searchBar
+            // Sticky system contacts (always visible, not affected by search)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                contactListRow(
+                    name: cachedAssistantDisplayName,
+                    role: "assistant",
+                    isSelected: selection == .assistant,
+                    isHovered: isAssistantHovered,
+                    onTap: { selection = .assistant },
+                    onHover: { isAssistantHovered = $0 }
+                )
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    // Assistant row (virtual — not a real contact)
-                    if matchesSearch(cachedAssistantDisplayName) {
-                        contactListRow(
-                            name: cachedAssistantDisplayName,
-                            role: "assistant",
-                            isSelected: selection == .assistant,
-                            isHovered: isAssistantHovered,
-                            onTap: { selection = .assistant },
-                            onHover: { isAssistantHovered = $0 }
-                        )
-                    }
-
-                    // All contacts in natural order
-                    ForEach(viewModel.filteredContacts, id: \.id) { contact in
-                        let isGuardian = contact.role == "guardian"
-                        contactListRow(
-                            name: isGuardian ? "\(contact.displayName) (You)" : contact.displayName,
-                            role: contact.role,
-                            isSelected: selection == .contact(contact.id),
-                            isHovered: hoveredContactId == contact.id,
-                            onTap: { selection = .contact(contact.id) },
-                            onHover: { hoveredContactId = $0 ? contact.id : nil }
-                        )
-                    }
-
-                    if viewModel.filteredContacts.isEmpty && !viewModel.contacts.isEmpty && !matchesSearch(cachedAssistantDisplayName) {
-                        VStack(spacing: VSpacing.sm) {
-                            Text("No matching contacts")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentSecondary)
-                            Text("Try a different search term")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, VSpacing.xl)
-                    }
+                if let guardian = viewModel.guardianContact {
+                    contactListRow(
+                        name: "\(guardian.displayName) (You)",
+                        role: guardian.role,
+                        isSelected: selection == .contact(guardian.id),
+                        isHovered: hoveredContactId == guardian.id,
+                        onTap: { selection = .contact(guardian.id) },
+                        onHover: { hoveredContactId = $0 ? guardian.id : nil }
+                    )
                 }
             }
 
+            Divider()
+
+            if viewModel.regularContacts.isEmpty {
+                regularContactsEmptyState
+            } else {
+                searchBar
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        ForEach(viewModel.filteredRegularContacts, id: \.id) { contact in
+                            contactListRow(
+                                name: contact.displayName,
+                                role: contact.role,
+                                isSelected: selection == .contact(contact.id),
+                                isHovered: hoveredContactId == contact.id,
+                                onTap: { selection = .contact(contact.id) },
+                                onHover: { hoveredContactId = $0 ? contact.id : nil }
+                            )
+                        }
+
+                        if viewModel.filteredRegularContacts.isEmpty {
+                            VStack(spacing: VSpacing.sm) {
+                                Text("No matching contacts")
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.contentSecondary)
+                                Text("Try a different search term")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.contentTertiary)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, VSpacing.xl)
+                        }
+                    }
+                }
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
@@ -177,22 +188,19 @@ struct ContactsListView: View {
 
     // MARK: - Empty State
 
-    private var emptyState: some View {
+    private var regularContactsEmptyState: some View {
         VStack(spacing: VSpacing.md) {
-            VIconView(.users, size: 32)
+            VIconView(.users, size: 24)
                 .foregroundColor(VColor.contentTertiary)
             Text("No contacts yet")
-                .font(VFont.headline)
-                .foregroundColor(VColor.contentDefault)
-            Text("Contacts are created automatically when people interact with your assistant, or you can add one manually.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 300)
-            VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary) {
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+            VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary, size: .compact) {
                 viewModel.isCreatingContact = true
             }
         }
+        .frame(maxWidth: .infinity)
+        .padding(.top, VSpacing.xl)
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -101,6 +101,30 @@ final class ContactsViewModel: ObservableObject {
         deduplicatedContacts.first { $0.role == "guardian" }
     }
 
+    /// Non-guardian contacts sorted alphabetically.
+    var regularContacts: [ContactPayload] {
+        deduplicatedContacts
+            .filter { $0.role != "guardian" }
+            .sorted { a, b in
+                a.displayName.localizedCaseInsensitiveCompare(b.displayName) == .orderedAscending
+            }
+    }
+
+    /// Regular contacts filtered by the current search query.
+    var filteredRegularContacts: [ContactPayload] {
+        let base = regularContacts
+        guard !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return base
+        }
+        let query = searchQuery.lowercased()
+        return base.filter { contact in
+            if contact.displayName.lowercased().contains(query) { return true }
+            return contact.channels.contains { channel in
+                channel.address.lowercased().contains(query)
+            }
+        }
+    }
+
     // MARK: - Actions
 
     /// Request the list of contacts from the daemon.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -390,7 +390,7 @@ struct SettingsPanel: View {
         case .permissionsAndPrivacy:
             permissionsAndPrivacyContent
         case .contacts:
-            ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled, showToast: showToast)
+            ContactsContainerView(daemonClient: daemonClient, store: store, conversationManager: conversationManager, isEmailEnabled: isEmailEnabled, showToast: showToast)
         case .billing:
             SettingsBillingTab(authManager: authManager)
         case .archivedConversations:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -170,6 +170,7 @@ struct SettingsBillingTab: View {
                     placeholder: "Enter amount",
                     text: $topUpAmount
                 )
+                .frame(maxWidth: 200)
             }
 
             VButton(


### PR DESCRIPTION
## Summary
- Pin assistant and guardian contact cards above the search bar with a divider, so they remain visible regardless of scrolling or search filtering
- Show a compact empty state with "Add Contact" button when there are no regular (non-system) contacts; hide the search bar until contacts exist
- Route channel setup actions (Telegram, Slack, Phone) through conversationManager instead of inline expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
