### PR TITLE
fix: bound identity context size in notification decision prompts

### DIFF
--- a/assistant/src/__tests__/notification-decision-identity.test.ts
+++ b/assistant/src/__tests__/notification-decision-identity.test.ts
@@ -185,6 +185,58 @@ describe("identity context in notification decision engine", () => {
     expect(capturedSystemPrompt).not.toContain("</assistant-identity>");
   });
 
+  test("large identity context is truncated in system prompt", async () => {
+    // Create an identity context that exceeds the 2000-char budget
+    mockIdentityContext = "A".repeat(3000);
+
+    configuredProvider = {
+      sendMessage: async (
+        _messages: unknown,
+        _tools: unknown,
+        systemPrompt: unknown,
+      ) => {
+        capturedSystemPrompt = systemPrompt as string;
+        return { content: [] };
+      },
+    };
+    extractedToolUse = {
+      name: "record_notification_decision",
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "LLM decision with truncated identity",
+        renderedCopy: {
+          vellum: {
+            title: "Guardian Question",
+            body: "What is the gate code?",
+          },
+        },
+        dedupeKey: "identity-truncated-test",
+        confidence: 0.9,
+      },
+    };
+
+    const signal = makeSignal();
+    await evaluateSignal(signal, ["vellum"] as NotificationChannel[]);
+
+    expect(capturedSystemPrompt).toBeDefined();
+    expect(capturedSystemPrompt).toContain("<assistant-identity>");
+    // The identity block should exist but should NOT contain the full 3000-char string
+    expect(capturedSystemPrompt).not.toContain("A".repeat(3000));
+    // It should contain the truncation marker
+    expect(capturedSystemPrompt).toContain("…[truncated]");
+    // The identity content within the block should be at most 2000 chars
+    const identityMatch = capturedSystemPrompt!.match(
+      /<assistant-identity>([\s\S]*?)<\/assistant-identity>/,
+    );
+    expect(identityMatch).toBeTruthy();
+    // The identity block includes the instruction text + the truncated context.
+    // Verify the raw identity portion is bounded.
+    const identityBlock = identityMatch![1];
+    expect(identityBlock).toContain("…[truncated]");
+    expect(identityBlock).not.toContain("A".repeat(2001));
+  });
+
   test("fallback path does not include identity context", async () => {
     mockIdentityContext = "I am Jarvis, a helpful assistant";
 

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -145,8 +145,13 @@ function buildExtractionSystemPrompt(
   messageRole: string,
 ): string {
   // Inject identity context so extracted memories use real names instead of
-  // generic "User ..." labels.
-  const identityContext = buildCoreIdentityContext();
+  // generic "User ..." labels. We truncate to a budget to prevent oversized
+  // prompts when SOUL.md / IDENTITY.md / USER.md are large — exceeding the
+  // provider context window would silently degrade extraction quality.
+  const rawIdentityContext = buildCoreIdentityContext();
+  const identityContext = rawIdentityContext
+    ? truncate(rawIdentityContext, 2000, "\n…[truncated]")
+    : null;
 
   let prompt = "";
   if (identityContext) {

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -169,7 +169,12 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   const now = new Date();
   const timeContext = `Current time: ${now.toLocaleString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit", hour12: true })}`;
 
-  const identityContext = buildCoreIdentityContext();
+  // Truncate identity context to prevent oversized prompts when SOUL.md /
+  // IDENTITY.md / USER.md are large.
+  const rawIdentityContext = buildCoreIdentityContext();
+  const identityContext = rawIdentityContext
+    ? truncate(rawIdentityContext, 2000, "\n…[truncated]")
+    : null;
 
   const systemPrompt = `You are generating 4 conversation starters for a personal assistant app. These appear as clickable chips on the empty conversation page — the first thing the user sees when they open the app.
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -22,6 +22,7 @@ import {
 } from "../providers/provider-send-message.js";
 import type { ModelIntent, Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { truncate } from "../util/truncate.js";
 import {
   buildConversationCandidates,
   type ConversationCandidateSet,
@@ -54,6 +55,15 @@ const log = getLogger("notification-decision-engine");
 
 const DECISION_TIMEOUT_MS = 15_000;
 const PROMPT_VERSION = "v4";
+
+/**
+ * Maximum character budget for identity context injected into the notification
+ * decision prompt. We truncate to prevent oversized prompts when SOUL.md /
+ * IDENTITY.md / USER.md are large — exceeding the provider context window
+ * would cause the LLM call to fail and silently degrade to deterministic
+ * fallback for all notifications.
+ */
+const MAX_IDENTITY_CONTEXT_CHARS = 2000;
 
 // ── System prompt ──────────────────────────────────────────────────────
 
@@ -790,7 +800,10 @@ async function classifyWithLLM(
   const candidateContext = candidateSet
     ? (serializeCandidatesForPrompt(candidateSet) ?? undefined)
     : undefined;
-  const identityContext = buildCoreIdentityContext() ?? undefined;
+  const rawIdentityContext = buildCoreIdentityContext();
+  const identityContext = rawIdentityContext
+    ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
+    : undefined;
   const systemPrompt = buildSystemPrompt(
     availableChannels,
     preferenceContext,


### PR DESCRIPTION
## Summary
- Add 2000-character truncation budget to `buildCoreIdentityContext()` output at all three call sites: `decision-engine.ts`, `items-extractor.ts`, and `conversation-starters.ts`
- Uses the existing `truncate()` utility with a `\n…[truncated]` suffix when the identity context exceeds the budget
- Adds a test verifying large identity context is truncated in the notification decision system prompt

## Context
Addresses review feedback from #17433 where both Codex and Devin flagged that identity context was injected verbatim without any size check. For users with large SOUL.md/IDENTITY.md/USER.md files, this could exceed the provider context window and cause the LLM call to fail, silently degrading all notifications to the deterministic fallback path.

## Test plan
- [x] Existing identity context tests pass (identity present, absent, fallback)
- [x] New truncation test verifies large context is bounded and includes truncation marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
