### PR TITLE
Move Linear reminder emails to gitignored config file

### DIFF
--- a/.claude/hooks/linear-ticket-reminder.sh
+++ b/.claude/hooks/linear-ticket-reminder.sh
@@ -2,22 +2,24 @@
 # Inject a Linear ticket reminder for specific team members.
 # Users NOT in the remind list see nothing added to context.
 #
-# Maintain REMIND_EMAILS below — use git email addresses.
-# To find a teammate's git email: git log --format='%ae' --author=Name | sort -u
+# The remind list lives in .private/linear-remind-emails.txt (gitignored).
+# Add one git email per line. To find a teammate's git email:
+#   git log --format='%ae' --author=Name | sort -u
 
-REMIND_EMAILS=(
-  "vincent@vellum.ai"
-  "0426vincent@gmail.com"
-  "harrison@vellum.ai"
-  "harrison.ngo719@gmail.com"
-  "48630278+alex-nork@users.noreply.github.com"
-  "alexnork@gmail.com"
-)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REMIND_FILE="$REPO_ROOT/.private/linear-remind-emails.txt"
+
+# No remind file → nothing to do
+[[ -f "$REMIND_FILE" ]] || exit 0
 
 CURRENT_EMAIL=$(git config user.email 2>/dev/null || echo "")
+[[ -n "$CURRENT_EMAIL" ]] || exit 0
 
-for e in "${REMIND_EMAILS[@]}"; do
-  if [[ "$CURRENT_EMAIL" == "$e" ]]; then
+while IFS= read -r email; do
+  # Skip blank lines and comments
+  [[ -z "$email" || "$email" == \#* ]] && continue
+  if [[ "$CURRENT_EMAIL" == "$email" ]]; then
     jq -n '{
       "hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
@@ -26,6 +28,6 @@ for e in "${REMIND_EMAILS[@]}"; do
     }'
     exit 0
   fi
-done
+done < "$REMIND_FILE"
 
 exit 0


### PR DESCRIPTION
## Summary

- Moves the hardcoded email list from `.claude/hooks/linear-ticket-reminder.sh` to `.private/linear-remind-emails.txt` (gitignored)
- The hook script now reads one email per line from the config file, supports comments and blank lines
- No personal emails committed to the repo — safe for open-sourcing

## Original prompt

this repo is going to be open source so is there a way we can not commit our own emails in the repo actually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
