### PR TITLE
fix(macos): gate expansion re-pin on near-bottom state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -887,7 +887,9 @@ struct MessageListView: View {
                 if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
                 // During content expansion while bottom-pinned, re-anchor to bottom
                 // on every frame so the viewport follows the growing content.
-                if scrollTracking.isPinningDuringExpansion {
+                // Gate on isNearBottom so that if the user scrolls away during
+                // the pinning window, we stop fighting their scroll.
+                if scrollTracking.isPinningDuringExpansion && isNearBottom {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 }
                 os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")


### PR DESCRIPTION
Addresses review feedback from #18726:

The frame-by-frame re-pin path during step expansion always forced a bottom scroll for the full 250ms window, even if the user scrolled away. Now gates the re-pin on `isNearBottom` so that manual scrolling away cancels the pinning behavior.

Follows up on #18726.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
