### PR TITLE
Use GitHub usernames instead of emails in Linear reminder hook

### DIFF
--- a/.claude/hooks/linear-ticket-reminder.sh
+++ b/.claude/hooks/linear-ticket-reminder.sh
@@ -2,22 +2,21 @@
 # Inject a Linear ticket reminder for specific team members.
 # Users NOT in the remind list see nothing added to context.
 #
-# Maintain REMIND_EMAILS below — use git email addresses.
-# To find a teammate's git email: git log --format='%ae' --author=Name | sort -u
+# Uses GitHub usernames (already public in CODEOWNERS) matched against
+# the git email's noreply pattern or the committer name.
+# To find a teammate's GitHub username: check CODEOWNERS
 
-REMIND_EMAILS=(
-  "vincent@vellum.ai"
-  "0426vincent@gmail.com"
-  "harrison@vellum.ai"
-  "harrison.ngo719@gmail.com"
-  "48630278+alex-nork@users.noreply.github.com"
-  "alexnork@gmail.com"
+REMIND_USERS=(
+  "vincent0426"
+  "NgoHarrison"
+  "alex-nork"
 )
 
 CURRENT_EMAIL=$(git config user.email 2>/dev/null || echo "")
+CURRENT_NAME=$(git config user.name 2>/dev/null || echo "")
 
-for e in "${REMIND_EMAILS[@]}"; do
-  if [[ "$CURRENT_EMAIL" == "$e" ]]; then
+for u in "${REMIND_USERS[@]}"; do
+  if [[ "$CURRENT_EMAIL" == *"$u"* || "$CURRENT_NAME" == "$u" ]]; then
     jq -n '{
       "hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",


### PR DESCRIPTION
## Summary

- Replaces personal email addresses with GitHub usernames (already public in CODEOWNERS) in the Linear ticket reminder hook
- Matches against the git email noreply pattern (`username@users.noreply.github.com`) and git committer name
- No private data committed to the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
