### PR TITLE
fix: gate bootstrap on conversation count instead of auto-deleting

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -6,6 +6,7 @@ import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
+import { countConversations } from "../memory/conversation-queries.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
@@ -143,7 +144,21 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const bootstrap = readPromptFile(bootstrapPath);
   const updates = readPromptFile(updatesPath);
 
-  const includeBootstrap = !!bootstrap && !options?.excludeBootstrap;
+  // Only include BOOTSTRAP.md when there are zero existing conversations
+  // (truly first-time user).  Once the user has any conversation history,
+  // bootstrap is suppressed so it doesn't re-trigger on new threads — even
+  // if the user skipped or ignored onboarding.
+  let includeBootstrap = !!bootstrap && !options?.excludeBootstrap;
+  if (includeBootstrap) {
+    try {
+      if (countConversations() > 0) {
+        includeBootstrap = false;
+      }
+    } catch {
+      // DB not ready yet (e.g. during early startup) — fall back to
+      // including bootstrap if the file exists.
+    }
+  }
 
   // Template prompt files contain placeholder fields and meta-instructions
   // meant for the assistant to fill in during onboarding.  When included
@@ -166,16 +181,6 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
-
-    // Auto-delete BOOTSTRAP.md after inclusion so the onboarding ritual
-    // only fires for the very first conversation.  Without this, every new
-    // thread would re-trigger the "Who am I? Who are you?" intro.
-    try {
-      unlinkSync(bootstrapPath);
-      log.info("Deleted BOOTSTRAP.md after first-run inclusion");
-    } catch (err) {
-      log.warn({ err }, "Failed to delete BOOTSTRAP.md after inclusion");
-    }
   }
   if (updates) {
     dynamicParts.push(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -14,6 +14,7 @@ extension ComposerView {
                     attachmentChip(attachment)
                 }
             }
+            .padding(.top, VSpacing.sm)
             .padding(.bottom, VSpacing.xs)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -14,7 +14,6 @@ extension ComposerView {
                     attachmentChip(attachment)
                 }
             }
-            .padding(.top, VSpacing.sm)
             .padding(.bottom, VSpacing.xs)
         }
     }


### PR DESCRIPTION
## Summary
- Replace the auto-delete approach for BOOTSTRAP.md with a `countConversations()` check
- Bootstrap onboarding prompt now only appears when there are zero existing conversations
- If a user skips or ignores onboarding, new threads won't keep showing the "I'm brand new, no name, no memories" message
- Removes the `unlinkSync` side effect from `buildSystemPrompt()` — BOOTSTRAP.md stays on disk

## Test plan
- [x] All 47 system-prompt tests pass
- [x] All 14 onboarding-template-contract tests pass
- [x] Type-check passes
- [ ] Verify first-time user still sees bootstrap onboarding
- [ ] Verify second thread after skipping onboarding does NOT show bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
