### PR TITLE
fix: add backfillMessageIdOnLogs to test mocks for llm-request-log-store

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -329,6 +329,7 @@ mock.module("../agent/message-types.js", () => ({
 
 mock.module("../memory/llm-request-log-store.js", () => ({
   recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
 }));
 
 // ── Imports (after mocks) ────────────────────────────────────────────

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -307,6 +307,7 @@ mock.module("../agent/message-types.js", () => ({
 
 mock.module("../memory/llm-request-log-store.js", () => ({
   recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
 }));
 
 // ── Imports (after mocks) ────────────────────────────────────────────

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -68,6 +68,7 @@ mock.module("../memory/conversation-crud.js", () => ({
 
 mock.module("../memory/llm-request-log-store.js", () => ({
   recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `backfillMessageIdOnLogs: () => {}` to the `llm-request-log-store.js` mock in three test files that were missing it
- Without this, `handleMessageComplete` calling `backfillMessageIdOnLogs` would get `undefined` (silently swallowed by try/catch)

## Test plan
- [x] Verified all three test files now include the mock export
- [x] Pre-commit and pre-push hooks pass

Part of llm-context-inspect plan review round 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
