### PR TITLE
fix: restore subcommand-level risk classification for assistant/vellum CLI

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -143,7 +143,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
-  "assistant",
 ]);
 
 // High-risk shell programs / patterns
@@ -195,6 +194,15 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "ls-tree",
   "cat-file",
   "reflog",
+]);
+
+// Vellum/assistant CLI subcommands that are low-risk (read-only)
+const LOW_RISK_CLI_SUBCOMMANDS = new Set([
+  "ps",
+  "doctor",
+  "audit",
+  "completions",
+  "map",
 ]);
 
 // Commands that wrap another program — the real program appears as the first
@@ -683,6 +691,17 @@ async function classifyRiskUncached(
           continue;
         }
         // Non-read-only git commands are medium
+        maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      if (prog === "vellum" || prog === "assistant") {
+        const subcommand = firstPositionalArg(seg.args);
+        if (subcommand && LOW_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
+          // Read-only subcommands stay at current risk
+          continue;
+        }
+        // Mutating subcommands are medium
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
## Summary
- Remove `"assistant"` from `LOW_RISK_PROGRAMS` — the assistant/vellum CLI has mutating subcommands (`sleep`, `wake`) and should not be blanket low-risk
- Restore `LOW_RISK_CLI_SUBCOMMANDS` set and per-subcommand handler so read-only subcommands (`ps`, `doctor`, `audit`, `completions`, `map`) stay Low risk while everything else escalates to Medium
- Addresses review feedback from #18567 where `LOW_RISK_PROGRAMS` additions were dead code (shadowed by the subcommand handler), and the subsequent fix in #18738 went the wrong direction by removing the handler instead

## Test plan
- [ ] Verify `assistant ps` is classified as Low risk
- [ ] Verify `assistant sleep` is classified as Medium risk
- [ ] Verify `vellum wake` is classified as Medium risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
