### PR TITLE
fix: update captureImageRefs JSDoc to reflect all-or-nothing return semantics

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -571,12 +571,13 @@ export async function stopContainers(
 
 /**
  * Capture the current image references for running service containers.
- * Returns a partial record of service → image tag string (e.g.
- * "vellumai/vellum-assistant:v1.2.3"). Used before stopping containers
- * so we can roll back to these exact images if the new version fails
- * readiness checks.
+ * Returns a complete record of service → image tag string for all three
+ * services (e.g. "vellumai/vellum-assistant:v1.2.3"). Used before stopping
+ * containers so we can roll back to these exact images if the new version
+ * fails readiness checks.
  *
- * Returns null if no containers could be inspected (e.g. fresh install).
+ * Returns null if any container could not be inspected (e.g. fresh install
+ * or partial deployment).
  */
 export async function captureImageRefs(
   res: ReturnType<typeof dockerResourceNames>,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for update-system-foundation.md.

**Gap:** Stale JSDoc on captureImageRefs
**What was expected:** JSDoc should describe the all-or-nothing return behavior after PR #18949
**What was found:** JSDoc still described partial record semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
