### PR TITLE
Replace Coming Soon with managed Google OAuth connect and connection rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -436,7 +436,7 @@ struct SettingsPanel: View {
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                GoogleOAuthServiceCard(store: store)
+                GoogleOAuthServiceCard(store: store, authManager: authManager)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -3,11 +3,13 @@ import VellumAssistantShared
 
 /// Card for the Google OAuth service with Managed/Your Own mode toggle.
 ///
-/// Both modes currently show a "Coming Soon" empty state.
+/// Managed mode shows a connect flow for linking Google accounts.
+/// Your Own mode shows a "Coming Soon" empty state.
 /// The mode selection is persisted so user preference is retained.
 @MainActor
 struct GoogleOAuthServiceCard: View {
     @ObservedObject var store: SettingsStore
+    var authManager: AuthManager
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -15,6 +17,10 @@ struct GoogleOAuthServiceCard: View {
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
         draftMode != store.googleOAuthMode
+    }
+
+    private var isLoggedIn: Bool {
+        authManager.isAuthenticated
     }
 
     var body: some View {
@@ -28,7 +34,7 @@ struct GoogleOAuthServiceCard: View {
             onReset: nil,
             showReset: false,
             managedContent: {
-                comingSoonState
+                managedBody
             },
             yourOwnContent: {
                 comingSoonState
@@ -36,9 +42,98 @@ struct GoogleOAuthServiceCard: View {
         )
         .onAppear {
             draftMode = store.googleOAuthMode
+            if store.googleOAuthMode == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
         }
         .onChange(of: store.googleOAuthMode) { _, newValue in
             draftMode = newValue
+            if newValue == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
+        }
+    }
+
+    // MARK: - Managed Content
+
+    @ViewBuilder
+    private var managedBody: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if !isLoggedIn {
+                managedLoginPrompt
+            } else if !store.googleOAuthConnections.isEmpty {
+                managedConnectionsList
+            } else if store.googleOAuthIsConnecting {
+                managedConnectingState
+            } else {
+                VButton(label: "Connect Google Account", style: .primary) {
+                    store.startGoogleOAuthConnect()
+                }
+            }
+
+            if let error = store.googleOAuthError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    private var managedLoginPrompt: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Log in to Vellum to connect Google.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+            VButton(
+                label: authManager.isSubmitting ? "Logging in..." : "Log In",
+                style: .primary,
+                isDisabled: authManager.isSubmitting
+            ) {
+                Task { await authManager.startWorkOSLogin() }
+            }
+        }
+    }
+
+    private var managedConnectingState: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VButton(label: "Connect Google Account", style: .primary, isDisabled: true) {}
+            Text("Waiting for authorization...")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+        }
+    }
+
+    private var managedConnectionsList: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            ForEach(store.googleOAuthConnections, id: \.id) { entry in
+                connectionRow(for: entry)
+            }
+            VButton(label: "Connect Another Account", style: .outlined) {
+                store.startGoogleOAuthConnect()
+            }
+        }
+    }
+
+    private func connectionRow(for entry: OAuthConnectionEntry) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.account_label ?? "Google Account")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                if let scopes = entry.scopes_granted, !scopes.isEmpty {
+                    Text(scopes.joined(separator: ", "))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            Text("Connected")
+                .font(VFont.caption)
+                .foregroundColor(VColor.systemPositiveStrong)
+            VButton(label: "Disconnect", style: .danger) {
+                store.disconnectGoogleOAuthConnection(entry.id)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -52,6 +52,11 @@ struct GoogleOAuthServiceCard: View {
                 Task { await store.fetchGoogleOAuthConnections() }
             }
         }
+        .onChange(of: isLoggedIn) { _, loggedIn in
+            if loggedIn && draftMode == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
+        }
     }
 
     // MARK: - Managed Content
@@ -108,8 +113,13 @@ struct GoogleOAuthServiceCard: View {
             ForEach(store.googleOAuthConnections, id: \.id) { entry in
                 connectionRow(for: entry)
             }
-            VButton(label: "Connect Another Account", style: .outlined) {
+            VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.googleOAuthIsConnecting) {
                 store.startGoogleOAuthConnect()
+            }
+            if store.googleOAuthIsConnecting {
+                Text("Waiting for authorization...")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
             }
         }
     }


### PR DESCRIPTION
Replace the Coming Soon placeholder in GoogleOAuthServiceCard managed mode with a working OAuth connect flow. Shows login prompt when not authenticated, connect button when logged in, connection rows with account info and disconnect buttons after connecting. Supports multiple Google connections. Part of #18867.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
