### PR TITLE
Move NewContactChannel from DaemonClient to ContactClient

### DIFF
--- a/clients/shared/Network/ContactClient.swift
+++ b/clients/shared/Network/ContactClient.swift
@@ -15,7 +15,7 @@ public protocol ContactClientProtocol {
     func createContact(
         displayName: String,
         notes: String?,
-        channels: [DaemonClient.NewContactChannel]?
+        channels: [NewContactChannel]?
     ) async throws -> ContactPayload?
 
     func createInvite(
@@ -35,6 +35,19 @@ public protocol ContactClientProtocol {
     func fetchContact(contactId: String) async throws -> ContactPayload?
     func deleteContact(contactId: String) async throws -> Bool
     func updateContactChannel(channelId: String, status: String?, policy: String?, reason: String?) async throws -> ContactPayload?
+}
+
+/// A channel to attach when creating a new contact.
+public struct NewContactChannel: Codable {
+    public let type: String
+    public let address: String
+    public let isPrimary: Bool
+
+    public init(type: String, address: String, isPrimary: Bool = false) {
+        self.type = type
+        self.address = address
+        self.isPrimary = isPrimary
+    }
 }
 
 /// Gateway-backed implementation of ``ContactClientProtocol``.
@@ -106,7 +119,7 @@ public struct ContactClient: ContactClientProtocol {
     public func createContact(
         displayName: String,
         notes: String? = nil,
-        channels: [DaemonClient.NewContactChannel]? = nil
+        channels: [NewContactChannel]? = nil
     ) async throws -> ContactPayload? {
         var body: [String: Any] = ["displayName": displayName]
         if let notes { body["notes"] = notes }

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -863,19 +863,4 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
 
-    // MARK: - Contacts Management
-
-    /// A channel to attach when creating a new contact.
-    public struct NewContactChannel: Codable {
-        public let type: String
-        public let address: String
-        public let isPrimary: Bool
-
-        public init(type: String, address: String, isPrimary: Bool = false) {
-            self.type = type
-            self.address = address
-            self.isPrimary = isPrimary
-        }
-    }
-
 }


### PR DESCRIPTION
## Summary
- Move `NewContactChannel` struct from `DaemonClient` to `ContactClient` where it's actually used
- Change from nested type (`DaemonClient.NewContactChannel`) to top-level type (`NewContactChannel`)

## Test plan
- [x] Swift build passes
- [ ] Contact creation still works with channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
