### PR TITLE
Add ConversationDiskView module for projecting conversations to disk

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/harrisonngo/Projects/claude-skills/scripts/worktree
+/Users/sidd/vocify/claude-skills/scripts/worktree

--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -1,0 +1,558 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must come before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "conv-disk-view-test-"));
+const workspaceDir = join(testDir, "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  flattenContentBlocks,
+  getConversationDirName,
+  getConversationDirPath,
+  initConversationDir,
+  removeConversationDir,
+  resolveUniqueFilename,
+  syncMessageToDisk,
+  updateMetaFile,
+} from "../memory/conversation-disk-view.js";
+import {
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../memory/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+// ---------------------------------------------------------------------------
+// getConversationDirName
+// ---------------------------------------------------------------------------
+
+describe("getConversationDirName", () => {
+  test("produces filesystem-safe name with colons replaced by hyphens", () => {
+    // 2026-03-18T14:23:00.000Z
+    const ts = new Date("2026-03-18T14:23:00.000Z").getTime();
+    const name = getConversationDirName("abc123", ts);
+    expect(name).toBe("abc123_2026-03-18T14-23-00.000Z");
+    // No colons in the name (safe for Windows/macOS/Linux)
+    expect(name).not.toContain(":");
+  });
+
+  test("handles epoch zero", () => {
+    const name = getConversationDirName("conv0", 0);
+    expect(name).toBe("conv0_1970-01-01T00-00-00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConversationDirPath
+// ---------------------------------------------------------------------------
+
+describe("getConversationDirPath", () => {
+  test("returns absolute path under conversations dir", () => {
+    const ts = Date.now();
+    const dirPath = getConversationDirPath("test-id", ts);
+    expect(dirPath.startsWith(conversationsDir)).toBe(true);
+    expect(dirPath).toContain("test-id_");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initConversationDir
+// ---------------------------------------------------------------------------
+
+describe("initConversationDir", () => {
+  beforeEach(resetTables);
+
+  test("creates directory and writes valid meta.json", () => {
+    const now = Date.now();
+    initConversationDir({
+      id: "conv-init-1",
+      title: "Test Conversation",
+      createdAt: now,
+      conversationType: "standard",
+      originChannel: "desktop",
+    });
+
+    const dirPath = getConversationDirPath("conv-init-1", now);
+    expect(existsSync(dirPath)).toBe(true);
+
+    const metaPath = join(dirPath, "meta.json");
+    expect(existsSync(metaPath)).toBe(true);
+
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.id).toBe("conv-init-1");
+    expect(meta.title).toBe("Test Conversation");
+    expect(meta.type).toBe("standard");
+    expect(meta.channel).toBe("desktop");
+    expect(meta.createdAt).toBe(new Date(now).toISOString());
+    expect(meta.updatedAt).toBe(new Date(now).toISOString());
+
+    // Cleanup
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+
+  test("handles null title and null originChannel", () => {
+    const now = Date.now();
+    initConversationDir({
+      id: "conv-init-null",
+      title: null,
+      createdAt: now,
+      conversationType: "private",
+      originChannel: null,
+    });
+
+    const dirPath = getConversationDirPath("conv-init-null", now);
+    const meta = JSON.parse(readFileSync(join(dirPath, "meta.json"), "utf-8"));
+    expect(meta.title).toBeNull();
+    expect(meta.channel).toBeNull();
+    expect(meta.type).toBe("private");
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateMetaFile
+// ---------------------------------------------------------------------------
+
+describe("updateMetaFile", () => {
+  beforeEach(resetTables);
+
+  test("rewrites meta.json with updated fields", () => {
+    const created = Date.now();
+    const updated = created + 5000;
+
+    initConversationDir({
+      id: "conv-update",
+      title: "Original",
+      createdAt: created,
+      conversationType: "standard",
+      originChannel: null,
+    });
+
+    updateMetaFile({
+      id: "conv-update",
+      title: "Updated Title",
+      createdAt: created,
+      updatedAt: updated,
+      conversationType: "standard",
+      originChannel: "telegram",
+    });
+
+    const dirPath = getConversationDirPath("conv-update", created);
+    const meta = JSON.parse(readFileSync(join(dirPath, "meta.json"), "utf-8"));
+    expect(meta.title).toBe("Updated Title");
+    expect(meta.channel).toBe("telegram");
+    expect(meta.updatedAt).toBe(new Date(updated).toISOString());
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flattenContentBlocks
+// ---------------------------------------------------------------------------
+
+describe("flattenContentBlocks", () => {
+  test("extracts text from text blocks", () => {
+    const blocks = JSON.stringify([
+      { type: "text", text: "Hello" },
+      { type: "text", text: "World" },
+    ]);
+    const result = flattenContentBlocks(blocks);
+    expect(result.content).toBe("Hello\nWorld");
+    expect(result.toolCalls).toEqual([]);
+    expect(result.toolResults).toEqual([]);
+  });
+
+  test("extracts tool_use blocks", () => {
+    const blocks = JSON.stringify([
+      { type: "tool_use", name: "image_resize", input: { width: 800 } },
+    ]);
+    const result = flattenContentBlocks(blocks);
+    expect(result.toolCalls).toEqual([
+      { name: "image_resize", input: { width: 800 } },
+    ]);
+  });
+
+  test("extracts tool_result blocks", () => {
+    const blocks = JSON.stringify([
+      { type: "tool_result", content: "Done!" },
+    ]);
+    const result = flattenContentBlocks(blocks);
+    expect(result.toolResults).toEqual([{ content: "Done!" }]);
+  });
+
+  test("skips image and file blocks", () => {
+    const blocks = JSON.stringify([
+      { type: "text", text: "Here is an image" },
+      { type: "image", source: { data: "base64..." } },
+      { type: "file", path: "/tmp/test.txt" },
+    ]);
+    const result = flattenContentBlocks(blocks);
+    expect(result.content).toBe("Here is an image");
+    expect(result.toolCalls).toEqual([]);
+    expect(result.toolResults).toEqual([]);
+  });
+
+  test("handles plain text (non-JSON) content", () => {
+    const result = flattenContentBlocks("Just a string message");
+    expect(result.content).toBe("Just a string message");
+  });
+
+  test("handles non-array JSON gracefully", () => {
+    const result = flattenContentBlocks(JSON.stringify({ text: "not an array" }));
+    expect(result.content).toBe(JSON.stringify({ text: "not an array" }));
+  });
+
+  test("handles mixed block types", () => {
+    const blocks = JSON.stringify([
+      { type: "text", text: "Can you resize this?" },
+      { type: "image", source: { data: "abc" } },
+      { type: "tool_use", name: "image_resize", input: { width: 800 } },
+      { type: "tool_result", content: "Resized to 800x600" },
+      { type: "text", text: "Done." },
+    ]);
+    const result = flattenContentBlocks(blocks);
+    expect(result.content).toBe("Can you resize this?\nDone.");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolResults).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveUniqueFilename
+// ---------------------------------------------------------------------------
+
+describe("resolveUniqueFilename", () => {
+  test("returns original filename when no collision", () => {
+    const dir = mkdtempSync(join(tmpdir(), "unique-fn-"));
+    expect(resolveUniqueFilename(dir, "photo.png")).toBe("photo.png");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("appends -2, -3 on collision", () => {
+    const dir = mkdtempSync(join(tmpdir(), "unique-fn-"));
+    writeFileSync(join(dir, "photo.png"), "");
+    expect(resolveUniqueFilename(dir, "photo.png")).toBe("photo-2.png");
+
+    writeFileSync(join(dir, "photo-2.png"), "");
+    expect(resolveUniqueFilename(dir, "photo.png")).toBe("photo-3.png");
+
+    rmSync(dir, { recursive: true });
+  });
+
+  test("handles files without extension", () => {
+    const dir = mkdtempSync(join(tmpdir(), "unique-fn-"));
+    writeFileSync(join(dir, "README"), "");
+    expect(resolveUniqueFilename(dir, "README")).toBe("README-2");
+    rmSync(dir, { recursive: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncMessageToDisk
+// ---------------------------------------------------------------------------
+
+describe("syncMessageToDisk", () => {
+  beforeEach(resetTables);
+
+  test("appends correct JSONL for text-only message", async () => {
+    const conv = createConversation("Test");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      "Hello, assistant!",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const jsonlPath = join(dirPath, "messages.jsonl");
+    expect(existsSync(jsonlPath)).toBe(true);
+
+    const lines = readFileSync(jsonlPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0]);
+    expect(record.role).toBe("user");
+    expect(record.content).toBe("Hello, assistant!");
+    expect(record.ts).toBeDefined();
+    expect(record.toolCalls).toBeUndefined();
+    expect(record.attachments).toBeUndefined();
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+
+  test("appends correct JSONL for message with tool calls", async () => {
+    const conv = createConversation("Tool Test");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const content = JSON.stringify([
+      { type: "text", text: "Resizing image..." },
+      { type: "tool_use", name: "image_resize", input: { width: 800 } },
+    ]);
+
+    const msg = await addMessage(conv.id, "assistant", content, undefined, {
+      skipIndexing: true,
+    });
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    const record = JSON.parse(lines[0]);
+    expect(record.content).toBe("Resizing image...");
+    expect(record.toolCalls).toEqual([
+      { name: "image_resize", input: { width: 800 } },
+    ]);
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+
+  test("copies attachments and includes filenames in JSONL", async () => {
+    const conv = createConversation("Attach Test");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const msg = await addMessage(conv.id, "user", "See attached", undefined, {
+      skipIndexing: true,
+    });
+
+    // Upload an attachment and link to the message
+    const att = uploadAttachment("photo.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(msg.id, att.id, 0);
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const attachDir = join(dirPath, "attachments");
+    expect(existsSync(join(attachDir, "photo.png"))).toBe(true);
+
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    const record = JSON.parse(lines[0]);
+    expect(record.attachments).toEqual(["photo.png"]);
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+
+  test("appends multiple messages sequentially", async () => {
+    const conv = createConversation("Multi");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const msg1 = await addMessage(conv.id, "user", "First", undefined, {
+      skipIndexing: true,
+    });
+    const msg2 = await addMessage(conv.id, "assistant", "Second", undefined, {
+      skipIndexing: true,
+    });
+
+    syncMessageToDisk(conv.id, msg1.id, conv.createdAt);
+    syncMessageToDisk(conv.id, msg2.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).role).toBe("user");
+    expect(JSON.parse(lines[1]).role).toBe("assistant");
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeConversationDir
+// ---------------------------------------------------------------------------
+
+describe("removeConversationDir", () => {
+  test("removes the directory and its contents", () => {
+    const now = Date.now();
+    initConversationDir({
+      id: "conv-remove",
+      title: "To be removed",
+      createdAt: now,
+      conversationType: "standard",
+      originChannel: null,
+    });
+
+    const dirPath = getConversationDirPath("conv-remove", now);
+    expect(existsSync(dirPath)).toBe(true);
+
+    removeConversationDir("conv-remove", now);
+    expect(existsSync(dirPath)).toBe(false);
+  });
+
+  test("handles non-existent directory gracefully", () => {
+    // Should not throw
+    removeConversationDir("nonexistent", Date.now());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error resilience
+// ---------------------------------------------------------------------------
+
+describe("error resilience", () => {
+  test("initConversationDir does not throw on write failure", () => {
+    // Create a file at the path where a directory would be created, so
+    // mkdirSync fails with EEXIST. This triggers the try/catch in
+    // initConversationDir. The function should swallow the error.
+    const badConvId = "conv-fail-write";
+    const now = Date.now();
+    const dirPath = getConversationDirPath(badConvId, now);
+
+    mkdirSync(conversationsDir, { recursive: true });
+    writeFileSync(dirPath, "blocker");
+
+    try {
+      // Should not throw despite the internal failure
+      expect(() => {
+        initConversationDir({
+          id: badConvId,
+          title: "Test",
+          createdAt: now,
+          conversationType: "standard",
+          originChannel: null,
+        });
+      }).not.toThrow();
+    } finally {
+      rmSync(dirPath, { force: true });
+    }
+  });
+
+  test("updateMetaFile does not throw when directory does not exist", () => {
+    expect(() => {
+      updateMetaFile({
+        id: "nonexistent",
+        title: "X",
+        createdAt: 1000,
+        updatedAt: 2000,
+        conversationType: "standard",
+        originChannel: null,
+      });
+    }).not.toThrow();
+  });
+
+  test("syncMessageToDisk does not throw when message is not found", () => {
+    // Should not throw — logs a warning instead
+    expect(() => {
+      syncMessageToDisk("missing-conv", "missing-msg", Date.now());
+    }).not.toThrow();
+  });
+
+  test("removeConversationDir does not throw on missing directory", () => {
+    expect(() => {
+      removeConversationDir("nonexistent-id", 0);
+    }).not.toThrow();
+  });
+});

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -1,0 +1,333 @@
+/**
+ * Write-through disk view for conversations.
+ *
+ * Projects conversation metadata, messages, and attachments to a browsable
+ * filesystem layout under ~/.vellum/workspace/conversations/. This enables
+ * the assistant to search/read/manipulate conversation data using standard
+ * file tools.
+ *
+ * All disk writes are best-effort — failures are logged but never thrown,
+ * so the disk view cannot break DB operations.
+ */
+
+import {
+  appendFileSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, extname, join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getConversationsDir } from "../util/platform.js";
+import {
+  getAttachmentContent,
+  getAttachmentMetadataForMessage,
+} from "./attachments-store.js";
+import { getMessageById } from "./conversation-crud.js";
+
+const log = getLogger("conversation-disk-view");
+
+// ---------------------------------------------------------------------------
+// Directory helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a filesystem-safe directory name for a conversation.
+ * Format: `{id}_{isoDate}` where colons in the ISO date are replaced with
+ * hyphens so the name is valid on all platforms (Windows forbids colons).
+ */
+export function getConversationDirName(
+  id: string,
+  createdAtMs: number,
+): string {
+  const isoDate = new Date(createdAtMs)
+    .toISOString()
+    .replace(/:/g, "-");
+  return `${id}_${isoDate}`;
+}
+
+/**
+ * Return the absolute path to a conversation's disk-view directory.
+ */
+export function getConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  return join(getConversationsDir(), getConversationDirName(id, createdAtMs));
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the conversation directory and write the initial meta.json.
+ */
+export function initConversationDir(conv: {
+  id: string;
+  title: string | null;
+  createdAt: number;
+  conversationType: string;
+  originChannel: string | null;
+}): void {
+  try {
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    mkdirSync(dirPath, { recursive: true });
+
+    const meta = {
+      id: conv.id,
+      title: conv.title,
+      type: conv.conversationType,
+      channel: conv.originChannel,
+      createdAt: new Date(conv.createdAt).toISOString(),
+      updatedAt: new Date(conv.createdAt).toISOString(),
+    };
+
+    writeFileSync(
+      join(dirPath, "meta.json"),
+      JSON.stringify(meta, null, 2) + "\n",
+    );
+  } catch (err) {
+    log.warn({ err, conversationId: conv.id }, "Failed to init conversation dir");
+  }
+}
+
+/**
+ * Rewrite meta.json with updated fields.
+ */
+export function updateMetaFile(conv: {
+  id: string;
+  title: string | null;
+  createdAt: number;
+  updatedAt: number;
+  conversationType: string;
+  originChannel: string | null;
+}): void {
+  try {
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+
+    const meta = {
+      id: conv.id,
+      title: conv.title,
+      type: conv.conversationType,
+      channel: conv.originChannel,
+      createdAt: new Date(conv.createdAt).toISOString(),
+      updatedAt: new Date(conv.updatedAt).toISOString(),
+    };
+
+    writeFileSync(
+      join(dirPath, "meta.json"),
+      JSON.stringify(meta, null, 2) + "\n",
+    );
+  } catch (err) {
+    log.warn({ err, conversationId: conv.id }, "Failed to update meta file");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content flattening
+// ---------------------------------------------------------------------------
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+  content?: unknown;
+}
+
+interface FlattenedContent {
+  content: string;
+  toolCalls: Array<{ name: string; input: unknown }>;
+  toolResults: Array<{ content: unknown }>;
+}
+
+/**
+ * Parse the message `content` JSON string (ContentBlock[]) and extract
+ * text, tool_use, and tool_result blocks into flat fields.
+ */
+export function flattenContentBlocks(rawContent: string): FlattenedContent {
+  const result: FlattenedContent = {
+    content: "",
+    toolCalls: [],
+    toolResults: [],
+  };
+
+  let blocks: ContentBlock[];
+  try {
+    const parsed = JSON.parse(rawContent);
+    if (!Array.isArray(parsed)) {
+      // Plain text content (not block array)
+      return { ...result, content: rawContent };
+    }
+    blocks = parsed;
+  } catch {
+    // Not valid JSON — treat as plain text
+    return { ...result, content: rawContent };
+  }
+
+  const textParts: string[] = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case "text":
+        if (typeof block.text === "string") {
+          textParts.push(block.text);
+        }
+        break;
+      case "tool_use":
+        if (typeof block.name === "string") {
+          result.toolCalls.push({ name: block.name, input: block.input });
+        }
+        break;
+      case "tool_result":
+        result.toolResults.push({ content: block.content });
+        break;
+      // Skip "image" and "file" blocks — represented via attachments
+    }
+  }
+
+  result.content = textParts.join("\n");
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Attachment projection
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a unique filename within a directory, handling collisions by
+ * appending a suffix (e.g., `photo-2.png`, `photo-3.png`).
+ */
+export function resolveUniqueFilename(dir: string, filename: string): string {
+  if (!existsSync(join(dir, filename))) return filename;
+
+  const ext = extname(filename);
+  const base = basename(filename, ext);
+  let counter = 2;
+  let candidate: string;
+  do {
+    candidate = `${base}-${counter}${ext}`;
+    counter++;
+  } while (existsSync(join(dir, candidate)));
+
+  return candidate;
+}
+
+/**
+ * Write an attachment's content to the conversation's attachments/ subdirectory.
+ * Returns the resolved filename (after collision handling), or null on failure.
+ */
+function writeAttachmentFile(
+  conversationDirPath: string,
+  attachmentId: string,
+  originalFilename: string,
+): string | null {
+  try {
+    const attachDir = join(conversationDirPath, "attachments");
+    mkdirSync(attachDir, { recursive: true });
+
+    const content = getAttachmentContent(attachmentId);
+    if (!content) return null;
+
+    const resolvedName = resolveUniqueFilename(attachDir, originalFilename);
+    writeFileSync(join(attachDir, resolvedName), content);
+    return resolvedName;
+  } catch (err) {
+    log.warn(
+      { err, attachmentId, originalFilename },
+      "Failed to write attachment file to disk",
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message sync
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a message and its attachments from DB, flatten content, and append
+ * a JSONL line to `messages.jsonl` in the conversation's disk-view directory.
+ * Also copies attachment files to the `attachments/` subdirectory.
+ *
+ * Requires `createdAtMs` of the conversation to resolve the directory path.
+ */
+export function syncMessageToDisk(
+  conversationId: string,
+  messageId: string,
+  createdAtMs: number,
+): void {
+  try {
+    const message = getMessageById(messageId, conversationId);
+    if (!message) {
+      log.warn(
+        { conversationId, messageId },
+        "syncMessageToDisk: message not found",
+      );
+      return;
+    }
+
+    const dirPath = getConversationDirPath(conversationId, createdAtMs);
+    const { content, toolCalls, toolResults } = flattenContentBlocks(
+      message.content,
+    );
+
+    // Project attachments to disk
+    const attachmentMeta = getAttachmentMetadataForMessage(messageId);
+    const attachmentFilenames: string[] = [];
+    for (const att of attachmentMeta) {
+      const resolved = writeAttachmentFile(
+        dirPath,
+        att.id,
+        att.originalFilename,
+      );
+      if (resolved) {
+        attachmentFilenames.push(resolved);
+      }
+    }
+
+    // Build JSONL record
+    const record: Record<string, unknown> = {
+      role: message.role,
+      ts: new Date(message.createdAt).toISOString(),
+    };
+
+    if (content) record.content = content;
+    if (toolCalls.length > 0) record.toolCalls = toolCalls;
+    if (toolResults.length > 0) record.toolResults = toolResults;
+    if (attachmentFilenames.length > 0) record.attachments = attachmentFilenames;
+
+    appendFileSync(
+      join(dirPath, "messages.jsonl"),
+      JSON.stringify(record) + "\n",
+    );
+  } catch (err) {
+    log.warn(
+      { err, conversationId, messageId },
+      "Failed to sync message to disk",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Removal
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove a conversation's disk-view directory entirely.
+ */
+export function removeConversationDir(
+  id: string,
+  createdAtMs: number,
+): void {
+  try {
+    const dirPath = getConversationDirPath(id, createdAtMs);
+    rmSync(dirPath, { recursive: true, force: true });
+  } catch (err) {
+    log.warn({ err, conversationId: id }, "Failed to remove conversation dir");
+  }
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -381,6 +381,11 @@ export function getWorkspaceHooksDir(): string {
   return join(getWorkspaceDir(), "hooks");
 }
 
+/** Returns ~/.vellum/workspace/conversations */
+export function getConversationsDir(): string {
+  return join(getWorkspaceDir(), "conversations");
+}
+
 /** Returns the workspace path for a prompt file (e.g. IDENTITY.md, SOUL.md, USER.md). */
 export function getWorkspacePromptPath(file: string): string {
   return join(getWorkspaceDir(), file);
@@ -399,6 +404,7 @@ export function ensureDataDir(): void {
     join(root, "hooks"),
     join(workspace, "skills"),
     join(workspace, "embedding-models"),
+    join(workspace, "conversations"),
     // Data sub-dirs under workspace
     wsData,
     join(wsData, "db"),


### PR DESCRIPTION
## Summary
- Add `getConversationsDir()` platform helper and directory creation in `ensureDataDir()`
- Create `conversation-disk-view.ts` module with write-through disk projection (meta.json, messages.jsonl, attachment files)
- Add comprehensive tests for content flattening, attachment projection, and error resilience

Part of plan: conv-disk-view.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
