### PR TITLE
Google OAuth Managed Mode — Settings Page

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -436,7 +436,7 @@ struct SettingsPanel: View {
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                GoogleOAuthServiceCard(store: store, authManager: authManager)
+                GoogleOAuthServiceCard(store: store, authManager: authManager, showToast: showToast)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -436,7 +436,7 @@ struct SettingsPanel: View {
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                GoogleOAuthServiceCard(store: store)
+                GoogleOAuthServiceCard(store: store, authManager: authManager)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -10,6 +10,7 @@ import VellumAssistantShared
 struct GoogleOAuthServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
+    var showToast: ((String, ToastInfo.Style) -> Void)?
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -56,11 +57,6 @@ struct GoogleOAuthServiceCard: View {
                 Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
             }
         }
-        .onChange(of: isLoggedIn) { _, loggedIn in
-            if loggedIn && draftMode == "managed" {
-                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
-            }
-        }
     }
 
     // MARK: - Managed Content
@@ -98,7 +94,18 @@ struct GoogleOAuthServiceCard: View {
                 style: .primary,
                 isDisabled: authManager.isSubmitting
             ) {
-                Task { await authManager.startWorkOSLogin() }
+                Task {
+                    if let showToast {
+                        await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                            Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                        })
+                    } else {
+                        await authManager.startWorkOSLogin()
+                        if authManager.isAuthenticated {
+                            await store.fetchGoogleOAuthConnections(userId: currentUserId)
+                        }
+                    }
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -23,6 +23,10 @@ struct GoogleOAuthServiceCard: View {
         authManager.isAuthenticated
     }
 
