### PR TITLE
fix: replace Label(systemImage:) with VIconView in context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -299,7 +299,11 @@ struct AgentPanelContent: View {
             Button(role: .destructive) {
                 skillToDelete = skill
             } label: {
-                Label("Remove", systemImage: "trash")
+                Label {
+                    Text("Remove")
+                } icon: {
+                    VIconView(.trash, size: 12)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap: context menu uses Label(systemImage: "trash") which violates the VIconView rule in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
