### PR TITLE
fix: sort imports in conversation-disk-view-integration test

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -9,8 +9,8 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-disk-view-integration.test.ts` by alphabetizing named imports (`readdirSync` before `readFileSync`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23273676506/job/67671851574

🤖 Generated with [Claude Code](https://claude.com/claude-code)