### PR TITLE
fix(macos): remove duplicate onRehydrate call in AssistantProgressView onAppear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -256,18 +256,7 @@ struct AssistantProgressView: View {
                MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
             {
                 isExpanded = true
-                if onRehydrate != nil {
-                    let hasStrippedToolCall = toolCalls.contains { tc in
-                        tc.isComplete
-                            && tc.inputFull.isEmpty
-                            && tc.result == nil
-                            && tc.inputRawDict == nil
-                            && tc.cachedImage == nil
-                    }
-                    if hasStrippedToolCall {
-                        onRehydrate?()
-                    }
-                }
+                // Rehydration is handled by onChange(of: isExpanded) above.
             }
             // Auto-expand when a pending confirmation exists on appear
             if hasPendingConfirmation && !isExpanded {


### PR DESCRIPTION
## Summary
- Remove redundant manual onRehydrate call in onAppear block that duplicated the onChange(of: isExpanded) handler
- The onChange handler already fires when isExpanded is set to true, covering the onAppear case
- Additionally, ChatViewModel now has in-flight dedup tracking (#18954), making this doubly safe

Follows up on #18941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
