### PR TITLE
fix: update comments and add test for persistent guardian expiry

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -813,6 +813,44 @@ describe("canonical-guardian-store", () => {
     );
   });
 
+  test("expireAllPendingCanonicalRequests expires persistent kinds with past expiresAt", () => {
+    const expiredAccess = createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      conversationId: "conv-bulk-persist-expired-1",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: Date.now() - 10_000,
+    });
+    const expiredGrant = createCanonicalGuardianRequest({
+      kind: "tool_grant_request",
+      sourceType: "channel",
+      conversationId: "conv-bulk-persist-expired-2",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: Date.now() - 10_000,
+    });
+    // Persistent kind with future expiresAt should NOT be expired
+    const futureAccess = createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      conversationId: "conv-bulk-persist-expired-3",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const count = expireAllPendingCanonicalRequests();
+    expect(count).toBe(2);
+
+    expect(getCanonicalGuardianRequest(expiredAccess.id)!.status).toBe(
+      "expired",
+    );
+    expect(getCanonicalGuardianRequest(expiredGrant.id)!.status).toBe(
+      "expired",
+    );
+    expect(getCanonicalGuardianRequest(futureAccess.id)!.status).toBe(
+      "pending",
+    );
+  });
+
   test("expireAllPendingCanonicalRequests does not affect already-resolved requests", () => {
     const approved = createCanonicalGuardianRequest({
       kind: "tool_approval",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -210,17 +210,21 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
-    // Expire pending interaction-bound canonical guardian requests left over
-    // from before this process started.  Their in-memory pending-interaction
-    // session references are gone, so they can never be completed.  Only
-    // interaction-bound kinds (tool_approval, pending_question) are expired;
-    // persistent kinds (access_request, tool_grant_request) remain valid
-    // across restarts.
+    // Expire stale pending canonical guardian requests left over from before
+    // this process started.  Two categories are cleaned up:
+    //
+    // 1. Interaction-bound kinds (tool_approval, pending_question) — their
+    //    in-memory pending-interaction session references are gone, so they
+    //    can never be completed.
+    // 2. Any pending request whose expiresAt has already passed — persistent
+    //    kinds (access_request, tool_grant_request) that expired while the
+    //    daemon was stopped are transitioned so dedup logic doesn't return
+    //    stale rows.
     const expiredCount = expireAllPendingCanonicalRequests();
     if (expiredCount > 0) {
       log.info(
         { event: "startup_expired_stale_requests", expiredCount },
-        `Expired ${expiredCount} stale interaction-bound canonical request(s) from previous process`,
+        `Expired ${expiredCount} stale canonical request(s) from previous process`,
       );
     }
 


### PR DESCRIPTION
Addresses review feedback from #17386. Updates stale comments/log messages and adds test coverage for the persistent-kind expiry path.

## Changes

1. **`assistant/src/daemon/lifecycle.ts`** — Updated comment and log message at the `expireAllPendingCanonicalRequests()` call site to reflect the broadened expiry scope (now includes both interaction-bound kinds and persistent kinds with past `expiresAt`). The log message now says "stale canonical request(s)" instead of "stale interaction-bound canonical request(s)".

2. **`assistant/src/__tests__/canonical-guardian-store.test.ts`** — Added test case "expires persistent kinds with past expiresAt" that creates `access_request` and `tool_grant_request` rows with already-past `expiresAt`, verifies they get expired, and also verifies a persistent kind with a future `expiresAt` remains pending.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
