### PR TITLE
fix: skip DB dumps when workspace payload budget is exhausted

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -12,7 +12,7 @@ import { eq, isNotNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getWorkspaceDir } from "../util/platform.js";
-import { getDb, rawAll, rawRun } from "./db.js";
+import { getDb, rawAll, rawGet, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
 
 export interface StoredAttachment {

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -513,6 +513,8 @@ function collectWorkspaceFiles(): Record<string, string> {
 
         // SQLite DB handling: dump as SQL text, then enforce size cap
         if (entry.endsWith(".db")) {
+          // Skip the dump entirely if the budget is already exhausted
+          if (totalBytes >= MAX_WORKSPACE_PAYLOAD_BYTES) continue;
           try {
             const proc = spawnSync("sqlite3", [fullPath, ".dump"], {
               timeout: 10_000,


### PR DESCRIPTION
## Summary
- Adds a pre-dump budget check before invoking `sqlite3 .dump` for `.db` files in the workspace export handler
- When `totalBytes >= MAX_WORKSPACE_PAYLOAD_BYTES`, the dump is skipped entirely, avoiding unnecessary synchronous work (with 10s timeout each)
- Also fixes a missing `rawGet` import in `attachments-store.ts` (pre-existing type error on main)

Addresses review feedback from #17384.

## Test plan
- [ ] Verify that workspace exports still include DB dumps when budget allows
- [ ] Verify that DB dumps are skipped when budget is exhausted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
