### PR TITLE
fix(macos): clear stale scroll suppression on near-bottom expansion

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/harrisonngo/Projects/claude-skills/scripts/worktree
+/Users/sidd/vocify/claude-skills/scripts/worktree

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -818,6 +818,8 @@ struct MessageListView: View {
             .environment(\.suppressAutoScroll, { [self] in
                 expandSuppressionTask?.cancel()
                 if isNearBottom {
+                    // Clear any stale suppression left by a canceled off-bottom expansion.
+                    isSuppressingBottomScroll = false
                     // When pinned to bottom, continuously re-pin on every frame
                     // of the expansion animation via the AnchorMinYKey handler.
                     scrollTracking.isPinningDuringExpansion = true


### PR DESCRIPTION
Addresses review feedback from #18725:

- **Clear stale suppression**: Reset `isSuppressingBottomScroll = false` at the start of the near-bottom expansion branch. When a previous invocation took the off-bottom path (setting `isSuppressingBottomScroll = true`) and was then canceled by a new near-bottom invocation, the flag would remain stranded, disabling auto-scroll conditions.

P2 (re-anchor delay) was already addressed — the current delay is 250ms which exceeds `VAnimation.fast` (0.15s).

Follows up on #18725.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
