### PR TITLE
fix: clear highlightedMessageId on disappear and reduce view invalidation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1004,6 +1004,7 @@ struct MessageListView: View {
                 avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
+                highlightedMessageId = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -1305,6 +1306,7 @@ private struct MessageCellView: View, Equatable {
             && lhs.activeSurfaceId == rhs.activeSurfaceId
             && lhs.isHighlighted == rhs.isHighlighted
             && lhs.selectedModel == rhs.selectedModel
+            && lhs.configuredProviders == rhs.configuredProviders
     }
 
     let message: ChatMessage

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -148,7 +148,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     @Published var pendingAnchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
     /// Set by MessageListView when it scrolls to the anchor, cleared after the flash animation.
-    @Published var highlightedMessageId: UUID?
+    /// Not @Published — this is a transient visual effect only consumed by MessageListView via
+    /// a direct Binding, so it does not need to fire objectWillChange on the entire subscriber tree.
+    var highlightedMessageId: UUID?
     /// Tracks which conversation the pending anchor belongs to so stale anchors are
     /// cleared automatically when the user switches to a different conversation.
     private var pendingAnchorConversationId: UUID?


### PR DESCRIPTION
## Summary
- Clear `highlightedMessageId` in `onDisappear` to prevent stale highlights persisting when the view disappears during the 1.5s flash animation window
- Remove `@Published` from `ConversationManager.highlightedMessageId` — this is a transient visual effect only consumed by `MessageListView` via a direct `Binding`, so it doesn't need to fire `objectWillChange` on the entire subscriber tree (avoids invalidating `MainWindowView`, `SidebarThreadItem`, `SettingsPanel`, etc.)
- Add missing `configuredProviders` comparison to `MessageCellView` `Equatable` conformance so provider changes correctly trigger re-renders

## Test plan
- [ ] Deep-link to a message, navigate away before the 1.5s highlight expires, return — highlight should be gone
- [ ] Deep-link to a message, stay on the view — highlight should still auto-dismiss after 1.5s as before
- [ ] Verify model list bubbles update when configured providers change

Addresses review feedback from #17432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
