### PR TITLE
fix: hydrate attachment base64 from disk for file-backed attachments

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -24,6 +24,7 @@ const ALLOWLIST = new Set([
   // --- Intentional local daemon-control paths ---
   "assistant/src/cli/commands/conversations.ts", // CLI wipe talks to runtime directly
   "clients/shared/Network/DaemonClient.swift",
+  "clients/shared/App/Auth/PlatformOAuthService.swift", // comment explaining runtimeUrl vs platformUrl
   "clients/macos/vellum-assistant/App/AppDelegate.swift",
   "clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift",
   ".claude/skills/update/SKILL.md", // daemon health check script

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -525,6 +525,16 @@ export function getAttachmentsByIds(
       .where(eq(attachments.id, id))
       .get();
     if (row) {
+      // File-backed attachments store data on disk with dataBase64 = "".
+      // Hydrate base64 from disk so callers get actual content.
+      let dataBase64 = row.dataBase64;
+      if (!dataBase64 && row.filePath) {
+        try {
+          dataBase64 = readFileSync(row.filePath).toString("base64");
+        } catch {
+          dataBase64 = "";
+        }
+      }
       results.push({
         id: row.id,
         originalFilename: row.originalFilename,
@@ -532,7 +542,7 @@ export function getAttachmentsByIds(
         sizeBytes: row.sizeBytes,
         kind: row.kind,
         thumbnailBase64: row.thumbnailBase64,
-        dataBase64: row.dataBase64,
+        dataBase64,
         createdAt: row.createdAt,
       });
     }


### PR DESCRIPTION
## Summary
- Fix `getAttachmentsByIds()` to read attachment content from disk when `dataBase64` is empty and `filePath` is set, restoring base64 data for all downstream consumers (`getAttachmentById`, `getAttachmentsForMessage`, `handleGetAttachment`, `handleListMessages`)
- Add `PlatformOAuthService.swift` to gateway-only guard allowlist — it mentions `localhost:7821` in a documentation comment explaining runtimeUrl vs platformUrl, not for API consumption

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23273676506/job/67671851577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
