### PR TITLE
Fix Google OAuth race condition with lazy bootstrap fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2214,8 +2214,10 @@ public final class SettingsStore: ObservableObject {
                 clientPlatform: "macos"
             )
         } catch {
-            log.error("Lazy bootstrap failed: \(error.localizedDescription)")
-            return nil
+            // Bootstrap can persist the keychain mapping during ensure-registration
+            // but then throw on daemon injection (e.g. gateway not reachable yet).
+            // Always retry the resolve — the mapping may already be cached.
+            log.warning("Lazy bootstrap threw (mapping may still be cached): \(error.localizedDescription)")
         }
 
         // Re-resolve userId after bootstrap (it may have become available).

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2198,13 +2198,17 @@ public final class SettingsStore: ObservableObject {
             userId: userId,
             credentialStorage: credentialStorage
         ) {
+            log.info("Resolved platform assistant ID (cached): \(resolved, privacy: .public) for runtime \(connectedId, privacy: .public)")
             return resolved
         }
 
         // For self-hosted assistants, the keychain mapping may not exist yet
         // (bootstrap is async and may not have completed). Trigger bootstrap
         // lazily and retry the resolve.
-        guard !assistant.isManaged else { return nil }
+        guard !assistant.isManaged else {
+            log.warning("Failed to resolve platform assistant ID for managed assistant \(connectedId, privacy: .public) (orgId=\(orgId ?? "nil", privacy: .public), userId=\(userId ?? "nil", privacy: .public))")
+            return nil
+        }
 
         log.info("Platform assistant ID not cached — triggering lazy bootstrap for \(connectedId, privacy: .public)")
         let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
@@ -2228,13 +2232,19 @@ public final class SettingsStore: ObservableObject {
         }
         let postBootstrapOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
 
