### PR TITLE
fix: gate source_paths to edit mode and allow attachment fallback

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/harrisonngo/Projects/claude-skills/scripts/worktree
+/Users/sidd/vocify/claude-skills/scripts/worktree

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -114,11 +114,14 @@ export async function run(
     );
 
     if (visibleAttachments.length === 0 && attachmentIds.length > 0) {
-      return {
-        content:
-          "None of the specified attachments could be found or are accessible.",
-        isError: true,
-      };
+      // Only error if source_paths won't provide images either
+      if (!sourcePaths || sourcePaths.length === 0) {
+        return {
+          content:
+            "None of the specified attachments could be found or are accessible.",
+          isError: true,
+        };
+      }
     }
 
     sourceImages = visibleAttachments
@@ -139,8 +142,8 @@ export async function run(
       .filter((img): img is NonNullable<typeof img> => img !== undefined);
   }
 
-  // Resolve source images from file paths (sandboxed to workingDir)
-  if (sourcePaths && sourcePaths.length > 0) {
+  // Resolve source images from file paths (sandboxed to workingDir, edit mode only)
+  if (mode === "edit" && sourcePaths && sourcePaths.length > 0) {
     const errors: string[] = [];
     const validPathImages: Array<{ mimeType: string; dataBase64: string }> = [];
     for (const filePath of sourcePaths) {
@@ -160,7 +163,7 @@ export async function run(
         dataBase64: buffer.toString("base64"),
       });
     }
-    if (validPathImages.length === 0) {
+    if (validPathImages.length === 0 && (!sourceImages || sourceImages.length === 0)) {
       return {
         content: `None of the specified file paths could be read.\n${errors.join("\n")}`,
         isError: true,


### PR DESCRIPTION
Addresses review feedback from #18909:

- **Edit-mode gate**: `source_paths` handling is now gated to edit mode only, since source images are irrelevant for generation.
- **Attachment fallback**: The early return on attachment failure now checks that `source_paths` are also absent/empty before erroring. When valid `source_paths` exist, processing continues.
- **Mixed inputs**: Both `attachment_ids` and `source_paths` can now contribute images as documented ('in addition to attachment_ids').

Follows up on #18909.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
