### PR TITLE
Log warning on client/daemon version mismatch at connection time

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -254,6 +254,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// The daemon version string, populated via `daemon_status` on connect.
     @Published public internal(set) var daemonVersion: String?
 
+    /// Whether the connected daemon's major.minor version differs from this client's version.
+    /// Set automatically when `daemon_status` is received. Does not block the connection.
+    @Published public internal(set) var versionMismatch: Bool = false
+
     /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
     /// Used to detect instance switches — if this changes, the stored actor token is stale.
     @Published public internal(set) var keyFingerprint: String?
@@ -542,12 +546,40 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         isAuthenticated = false
         httpPort = nil
         daemonVersion = nil
+        versionMismatch = false
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
         #if os(macOS)
         lastAutoWakeAttempt = nil
         #endif
+    }
+
+    /// Extract (major, minor) from a semver string like "1.2.3" or "v1.2.3".
+    private func parseMajorMinor(_ version: String) -> (Int, Int)? {
+        let cleaned = version.hasPrefix("v") ? String(version.dropFirst()) : version
+        let components = cleaned.split(separator: ".").compactMap { Int($0) }
+        guard components.count >= 2 else { return nil }
+        return (components[0], components[1])
+    }
+
+    /// Compare client and daemon major.minor versions. Logs a warning and sets
+    /// `versionMismatch` if they differ. Patch version differences are tolerated.
+    func checkVersionCompatibility(daemonVersion: String) {
+        guard let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return
+        }
+        guard let (daemonMajor, daemonMinor) = parseMajorMinor(daemonVersion),
+              let (clientMajor, clientMinor) = parseMajorMinor(clientVersion) else {
+            return
+        }
+        let mismatch = daemonMajor != clientMajor || daemonMinor != clientMinor
+        if mismatch != versionMismatch {
+            versionMismatch = mismatch
+        }
+        if mismatch {
+            log.warning("Version mismatch: client \(clientVersion, privacy: .public) vs daemon \(daemonVersion, privacy: .public) — major.minor differs, features may not work correctly")
+        }
     }
 
     deinit {

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -13,6 +13,7 @@ extension DaemonClient {
             httpPort = status.httpPort.flatMap { Int(exactly: $0) }
             if let version = status.version {
                 daemonVersion = version
+                checkVersionCompatibility(daemonVersion: version)
             }
             if let newFingerprint = status.keyFingerprint {
                 let oldFingerprint = keyFingerprint


### PR DESCRIPTION
## Summary
- Add `versionMismatch` published property to `DaemonClient` to track major.minor version differences
- Add `checkVersionCompatibility()` helper that parses semver and logs warnings on mismatch
- Wire the check into the `daemon_status` handler in `DaemonMessageRouter`
- Informational only — never blocks or fails the connection

Part of plan: update-system-foundation.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
