### PR TITLE
fix: resolve circuit breaker and empty payload issues in attachment handling

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -11,6 +11,7 @@ describe("config: hardcoded defaults", () => {
     expect(config.maxWebhookPayloadBytes).toBe(1024 * 1024);
     expect(config.maxAttachmentBytes).toEqual({
       telegram: 20 * 1024 * 1024,
+      telegramOutbound: 50 * 1024 * 1024,
       slack: 100 * 1024 * 1024,
       whatsapp: 16 * 1024 * 1024,
       default: 100 * 1024 * 1024,

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -137,7 +137,8 @@ export function loadConfig(): GatewayConfig {
     gatewayInternalBaseUrl,
     logFile,
     maxAttachmentBytes: {
-      telegram: 20 * 1024 * 1024, // Telegram Bot API getFile limit
+      telegram: 20 * 1024 * 1024, // Telegram Bot API getFile (download) limit
+      telegramOutbound: 50 * 1024 * 1024, // Telegram Bot API sendDocument (upload) limit
       slack: 100 * 1024 * 1024, // Slack standard plan
       whatsapp: 16 * 1024 * 1024, // WhatsApp Business API limit
       default: 100 * 1024 * 1024, // Fallback; capped by runtime MAX_UPLOAD_BYTES (100 MB)

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -310,38 +310,50 @@ export type UploadAttachmentResponse = {
   id: string;
 };
 
+/**
+ * Internal helper that fetches raw attachment content without interacting
+ * with the circuit breaker. Used by downloadAttachment's hydration path
+ * which already owns the breaker lifecycle for the compound operation.
+ */
+async function fetchAttachmentContentRaw(
+  config: GatewayConfig,
+  attachmentId: string,
+): Promise<Buffer> {
+  const url = `${
+    config.assistantRuntimeBaseUrl
+  }/v1/attachments/${encodeURIComponent(attachmentId)}/content`;
+
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: runtimeServiceHeaders(config),
+    signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Attachment content download failed (${response.status}): ${body}`,
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
 export async function downloadAttachmentContent(
   config: GatewayConfig,
   attachmentId: string,
 ): Promise<Buffer> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}/content`;
-
-  let response: Response;
   try {
-    response = await fetchImpl(url, {
-      method: "GET",
-      headers: runtimeServiceHeaders(config),
-      signal: AbortSignal.timeout(config.runtimeTimeoutMs),
-    });
+    const buffer = await fetchAttachmentContentRaw(config, attachmentId);
+    cbOnSuccess();
+    return buffer;
   } catch (err) {
     cbOnFailure();
     throw err;
   }
-
-  if (!response.ok) {
-    const body = await response.text();
-    if (response.status >= 500) cbOnFailure();
-    else cbOnSuccess();
-    throw new Error(
-      `Attachment content download failed (${response.status}): ${body}`,
-    );
-  }
-
-  cbOnSuccess();
-  const arrayBuffer = await response.arrayBuffer();
-  return Buffer.from(arrayBuffer);
 }
 
 export async function downloadAttachment(
@@ -350,7 +362,9 @@ export async function downloadAttachment(
 ): Promise<HydratedAttachmentPayload> {
   cbBeforeRequest();
 
-  const url = `${config.assistantRuntimeBaseUrl}/v1/attachments/${encodeURIComponent(attachmentId)}`;
+  const url = `${
+    config.assistantRuntimeBaseUrl
+  }/v1/attachments/${encodeURIComponent(attachmentId)}`;
 
   let response: Response;
   try {
@@ -375,15 +389,24 @@ export async function downloadAttachment(
 
   // Transparently hydrate file-backed attachments: fetch the binary content
   // from the dedicated /content endpoint and inline it as base64.
-  // Note: we defer cbOnSuccess() until after hydration so that a recurring
-  // pattern of metadata-200 + content-5xx correctly accumulates breaker
-  // failures instead of resetting the counter on every metadata success.
-  if (payload.fileBacked && !payload.data) {
-    const contentBuffer = await downloadAttachmentContent(config, attachmentId);
-    payload.data = contentBuffer.toString("base64");
+  // We use the raw helper (no nested circuit breaker) so the compound
+  // metadata+content operation is treated as a single breaker unit.
+  // If content fetch fails, cbOnFailure() fires for the whole operation.
+  if (payload.fileBacked && payload.data == null) {
+    try {
+      const contentBuffer = await fetchAttachmentContentRaw(
+        config,
+        attachmentId,
+      );
+      payload.data = contentBuffer.toString("base64");
+    } catch (err) {
+      cbOnFailure();
+      throw err;
+    }
   }
 
-  if (!payload.data) {
+  // Use == null to allow empty string (valid base64 for zero-byte attachments)
+  if (payload.data == null) {
     throw new Error(`Attachment ${attachmentId} has no data after hydration`);
   }
 

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -82,10 +82,12 @@ export async function sendTelegramAttachments(
 
   for (const meta of attachments) {
     // When size is known upfront, skip oversized attachments before downloading.
+    // Use the outbound limit (sendDocument supports 50 MB) rather than the
+    // inbound getFile limit (20 MB).
     if (
       meta.sizeBytes !== undefined &&
       meta.sizeBytes >
-        (config.maxAttachmentBytes.telegram ??
+        (config.maxAttachmentBytes.telegramOutbound ??
           config.maxAttachmentBytes.default)
     ) {
       log.warn(
@@ -111,7 +113,7 @@ export async function sendTelegramAttachments(
       // Check size after hydration for ID-only payloads where size was unknown.
       if (
         sizeBytes >
-        (config.maxAttachmentBytes.telegram ??
+        (config.maxAttachmentBytes.telegramOutbound ??
           config.maxAttachmentBytes.default)
       ) {
         log.warn(


### PR DESCRIPTION
## Summary
- Fixes circuit breaker permanently locking in HALF_OPEN when hydrating file-backed attachments by extracting a raw content fetch helper that doesn't interact with the breaker
- Fixes empty base64 strings (valid for zero-byte attachments) being treated as missing data by using `== null` instead of falsy check
- Separates Telegram inbound (20 MB getFile) and outbound (50 MB sendDocument) attachment limits so valid non-photo files aren't rejected on delivery

Addresses review feedback from #17393.

## Test plan
- [x] Config test updated to include telegramOutbound key
- [ ] Verify file-backed attachment hydration works in HALF_OPEN circuit breaker state
- [ ] Verify zero-byte attachments pass through without error
- [ ] Verify Telegram outbound files between 20-50 MB are delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
