### PR TITLE
fix: add missing drainQueue() in canned first-greeting fast path

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -843,6 +843,10 @@ export async function handleSendMessage(
         onEvent({ type: "assistant_text_delta", text: cannedGreeting });
         onEvent({ type: "message_complete", conversationId });
         conversation.processing = false;
+        silentlyWithLog(
+          conversation.drainQueue(),
+          "canned-greeting queue drain",
+        );
       }, 0);
 
       log.info(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for reduce-ttft-hatch.md.

**Gap:** Missing drainQueue() in canned first-greeting fast path
**What was expected:** The canned greeting setTimeout callback should drain the message queue after setting processing = false
**What was found:** Queue drain was missing, which could strand queued messages if a second message arrives during the brief processing window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
