### PR TITLE
Use GitHub usernames instead of emails in Linear reminder hook

### DIFF
--- a/.claude/hooks/linear-ticket-reminder.sh
+++ b/.claude/hooks/linear-ticket-reminder.sh
@@ -2,24 +2,21 @@
 # Inject a Linear ticket reminder for specific team members.
 # Users NOT in the remind list see nothing added to context.
 #
-# The remind list lives in .private/linear-remind-emails.txt (gitignored).
-# Add one git email per line. To find a teammate's git email:
-#   git log --format='%ae' --author=Name | sort -u
+# Uses GitHub usernames (already public in CODEOWNERS) matched against
+# the git email's noreply pattern or the committer name.
+# To find a teammate's GitHub username: check CODEOWNERS
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-REMIND_FILE="$REPO_ROOT/.private/linear-remind-emails.txt"
-
-# No remind file → nothing to do
-[[ -f "$REMIND_FILE" ]] || exit 0
+REMIND_USERS=(
+  "vincent0426"
+  "NgoHarrison"
+  "alex-nork"
+)
 
 CURRENT_EMAIL=$(git config user.email 2>/dev/null || echo "")
-[[ -n "$CURRENT_EMAIL" ]] || exit 0
+CURRENT_NAME=$(git config user.name 2>/dev/null || echo "")
 
-while IFS= read -r email; do
-  # Skip blank lines and comments
-  [[ -z "$email" || "$email" == \#* ]] && continue
-  if [[ "$CURRENT_EMAIL" == "$email" ]]; then
+for u in "${REMIND_USERS[@]}"; do
+  if [[ "$CURRENT_EMAIL" == *"$u"* || "$CURRENT_NAME" == "$u" ]]; then
     jq -n '{
       "hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
@@ -28,6 +25,6 @@ while IFS= read -r email; do
     }'
     exit 0
   fi
-done < "$REMIND_FILE"
+done
 
 exit 0


### PR DESCRIPTION
## Summary

- Replaces `.private/linear-remind-emails.txt` approach with GitHub usernames hardcoded in the hook script (already public in CODEOWNERS)
- Matches against git email noreply pattern (`*username*`) and git committer name
- No personal emails committed to the repo — safe for open-sourcing

## Original prompt

this repo is going to be open source so is there a way we can not commit our own emails in the repo actually

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
