### PR TITLE
Workspace migration to rebuild disk view for existing conversations

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { asc, eq } from "drizzle-orm";
+
+import {
+  getConversationDirPath,
+  initConversationDir,
+  syncMessageToDisk,
+  updateMetaFile,
+} from "../../memory/conversation-disk-view.js";
+import { getDb } from "../../memory/db.js";
+import { conversations, messages } from "../../memory/schema.js";
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migrations");
+
+export const backfillConversationDiskViewMigration: WorkspaceMigration = {
+  id: "009-backfill-conversation-disk-view",
+  description: "Rebuild conversation disk view for existing conversations",
+  run(_workspaceDir: string): void {
+    const db = getDb();
+
+    const allConversations = db
+      .select()
+      .from(conversations)
+      .orderBy(asc(conversations.createdAt))
+      .all();
+
+    const total = allConversations.length;
+    let processed = 0;
+
+    for (const conv of allConversations) {
+      // Check if already migrated (idempotent)
+      const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+      const metaPath = join(dirPath, "meta.json");
+
+      if (existsSync(metaPath)) {
+        try {
+          const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
+          const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
+          if (existing.updatedAt === expectedUpdatedAt) {
+            processed++;
+            if (processed % 50 === 0) {
+              log.info(`Backfilled ${processed}/${total} conversations to disk`);
+            }
+            continue;
+          }
+        } catch {
+          // meta.json exists but is unreadable/malformed — re-create it
+        }
+      }
+
+      // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
+      initConversationDir(conv);
+      // Write the real updatedAt so the idempotency check works on re-run
+      updateMetaFile(conv);
+
+      // Query all messages for this conversation and sync each to disk
+      const convMessages = db
+        .select()
+        .from(messages)
+        .where(eq(messages.conversationId, conv.id))
+        .orderBy(asc(messages.createdAt))
+        .all();
+
+      for (const msg of convMessages) {
+        syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+      }
+
+      processed++;
+      if (processed % 50 === 0) {
+        log.info(`Backfilled ${processed}/${total} conversations to disk`);
+      }
+    }
+
+    if (total > 0) {
+      log.info(`Backfilled ${processed}/${total} conversations to disk`);
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -6,6 +6,7 @@ import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
 import { servicesConfigMigration } from "./006-services-config.js";
 import { webSearchProviderRenameMigration } from "./007-web-search-provider-rename.js";
 import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-steps.js";
+import { backfillConversationDiskViewMigration } from "./009-backfill-conversation-disk-view.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -21,4 +22,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   servicesConfigMigration,
   webSearchProviderRenameMigration,
   voiceTimeoutAndMaxStepsMigration,
+  backfillConversationDiskViewMigration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration 009 to backfill existing conversations to the disk view
- Iterates all conversations, creates directories with meta.json and messages.jsonl
- Idempotent: skips conversations already migrated (checks updatedAt in meta.json)
- Logs progress every 50 conversations

Part of plan: conv-disk-view.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)