### PR TITLE
Add isWakeUpGreeting() and getCannedFirstGreeting() helpers

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/sidd/vocify/claude-skills/scripts/worktree
+/Users/harrisonngo/Projects/claude-skills/scripts/worktree

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let tempDir: string;
+
+mock.module("../util/platform.js", () => ({
+  getWorkspacePromptPath: mock((file: string) => join(tempDir, file)),
+  getWorkspaceDir: () => tempDir,
+  getRootDir: () => tempDir,
+  getDataDir: () => join(tempDir, "data"),
+  getPlatformName: () => "darwin",
+  isMacOS: () => false,
+  isLinux: () => false,
+  isWindows: () => false,
+  ensureDataDir: () => {},
+  getDbPath: () => "",
+  getLogPath: () => "",
+  getHistoryPath: () => "",
+  getHooksDir: () => "",
+  getSessionTokenPath: () => "",
+  getPlatformTokenPath: () => "",
+  getPidPath: () => "",
+}));
+
+const { isWakeUpGreeting, getCannedFirstGreeting, CANNED_FIRST_GREETING } =
+  await import("../daemon/first-greeting.js");
+
+describe("first-greeting", () => {
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `first-greeting-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("isWakeUpGreeting", () => {
+    it("returns true for wake-up greeting with 0 messages and BOOTSTRAP.md present", () => {
+      writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
+      expect(isWakeUpGreeting("Wake up, my friend.", 0)).toBe(true);
+    });
+
+    it("returns true for case variations", () => {
+      writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
+      expect(isWakeUpGreeting("wake up, my friend.", 0)).toBe(true);
+      expect(isWakeUpGreeting("WAKE UP, MY FRIEND.", 0)).toBe(true);
+      expect(isWakeUpGreeting("Wake Up, My Friend.", 0)).toBe(true);
+    });
+
+    it("returns false when content doesn't match wake-up greeting", () => {
+      writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
+      expect(isWakeUpGreeting("Hello", 0)).toBe(false);
+      expect(isWakeUpGreeting("Hey there", 0)).toBe(false);
+      expect(isWakeUpGreeting("Wake up", 0)).toBe(false);
+    });
+
+    it("returns false when conversationMessageCount > 0", () => {
+      writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
+      expect(isWakeUpGreeting("Wake up, my friend.", 1)).toBe(false);
+      expect(isWakeUpGreeting("Wake up, my friend.", 5)).toBe(false);
+    });
+
+    it("returns false when BOOTSTRAP.md doesn't exist", () => {
+      expect(existsSync(join(tempDir, "BOOTSTRAP.md"))).toBe(false);
+      expect(isWakeUpGreeting("Wake up, my friend.", 0)).toBe(false);
+    });
+  });
+
+  describe("getCannedFirstGreeting", () => {
+    it("returns the expected greeting string", () => {
+      const greeting = getCannedFirstGreeting();
+      expect(greeting).toBe(CANNED_FIRST_GREETING);
+      expect(greeting).toContain("brand new");
+      expect(greeting).toContain("no name, no memories");
+    });
+  });
+});

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -1,0 +1,34 @@
+import { existsSync } from "node:fs";
+import { getWorkspacePromptPath } from "../util/platform.js";
+
+/**
+ * The canned assistant response for the wake-up greeting on a fresh workspace.
+ * Warm, non-presumptuous greeting that communicates "I'm new," "I improve over
+ * time," "I'm ready to be useful," and "you're in control."
+ */
+export const CANNED_FIRST_GREETING =
+  "Hey. I'm brand new, no name, no memories, nothing yet. The more we work together, the more context and memory I build, and the better I get. But let's not wait around. Throw a question at me, give me a task, or ask what I can do.";
+
+/**
+ * Returns `true` when all of the following are true:
+ * - `conversationMessageCount === 0` (no prior messages in this conversation)
+ * - BOOTSTRAP.md exists at the workspace prompt path
+ * - The trimmed content matches the macOS wake-up greeting (case-insensitive)
+ */
+export function isWakeUpGreeting(
+  content: string,
+  conversationMessageCount: number,
+): boolean {
+  if (conversationMessageCount !== 0) return false;
+  if (!existsSync(getWorkspacePromptPath("BOOTSTRAP.md"))) return false;
+  return content.trim().toLowerCase() === "wake up, my friend.";
+}
+
+/**
+ * Returns the canned first-greeting string. Simple getter that exists to keep
+ * the call site consistent and allow future flexibility (e.g., locale-aware
+ * greetings) without changing the API.
+ */
+export function getCannedFirstGreeting(): string {
+  return CANNED_FIRST_GREETING;
+}

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+
 import { getWorkspacePromptPath } from "../util/platform.js";
 
 /**


### PR DESCRIPTION
## Summary
- Add detection helper that identifies the macOS wake-up greeting on fresh workspaces (zero messages + BOOTSTRAP.md present)
- Add canned first-greeting constant and getter for instant response without LLM inference
- Add comprehensive tests for detection logic and canned response

Part of plan: reduce-ttft-hatch.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
