### PR TITLE
fix: queue notification catch-up during active send and update recency

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -158,6 +158,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     private var pendingSeenConversationIds: [String] = []
     /// Task that auto-commits deferred seen signals after the undo window.
     private var pendingSeenSignalTask: Task<Void, Never>?
+    /// Daemon conversation IDs that need a notification catch-up (history fetch)
+    /// once the associated ChatViewModel finishes its current send/think cycle.
+    /// Populated when a notification_intent arrives while the VM is busy.
+    private var pendingNotificationCatchUpIds: Set<String> = []
     /// Local seen/unread toggles should survive a stale daemon conversation-list
     /// replay until the daemon either acknowledges them or reports a newer reply.
     private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
@@ -1369,33 +1373,52 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     }
 
     /// Handle a `notification_intent` that targets a conversation the client already
-    /// knows about (reuse case). Two effects:
+    /// knows about (reuse case). Three effects:
     ///
     /// 1. **Unseen badge** — marks the conversation as having unseen content (if it's
     ///    not the active conversation). Does NOT send a signal to the daemon because
     ///    the server already advanced the attention cursor via `projectAssistantMessage`.
+    ///    Also removes the conversation from `pendingSeenConversationIds` so a
+    ///    concurrent mark-all-seen undo window doesn't re-send a stale seen signal.
     ///
-    /// 2. **Message visibility** — triggers a reconnect-style history fetch so the
+    /// 2. **Recency** — updates `lastInteractedAt` so the conversation sorts to the
+    ///    top of the sidebar, matching the contract for incoming messages.
+    ///
+    /// 3. **Message visibility** — triggers a reconnect-style history fetch so the
     ///    notification seed message appears in the chat view. Only fires when a
     ///    ViewModel exists and is idle (not mid-response), to avoid disrupting
-    ///    active streaming. For inactive conversations without a ViewModel, the
-    ///    message will load normally when the user opens the conversation.
+    ///    active streaming. When the VM is busy, the daemon conversation ID is queued
+    ///    in `pendingNotificationCatchUpIds` and drained when the VM becomes idle
+    ///    (via `subscribeToBusyState`). For inactive conversations without a ViewModel,
+    ///    the message will load normally when the user opens the conversation.
     func handleNotificationIntentForExistingConversation(daemonConversationId: String) {
         guard let idx = conversations.firstIndex(where: { $0.conversationId == daemonConversationId }) else { return }
         let localId = conversations[idx].id
+
+        // Always update recency so the conversation surfaces in the sidebar.
+        conversations[idx].lastInteractedAt = Date()
 
         if localId != activeConversationId {
             // Background conversation: mark unseen. Message loads on activation.
             conversations[idx].hasUnseenLatestAssistantMessage = true
             conversations[idx].latestAssistantMessageAt = Date()
+
+            // Prevent a concurrent mark-all-seen undo window from sending a
+            // stale seen signal that would conflict with the server's
+            // notification-driven unseen state.
+            pendingSeenConversationIds.removeAll { $0 == daemonConversationId }
         }
 
         // Trigger history catch-up so the new message appears in the chat view.
         // Guard: only when a ViewModel exists and is idle — triggering populateFromHistory
         // mid-stream would discard the in-flight streaming buffer (line 2709 of ChatViewModel).
         if let vm = chatViewModels[localId], !vm.isThinking, !vm.isSending {
+            pendingNotificationCatchUpIds.remove(daemonConversationId)
             vm.prepareForNotificationCatchUp()
             conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
+        } else if chatViewModels[localId] != nil {
+            // VM exists but is busy — queue for retry when it becomes idle.
+            pendingNotificationCatchUpIds.insert(daemonConversationId)
         }
     }
 
@@ -1883,11 +1906,22 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                 self.busyConversationIds.insert(conversationId)
             } else {
                 self.busyConversationIds.remove(conversationId)
+                self.drainPendingNotificationCatchUp(for: conversationId)
             }
         }
         .store(in: &subs)
 
         busyStateCancellables[conversationId] = subs
+    }
+
+    /// If `conversationId` has a queued notification catch-up, trigger it now
+    /// that the VM is idle.
+    private func drainPendingNotificationCatchUp(for conversationId: UUID) {
+        guard let daemonId = conversations.first(where: { $0.id == conversationId })?.conversationId,
+              pendingNotificationCatchUpIds.remove(daemonId) != nil,
+              let vm = chatViewModels[conversationId] else { return }
+        vm.prepareForNotificationCatchUp()
+        conversationRestorer.requestReconnectHistory(conversationId: daemonId)
     }
 
     /// Subscribe to assistant activity for a conversation.

--- a/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerUnseenStateTests.swift
@@ -736,8 +736,9 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
             return
         }
 
-        // Simulate previously seen state
+        // Simulate previously seen state with stale recency
         conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[idx].lastInteractedAt = Date(timeIntervalSince1970: 1000)
 
         // Ensure the active conversation is a different one (the default from setUp)
         XCTAssertNotEqual(conversationManager.conversations[idx].id, conversationManager.activeConversationId)
@@ -751,6 +752,10 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(
             abs(conversationManager.conversations[idx].latestAssistantMessageAt!.timeIntervalSinceNow) < 1.0,
             "latestAssistantMessageAt should be recent (within last second)"
+        )
+        XCTAssertTrue(
+            abs(conversationManager.conversations[idx].lastInteractedAt.timeIntervalSinceNow) < 1.0,
+            "lastInteractedAt should be updated so the conversation sorts to the top of the sidebar"
         )
     }
 
