### PR TITLE
fix: verify gateway source files exist in watch-mode check

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -805,8 +805,8 @@ export function isAssistantWatchModeAvailable(): boolean {
  */
 export function isGatewayWatchModeAvailable(): boolean {
   try {
-    resolveGatewayDir();
-    return true;
+    const dir = resolveGatewayDir();
+    return existsSync(join(dir, "src", "index.ts"));
   } catch {
     return false;
   }


### PR DESCRIPTION
Addresses review feedback from #17387. isGatewayWatchModeAvailable now verifies that gateway source files actually exist, not just the directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
