### PR TITLE
Simplify Google OAuth to use connectedAssistantId directly

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -24,10 +24,6 @@ struct GoogleOAuthServiceCard: View {
         authManager.isAuthenticated
     }
 
-    private var currentUserId: String? {
-        authManager.currentUser?.id
-    }
-
     var body: some View {
         ServiceModeCard(
             title: "Google OAuth",
@@ -48,13 +44,13 @@ struct GoogleOAuthServiceCard: View {
         .onAppear {
             draftMode = store.googleOAuthMode
             if store.googleOAuthMode == "managed" {
-                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                Task { await store.fetchGoogleOAuthConnections() }
             }
         }
         .onChange(of: store.googleOAuthMode) { _, newValue in
             draftMode = newValue
             if newValue == "managed" {
-                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                Task { await store.fetchGoogleOAuthConnections() }
             }
         }
     }
@@ -72,7 +68,7 @@ struct GoogleOAuthServiceCard: View {
                 managedConnectingState
             } else {
                 VButton(label: "Connect Google Account", style: .primary) {
-                    store.startGoogleOAuthConnect(userId: currentUserId)
+                    store.startGoogleOAuthConnect()
                 }
             }
 
@@ -97,12 +93,12 @@ struct GoogleOAuthServiceCard: View {
                 Task {
                     if let showToast {
                         await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                            Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                            Task { await store.fetchGoogleOAuthConnections() }
                         })
                     } else {
                         await authManager.startWorkOSLogin()
                         if authManager.isAuthenticated {
-                            await store.fetchGoogleOAuthConnections(userId: currentUserId)
+                            await store.fetchGoogleOAuthConnections()
                         }
                     }
                 }
@@ -125,7 +121,7 @@ struct GoogleOAuthServiceCard: View {
                 connectionRow(for: entry)
             }
             VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.googleOAuthIsConnecting) {
-                store.startGoogleOAuthConnect(userId: currentUserId)
+                store.startGoogleOAuthConnect()
             }
             if store.googleOAuthIsConnecting {
                 Text("Waiting for authorization...")
@@ -153,7 +149,7 @@ struct GoogleOAuthServiceCard: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.systemPositiveStrong)
             VButton(label: "Disconnect", style: .danger) {
-                store.disconnectGoogleOAuthConnection(entry.id, userId: currentUserId)
+                store.disconnectGoogleOAuthConnection(entry.id)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2172,27 +2172,9 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Google OAuth Connections
 
-    /// Resolves the platform assistant UUID for OAuth endpoints.
-    /// For managed assistants, the lockfile ID is the platform UUID.
-    /// For self-hosted local assistants, looks up the persisted mapping via PlatformAssistantIdResolver.
-    private func resolvePlatformAssistantId(userId: String?) -> String? {
-        guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !connectedId.isEmpty,
-              let assistant = LockfileAssistant.loadByName(connectedId) else {
-            return nil
-        }
-        let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-        return PlatformAssistantIdResolver.resolve(
-            lockfileAssistantId: assistant.assistantId,
-            isManaged: assistant.isManaged,
-            organizationId: orgId,
-            userId: userId,
-            credentialStorage: KeychainCredentialStorage()
-        )
-    }
-
-    func fetchGoogleOAuthConnections(userId: String? = nil) async {
+    func fetchGoogleOAuthConnections() async {
         guard googleOAuthMode == "managed" else { return }
-        guard let assistantId = resolvePlatformAssistantId(userId: userId) else { return }
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else { return }
 
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
@@ -2205,13 +2187,13 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func startGoogleOAuthConnect(userId: String? = nil) {
+    func startGoogleOAuthConnect() {
         Task {
             googleOAuthIsConnecting = true
             googleOAuthError = nil
             defer { googleOAuthIsConnecting = false }
 
-            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
+            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
                 googleOAuthError = "No connected assistant"
                 return
             }
@@ -2248,7 +2230,7 @@ public final class SettingsStore: ObservableObject {
                 let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
 
                 if oauthStatus == "connected" {
-                    await fetchGoogleOAuthConnections(userId: userId)
+                    await fetchGoogleOAuthConnections()
                 } else if oauthStatus == "error" {
                     let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
                     googleOAuthError = errorCode ?? "OAuth connection failed"
@@ -2260,16 +2242,16 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func disconnectGoogleOAuthConnection(_ connectionId: String, userId: String? = nil) {
+    func disconnectGoogleOAuthConnection(_ connectionId: String) {
         Task {
-            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
+            guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !assistantId.isEmpty else {
                 googleOAuthError = "No connected assistant"
                 return
             }
 
             do {
                 try await PlatformOAuthService.shared.disconnectConnection(assistantId: assistantId, connectionId: connectionId)
-                await fetchGoogleOAuthConnections(userId: userId)
+                await fetchGoogleOAuthConnections()
             } catch {
                 log.error("Failed to disconnect Google OAuth connection: \(error)")
                 googleOAuthError = error.localizedDescription


### PR DESCRIPTION
## Summary
Remove `PlatformAssistantIdResolver` usage from Google OAuth methods. The platform will resolve runtime slugs to platform UUIDs server-side (via `SelfHostedLocalAssistantRegistration` lookup), eliminating the dependency on a local keychain cache that may not be populated.

## Changes
- Remove `resolvePlatformAssistantId` helper from SettingsStore
- Remove `userId` parameter from `fetchGoogleOAuthConnections`, `startGoogleOAuthConnect`, `disconnectGoogleOAuthConnection`
- Remove `currentUserId` from GoogleOAuthServiceCard
- Use `connectedAssistantId` directly (same pattern as all other SettingsStore methods)

## Why
For self-hosted local assistants, the `PlatformAssistantIdResolver` requires a keychain mapping that may not exist even when the assistant IS registered on the platform. This caused "No connected assistant" errors. The platform-side fix (accepting runtime slugs in `_get_assistant_for_authenticated_user`) makes this client-side cache unnecessary.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
