### PR TITLE
fix: add isBootstrapping guard to document editor handlers

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -225,22 +225,22 @@ extension AppDelegate {
         }
 
         daemonClient.onDocumentEditorShow = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.handleDocumentEditorShow(msg)
         }
         daemonClient.onDocumentEditorUpdate = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.handleDocumentEditorUpdate(msg)
         }
         daemonClient.onDocumentSaveResponse = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.handleDocumentSaveResponse(msg)
         }
         daemonClient.onDocumentLoadResponse = { [weak self] msg in
-            guard let self else { return }
+            guard let self, !self.isBootstrapping else { return }
             self.ensureMainWindowExists()
             self.mainWindow?.handleDocumentLoadResponse(msg)
         }


### PR DESCRIPTION
## Summary

- Adds `!self.isBootstrapping` guard to the four document editor daemon handlers (`onDocumentEditorShow`, `onDocumentEditorUpdate`, `onDocumentSaveResponse`, `onDocumentLoadResponse`)
- Matches the pattern used by `onTaskRunConversationCreated`, `onScheduleConversationCreated`, and `onNotificationConversationCreated`
- Prevents premature `mainWindow` creation during first-launch bootstrap if a document editor event arrives before `performRetriableWakeUpSend()` runs

Addresses review feedback from #17398.

## Test plan

- [ ] Verify document editor events still create the main window when not bootstrapping
- [ ] Verify document editor events during bootstrap are dropped (no premature window creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
