### PR TITLE
fix: hide system-managed capability memories from Memories UI

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -103,6 +103,8 @@ export function handleListMemoryItems(url: URL): Response {
 
   // Build WHERE conditions
   const conditions = [];
+  // Hide system-managed capability memories (skill announcements) from the UI
+  conditions.push(ne(memoryItems.kind, "capability"));
   if (statusParam && statusParam !== "all") {
     conditions.push(eq(memoryItems.status, statusParam));
   }


### PR DESCRIPTION
## Summary
- Skill capability memories (`kind=capability`) are seeded on daemon startup for internal recall — they let the assistant know what skills are available via semantic search
- These are system-managed, not user-created, and shouldn't clutter the Intelligence > Memories UI
- Filters them out of the `GET /v1/memory-items` list endpoint

## Test plan
- [ ] Open Intelligence > Memories and verify no `Capability` entries appear
- [ ] Verify the assistant can still recall skill capabilities during conversation (internal recall unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
