### PR TITLE
Add inline error message policy closure to suppress duplicate credits-exhausted UI on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1212,6 +1212,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             guard let self, let viewModel else { return false }
             return self.isLatestToolUseRecipient(viewModel)
         }
+        viewModel.shouldCreateInlineErrorMessage = { error in
+            // Credits-exhausted errors use the dedicated CreditsExhaustedBanner
+            // instead of the generic InlineChatErrorAlert
+            !error.isCreditsExhausted
+        }
         viewModel.onInlineConfirmationResponse = { [weak self] requestId, decision in
             // The decision was already sent to the daemon by ChatViewModel.
             // Forward to the app layer so it can dismiss the native notification

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1794,13 +1794,15 @@ extension ChatViewModel {
                    messages.last?.toolCalls.isEmpty == true {
                     messages.removeAll(where: { $0.id == existingId })
                 }
-                let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true, conversationError: typedError)
-                messages.append(errorMsg)
-                // Mark the error as displayed inline so the toast overlay
-                // suppresses its duplicate display, while keeping the typed
-                // error state available for downstream consumers (credits-
-                // exhausted recovery, sidebar state, iOS banner).
-                errorManager.isConversationErrorDisplayedInline = true
+                if shouldCreateInlineErrorMessage?(typedError) ?? true {
+                    let errorMsg = ChatMessage(role: .assistant, text: msg.userMessage, isError: true, conversationError: typedError)
+                    messages.append(errorMsg)
+                    // Mark the error as displayed inline so the toast overlay
+                    // suppresses its duplicate display, while keeping the typed
+                    // error state available for downstream consumers (credits-
+                    // exhausted recovery, sidebar state, iOS banner).
+                    errorManager.isConversationErrorDisplayedInline = true
+                }
             }
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -348,6 +348,12 @@ public final class ChatViewModel: ObservableObject {
         set { errorManager.connectionDiagnosticHint = newValue }
     }
 
+    /// Platform-provided policy controlling whether a conversation error should
+    /// produce an inline ChatMessage in the message list. When this returns false,
+    /// the error is still set on errorManager (for toasts, banners, sidebar state)
+    /// but no ChatMessage is appended. Defaults to true for all errors.
+    public var shouldCreateInlineErrorMessage: ((ConversationError) -> Bool)?
+
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5MB limit per image; base64 encoding adds ~33% overhead.
     static let maxImageSize = ChatAttachmentManager.maxImageSize


### PR DESCRIPTION
## Summary
- Add shouldCreateInlineErrorMessage policy closure to ChatViewModel for platform-specific control over inline error messages
- Gate inline ChatMessage creation behind the policy, defaulting to true for backward compatibility
- Configure macOS ConversationManager to suppress inline messages for credits-exhausted errors, letting CreditsExhaustedBanner be the sole UI

Part of plan: inline-error-policy-plan.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
