### PR TITLE
Replace attachment_id parameters with file paths in transcribe and image-studio skills

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -77,84 +77,6 @@ mock.module("../providers/managed-proxy/context.js", () => ({
   resolveManagedProxyContext: async () => mockManagedProxyContext,
 }));
 
-let mockAttachments: Array<{
-  id: string;
-  assistantId: string;
-  originalFilename: string;
-  mimeType: string;
-  sizeBytes: number;
-  kind: string;
-  createdAt: number;
-  dataBase64: string;
-}> = [];
-
-mock.module("../memory/attachments-store.js", () => ({
-  getAttachmentsByIds: (_assistantId: string, _ids: string[]) =>
-    mockAttachments,
-  getAttachmentContent: (id: string) => {
-    const att = mockAttachments.find((a) => a.id === id);
-    if (!att) return null;
-    return Buffer.from(att.dataBase64, "base64");
-  },
-}));
-
-mock.module("../memory/db.js", () => ({
-  getDb: () => ({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          get: () => ({ assistantId: "test-assistant" }),
-        }),
-      }),
-    }),
-  }),
-}));
-
-mock.module("../memory/schema.js", () => ({
-  conversationKeys: {
-    assistantId: "assistantId",
-    conversationId: "conversationId",
-  },
-}));
-
-mock.module("drizzle-orm", () => ({
-  eq: () => true,
-}));
-
-mock.module("../memory/conversation-crud.js", () => ({
-  setConversationOriginChannelIfUnset: () => {},
-  updateConversationContextWindow: () => {},
-  deleteMessageById: () => {},
-  updateConversationTitle: () => {},
-  updateConversationUsage: () => {},
-  addMessage: () => ({ id: "mock-msg-id" }),
-  getMessages: () => [],
-  getConversation: () => ({
-    id: "conv-1",
-    contextSummary: null,
-    contextCompactedMessageCount: 0,
-    totalInputTokens: 0,
-    totalOutputTokens: 0,
-    totalEstimatedCost: 0,
-    title: null,
-  }),
-  provenanceFromTrustContext: () => ({
-    source: "user",
-    trustContext: undefined,
-  }),
-  getConversationOriginInterface: () => null,
-  getConversationOriginChannel: () => null,
-  getConversationType: () => "standard",
-}));
-
-mock.module("../daemon/media-visibility-policy.js", () => ({
-  isAttachmentVisible: () => true,
-}));
-
-mock.module("../tools/assets/search.js", () => ({
-  getAttachmentSourceConversations: () => [],
-}));
-
 // Import after mocking
 import { run } from "../config/bundled-skills/image-studio/tools/media-generate-image.js";
 
