### PR TITLE
Bridge OAuth connections into proxy credential resolver

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -85,6 +85,7 @@ mock.module("../util/platform.js", () => ({
 
 mock.module("../tools/credentials/resolve.js", () => ({
   resolveCredentialRef: () => null,
+  listActiveOAuthConnectionsWithTemplates: () => [],
 }));
 
 mock.module("../tools/network/script-proxy/logging.js", () => ({

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -225,14 +225,14 @@ function buildAccessPreferenceSection(hasNoClient: boolean): string {
     return [
       "## External Service Access",
       "",
-      "Priority: (1) sandbox `bash` — install tools yourself; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).",
+      "Priority: (0) check Connected Services for an existing integration and Available Skills for a setup skill — if the service has an OAuth setup skill, load it instead of improvising; (1) sandbox `bash` — install tools yourself; (2) browser automation as last resort (no API, visual interaction, or OAuth consent).",
     ].join("\n");
   }
 
   return [
     "## External Service Access",
     "",
-    "Priority: (1) sandbox `bash` - install tools yourself, only fall back to host when you need local files/auth; (2) `host_bash` with CLIs (gh, aws, etc.) using --json flags; (3) browser automation as last resort (no API, visual interaction, or OAuth consent).",
+    "Priority: (0) check Connected Services for an existing integration and Available Skills for a setup skill — if the service has an OAuth setup skill, load it instead of improvising; (1) sandbox `bash` - install tools yourself, only fall back to host when you need local files/auth; (2) `host_bash` with CLIs (gh, aws, etc.) using --json flags; (3) browser automation as last resort (no API, visual interaction, or OAuth consent).",
     ...(isMacOS()
       ? [
           "",

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -319,6 +319,45 @@ export async function withValidToken<T>(
   }
 }
 
+/**
+ * Get a valid access token for an OAuth connection, proactively refreshing
+ * if expired or near-expiry. Unlike `withValidToken`, this returns the token
+ * directly without a callback wrapper.
+ *
+ * Used by the proxy rewrite callback to inject fresh OAuth tokens into
+ * outbound requests.
+ *
+ * Returns `undefined` if no token exists or refresh fails.
+ */
+export async function getValidOAuthToken(
+  connectionId: string,
+): Promise<string | undefined> {
+  const conn = getConnection(connectionId);
+  if (!conn || conn.status !== "active") return undefined;
+
+  let token = await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id));
+  if (!token) return undefined;
+
+  // Proactively refresh if expired or about to expire.
+  if (isTokenExpired(conn.expiresAt)) {
+    try {
+      token = await refreshDeduplicator.deduplicate(conn.id, () =>
+        doRefresh(conn.providerKey, conn.id),
+      );
+    } catch (err) {
+      log.warn(
+        { err, connectionId, provider: conn.providerKey },
+        "OAuth token refresh failed during proxy injection",
+      );
+      // Return the stale token — the upstream service may still accept it,
+      // and the proxy should not silently swallow the request.
+      return token;
+    }
+  }
+
+  return token;
+}
+
 function is401Error(err: unknown): boolean {
   if (err && typeof err === "object") {
     if ("status" in err && (err as { status: number }).status === 401)

--- a/assistant/src/tools/credentials/resolve.ts
+++ b/assistant/src/tools/credentials/resolve.ts
@@ -4,10 +4,29 @@
  *
  * This decouples external credential references from the underlying
  * secure key naming convention.
+ *
+ * Supports two credential backends:
+ * 1. **Manual credentials** — stored in the JSON metadata store with secrets
+ *    at `credential/{service}/{field}`.
+ * 2. **OAuth connections** — stored in SQLite (`oauth_connections`) with
+ *    access tokens at `oauth_connection/{connId}/access_token`. Injection
+ *    templates come from `PROVIDER_BEHAVIORS` in `provider-behaviors.ts`.
+ *    These are synthesized as virtual `ResolvedCredential` objects so the
+ *    proxy can inject OAuth tokens transparently.
  */
 
-import { credentialKey } from "@vellumai/credential-storage";
+import {
+  credentialKey,
+  oauthConnectionAccessTokenPath,
+} from "@vellumai/credential-storage";
 
+import {
+  getActiveConnection,
+  getConnection,
+  listConnections,
+  type OAuthConnectionRow,
+} from "../../oauth/oauth-store.js";
+import { getProviderBehavior } from "../../oauth/provider-behaviors.js";
 import { matchHostPattern } from "./host-pattern-match.js";
 import {
   type CredentialMetadata,
@@ -28,6 +47,22 @@ export interface ResolvedCredential {
   /** Injection templates for proxied requests. */
   injectionTemplates: CredentialInjectionTemplate[];
   metadata: CredentialMetadata;
+  /**
+   * When true, this credential is backed by an OAuth connection rather than
+   * a manual credential. The `storageKey` points to
+   * `oauth_connection/{connId}/access_token` and the token may need proactive
+   * refresh before injection.
+   */
+  isOAuthConnection?: boolean;
+  /** The OAuth connection ID, set when `isOAuthConnection` is true. */
+  oauthConnectionId?: string;
+}
+
+/** Quick check for UUID-shaped strings (8-4-4-4-12 hex). */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isPlausibleUuid(s: string): boolean {
+  return UUID_RE.test(s);
 }
 
 function toResolved(metadata: CredentialMetadata): ResolvedCredential {
@@ -43,6 +78,44 @@ function toResolved(metadata: CredentialMetadata): ResolvedCredential {
 }
 
 /**
+ * Synthesize a `ResolvedCredential` from an active OAuth connection and its
+ * provider behavior. Returns `undefined` if the provider has no injection
+ * templates defined.
+ */
+function oauthConnectionToResolved(
+  conn: OAuthConnectionRow,
+): ResolvedCredential | undefined {
+  const behavior = getProviderBehavior(conn.providerKey);
+  const templates = behavior?.injectionTemplates;
+  if (!templates || templates.length === 0) return undefined;
+
+  // Build a synthetic CredentialMetadata so existing code that reads
+  // `resolved.metadata` doesn't break.
+  const syntheticMetadata: CredentialMetadata = {
+    credentialId: conn.id,
+    service: conn.providerKey,
+    field: "oauth_access_token",
+    allowedTools: [],
+    allowedDomains: [],
+    injectionTemplates: templates,
+    createdAt: typeof conn.createdAt === "number" ? conn.createdAt : Date.now(),
+    updatedAt: typeof conn.updatedAt === "number" ? conn.updatedAt : Date.now(),
+  };
+
+  return {
+    credentialId: conn.id,
+    service: conn.providerKey,
+    field: "oauth_access_token",
+    storageKey: oauthConnectionAccessTokenPath(conn.id),
+    alias: conn.accountInfo ?? undefined,
+    injectionTemplates: templates,
+    metadata: syntheticMetadata,
+    isOAuthConnection: true,
+    oauthConnectionId: conn.id,
+  };
+}
+
+/**
  * Resolve a credential by service and field.
  * Returns the resolved credential or undefined if not found.
  */
@@ -51,8 +124,20 @@ export function resolveByServiceField(
   field: string,
 ): ResolvedCredential | undefined {
   const metadata = getCredentialMetadata(service, field);
-  if (!metadata) return undefined;
-  return toResolved(metadata);
+  if (metadata) return toResolved(metadata);
+
+  // Fall back to OAuth connection: treat the service as a provider key
+  // (e.g. "integration:linear") with the synthetic field "oauth_access_token".
+  if (field === "oauth_access_token") {
+    try {
+      const conn = getActiveConnection(service);
+      if (conn) return oauthConnectionToResolved(conn);
+    } catch {
+      // DB not available
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -62,16 +147,32 @@ export function resolveByServiceField(
 export function resolveById(
   credentialId: string,
 ): ResolvedCredential | undefined {
+  // Try manual credential metadata first
   const metadata = getCredentialMetadataById(credentialId);
-  if (!metadata) return undefined;
-  return toResolved(metadata);
+  if (metadata) return toResolved(metadata);
+
+  // Fall back to OAuth connection by UUID.
+  // Only attempt the DB lookup for plausible UUIDs to avoid spurious queries
+  // for service/field-style refs like "fal/api_key".
+  if (isPlausibleUuid(credentialId)) {
+    try {
+      const conn = getConnection(credentialId);
+      if (conn && conn.status === "active") {
+        return oauthConnectionToResolved(conn);
+      }
+    } catch {
+      // DB not available (e.g. during tests or early startup)
+    }
+  }
+
+  return undefined;
 }
 
 /**
  * Resolve a credential reference that may be either a UUID or a "service/field" string.
  *
  * Resolution order:
- * 1. Try as UUID via resolveById
+ * 1. Try as UUID via resolveById (checks both manual credentials and OAuth connections)
  * 2. If not found, try parsing as "service/field" via resolveByServiceField
  *
  * Returns undefined for malformed refs (e.g. no slash, too many slashes, empty segments)
@@ -101,12 +202,15 @@ export function resolveCredentialRef(
  * Find all credentials whose injection templates match a given hostname.
  * Returns resolved credentials with their `injectionTemplates` filtered
  * to only the matching entries.
+ *
+ * Checks both manual credentials and active OAuth connections.
  */
 export function resolveForDomain(hostname: string): ResolvedCredential[] {
-  const all = listCredentialMetadata();
   const results: ResolvedCredential[] = [];
+  const seenIds = new Set<string>();
 
-  for (const meta of all) {
+  // 1. Manual credentials from metadata store
+  for (const meta of listCredentialMetadata()) {
     const templates = meta.injectionTemplates ?? [];
     const matching = templates.filter(
       (t) =>
@@ -115,11 +219,53 @@ export function resolveForDomain(hostname: string): ResolvedCredential[] {
         }) !== "none",
     );
     if (matching.length === 0) continue;
+    seenIds.add(meta.credentialId);
     results.push({
       ...toResolved(meta),
       injectionTemplates: matching,
     });
   }
 
+  // 2. Active OAuth connections with injection templates
+  for (const conn of listActiveOAuthConnectionsWithTemplates()) {
+    if (seenIds.has(conn.id)) continue;
+    const behavior = getProviderBehavior(conn.providerKey);
+    const templates = behavior?.injectionTemplates ?? [];
+    const matching = templates.filter(
+      (t) =>
+        matchHostPattern(hostname, t.hostPattern, {
+          includeApexForWildcard: true,
+        }) !== "none",
+    );
+    if (matching.length === 0) continue;
+    const resolved = oauthConnectionToResolved(conn);
+    if (!resolved) continue;
+    results.push({
+      ...resolved,
+      injectionTemplates: matching,
+    });
+  }
+
   return results;
+}
+
+/**
+ * List all active OAuth connections that have injection templates defined
+ * in their provider behavior. Used by the proxy to auto-discover OAuth
+ * credentials for injection.
+ */
+export function listActiveOAuthConnectionsWithTemplates(): OAuthConnectionRow[] {
+  try {
+    return listConnections()
+      .filter((c) => c.status === "active")
+      .filter((c) => {
+        const behavior = getProviderBehavior(c.providerKey);
+        return (
+          behavior?.injectionTemplates && behavior.injectionTemplates.length > 0
+        );
+      });
+  } catch {
+    // DB not available (e.g. during tests or early startup)
+    return [];
+  }
 }

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -32,6 +32,7 @@ import {
   stripQueryString,
 } from "../../../outbound-proxy/index.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
+import { getValidOAuthToken } from "../../../security/token-manager.js";
 import { getLogger } from "../../../util/logger.js";
 import {
   compareMatchSpecificity,
@@ -41,6 +42,7 @@ import {
 import { listCredentialMetadata } from "../../credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../../credentials/policy-types.js";
 import {
+  listActiveOAuthConnectionsWithTemplates,
   resolveById,
   resolveByServiceField,
   type ResolvedCredential,
@@ -125,6 +127,19 @@ function resolveInjectionTemplates(
 ): CredentialInjectionTemplate[] {
   if (!resolved) return [];
   return resolved.injectionTemplates;
+}
+
+/**
+ * Fetch the secret value for a resolved credential. For OAuth-backed
+ * credentials, proactively refreshes the token if near expiry.
+ */
+async function getCredentialValue(
+  resolved: ResolvedCredential,
+): Promise<string | undefined> {
+  if (resolved.isOAuthConnection && resolved.oauthConnectionId) {
+    return getValidOAuthToken(resolved.oauthConnectionId);
+  }
+  return getSecureKeyAsync(resolved.storageKey);
 }
 
 // ---------------------------------------------------------------------------
@@ -238,7 +253,7 @@ function buildSessionStartHooks(): SessionStartHooks {
             if (tpl.injectionType === "header" && tpl.headerName) {
               const resolved = resolveById(credId);
               if (!resolved) return req.headers;
-              const value = await getSecureKeyAsync(resolved.storageKey);
+              const value = await getCredentialValue(resolved);
               if (!value) return req.headers;
 
               const headerValue = await buildInjectedValue(tpl, value);
@@ -267,9 +282,17 @@ function buildSessionStartHooks(): SessionStartHooks {
         const now = Date.now();
         if (!allKnownCache || now - allKnownCacheTime > CACHE_TTL_MS) {
           allKnownCache = [];
+          // Manual credentials
           for (const meta of listCredentialMetadata()) {
             if (meta.injectionTemplates?.length) {
               allKnownCache.push(...meta.injectionTemplates);
+            }
+          }
+          // OAuth connections with provider-defined injection templates
+          for (const conn of listActiveOAuthConnectionsWithTemplates()) {
+            const resolved = resolveById(conn.id);
+            if (resolved?.injectionTemplates?.length) {
+              allKnownCache.push(...resolved.injectionTemplates);
             }
           }
           allKnownCacheTime = now;
@@ -317,7 +340,7 @@ function buildSessionStartHooks(): SessionStartHooks {
             const { credentialId, template } = decision;
             const resolved = resolveById(credentialId);
             if (!resolved) return {};
-            const value = await getSecureKeyAsync(resolved.storageKey);
+            const value = await getCredentialValue(resolved);
             if (!value) return {};
 
             if (template.injectionType === "header" && template.headerName) {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -9,7 +9,10 @@ import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir, getRootDir } from "../../util/platform.js";
-import { resolveCredentialRef } from "../credentials/resolve.js";
+import {
+  listActiveOAuthConnectionsWithTemplates,
+  resolveCredentialRef,
+} from "../credentials/resolve.js";
 import {
   getOrStartSession,
   getSessionEnv,
@@ -242,6 +245,19 @@ class ShellTool implements Tool {
       );
     } else {
       credentialIds.push(...rawCredentialRefs);
+    }
+
+    // Auto-discover active OAuth connections with injection templates.
+    // These are included automatically so the proxy can inject OAuth tokens
+    // without the model needing to explicitly pass credential_ids.
+    if (networkMode === "proxied" && !shellLockdownActive) {
+      const seenIds = new Set(credentialIds);
+      for (const conn of listActiveOAuthConnectionsWithTemplates()) {
+        if (!seenIds.has(conn.id)) {
+          seenIds.add(conn.id);
+          credentialIds.push(conn.id);
+        }
+      }
     }
 
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -303,6 +303,11 @@
           "feature-flag": "integration-linear",
           "includes": [
             "collaborative-oauth-flow"
+          ],
+          "activation-hints": [
+            "Create, update, or manage Linear issues",
+            "Interact with Linear workspace, projects, or teams",
+            "User mentions Linear (load for both setup and API usage guidance)"
           ]
         }
       },

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -8,6 +8,10 @@ metadata:
     display-name: "Linear OAuth Setup"
     feature-flag: "integration-linear"
     includes: ["collaborative-oauth-flow"]
+    activation-hints:
+      - "Create, update, or manage Linear issues"
+      - "Interact with Linear workspace, projects, or teams"
+      - "User mentions Linear (load for both setup and API usage guidance)"
 ---
 
 You are helping your user set up Linear OAuth credentials so the Linear integration can connect to their workspace.
@@ -159,6 +163,58 @@ bash:
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."
+
+---
+
+## Using the Linear API (After Setup)
+
+If `integration:linear` already appears in Connected Services, skip the setup flow above and use the API directly.
+
+**Getting a valid token:** Use the `assistant oauth connections token` CLI command. Do NOT use `assistant credentials reveal` — OAuth tokens are managed separately from manual credentials.
+
+```bash
+assistant oauth connections token integration:linear
+```
+
+**Making API calls:** Linear uses a GraphQL API at `https://api.linear.app/graphql`. Use shell substitution to inject the token:
+
+```bash
+curl -s -X POST https://api.linear.app/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(assistant oauth connections token integration:linear)" \
+  -d '{"query":"{ viewer { id name email } }"}'
+```
+
+**Common operations:**
+
+Create an issue:
+```bash
+curl -s -X POST https://api.linear.app/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(assistant oauth connections token integration:linear)" \
+  -d '{"query":"mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier title url } } }", "variables":{"input":{"teamId":"<TEAM_ID>","title":"<TITLE>","description":"<DESC>","assigneeId":"<USER_ID>"}}}'
+```
+
+Look up teams and users (needed for creating issues):
+```bash
+curl -s -X POST https://api.linear.app/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(assistant oauth connections token integration:linear)" \
+  -d '{"query":"{ teams { nodes { id name key } } users { nodes { id name email } } }"}'
+```
+
+Search issues:
+```bash
+curl -s -X POST https://api.linear.app/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $(assistant oauth connections token integration:linear)" \
+  -d '{"query":"{ issueSearch(query: \"<SEARCH_TERM>\") { nodes { id identifier title state { name } assignee { name } url } } }"}'
+```
+
+**Important:**
+- Use `network_mode: proxied` for network access (required for outbound HTTP from the sandbox).
+- Do NOT pass `credential_ids` — OAuth tokens are not in the credential store. Instead, inject the token via shell substitution using `$(assistant oauth connections token integration:linear)` in the Authorization header.
+- Do NOT use `assistant credentials reveal` — that command is for manually stored API keys, not OAuth tokens. Always use `assistant oauth connections token`.
 
 ---
 

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -188,6 +188,7 @@ curl -s -X POST https://api.linear.app/graphql \
 **Common operations:**
 
 Create an issue:
+
 ```bash
 curl -s -X POST https://api.linear.app/graphql \
   -H "Content-Type: application/json" \
@@ -196,6 +197,7 @@ curl -s -X POST https://api.linear.app/graphql \
 ```
 
 Look up teams and users (needed for creating issues):
+
 ```bash
 curl -s -X POST https://api.linear.app/graphql \
   -H "Content-Type: application/json" \
@@ -204,6 +206,7 @@ curl -s -X POST https://api.linear.app/graphql \
 ```
 
 Search issues:
+
 ```bash
 curl -s -X POST https://api.linear.app/graphql \
   -H "Content-Type: application/json" \
@@ -212,6 +215,7 @@ curl -s -X POST https://api.linear.app/graphql \
 ```
 
 **Important:**
+
 - Use `network_mode: proxied` for network access (required for outbound HTTP from the sandbox).
 - Do NOT pass `credential_ids` — OAuth tokens are not in the credential store. Instead, inject the token via shell substitution using `$(assistant oauth connections token integration:linear)` in the Authorization header.
 - Do NOT use `assistant credentials reveal` — that command is for manually stored API keys, not OAuth tokens. Always use `assistant oauth connections token`.


### PR DESCRIPTION
## Summary

- **OAuth tokens are now auto-injected by the proxy** for connected services (Linear, Notion, etc.). Previously, OAuth connections stored in SQLite were invisible to the proxy's credential resolver (which only checked the JSON metadata store), causing proxied requests to hang or forcing the model to manually fetch tokens.
- **Credential resolver extended with OAuth fallback**: `resolveById`, `resolveByServiceField`, and `resolveForDomain` now synthesize virtual `ResolvedCredential` objects from active OAuth connections, pulling injection templates from `PROVIDER_BEHAVIORS`.
- **Token refresh integrated into proxy injection**: new `getValidOAuthToken()` proactively refreshes expired tokens before injection, replacing bare `getSecureKeyAsync` calls for OAuth-backed credentials.
- **Auto-discovery in shell tool**: proxied sessions automatically include active OAuth connections with injection templates, so the model doesn't need to pass explicit `credential_ids`.
- **Linear OAuth skill improved**: added activation hints so the skill loads when the user mentions Linear, and added API usage guide with correct commands (`assistant oauth connections token` instead of `assistant credentials reveal`).
- **System prompt updated**: access preference guidance now includes priority step (0) — check Connected Services and Available Skills before improvising with browser automation.

## Test plan

- [x] `credential-resolve.test.ts` — 31/31 passing
- [x] `shell-credential-ref.test.ts` — 6/6 passing
- [x] `shell-tool-proxy-mode.test.ts` — 9/9 passing
- [x] `script-proxy-injection-runtime.test.ts` — passing
- [x] `script-proxy-policy-runtime.test.ts` — passing
- [x] `credential-security-invariants.test.ts` — 35/35 passing
- [x] TypeScript compilation clean (no errors in changed files)
- [ ] Manual test: connect Linear OAuth, then `curl api.linear.app/graphql` via proxied bash — verify token auto-injected
- [ ] Manual test: verify Notion OAuth proxy injection works similarly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
