### PR TITLE
fix: handle (not set) config response in self-info script

### DIFF
--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -68,11 +68,25 @@ async function main(): Promise<void> {
       return;
     }
 
-    const config = JSON.parse(stdout.trim()) as {
-      model?: string;
-      provider?: string;
-      mode?: string;
-    };
+    const raw = stdout.trim();
+
+    // When the inference config hasn't been explicitly set, the CLI returns
+    // the literal string "(not set)". Fall back to sensible defaults rather
+    // than crashing with a cryptic JSON-parse error.
+    let config: { model?: string; provider?: string; mode?: string };
+    if (raw === "(not set)" || raw === "") {
+      config = {
+        model: "claude-opus-4-6",
+        provider: "anthropic",
+        mode: "unknown",
+      };
+    } else {
+      config = JSON.parse(raw) as {
+        model?: string;
+        provider?: string;
+        mode?: string;
+      };
+    }
 
     const modelId = config.model ?? "unknown";
     const providerId = config.provider ?? "unknown";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for model-identity-in-system-prompt.md.

**Gap:** Script fails with unhelpful error when inference config not set
**What was expected:** Clear error or fallback to defaults
**What was found:** JSON.parse on '(not set)' string produces cryptic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
