### PR TITLE
fix: include filePath in attachment upload during retry

### DIFF
--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route handlers for attachment upload, download, and deletion.
  */
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
@@ -42,29 +42,49 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
     return httpError("BAD_REQUEST", "mimeType is required", 400);
   }
 
-  if (!data || typeof data !== "string") {
-    return httpError("BAD_REQUEST", "data (base64) is required", 400);
-  }
-
   const validation = validateAttachmentUpload(filename, mimeType);
   if (!validation.ok) {
     return httpError("UNPROCESSABLE_ENTITY", validation.error, 415);
   }
 
   let attachment: attachmentsStore.StoredAttachment;
-  try {
-    attachment = attachmentsStore.uploadAttachment(
+
+  // File-backed upload: when filePath is provided and data is empty/missing,
+  // register the attachment by path reference instead of requiring base64 data.
+  // This supports retry of file-backed attachments (e.g. recordings) where the
+  // client no longer holds the inline data but the file still exists on disk.
+  if (filePath && typeof filePath === "string" && (!data || data === "")) {
+    if (!existsSync(filePath)) {
+      return httpError("BAD_REQUEST", "filePath does not exist on disk", 400);
+    }
+    const sizeBytes = statSync(filePath).size;
+    attachment = attachmentsStore.uploadFileBackedAttachment(
       filename,
       mimeType,
-      data,
-      filePath ?? undefined,
+      filePath,
+      sizeBytes,
     );
-  } catch (err) {
-    if (err instanceof AttachmentUploadError) {
-      const status = err.message.startsWith("Attachment too large") ? 413 : 400;
-      return httpError("BAD_REQUEST", err.message, status);
+  } else {
+    if (!data || typeof data !== "string") {
+      return httpError("BAD_REQUEST", "data (base64) is required", 400);
     }
-    throw err;
+
+    try {
+      attachment = attachmentsStore.uploadAttachment(
+        filename,
+        mimeType,
+        data,
+        filePath ?? undefined,
+      );
+    } catch (err) {
+      if (err instanceof AttachmentUploadError) {
+        const status = err.message.startsWith("Attachment too large")
+          ? 413
+          : 400;
+        return httpError("BAD_REQUEST", err.message, status);
+      }
+      throw err;
+    }
   }
 
   return Response.json({

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1107,10 +1107,21 @@ extension ChatViewModel {
                     } else if let blockedUserMessage {
                         secretBlockedMessageText = blockedUserMessage.text
                     }
-                    // Reconstruct attachments from the blocked user message's ChatAttachments
+                    // Reconstruct attachments from the blocked user message's ChatAttachments.
+                    // Include filePath, sizeBytes, and thumbnailData so file-backed
+                    // attachments survive the secret-ingress redirect.
                     if let blockedUserMessage, !blockedUserMessage.attachments.isEmpty {
-                        secretBlockedAttachments = blockedUserMessage.attachments.map {
-                            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                        secretBlockedAttachments = blockedUserMessage.attachments.compactMap { att in
+                            guard !att.data.isEmpty || att.filePath != nil else { return nil }
+                            return UserMessageAttachment(
+                                filename: att.filename,
+                                mimeType: att.mimeType,
+                                data: att.data,
+                                extractedText: nil,
+                                sizeBytes: att.sizeBytes,
+                                thumbnailData: att.thumbnailData?.base64EncodedString(),
+                                filePath: att.filePath
+                            )
                         }
                     }
                     secretBlockedActiveSurfaceId = activeSurfaceId


### PR DESCRIPTION
## Summary
- Updates the daemon's `/v1/attachments` upload handler to accept file-path-only uploads (no base64 data required) by routing through `uploadFileBackedAttachment` when `filePath` is provided and `data` is empty
- Fixes the secret-blocked message reconstruction in `ChatViewModel+MessageHandling.swift` to preserve `filePath`, `sizeBytes`, and `thumbnailData` on file-backed attachments, matching the pattern already used in `retryFailedMessage` and `retryAfterConversationError`

Addresses review feedback from #17395. Closes #17395.

## Test plan
- [ ] Retry a failed message with a file-path-backed attachment (e.g. recording) — verify the upload succeeds instead of rejecting with "data (base64) is required"
- [ ] Retry a failed message with an inline-data attachment — verify behavior unchanged
- [ ] Trigger secret-ingress block on a message with file-path attachments, then "send anyway" — verify attachments are preserved through the redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
