### PR TITLE
Define service group upgrade lifecycle event types in message protocol

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -38,6 +38,7 @@ export * from "./message-types/skills.js";
 export * from "./message-types/subagents.js";
 export * from "./message-types/surfaces.js";
 export * from "./message-types/trust.js";
+export * from "./message-types/upgrades.js";
 export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
@@ -123,6 +124,7 @@ import type {
   _TrustClientMessages,
   _TrustServerMessages,
 } from "./message-types/trust.js";
+import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
 import type {
   _WorkItemsClientMessages,
   _WorkItemsServerMessages,
@@ -194,6 +196,7 @@ export type ServerMessage =
   | _InboxServerMessages
   | _PairingServerMessages
   | _NotificationsServerMessages
+  | _UpgradesServerMessages
   | _AcpServerMessages
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/upgrades.ts
+++ b/assistant/src/daemon/message-types/upgrades.ts
@@ -1,0 +1,23 @@
+/** Broadcast to connected clients when a service group update is about to begin. */
+export interface ServiceGroupUpdateStarting {
+  type: "service_group_update_starting";
+  /** The version being upgraded to. */
+  targetVersion: string;
+  /** Estimated seconds of downtime. */
+  expectedDowntimeSeconds: number;
+}
+
+/** Broadcast to connected clients when a service group update has completed. */
+export interface ServiceGroupUpdateComplete {
+  type: "service_group_update_complete";
+  /** The version that was installed (may differ from target if rolled back). */
+  installedVersion: string;
+  /** Whether the update succeeded or rolled back. */
+  success: boolean;
+  /** If rolled back, the version reverted to. */
+  rolledBackToVersion?: string;
+}
+
+export type _UpgradesServerMessages =
+  | ServiceGroupUpdateStarting
+  | ServiceGroupUpdateComplete;


### PR DESCRIPTION
## Summary
- Create new `upgrades.ts` message types file with `ServiceGroupUpdateStarting` and `ServiceGroupUpdateComplete` interfaces
- Wire the new types into the `ServerMessage` union in `message-protocol.ts`
- No runtime behavior changes — types are defined but nothing publishes them yet

Part of plan: update-system-foundation.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
