### PR TITLE
fix: add unique identifiers to watcher notification dedupe keys

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -477,7 +477,7 @@ export async function runDaemon(): Promise<void> {
             title: notification.title,
             body: notification.body,
           },
-          dedupeKey: `watcher:notification:${Date.now()}`,
+          dedupeKey: `watcher:notification:${crypto.randomUUID()}`,
         });
       },
       (params) => {
@@ -495,7 +495,7 @@ export async function runDaemon(): Promise<void> {
             title: params.title,
             body: params.body,
           },
-          dedupeKey: `watcher:escalation:${Date.now()}`,
+          dedupeKey: `watcher:escalation:${crypto.randomUUID()}`,
         });
       },
       (info) => {


### PR DESCRIPTION
Addresses review feedback from #17389. Watcher notification and escalation dedupeKeys now include unique identifiers beyond just `Date.now()` to prevent collision when multiple notifications fire in the same millisecond.

## Changes

- Replace `Date.now()` with `crypto.randomUUID()` in `watcher:notification` dedupeKey
- Replace `Date.now()` with `crypto.randomUUID()` in `watcher:escalation` dedupeKey

This ensures that each notification/escalation event gets a globally unique dedupe key, eliminating the risk of silent signal drops when multiple watcher events fire within the same millisecond.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
