### PR TITLE
feat: move Contacts tab to Intelligence panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -426,7 +426,7 @@ struct AssistantChannelsDetailView: View {
 
                     // Inline disconnect X button
                     if let channelKey {
-                        VButton(label: "Disconnect", style: .dangerGhost, isDisabled: isDisconnectDisabled) {
+                        VButton(label: "Disconnect", style: .danger, isDisabled: isDisconnectDisabled) {
                             onDisconnect?(channelKey)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -426,7 +426,7 @@ struct AssistantChannelsDetailView: View {
 
                     // Inline disconnect X button
                     if let channelKey {
-                        VButton(label: "Disconnect", style: .dangerGhost, size: .compact, isDisabled: isDisconnectDisabled) {
+                        VButton(label: "Disconnect", style: .dangerGhost, isDisabled: isDisconnectDisabled) {
                             onDisconnect?(channelKey)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -426,7 +426,7 @@ struct AssistantChannelsDetailView: View {
 
                     // Inline disconnect X button
                     if let channelKey {
-                        VButton(label: "Disconnect", iconOnly: VIcon.x.rawValue, style: .danger, isDisabled: isDisconnectDisabled, tooltip: "Disconnect") {
+                        VButton(label: "Disconnect", style: .dangerGhost, size: .compact, isDisabled: isDisconnectDisabled) {
                             onDisconnect?(channelKey)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -126,10 +126,11 @@ struct ContactDetailView: View {
             }
             Spacer()
             VButton(
-                label: "Delete Contact",
-                leftIcon: VIcon.trash.rawValue,
+                label: "Delete",
+                iconOnly: VIcon.trash.rawValue,
                 style: .dangerGhost,
-                isDisabled: isDeleting
+                isDisabled: isDeleting,
+                tooltip: "Delete Contact"
             ) {
                 // Skip confirmation for empty/placeholder contacts
                 if displayContact.displayName == "New Contact" && displayContact.channels.isEmpty && displayContact.interactionCount == 0 {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -49,6 +49,8 @@ struct ContactDetailView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .contentMargins(0)
         .confirmationDialog(
             "Delete \(displayContact.displayName)?",
             isPresented: $showDeleteConfirmation,

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -33,7 +33,6 @@ struct ContactDetailView: View {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 headerSection
                     .padding(VSpacing.lg)
-                    .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                 GuardianChannelsDetailView(
                     contact: displayContact,
@@ -43,7 +42,6 @@ struct ContactDetailView: View {
                     showCardBorders: false
                 )
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                 if let errorMessage {
                     VInlineMessage(errorMessage)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -32,7 +32,8 @@ struct ContactDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 headerSection
-                    .padding(VSpacing.lg)
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.lg)
 
                 GuardianChannelsDetailView(
                     contact: displayContact,

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -56,7 +56,8 @@ struct ContactsContainerView: View {
                 .frame(maxHeight: .infinity)
                 .shadow(color: VColor.auxBlack.opacity(0.08), radius: 2, x: 1, y: 0)
 
-            // Right pane: detail, loading, or placeholder
+            // Right pane: detail, loading, or placeholder (max 700pt, left-aligned)
+            VStack(alignment: .leading, spacing: 0) {
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 // Skeleton loading state for detail pane
                 ScrollView {
@@ -152,6 +153,9 @@ struct ContactsContainerView: View {
                     .background(VColor.surfaceOverlay)
                 }
             }
+            }
+            .frame(maxWidth: 700, maxHeight: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
         .onReceive(viewModel.$contacts) { newContacts in
             // Default to assistant on first load (don't override existing selection)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -54,7 +54,7 @@ struct ContactsContainerView: View {
             VColor.borderDisabled
                 .frame(width: 1)
                 .frame(maxHeight: .infinity)
-                .shadow(color: Color.black.opacity(0.08), radius: 2, x: 1, y: 0)
+                .shadow(color: VColor.auxBlack.opacity(0.08), radius: 2, x: 1, y: 0)
 
             // Right pane: detail, loading, or placeholder
             if viewModel.isLoading && viewModel.contacts.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -301,11 +301,20 @@ struct ContactsContainerView: View {
 
     @State private var cachedAssistantName: String = AssistantDisplayName.placeholder
 
-    /// Assistant detail — channels card only (top summary tile removed per design review).
+    /// Assistant detail — header + channels.
     @ViewBuilder
     private var assistantDetailView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Header matching contact/guardian detail pattern
+                HStack(spacing: VSpacing.sm) {
+                    Text(cachedAssistantName)
+                        .font(VFont.display)
+                        .foregroundColor(VColor.contentDefault)
+                    ContactTypeBadge(role: "assistant")
+                }
+                .padding(.horizontal, VSpacing.lg)
+
                 if let store {
                     AssistantChannelsDetailView(store: store, daemonClient: daemonClient, conversationManager: conversationManager, assistantName: cachedAssistantName, isEmailEnabled: isEmailEnabled, showCardBorders: false)
                         .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -34,7 +34,7 @@ struct ContactsContainerView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: VSpacing.lg) {
+        HStack(alignment: .top, spacing: 0) {
             // Left pane: contacts list (full height, internal scrolling)
             VStack(spacing: VSpacing.sm) {
                 ContactsListView(
@@ -49,6 +49,13 @@ struct ContactsContainerView: View {
             }
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
+
+            // Thin vertical separator with shadow
+            VColor.borderDisabled
+                .frame(width: 1)
+                .frame(maxHeight: .infinity)
+                .shadow(color: Color.black.opacity(0.08), radius: 2, x: 1, y: 0)
+
             // Right pane: detail, loading, or placeholder
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 // Skeleton loading state for detail pane
@@ -74,7 +81,6 @@ struct ContactsContainerView: View {
                             VSkeletonBone(width: 60, height: 28, radius: VRadius.md)
                         }
                         .padding(VSpacing.lg)
-                        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                         // Channels card skeleton
                         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -97,7 +103,6 @@ struct ContactsContainerView: View {
                             }
                         }
                         .padding(VSpacing.lg)
-                        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -226,7 +231,6 @@ struct ContactsContainerView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
 
                 GuardianChannelsDetailView(
                     contact: contact,
@@ -236,7 +240,6 @@ struct ContactsContainerView: View {
                     showCardBorders: false
                 )
                 .padding(VSpacing.lg)
-                .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
             }
         }
         .id(contact.id)
@@ -299,7 +302,6 @@ struct ContactsContainerView: View {
                 if let store {
                     AssistantChannelsDetailView(store: store, daemonClient: daemonClient, conversationManager: conversationManager, assistantName: cachedAssistantName, isEmailEnabled: isEmailEnabled, showCardBorders: false)
                         .padding(VSpacing.lg)
-                        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -308,7 +308,7 @@ struct ContactsContainerView: View {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 // Header matching contact/guardian detail pattern
                 HStack(spacing: VSpacing.sm) {
-                    Text(cachedAssistantName)
+                    Text("\(cachedAssistantName) (Your Assistant)")
                         .font(VFont.display)
                         .foregroundColor(VColor.contentDefault)
                     ContactTypeBadge(role: "assistant")

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -234,7 +234,8 @@ struct ContactsContainerView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(VSpacing.lg)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.bottom, VSpacing.lg)
 
                 GuardianChannelsDetailView(
                     contact: contact,
@@ -305,7 +306,8 @@ struct ContactsContainerView: View {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 if let store {
                     AssistantChannelsDetailView(store: store, daemonClient: daemonClient, conversationManager: conversationManager, assistantName: cachedAssistantName, isEmailEnabled: isEmailEnabled, showCardBorders: false)
-                        .padding(VSpacing.lg)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.bottom, VSpacing.lg)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -247,6 +247,8 @@ struct ContactsContainerView: View {
                 .padding(VSpacing.lg)
             }
         }
+        .scrollContentBackground(.hidden)
+        .contentMargins(0)
         .id(contact.id)
         .onAppear {
             guardianEditedName = contact.displayName
@@ -311,6 +313,8 @@ struct ContactsContainerView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .contentMargins(0)
         .task {
             cachedAssistantName = AssistantDisplayName.firstUserFacing(from: [IdentityInfo.load()?.name]) ?? AssistantDisplayName.placeholder
         }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -36,14 +36,10 @@ struct ContactsListView: View {
 
     private var contactsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            Text("Contacts")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.contentEmphasized)
-
-            // Sticky system contacts (always visible, not affected by search)
+            // System contacts (always visible, not affected by search)
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 contactListRow(
-                    name: cachedAssistantDisplayName,
+                    name: "Your Assistant",
                     role: "assistant",
                     isSelected: selection == .assistant,
                     isHovered: isAssistantHovered,
@@ -53,7 +49,7 @@ struct ContactsListView: View {
 
                 if let guardian = viewModel.guardianContact {
                     contactListRow(
-                        name: "\(guardian.displayName) (You)",
+                        name: "You",
                         role: guardian.role,
                         isSelected: selection == .contact(guardian.id),
                         isHovered: hoveredContactId == guardian.id,
@@ -66,8 +62,12 @@ struct ContactsListView: View {
             Divider()
 
             if viewModel.regularContacts.isEmpty {
-                regularContactsEmptyState
+                // No contacts yet — show full-width add button
+                VButton(label: "Add Contact", leftIcon: VIcon.user.rawValue, style: .outlined, isFullWidth: true) {
+                    viewModel.isCreatingContact = true
+                }
             } else {
+                // Search + Add button
                 HStack(spacing: VSpacing.sm) {
                     searchBar
                     VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
@@ -182,23 +182,6 @@ struct ContactsListView: View {
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
         .accessibilityHidden(true)
-    }
-
-    // MARK: - Empty State
-
-    private var regularContactsEmptyState: some View {
-        VStack(spacing: VSpacing.md) {
-            VIconView(.users, size: 24)
-                .foregroundColor(VColor.contentTertiary)
-            Text("No contacts yet")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentSecondary)
-            VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary, size: .compact) {
-                viewModel.isCreatingContact = true
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.top, VSpacing.xl)
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -105,7 +105,8 @@ struct ContactsListView: View {
                 }
             }
         }
-        .padding(VSpacing.lg)
+        .padding(.trailing, VSpacing.lg)
+        .padding(.bottom, VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -62,10 +62,8 @@ struct ContactsListView: View {
             Divider()
 
             if viewModel.regularContacts.isEmpty {
-                // No contacts yet — show full-width add button
-                VButton(label: "Add Contact", leftIcon: VIcon.user.rawValue, style: .outlined, isFullWidth: true) {
-                    viewModel.isCreatingContact = true
-                }
+                // No contacts yet — full-width add button matching contact row height
+                addContactButton
             } else {
                 // Search + Add button
                 HStack(spacing: VSpacing.sm) {
@@ -115,6 +113,34 @@ struct ContactsListView: View {
         let query = viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return true }
         return name.lowercased().contains(query.lowercased())
+    }
+
+    // MARK: - Add Contact Button
+
+    @State private var isAddContactHovered = false
+
+    private var addContactButton: some View {
+        Button {
+            viewModel.isCreatingContact = true
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Image(systemName: "person.badge.plus")
+                    .font(.system(size: 14))
+                Text("Add Contact")
+                    .font(VFont.bodyMedium)
+            }
+            .foregroundColor(VColor.primaryBase)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceBase.opacity(isAddContactHovered ? 1 : 0))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isAddContactHovered = $0 }
     }
 
     // MARK: - Contact List Row

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -36,16 +36,9 @@ struct ContactsListView: View {
 
     private var contactsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            HStack {
-                Text("Contacts")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.contentEmphasized)
-                Spacer()
-                VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
-                    viewModel.isCreatingContact = true
-                }
-                .accessibilityLabel("Add contact")
-            }
+            Text("Contacts")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.contentEmphasized)
 
             // Sticky system contacts (always visible, not affected by search)
             VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -75,7 +68,13 @@ struct ContactsListView: View {
             if viewModel.regularContacts.isEmpty {
                 regularContactsEmptyState
             } else {
-                searchBar
+                HStack(spacing: VSpacing.sm) {
+                    searchBar
+                    VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
+                        viewModel.isCreatingContact = true
+                    }
+                    .accessibilityLabel("Add contact")
+                }
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -123,7 +123,7 @@ struct ContactsListView: View {
         Button {
             viewModel.isCreatingContact = true
         } label: {
-            HStack(spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
                 Image(systemName: "person.badge.plus")
                     .font(.system(size: 14))
                 Text("Add Contact")

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -108,7 +108,6 @@ struct ContactsListView: View {
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
-        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
     }
 
     /// Whether a name matches the current search query (or query is empty).
@@ -182,7 +181,6 @@ struct ContactsListView: View {
         }
         .padding(VSpacing.lg)
         .frame(maxHeight: .infinity, alignment: .top)
-        .vCard(radius: VRadius.lg, background: VColor.surfaceOverlay)
         .accessibilityHidden(true)
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -204,7 +204,7 @@ struct GuardianChannelsDetailView: View {
                     if isVerified {
                         VButton(label: "Verified", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
                         if let channel = activeChannel, daemonClient != nil {
-                            VButton(label: "Revoke", style: .dangerGhost, size: .compact) {
+                            VButton(label: "Revoke", style: .dangerGhost) {
                                 channelToRevoke = (id: channel.id, type: type)
                             }
                         }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -204,7 +204,7 @@ struct GuardianChannelsDetailView: View {
                     if isVerified {
                         VButton(label: "Verified", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
                         if let channel = activeChannel, daemonClient != nil {
-                            VButton(label: "Revoke", iconOnly: VIcon.x.rawValue, style: .danger, tooltip: "Revoke access") {
+                            VButton(label: "Revoke", style: .dangerGhost, size: .compact) {
                                 channelToRevoke = (id: channel.id, type: type)
                             }
                         }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -204,7 +204,7 @@ struct GuardianChannelsDetailView: View {
                     if isVerified {
                         VButton(label: "Verified", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
                         if let channel = activeChannel, daemonClient != nil {
-                            VButton(label: "Revoke", style: .dangerGhost) {
+                            VButton(label: "Revoke", style: .danger) {
                                 channelToRevoke = (id: channel.id, type: type)
                             }
                         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -94,6 +94,9 @@ extension MainWindowView {
                     windowState.selection = nil
                 },
                 daemonClient: daemonClient,
+                store: settingsStore,
+                conversationManager: conversationManager,
+                showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId
             )
@@ -467,6 +470,9 @@ extension MainWindowView {
                     windowState.dismissOverlay()
                 },
                 daemonClient: daemonClient,
+                store: settingsStore,
+                conversationManager: conversationManager,
+                showToast: { msg, style in windowState.showToast(message: msg, style: style) },
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -187,7 +187,6 @@ struct IntelligencePanel: View {
                 isEmailEnabled: isEmailEnabled,
                 showToast: showToast
             )
-            .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -7,15 +7,25 @@ struct IntelligencePanel: View {
     var onClose: () -> Void
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
+    var store: SettingsStore?
+    var conversationManager: ConversationManager?
+    var showToast: ((String, ToastInfo.Style) -> Void)?
     var initialTab: String? = nil
     @Binding var pendingMemoryId: String?
 
     @State private var selectedTab: IntelligenceTab
+    @State private var isContactsEnabled: Bool = false
+    @State private var isEmailEnabled: Bool = false
+    private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
+    private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.daemonClient = daemonClient
+        self.store = store
+        self.conversationManager = conversationManager
+        self.showToast = showToast
         self.initialTab = initialTab
         _pendingMemoryId = pendingMemoryId
         _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
@@ -25,6 +35,7 @@ struct IntelligencePanel: View {
         case identity = "Identity"
         case installedSkills = "Skills"
         case workspace = "Workspace"
+        case contacts = "Contacts"
         case memories = "Memories"
     }
 
@@ -44,7 +55,7 @@ struct IntelligencePanel: View {
             // Tab bar
             VStack(spacing: 0) {
                 HStack(spacing: VSpacing.xl) {
-                    ForEach(IntelligenceTab.allCases, id: \.self) { tab in
+                    ForEach(visibleTabs, id: \.self) { tab in
                         tabButton(tab.rawValue, tab: tab)
                     }
                     Spacer()
@@ -62,6 +73,57 @@ struct IntelligencePanel: View {
         .onChange(of: pendingMemoryId) {
             if pendingMemoryId != nil {
                 withAnimation(VAnimation.fast) { selectedTab = .memories }
+            }
+        }
+        .task {
+            await loadContactsFeatureFlag()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
+            if let key = notification.userInfo?["key"] as? String,
+               let enabled = notification.userInfo?["enabled"] as? Bool {
+                if key == Self.contactsFeatureFlagKey {
+                    isContactsEnabled = enabled
+                    if !enabled && selectedTab == .contacts {
+                        selectedTab = .identity
+                    }
+                } else if key == Self.emailFeatureFlagKey {
+                    isEmailEnabled = enabled
+                }
+            }
+        }
+    }
+
+    private var visibleTabs: [IntelligenceTab] {
+        IntelligenceTab.allCases.filter { tab in
+            if tab == .contacts { return isContactsEnabled }
+            return true
+        }
+    }
+
+    private func loadContactsFeatureFlag() async {
+        let featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
+        do {
+            let flags = try await featureFlagClient.getFeatureFlags()
+            if let contactsFlag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {
+                isContactsEnabled = contactsFlag.enabled
+            }
+            if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
+                isEmailEnabled = emailFlag.enabled
+            }
+        } catch {
+            // Fall through to local config fallback
+            let registry = loadFeatureFlagRegistry()
+            let registryDefaults = Dictionary(
+                uniqueKeysWithValues: (registry?.assistantScopeFlags() ?? []).map { ($0.key, $0.defaultEnabled) }
+            )
+            let config = WorkspaceConfigIO.read()
+            let persistedFlags = (config["assistantFeatureFlagValues"] as? [String: Bool]) ?? [:]
+            let resolved = registryDefaults.merging(persistedFlags) { _, persisted in persisted }
+            if let contactsEnabled = resolved[Self.contactsFeatureFlagKey] {
+                isContactsEnabled = contactsEnabled
+            }
+            if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
+                isEmailEnabled = emailEnabled
             }
         }
     }
@@ -116,6 +178,17 @@ struct IntelligencePanel: View {
             WorkspacePanel(daemonClient: daemonClient)
                 .padding(.top, VSpacing.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+
+        case .contacts:
+            ContactsContainerView(
+                daemonClient: daemonClient,
+                store: store,
+                conversationManager: conversationManager,
+                isEmailEnabled: isEmailEnabled,
+                showToast: showToast
+            )
+            .padding(.top, VSpacing.sm)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:
             MemoriesPanel(daemonClient: daemonClient, focusedMemoryId: $pendingMemoryId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -6,17 +6,13 @@ enum SettingsTab: String {
     case modelsAndServices = "Models & Services"
     case voice = "Voice"
     case permissionsAndPrivacy = "Permissions & Privacy"
-    case contacts = "Contacts"
     case billing = "Billing"
     case archivedConversations = "Archived Conversations"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(contactsEnabled: Bool = false, billingEnabled: Bool = false) -> [SettingsTab] {
+    static func primaryTabs(billingEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general]
-        if contactsEnabled {
-            tabs.append(.contacts)
-        }
         tabs.append(contentsOf: [
             .voice, .modelsAndServices,
             .permissionsAndPrivacy,
@@ -29,10 +25,9 @@ enum SettingsTab: String {
     }
 
     /// Resolves a tab name string to a SettingsTab. Only accepts current canonical names.
-    static func fromRawValue(_ value: String, contactsEnabled: Bool = false, billingEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
+    static func fromRawValue(_ value: String, billingEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
         guard let tab = SettingsTab(rawValue: value) else { return nil }
         // Block feature-flagged tabs when disabled
-        if tab == .contacts && !contactsEnabled { return nil }
         if tab == .billing && !billingEnabled { return nil }
         if tab == .developer && !developerEnabled { return nil }
         return tab
@@ -90,11 +85,11 @@ struct SettingsPanel: View {
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
-            let visibleTabs = SettingsTab.primaryTabs(contactsEnabled: false, billingEnabled: canShowBilling)
+            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {
-                // Tab may become visible once feature flags load (e.g. .contacts, .developer).
+                // Tab may become visible once feature flags load (e.g. .developer).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
             }
@@ -118,20 +113,16 @@ struct SettingsPanel: View {
     /// Deep-linked tab that wasn't visible at init (feature flags not yet loaded).
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
-    @State private var isContactsEnabled: Bool = false
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
-    @State private var isEmailEnabled: Bool = false
     @State private var isGoogleOAuthEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-    private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
-    private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
 
     var body: some View {
@@ -164,25 +155,16 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                if selectedTab == .contacts {
+                ScrollView {
                     selectedTabContent
                         .padding(.top, VSpacing.lg)
                         .padding(.trailing, VSpacing.xl)
                         .padding(.bottom, VSpacing.xl)
                         .frame(maxWidth: 900, alignment: .top)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    ScrollView {
-                        selectedTabContent
-                            .padding(.top, VSpacing.lg)
-                            .padding(.trailing, VSpacing.xl)
-                            .padding(.bottom, VSpacing.xl)
-                            .frame(maxWidth: 900, alignment: .top)
-                            .frame(maxWidth: .infinity)
-                            .background { OverlayScrollerStyle() }
-                    }
-                    .scrollContentBackground(.hidden)
+                        .frame(maxWidth: .infinity)
+                        .background { OverlayScrollerStyle() }
                 }
+                .scrollContentBackground(.hidden)
             }
             .frame(maxWidth: .infinity)
         }
@@ -216,7 +198,7 @@ struct SettingsPanel: View {
                 // the flag manager directly avoids a stale billingVisible.
                 let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
                 let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
-                let visibleTabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: canShowBilling)
+                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
                     + (isDeveloperEnabled ? [.developer] : [])
                 if visibleTabs.contains(tab) {
                     selectedTab = tab
@@ -241,20 +223,13 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                if key == Self.contactsFeatureFlagKey {
-                    isContactsEnabled = enabled
-                    if !enabled && selectedTab == .contacts {
-                        selectedTab = .general
-                    }
-                } else if key == Self.developerFeatureFlagKey {
+                if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
                     if !enabled && selectedTab == .developer {
                         selectedTab = .general
                     }
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
-                } else if key == Self.emailFeatureFlagKey {
-                    isEmailEnabled = enabled
                 } else if key == Self.googleOAuthFeatureFlagKey {
                     isGoogleOAuthEnabled = enabled
                 }
@@ -332,7 +307,7 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (primary + gated bottom tabs).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: billingVisible)
+        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible)
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
@@ -347,7 +322,7 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled, billingEnabled: billingVisible), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -389,8 +364,6 @@ struct SettingsPanel: View {
             VoiceSettingsView(store: store)
         case .permissionsAndPrivacy:
             permissionsAndPrivacyContent
-        case .contacts:
-            ContactsContainerView(daemonClient: daemonClient, store: store, conversationManager: conversationManager, isEmailEnabled: isEmailEnabled, showToast: showToast)
         case .billing:
             SettingsBillingTab(authManager: authManager)
         case .archivedConversations:
@@ -569,14 +542,8 @@ struct SettingsPanel: View {
         if daemonClient != nil {
             do {
                 let flags = try await featureFlagClient.getFeatureFlags()
-                if let contactsFlag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {
-                    isContactsEnabled = contactsFlag.enabled
-                }
                 if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
                     isDeveloperEnabled = developerFlag.enabled
-                }
-                if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
-                    isEmailEnabled = emailFlag.enabled
                 }
                 if let googleOAuthFlag = flags.first(where: { $0.key == Self.googleOAuthFeatureFlagKey }) {
                     isGoogleOAuthEnabled = googleOAuthFlag.enabled
@@ -596,14 +563,8 @@ struct SettingsPanel: View {
         let persistedFlags = (config["assistantFeatureFlagValues"] as? [String: Bool]) ?? [:]
         let resolved = registryDefaults.merging(persistedFlags) { _, persisted in persisted }
 
-        if let contactsEnabled = resolved[Self.contactsFeatureFlagKey] {
-            isContactsEnabled = contactsEnabled
-        }
         if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
             isDeveloperEnabled = developerEnabled
-        }
-        if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
-            isEmailEnabled = emailEnabled
         }
         if let googleOAuthEnabled = resolved[Self.googleOAuthFeatureFlagKey] {
             isGoogleOAuthEnabled = googleOAuthEnabled


### PR DESCRIPTION
## Summary
- Move Contacts from Settings panel to Intelligence panel as a new tab (after Workspace, before Memories)
- Remove rounded border card wrappers (`.vCard()`) from contacts list, contact detail, and channels sections
- Add thin vertical separator with box shadow between the contact list and detail pane
- Thread `store`, `conversationManager`, and `showToast` through IntelligencePanel to ContactsContainerView
- Contacts tab is feature-flagged (only visible when contacts feature flag is enabled)

## Original prompt
move contacts from Settings to Intelligence, make Contacts Tab after Workspace tab, remove rounded border wrappers (and extra padding), add thin shadow separator between contact list and right side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