-        return PlatformAssistantIdResolver.resolve(
+        let postBootstrapResolved = PlatformAssistantIdResolver.resolve(
             lockfileAssistantId: assistant.assistantId,
             isManaged: assistant.isManaged,
             organizationId: postBootstrapOrgId,
             userId: postBootstrapUserId,
             credentialStorage: credentialStorage
         )
+        if let resolved = postBootstrapResolved {
+            log.info("Resolved platform assistant ID (after lazy bootstrap): \(resolved, privacy: .public) for runtime \(connectedId, privacy: .public)")
+        } else {
+            log.error("Failed to resolve platform assistant ID after lazy bootstrap for runtime \(connectedId, privacy: .public) (orgId=\(postBootstrapOrgId ?? "nil", privacy: .public), userId=\(postBootstrapUserId ?? "nil", privacy: .public))")
+        }
+        return postBootstrapResolved
     }
 
     func fetchGoogleOAuthConnections(userId: String? = nil) async {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2174,25 +2174,66 @@ public final class SettingsStore: ObservableObject {
 
     /// Resolves the platform assistant UUID for OAuth endpoints.
     /// For managed assistants, the lockfile ID is the platform UUID.
-    /// For self-hosted local assistants, looks up the persisted mapping via PlatformAssistantIdResolver.
-    private func resolvePlatformAssistantId(userId: String?) -> String? {
+    /// For self-hosted local assistants, looks up the persisted mapping via PlatformAssistantIdResolver,
+    /// triggering bootstrap lazily if the mapping is not yet cached.
+    private func resolvePlatformAssistantId(userId: String?) async -> String? {
         guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"), !connectedId.isEmpty,
               let assistant = LockfileAssistant.loadByName(connectedId) else {
             return nil
         }
+
+        #if DEBUG
+        let credentialStorage = FileCredentialStorage()
+        #else
+        let credentialStorage = KeychainCredentialStorage()
+        #endif
+
         let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-        return PlatformAssistantIdResolver.resolve(
+
+        // Try the fast synchronous path first.
+        if let resolved = PlatformAssistantIdResolver.resolve(
             lockfileAssistantId: assistant.assistantId,
             isManaged: assistant.isManaged,
             organizationId: orgId,
             userId: userId,
-            credentialStorage: KeychainCredentialStorage()
+            credentialStorage: credentialStorage
+        ) {
+            return resolved
+        }
+
+        // For self-hosted assistants, the keychain mapping may not exist yet
+        // (bootstrap is async and may not have completed). Trigger bootstrap
+        // lazily and retry the resolve.
+        guard !assistant.isManaged else { return nil }
+
+        log.info("Platform assistant ID not cached — triggering lazy bootstrap for \(connectedId, privacy: .public)")
+        let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
+        do {
+            _ = try await bootstrapService.bootstrap(
+                runtimeAssistantId: assistant.assistantId,
+                clientPlatform: "macos"
+            )
+        } catch {
+            log.error("Lazy bootstrap failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        // Re-resolve userId after bootstrap (it may have become available).
+        let postBootstrapUserId = userId ?? (try? await AuthService.shared.getSession())?.data?.user?.id
+        let postBootstrapOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+
+        return PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: assistant.assistantId,
+            isManaged: assistant.isManaged,
+            organizationId: postBootstrapOrgId,
+            userId: postBootstrapUserId,
+            credentialStorage: credentialStorage
         )
     }
 
     func fetchGoogleOAuthConnections(userId: String? = nil) async {
         guard googleOAuthMode == "managed" else { return }
-        guard let assistantId = resolvePlatformAssistantId(userId: userId) else { return }
+        guard let assistantId = await resolvePlatformAssistantId(userId: userId) else { return }
 
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
@@ -2211,7 +2252,7 @@ public final class SettingsStore: ObservableObject {
             googleOAuthError = nil
             defer { googleOAuthIsConnecting = false }
 
-            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
+            guard let assistantId = await resolvePlatformAssistantId(userId: userId) else {
                 googleOAuthError = "No connected assistant"
                 return
             }
@@ -2262,7 +2303,7 @@ public final class SettingsStore: ObservableObject {
 
     func disconnectGoogleOAuthConnection(_ connectionId: String, userId: String? = nil) {
         Task {
-            guard let assistantId = resolvePlatformAssistantId(userId: userId) else {
+            guard let assistantId = await resolvePlatformAssistantId(userId: userId) else {
                 googleOAuthError = "No connected assistant"
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2219,7 +2219,11 @@ public final class SettingsStore: ObservableObject {
         }
 
         // Re-resolve userId after bootstrap (it may have become available).
-        let postBootstrapUserId = userId ?? (try? await AuthService.shared.getSession())?.data?.user?.id
+        var postBootstrapUserId = userId
+        if postBootstrapUserId == nil {
+            let session = try? await AuthService.shared.getSession()
+            postBootstrapUserId = session?.data?.user?.id
+        }
         let postBootstrapOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
 
         return PlatformAssistantIdResolver.resolve(

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -51,24 +51,13 @@ public final class PlatformOAuthService {
 
     // MARK: - Private Helpers
 
-    /// Resolve the platform base URL for the connected assistant.
+    /// Resolve the platform base URL for OAuth endpoints.
     ///
-    /// On macOS, reads the lockfile `runtimeUrl` for the connected assistant
-    /// (same resolution as `GatewayHTTPClient`) so that staging, self-hosted,
-    /// or `VELLUM_PLATFORM_URL`-overridden connections hit the correct host.
-    /// Falls back to `AuthService.shared.baseURL` when no override is stored.
+    /// Uses `AuthService.shared.baseURL` which respects `VELLUM_PLATFORM_URL`
+    /// env override, daemon-configured URL, and debug defaults.
+    /// Note: the lockfile `runtimeUrl` is the daemon URL (e.g. localhost:7821),
+    /// NOT the platform URL — it must not be used for platform API calls.
     private func resolvePlatformBaseURL() -> String {
-        #if os(macOS)
-        if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty,
-           let assistant = LockfileAssistant.loadByName(id),
-           let runtimeUrl = assistant.runtimeUrl {
-            return runtimeUrl
-        }
-        #else
-        if let url = UserDefaults.standard.string(forKey: "managed_platform_base_url"), !url.isEmpty {
-            return url
-        }
-        #endif
         return AuthService.shared.baseURL
     }
 


### PR DESCRIPTION
## Summary
- Fix race condition where opening Google OAuth settings before bootstrap completes causes "No connected assistant" errors for self-hosted local assistants
- Make `resolvePlatformAssistantId` async with a lazy bootstrap fallback when the keychain mapping isn't cached yet
- Fast path (cached keychain hit) is unchanged — no latency added for the happy case

## Problem
`ensureLocalAssistantApiKey()` runs as a fire-and-forget async Task at app launch and can take 5-15s (waiting for actor token + daemon connection + network call). If the user opens Settings before it completes, `PlatformAssistantIdResolver.resolve()` returns `nil` because the keychain mapping hasn't been persisted yet.

## Fix
When the sync resolve fails for a self-hosted assistant, trigger `LocalAssistantBootstrapService.bootstrap()` inline (it's idempotent), then retry the resolve. This also handles keychain loss scenarios (app reinstall, keychain reset).

## Test plan
- [ ] Launch app with a self-hosted local assistant
- [ ] Immediately open Settings → Google OAuth before bootstrap completes
- [ ] Verify "Connect Google Account" works (may show brief delay on first use instead of error)
- [ ] Verify managed assistants are unaffected (fast path returns immediately)
- [ ] Verify subsequent OAuth operations (list, disconnect) work after lazy bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