@@ -183,7 +105,6 @@ beforeEach(() => {
     resolvedModel: "gemini-3.1-flash-image-preview",
   };
   mockGenerateError = null;
-  mockAttachments = [];
   lastGenerateCredentials = null;
   mockManagedBaseUrl = undefined;
   mockManagedProxyContext = {
@@ -307,28 +228,6 @@ describe("image-studio skill script wrapper", () => {
     expect(result.content).toContain("Mock error: API failure");
   });
 
-  test("passes attachment data as sourceImages for edit mode", async () => {
-    mockAttachments = [
-      {
-        id: "att-1",
-        assistantId: "test-assistant",
-        originalFilename: "photo.jpg",
-        mimeType: "image/jpeg",
-        sizeBytes: 1000,
-        kind: "image",
-        createdAt: Date.now(),
-        dataBase64: "attachment-data",
-      },
-    ];
-
-    const result = await run(
-      { prompt: "remove bg", mode: "edit", attachment_ids: ["att-1"] },
-      fakeContext,
-    );
-
-    expect(result.isError).toBe(false);
-  });
-
   test("reads source images from file paths on disk", async () => {
     // Write a temp image file inside the workspace (fakeContext.workingDir = /tmp)
     const tmpPath = join("/tmp", "test-source-image.png");
@@ -423,10 +322,11 @@ describe("image-studio TOOLS.json manifest", () => {
     expect(schema.properties.prompt.type).toBe("string");
   });
 
-  test("input schema has optional mode, attachment_ids, model, variants", () => {
+  test("input schema has optional mode, source_paths, model, variants", () => {
     const props = manifest.tools[0].input_schema.properties;
     expect(props.mode.enum).toEqual(["generate", "edit"]);
-    expect(props.attachment_ids.type).toBe("array");
+    expect(props.source_paths.type).toBe("array");
+    expect(props.attachment_ids).toBeUndefined();
     expect(props.model.enum).toEqual([
       "gemini-3.1-flash-image-preview",
       "gemini-3-pro-image-preview",

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -13,13 +13,13 @@ You are an image generation assistant. When the user asks you to create or edit 
 ## Usage
 
 - **Text-to-image**: "Generate an image of a sunset over the ocean"
-- **Image editing**: "Remove the background from this image" (requires attaching an image)
+- **Image editing**: "Remove the background from this image" (requires providing source image file paths)
 - **Multiple variants**: "Generate 3 variations of a logo for a coffee shop"
 
 ## Modes
 
 - **generate** (default): Create a new image from a text prompt.
-- **edit**: Modify an existing image based on a text prompt. Requires one or more source images via `attachment_ids` and/or `source_paths` (file paths on disk).
+- **edit**: Modify an existing image based on a text prompt. Requires one or more source images via `source_paths` (file paths on disk).
 
 ## Models
 

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -18,19 +18,12 @@
             "enum": ["generate", "edit"],
             "description": "Whether to generate a new image or edit an existing one (default: generate)"
           },
-          "attachment_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "IDs of attached source images to edit (for edit mode)"
-          },
           "source_paths": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "File paths to source images in the workspace (for edit mode). Can be used instead of or in addition to attachment_ids."
+            "description": "File paths to source images in the workspace (for edit mode)"
           },
           "model": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,55 +1,20 @@
 import { getConfig } from "../../../../config/loader.js";
 import {
-  type AttachmentContext,
-  isAttachmentVisible,
-} from "../../../../daemon/media-visibility-policy.js";
-import {
   generateImage,
   type ImageGenCredentials,
   mapGeminiError,
 } from "../../../../media/gemini-image-service.js";
-import {
-  getAttachmentContent,
-  getAttachmentsByIds,
-} from "../../../../memory/attachments-store.js";
-import { getConversationType } from "../../../../memory/conversation-crud.js";
 import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
 import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
-import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
 import { sandboxPolicy } from "../../../../tools/shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-
-/**
- * Check whether an attachment is visible from the given context.
- * Mirrors the logic in tools/assets/search.ts:isAttachmentVisibleFromContext.
- */
-function isAttachmentAccessible(
-  attachmentId: string,
-  currentContext: AttachmentContext,
-): boolean {
-  const sources = getAttachmentSourceConversations(attachmentId);
-  if (sources.length === 0) {
-    return true; // orphan attachments are universally visible
-  }
-  const hasStandard = sources.some((s) => s.conversationType !== "private");
-  if (hasStandard) {
-    return true;
-  }
-  // All sources are private - visible only if the caller is in one of those conversations
-  return sources.some((s) =>
-    isAttachmentVisible(
-      { conversationId: s.conversationId, isPrivate: true },
-      currentContext,
-    ),
-  );
-}
 
 export async function run(
   input: Record<string, unknown>,
@@ -88,61 +53,15 @@ export async function run(
 
   const prompt = input.prompt as string;
   const mode = (input.mode as "generate" | "edit") ?? "generate";
-  const attachmentIds = input.attachment_ids as string[] | undefined;
   const sourcePaths = input.source_paths as string[] | undefined;
   const model =
     (input.model as string | undefined) ??
     config.services["image-generation"].model;
   const variants = input.variants as number | undefined;
 
-  // Resolve source images from attachments for edit mode
+  // Resolve source images from file paths (sandboxed to workingDir, edit mode only)
   let sourceImages: Array<{ mimeType: string; dataBase64: string }> | undefined;
 
-  if (attachmentIds && attachmentIds.length > 0) {
-    const attachments = getAttachmentsByIds(attachmentIds);
-
-    // Build visibility context for the current conversation
-    const conversationType = getConversationType(context.conversationId);
-    const currentContext: AttachmentContext = {
-      conversationId: context.conversationId,
-      isPrivate: conversationType === "private",
-    };
-
-    // Filter to only visible attachments using their originating context
-    const visibleAttachments = attachments.filter((att) =>
-      isAttachmentAccessible(att.id, currentContext),
-    );
-
-    if (visibleAttachments.length === 0 && attachmentIds.length > 0) {
-      // Only error if source_paths won't provide images either
-      if (!sourcePaths || sourcePaths.length === 0) {
-        return {
-          content:
-            "None of the specified attachments could be found or are accessible.",
-          isError: true,
-        };
-      }
-    }
-
-    sourceImages = visibleAttachments
-      .map((att) => {
-        let buffer: Buffer | null | undefined;
-        try {
-          buffer = getAttachmentContent(att.id);
-        } catch {
-          // File-backed attachment may point to a missing or unreadable file
-          return undefined;
-        }
-        if (!buffer) return undefined;
-        return {
-          mimeType: att.mimeType,
-          dataBase64: buffer.toString("base64"),
-        };
-      })
-      .filter((img): img is NonNullable<typeof img> => img !== undefined);
-  }
-
-  // Resolve source images from file paths (sandboxed to workingDir, edit mode only)
   if (mode === "edit" && sourcePaths && sourcePaths.length > 0) {
     const errors: string[] = [];
     const validPathImages: Array<{ mimeType: string; dataBase64: string }> = [];
@@ -163,16 +82,13 @@ export async function run(
         dataBase64: buffer.toString("base64"),
       });
     }
-    if (
-      validPathImages.length === 0 &&
-      (!sourceImages || sourceImages.length === 0)
-    ) {
+    if (validPathImages.length === 0) {
       return {
         content: `None of the specified file paths could be read.\n${errors.join("\n")}`,
         isError: true,
       };
     }
-    sourceImages = [...(sourceImages ?? []), ...validPathImages];
+    sourceImages = validPathImages;
   }
 
   try {

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -22,7 +22,7 @@ If the user says "local", "offline", "private", or "on-device" → use `local`.
 
 ## Usage Notes
 
-- The tool accepts either a `file_path` (absolute path to a local file) or an `attachment_id` (for uploaded attachments). Prefer `file_path` when the user references a file on disk.
+- The tool accepts a `file_path` (absolute path to a local audio or video file) to transcribe.
 - Supported formats: any video (mp4, mov, etc.) or audio (mp3, wav, m4a, etc.) file.
 - For video files, audio is automatically extracted via ffmpeg before transcription.
 - The API mode has a 25MB per-request limit - large files are automatically split into chunks.

--- a/assistant/src/config/bundled-skills/transcribe/TOOLS.json
+++ b/assistant/src/config/bundled-skills/transcribe/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "transcribe_media",
-      "description": "Transcribe an audio or video file using Whisper. Provide either a file_path to a local file or an attachment_id for an uploaded attachment. Set mode to 'api' (OpenAI cloud) or 'local' (whisper.cpp on-device). Ask the user which mode they prefer before calling.",
+      "description": "Transcribe an audio or video file using Whisper. Provide a file_path to the media file. Set mode to 'api' (OpenAI cloud) or 'local' (whisper.cpp on-device). Ask the user which mode they prefer before calling.",
       "category": "transcribe",
       "risk": "low",
       "input_schema": {
@@ -12,10 +12,6 @@
           "file_path": {
             "type": "string",
             "description": "Absolute path to a local audio or video file to transcribe"
-          },
-          "attachment_id": {
-            "type": "string",
-            "description": "The ID of an attached audio or video file to transcribe"
           },
           "mode": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -10,10 +10,6 @@ import {
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
 
-import {
-  getAttachmentsByIds,
-  getFilePathForAttachment,
-} from "../../../../memory/attachments-store.js";
 import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
@@ -128,79 +124,29 @@ async function resolveSource(
   | ToolExecutionResult
 > {
   const filePath = input.file_path as string | undefined;
-  const attachmentId = input.attachment_id as string | undefined;
 
-  if (filePath) {
-    try {
-      await access(filePath);
-    } catch {
-      return { content: `File not found: ${filePath}`, isError: true };
-    }
-    const ext = extname(filePath).toLowerCase();
-    const isVideo = VIDEO_EXTENSIONS.has(ext);
-    const isAudio = AUDIO_EXTENSIONS.has(ext);
-    if (!isVideo && !isAudio) {
-      return {
-        content: `Unsupported file type: ${ext}. Only video and audio files can be transcribed.`,
-        isError: true,
-      };
-    }
-    return { inputPath: filePath, isVideo, tempFile: null };
-  }
-
-  if (attachmentId) {
-    const attachments = getAttachmentsByIds([attachmentId]);
-    if (attachments.length === 0) {
-      return {
-        content: `Attachment not found: ${attachmentId}`,
-        isError: true,
-      };
-    }
-    const attachment = attachments[0];
-    const mime = attachment.mimeType;
-    if (!mime.startsWith("video/") && !mime.startsWith("audio/")) {
-      return {
-        content: `Unsupported file type: ${mime}. Only video and audio files can be transcribed.`,
-        isError: true,
-      };
-    }
-    // Check if this is a file-backed attachment (large files stored on disk)
-    const onDiskPath = getFilePathForAttachment(attachment.id);
-    if (onDiskPath) {
-      // File-backed attachment - use the on-disk file directly
-      try {
-        await access(onDiskPath);
-      } catch {
-        return {
-          content: `Attachment file not found on disk: ${onDiskPath}`,
-          isError: true,
-        };
-      }
-      return {
-        inputPath: onDiskPath,
-        isVideo: mime.startsWith("video/"),
-        tempFile: null,
-      };
-    }
-
-    // Inline attachment - decode base64 to a temp file
-    const ext = mime.startsWith("video/") ? ".mp4" : ".m4a";
-    const tempPath = join(
-      tmpdir(),
-      `vellum-transcribe-in-${randomUUID()}${ext}`,
-    );
-    await writeFile(tempPath, Buffer.from(attachment.dataBase64, "base64"));
+  if (!filePath) {
     return {
-      inputPath: tempPath,
-      isVideo: mime.startsWith("video/"),
-      tempFile: tempPath,
+      content: "Provide a file_path to the audio or video file to transcribe.",
+      isError: true,
     };
   }
 
-  return {
-    content: "Provide either file_path or attachment_id.",
-    isError: true,
-  };
+  try {
+    await access(filePath);
+  } catch {
+    return { content: `File not found: ${filePath}`, isError: true };
+  }
+  const ext = extname(filePath).toLowerCase();
+  const isVideo = VIDEO_EXTENSIONS.has(ext);
+  const isAudio = AUDIO_EXTENSIONS.has(ext);
+  if (!isVideo && !isAudio) {
+    return {
+      content: `Unsupported file type: ${ext}. Only video and audio files can be transcribed.`,
+      isError: true,
+    };
+  }
+  return { inputPath: filePath, isVideo, tempFile: null };
 }
 
 /** Convert source to 16kHz mono WAV for consistent processing. */


### PR DESCRIPTION
## Summary
- Remove `attachment_id` parameter from transcribe_media tool, keep `file_path` only
- Remove `attachment_ids` parameter from media_generate_image tool, keep `source_paths` only
- Update TOOLS.json schemas and SKILL.md documentation for both skills
- Remove attachment store imports from skill tool implementations

Part of plan: conv-disk-view.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
