### PR TITLE
fix: preserve secret-blocked error handling path

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1127,8 +1127,7 @@ public final class HTTPTransport {
                     conversationId: conversationId,
                     code: .providerApi,
                     userMessage: message,
-                    retryable: false,
-                    failedMessageContent: content
+                    retryable: false
                 )))
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"


### PR DESCRIPTION
## Summary
- Removes `failedMessageContent` from the secret-blocked `.conversationError` in HTTP mode
- Without this fix, `failedMessageContent` triggers the per-message failure early-return path in `ChatViewModel+MessageHandling`, which marks the message as `.sendFailed` (always showing a Retry button) and returns before `retryable: false` is ever consulted
- With this fix, the session-level error path is taken instead, which respects `retryable: false`, displays the actual error message ("Message blocked — contains secrets"), and does not offer a retry mechanism

## Test plan
- [ ] Verify secret-blocked message on desktop via HTTP transport shows a non-retryable error (no Retry button, no Send Anyway)
- [ ] Verify SSE transport secret-blocked flow still works as before (unchanged)

Addresses review feedback from #17401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
