### PR TITLE
fix: restore targeted risk escalation for mutating assistant/vellum subcommands

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -144,6 +144,7 @@ const LOW_RISK_PROGRAMS = new Set([
   "du",
   "df",
   "assistant",
+  "vellum",
 ]);
 
 // High-risk shell programs / patterns
@@ -195,6 +196,32 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "ls-tree",
   "cat-file",
   "reflog",
+]);
+
+// Mutating assistant/vellum CLI subcommands that should be escalated to Medium
+// risk. Most assistant/vellum subcommands are read-only and stay Low risk.
+// This mirrors the git subcommand pattern — only known mutating operations
+// get escalated.
+const MEDIUM_RISK_CLI_SUBCOMMANDS = new Set([
+  "credentials",
+  "config",
+  "bash",
+  "trust",
+  "autonomy",
+  "contacts",
+  "mcp",
+  "keys",
+  "wake",
+  "sleep",
+  "hatch",
+  "retire",
+  "clean",
+  "setup",
+  "upgrade",
+  "recover",
+  "login",
+  "use",
+  "pair",
 ]);
 
 // Commands that wrap another program — the real program appears as the first
@@ -684,6 +711,17 @@ async function classifyRiskUncached(
         }
         // Non-read-only git commands are medium
         maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      if (prog === "vellum" || prog === "assistant") {
+        const subcommand = firstPositionalArg(seg.args);
+        if (subcommand && MEDIUM_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
+          // Known mutating subcommands are medium
+          maxRisk = RiskLevel.Medium;
+          continue;
+        }
+        // Read-only / unknown subcommands stay at current risk
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Adds `vellum` to `LOW_RISK_PROGRAMS` so read-only vellum commands stay Low risk (fixes over-escalation from #18738)
- Introduces `MEDIUM_RISK_CLI_SUBCOMMANDS` set listing known mutating subcommands (credentials, config, bash, trust, wake, sleep, etc.)
- Adds targeted `vellum`/`assistant` subcommand handler that escalates only mutating subcommands to Medium risk
- Preserves the intent of #18738 (no blanket escalation of unknown subcommands) while restoring safety for known mutating operations
- Mirrors the existing `git` subcommand pattern for symmetry

## Test plan
- [ ] Verify `vellum ps` / `vellum doctor` classify as Low risk
- [ ] Verify `vellum wake` / `vellum sleep` classify as Medium risk
- [ ] Verify `assistant credentials` / `assistant config` classify as Medium risk
- [ ] Verify `assistant audit` / `assistant doctor` classify as Low risk
- [ ] Verify `git` subcommand handling is unchanged

Addresses review feedback from #18738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
