### PR TITLE
Add message_id to llm_request_logs for per-message LLM context lookup

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -78,6 +78,7 @@ import {
   migrateGuardianVerificationSessions,
   migrateInviteCodeHashColumn,
   migrateInviteContactId,
+  migrateLlmRequestLogMessageId,
   migrateMemoryItemSupersession,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -459,6 +460,9 @@ export function initializeDb(): void {
 
   // 81. Add managed_service_config_key column to oauth_providers
   migrateOAuthProvidersManagedServiceConfigKey(database);
+
+  // 82. Add message_id column to llm_request_logs for per-message LLM context lookup
+  migrateLlmRequestLogMessageId(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, isNull, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "./db.js";
@@ -8,12 +8,14 @@ export function recordRequestLog(
   conversationId: string,
   requestPayload: string,
   responsePayload: string,
+  messageId?: string,
 ): void {
   const db = getDb();
   db.insert(llmRequestLogs)
     .values({
       id: uuid(),
       conversationId,
+      messageId: messageId ?? null,
       requestPayload,
       responsePayload,
       createdAt: Date.now(),
@@ -43,6 +45,46 @@ export function queryRequestLogs(
         lte(llmRequestLogs.createdAt, endTime),
       ),
     )
+    .orderBy(llmRequestLogs.createdAt)
+    .all();
+}
+
+export function backfillMessageIdOnLogs(
+  conversationId: string,
+  messageId: string,
+): void {
+  const db = getDb();
+  db.update(llmRequestLogs)
+    .set({ messageId })
+    .where(
+      and(
+        eq(llmRequestLogs.conversationId, conversationId),
+        isNull(llmRequestLogs.messageId),
+      ),
+    )
+    .run();
+}
+
+export function getRequestLogsByMessageId(messageId: string): Array<{
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+}> {
+  const db = getDb();
+  return db
+    .select({
+      id: llmRequestLogs.id,
+      conversationId: llmRequestLogs.conversationId,
+      messageId: llmRequestLogs.messageId,
+      requestPayload: llmRequestLogs.requestPayload,
+      responsePayload: llmRequestLogs.responsePayload,
+      createdAt: llmRequestLogs.createdAt,
+    })
+    .from(llmRequestLogs)
+    .where(eq(llmRequestLogs.messageId, messageId))
     .orderBy(llmRequestLogs.createdAt)
     .all();
 }

--- a/assistant/src/memory/migrations/179-llm-request-log-message-id.ts
+++ b/assistant/src/memory/migrations/179-llm-request-log-message-id.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateLlmRequestLogMessageId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(/*sql*/ `ALTER TABLE llm_request_logs ADD COLUMN message_id TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_llm_request_logs_message_id
+    ON llm_request_logs(message_id)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -120,6 +120,7 @@ export { createLifecycleEventsTable } from "./175-create-lifecycle-events.js";
 export { migrateDropCapabilityCardState } from "./176-drop-capability-card-state.js";
 export { migrateCreateTraceEventsTable } from "./177-create-trace-events-table.js";
 export { migrateOAuthProvidersManagedServiceConfigKey } from "./178-oauth-providers-managed-service-config-key.js";
+export { migrateLlmRequestLogMessageId } from "./179-llm-request-log-message-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -106,13 +106,18 @@ export const watcherEvents = sqliteTable("watcher_events", {
   createdAt: integer("created_at").notNull(),
 });
 
-export const llmRequestLogs = sqliteTable("llm_request_logs", {
-  id: text("id").primaryKey(),
-  conversationId: text("conversation_id").notNull(),
-  requestPayload: text("request_payload").notNull(),
-  responsePayload: text("response_payload").notNull(),
-  createdAt: integer("created_at").notNull(),
-});
+export const llmRequestLogs = sqliteTable(
+  "llm_request_logs",
+  {
+    id: text("id").primaryKey(),
+    conversationId: text("conversation_id").notNull(),
+    messageId: text("message_id"),
+    requestPayload: text("request_payload").notNull(),
+    responsePayload: text("response_payload").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [index("idx_llm_request_logs_message_id").on(table.messageId)],
+);
 
 export const llmUsageEvents = sqliteTable(
   "llm_usage_events",


### PR DESCRIPTION
## Summary
- Adds `message_id` column to `llm_request_logs` table via idempotent migration
- Updates Drizzle schema to include the new column with an index
- Extends `recordRequestLog` to accept an optional `messageId` parameter
- Adds `backfillMessageIdOnLogs` and `getRequestLogsByMessageId` store functions

Part of plan: llm-context-inspector.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
