### PR TITLE
fix: handle image files before host proxy short-circuit in file_read

### DIFF
--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -54,6 +54,19 @@ class HostFileReadTool implements Tool {
       };
     }
 
+    // Image files must be handled locally — the host-file proxy protocol
+    // only carries {content, isError} and cannot transport contentBlocks
+    // (base64 image data). Check for image extensions before the proxy
+    // short-circuit so image reads work in managed/macOS+iOS sessions.
+    const ext = extname(rawPath).toLowerCase();
+    if (IMAGE_EXTENSIONS.has(ext)) {
+      const pathCheck = hostPolicy(rawPath);
+      if (!pathCheck.ok) {
+        return { content: `Error: ${pathCheck.error}`, isError: true };
+      }
+      return readImageFile(pathCheck.resolved);
+    }
+
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (context.hostFileProxy?.isAvailable()) {
@@ -67,16 +80,6 @@ class HostFileReadTool implements Tool {
         context.conversationId,
         context.signal,
       );
-    }
-
-    // For image files, delegate to the shared image reader.
-    const ext = extname(rawPath).toLowerCase();
-    if (IMAGE_EXTENSIONS.has(ext)) {
-      const pathCheck = hostPolicy(rawPath);
-      if (!pathCheck.ok) {
-        return { content: `Error: ${pathCheck.error}`, isError: true };
-      }
-      return readImageFile(pathCheck.resolved);
     }
 
     const ops = new FileSystemOps(hostPolicy);


### PR DESCRIPTION
Addresses review feedback from #18696. Moves image file detection before the host proxy early-return so image reads work correctly in managed/macOS+iOS sessions.

## Summary
- Reorders `host_file_read` execution so image extension detection runs **before** the host-file proxy short-circuit
- The proxy protocol only carries `{content, isError}` and cannot transport `contentBlocks` (base64 image data), so proxied image reads were silently dropping the image block
- Non-image reads continue to use the proxy path as before

## Test plan
- [ ] Verify image file reads in managed/macOS+iOS sessions return contentBlocks with base64 image data
- [ ] Verify non-image file reads still proxy correctly to the connected client
- [ ] Verify image reads in local (non-proxied) mode continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
