### PR TITLE
fix: restore worktree helper and fix guardian test name

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,530 @@
-/Users/sidd/vocify/claude-skills/scripts/worktree
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"  # .claude/ → repo root
+
+# Resolve main repo — if we're running from a linked worktree, caches and
+# naming should come from the main repo, not the worktree.
+# Detect linked worktrees by comparing --git-dir and --git-common-dir:
+# they differ only in linked worktrees (not in submodules or --separate-git-dir).
+_git_dir="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-dir)"
+_git_common="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+if [ "$_git_dir" != "$_git_common" ]; then
+  MAIN_REPO="$(printf '%s' "$_git_common" | sed 's|/\.git$||')"
+else
+  MAIN_REPO="$REPO_ROOT"
+fi
+
+PARENT_DIR="$(dirname "$MAIN_REPO")"
+REPO_NAME="$(basename "$MAIN_REPO")"
+WT_PREFIX="${REPO_NAME}-wt"
+
+# Disable TypeScript LSP in worktree settings — the LSP server can't resolve
+# modules for files outside the main project root, producing false-positive
+# diagnostics in worktrees. Agents use explicit `tsc --noEmit` instead.
+disable_worktree_lsp() {
+  local settings="$1/.claude/settings.local.json"
+  mkdir -p "$(dirname "$settings")"
+  [ -f "$settings" ] || echo '{}' > "$settings"
+  python3 -c "
+import json, re, sys
+f = sys.argv[1]
+with open(f) as fh:
+    raw = fh.read()
+def strip_jsonc(text):
+    # Strip comments while preserving string contents (e.g. URLs with //)
+    text = re.sub(
+        r'\"(?:[^\"\\\\]|\\\\.)*\"|//[^\n]*|/\*.*?\*/',
+        lambda m: m.group() if m.group().startswith('\"') else '',
+        text, flags=re.DOTALL)
+    # Remove trailing commas before } or ] (string-aware — preserve quoted strings)
+    text = re.sub(
+        r'\"(?:[^\"\\\\]|\\\\.)*\"|,\s*([}\]])',
+        lambda m: m.group() if m.group().startswith('\"') else m.group(1),
+        text, flags=re.DOTALL)
+    return text
+try:
+    d = json.loads(raw)
+except (json.JSONDecodeError, ValueError):
+    try:
+        d = json.loads(strip_jsonc(raw))
+    except (json.JSONDecodeError, ValueError):
+        d = {}
+d.setdefault('enabledPlugins', {})['typescript-lsp@claude-plugins-official'] = False
+with open(f, 'w') as fh:
+    json.dump(d, fh, indent=2)
+    fh.write('\n')
+" "$settings"
+}
+
+usage() {
+  echo "Usage: .claude/worktree <create|create-batch|remove|list|clean> [args]"
+  echo ""
+  echo "Commands:"
+  echo "  create <branch-name> [start-point]  Create a worktree + branch and install deps"
+  echo "  create-batch [opts] <branches...>    Create multiple worktrees in parallel"
+  echo "  remove <branch-name> [options]       Remove a worktree and optionally delete the branch"
+  echo "  list                                 List all worktrees"
+  echo "  clean [options]                      Remove ALL worktrees and their branches"
+  echo ""
+  echo "Create-batch options:"
+  echo "  --start-point <ref>  Start point for all worktrees (default: HEAD)"
+  echo "  --jobs <N>           Max parallel checkout workers (default: 8)"
+  echo ""
+  echo "Remove/clean options:"
+  echo "  --delete-branch      Always delete the branch (no prompt)"
+  echo "  --no-delete-branch   Never delete the branch (no prompt)"
+  echo ""
+  echo "Examples:"
+  echo "  .claude/worktree create feat/streaming"
+  echo "  .claude/worktree create-batch --start-point origin/main feat/pr-1 feat/pr-2 feat/pr-3"
+  echo "  .claude/worktree remove feat/streaming"
+  echo "  .claude/worktree remove feat/streaming --delete-branch"
+  echo "  .claude/worktree list"
+  echo "  .claude/worktree clean --delete-branch"
+}
+
+create() {
+  local branch="$1"
+  local start_point="${2:-}"
+  local slug="${branch//\//-}"
+  local dir="$PARENT_DIR/${WT_PREFIX}-${slug}"
+
+  if [ -d "$dir" ]; then
+    echo "Error: worktree already exists at $dir"
+    exit 1
+  fi
+
+  echo "Creating worktree at $dir on branch $branch..."
+  if [ -n "$start_point" ]; then
+    git -C "$MAIN_REPO" worktree add "$dir" -b "$branch" "$start_point"
+  else
+    git -C "$MAIN_REPO" worktree add "$dir" -b "$branch"
+  fi
+
+  # Copy local settings so agents spawned in this worktree have tool permissions
+  if [ -f "$MAIN_REPO/.claude/settings.local.json" ]; then
+    mkdir -p "$dir/.claude"
+    cp "$MAIN_REPO/.claude/settings.local.json" "$dir/.claude/settings.local.json"
+  fi
+
+  disable_worktree_lsp "$dir"
+
+  # Symlink node_modules directories so the worktree reuses installed deps
+  # from the main repo. This avoids a slow `bun install` and — crucially —
+  # keeps the seeded .tsbuildinfo valid (the file hashes in the cache match
+  # because the node_modules files are literally the same inodes).
+  # If a change requires different deps, `bun install` in the worktree will
+  # replace the symlink with a real directory automatically.
+  local nm_count=0
+  while IFS= read -r -d '' nm; do
+    rel="${nm#$MAIN_REPO/}"
+    pkg_dir="$dir/$(dirname "$rel")"
+    mkdir -p "$pkg_dir"
+    ln -s "$nm" "$pkg_dir/node_modules"
+    nm_count=$((nm_count + 1))
+  done < <(find "$MAIN_REPO" -maxdepth 2 -name node_modules -type d -not -path '*/.git/*' -print0 2>/dev/null)
+  if [ "$nm_count" -gt 0 ]; then
+    echo "  -> Symlinked $nm_count node_modules director$([ "$nm_count" -eq 1 ] && echo "y" || echo "ies")"
+  else
+    echo "  -> Skipped node_modules symlinking (none found)"
+  fi
+
+  # Symlink Swift Package Manager .build directories so worktrees reuse
+  # resolved packages and build artifacts. Avoids stale SPM cache errors
+  # (e.g. sentry-cocoa dependency resolution failures) in pre-push hooks.
+  local spm_count=0
+  while IFS= read -r -d '' pkg; do
+    local pkg_dir="$(dirname "$pkg")"
+    local build_dir="$pkg_dir/.build"
+    [ -d "$build_dir" ] || continue
+    local rel="${build_dir#$MAIN_REPO/}"
+    local wt_pkg_dir="$dir/$(dirname "$rel")"
+    mkdir -p "$wt_pkg_dir"
+    ln -s "$build_dir" "$wt_pkg_dir/.build"
+    spm_count=$((spm_count + 1))
+  done < <(find "$MAIN_REPO" -maxdepth 4 -name Package.swift -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/.build/*' -print0 2>/dev/null)
+  if [ "$spm_count" -gt 0 ]; then
+    echo "  -> Symlinked $spm_count SPM .build director$([ "$spm_count" -eq 1 ] && echo "y" || echo "ies")"
+  fi
+
+  # Seed incremental TypeScript caches so the first tsc run in the worktree
+  # only rechecks the delta instead of doing a full cold build.
+  local ts_count=0
+  while IFS= read -r -d '' buildinfo; do
+    rel="${buildinfo#$MAIN_REPO/}"
+    mkdir -p "$dir/$(dirname "$rel")"
+    cp "$buildinfo" "$dir/$rel"
+    ts_count=$((ts_count + 1))
+  done < <(find "$MAIN_REPO" -maxdepth 3 -name '*.tsbuildinfo' -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
+  if [ "$ts_count" -gt 0 ]; then
+    echo "  -> Seeded $ts_count .tsbuildinfo cache$([ "$ts_count" -eq 1 ] && echo "" || echo "s")"
+  else
+    echo "  -> Skipped .tsbuildinfo seeding (none found)"
+  fi
+
+  # Mirror gitignored symlinks (claude-skills scripts, commands, phases) into the worktree
+  local link_count=0
+  while IFS= read -r -d '' link; do
+    rel="${link#$MAIN_REPO/.claude/}"
+    target_dir="$dir/.claude/$(dirname "$rel")"
+    mkdir -p "$target_dir"
+    cp -a "$link" "$dir/.claude/$rel"
+    link_count=$((link_count + 1))
+  done < <(find "$MAIN_REPO/.claude" -path "$MAIN_REPO/.claude/worktrees" -prune -o -type l -print0 2>/dev/null)
+  if [ "$link_count" -gt 0 ]; then
+    echo "  -> Mirrored $link_count .claude symlink$([ "$link_count" -eq 1 ] && echo "" || echo "s")"
+  fi
+
+  # Symlink .githooks so pre-push hook runs in worktrees
+  if [ -d "$MAIN_REPO/.githooks" ]; then
+    ln -sf "$MAIN_REPO/.githooks" "$dir/.githooks"
+    echo "  -> Linked .githooks"
+  fi
+
+  echo ""
+  echo "Ready! To start working:"
+  echo "  cd $dir && claude"
+}
+
+create_batch() {
+  local start_point=""
+  local max_jobs=8
+  local branches=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --start-point) start_point="$2"; shift 2 ;;
+      --jobs) max_jobs="$2"; shift 2 ;;
+      *) branches+=("$1"); shift ;;
+    esac
+  done
+
+  if [[ ${#branches[@]} -eq 0 ]]; then
+    echo "Error: at least one branch name required"
+    exit 1
+  fi
+
+  if [[ $max_jobs -lt 1 ]]; then
+    echo "Error: --jobs must be >= 1 (got $max_jobs)"
+    exit 1
+  fi
+
+  local total=${#branches[@]}
+  echo "Creating $total worktrees (up to $max_jobs parallel)..."
+
+  # Pre-cache: run each find once instead of once per worktree
+  local nm_cache ts_cache link_cache spm_cache
+  nm_cache="$(find "$MAIN_REPO" -maxdepth 2 -name node_modules -type d -not -path '*/.git/*' 2>/dev/null || true)"
+  ts_cache="$(find "$MAIN_REPO" -maxdepth 3 -name '*.tsbuildinfo' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null || true)"
+  link_cache="$(find "$MAIN_REPO/.claude" -path "$MAIN_REPO/.claude/worktrees" -prune -o -type l -print 2>/dev/null || true)"
+  spm_cache="$(find "$MAIN_REPO" -maxdepth 4 -name Package.swift -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/.build/*' -exec sh -c 'dir="$(dirname "$1")"; [ -d "$dir/.build" ] && echo "$dir/.build"' _ {} \; 2>/dev/null || true)"
+
+  local has_settings=false
+  [ -f "$MAIN_REPO/.claude/settings.local.json" ] && has_settings=true
+  local has_githooks=false
+  [ -d "$MAIN_REPO/.githooks" ] && has_githooks=true
+
+  # Phase 1: Register worktrees without checkout (sequential, fast — metadata only)
+  local dirs=() wt_branches=() reg_failed=0
+  for branch in "${branches[@]}"; do
+    local slug="${branch//\//-}"
+    local dir="$PARENT_DIR/${WT_PREFIX}-${slug}"
+
+    if [ -d "$dir" ]; then
+      echo "  skip: $branch (already exists)"
+      continue
+    fi
+
+    local git_args=("worktree" "add" "--no-checkout" "-b" "$branch" "$dir")
+    [ -n "$start_point" ] && git_args+=("$start_point")
+
+    if ! git -C "$MAIN_REPO" "${git_args[@]}" 2>/dev/null; then
+      echo "  ✗ $branch (failed to register)"
+      reg_failed=$((reg_failed + 1))
+      continue
+    fi
+
+    dirs+=("$dir")
+    wt_branches+=("$branch")
+  done
+
+  if [[ ${#dirs[@]} -eq 0 ]]; then
+    echo "No worktrees to create."
+    [[ $reg_failed -gt 0 ]] && return 1
+    return 0
+  fi
+
+  echo "  registered ${#dirs[@]} worktrees"
+
+  # Phase 2: Checkout + post-setup in parallel
+  local pids=()
+  for i in "${!dirs[@]}"; do
+    local dir="${dirs[$i]}"
+    local branch="${wt_branches[$i]}"
+
+    (
+      # Check out files from HEAD
+      git -C "$dir" checkout -f >/dev/null 2>&1
+
+      # Copy local settings
+      if $has_settings; then
+        mkdir -p "$dir/.claude"
+        cp "$MAIN_REPO/.claude/settings.local.json" "$dir/.claude/settings.local.json"
+      fi
+
+      disable_worktree_lsp "$dir"
+
+      # Symlink node_modules (from cache)
+      if [ -n "$nm_cache" ]; then
+        while IFS= read -r nm; do
+          [ -z "$nm" ] && continue
+          rel="${nm#$MAIN_REPO/}"
+          pkg_dir="$dir/$(dirname "$rel")"
+          mkdir -p "$pkg_dir"
+          ln -s "$nm" "$pkg_dir/node_modules"
+        done <<< "$nm_cache"
+      fi
+
+      # Symlink SPM .build directories (from cache)
+      if [ -n "$spm_cache" ]; then
+        while IFS= read -r build_dir; do
+          [ -z "$build_dir" ] && continue
+          rel="${build_dir#$MAIN_REPO/}"
+          wt_pkg_dir="$dir/$(dirname "$rel")"
+          mkdir -p "$wt_pkg_dir"
+          ln -s "$build_dir" "$wt_pkg_dir/.build"
+        done <<< "$spm_cache"
+      fi
+
+      # Seed .tsbuildinfo (from cache)
+      if [ -n "$ts_cache" ]; then
+        while IFS= read -r buildinfo; do
+          [ -z "$buildinfo" ] && continue
+          rel="${buildinfo#$MAIN_REPO/}"
+          mkdir -p "$dir/$(dirname "$rel")"
+          cp "$buildinfo" "$dir/$rel"
+        done <<< "$ts_cache"
+      fi
+
+      # Mirror .claude symlinks (from cache)
+      if [ -n "$link_cache" ]; then
+        while IFS= read -r link; do
+          [ -z "$link" ] && continue
+          rel="${link#$MAIN_REPO/.claude/}"
+          target_dir="$dir/.claude/$(dirname "$rel")"
+          mkdir -p "$target_dir"
+          cp -a "$link" "$dir/.claude/$rel"
+        done <<< "$link_cache"
+      fi
+
+      # Link .githooks
+      if $has_githooks; then
+        ln -sf "$MAIN_REPO/.githooks" "$dir/.githooks"
+      fi
+
+      echo "  ✓ $branch"
+    ) &
+    pids+=($!)
+
+    # Throttle to max_jobs
+    while [[ $(jobs -rp | wc -l) -ge $max_jobs ]]; do
+      sleep 0.1
+    done
+  done
+
+  # Wait for all and count failures
+  local failed=0
+  for pid in "${pids[@]}"; do
+    wait "$pid" || failed=$((failed + 1))
+  done
+
+  local succeeded=$(( ${#dirs[@]} - failed ))
+  local total_failed=$(( reg_failed + failed ))
+  echo ""
+  if [[ $total_failed -gt 0 ]]; then
+    echo "Done: $succeeded created, $total_failed failed."
+    return 1
+  else
+    echo "Done: $succeeded worktrees ready."
+  fi
+}
+
+remove() {
+  local branch="$1"
+  local delete_branch=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --delete-branch) delete_branch="yes"; shift ;;
+      --no-delete-branch) delete_branch="no"; shift ;;
+      *) echo "Error: unknown option $1"; usage; exit 1 ;;
+    esac
+  done
+
+  local slug="${branch//\//-}"
+  local dir="$PARENT_DIR/${WT_PREFIX}-${slug}"
+
+  # Fall back to legacy prefix for worktrees created before the rename
+  if [ ! -d "$dir" ]; then
+    local legacy_dir="$PARENT_DIR/vellum-wt-${slug}"
+    if [ -d "$legacy_dir" ]; then
+      dir="$legacy_dir"
+    else
+      echo "Error: no worktree at $dir"
+      exit 1
+    fi
+  fi
+
+  echo "Removing worktree at $dir..."
+  git -C "$MAIN_REPO" worktree remove "$dir"
+
+  if [[ "$delete_branch" == "yes" ]]; then
+    REPLY="y"
+  elif [[ "$delete_branch" == "no" ]]; then
+    REPLY="n"
+  elif [[ -t 0 ]]; then
+    read -p "Delete branch $branch? [y/N] " -n 1 -r
+    echo
+  else
+    # Non-TTY: no interactive prompt available — default to keeping the branch.
+    # (Using `read` here would hang if stdin is a pipe that stays open.)
+    REPLY="n"
+  fi
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    git -C "$MAIN_REPO" branch -d "$branch" 2>/dev/null || \
+      git -C "$MAIN_REPO" branch -D "$branch"
+    echo "Branch $branch deleted."
+  fi
+}
+
+list() {
+  git -C "$MAIN_REPO" worktree list
+}
+
+clean() {
+  local delete_branch=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --delete-branch) delete_branch="yes"; shift ;;
+      --no-delete-branch) delete_branch="no"; shift ;;
+      *) echo "Error: unknown option $1"; usage; exit 1 ;;
+    esac
+  done
+
+  # Parse porcelain output into parallel arrays to avoid stdin redirection
+  # issues (which would break interactive prompts) and handle paths with spaces.
+  local dirs=() branches=()
+  local cur_dir="" cur_branch=""
+  local canonical_root
+  canonical_root="$(realpath "$MAIN_REPO")"
+  while IFS= read -r line; do
+    if [[ "$line" == "worktree "* ]]; then
+      cur_dir="${line#worktree }"
+      cur_branch=""
+    elif [[ "$line" == "branch "* ]]; then
+      # refs/heads/foo → foo
+      cur_branch="${line#branch refs/heads/}"
+    elif [[ -z "$line" ]]; then
+      # End of record — store if not the main worktree
+      if [[ -n "$cur_dir" ]] && [[ "$(realpath "$cur_dir")" != "$canonical_root" ]]; then
+        dirs+=("$cur_dir")
+        branches+=("$cur_branch")
+      fi
+      cur_dir=""
+      cur_branch=""
+    fi
+  done < <(git -C "$MAIN_REPO" worktree list --porcelain)
+
+  local count=${#dirs[@]}
+
+  if [[ $count -eq 0 ]]; then
+    echo "No worktrees to clean up."
+    return
+  fi
+
+  # In interactive mode, collect branch deletion decisions upfront so we can
+  # parallelise the actual removal work afterwards.
+  local delete_branches=()
+  for i in "${!dirs[@]}"; do
+    local branch="${branches[$i]}"
+    if [[ -z "$branch" ]]; then
+      delete_branches+=("no")
+    elif [[ "$delete_branch" == "yes" ]]; then
+      delete_branches+=("yes")
+    elif [[ "$delete_branch" == "no" ]]; then
+      delete_branches+=("no")
+    elif [[ -t 0 ]]; then
+      read -p "Delete branch $branch? [y/N] " -n 1 -r
+      echo
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        delete_branches+=("yes")
+      else
+        delete_branches+=("no")
+      fi
+    else
+      delete_branches+=("no")
+    fi
+  done
+
+  # Remove worktrees sequentially to avoid git lock contention
+  # (all operations target the same repo's .git/worktrees/ metadata)
+  local failed=0
+  for i in "${!dirs[@]}"; do
+    echo "Removing worktree at ${dirs[$i]}..."
+    git -C "$MAIN_REPO" worktree remove --force "${dirs[$i]}" || failed=$((failed + 1))
+  done
+
+  if [[ $failed -gt 0 ]]; then
+    echo "Warning: $failed worktree removal(s) failed."
+  fi
+
+  # Delete branches sequentially (cheap and avoids git lock contention)
+  for i in "${!branches[@]}"; do
+    if [[ "${delete_branches[$i]}" == "yes" ]]; then
+      git -C "$MAIN_REPO" branch -D "${branches[$i]}" 2>/dev/null && \
+        echo "Branch ${branches[$i]} deleted." || true
+    fi
+  done
+
+  # Prune stale worktree metadata
+  git -C "$MAIN_REPO" worktree prune
+
+  echo "Cleaned up $((count - failed)) worktree(s)."
+
+  if [[ $failed -gt 0 ]]; then
+    return 1
+  fi
+}
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  create)
+    [ $# -lt 2 ] && { echo "Error: branch name required"; usage; exit 1; }
+    create "$2" "${3:-}"
+    ;;
+  create-batch)
+    shift
+    create_batch "$@"
+    ;;
+  remove)
+    [ $# -lt 2 ] && { echo "Error: branch name required"; usage; exit 1; }
+    shift
+    remove "$@"
+    ;;
+  list)
+    list
+    ;;
+  clean)
+    shift
+    clean "$@"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -216,7 +216,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(runAgentLoop).toHaveBeenCalledTimes(0);
   });
 
-  test("passes undefined pendingRequestIds when no canonical hints are found", async () => {
+  test("passes empty pendingRequestIds array when no canonical hints are found", async () => {
     listPendingByDestinationMock.mockReturnValue([]);
     listCanonicalMock.mockReturnValue([]);
     routeGuardianReplyMock.mockResolvedValue({


### PR DESCRIPTION
Addresses review feedback from #18881:

- **Worktree helper**: `.claude/worktree` was accidentally changed to a symlink pointing to a local path. Restored as a proper executable file so it works on all machines and CI.
- **Test name**: Updated test description from 'passes undefined pendingRequestIds...' to match the new `toEqual([])` assertion.

Follows up on #18881.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
