### PR TITLE
Add Linear ticket ID reminder hook for team members

### DIFF
--- a/.claude/hooks/linear-ticket-reminder.sh
+++ b/.claude/hooks/linear-ticket-reminder.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Inject a Linear ticket reminder for specific team members.
+# Users NOT in the remind list see nothing added to context.
+#
+# Maintain REMIND_EMAILS below — use git email addresses.
+# To find a teammate's git email: git log --format='%ae' --author=Name | sort -u
+
+REMIND_EMAILS=(
+  "vincent@vellum.ai"
+  "0426vincent@gmail.com"
+  "harrison@vellum.ai"
+  "harrison.ngo719@gmail.com"
+  "48630278+alex-nork@users.noreply.github.com"
+  "alexnork@gmail.com"
+)
+
+CURRENT_EMAIL=$(git config user.email 2>/dev/null || echo "")
+
+for e in "${REMIND_EMAILS[@]}"; do
+  if [[ "$CURRENT_EMAIL" == "$e" ]]; then
+    jq -n '{
+      "hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": "IMPORTANT: If you are starting work on a task (feature, bug fix, refactor, etc.), a Linear ticket ID (e.g. JARVIS-123) must be provided so PRs auto-link and auto-close the issue. If no ticket ID appears in this prompt or earlier in the conversation, ask the user for one before proceeding with implementation."
+      }
+    }'
+    exit 0
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/linear-ticket-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ worktrees/
 !.claude/commands/
 !.claude/phases/
 !.claude/skills/
+!.claude/hooks/
 !.claude/README.md
+!.claude/settings.json
 
 # Shared claude-skills symlinks are gitignored; only repo-local skills are tracked.
 .claude/skills/*


### PR DESCRIPTION
## Summary

- Adds a `UserPromptSubmit` hook (`.claude/hooks/linear-ticket-reminder.sh`) that checks the current user's git email against a configurable list and injects a reminder to provide a Linear ticket ID when starting work
- Registers the hook in `.claude/settings.json` (project scope) so it applies to all collaborators automatically — no per-user setup needed
- Excludes Aaron from the remind list; currently targets Vincent, Harrison, and Alex

## Original prompt

ok this looks awesome. go for it. look in git log to figure out the github usernames or emails for vincent, harrison, alex, and aaron

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
