### PR TITLE
fix: guard dismissConversationError from removing unrelated historical error cards

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2132,15 +2132,20 @@ public final class ChatViewModel: ObservableObject {
 
     /// Dismiss the typed conversation error state. Clears both the typed error
     /// and any corresponding `errorText` so the UI can return to normal.
-    /// Also removes the most recent inline error message from the message list.
+    /// Removes the most recent inline error message only if one was created.
     public func dismissConversationError() {
         conversationError = nil
         errorText = nil
-        errorManager.isConversationErrorDisplayedInline = false
-        // Remove only the most recent inline error card (not all historical ones).
-        if let lastErrorIndex = messages.lastIndex(where: { $0.isError }) {
+        // Only remove the inline error card if the current error actually
+        // produced one. When shouldCreateInlineErrorMessage returned false
+        // (e.g. credits-exhausted on macOS), no card was appended, so
+        // removing the last .isError message would delete an unrelated
+        // historical error card.
+        if errorManager.isConversationErrorDisplayedInline,
+           let lastErrorIndex = messages.lastIndex(where: { $0.isError }) {
             messages.remove(at: lastErrorIndex)
         }
+        errorManager.isConversationErrorDisplayedInline = false
     }
 
     /// Copy conversation error details to the clipboard for debugging.


### PR DESCRIPTION
## Summary
- Guard the inline error card removal in `dismissConversationError()` behind `isConversationErrorDisplayedInline` so that dismissing an error that didn't produce an inline message (e.g. credits-exhausted on macOS) doesn't accidentally delete an unrelated historical error card.

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