+    private var currentUserId: String? {
+        authManager.currentUser?.id
+    }
+
     var body: some View {
         ServiceModeCard(
             title: "Google OAuth",
@@ -43,18 +47,18 @@ struct GoogleOAuthServiceCard: View {
         .onAppear {
             draftMode = store.googleOAuthMode
             if store.googleOAuthMode == "managed" {
-                Task { await store.fetchGoogleOAuthConnections() }
+                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
             }
         }
         .onChange(of: store.googleOAuthMode) { _, newValue in
             draftMode = newValue
             if newValue == "managed" {
-                Task { await store.fetchGoogleOAuthConnections() }
+                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
             }
         }
         .onChange(of: isLoggedIn) { _, loggedIn in
             if loggedIn && draftMode == "managed" {
-                Task { await store.fetchGoogleOAuthConnections() }
+                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
             }
         }
     }
@@ -72,7 +76,7 @@ struct GoogleOAuthServiceCard: View {
                 managedConnectingState
             } else {
                 VButton(label: "Connect Google Account", style: .primary) {
-                    store.startGoogleOAuthConnect()
+                    store.startGoogleOAuthConnect(userId: currentUserId)
                 }
             }
 
@@ -114,7 +118,7 @@ struct GoogleOAuthServiceCard: View {
                 connectionRow(for: entry)
             }
             VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.googleOAuthIsConnecting) {
-                store.startGoogleOAuthConnect()
+                store.startGoogleOAuthConnect(userId: currentUserId)
             }
             if store.googleOAuthIsConnecting {
                 Text("Waiting for authorization...")
@@ -142,7 +146,7 @@ struct GoogleOAuthServiceCard: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.systemPositiveStrong)
             VButton(label: "Disconnect", style: .danger) {
-                store.disconnectGoogleOAuthConnection(entry.id)
+                store.disconnectGoogleOAuthConnection(entry.id, userId: currentUserId)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -3,11 +3,13 @@ import VellumAssistantShared
 
 /// Card for the Google OAuth service with Managed/Your Own mode toggle.
 ///
-/// Both modes currently show a "Coming Soon" empty state.
+/// Managed mode shows a connect flow for linking Google accounts.
+/// Your Own mode shows a "Coming Soon" empty state.
 /// The mode selection is persisted so user preference is retained.
 @MainActor
 struct GoogleOAuthServiceCard: View {
     @ObservedObject var store: SettingsStore
+    var authManager: AuthManager
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -15,6 +17,10 @@ struct GoogleOAuthServiceCard: View {
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
         draftMode != store.googleOAuthMode
+    }
+
+    private var isLoggedIn: Bool {
+        authManager.isAuthenticated
     }
 
     var body: some View {
@@ -28,7 +34,7 @@ struct GoogleOAuthServiceCard: View {
             onReset: nil,
             showReset: false,
             managedContent: {
-                comingSoonState
+                managedBody
             },
             yourOwnContent: {
                 comingSoonState
@@ -36,9 +42,108 @@ struct GoogleOAuthServiceCard: View {
         )
         .onAppear {
             draftMode = store.googleOAuthMode
+            if store.googleOAuthMode == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
         }
         .onChange(of: store.googleOAuthMode) { _, newValue in
             draftMode = newValue
+            if newValue == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
+        }
+        .onChange(of: isLoggedIn) { _, loggedIn in
+            if loggedIn && draftMode == "managed" {
+                Task { await store.fetchGoogleOAuthConnections() }
+            }
+        }
+    }
+
+    // MARK: - Managed Content
+
+    @ViewBuilder
+    private var managedBody: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            if !isLoggedIn {
+                managedLoginPrompt
+            } else if !store.googleOAuthConnections.isEmpty {
+                managedConnectionsList
+            } else if store.googleOAuthIsConnecting {
+                managedConnectingState
+            } else {
+                VButton(label: "Connect Google Account", style: .primary) {
+                    store.startGoogleOAuthConnect()
+                }
+            }
+
+            if let error = store.googleOAuthError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    private var managedLoginPrompt: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Log in to Vellum to connect Google.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+            VButton(
+                label: authManager.isSubmitting ? "Logging in..." : "Log In",
+                style: .primary,
+                isDisabled: authManager.isSubmitting
+            ) {
+                Task { await authManager.startWorkOSLogin() }
+            }
+        }
+    }
+
+    private var managedConnectingState: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VButton(label: "Connect Google Account", style: .primary, isDisabled: true) {}
+            Text("Waiting for authorization...")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+        }
+    }
+
+    private var managedConnectionsList: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            ForEach(store.googleOAuthConnections, id: \.id) { entry in
+                connectionRow(for: entry)
+            }
+            VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.googleOAuthIsConnecting) {
+                store.startGoogleOAuthConnect()
+            }
+            if store.googleOAuthIsConnecting {
+                Text("Waiting for authorization...")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        }
+    }
+
+    private func connectionRow(for entry: OAuthConnectionEntry) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.account_label ?? "Google Account")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                if let scopes = entry.scopes_granted, !scopes.isEmpty {
+                    Text(scopes.joined(separator: ", "))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            Text("Connected")
+                .font(VFont.caption)
+                .foregroundColor(VColor.systemPositiveStrong)
+            VButton(label: "Disconnect", style: .danger) {
+                store.disconnectGoogleOAuthConnection(entry.id)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2170,9 +2170,27 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Google OAuth Connections
 
-    func fetchGoogleOAuthConnections() async {
+    /// Resolves the platform assistant UUID for OAuth endpoints.
+    /// For managed assistants, the lockfile ID is the platform UUID.
+    /// For self-hosted local assistants, looks up the persisted mapping via PlatformAssistantIdResolver.
+    private func resolvePlatformAssistantId(userId: String?) -> String? {
+        guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !connectedId.isEmpty,
+              let assistant = LockfileAssistant.loadByName(connectedId) else {
+            return nil
+        }
+        let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+        return PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: assistant.assistantId,
+            isManaged: assistant.isManaged,
+            organizationId: orgId,
+            userId: userId,
+            credentialStorage: KeychainCredentialStorage()
+        )
+    }
+
+    func fetchGoogleOAuthConnections(userId: String? = nil) async {
         guard googleOAuthMode == "managed" else { return }
-        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else { return }
+        guard let assistantId = resolvePlatformAssistantId(userId: userId) else { return }
 
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
@@ -2185,13 +2203,13 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func startGoogleOAuthConnect() {
+    func startGoogleOAuthConnect(userId: String? = nil) {
         Task {
             googleOAuthIsConnecting = true
             googleOAuthError = nil
             defer { googleOAuthIsConnecting = false }
 
-            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
+            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
                 googleOAuthError = "No connected assistant"
                 return
             }
@@ -2226,7 +2244,7 @@ public final class SettingsStore: ObservableObject {
                 let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
 
                 if oauthStatus == "connected" {
-                    await fetchGoogleOAuthConnections()
+                    await fetchGoogleOAuthConnections(userId: userId)
                 } else if oauthStatus == "error" {
                     let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
                     googleOAuthError = errorCode ?? "OAuth connection failed"
@@ -2238,16 +2256,16 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func disconnectGoogleOAuthConnection(_ connectionId: String) {
+    func disconnectGoogleOAuthConnection(_ connectionId: String, userId: String? = nil) {
         Task {
-            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
+            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
                 googleOAuthError = "No connected assistant"
                 return
             }
 
             do {
                 try await PlatformOAuthService.shared.disconnectConnection(assistantId: assistantId, connectionId: connectionId)
-                await fetchGoogleOAuthConnections()
+                await fetchGoogleOAuthConnections(userId: userId)
             } catch {
                 log.error("Failed to disconnect Google OAuth connection: \(error)")
                 googleOAuthError = error.localizedDescription

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AuthenticationServices
 import Carbon.HIToolbox
 import Combine
 import Foundation
@@ -258,6 +259,9 @@ public final class SettingsStore: ObservableObject {
 
     /// Current Google OAuth mode. Values: "managed" or "your-own".
     @Published var googleOAuthMode: String = "your-own"
+    @Published var googleOAuthConnections: [OAuthConnectionEntry] = []
+    @Published var googleOAuthIsConnecting: Bool = false
+    @Published var googleOAuthError: String? = nil
 
     static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
 
@@ -2161,6 +2165,93 @@ public final class SettingsStore: ObservableObject {
             try WorkspaceConfigIO.merge(["services": services], into: configPath)
         } catch {
             log.error("Failed to merge workspace config for google-oauth mode: \(error)")
+        }
+    }
+
+    // MARK: - Google OAuth Connections
+
+    func fetchGoogleOAuthConnections() async {
+        guard googleOAuthMode == "managed" else { return }
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else { return }
+
+        do {
+            let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
+            googleOAuthConnections = connections.filter { $0.provider == "google" }
+            googleOAuthError = nil
+        } catch {
+            log.error("Failed to fetch Google OAuth connections: \(error)")
+            googleOAuthError = error.localizedDescription
+            googleOAuthConnections = []
+        }
+    }
+
+    func startGoogleOAuthConnect() {
+        Task {
+            googleOAuthIsConnecting = true
+            googleOAuthError = nil
+            defer { googleOAuthIsConnecting = false }
+
+            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
+                googleOAuthError = "No connected assistant"
+                return
+            }
+
+            do {
+                let response = try await PlatformOAuthService.shared.startGoogleOAuth(
+                    assistantId: assistantId,
+                    redirectAfterConnect: "vellum-assistant://oauth/google/callback"
+                )
+
+                guard let connectURL = URL(string: response.connect_url) else {
+                    googleOAuthError = "Invalid connect URL"
+                    return
+                }
+
+                let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
+                    let session = ASWebAuthenticationSession(url: connectURL, callbackURLScheme: "vellum-assistant") { callbackURL, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else if let callbackURL {
+                            continuation.resume(returning: callbackURL)
+                        } else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                        }
+                    }
+                    session.prefersEphemeralWebBrowserSession = false
+                    session.presentationContextProvider = WebAuthPresentationContext.shared
+                    session.start()
+                }
+
+                let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+                let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
+
+                if oauthStatus == "connected" {
+                    await fetchGoogleOAuthConnections()
+                } else if oauthStatus == "error" {
+                    let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
+                    googleOAuthError = errorCode ?? "OAuth connection failed"
+                }
+            } catch {
+                log.error("Google OAuth connect failed: \(error)")
+                googleOAuthError = error.localizedDescription
+            }
+        }
+    }
+
+    func disconnectGoogleOAuthConnection(_ connectionId: String) {
+        Task {
+            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
+                googleOAuthError = "No connected assistant"
+                return
+            }
+
+            do {
+                try await PlatformOAuthService.shared.disconnectConnection(assistantId: assistantId, connectionId: connectionId)
+                await fetchGoogleOAuthConnections()
+            } catch {
+                log.error("Failed to disconnect Google OAuth connection: \(error)")
+                googleOAuthError = error.localizedDescription
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -262,6 +262,8 @@ public final class SettingsStore: ObservableObject {
     @Published var googleOAuthConnections: [OAuthConnectionEntry] = []
     @Published var googleOAuthIsConnecting: Bool = false
     @Published var googleOAuthError: String? = nil
+    /// Strong reference to prevent the auth session from being deallocated mid-flow.
+    private var googleOAuthWebAuthSession: ASWebAuthenticationSession?
 
     static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
 
@@ -2226,7 +2228,8 @@ public final class SettingsStore: ObservableObject {
                 }
 
                 let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
-                    let session = ASWebAuthenticationSession(url: connectURL, callbackURLScheme: "vellum-assistant") { callbackURL, error in
+                    let session = ASWebAuthenticationSession(url: connectURL, callbackURLScheme: "vellum-assistant") { [weak self] callbackURL, error in
+                        self?.googleOAuthWebAuthSession = nil
                         if let error {
                             continuation.resume(throwing: error)
                         } else if let callbackURL {
@@ -2237,6 +2240,7 @@ public final class SettingsStore: ObservableObject {
                     }
                     session.prefersEphemeralWebBrowserSession = false
                     session.presentationContextProvider = WebAuthPresentationContext.shared
+                    self.googleOAuthWebAuthSession = session
                     session.start()
                 }
 

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -1,0 +1,213 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "PlatformOAuthService")
+
+// MARK: - Response Types
+
+public struct OAuthStartResponse: Codable, Sendable {
+    public let success: Bool
+    public let deferred: Bool
+    public let provider: String
+    public let connect_url: String
+    public let state_id: String?
+
+    enum CodingKeys: String, CodingKey {
+        case success
+        case deferred
+        case provider
+        case connect_url
+        case state_id
+    }
+}
+
+public struct OAuthConnectionEntry: Codable, Sendable {
+    public let id: String
+    public let provider: String
+    public let status: String
+    public let connected: Bool
+    public let account_label: String?
+    public let scopes_granted: [String]?
+    public let expires_at: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case provider
+        case status
+        case connected
+        case account_label
+        case scopes_granted
+        case expires_at
+    }
+}
+
+// MARK: - Service
+
+@MainActor
+public final class PlatformOAuthService {
+    public static let shared = PlatformOAuthService()
+
+    private init() {}
+
+    // MARK: - Private Helpers
+
+    /// Resolve the platform base URL for the connected assistant.
+    ///
+    /// On macOS, reads the lockfile `runtimeUrl` for the connected assistant
+    /// (same resolution as `GatewayHTTPClient`) so that staging, self-hosted,
+    /// or `VELLUM_PLATFORM_URL`-overridden connections hit the correct host.
+    /// Falls back to `AuthService.shared.baseURL` when no override is stored.
+    private func resolvePlatformBaseURL() -> String {
+        #if os(macOS)
+        if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty,
+           let assistant = LockfileAssistant.loadByName(id),
+           let runtimeUrl = assistant.runtimeUrl {
+            return runtimeUrl
+        }
+        #else
+        if let url = UserDefaults.standard.string(forKey: "managed_platform_base_url"), !url.isEmpty {
+            return url
+        }
+        #endif
+        return AuthService.shared.baseURL
+    }
+
+    private func authenticatedRequest(url: URL, method: String) async throws -> URLRequest {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        return urlRequest
+    }
+
+    // MARK: - Public Methods
+
+    /// Start a Google OAuth flow for the given assistant.
+    public func startGoogleOAuth(assistantId: String, redirectAfterConnect: String? = nil) async throws -> OAuthStartResponse {
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/google/start/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = try await authenticatedRequest(url: url, method: "POST")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let redirectValue = redirectAfterConnect ?? "/"
+        let body: [String: Any] = [
+            "requested_scopes": [] as [String],
+            "redirect_after_connect": redirectValue
+        ]
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/oauth/google/start/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(OAuthStartResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// List OAuth connections for the given assistant.
+    public func listConnections(assistantId: String) async throws -> [OAuthConnectionEntry] {
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/connections/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        let urlRequest = try await authenticatedRequest(url: url, method: "GET")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET assistants/\(assistantId)/oauth/connections/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode([OAuthConnectionEntry].self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Disconnect a specific OAuth connection for the given assistant.
+    public func disconnectConnection(assistantId: String, connectionId: String) async throws {
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = try await authenticatedRequest(url: url, method: "POST")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = "{}".data(using: .utf8)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/oauth/connections/\(connectionId)/disconnect/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Replace the "Coming Soon" placeholder in the Google OAuth service card's managed mode with a working OAuth connect flow. Users can connect Google accounts via the platform's OAuth endpoints (XSessionTokenAuth), view connected accounts as rows with metadata, and disconnect individual connections. Behind the `managed-google-oauth` feature flag.

## Changes
- **PlatformOAuthService** (`clients/shared/App/Auth/`): New singleton service for platform OAuth API calls (start, list connections, disconnect). Follows BillingService pattern with per-assistant URL resolution via lockfile `runtimeUrl`.
- **SettingsStore**: Published properties for connections, connecting state, and errors. Methods for fetching connections, starting OAuth flow via ASWebAuthenticationSession, and disconnecting.
- **GoogleOAuthServiceCard**: Managed mode shows login prompt (when not authenticated), connect button, connection rows with account email/scopes/disconnect, and loading states. Fetches connections on appear, mode change, and login.
- **SettingsPanel**: Passes `authManager` to GoogleOAuthServiceCard.

## Milestone PRs (merged into feature branch)
- #18871: Add PlatformOAuthService for Google OAuth platform API calls
- #18879: Add Google OAuth connection state and methods to SettingsStore
- #18880: Replace Coming Soon with managed Google OAuth connect and connection rows

## Project issue
Closes #18867

## Test plan
- [ ] Enable `managed-google-oauth` feature flag
- [ ] Open Settings > Models & Services > Google OAuth
- [ ] Toggle to Managed mode
- [ ] Verify login prompt appears when not authenticated
- [ ] Log in and verify "Connect Google Account" button appears
- [ ] Click Connect and verify browser opens with Google OAuth consent
- [ ] Complete authentication and verify connection appears as a row
- [ ] Verify account email and scopes are shown
- [ ] Click "Connect Another Account" and add a second connection
- [ ] Verify both connections show as separate rows
- [ ] Click Disconnect on a connection and verify it's removed
- [ ] Verify "Your Own" mode still shows "Coming Soon"

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
