### PR TITLE
fix: rename duplicate Reference Files heading in SKILL.md

### DIFF
--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -29,7 +29,7 @@ Config is stored in `config.json` in the workspace directory. Use the CLI to int
 - **Set a value**: `assistant config set <key> <value>`
 - **Search config**: `assistant config list --search <query>`
 
-## Reference Files
+## When to Consult References
 
 Consult these reference files for detailed knowledge on specific topics. Read the relevant file before answering questions in that domain.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for model-identity-in-system-prompt.md.

**Gap:** Duplicate Reference Files heading
**What was expected:** Single clean Reference Files section
**What was found:** Manual section in SKILL.md duplicates auto-generated heading from skill loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
