### PR TITLE
fix: use correct assistant restart command in debug hint

### DIFF
--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -80,7 +80,7 @@ export function handleBashSignal(filename: string): void {
         exitCode: null,
         timedOut: false,
         error:
-          "Bash signals are disabled. The running assistant process must have been started with VELLUM_DEBUG=1 (setting it on the CLI command alone is not enough). Restart the assistant with: VELLUM_DEBUG=1 assistant start",
+          "Bash signals are disabled. The running assistant process must have been started with VELLUM_DEBUG=1 (setting it on the CLI command alone is not enough). Restart the assistant with: vellum sleep && VELLUM_DEBUG=1 vellum wake",
       });
     }
     return;


### PR DESCRIPTION
## Summary
- Updates the debug error message in `bash.ts` to reference the correct assistant lifecycle command (`vellum sleep && VELLUM_DEBUG=1 vellum wake`) instead of the non-existent `assistant start`

## Context
Addresses review feedback from #17808. The previous message told users to run `VELLUM_DEBUG=1 assistant start`, but the assistant CLI does not have a `start` command. The correct lifecycle commands are `vellum sleep` and `vellum wake`.

## Test plan
- [ ] Verify the error message text is correct when bash signals are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
