### PR TITLE
Link LLM request logs to assistant messages via message_id backfill

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -19,7 +19,10 @@ import {
   provenanceFromTrustContext,
   updateMessageContent,
 } from "../memory/conversation-crud.js";
-import { recordRequestLog } from "../memory/llm-request-log-store.js";
+import {
+  backfillMessageIdOnLogs,
+  recordRequestLog,
+} from "../memory/llm-request-log-store.js";
 import type { ContentBlock, ImageContent } from "../providers/types.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
 import {
@@ -696,6 +699,18 @@ export async function handleMessageComplete(
     assistantChannelMetadata,
   );
   state.lastAssistantMessageId = assistantMsg.id;
+
+  // Backfill message_id on all LLM request logs from this turn.
+  // The agent loop is single-threaded per conversation, so all rows with
+  // message_id IS NULL belong to the current turn.
+  try {
+    backfillMessageIdOnLogs(deps.ctx.conversationId, assistantMsg.id);
+  } catch (err) {
+    deps.rlog.warn(
+      { err },
+      "Failed to backfill message_id on LLM request logs (non-fatal)",
+    );
+  }
 
   deps.ctx.currentTurnSurfaces = [];
 


### PR DESCRIPTION
## Summary
- After each assistant message is persisted, backfills `message_id` on all LLM request logs from that turn
- Non-fatal: failure to backfill is logged as a warning and does not crash the agent loop
- Links multiple LLM calls per turn (tool use chains) to the final assistant message

Part of plan: llm-context-inspector.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
