### PR TITLE
Soften no-new-tools policy to strongly discouraged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Use `modelIntent` (`'latency-optimized'`, `'quality-optimized'`, `'vision-optimi
 
 ## Tooling Direction
 
-Do not add new tool registrations. See `assistant/src/tools/AGENTS.md` for the full no-new-tools policy, approved CES exceptions, and what to do instead.
+New non-skill tool registrations are strongly discouraged — prefer skills instead. See `assistant/src/tools/AGENTS.md` for rationale, approved CES exceptions, and alternatives.
 
 ## System Prompt Minimalism
 

--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -46,7 +46,7 @@ CES exposes exactly three tools to the assistant, registered as a **deliberate e
 
 ### Tool registration
 
-CES tools use the standard `class ... implements Tool` registration pattern. This is explicitly approved as a deliberate exception to the no-new-tools policy because:
+CES tools use the standard `class ... implements Tool` registration pattern. These are justified exceptions to the general preference for skills because:
 
 - The security boundary requires that credential materialization happens in a separate process
 - Skill scripts run inside the assistant process and cannot enforce the hard isolation invariant
@@ -223,7 +223,7 @@ These invariants are enforced by guard tests and code review:
 
 1. **No cross-package source imports**: `assistant/` must not import from `credential-executor/` and vice versa. Communication is RPC only. Shared types flow through `packages/` only.
 2. **No credential values in assistant process memory**: The assistant sends credential handles (not values) to CES. CES materializes and uses them internally.
-3. **CES tools are the only approved exception to the no-new-tools policy** for credential-bearing execution. All other credential use continues through the existing broker for local deployments.
+3. **CES tools justify tool registrations over skills** for credential-bearing execution because of the hard process-boundary isolation requirement. All other credential use continues through the existing broker for local deployments.
 4. **Grants and audit logs are CES-internal**: The assistant cannot read CES grant tables or audit logs directly. CES exposes grant status and audit summaries via RPC responses.
 5. **No generic authenticated HTTP clients in secure commands**: `curl`, `wget`, `httpie`, interpreters, and shell trampolines are structurally denied as secure command entrypoints. This is checked at manifest validation and re-checked at execution time.
 6. **Managed CES container runs as non-root**: The CES Docker image runs as `uid 1001` (user `ces`). The CES data volume is owned by this user.
@@ -400,5 +400,5 @@ The following capabilities are intentionally deferred beyond v1:
 
 - [Security architecture](architecture/security.md) — existing credential broker and permission model
 - [AGENTS.md](../../AGENTS.md) — tooling direction and CES exception
-- [Tools AGENTS.md](../src/tools/AGENTS.md) — no-new-tools policy and CES exception
+- [Tools AGENTS.md](../src/tools/AGENTS.md) — tooling direction and CES exception
 - [Network traffic matrix](../../../vellum-assistant-platform/docs/network-traffic-matrix.md) — managed pod network policies

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -1,18 +1,14 @@
 # Tools - Agent Instructions
 
-## No New Tools Policy
+## New Non-Skill Tools Are Strongly Discouraged
 
-**New tool registrations require approval from Team Jarvis.**
+**Prefer skills over new non-skill tool registrations.** Non-skill tools require approval from Team Jarvis.
 
-The tool registration system (`class ... implements Tool` + `registerTool()`) is being phased out in favor of skill-based approaches. Before adding a new tool, contact Team Jarvis for approval.
+Skills are the preferred approach for adding new capabilities — they are progressively disclosed into context, more portable, and can be iterated on independently. New non-skill tool registrations (`class ... implements Tool` + `registerTool()`) carry additional costs:
 
-## Why This Policy Exists
+1. **Context overhead** — Each registered tool adds to the system prompt and increases token usage for every conversation.
 
-1. **Skills are preferred** - The project direction is to teach the assistant CLI tools via skills rather than hardcoding tool implementations. Skills are progressively disclosed into context, are more portable, and are often self-contained.
-
-2. **Context overhead** - Each registered tool adds to the system prompt and increases token usage for every conversation.
-
-3. **Maintenance burden** - Tools require ongoing maintenance, testing, and security review. Skills can be iterated on independently.
+2. **Maintenance burden** — Tools require ongoing maintenance, testing, and security review.
 
 ## What To Do Instead
 
@@ -26,7 +22,7 @@ Instead of creating a new tool, consider:
 
 ## Approved Exception: Credential Execution Service (CES) Tools
 
-The following three CES tools are the only approved exception to the no-new-tools policy:
+The following three CES tools are approved exceptions that justify tool registrations over skills:
 
 | Tool                         | Purpose                                                                                                                                                    |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Reframe tooling direction from "do not add new tools" to "new non-skill tool registrations are strongly discouraged"
- Clarify that skills are welcome — only `class ... implements Tool` registrations need approval
- Update CES doc references to use consistent softened language

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
