### PR TITLE
fix: move {baseDir} script command to SKILL.md where substitution works

### DIFF
--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -35,6 +35,16 @@ Consult these reference files for detailed knowledge on specific topics. Read th
 
 - `references/inference.md` — Model identity, provider details, model catalog, and how inference routing works. **Read this when asked what model you are or about inference configuration.**
 
+## Self-Info Script
+
+To determine what model and provider you are currently running as, run:
+
+```bash
+bun run {baseDir}/scripts/self-info.ts
+```
+
+**Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
+
 ## Critical Rule
 
-Never guess or hallucinate information about yourself. If unsure, consult the relevant reference file or run the self-info script.
+Never guess or hallucinate information about yourself. If unsure, consult the relevant reference file or run the self-info script above.

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -2,11 +2,7 @@
 
 ## Current Model Identity
 
-To determine what model and provider you are currently running as, run the self-info script:
-
-```bash
-bun run {baseDir}/scripts/self-info.ts
-```
+To determine what model and provider you are currently running as, run the self-info script command shown in SKILL.md above.
 
 The script returns JSON with the current model ID, display name, provider, and provider display name. **Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for model-identity-in-system-prompt.md.

**Gap:** {baseDir} in reference file not substituted
**What was expected:** Usable script invocation instructions
**What was found:** {baseDir} placeholder in references/inference.md is never resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
