### PR TITLE
fix: suppress auto-wake during planned service group updates

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -174,6 +174,11 @@ extension DaemonClient {
     /// `onConnectionStateChanged` callback when the health check reports
     /// disconnection.
     private func autoWakeIfDaemonDied() {
+        guard !isUpdateInProgress else {
+            log.info("auto-wake: skipping — planned service group update in progress")
+            return
+        }
+
         guard let wakeHandler,
               config.transportMetadata.routeMode == .runtimeFlat
         else { return }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for update-system-foundation.md.

**Gap:** Auto-wake not suppressed during planned service group updates
**What was expected:** autoWakeIfDaemonDied() should check isUpdateInProgress before attempting to restart the daemon
**What was found:** No guard existed, so health check failures during planned updates triggered unnecessary wake attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
