### PR TITLE
Match git user.name in Linear reminder hook

### DIFF
--- a/.claude/hooks/linear-ticket-reminder.sh
+++ b/.claude/hooks/linear-ticket-reminder.sh
@@ -2,21 +2,20 @@
 # Inject a Linear ticket reminder for specific team members.
 # Users NOT in the remind list see nothing added to context.
 #
-# Uses GitHub usernames (already public in CODEOWNERS) matched against
-# the git email's noreply pattern or the committer name.
-# To find a teammate's GitHub username: check CODEOWNERS
+# Matches against git user.name (from `git config user.name`).
+# To find a teammate's name: git log --format='%an' --author=Name | sort -u
 
-REMIND_USERS=(
-  "vincent0426"
+REMIND_NAMES=(
+  "Vincent"
+  "Harrison Ngo"
   "NgoHarrison"
-  "alex-nork"
+  "Alex Nork"
 )
 
-CURRENT_EMAIL=$(git config user.email 2>/dev/null || echo "")
 CURRENT_NAME=$(git config user.name 2>/dev/null || echo "")
 
-for u in "${REMIND_USERS[@]}"; do
-  if [[ "$CURRENT_EMAIL" == *"$u"* || "$CURRENT_NAME" == "$u" ]]; then
+for n in "${REMIND_NAMES[@]}"; do
+  if [[ "$CURRENT_NAME" == "$n" ]]; then
     jq -n '{
       "hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",


### PR DESCRIPTION
## Summary

- Simplifies the hook to match against `git config user.name` instead of GitHub usernames/email patterns
- More reliable — `user.name` is always set and doesn't depend on noreply email conventions
- Includes known name variants from git log (e.g. both "Harrison Ngo" and "NgoHarrison")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
