### PR TITLE
Store all attachments on disk, remove inline base64 storage path

### DIFF
--- a/.claude/worktree
+++ b/.claude/worktree
@@ -1,1 +1,1 @@
-/Users/harrisonngo/Projects/claude-skills/scripts/worktree
+/Users/sidd/vocify/claude-skills/scripts/worktree

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -15,6 +15,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(testDir, "test.log"),
   ensureDataDir: () => {},
   getRootDir: () => testDir,
+  getWorkspaceDir: () => join(testDir, "workspace"),
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -40,8 +41,10 @@ import {
   deleteAttachment,
   deleteOrphanAttachments,
   getAttachmentById,
+  getAttachmentContent,
   getAttachmentsByIds,
   getAttachmentsForMessage,
+  getFilePathForAttachment,
   isValidBase64,
   linkAttachmentToMessage,
   MAX_UPLOAD_BYTES,
@@ -71,7 +74,7 @@ function resetTables() {
 }
 
 // ---------------------------------------------------------------------------
-// uploadAttachment
+// uploadAttachment — always writes to disk
 // ---------------------------------------------------------------------------
 
 describe("uploadAttachment", () => {
@@ -86,6 +89,26 @@ describe("uploadAttachment", () => {
     expect(stored.kind).toBe("image");
     expect(stored.sizeBytes).toBeGreaterThan(0);
     expect(stored.createdAt).toBeGreaterThan(0);
+  });
+
+  test("always writes file to disk", () => {
+    const stored = uploadAttachment("small.txt", "text/plain", "aGVsbG8=");
+    const filePath = getFilePathForAttachment(stored.id);
+
+    expect(filePath).toBeTruthy();
+    expect(existsSync(filePath!)).toBe(true);
+
+    // The on-disk file should contain the decoded bytes
+    const content = readFileSync(filePath!);
+    expect(content.toString()).toBe("hello");
+  });
+
+  test("stores empty dataBase64 in DB row", () => {
+    const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
+    const row = getAttachmentById(stored.id);
+
+    expect(row).not.toBeNull();
+    expect(row!.dataBase64).toBe("");
   });
 
   test("classifies image MIME as image kind", () => {
@@ -105,7 +128,7 @@ describe("uploadAttachment", () => {
   });
 
   test("computes sizeBytes from base64 correctly", () => {
-    // "hello" = "aGVsbG8=" (8 chars, 1 pad → 5 bytes)
+    // "hello" = "aGVsbG8=" (8 chars, 1 pad -> 5 bytes)
     const stored = uploadAttachment("hello.txt", "text/plain", "aGVsbG8=");
     expect(stored.sizeBytes).toBe(5);
   });
@@ -146,7 +169,7 @@ describe("uploadAttachment", () => {
 
   test("rejects payloads exceeding MAX_UPLOAD_BYTES", () => {
     // Build a base64 string that decodes to just over the limit.
-    // 4 base64 chars → 3 bytes, so we need ceil((MAX_UPLOAD_BYTES+1)/3)*4 chars.
+    // 4 base64 chars -> 3 bytes, so we need ceil((MAX_UPLOAD_BYTES+1)/3)*4 chars.
     const oversizedLength = Math.ceil((MAX_UPLOAD_BYTES + 1) / 3) * 4;
     const oversizedData = "A".repeat(oversizedLength);
 
@@ -162,7 +185,7 @@ describe("uploadAttachment", () => {
   });
 
   test("accepts base64 with non-standard padding/length", () => {
-    // Lenient on length — only character set is validated
+    // Lenient on length -- only character set is validated
     expect(() => uploadAttachment("ok.txt", "text/plain", "AAA")).not.toThrow();
   });
 
@@ -175,6 +198,38 @@ describe("uploadAttachment", () => {
     expect(() =>
       uploadAttachment("exact.bin", "application/octet-stream", exactData),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAttachmentContent — always reads from disk
+// ---------------------------------------------------------------------------
+
+describe("getAttachmentContent", () => {
+  beforeEach(resetTables);
+
+  test("reads content from on-disk file", () => {
+    const stored = uploadAttachment("hello.txt", "text/plain", "aGVsbG8=");
+    const content = getAttachmentContent(stored.id);
+
+    expect(content).not.toBeNull();
+    expect(content!.toString()).toBe("hello");
+  });
+
+  test("returns null for nonexistent attachment", () => {
+    const content = getAttachmentContent("no-such-id");
+    expect(content).toBeNull();
+  });
+
+  test("returns null when on-disk file is missing (ENOENT)", () => {
+    const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
+    const filePath = getFilePathForAttachment(stored.id);
+
+    // Remove the file to simulate ENOENT
+    rmSync(filePath!);
+
+    const content = getAttachmentContent(stored.id);
+    expect(content).toBeNull();
   });
 });
 
@@ -219,6 +274,15 @@ describe("deleteAttachment", () => {
     expect(fetched).toBeNull();
   });
 
+  test("cleans up on-disk file when deleting", () => {
+    const stored = uploadAttachment("cleanup.txt", "text/plain", "dGVzdA==");
+    const filePath = getFilePathForAttachment(stored.id);
+    expect(existsSync(filePath!)).toBe(true);
+
+    deleteAttachment(stored.id);
+    expect(existsSync(filePath!)).toBe(false);
+  });
+
   test("returns not_found for nonexistent attachment", () => {
     const result = deleteAttachment("nonexistent-id");
     expect(result).toBe("not_found");
@@ -254,7 +318,7 @@ describe("deleteAttachment", () => {
 
   test("deletes attachment when no messages reference it", () => {
     const stored = uploadAttachment("lonely.txt", "text/plain", "UNREFERENCED");
-    // No linkAttachmentToMessage call — zero references
+    // No linkAttachmentToMessage call -- zero references
     const result = deleteAttachment(stored.id);
     expect(result).toBe("deleted");
 
@@ -270,14 +334,15 @@ describe("deleteAttachment", () => {
 describe("getAttachmentsByIds", () => {
   beforeEach(resetTables);
 
-  test("returns matching attachments with data", () => {
+  test("returns matching attachments with empty dataBase64", () => {
     const a = uploadAttachment("a.txt", "text/plain", "AAAA");
     const b = uploadAttachment("b.txt", "text/plain", "BBBB");
 
     const results = getAttachmentsByIds([a.id, b.id]);
     expect(results).toHaveLength(2);
-    expect(results[0].dataBase64).toBe("AAAA");
-    expect(results[1].dataBase64).toBe("BBBB");
+    // dataBase64 is always empty since content is on disk
+    expect(results[0].dataBase64).toBe("");
+    expect(results[1].dataBase64).toBe("");
   });
 
   test("returns empty array for empty IDs list", () => {
@@ -299,14 +364,15 @@ describe("getAttachmentsByIds", () => {
 describe("getAttachmentById", () => {
   beforeEach(resetTables);
 
-  test("returns attachment with data when found", () => {
+  test("returns attachment with empty dataBase64 when found", () => {
     const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
     const result = getAttachmentById(stored.id);
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(stored.id);
     expect(result!.originalFilename).toBe("report.pdf");
-    expect(result!.dataBase64).toBe("JVBER");
+    // dataBase64 is empty; content is on disk
+    expect(result!.dataBase64).toBe("");
   });
 
   test("returns null for nonexistent ID", () => {
@@ -333,7 +399,8 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     expect(linked).toHaveLength(1);
     expect(linked[0].id).toBe(stored.id);
     expect(linked[0].originalFilename).toBe("chart.png");
-    expect(linked[0].dataBase64).toBe("iVBORw0K");
+    // dataBase64 is empty; content is on disk
+    expect(linked[0].dataBase64).toBe("");
   });
 
   test("returns attachments in position order", async () => {
@@ -373,6 +440,15 @@ describe("deleteOrphanAttachments", () => {
 
     const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(1);
+  });
+
+  test("cleans up on-disk files when removing orphans", () => {
+    const stored = uploadAttachment("orphan.txt", "text/plain", "ZGF0YQ==");
+    const filePath = getFilePathForAttachment(stored.id);
+    expect(existsSync(filePath!)).toBe(true);
+
+    deleteOrphanAttachments([stored.id]);
+    expect(existsSync(filePath!)).toBe(false);
   });
 
   test("preserves attachments that are still linked", async () => {
@@ -500,7 +576,7 @@ describe("validateAttachmentUpload", () => {
   });
 
   test("handles filenames without extensions", () => {
-    // No extension — only MIME check applies
+    // No extension -- only MIME check applies
     expect(validateAttachmentUpload("Makefile", "text/plain").ok).toBe(true);
     expect(validateAttachmentUpload("Makefile", "application/x-evil").ok).toBe(
       false,

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -60,7 +60,6 @@ mock.module("../permissions/types.js", () => ({
 
 import type { AssistantAttachmentDraft } from "../daemon/assistant-attachments.js";
 import {
-  FILE_BACKED_THRESHOLD_BYTES,
   getFilePathForAttachment,
 } from "../memory/attachments-store.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
@@ -94,13 +93,13 @@ function makeBase64(bytes: number): string {
 }
 
 // ---------------------------------------------------------------------------
-// resolveAssistantAttachments — inline vs file-backed storage
+// resolveAssistantAttachments — all attachments are now file-backed
 // ---------------------------------------------------------------------------
 
 describe("resolveAssistantAttachments", () => {
   beforeEach(resetTables);
 
-  test("attachments under 5 MB are stored inline via uploadAttachment", async () => {
+  test("small attachments are stored on disk via uploadAttachment", async () => {
     const conv = createConversation("test-conv");
     const msg = await addMessage(conv.id, "assistant", "hello");
 
@@ -150,15 +149,17 @@ describe("resolveAssistantAttachments", () => {
     expect(result.emittedAttachments.length).toBe(1);
     const emitted = result.emittedAttachments[0];
     expect(emitted.id).toBeDefined();
-    expect(emitted.data).toBe(dataBase64); // inline — data is present
-    expect(emitted.sizeBytes).toBeUndefined(); // no sizeBytes hint for inline
 
-    // Verify the attachment is in the DB and not file-backed
+    // All attachments are file-backed and have a file on disk
     const filePath = getFilePathForAttachment(emitted.id!);
-    expect(filePath).toBeNull();
+    expect(filePath).not.toBeNull();
+    expect(existsSync(filePath!)).toBe(true);
+
+    // fileBacked flag is always true now
+    expect(emitted.fileBacked).toBe(true);
   });
 
-  test("attachments over 5 MB are stored via uploadFileBackedAttachment with file on disk", async () => {
+  test("large attachments are stored on disk with file path", async () => {
     const conv = createConversation("test-conv-large");
     const msg = await addMessage(conv.id, "assistant", "hello");
 
@@ -207,9 +208,6 @@ describe("resolveAssistantAttachments", () => {
     expect(result.emittedAttachments.length).toBe(1);
     const emitted = result.emittedAttachments[0];
     expect(emitted.id).toBeDefined();
-    // File-backed: data should be empty, sizeBytes should be set
-    expect(emitted.data).toBe("");
-    expect(emitted.sizeBytes).toBe(largeSize);
 
     // Verify the file exists on disk at the expected path
     const filePath = getFilePathForAttachment(emitted.id!);
@@ -217,11 +215,8 @@ describe("resolveAssistantAttachments", () => {
     expect(filePath!).toContain("attachments");
     expect(filePath!).toContain("big-video.mov");
     expect(existsSync(filePath!)).toBe(true);
-  });
-});
 
-describe("FILE_BACKED_THRESHOLD_BYTES", () => {
-  test("is 5 MB", () => {
-    expect(FILE_BACKED_THRESHOLD_BYTES).toBe(5 * 1024 * 1024);
+    // fileBacked flag is always true now
+    expect(emitted.fileBacked).toBe(true);
   });
 });

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -1,7 +1,8 @@
 import {
   AttachmentUploadError,
-  FILE_BACKED_THRESHOLD_BYTES,
+  getFilePathForAttachment,
   linkAttachmentToMessage,
+  MAX_UPLOAD_BYTES,
   setAttachmentThumbnail,
   uploadAttachment,
   uploadFileBackedAttachment,
@@ -211,12 +212,13 @@ export async function resolveAssistantAttachments(
   if (assistantAttachments.length > 0 && lastAssistantMessageId) {
     for (let i = 0; i < assistantAttachments.length; i++) {
       const draft = assistantAttachments[i];
-      const isFileBacked = draft.sizeBytes > FILE_BACKED_THRESHOLD_BYTES;
       let stored;
-      let diskFilePath: string | undefined;
       try {
-        if (isFileBacked) {
-          diskFilePath = writeAttachmentToDisk(
+        // uploadAttachment always writes to disk now. For oversized files
+        // that exceed the upload limit, use the file-backed path which
+        // bypasses the size check.
+        if (draft.sizeBytes > MAX_UPLOAD_BYTES) {
+          const diskFilePath = writeAttachmentToDisk(
             draft.dataBase64,
             draft.filename,
           );
@@ -248,9 +250,9 @@ export async function resolveAssistantAttachments(
       }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       const isVideo = draft.mimeType.startsWith("video/");
+      // All attachments are file-backed; omit large data from the event payload
       const omitData =
-        isFileBacked ||
-        (isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE);
+        isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
 
       // Generate and persist a thumbnail for video attachments.
       let thumbnailData: string | undefined;
@@ -259,6 +261,7 @@ export async function resolveAssistantAttachments(
         if (existing) {
           thumbnailData = existing;
         } else {
+          const diskFilePath = getFilePathForAttachment(stored.id);
           const generated = diskFilePath
             ? await generateVideoThumbnailFromPath(diskFilePath)
             : await generateVideoThumbnail(draft.dataBase64);
@@ -275,7 +278,7 @@ export async function resolveAssistantAttachments(
         mimeType: draft.mimeType,
         data: omitData ? "" : draft.dataBase64,
         ...(omitData ? { sizeBytes: draft.sizeBytes } : {}),
-        ...(isFileBacked ? { fileBacked: true } : {}),
+        fileBacked: true,
         ...(thumbnailData ? { thumbnailData } : {}),
       });
     }

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1,18 +1,18 @@
 /**
  * Assistant-owned attachment storage.
  *
- * Stores attachments in the local SQLite database with base64-encoded
- * data. Provides upload, delete, and message-linkage operations.
+ * All attachments are stored on disk; the database row references the
+ * on-disk file path. Provides upload, delete, and message-linkage operations.
  */
 
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
-import { eq } from "drizzle-orm";
+import { eq, isNotNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getWorkspaceDir } from "../util/platform.js";
-import { getDb, rawAll, rawGet, rawRun } from "./db.js";
+import { getDb, rawAll, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
 
 export interface StoredAttachment {
@@ -50,9 +50,6 @@ function formatBytes(bytes: number): string {
 
 /** Hard ceiling on a single uploaded attachment (100 MB, matching assistant limits). */
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
-
-/** Attachments larger than this are stored on disk instead of inline in SQLite. */
-export const FILE_BACKED_THRESHOLD_BYTES = 5 * 1024 * 1024;
 
 /**
  * Write decoded base64 data to disk under the workspace attachments directory.
@@ -231,8 +228,7 @@ function computeContentHash(dataBase64: string): string {
  * normal 100 MB upload limit.
  *
  * The file stays on disk; the attachment row stores an empty dataBase64 and
- * records the on-disk path in a `file_path` column (added via DB migration
- * in 102-alter-table-columns.ts since the Drizzle schema doesn't know about it).
+ * records the on-disk path in the `file_path` column.
  */
 export function uploadFileBackedAttachment(
   filename: string,
@@ -243,19 +239,20 @@ export function uploadFileBackedAttachment(
   const now = Date.now();
   const kind = classifyKind(mimeType);
   const id = uuid();
+  const db = getDb();
 
-  // Use raw SQL since the Drizzle schema doesn't know about the file_path column
-  rawRun(
-    `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, file_path, created_at)
-     VALUES (?, ?, ?, ?, ?, '', ?, ?)`,
-    id,
-    filename,
-    mimeType,
-    sizeBytes,
-    kind,
-    filePath,
-    now,
-  );
+  db.insert(attachments)
+    .values({
+      id,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes,
+      kind,
+      dataBase64: "",
+      filePath,
+      createdAt: now,
+    })
+    .run();
 
   return {
     id,
@@ -270,66 +267,64 @@ export function uploadFileBackedAttachment(
 }
 
 /**
- * Returns the file_path for a file-backed attachment, or null if not file-backed.
- * Uses raw SQL since file_path is added via DB migration and is not in the Drizzle schema.
+ * Returns the file_path for an attachment, or null if not set.
+ * Now uses Drizzle since filePath is in the schema.
  */
 export function getFilePathForAttachment(attachmentId: string): string | null {
-  const row = rawGet<{ file_path: string | null }>(
-    "SELECT file_path FROM attachments WHERE id = ?",
-    attachmentId,
-  );
-  return row?.file_path ?? null;
+  const db = getDb();
+  const row = db
+    .select({ filePath: attachments.filePath })
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+  return row?.filePath ?? null;
 }
 
 /**
  * Batch-fetch file_path values for multiple attachment IDs in a single query.
- * Returns a Set of attachment IDs that are file-backed (have a non-null file_path).
- * Uses raw SQL since file_path is added via runtime migration and is not in the Drizzle schema.
+ * Returns a Set of attachment IDs that have a non-null file_path.
+ *
+ * @deprecated All attachments are now file-backed. This function is retained
+ * for callers that have not yet been updated.
  */
 export function getFileBackedAttachmentIds(
   attachmentIds: string[],
 ): Set<string> {
   if (attachmentIds.length === 0) return new Set();
-  const placeholders = attachmentIds.map(() => "?").join(", ");
-  const rows = rawAll<{ id: string }>(
-    `SELECT id FROM attachments WHERE id IN (${placeholders}) AND file_path IS NOT NULL`,
-    ...attachmentIds,
-  );
-  return new Set(rows.map((r) => r.id));
+  const db = getDb();
+  const rows = db
+    .select({ id: attachments.id })
+    .from(attachments)
+    .where(isNotNull(attachments.filePath))
+    .all();
+  const fileBackedSet = new Set(rows.map((r) => r.id));
+  return new Set(attachmentIds.filter((id) => fileBackedSet.has(id)));
 }
 
 /**
- * Return the raw binary content for an attachment, abstracting over inline
- * (base64-in-DB) vs file-backed (on-disk) storage.
+ * Return the raw binary content for an attachment by reading from its
+ * on-disk file path.
  *
- * For file-backed attachments the bytes are read from the on-disk path;
- * for inline attachments the base64 payload is decoded from the DB row.
- *
- * Returns null if the attachment does not exist.
+ * Returns null if the attachment does not exist or the file is missing.
  */
 export function getAttachmentContent(attachmentId: string): Buffer | null {
-  const filePath = getFilePathForAttachment(attachmentId);
-  if (filePath) {
-    try {
-      return readFileSync(filePath);
-    } catch (err: unknown) {
-      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-        return null;
-      }
-      throw err;
-    }
-  }
-
-  // Fall back to inline base64 stored in the DB
   const db = getDb();
   const row = db
-    .select({ dataBase64: attachments.dataBase64 })
+    .select({ filePath: attachments.filePath })
     .from(attachments)
     .where(eq(attachments.id, attachmentId))
     .get();
 
-  if (!row) return null;
-  return Buffer.from(row.dataBase64, "base64");
+  if (!row?.filePath) return null;
+
+  try {
+    return readFileSync(row.filePath);
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
 }
 
 export function uploadAttachment(
@@ -385,13 +380,17 @@ export function uploadAttachment(
   const now = Date.now();
   const kind = classifyKind(mimeType);
 
+  // Always write to disk
+  const filePath = writeAttachmentToDisk(dataBase64, filename);
+
   const record = {
     id: uuid(),
     originalFilename: filename,
     mimeType,
     sizeBytes,
     kind,
-    dataBase64,
+    dataBase64: "",
+    filePath,
     contentHash,
     createdAt: now,
   };
@@ -431,7 +430,7 @@ export type DeleteAttachmentResult =
 export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
   const db = getDb();
   const existing = db
-    .select({ id: attachments.id })
+    .select({ id: attachments.id, filePath: attachments.filePath })
     .from(attachments)
     .where(eq(attachments.id, attachmentId))
     .get();
@@ -450,7 +449,7 @@ export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
   if (refCount > 0) return "still_referenced";
 
   // Collect file path BEFORE deleting the DB row (the row contains the path reference)
-  const filePath = getFilePathForAttachment(attachmentId);
+  const { filePath } = existing;
 
   db.delete(attachments).where(eq(attachments.id, attachmentId)).run();
 
@@ -597,6 +596,8 @@ export function getAttachmentById(
 export function deleteOrphanAttachments(candidateIds: string[]): number {
   if (candidateIds.length === 0) return 0;
 
+  const db = getDb();
+
   // Identify truly orphaned attachment IDs first (not referenced by any message)
   const placeholders = candidateIds.map(() => "?").join(", ");
   const orphanIds = rawAll<{ id: string }>(
@@ -606,11 +607,15 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
 
   if (orphanIds.length === 0) return 0;
 
-  // Collect file paths BEFORE deleting the DB rows (the rows contain the path reference)
+  // Collect file paths BEFORE deleting the DB rows via Drizzle
   const orphanFilePaths: string[] = [];
   for (const id of orphanIds) {
-    const filePath = getFilePathForAttachment(id);
-    if (filePath) orphanFilePaths.push(filePath);
+    const row = db
+      .select({ filePath: attachments.filePath })
+      .from(attachments)
+      .where(eq(attachments.id, id))
+      .get();
+    if (row?.filePath) orphanFilePaths.push(row.filePath);
   }
 
   // Delete the orphaned DB rows first — if this fails, the on-disk files

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   migrateAssistantContactMetadata,
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
+  migrateBackfillInlineAttachmentsToDisk,
   migrateBackfillUsageCacheAccounting,
   migrateCallSessionInviteMetadata,
   migrateCallSessionMode,
@@ -463,6 +464,9 @@ export function initializeDb(): void {
 
   // 82. Add message_id column to llm_request_logs for per-message LLM context lookup
   migrateLlmRequestLogMessageId(database);
+
+  // 83. Backfill existing inline (base64-in-DB) attachments to on-disk storage
+  migrateBackfillInlineAttachmentsToDisk(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
+++ b/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
@@ -1,0 +1,68 @@
+import { writeAttachmentToDisk } from "../attachments-store.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Backfill existing inline (base64-in-DB) attachments to disk.
+ *
+ * Finds attachment rows that have non-empty data_base64 but no file_path,
+ * writes each one to disk, and updates the row to store the file path
+ * while clearing the inline data.
+ *
+ * Processes in batches of 50 to avoid holding large amounts of base64 data
+ * in memory at once.
+ */
+export function migrateBackfillInlineAttachmentsToDisk(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_backfill_inline_attachments_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+      const BATCH_SIZE = 50;
+      let totalMigrated = 0;
+
+      for (;;) {
+        const rows = raw
+          .query(
+            `SELECT id, original_filename, data_base64 FROM attachments
+             WHERE (file_path IS NULL OR file_path = '')
+               AND data_base64 != ''
+               AND length(data_base64) > 0
+             LIMIT ?`,
+          )
+          .all(BATCH_SIZE) as Array<{
+          id: string;
+          original_filename: string;
+          data_base64: string;
+        }>;
+
+        if (rows.length === 0) break;
+
+        for (const row of rows) {
+          const filePath = writeAttachmentToDisk(
+            row.data_base64,
+            row.original_filename,
+          );
+          raw
+            .query(
+              `UPDATE attachments SET file_path = ?, data_base64 = '' WHERE id = ?`,
+            )
+            .run(filePath, row.id);
+        }
+
+        totalMigrated += rows.length;
+      }
+
+      if (totalMigrated > 0) {
+        // Log is intentionally not imported to keep migration self-contained;
+        // the checkpoint value records completion.
+        console.log(
+          `Migrated ${totalMigrated} inline attachments to disk`,
+        );
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -121,6 +121,7 @@ export { migrateDropCapabilityCardState } from "./176-drop-capability-card-state
 export { migrateCreateTraceEventsTable } from "./177-create-trace-events-table.js";
 export { migrateOAuthProvidersManagedServiceConfigKey } from "./178-oauth-providers-managed-service-config-key.js";
 export { migrateLlmRequestLogMessageId } from "./179-llm-request-log-message-id.js";
+export { migrateBackfillInlineAttachmentsToDisk } from "./180-backfill-inline-attachments-to-disk.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -228,6 +228,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Remove deleted capability-card rows, jobs, checkpoints, and category state",
   },
+  {
+    key: "migration_backfill_inline_attachments_v1",
+    version: 34,
+    description:
+      "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64",
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -88,6 +88,7 @@ export const attachments = sqliteTable("attachments", {
   dataBase64: text("data_base64").notNull(),
   contentHash: text("content_hash"),
   thumbnailBase64: text("thumbnail_base64"),
+  filePath: text("file_path"),
   createdAt: integer("created_at").notNull(),
 });
 


### PR DESCRIPTION
## Summary
- Remove inline base64 attachment storage — all attachments now written to disk
- Add `filePath` column to Drizzle schema (was only in migration 102)
- Add backfill migration (180) to convert existing inline attachments to file-backed
- Simplify attachment content retrieval to always read from disk
- Update `conversation-attachments.ts` to remove threshold-based branching

Part of plan: conv-disk-view.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)