### PR TITLE
Add utility to capture running Docker container image references for rollback

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -570,6 +570,49 @@ export async function stopContainers(
 }
 
 /**
+ * Capture the current image references for running service containers.
+ * Returns a partial record of service → image tag string (e.g.
+ * "vellumai/vellum-assistant:v1.2.3"). Used before stopping containers
+ * so we can roll back to these exact images if the new version fails
+ * readiness checks.
+ *
+ * Returns null if no containers could be inspected (e.g. fresh install).
+ */
+export async function captureImageRefs(
+  res: ReturnType<typeof dockerResourceNames>,
+): Promise<Record<ServiceName, string> | null> {
+  const containerForService: Record<ServiceName, string> = {
+    assistant: res.assistantContainer,
+    "credential-executor": res.cesContainer,
+    gateway: res.gatewayContainer,
+  };
+
+  const refs: Partial<Record<ServiceName, string>> = {};
+  let foundAny = false;
+
+  for (const [service, container] of Object.entries(containerForService)) {
+    try {
+      const imageRef = (
+        await execOutput("docker", [
+          "inspect",
+          "--format",
+          "{{.Config.Image}}",
+          container,
+        ])
+      ).trim();
+      if (imageRef) {
+        refs[service as ServiceName] = imageRef;
+        foundAny = true;
+      }
+    } catch {
+      // Container doesn't exist or can't be inspected — skip
+    }
+  }
+
+  return foundAny ? (refs as Record<ServiceName, string>) : null;
+}
+
+/**
  * Determine which services are affected by a changed file path relative
  * to the repository root.
  */


### PR DESCRIPTION
## Summary
- Add `captureImageRefs()` function to `cli/src/lib/docker.ts` that inspects running containers and returns their current image tags
- Used before stopping containers during upgrade so we can roll back to these exact images if readiness checks fail
- Returns null when no containers exist (fresh install scenario)

Part of plan: update-system-foundation.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
