### PR TITLE
Fix consistent logo positioning and font in onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -21,7 +21,7 @@ struct APIKeyEntryStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Since you skipped creating an account,\nwe\u{2019}ll need your Anthropic API key.")
-            .font(.system(size: 16))
+            .font(VFont.buttonLarge)
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -23,7 +23,7 @@ struct APIKeyStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Where do you want your assistant to run?")
-            .font(.system(size: 16))
+            .font(VFont.buttonLarge)
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -23,7 +23,7 @@ struct ImproveExperienceStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text("Choose your privacy preferences.\nYou can update these anytime in Settings.")
-            .font(.system(size: 16))
+            .font(VFont.buttonLarge)
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
             .opacity(showTitle ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -56,7 +56,7 @@ struct OnboardingFlowView: View {
                 VStack(spacing: 0) {
                     // Fixed top inset — positions the icon consistently
                     // across all steps regardless of bottom content weight.
-                    Color.clear.frame(height: geometry.size.height * 0.08)
+                    Color.clear.frame(height: VSpacing.xxxl)
 
                     if let nsImage = Self.appIcon {
                         Image(nsImage: nsImage)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -249,7 +249,7 @@ struct OnboardingFlowView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Setting up your assistant...")
-                        .font(.system(size: 16))
+                        .font(VFont.buttonLarge)
                         .foregroundColor(VColor.contentSecondary)
                 }
             } else {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -134,13 +134,13 @@ struct OnboardingFlowView: View {
                     .id(isBootstrappingManaged ? -1 : state.currentStep)
 
                     // Bottom padding so content isn't flush with window edge.
-                    // Skip for step 0 (WakeUpStepView) where the characters
+                    // Skip for steps with characters footer (0, 2) where the
                     // graphic is designed to sit flush at the window bottom.
-                    if state.currentStep != 0 || isBootstrappingManaged {
+                    if (state.currentStep != 0 && state.currentStep != 2) || isBootstrappingManaged {
                         Color.clear.frame(height: VSpacing.xxl)
                     }
                 }
-                .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -249,7 +249,7 @@ struct OnboardingFlowView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Setting up your assistant...")
-                        .font(VFont.monoMedium)
+                        .font(.system(size: 16))
                         .foregroundColor(VColor.contentSecondary)
                 }
             } else {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -51,7 +51,7 @@ struct ReauthView: View {
                             .controlSize(.small)
                             .progressViewStyle(.circular)
                         Text("Checking...")
-                            .font(VFont.monoMedium)
+                            .font(.system(size: 16))
                             .foregroundColor(VColor.contentSecondary)
                     }
                     .frame(height: 36)
@@ -61,7 +61,7 @@ struct ReauthView: View {
                             .controlSize(.small)
                             .progressViewStyle(.circular)
                         Text("Logging in...")
-                            .font(VFont.monoMedium)
+                            .font(.system(size: 16))
                             .foregroundColor(VColor.contentSecondary)
                     }
                     .frame(height: 36)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -40,7 +40,7 @@ struct ReauthView: View {
                 .padding(.bottom, VSpacing.xs)
 
             Text("Log in to continue.")
-                .font(.system(size: 16))
+                .font(VFont.buttonLarge)
                 .foregroundColor(VColor.contentSecondary)
                 .padding(.bottom, VSpacing.xxl)
 
@@ -51,7 +51,7 @@ struct ReauthView: View {
                             .controlSize(.small)
                             .progressViewStyle(.circular)
                         Text("Checking...")
-                            .font(.system(size: 16))
+                            .font(VFont.buttonLarge)
                             .foregroundColor(VColor.contentSecondary)
                     }
                     .frame(height: 36)
@@ -61,7 +61,7 @@ struct ReauthView: View {
                             .controlSize(.small)
                             .progressViewStyle(.circular)
                         Text("Logging in...")
-                            .font(.system(size: 16))
+                            .font(VFont.buttonLarge)
                             .foregroundColor(VColor.contentSecondary)
                     }
                     .frame(height: 36)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -64,7 +64,7 @@ struct WakeUpStepView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Checking...")
-                        .font(VFont.monoMedium)
+                        .font(.system(size: 16))
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)
@@ -74,7 +74,7 @@ struct WakeUpStepView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Logging in...")
-                        .font(VFont.monoMedium)
+                        .font(.system(size: 16))
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -43,7 +43,7 @@ struct WakeUpStepView: View {
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
-            .padding(.bottom, VSpacing.xs)
+            .padding(.bottom, VSpacing.md)
 
         // Subtitle
         Text("Your personal AI assistant,\nrunning on your terms.")

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -47,7 +47,7 @@ struct WakeUpStepView: View {
 
         // Subtitle
         Text("Your personal AI assistant,\nrunning on your terms.")
-            .font(.system(size: 16))
+            .font(VFont.buttonLarge)
             .foregroundColor(VColor.contentSecondary)
             .multilineTextAlignment(.center)
             .opacity(showSubtext ? 1 : 0)
@@ -64,7 +64,7 @@ struct WakeUpStepView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Checking...")
-                        .font(.system(size: 16))
+                        .font(VFont.buttonLarge)
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)
@@ -74,7 +74,7 @@ struct WakeUpStepView: View {
                         .controlSize(.small)
                         .progressViewStyle(.circular)
                     Text("Logging in...")
-                        .font(.system(size: 16))
+                        .font(VFont.buttonLarge)
                         .foregroundColor(VColor.contentSecondary)
                 }
                 .frame(height: 36)


### PR DESCRIPTION
## Summary
- Use fixed `VSpacing.xxxl` (48pt) top inset with `.top` alignment so the V logo stays at the exact same position across all onboarding steps
- Standardize title-to-subtitle spacing to `VSpacing.md` (12pt) on WakeUp step to match steps 1-3
- Skip bottom padding for step 2 (APIKeyEntry characters footer)
- Replace `VFont.monoMedium` (DM Mono 16pt) with `.system(size: 16)` in all onboarding loading states to match the subtitle font

## Test plan
- [ ] Verify V logo stays at the same vertical position across all 4 onboarding steps
- [ ] Verify "Checking..." and "Logging in..." text matches subtitle font style
- [ ] Verify characters image sits flush at bottom on steps 0 and 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
