### PR TITLE
Add service group upgrade event types to Swift message protocol

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -340,6 +340,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a notification delivery creates a new vellum conversation.
     public var onNotificationConversationCreated: ((NotificationConversationCreated) -> Void)?
 
+    /// Called when the daemon broadcasts that a service group update is starting.
+    public var onServiceGroupUpdateStarting: ((ServiceGroupUpdateStartingMessage) -> Void)?
+
+    /// Called when the daemon broadcasts that a service group update has completed.
+    public var onServiceGroupUpdateComplete: ((ServiceGroupUpdateCompleteMessage) -> Void)?
+
     /// Called when the server-assigned conversation ID differs from the
     /// client-local ID. Parameters: (localId, serverId).
     public var onConversationIdResolved: ((_ localId: String, _ serverId: String) -> Void)?

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -92,6 +92,10 @@ extension DaemonClient {
             onNotificationIntent?(msg)
         case .notificationConversationCreated(let msg):
             onNotificationConversationCreated?(msg)
+        case .serviceGroupUpdateStarting(let msg):
+            onServiceGroupUpdateStarting?(msg)
+        case .serviceGroupUpdateComplete(let msg):
+            onServiceGroupUpdateComplete?(msg)
         case .trustRulesListResponse:
             break // Handled by TrustRuleClient via GatewayHTTPClient.
         case .toolPermissionSimulateResponse:

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2752,6 +2752,39 @@ public struct NotificationIntentResult: Codable, Sendable {
     }
 }
 
+/// Broadcast to connected clients when a service group update is about to begin.
+public struct ServiceGroupUpdateStarting: Codable, Sendable {
+    public let type: String
+    /// The version being upgraded to.
+    public let targetVersion: String
+    /// Estimated seconds of downtime.
+    public let expectedDowntimeSeconds: Double
+
+    public init(type: String, targetVersion: String, expectedDowntimeSeconds: Double) {
+        self.type = type
+        self.targetVersion = targetVersion
+        self.expectedDowntimeSeconds = expectedDowntimeSeconds
+    }
+}
+
+/// Broadcast to connected clients when a service group update has completed.
+public struct ServiceGroupUpdateComplete: Codable, Sendable {
+    public let type: String
+    /// The version that was installed (may differ from target if rolled back).
+    public let installedVersion: String
+    /// Whether the update succeeded or rolled back.
+    public let success: Bool
+    /// If rolled back, the version reverted to.
+    public let rolledBackToVersion: String?
+
+    public init(type: String, installedVersion: String, success: Bool, rolledBackToVersion: String? = nil) {
+        self.type = type
+        self.installedVersion = installedVersion
+        self.success = success
+        self.rolledBackToVersion = rolledBackToVersion
+    }
+}
+
 /// Server push — broadcast when a notification creates a new vellum conversation.
 public struct NotificationConversationCreated: Codable, Sendable {
     public let type: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1296,6 +1296,14 @@ public struct ConversationErrorMessage: Decodable, Sendable {
 /// Backed by generated `NotificationIntent`.
 public typealias NotificationIntentMessage = NotificationIntent
 
+/// Broadcast when a service group update is starting.
+/// Backed by generated `ServiceGroupUpdateStarting`.
+public typealias ServiceGroupUpdateStartingMessage = ServiceGroupUpdateStarting
+
+/// Broadcast when a service group update has completed.
+/// Backed by generated `ServiceGroupUpdateComplete`.
+public typealias ServiceGroupUpdateCompleteMessage = ServiceGroupUpdateComplete
+
 /// Watch session started notification from daemon.
 /// Backed by generated `WatchStarted`.
 public typealias WatchStartedMessage = WatchStarted
@@ -2215,6 +2223,8 @@ public enum ServerMessage: Decodable, Sendable {
     case hostFileRequest(HostFileRequest)
     case hostCuRequest(HostCuRequest)
     case usageUpdate(UsageUpdate)
+    case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
+    case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case pong
     case unknown(String)
 
@@ -2641,6 +2651,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
+        case "service_group_update_starting":
+            let message = try ServiceGroupUpdateStartingMessage(from: decoder)
+            self = .serviceGroupUpdateStarting(message)
+        case "service_group_update_complete":
+            let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
+            self = .serviceGroupUpdateComplete(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add `ServiceGroupUpdateStarting` and `ServiceGroupUpdateComplete` structs to `GeneratedAPITypes.swift`
- Wire new types into `ServerMessage` enum with decoder cases in `MessageTypes.swift`
- Add routing handlers in `DaemonMessageRouter.swift` and callback properties in `DaemonClient.swift`
- No user-visible behavior changes — handlers are defined but nothing triggers them

Part of plan: update-system-foundation.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
