### PR TITLE
fix: broaden guard test regex for isToolResult helpers

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -821,7 +821,7 @@ describe("web_search_tool_result structural guard", () => {
       if (
         !insideHelperSignature &&
         helperBraceDepth === 0 &&
-        /function isToolResult(Block|Content)\b/.test(line)
+        /function isToolResult\w*\b/.test(line)
       ) {
         // The opening `{` may be on this line or a subsequent line (multi-line
         // signatures). Check if there are braces on this line to determine


### PR DESCRIPTION
Addresses review feedback from #17388. Updates the guard test regex to cover all `isToolResult*` helper variants, not just Block/Content.

The regex `/function isToolResult(Block|Content)\b/` only covered `isToolResultBlock` and `isToolResultContent`. Other helpers like `isToolResultOnly`, `isToolResultOnlyUserTurn`, and `isToolResultOnlyMessage` were not covered. Changed to `/function isToolResult\w*\b/` which matches any `isToolResult`-prefixed function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
