### PR TITLE
fix: add route policy for messages/llm-context endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -351,6 +351,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Message content
   { endpoint: "messages/content", scopes: ["chat.read"] },
+  { endpoint: "messages/llm-context", scopes: ["chat.read"] },
 
   // Queued message deletion
   { endpoint: "messages/queued", scopes: ["chat.write"] },


### PR DESCRIPTION
## Summary
- The new `messages/llm-context` endpoint was missing a route policy entry in `ACTOR_ENDPOINTS`, leaving it unprotected (no scope enforcement)
- Added `{ endpoint: "messages/llm-context", scopes: ["chat.read"] }` adjacent to the existing `messages/content` entry, consistent with its read-only semantics

## Test plan
- [ ] Verify `enforcePolicy("messages/llm-context", ...)` now requires `chat.read` scope
- [ ] Confirm unauthenticated/insufficient-scope requests to the endpoint are properly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
