### PR TITLE
Add source_paths support to media_generate_image

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -328,6 +328,59 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(false);
   });
+
+  test("reads source images from file paths on disk", async () => {
+    // Write a temp image file inside the workspace (fakeContext.workingDir = /tmp)
+    const tmpPath = join("/tmp", "test-source-image.png");
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "base64",
+    );
+    await Bun.write(tmpPath, pngBytes);
+
+    try {
+      const result = await run(
+        { prompt: "edit this", mode: "edit", source_paths: [tmpPath] },
+        fakeContext,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Generated 1 image");
+    } finally {
+      const { unlink } = await import("fs/promises");
+      if (await Bun.file(tmpPath).exists()) await unlink(tmpPath);
+    }
+  });
+
+  test("returns error when all source_paths are invalid", async () => {
+    const result = await run(
+      {
+        prompt: "edit this",
+        mode: "edit",
+        source_paths: ["/nonexistent/path.png"],
+      },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "None of the specified file paths could be read",
+    );
+  });
+
+  test("rejects source_paths outside the workspace", async () => {
+    const result = await run(
+      {
+        prompt: "edit this",
+        mode: "edit",
+        source_paths: ["/etc/passwd"],
+      },
+      fakeContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside the working directory");
+  });
 });
 
 describe("image-studio TOOLS.json manifest", () => {

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -19,7 +19,7 @@ You are an image generation assistant. When the user asks you to create or edit 
 ## Modes
 
 - **generate** (default): Create a new image from a text prompt.
-- **edit**: Modify an existing image based on a text prompt. Requires one or more attached source images via `attachment_ids`.
+- **edit**: Modify an existing image based on a text prompt. Requires one or more source images via `attachment_ids` and/or `source_paths` (file paths on disk).
 
 ## Models
 

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -23,7 +23,14 @@
             "items": {
               "type": "string"
             },
-            "description": "IDs of attached source images to edit (required for edit mode)"
+            "description": "IDs of attached source images to edit (for edit mode)"
+          },
+          "source_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "File paths to source images in the workspace (for edit mode). Can be used instead of or in addition to attachment_ids."
           },
           "model": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -20,6 +20,7 @@ import {
 import type { ImageContent } from "../../../../providers/types.js";
 import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
+import { sandboxPolicy } from "../../../../tools/shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -88,6 +89,7 @@ export async function run(
   const prompt = input.prompt as string;
   const mode = (input.mode as "generate" | "edit") ?? "generate";
   const attachmentIds = input.attachment_ids as string[] | undefined;
+  const sourcePaths = input.source_paths as string[] | undefined;
   const model =
     (input.model as string | undefined) ??
     config.services["image-generation"].model;
@@ -135,6 +137,36 @@ export async function run(
         };
       })
       .filter((img): img is NonNullable<typeof img> => img !== undefined);
+  }
+
+  // Resolve source images from file paths (sandboxed to workingDir)
+  if (sourcePaths && sourcePaths.length > 0) {
+    const errors: string[] = [];
+    const validPathImages: Array<{ mimeType: string; dataBase64: string }> = [];
+    for (const filePath of sourcePaths) {
+      const pathCheck = sandboxPolicy(filePath, context.workingDir);
+      if (!pathCheck.ok) {
+        errors.push(pathCheck.error);
+        continue;
+      }
+      const file = Bun.file(pathCheck.resolved);
+      if (!(await file.exists())) {
+        errors.push(`File not found: ${filePath}`);
+        continue;
+      }
+      const buffer = Buffer.from(await file.arrayBuffer());
+      validPathImages.push({
+        mimeType: file.type,
+        dataBase64: buffer.toString("base64"),
+      });
+    }
+    if (validPathImages.length === 0) {
+      return {
+        content: `None of the specified file paths could be read.\n${errors.join("\n")}`,
+        isError: true,
+      };
+    }
+    sourceImages = [...(sourceImages ?? []), ...validPathImages];
   }
 
   try {


### PR DESCRIPTION
## Summary
- Add `source_paths` parameter to `media_generate_image` tool, allowing workspace file paths as source images for edit mode
- Paths are sandboxed to `context.workingDir` via `sandboxPolicy`, consistent with `file_read` and `asset_materialize`
- Can be used alongside or instead of `attachment_ids`

## Test plan
- [x] Existing tests pass (20 tests)
- [x] New test: reads source images from file paths on disk
- [x] New test: returns error when all source_paths are invalid
- [x] New test: rejects source_paths outside the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
