### PR TITLE
Add PlatformOAuthService for Google OAuth platform API calls

### DIFF
--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -41,10 +41,6 @@ public struct OAuthConnectionEntry: Codable, Sendable {
     }
 }
 
-public struct OAuthDisconnectResponse: Codable, Sendable {
-    public let success: Bool
-}
-
 // MARK: - Service
 
 @MainActor
@@ -169,6 +165,7 @@ public final class PlatformOAuthService {
 
         var urlRequest = try await authenticatedRequest(url: url, method: "POST")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = "{}".data(using: .utf8)
 
         let data: Data
         let response: URLResponse

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -51,6 +51,27 @@ public final class PlatformOAuthService {
 
     // MARK: - Private Helpers
 
+    /// Resolve the platform base URL for the connected assistant.
+    ///
+    /// On macOS, reads the lockfile `runtimeUrl` for the connected assistant
+    /// (same resolution as `GatewayHTTPClient`) so that staging, self-hosted,
+    /// or `VELLUM_PLATFORM_URL`-overridden connections hit the correct host.
+    /// Falls back to `resolvePlatformBaseURL()` when no override is stored.
+    private func resolvePlatformBaseURL() -> String {
+        #if os(macOS)
+        if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty,
+           let assistant = LockfileAssistant.loadByName(id),
+           let runtimeUrl = assistant.runtimeUrl {
+            return runtimeUrl
+        }
+        #else
+        if let url = UserDefaults.standard.string(forKey: "managed_platform_base_url"), !url.isEmpty {
+            return url
+        }
+        #endif
+        return resolvePlatformBaseURL()
+    }
+
     private func authenticatedRequest(url: URL, method: String) async throws -> URLRequest {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
@@ -74,7 +95,7 @@ public final class PlatformOAuthService {
 
     /// Start a Google OAuth flow for the given assistant.
     public func startGoogleOAuth(assistantId: String, redirectAfterConnect: String? = nil) async throws -> OAuthStartResponse {
-        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/google/start/"
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/google/start/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -120,7 +141,7 @@ public final class PlatformOAuthService {
 
     /// List OAuth connections for the given assistant.
     public func listConnections(assistantId: String) async throws -> [OAuthConnectionEntry] {
-        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/connections/"
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/connections/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -158,7 +179,7 @@ public final class PlatformOAuthService {
 
     /// Disconnect a specific OAuth connection for the given assistant.
     public func disconnectConnection(assistantId: String, connectionId: String) async throws {
-        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/"
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -56,7 +56,7 @@ public final class PlatformOAuthService {
     /// On macOS, reads the lockfile `runtimeUrl` for the connected assistant
     /// (same resolution as `GatewayHTTPClient`) so that staging, self-hosted,
     /// or `VELLUM_PLATFORM_URL`-overridden connections hit the correct host.
-    /// Falls back to `resolvePlatformBaseURL()` when no override is stored.
+    /// Falls back to `AuthService.shared.baseURL` when no override is stored.
     private func resolvePlatformBaseURL() -> String {
         #if os(macOS)
         if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty,
@@ -69,7 +69,7 @@ public final class PlatformOAuthService {
             return url
         }
         #endif
-        return resolvePlatformBaseURL()
+        return AuthService.shared.baseURL
     }
 
     private func authenticatedRequest(url: URL, method: String) async throws -> URLRequest {

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -1,0 +1,195 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "PlatformOAuthService")
+
+// MARK: - Response Types
+
+public struct OAuthStartResponse: Codable, Sendable {
+    public let success: Bool
+    public let deferred: Bool
+    public let provider: String
+    public let connect_url: String
+    public let state_id: String?
+
+    enum CodingKeys: String, CodingKey {
+        case success
+        case deferred
+        case provider
+        case connect_url
+        case state_id
+    }
+}
+
+public struct OAuthConnectionEntry: Codable, Sendable {
+    public let id: String
+    public let provider: String
+    public let status: String
+    public let connected: Bool
+    public let account_label: String?
+    public let scopes_granted: [String]?
+    public let expires_at: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case provider
+        case status
+        case connected
+        case account_label
+        case scopes_granted
+        case expires_at
+    }
+}
+
+public struct OAuthDisconnectResponse: Codable, Sendable {
+    public let success: Bool
+}
+
+// MARK: - Service
+
+@MainActor
+public final class PlatformOAuthService {
+    public static let shared = PlatformOAuthService()
+
+    private init() {}
+
+    // MARK: - Private Helpers
+
+    private func authenticatedRequest(url: URL, method: String) async throws -> URLRequest {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        return urlRequest
+    }
+
+    // MARK: - Public Methods
+
+    /// Start a Google OAuth flow for the given assistant.
+    public func startGoogleOAuth(assistantId: String, redirectAfterConnect: String? = nil) async throws -> OAuthStartResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/google/start/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = try await authenticatedRequest(url: url, method: "POST")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let redirectValue = redirectAfterConnect ?? "/"
+        let body: [String: Any] = [
+            "requested_scopes": [] as [String],
+            "redirect_after_connect": redirectValue
+        ]
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/oauth/google/start/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(OAuthStartResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// List OAuth connections for the given assistant.
+    public func listConnections(assistantId: String) async throws -> [OAuthConnectionEntry] {
+        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/connections/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        let urlRequest = try await authenticatedRequest(url: url, method: "GET")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET assistants/\(assistantId)/oauth/connections/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode([OAuthConnectionEntry].self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Disconnect a specific OAuth connection for the given assistant.
+    public func disconnectConnection(assistantId: String, connectionId: String) async throws {
+        let urlString = "\(AuthService.shared.baseURL)/v1/assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = try await authenticatedRequest(url: url, method: "POST")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+    }
+}


### PR DESCRIPTION
Add a new platform API client service for managed Google OAuth operations. Follows the BillingService pattern with X-Session-Token auth. Provides startGoogleOAuth, listConnections, and disconnectConnection methods. Part of #18867.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
