### PR TITLE
fix: defer unread badge until assistant reply exists

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -314,8 +314,7 @@ class IOSConversationStore: ObservableObject {
             let conversation = IOSConversation(
                 title: msg.title,
                 conversationId: msg.conversationId,
-                scheduleJobId: msg.scheduleJobId,
-                hasUnseenLatestAssistantMessage: true
+                scheduleJobId: msg.scheduleJobId
             )
             // Remove the empty placeholder conversation if it's still present (race:
             // schedule_conversation_created can arrive before the first conversation_list_response).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -465,8 +465,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     }
 
     /// Shared creation path for conversations spawned by background processes
-    /// (schedules, task runs, notifications). All background conversations start
-    /// with the unread badge set, ensuring the user sees new activity.
+    /// (schedules, task runs, notifications). The unread badge is NOT set at
+    /// creation time — it is deferred until an actual assistant message arrives
+    /// via `subscribeToAssistantActivity`, preventing false unread dots when the
+    /// background process fails before generating a reply.
     ///
     /// - Parameters:
     ///   - conversationId: Daemon conversation ID to bind.
@@ -492,8 +494,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         var conversation = ConversationModel(title: title, conversationId: conversationId)
         if let source { conversation.source = source }
         if let scheduleJobId { conversation.scheduleJobId = scheduleJobId }
-        conversation.hasUnseenLatestAssistantMessage = true
-
         let viewModel = makeViewModel()
         viewModel.conversationId = conversationId
         if markHistoryLoaded {


### PR DESCRIPTION
## Summary
- Removes eager `hasUnseenLatestAssistantMessage = true` from background conversation creation on both macOS and iOS
- On macOS, the existing `subscribeToAssistantActivity` / `handleAssistantMessageArrival` reactive pipeline already sets the badge when an actual assistant message streams in
- On iOS, the next conversation list refresh populates the correct unread state once the assistant replies
- Prevents false unread dots when `processMessage` fails and no assistant reply is ever generated

Addresses review feedback from #17530.

## Test plan
- [ ] Create a schedule conversation and verify no unread badge appears until the assistant actually replies
- [ ] Verify that once an assistant message arrives, the unread badge appears as expected
- [ ] Verify notification conversations still show unread badges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
