### PR TITLE
fix: sanitize attachment filenames to prevent path traversal in disk view

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -315,6 +315,14 @@ describe("resolveUniqueFilename", () => {
     expect(resolveUniqueFilename(dir, "README")).toBe("README-2");
     rmSync(dir, { recursive: true });
   });
+
+  test("strips path traversal sequences from filename", () => {
+    const dir = mkdtempSync(join(tmpdir(), "unique-fn-"));
+    expect(resolveUniqueFilename(dir, "../../evil.txt")).toBe("evil.txt");
+    expect(resolveUniqueFilename(dir, "../secret.png")).toBe("secret.png");
+    expect(resolveUniqueFilename(dir, "foo/bar/baz.txt")).toBe("baz.txt");
+    rmSync(dir, { recursive: true });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -203,10 +203,11 @@ export function flattenContentBlocks(rawContent: string): FlattenedContent {
  * appending a suffix (e.g., `photo-2.png`, `photo-3.png`).
  */
 export function resolveUniqueFilename(dir: string, filename: string): string {
-  if (!existsSync(join(dir, filename))) return filename;
+  const sanitized = basename(filename);
+  if (!existsSync(join(dir, sanitized))) return sanitized;
 
-  const ext = extname(filename);
-  const base = basename(filename, ext);
+  const ext = extname(sanitized);
+  const base = basename(sanitized, ext);
   let counter = 2;
   let candidate: string;
   do {


### PR DESCRIPTION
## Summary
- Apply basename() sanitization at the start of resolveUniqueFilename before the existence check
- Prevents path traversal attacks where filenames like ../../evil.txt could write outside the attachments directory

Follows up on #18933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
