### PR TITLE
fix: use index-based position tracking in YAML parser

### DIFF
--- a/scripts/skills/generate-catalog.mjs
+++ b/scripts/skills/generate-catalog.mjs
@@ -14,124 +14,11 @@ import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseFrontmatter } from "./parse-skill-yaml.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_DIR = resolve(__dirname, "../../skills");
 const CATALOG_PATH = join(SKILLS_DIR, "catalog.json");
-
-/**
- * Minimal YAML frontmatter parser (same approach as lint-skill-spec.mjs).
- * Returns the parsed frontmatter object.
- */
-function parseFrontmatter(content) {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith("---")) {
-    throw new Error("SKILL.md must start with YAML frontmatter (---).");
-  }
-
-  const endIndex = trimmed.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    throw new Error("SKILL.md frontmatter is missing closing delimiter (---).");
-  }
-
-  const yamlBlock = trimmed.slice(trimmed.indexOf("\n", 0) + 1, endIndex);
-  return parseSimpleYaml(yamlBlock);
-}
-
-/**
- * Minimal YAML parser for flat key-value pairs, nested maps, and arrays.
- * Handles string values (quoted or unquoted), inline JSON objects/arrays,
- * YAML list syntax (`- item`), and multiple levels of nesting.
- */
-function parseSimpleYaml(yaml) {
-  const result = {};
-  const lines = yaml.split("\n");
-  // Stack of { indent, obj, key } to track nesting context
-  const stack = [{ indent: -1, obj: result, key: null }];
-
-  for (const line of lines) {
-    if (line.trim() === "" || line.trim().startsWith("#")) {
-      continue;
-    }
-
-    // Calculate indentation (number of leading spaces)
-    const indent = line.match(/^(\s*)/)[1].length;
-
-    // Check for YAML list item: `- value`
-    const listMatch = line.match(/^(\s*)-\s+(.*)/);
-    if (listMatch) {
-      const listValue = listMatch[2].trim();
-      // Pop stack to find the parent array at the right indentation level
-      while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-        stack.pop();
-      }
-      const parent = stack[stack.length - 1];
-      if (Array.isArray(parent.obj)) {
-        parent.obj.push(stripQuotes(listValue));
-      }
-      continue;
-    }
-
-    const match = line.match(/^(\s*)(\S+):\s*(.*)/);
-    if (!match) continue;
-
-    const key = match[2];
-    const value = match[3].trim();
-
-    // Pop stack to find the parent at the right indentation level
-    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-      stack.pop();
-    }
-    const parent = stack[stack.length - 1].obj;
-
-    if (value === "" || value === "|" || value === ">") {
-      // Start of a nested object or array — peek ahead to determine which
-      const nextNonEmpty = lines
-        .slice(lines.indexOf(line) + 1)
-        .find((l) => l.trim() !== "" && !l.trim().startsWith("#"));
-      if (nextNonEmpty && nextNonEmpty.match(/^\s*-\s+/)) {
-        // Next meaningful line is a list item -> initialize as array
-        parent[key] = [];
-        stack.push({ indent, obj: parent[key], key });
-      } else {
-        parent[key] = {};
-        stack.push({ indent, obj: parent[key], key });
-      }
-    } else if (
-      (value.startsWith("{") && value.endsWith("}")) ||
-      (value.startsWith("[") && value.endsWith("]"))
-    ) {
-      // Inline JSON
-      try {
-        parent[key] = JSON.parse(value);
-      } catch {
-        parent[key] = stripQuotes(value);
-      }
-    } else {
-      parent[key] = stripQuotes(value);
-    }
-  }
-
-  return result;
-}
-
-function stripQuotes(s) {
-  if (
-    (s.startsWith('"') && s.endsWith('"')) ||
-    (s.startsWith("'") && s.endsWith("'"))
-  ) {
-    return processEscapes(s.slice(1, -1));
-  }
-  return s;
-}
-
-/**
- * Process JSON-style unicode escape sequences (\uXXXX) in a string.
- */
-function processEscapes(s) {
-  return s.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
-    String.fromCharCode(parseInt(hex, 16)),
-  );
-}
 
 /**
  * Build a catalog entry from a skill directory.
@@ -146,7 +33,7 @@ function buildEntry(skillName) {
   }
 
   const content = readFileSync(skillMdPath, "utf-8");
-  const frontmatter = parseFrontmatter(content);
+  const { frontmatter } = parseFrontmatter(content);
 
   const entry = {
     id: skillName,

--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -32,6 +32,8 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseFrontmatter } from "./parse-skill-yaml.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SKILLS_DIR = resolve(__dirname, "../../skills");
 
@@ -65,91 +67,6 @@ function parseCLIArgs(argv) {
 }
 
 const { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, allowToolsJson: ALLOW_TOOLS_JSON, filterSkills: CLI_FILTER_SKILLS } = parseCLIArgs(process.argv);
-
-/**
- * Parse YAML frontmatter from a string.
- * Returns { frontmatter: Record<string, unknown>, body: string } or throws.
- *
- * This is a minimal parser that handles the subset of YAML used in
- * SKILL.md frontmatter without requiring external dependencies.
- */
-function parseFrontmatter(content) {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith("---")) {
-    throw new Error("SKILL.md must start with YAML frontmatter (---).");
-  }
-
-  const endIndex = trimmed.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    throw new Error(
-      "SKILL.md frontmatter is missing closing delimiter (---).",
-    );
-  }
-
-  const yamlBlock = trimmed.slice(trimmed.indexOf("\n", 0) + 1, endIndex);
-  const body = trimmed.slice(endIndex + 4).trim();
-  const frontmatter = parseSimpleYaml(yamlBlock);
-
-  return { frontmatter, body };
-}
-
-/**
- * Minimal YAML parser for flat key-value pairs and nested maps.
- * Handles string values (quoted or unquoted) and multiple levels of nesting.
- */
-function parseSimpleYaml(yaml) {
-  const result = {};
-  const lines = yaml.split("\n");
-  // Stack of { indent, obj } to track nesting context
-  const stack = [{ indent: -1, obj: result, key: null }];
-
-  for (const line of lines) {
-    // Skip blank lines and comments
-    if (line.trim() === "" || line.trim().startsWith("#")) {
-      continue;
-    }
-
-    // Calculate indentation (number of leading spaces)
-    const indent = line.match(/^(\s*)/)[1].length;
-    const match = line.match(/^(\s*)(\S+):\s*(.*)/);
-    if (!match) continue;
-
-    const key = match[2];
-    const value = match[3].trim();
-
-    // Pop stack to find the parent at the right indentation level
-    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
-      stack.pop();
-    }
-    const parent = stack[stack.length - 1].obj;
-
-    if (value === "" || value === "|" || value === ">") {
-      // Start of a nested object
-      parent[key] = {};
-      stack.push({ indent, obj: parent[key], key });
-    } else {
-      parent[key] = stripQuotes(value);
-    }
-  }
-
-  return result;
-}
-
-function stripQuotes(s) {
-  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
-    return processEscapes(s.slice(1, -1));
-  }
-  return s;
-}
-
-/**
- * Process JSON-style unicode escape sequences (\uXXXX) in a string.
- */
-function processEscapes(s) {
-  return s.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
-    String.fromCharCode(parseInt(hex, 16)),
-  );
-}
 
 // --- Validation Rules ---
 

