### PR TITLE
Replace exponential backoff with fixed 500ms polling in credential bootstrap

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/sidd/vocify/claude-skills/scripts/worktree
+/Users/harrisonngo/Projects/claude-skills/scripts/worktree

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -215,7 +215,7 @@ extension AppDelegate {
         }
     }
 
-    /// Performs the initial actor token bootstrap with exponential backoff.
+    /// Performs the initial actor token bootstrap with fixed-interval polling.
     /// Called only when no actor token exists (first launch or after credential wipe).
     ///
     /// Before hitting the network, checks whether the CLI already persisted a
@@ -236,10 +236,9 @@ extension AppDelegate {
         }
 
         let deviceId = PairingQRCodeSheet.computeHostId()
-        var delay: UInt64 = 2_000_000_000
-        let maxDelay: UInt64 = 60_000_000_000
-        var connectionDelay: UInt64 = 2_000_000_000
-        let connectionMaxDelay: UInt64 = 300_000_000_000
+        let delay: UInt64 = 500_000_000
+        var connectionDelay: UInt64 = 500_000_000
+        let connectionMaxDelay: UInt64 = 10_000_000_000
 
         while !Task.isCancelled {
             guard daemonClient.isConnected else {
@@ -265,7 +264,6 @@ extension AppDelegate {
 
             let jitter = UInt64.random(in: 0...(delay / 4))
             try? await Task.sleep(nanoseconds: delay + jitter)
-            delay = min(delay * 2, maxDelay)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change token bootstrap retry from exponential backoff (2s-60s) to fixed 500ms polling with jitter
- Tighten connection backoff from 2s-300s to 500ms-10s
- Reduces dead wait time during first-launch credential bootstrap by ~5-12s

Part of plan: reduce-ttft-hatch.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
