### PR TITLE
fix: require all service image refs before returning from captureImageRefs

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -588,7 +588,6 @@ export async function captureImageRefs(
   };
 
   const refs: Partial<Record<ServiceName, string>> = {};
-  let foundAny = false;
 
   for (const [service, container] of Object.entries(containerForService)) {
     try {
@@ -602,14 +601,19 @@ export async function captureImageRefs(
       ).trim();
       if (imageRef) {
         refs[service as ServiceName] = imageRef;
-        foundAny = true;
       }
     } catch {
       // Container doesn't exist or can't be inspected — skip
     }
   }
 
-  return foundAny ? (refs as Record<ServiceName, string>) : null;
+  const allServices: ServiceName[] = [
+    "assistant",
+    "credential-executor",
+    "gateway",
+  ];
+  const hasAll = allServices.every((s) => s in refs);
+  return hasAll ? (refs as Record<ServiceName, string>) : null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for update-system-foundation.md.

**Gap:** Unsafe Partial<Record> cast in captureImageRefs
**What was expected:** captureImageRefs should only return non-null when all 3 service keys are present
**What was found:** Function returned non-null when any single service was inspectable, casting Partial to full Record

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
