### PR TITLE
Use assistant avatar and name in menu bar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -34,6 +34,17 @@ extension AppDelegate {
         }
 
         rebindConnectionStatusObserver()
+
+        // Update menu bar icon when the assistant's avatar changes.
+        if avatarChangeObserver == nil {
+            avatarChangeObserver = NotificationCenter.default.addObserver(
+                forName: AvatarAppearanceManager.avatarDidChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.updateMenuBarIcon()
+            }
+        }
     }
 
     /// (Re-)subscribe to `daemonClient.$isConnected` so the menu bar icon
@@ -120,16 +131,20 @@ extension AppDelegate {
         let dotPadding: CGFloat = 0.5
 
         let appIcon: NSImage = {
-            let bundle = ResourceBundle.bundle
-            if let url = bundle.url(
-                forResource: "icon-64",
-                withExtension: "png",
-                subdirectory: "Assets.xcassets/MenuBarIcon.imageset"
-            ), let img = NSImage(contentsOf: url) {
-                return img
+            // Use the assistant's avatar (same image used for dock icon / chat),
+            // rendered as a circle at menu-bar size.
+            let avatarManager = AvatarAppearanceManager.shared
+            let avatar = avatarManager.customAvatarImage
+                ?? avatarManager.fullAvatarImage
+
+            let size = iconSize
+            let square = AvatarAppearanceManager.resizedImage(avatar, to: size)
+            return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+                NSBezierPath(ovalIn: rect).addClip()
+                square.draw(in: rect, from: NSRect(origin: .zero, size: square.size),
+                            operation: .copy, fraction: 1.0)
+                return true
             }
-            return VIcon.sparkles.nsImage(size: 18)
-                ?? NSImage()
         }()
 
         let status = currentAssistantStatus
@@ -213,7 +228,8 @@ extension AppDelegate {
         menu.autoenablesItems = false
 
         let status = currentAssistantStatus
-        let statusItem = NSMenuItem(title: status.menuTitle, action: nil, keyEquivalent: "")
+        let name = AssistantDisplayName.resolve(IdentityInfo.load()?.name)
+        let statusItem = NSMenuItem(title: status.menuTitle(assistantName: name), action: nil, keyEquivalent: "")
         statusItem.isEnabled = false
         statusItem.image = status.statusIcon
         menu.addItem(statusItem)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -451,6 +451,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         if let observer = windowObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = avatarChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
         statusIconCancellable?.cancel()
         conversationBadgeCancellable?.cancel()
         NSApp.dockTile.badgeLabel = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -108,6 +108,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var connectionStatusCancellable: AnyCancellable?
     var quickInputAttachmentCancellable: AnyCancellable?
     var conversationBadgeCancellable: AnyCancellable?
+    var avatarChangeObserver: NSObjectProtocol?
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
     var pulseDirection: CGFloat = -1.0

--- a/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
@@ -7,11 +7,16 @@ enum AssistantStatus {
     case disconnected
 
     var menuTitle: String {
+        menuTitle(assistantName: nil)
+    }
+
+    func menuTitle(assistantName: String?) -> String {
+        let name = assistantName ?? "Assistant"
         switch self {
-        case .idle: return "Assistant is idle"
-        case .thinking: return "Assistant is thinking..."
+        case .idle: return "\(name) is idle"
+        case .thinking: return "\(name) is thinking..."
         case .error(let msg): return "Error: \(msg)"
-        case .disconnected: return "Disconnected from assistant"
+        case .disconnected: return "Disconnected from \(name)"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -476,10 +476,15 @@ final class AvatarAppearanceManager {
 
     // MARK: - Dock Icon
 
+    /// Posted whenever the avatar changes so other components (e.g. menu bar icon) can update.
+    static let avatarDidChangeNotification = Notification.Name("AvatarAppearanceManager.avatarDidChange")
+
     /// Updates the application dock icon to match the current avatar.
     /// When a custom avatar exists, renders it inside a macOS-style squircle mask.
     /// When cleared, reverts to the default bundle icon.
     private func updateDockIcon() {
+        NotificationCenter.default.post(name: Self.avatarDidChangeNotification, object: nil)
+
         guard let avatar = customAvatarImage else {
             NSApplication.shared.applicationIconImage = nil
             NSApp.dockTile.display()


### PR DESCRIPTION
## Summary
- Menu bar icon now displays the assistant's avatar as a circle instead of the static app icon, updating reactively on avatar changes (upload, regeneration, logout, switch)
- Status menu first item shows the assistant's name (e.g. "Aria is idle") instead of generic "Assistant"

## Test plan
- [ ] Verify menu bar icon shows the assistant's avatar (custom or character)
- [ ] Change the avatar and confirm the menu bar icon updates
- [ ] Click the menu bar icon and verify the status line uses the assistant's name
- [ ] Log out and confirm the menu bar icon resets to the default fallback
- [ ] Switch assistants and confirm both the icon and name update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
