### PR TITLE
fix: require activity field on skill_execute tool

### DIFF
--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -33,7 +33,7 @@ export class SkillExecuteTool implements Tool {
               "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
           },
         },
-        required: ["tool", "input"],
+        required: ["tool", "input", "activity"],
       },
     };
   }


### PR DESCRIPTION
## Summary
- The `skill_execute` tool defined `activity` in its schema properties but did not include it in the `required` array
- Since `injectActivityField` in `schema-transforms.ts` skips tools that already define `activity` in their properties, this meant the LLM could omit the `activity` field entirely on `skill_execute` calls — unlike every other tool where `activity` is required
- Adding `"activity"` to the `required` array makes `skill_execute` consistent with `bash`, `host_bash`, `request_system_permission`, and all auto-injected tools

## Audit findings
- **`skill_execute`** (fixed): Had `activity` in properties but not in `required`. Since `injectActivityField` skips tools that already define `activity`, this was the only built-in tool where `activity` was effectively optional.
- **All other core tools** (`file_read`, `file_write`, `file_edit`, `web_search`, `web_fetch`, `memory_manage`, `memory_recall`, `skill_load`, `credential_store`, `asset_search`, `asset_materialize`): Do not define `activity` inline, so they correctly receive it via `injectActivityField` with `required`.
- **`bash`, `host_bash`, `request_system_permission`**: Define `activity` inline and include it in `required`. Consistent.
- **Computer-use tools**: Define `activity` via `activityProperty` but use `reasoning` as their primary required field. These are a distinct pattern (proxy execution mode) and are consistent within their own category.
- **TOOLS.json skill tools**: Define `activity` in properties but not `required` for inner tool schemas. This is by design — the outer `skill_execute` `activity` is propagated as a fallback (see `conversation-tool-setup.ts` lines 357-365).

## Test plan
- [x] `schema-transforms.test.ts` passes (27/27)
- [ ] Verify `skill_execute` calls from the LLM now always include `activity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
