### PR TITLE
Hook ConversationDiskView into conversation create/message/delete lifecycle

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Integration tests for the ConversationDiskView lifecycle hooks.
+ *
+ * Verifies that creating, messaging, updating titles, deleting, and clearing
+ * conversations correctly projects to the disk-view filesystem layout.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must come before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "conv-disk-view-integration-"));
+const workspaceDir = join(testDir, "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../memory/attachments-store.js";
+import {
+  addMessage,
+  clearAll,
+  createConversation,
+  deleteConversation,
+  updateConversationTitle,
+} from "../memory/conversation-crud.js";
+import {
+  getConversationDirPath,
+  syncMessageToDisk,
+} from "../memory/conversation-disk-view.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function resetConversationsDir() {
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle integration: createConversation
+// ---------------------------------------------------------------------------
+
+describe("createConversation → disk view", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("creates directory and meta.json on createConversation", () => {
+    const conv = createConversation("My Conversation");
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    expect(existsSync(dirPath)).toBe(true);
+
+    const metaPath = join(dirPath, "meta.json");
+    expect(existsSync(metaPath)).toBe(true);
+
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.id).toBe(conv.id);
+    expect(meta.title).toBe("My Conversation");
+    expect(meta.type).toBe("standard");
+    expect(meta.createdAt).toBe(new Date(conv.createdAt).toISOString());
+  });
+
+  test("handles null title in createConversation", () => {
+    const conv = createConversation();
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const meta = JSON.parse(
+      readFileSync(join(dirPath, "meta.json"), "utf-8"),
+    );
+    expect(meta.title).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle integration: addMessage + syncMessageToDisk
+// ---------------------------------------------------------------------------
+
+describe("addMessage + syncMessageToDisk → disk view", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("appends JSONL line for a text message", async () => {
+    const conv = createConversation("Msg Test");
+
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      "Hello world",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const jsonlPath = join(dirPath, "messages.jsonl");
+    expect(existsSync(jsonlPath)).toBe(true);
+
+    const lines = readFileSync(jsonlPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0]);
+    expect(record.role).toBe("user");
+    expect(record.content).toBe("Hello world");
+    expect(record.ts).toBeDefined();
+  });
+
+  test("message with attachment copies file and includes in JSONL", async () => {
+    const conv = createConversation("Attach Test");
+
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      "See attached",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const att = uploadAttachment("screenshot.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(msg.id, att.id, 0);
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+
+    // Attachment file exists in attachments/ subdirectory
+    const attachDir = join(dirPath, "attachments");
+    expect(existsSync(join(attachDir, "screenshot.png"))).toBe(true);
+
+    // JSONL references the attachment
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    const record = JSON.parse(lines[0]);
+    expect(record.attachments).toEqual(["screenshot.png"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle integration: updateConversationTitle
+// ---------------------------------------------------------------------------
+
+describe("updateConversationTitle → disk view", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("rewrites meta.json with new title", () => {
+    const conv = createConversation("Original Title");
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+
+    // Verify original
+    let meta = JSON.parse(readFileSync(join(dirPath, "meta.json"), "utf-8"));
+    expect(meta.title).toBe("Original Title");
+
+    // Update
+    updateConversationTitle(conv.id, "New Title");
+
+    // Verify updated
+    meta = JSON.parse(readFileSync(join(dirPath, "meta.json"), "utf-8"));
+    expect(meta.title).toBe("New Title");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle integration: deleteConversation
+// ---------------------------------------------------------------------------
+
+describe("deleteConversation → disk view", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("removes conversation directory on delete", () => {
+    const conv = createConversation("To Delete");
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    expect(existsSync(dirPath)).toBe(true);
+
+    deleteConversation(conv.id);
+
+    expect(existsSync(dirPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle integration: clearAll
+// ---------------------------------------------------------------------------
+
+describe("clearAll → disk view", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("empties the conversations directory", () => {
+    // Create two conversations
+    createConversation("Conv A");
+    createConversation("Conv B");
+
+    // Verify directories exist
+    const entries = readdirSync(conversationsDir);
+    expect(entries.length).toBe(2);
+
+    // Clear all
+    clearAll();
+
+    // Conversations directory should exist but be empty
+    expect(existsSync(conversationsDir)).toBe(true);
+    const afterEntries = readdirSync(conversationsDir);
+    expect(afterEntries.length).toBe(0);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -15,10 +15,12 @@ import type {
 } from "../channels/types.js";
 import {
   addMessage,
+  getConversation,
   getMessageById,
   provenanceFromTrustContext,
   updateMessageContent,
 } from "../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
 import {
   backfillMessageIdOnLogs,
   recordRequestLog,
@@ -709,6 +711,16 @@ export async function handleMessageComplete(
     assistantChannelMetadata,
   );
   state.lastAssistantMessageId = assistantMsg.id;
+
+  // Sync assistant message to disk view
+  const convForDisk = getConversation(deps.ctx.conversationId);
+  if (convForDisk) {
+    syncMessageToDisk(
+      deps.ctx.conversationId,
+      assistantMsg.id,
+      convForDisk.createdAt,
+    );
+  }
 
   // Backfill message_id on all LLM request logs from this turn.
   // The agent loop is single-threaded per conversation, so all rows with

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -21,10 +21,12 @@ import {
 } from "../memory/attachments-store.js";
 import {
   addMessage,
+  getConversation,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -381,6 +383,16 @@ export async function persistUserMessage(
           );
         }
       }
+    }
+
+    // Sync the persisted user message (with attachments) to the disk view
+    const conv = getConversation(ctx.conversationId);
+    if (conv) {
+      syncMessageToDisk(
+        ctx.conversationId,
+        persistedUserMessage.id,
+        conv.createdAt,
+      );
     }
 
     return persistedUserMessage.id;

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -7,7 +7,11 @@ import {
   linkAttachmentToMessage,
   uploadFileBackedAttachment,
 } from "../../memory/attachments-store.js";
-import { addMessage } from "../../memory/conversation-crud.js";
+import {
+  addMessage,
+  getConversation,
+} from "../../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../../memory/conversation-disk-view.js";
 import type { RecordingOptions, RecordingStatus } from "../message-protocol.js";
 import { type HandlerContext, log } from "./shared.js";
 
@@ -653,6 +657,12 @@ export async function finalizeAndPublishRecording(params: {
       { recordingId, messageId, attachmentId: attachment.id },
       "Linked recording attachment to assistant message",
     );
+
+    // Sync the recording message (with attachment) to the disk view
+    const convForDisk = getConversation(conversationId);
+    if (convForDisk) {
+      syncMessageToDisk(conversationId, messageId, convForDisk.createdAt);
+    }
 
     // Skip server-side thumbnail generation for recordings — the client
     // generates thumbnails natively from the local file path using

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync } from "node:fs";
+
 import { and, asc, count, eq, inArray, isNull, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { z } from "zod";
@@ -8,9 +10,15 @@ import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import { getLogger } from "../util/logger.js";
+import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
 import { deleteOrphanAttachments } from "./attachments-store.js";
 import { projectAssistantMessage } from "./conversation-attention-store.js";
+import {
+  initConversationDir,
+  removeConversationDir,
+  updateMetaFile,
+} from "./conversation-disk-view.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { getDb, rawAll, rawExec, rawGet, rawRun } from "./db.js";
 import { indexMessageNow } from "./indexer.js";
@@ -232,6 +240,8 @@ export function createConversation(
     }
   }
 
+  initConversationDir({ ...conversation, originChannel: null });
+
   return conversation;
 }
 
@@ -266,6 +276,11 @@ export function getConversationMemoryScopeId(conversationId: string): string {
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+
+  // Capture createdAt before the transaction deletes the row — needed to
+  // resolve the conversation's disk-view directory path after deletion.
+  const convBeforeDelete = getConversation(id);
+  const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.
@@ -356,6 +371,11 @@ export function deleteConversation(id: string): DeletedMemoryIds {
 
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
+
+  // Remove the conversation's disk-view directory after the DB transaction
+  if (createdAtForDiskCleanup != null) {
+    removeConversationDir(id, createdAtForDiskCleanup);
+  }
 
   return result;
 }
@@ -759,6 +779,12 @@ export function updateConversationTitle(
   const set: Record<string, unknown> = { title, updatedAt: Date.now() };
   if (isAutoTitle !== undefined) set.isAutoTitle = isAutoTitle;
   db.update(conversations).set(set).where(eq(conversations.id, id)).run();
+
+  // Update disk view meta.json with the new title
+  const conv = getConversation(id);
+  if (conv) {
+    updateMetaFile(conv);
+  }
 }
 
 export function updateConversationUsage(
@@ -862,6 +888,14 @@ export function clearAll(): { conversations: number; messages: number } {
     rawExec(
       `CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages BEGIN DELETE FROM messages_fts WHERE message_id = old.id; INSERT INTO messages_fts(message_id, content) VALUES (new.id, new.content); END`,
     );
+  }
+
+  // Clear the disk-view conversations directory and recreate it empty
+  try {
+    rmSync(getConversationsDir(), { recursive: true, force: true });
+    mkdirSync(getConversationsDir(), { recursive: true });
+  } catch (err) {
+    log.warn({ err }, "clearAll: failed to reset conversations directory");
   }
 
   return { conversations: convCount, messages: msgCount };


### PR DESCRIPTION
## Summary
- Wire disk view into createConversation, updateConversationTitle, deleteConversation, and clearAll
- Sync user messages and assistant messages to JSONL after persistence
- Sync recording handler messages to disk
- Add integration tests covering the full lifecycle

Part of plan: conv-disk-view.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
