### PR TITLE
fix: reset yieldedForBudget and fold rerun history in convergence loop

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1182,6 +1182,7 @@ export async function runAgentLoopImpl(
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
         state.contextTooLargeDetected = false;
+        yieldedForBudget = false;
 
         updatedHistory = await ctx.agentLoop.run(
           runMessages,
@@ -1204,6 +1205,15 @@ export async function runAgentLoopImpl(
             "Post-convergence rerun still yielded at checkpoint — continuing reduction",
           );
           state.contextTooLargeDetected = true;
+
+          // Fold rerun progress into ctx.messages so the next reducer
+          // tier operates on up-to-date history instead of stale
+          // pre-rerun messages.
+          if (updatedHistory.length > preRunHistoryLength) {
+            ctx.messages = stripInjectedContext(updatedHistory);
+            preRepairMessages = updatedHistory;
+            preRunHistoryLength = updatedHistory.length;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Resets `yieldedForBudget` to `false` before each convergence rerun, preventing stale flag detection from triggering unnecessary reducer tiers
- Folds `updatedHistory` into `ctx.messages` when a post-convergence rerun still yields, so the next reducer tier operates on up-to-date history instead of stale pre-rerun messages

## Test plan
- [ ] Verify convergence loop no longer applies extra reducer tiers when the rerun completes successfully (flag was stale)
- [ ] Verify that when a rerun does yield, the next reduction tier sees the updated messages including progress from the yielded rerun

Addresses review feedback from #17408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
