### PR TITLE
M1: Unify mic button as 3-state toggle and remove voice mode button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -78,7 +78,6 @@ struct ComposerView: View {
     @State private var avatarSeed: String = "default"
     /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
     @State private var preDictationText: String = ""
-    @State private var showVoiceModeHover: Bool = false
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
     @State private var liveAmplitude: Float = 0
     @State private var isComposerDropTargeted = false
@@ -454,10 +453,6 @@ struct ComposerView: View {
         }
     }
 
-    /// Gap between a ghost button and a filled (primary/contrast) button — uses the standard
-    /// small spacing token for consistent spacing across the composer action bar.
-    private let composerFilledGap: CGFloat = VSpacing.sm
-
     /// Bottom action bar: paperclip on the left, send/mic/stop on the right.
     @ViewBuilder
     private var composerActionBar: some View {
@@ -499,31 +494,14 @@ struct ComposerView: View {
                 }
             } else if inputText.isEmpty && !hasPendingConfirmation {
                 VButton(
-                    label: "Dictate",
+                    label: micButtonLabel,
                     iconOnly: VIcon.mic.rawValue,
                     style: .ghost,
                     iconSize: composerActionButtonSize,
-                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                    action: { handleMicTap() }
                 )
                 .disabled(!hasAPIKey)
-
-                Spacer().frame(width: composerFilledGap)
-                VButton(
-                    label: "Voice mode",
-                    iconOnly: VIcon.audioWaveform.rawValue,
-                    style: .contrast,
-                    iconSize: composerActionButtonSize,
-                    action: { onVoiceModeToggle?() }
-                )
-                .disabled(!hasAPIKey)
-                .popover(isPresented: $showVoiceModeHover, arrowEdge: .top) {
-                    Text("Live voice conversation (not dictation)")
-                        .font(VFont.caption)
-                        .padding(VSpacing.sm)
-                }
-                .onHover { hovering in
-                    showVoiceModeHover = hovering
-                }
+                .help("Tap: dictation. Tap again: live voice. Tap in live: off")
             } else {
                 VButton(
                     label: isRecording ? "Stop recording" : "Start voice input",
@@ -534,6 +512,33 @@ struct ComposerView: View {
                 )
                 .disabled(!hasAPIKey)
             }
+        }
+    }
+
+    // MARK: - Mic Button 3-State Toggle
+
+    /// Accessibility label for the mic button based on current mode.
+    private var micButtonLabel: String {
+        switch currentMode {
+        case .textEntry: return "Start dictation"
+        case .dictationInline: return "Switch to live voice"
+        case .voiceConversation: return "End voice mode"
+        }
+    }
+
+    /// Cycles the mic button through: off → dictation → live voice → off.
+    private func handleMicTap() {
+        switch currentMode {
+        case .textEntry:
+            // Start dictation
+            (onDictateToggle ?? onMicrophoneToggle)()
+        case .dictationInline:
+            // Stop dictation, then activate live voice
+            onMicrophoneToggle()
+            onVoiceModeToggle?()
+        case .voiceConversation:
+            // Turn off voice mode
+            onVoiceModeToggle?()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -579,6 +579,22 @@ VStreamingWaveform(
                         }
                     )
 
+                    // Live voice: stop dictation and switch to voice mode
+                    if onVoiceModeToggle != nil {
+                        VButton(
+                            label: "Switch to live voice",
+                            iconOnly: VIcon.mic.rawValue,
+                            style: .ghost,
+                            iconSize: composerActionButtonSize,
+                            action: {
+                                preDictationText = ""
+                                (onDictateToggle ?? onMicrophoneToggle)()
+                                onVoiceModeToggle?()
+                            }
+                        )
+                        .help("Switch to live voice conversation")
+                    }
+
                     // Accept: stop dictation and keep transcribed text
                     VButton(
                         label: "Accept dictation",


### PR DESCRIPTION
Part of #18890. Fixes #18891.

- Remove the dedicated voice mode (audio waveform) button from composer action bar
- Make the mic button a 3-state toggle: off → dictation → live voice → off
- Add `.help()` tooltip: "Tap: dictation. Tap again: live voice. Tap in live: off"
- Clean up unused `showVoiceModeHover` state and `composerFilledGap` constant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