@@ -775,11 +780,16 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
         }
 
         conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = false
+        conversationManager.conversations[idx].lastInteractedAt = Date(timeIntervalSince1970: 1000)
 
         conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-active-1")
 
         XCTAssertFalse(conversationManager.conversations[idx].hasUnseenLatestAssistantMessage,
                        "Active conversation should not be marked unseen — user is looking at it")
+        XCTAssertTrue(
+            abs(conversationManager.conversations[idx].lastInteractedAt.timeIntervalSinceNow) < 1.0,
+            "lastInteractedAt should still be updated for active conversations so sidebar order reflects the notification"
+        )
     }
 
     func testNotificationIntentNoopsForUnknownConversation() {
@@ -840,6 +850,83 @@ final class ConversationManagerUnseenStateTests: XCTestCase {
                        "handleNotificationIntentForExistingConversation should trigger a history request")
         XCTAssertEqual(historyRequests.first?.conversationId, "notif-history-1",
                        "History request should target the correct conversation")
+    }
+
+    func testNotificationIntentRemovesPendingSeenSignal() {
+        // Create a background conversation and mark it unseen
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-seen-race",
+            scheduleJobId: "sched-seen-race",
+            title: "Seen Race Target"
+        )
+
+        guard let idx = conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-seen-race" }) else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        conversationManager.conversations[idx].hasUnseenLatestAssistantMessage = true
+        conversationManager.conversations[idx].latestAssistantMessageAt = Date(timeIntervalSince1970: 1)
+
+        // Mark all seen — this defers the seen signal in pendingSeenConversationIds
+        conversationManager.markAllConversationsSeen()
+
+        // A notification intent arrives during the undo window
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-seen-race")
+
+        // Commit the pending seen signals — should NOT include the notification conversation
+        sentMessages.removeAll()
+        conversationManager.commitPendingSeenSignals()
+
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
+        XCTAssertFalse(seenSignals.contains(where: { $0.conversationId == "notif-seen-race" }),
+                       "Pending seen signal should be removed when a notification intent marks the conversation unseen")
+        XCTAssertTrue(conversationManager.conversations[idx].hasUnseenLatestAssistantMessage,
+                      "Conversation should remain unseen after notification intent")
+    }
+
+    func testNotificationIntentQueuesCatchUpWhenVMBusy() {
+        conversationManager.createScheduleConversation(
+            conversationId: "notif-busy-1",
+            scheduleJobId: "sched-busy-1",
+            title: "Busy Target"
+        )
+
+        guard let idx = conversationManager.conversations.firstIndex(where: { $0.conversationId == "notif-busy-1" }) else {
+            XCTFail("Expected conversation to exist")
+            return
+        }
+
+        let localId = conversationManager.conversations[idx].id
+
+        guard let vm = conversationManager.chatViewModel(for: localId) else {
+            XCTFail("Expected ChatViewModel")
+            return
+        }
+
+        // Simulate a busy VM
+        vm.isSending = true
+        waitForPropagation()
+
+        sentMessages.removeAll()
+
+        // Notification arrives while VM is busy — should NOT trigger history request yet
+        conversationManager.handleNotificationIntentForExistingConversation(daemonConversationId: "notif-busy-1")
+
+        let historyRequestsDuringBusy = sentMessages.compactMap { $0 as? HistoryRequestMessage }
+        XCTAssertTrue(historyRequestsDuringBusy.isEmpty,
+                      "History request should be deferred while VM is busy")
+
+        // VM finishes — should trigger the queued catch-up
+        sentMessages.removeAll()
+        vm.isSending = false
+        waitForPropagation()
+
+        let historyRequestsAfterIdle = sentMessages.compactMap { $0 as? HistoryRequestMessage }
+        XCTAssertFalse(historyRequestsAfterIdle.isEmpty,
+                       "Queued history request should fire when VM becomes idle")
+        XCTAssertEqual(historyRequestsAfterIdle.first?.conversationId, "notif-busy-1",
+                       "Deferred history request should target the correct conversation")
     }
 
     private func waitForPropagation() {


### PR DESCRIPTION
## Summary
- Queues notification catch-up for retry when the conversation's ChatViewModel is busy (isThinking/isSending), draining via the existing `subscribeToBusyState` Combine pipeline when the VM becomes idle
- Updates `lastInteractedAt` when handling notification intents so reused conversations sort to the top of the sidebar
- Removes the daemon conversation ID from `pendingSeenConversationIds` when a notification marks a conversation unseen, preventing the mark-all-seen undo window from sending a conflicting stale seen signal

Addresses review feedback from #18022.

## Test plan
- [x] Updated `testNotificationIntentMarksInactiveConversationUnseen` to verify `lastInteractedAt` update
- [x] Updated `testNotificationIntentSkipsUnseenBadgeForActiveConversation` to verify `lastInteractedAt` update for active conversations
- [x] Added `testNotificationIntentRemovesPendingSeenSignal` for the mark-all-seen race
- [x] Added `testNotificationIntentQueuesCatchUpWhenVMBusy` for the deferred catch-up drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
