### PR TITLE
fix(macos): deduplicate rehydration requests and align ScrollView strategy

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -734,17 +734,23 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - On-Demand Content Rehydration
 
+    /// Message IDs currently being rehydrated — prevents duplicate concurrent fetches.
+    private var rehydratingMessageIds: Set<UUID> = []
+
     /// Fetch full (untruncated) content for a message that was loaded with truncated
     /// text/tool results or had its heavy content stripped. No-ops if the message is
-    /// not found or doesn't need rehydration.
+    /// not found, doesn't need rehydration, or is already being fetched.
     public func rehydrateMessage(id: UUID) {
+        guard !rehydratingMessageIds.contains(id) else { return }
         guard let idx = messages.firstIndex(where: { $0.id == id }),
               messages[idx].wasTruncated || messages[idx].isContentStripped,
               let conversationId = conversationId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
         guard daemonClient.isConnected else { return }
+        rehydratingMessageIds.insert(id)
         Task { [weak self] in
             guard let self else { return }
+            defer { self.rehydratingMessageIds.remove(id) }
             if let response = await ConversationClient().fetchMessageContent(conversationId: conversationId, messageId: daemonMessageId) {
                 self.handleMessageContentResponse(response)
             }

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -206,14 +206,24 @@ public struct ToolCallChip: View {
                                         .foregroundColor(VColor.contentSecondary)
                                 }
                             } else {
-                                ScrollView {
+                                let lineCount = result.components(separatedBy: "\n").count
+                                if lineCount > 500 {
+                                    ScrollView {
+                                        Text(result)
+                                            .font(VFont.monoSmall)
+                                            .foregroundColor(VColor.contentSecondary)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .textSelection(.enabled)
+                                    }
+                                    .frame(maxHeight: 400)
+                                } else {
                                     Text(result)
                                         .font(VFont.monoSmall)
                                         .foregroundColor(VColor.contentSecondary)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .textSelection(.enabled)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
-                                .frame(maxHeight: 200)
                             }
                         }
                         .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add in-flight tracking to `ChatViewModel.rehydrateMessage` via a `Set<UUID>` to prevent duplicate concurrent `fetchMessageContent` requests when expanding tool calls repeatedly
- Align ScrollView wrapping strategy between `ToolCallChip` and `AssistantProgressView` — both now conditionally wrap in ScrollView only when `lineCount > 500`, using consistent `maxHeight: 400`

Follows up on #18939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
