### PR TITLE
Add isUpdateInProgress state and accelerated health polling for planned updates

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -258,6 +258,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Set automatically when `daemon_status` is received. Does not block the connection.
     @Published public internal(set) var versionMismatch: Bool = false
 
+    /// Whether a planned service group update is in progress.
+    /// Set when a `service_group_update_starting` event is received,
+    /// cleared when reconnected and `daemon_status` confirms the new version.
+    @Published public internal(set) var isUpdateInProgress: Bool = false
+
+    /// The version being upgraded to, if an update is in progress.
+    @Published public internal(set) var updateTargetVersion: String?
+
     /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
     /// Used to detect instance switches — if this changes, the stored actor token is stale.
     @Published public internal(set) var keyFingerprint: String?
@@ -553,6 +561,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         httpPort = nil
         daemonVersion = nil
         versionMismatch = false
+        isUpdateInProgress = false
+        updateTargetVersion = nil
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -14,6 +14,17 @@ extension DaemonClient {
             if let version = status.version {
                 daemonVersion = version
                 checkVersionCompatibility(daemonVersion: version)
+                // If we were awaiting a planned update, check the outcome
+                if self.isUpdateInProgress {
+                    if version == self.updateTargetVersion {
+                        log.info("Planned update completed — now running \(version, privacy: .public)")
+                    } else {
+                        log.warning("Planned update may have rolled back — expected \(self.updateTargetVersion ?? "?", privacy: .public) but running \(version, privacy: .public)")
+                    }
+                    self.isUpdateInProgress = false
+                    self.updateTargetVersion = nil
+                    self.httpTransport?.isUpdateInProgress = false
+                }
             }
             if let newFingerprint = status.keyFingerprint {
                 let oldFingerprint = keyFingerprint
@@ -94,8 +105,16 @@ extension DaemonClient {
         case .notificationConversationCreated(let msg):
             onNotificationConversationCreated?(msg)
         case .serviceGroupUpdateStarting(let msg):
+            self.isUpdateInProgress = true
+            self.updateTargetVersion = msg.targetVersion
+            self.httpTransport?.isUpdateInProgress = true
+            log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
             onServiceGroupUpdateStarting?(msg)
         case .serviceGroupUpdateComplete(let msg):
+            self.isUpdateInProgress = false
+            self.updateTargetVersion = nil
+            self.httpTransport?.isUpdateInProgress = false
+            log.info("Service group update complete — version: \(msg.installedVersion, privacy: .public), success: \(msg.success)")
             onServiceGroupUpdateComplete?(msg)
         case .trustRulesListResponse:
             break // Handled by TrustRuleClient via GatewayHTTPClient.

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -150,6 +150,10 @@ public final class HTTPTransport {
     /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
 
+    /// Set by the owning DaemonClient when a planned service group update
+    /// is in progress. Accelerates health check polling for faster reconnection.
+    var isUpdateInProgress: Bool = false
+
     /// Current reconnect backoff delay in seconds (for SSE).
     private var sseReconnectDelay: TimeInterval = 1.0
 
@@ -696,7 +700,8 @@ public final class HTTPTransport {
         healthCheckTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(nanoseconds: UInt64((self?.healthCheckInterval ?? 15.0) * 1_000_000_000))
+                    let interval = (self?.isUpdateInProgress == true) ? 2.0 : (self?.healthCheckInterval ?? 15.0)
+                    try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
                 } catch {
                     return
                 }


### PR DESCRIPTION
## Summary
- Add `isUpdateInProgress` and `updateTargetVersion` published properties to `DaemonClient`
- Accelerate health check polling from 15s to 2s when a planned update is in progress
- Log version outcome when reconnecting after a planned update (success vs rollback)
- Clear update state on reconnection and reconfigure

Part of plan: update-system-foundation.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
