### PR TITLE
fix: restore UI bounds and rehydration after truncation removal

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/harrisonngo/Projects/claude-skills/scripts/worktree
+/Users/sidd/vocify/claude-skills/scripts/worktree

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -239,13 +239,13 @@ describe("tool preview lifecycle", () => {
       expect(activity.statusText).toMatch(/^Preparing/);
     });
 
-    test("handleInputJsonDelta includes toolUseId", () => {
+    test("handleInputJsonDelta includes toolUseId for app tools", () => {
       const collector = createEventCollector();
       const deps = createMockDeps({ onEvent: collector.onEvent });
 
       handleInputJsonDelta(state, deps, {
         type: "input_json_delta",
-        toolName: "bash",
+        toolName: "app_create",
         toolUseId: "toolu_delta456",
         accumulatedJson: '{"command": "ls"}',
       });
@@ -254,7 +254,7 @@ describe("tool preview lifecycle", () => {
       const emitted = collector.events[0];
       expect(emitted.type).toBe("tool_input_delta");
       expect((emitted as any).toolUseId).toBe("toolu_delta456");
-      expect((emitted as any).toolName).toBe("bash");
+      expect((emitted as any).toolName).toBe("app_create");
       expect((emitted as any).content).toBe('{"command": "ls"}');
       expect((emitted as any).conversationId).toBe("test-session-id");
     });
@@ -306,7 +306,8 @@ describe("tool preview lifecycle", () => {
       });
 
       const toolUseId = "toolu_ordering_test";
-      const toolName = "file_read";
+      // Use an app tool so input_json_delta is forwarded to the client
+      const toolName = "app_create";
 
       // Step 1: tool_use_preview_start (emitted by provider on content_block_start)
       handleToolUsePreviewStart(state, deps, {
@@ -345,6 +346,30 @@ describe("tool preview lifecycle", () => {
       }
     });
 
+    test("non-app tool input_json_delta events are not forwarded to client", () => {
+      const collector = createEventCollector();
+      const deps = createMockDeps({
+        onEvent: collector.onEvent,
+        ctx: {
+          ...createMockDeps().ctx,
+          emitActivityState: collector.emitActivityState,
+        } as unknown as EventHandlerDeps["ctx"],
+      });
+
+      const toolUseId = "toolu_non_app_delta";
+      const toolName = "file_read";
+
+      handleInputJsonDelta(state, deps, {
+        type: "input_json_delta",
+        toolName,
+        toolUseId,
+        accumulatedJson: '{"path": "/test"}',
+      });
+
+      // Non-app tools should not emit tool_input_delta to the client
+      expect(collector.events).toEqual([]);
+    });
+
     test("full lifecycle: preview_start → input_delta → tool_use → tool_result", () => {
       const collector = createEventCollector();
       const deps = createMockDeps({
@@ -356,7 +381,8 @@ describe("tool preview lifecycle", () => {
       });
 
       const toolUseId = "toolu_full_lifecycle";
-      const toolName = "bash";
+      // Use an app tool so input_json_delta is forwarded to the client
+      const toolName = "app_update";
 
       // 1. Preview start
       handleToolUsePreviewStart(state, deps, {

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -170,6 +170,12 @@ export function emitLlmCallStartedIfNeeded(
   );
 }
 
+// ── Client Payload Size Caps ─────────────────────────────────────────
+// tool_input_delta streams accumulated JSON as tools run. For non-app
+// tools the client discards it (extractCodePreview only handles app tools),
+// so we skip forwarding entirely to avoid transport/decode overhead.
+const APP_TOOL_NAMES = new Set(["app_create", "app_update"]);
+
 // ── Friendly Tool Names ──────────────────────────────────────────────
 
 const TOOL_FRIENDLY_NAMES: Record<string, string> = {
@@ -388,6 +394,10 @@ export function handleInputJsonDelta(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "input_json_delta" }>,
 ): void {
+  // Only forward input deltas for app tools — the client only uses this
+  // stream for app_create/app_update code previews. Non-app tools would
+  // send large cumulative JSON on every delta with no benefit.
+  if (!APP_TOOL_NAMES.has(event.toolName)) return;
   deps.onEvent({
     type: "tool_input_delta",
     toolName: event.toolName,

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -502,7 +502,7 @@ private struct StepDetailRow: View {
     @State private var isHovered = false
     /// Cached formatted input — computed once on first expand.
     @State private var cachedInputFull: String?
-@Environment(\.displayScale) private var displayScale
+    @Environment(\.displayScale) private var displayScale
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
 
     /// Lazily resolved full input text.
@@ -643,6 +643,8 @@ private struct StepDetailRow: View {
                                 cachedInputFull = ToolCallData.formatAllToolInput(dict)
                             }
                         }
+                        // Trigger on-demand rehydration when expanding truncated content.
+                        onRehydrate?()
                     }
             }
         }
@@ -756,7 +758,7 @@ private struct StepDetailRow: View {
 
     // MARK: - Output Block
 
-    /// Reusable output block — shows full text with a copy button.
+    /// Reusable output block with a height-bounded ScrollView for long outputs.
     @ViewBuilder
     private func outputBlock(
         text: String?,
@@ -764,9 +766,17 @@ private struct StepDetailRow: View {
         copyText: String,
         copyLabel: String
     ) -> some View {
+        let lineCount = copyText.components(separatedBy: "\n").count
+
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                if let attrText = attributedText {
+                if lineCount > 500 {
+                    // Long outputs get a height-bounded ScrollView
+                    ScrollView {
+                        outputTextView(text: text, attributedText: attributedText)
+                    }
+                    .frame(maxHeight: 400)
+                } else if let attrText = attributedText {
                     Text(attrText)
                         .font(VFont.monoSmall)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -796,6 +806,26 @@ private struct StepDetailRow: View {
                 NSPasteboard.general.setString(copyText, forType: .string)
             }
             .padding(VSpacing.xs)
+        }
+    }
+
+    /// Text view used inside the ScrollView for long outputs.
+    @ViewBuilder
+    private func outputTextView(
+        text: String?,
+        attributedText: AttributedString?
+    ) -> some View {
+        if let attrText = attributedText {
+            Text(attrText)
+                .font(VFont.monoSmall)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        } else if let plainText = text {
+            Text(plainText)
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -797,6 +797,9 @@ public struct ToolCallData: Identifiable, Equatable {
     /// rehydration (empty -> populated) without expensive full-string comparison.
     public var inputRawValueLength: Int = 0
     public var result: String?
+    /// Lightweight sentinel tracking `result?.count` so that `==` can detect
+    /// rehydration without expensive full-string comparison on multi-MB results.
+    public var resultLength: Int = 0
     public var isError: Bool
     public var isComplete: Bool
     /// Raw decoded tool input dictionary, stored for lazy formatting of `inputFull`.
@@ -845,7 +848,7 @@ public struct ToolCallData: Identifiable, Equatable {
         lhs.id == rhs.id
             && lhs.toolName == rhs.toolName
             && lhs.inputSummary == rhs.inputSummary
-            && lhs.result == rhs.result
+            && lhs.resultLength == rhs.resultLength
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
@@ -877,6 +880,7 @@ public struct ToolCallData: Identifiable, Equatable {
         self.inputRawValue = rawValue
         self.inputRawValueLength = rawValue.count
         self.result = result
+        self.resultLength = result?.count ?? 0
         self.isError = isError
         self.isComplete = isComplete
         self.arrivedBeforeText = arrivedBeforeText
@@ -1728,6 +1732,7 @@ public struct ChatMessage: Identifiable, Equatable {
             toolCalls[i].cachedImage = nil
             toolCalls[i].imageData = nil
             toolCalls[i].result = nil
+            toolCalls[i].resultLength = 0
             toolCalls[i].inputFull = ""
             toolCalls[i].inputFullLength = 0
             toolCalls[i].inputRawDict = nil

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1526,6 +1526,7 @@ extension ChatViewModel {
             }
             if let msgIndex = targetMsgIndex, let tcIndex = targetTcIndex {
                 messages[msgIndex].toolCalls[tcIndex].result = msg.result
+                messages[msgIndex].toolCalls[tcIndex].resultLength = msg.result.count
                 messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
                 messages[msgIndex].toolCalls[tcIndex].isComplete = true
                 messages[msgIndex].toolCalls[tcIndex].completedAt = Date()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -799,6 +799,7 @@ public final class ChatViewModel: ObservableObject {
                 }
                 if let result = fullTC.result {
                     messages[idx].toolCalls[tcIdx].result = result
+                    messages[idx].toolCalls[tcIdx].resultLength = result.count
                 }
                 if let input = fullTC.input {
                     let formatted = ToolCallData.formatAllToolInput(input)

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -18,7 +18,7 @@ public struct ToolCallChip: View {
     /// `formatAllToolInput` on every SwiftUI render pass.
     @State private var cachedInputFull: String?
 
-/// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
+    /// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
     static func parseExitCode(from result: String) -> Int? {
         // Match <command_exit code="N" /> where N is an integer
         guard let codeRange = result.range(of: #"<command_exit code="(\d+)" />"#, options: .regularExpression) else {
@@ -206,12 +206,14 @@ public struct ToolCallChip: View {
                                         .foregroundColor(VColor.contentSecondary)
                                 }
                             } else {
-                                Text(result)
-                                .font(VFont.monoSmall)
-                                .foregroundColor(VColor.contentSecondary)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: false, vertical: true)
+                                ScrollView {
+                                    Text(result)
+                                        .font(VFont.monoSmall)
+                                        .foregroundColor(VColor.contentSecondary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .textSelection(.enabled)
+                                }
+                                .frame(maxHeight: 200)
                             }
                         }
                         .padding(.horizontal, VSpacing.sm)
@@ -229,6 +231,8 @@ public struct ToolCallChip: View {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
                     }
+                    // Trigger on-demand rehydration when expanding truncated content.
+                    onRehydrate?()
                 }
             }
         }


### PR DESCRIPTION
Addresses review feedback from #18745:

- **Rehydration trigger**: Restore `onRehydrate` call path in both `ToolCallChip` and `AssistantProgressView` so that `wasTruncated` history entries (loaded with `maxToolResultChars: 1000`) fetch full data on expand.
- **Non-app delta cap**: Only forward `tool_input_delta` events for app tools (`app_create`/`app_update`); other tools don't use the stream (`extractCodePreview` returns nil), so large cumulative JSON was sent on every delta with no benefit.
- **UI bounds**: Wrap unbounded `Text.fixedSize` in `ScrollView { ... }.frame(maxHeight: 200)` for tool results in `ToolCallChip`. Add `ScrollView { ... }.frame(maxHeight: 400)` for output blocks with >500 lines in `AssistantProgressView`.
- **Equatable sentinel**: Add `resultLength` to `ToolCallData` and compare it instead of the full `result` string in `==`, matching the existing `inputFullLength`/`inputRawValueLength` pattern.

Follows up on #18745.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
