### PR TITLE
fix: unify chat inline component backgrounds to surfaceOverlay

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/InlineWidgetCardModifier.swift
@@ -15,7 +15,7 @@ public struct InlineWidgetCardModifier: ViewModifier {
             .padding(VSpacing.lg)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(VColor.surfaceBase)
+                    .fill(VColor.surfaceOverlay)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.lg)

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -29,7 +29,7 @@ public struct ChatErrorBanner: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(VColor.surfaceBase, in: RoundedRectangle(cornerRadius: 8))
+        .background(VColor.surfaceOverlay, in: RoundedRectangle(cornerRadius: 8))
         .padding(.horizontal)
     }
 }


### PR DESCRIPTION
## Summary
- Replace `VColor.surfaceBase` with `VColor.surfaceOverlay` in `InlineWidgetCardModifier` and `ChatErrorBanner` so all inline chat components (confirmation cards, form surfaces, error banners) share a consistent background color.

## Test plan
- [ ] Open a chat conversation and trigger a confirmation card — verify it uses the overlay background
- [ ] Trigger a form surface — verify consistent background with other inline components
- [ ] Trigger a chat error — verify the error banner background matches other inline components
- [ ] Verify no visual regressions in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