--- a/scripts/skills/parse-skill-yaml.mjs
+++ b/scripts/skills/parse-skill-yaml.mjs
@@ -1,0 +1,126 @@
+/**
+ * Shared minimal YAML parser for SKILL.md frontmatter.
+ *
+ * Used by both `generate-catalog.mjs` and `lint-skill-spec.mjs` to ensure
+ * consistent parsing of skill frontmatter across tooling.
+ */
+
+/**
+ * Parse YAML frontmatter from a SKILL.md content string.
+ * Returns { frontmatter: Record<string, unknown>, body: string }.
+ */
+export function parseFrontmatter(content) {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) {
+    throw new Error("SKILL.md must start with YAML frontmatter (---).");
+  }
+
+  const endIndex = trimmed.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    throw new Error("SKILL.md frontmatter is missing closing delimiter (---).");
+  }
+
+  const yamlBlock = trimmed.slice(trimmed.indexOf("\n", 0) + 1, endIndex);
+  const body = trimmed.slice(endIndex + 4).trim();
+  const frontmatter = parseSimpleYaml(yamlBlock);
+
+  return { frontmatter, body };
+}
+
+/**
+ * Minimal YAML parser for flat key-value pairs, nested maps, and arrays.
+ * Handles string values (quoted or unquoted), inline JSON objects/arrays,
+ * YAML list syntax (`- item`), and multiple levels of nesting.
+ */
+export function parseSimpleYaml(yaml) {
+  const result = {};
+  const lines = yaml.split("\n");
+  // Stack of { indent, obj, key } to track nesting context
+  const stack = [{ indent: -1, obj: result, key: null }];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      continue;
+    }
+
+    // Calculate indentation (number of leading spaces)
+    const indent = line.match(/^(\s*)/)[1].length;
+
+    // Check for YAML list item: `- value`
+    const listMatch = line.match(/^(\s*)-\s+(.*)/);
+    if (listMatch) {
+      const listValue = listMatch[2].trim();
+      // Pop stack to find the parent array at the right indentation level
+      while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+        stack.pop();
+      }
+      const parent = stack[stack.length - 1];
+      if (Array.isArray(parent.obj)) {
+        parent.obj.push(stripQuotes(listValue));
+      }
+      continue;
+    }
+
+    const match = line.match(/^(\s*)(\S+):\s*(.*)/);
+    if (!match) continue;
+
+    const key = match[2];
+    const value = match[3].trim();
+
+    // Pop stack to find the parent at the right indentation level
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1].obj;
+
+    if (value === "" || value === "|" || value === ">") {
+      // Start of a nested object or array — peek ahead to determine which
+      const nextNonEmpty = lines
+        .slice(i + 1)
+        .find((l) => l.trim() !== "" && !l.trim().startsWith("#"));
+      if (nextNonEmpty && nextNonEmpty.match(/^\s*-\s+/)) {
+        // Next meaningful line is a list item -> initialize as array
+        parent[key] = [];
+        stack.push({ indent, obj: parent[key], key });
+      } else {
+        parent[key] = {};
+        stack.push({ indent, obj: parent[key], key });
+      }
+    } else if (
+      (value.startsWith("{") && value.endsWith("}")) ||
+      (value.startsWith("[") && value.endsWith("]"))
+    ) {
+      // Inline JSON
+      try {
+        parent[key] = JSON.parse(value);
+      } catch {
+        parent[key] = stripQuotes(value);
+      }
+    } else {
+      parent[key] = stripQuotes(value);
+    }
+  }
+
+  return result;
+}
+
+function stripQuotes(s) {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return processEscapes(s.slice(1, -1));
+  }
+  return s;
+}
+
+/**
+ * Process JSON-style unicode escape sequences (\uXXXX) in a string.
+ */
+function processEscapes(s) {
+  return s.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  );
+}


### PR DESCRIPTION
## Summary
- Fixes `lines.indexOf(line)` bug that caused wrong peek-ahead position when YAML frontmatter contains duplicate key lines (e.g. repeated nested keys under different parents)
- Extracts shared `parse-skill-yaml.mjs` module so both `generate-catalog.mjs` and `lint-skill-spec.mjs` use the same parser with full array/inline-JSON support
- Addresses review feedback from #17392

## Test plan
- [x] `node scripts/skills/generate-catalog.mjs` succeeds (45 skills)
- [x] `node scripts/skills/lint-skill-spec.mjs` succeeds (45 skills validated)
- [x] Generated catalog.json unchanged (no existing SKILL.md triggers the duplicate-line edge case)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
