### PR TITLE
fix: return error when image studio attachment reads fail

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -124,22 +124,37 @@ export async function run(
       }
     }
 
+    const readErrors: string[] = [];
     sourceImages = visibleAttachments
       .map((att) => {
         let buffer: Buffer | null | undefined;
         try {
           buffer = getAttachmentContent(att.id);
-        } catch {
-          // File-backed attachment may point to a missing or unreadable file
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : "unknown error";
+          readErrors.push(`Failed to read attachment ${att.id}: ${msg}`);
           return undefined;
         }
-        if (!buffer) return undefined;
+        if (!buffer) {
+          readErrors.push(`Attachment ${att.id} has no content`);
+          return undefined;
+        }
         return {
           mimeType: att.mimeType,
           dataBase64: buffer.toString("base64"),
         };
       })
       .filter((img): img is NonNullable<typeof img> => img !== undefined);
+
+    // If all visible attachments failed to read and file paths won't supplement, report the error
+    if (sourceImages.length === 0 && readErrors.length > 0) {
+      if (!sourcePaths || sourcePaths.length === 0) {
+        return {
+          content: `Could not read any of the specified attachments:\n${readErrors.join("\n")}`,
+          isError: true,
+        };
+      }
+    }
   }
 
   // Resolve source images from file paths (sandboxed to workingDir, edit mode only)


### PR DESCRIPTION
Addresses review feedback from #17394. Instead of silently swallowing attachment read errors and proceeding with empty sourceImages, the tool now returns an error message to the user.

Changes:
- Track read errors (exceptions and null buffers) during attachment content loading
- When all attachments fail to read and no source_paths supplement them, return an `isError: true` result with details about what went wrong
- Preserves the existing behavior of skipping individual failed attachments when others succeed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
