### PR TITLE
Update system foundation: version compat, upgrade lifecycle events, Docker rollback

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -38,6 +38,7 @@ export * from "./message-types/skills.js";
 export * from "./message-types/subagents.js";
 export * from "./message-types/surfaces.js";
 export * from "./message-types/trust.js";
+export * from "./message-types/upgrades.js";
 export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
@@ -123,6 +124,7 @@ import type {
   _TrustClientMessages,
   _TrustServerMessages,
 } from "./message-types/trust.js";
+import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
 import type {
   _WorkItemsClientMessages,
   _WorkItemsServerMessages,
@@ -194,6 +196,7 @@ export type ServerMessage =
   | _InboxServerMessages
   | _PairingServerMessages
   | _NotificationsServerMessages
+  | _UpgradesServerMessages
   | _AcpServerMessages
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/upgrades.ts
+++ b/assistant/src/daemon/message-types/upgrades.ts
@@ -1,0 +1,23 @@
+/** Broadcast to connected clients when a service group update is about to begin. */
+export interface ServiceGroupUpdateStarting {
+  type: "service_group_update_starting";
+  /** The version being upgraded to. */
+  targetVersion: string;
+  /** Estimated seconds of downtime. */
+  expectedDowntimeSeconds: number;
+}
+
+/** Broadcast to connected clients when a service group update has completed. */
+export interface ServiceGroupUpdateComplete {
+  type: "service_group_update_complete";
+  /** The version that was installed (may differ from target if rolled back). */
+  installedVersion: string;
+  /** Whether the update succeeded or rolled back. */
+  success: boolean;
+  /** If rolled back, the version reverted to. */
+  rolledBackToVersion?: string;
+}
+
+export type _UpgradesServerMessages =
+  | ServiceGroupUpdateStarting
+  | ServiceGroupUpdateComplete;

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -7,6 +7,7 @@ import {
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import {
+  captureImageRefs,
   DOCKERHUB_IMAGES,
   DOCKER_READY_TIMEOUT_MS,
   GATEWAY_INTERNAL_PORT,
@@ -224,6 +225,16 @@ async function upgradeDocker(
     `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
   );
 
+  console.log("📸 Capturing current image references for rollback...");
+  const previousImageRefs = await captureImageRefs(res);
+  if (previousImageRefs) {
+    console.log(
+      `   Captured refs for ${Object.keys(previousImageRefs).length} service(s)\n`,
+    );
+  } else {
+    console.log("   No existing containers found (fresh install)\n");
+  }
+
   console.log("🛑 Stopping existing containers...");
   await stopContainers(res);
   console.log("✅ Containers stopped\n");
@@ -281,10 +292,44 @@ async function upgradeDocker(
       `\n✅ Docker assistant '${instanceName}' upgraded to ${versionTag}.`,
     );
   } else {
-    console.log(
-      `\n⚠️  Containers are running but the assistant did not become ready within the timeout.`,
-    );
-    console.log(`   Check logs with: docker logs -f ${res.assistantContainer}`);
+    console.error(`\n❌ Containers failed to become ready within the timeout.`);
+
+    if (previousImageRefs) {
+      console.log(`\n🔄 Rolling back to previous images...`);
+      await stopContainers(res);
+
+      await startContainers(
+        {
+          extraAssistantEnv,
+          gatewayPort,
+          imageTags: previousImageRefs,
+          instanceName,
+          res,
+        },
+        (msg) => console.log(msg),
+      );
+
+      const rollbackReady = await waitForReady(entry.runtimeUrl);
+      if (rollbackReady) {
+        console.log(
+          `\n⚠️  Rolled back to previous version. Upgrade to ${versionTag} failed.`,
+        );
+      } else {
+        console.error(
+          `\n❌ Rollback also failed. Manual intervention required.`,
+        );
+        console.log(
+          `   Check logs with: docker logs -f ${res.assistantContainer}`,
+        );
+      }
+    } else {
+      console.log(`   No previous images available for rollback.`);
+      console.log(
+        `   Check logs with: docker logs -f ${res.assistantContainer}`,
+      );
+    }
+
+    process.exit(1);
   }
 }
 

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -571,12 +571,13 @@ export async function stopContainers(
 
 /**
  * Capture the current image references for running service containers.
- * Returns a partial record of service → image tag string (e.g.
- * "vellumai/vellum-assistant:v1.2.3"). Used before stopping containers
- * so we can roll back to these exact images if the new version fails
- * readiness checks.
+ * Returns a complete record of service → image tag string for all three
+ * services (e.g. "vellumai/vellum-assistant:v1.2.3"). Used before stopping
+ * containers so we can roll back to these exact images if the new version
+ * fails readiness checks.
  *
- * Returns null if no containers could be inspected (e.g. fresh install).
+ * Returns null if any container could not be inspected (e.g. fresh install
+ * or partial deployment).
  */
 export async function captureImageRefs(
   res: ReturnType<typeof dockerResourceNames>,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -588,7 +588,6 @@ export async function captureImageRefs(
   };
 
   const refs: Partial<Record<ServiceName, string>> = {};
-  let foundAny = false;
 
   for (const [service, container] of Object.entries(containerForService)) {
     try {
@@ -602,14 +601,19 @@ export async function captureImageRefs(
       ).trim();
       if (imageRef) {
         refs[service as ServiceName] = imageRef;
-        foundAny = true;
       }
     } catch {
       // Container doesn't exist or can't be inspected — skip
     }
   }
 
-  return foundAny ? (refs as Record<ServiceName, string>) : null;
+  const allServices: ServiceName[] = [
+    "assistant",
+    "credential-executor",
+    "gateway",
+  ];
+  const hasAll = allServices.every((s) => s in refs);
+  return hasAll ? (refs as Record<ServiceName, string>) : null;
 }
 
 /**

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -571,10 +571,10 @@ export async function stopContainers(
 
 /**
  * Capture the current image references for running service containers.
- * Returns a complete record of service → image tag string for all three
- * services (e.g. "vellumai/vellum-assistant:v1.2.3"). Used before stopping
- * containers so we can roll back to these exact images if the new version
- * fails readiness checks.
+ * Returns a complete record of service → immutable image ID (sha256 digest)
+ * for all three services. Uses `{{.Image}}` rather than `{{.Config.Image}}`
+ * so rollback targets the exact image that was running, even if the tag has
+ * since been retagged to a different image.
  *
  * Returns null if any container could not be inspected (e.g. fresh install
  * or partial deployment).
@@ -596,7 +596,7 @@ export async function captureImageRefs(
         await execOutput("docker", [
           "inspect",
           "--format",
-          "{{.Config.Image}}",
+          "{{.Image}}",
           container,
         ])
       ).trim();

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -570,6 +570,49 @@ export async function stopContainers(
 }
 
 /**
+ * Capture the current image references for running service containers.
+ * Returns a partial record of service → image tag string (e.g.
+ * "vellumai/vellum-assistant:v1.2.3"). Used before stopping containers
+ * so we can roll back to these exact images if the new version fails
+ * readiness checks.
+ *
+ * Returns null if no containers could be inspected (e.g. fresh install).
+ */
+export async function captureImageRefs(
+  res: ReturnType<typeof dockerResourceNames>,
+): Promise<Record<ServiceName, string> | null> {
+  const containerForService: Record<ServiceName, string> = {
+    assistant: res.assistantContainer,
+    "credential-executor": res.cesContainer,
+    gateway: res.gatewayContainer,
+  };
+
+  const refs: Partial<Record<ServiceName, string>> = {};
+  let foundAny = false;
+
+  for (const [service, container] of Object.entries(containerForService)) {
+    try {
+      const imageRef = (
+        await execOutput("docker", [
+          "inspect",
+          "--format",
+          "{{.Config.Image}}",
+          container,
+        ])
+      ).trim();
+      if (imageRef) {
+        refs[service as ServiceName] = imageRef;
+        foundAny = true;
+      }
+    } catch {
+      // Container doesn't exist or can't be inspected — skip
+    }
+  }
+
+  return foundAny ? (refs as Record<ServiceName, string>) : null;
+}
+
+/**
  * Determine which services are affected by a changed file path relative
  * to the repository root.
  */

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -254,6 +254,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// The daemon version string, populated via `daemon_status` on connect.
     @Published public internal(set) var daemonVersion: String?
 
+    /// Whether the connected daemon's major.minor version differs from this client's version.
+    /// Set automatically when `daemon_status` is received. Does not block the connection.
+    @Published public internal(set) var versionMismatch: Bool = false
+
     /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
     /// Used to detect instance switches — if this changes, the stored actor token is stale.
     @Published public internal(set) var keyFingerprint: String?
@@ -542,12 +546,40 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         isAuthenticated = false
         httpPort = nil
         daemonVersion = nil
+        versionMismatch = false
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
         #if os(macOS)
         lastAutoWakeAttempt = nil
         #endif
+    }
+
+    /// Extract (major, minor) from a semver string like "1.2.3" or "v1.2.3".
+    private func parseMajorMinor(_ version: String) -> (Int, Int)? {
+        let cleaned = version.hasPrefix("v") ? String(version.dropFirst()) : version
+        let components = cleaned.split(separator: ".").compactMap { Int($0) }
+        guard components.count >= 2 else { return nil }
+        return (components[0], components[1])
+    }
+
+    /// Compare client and daemon major.minor versions. Logs a warning and sets
+    /// `versionMismatch` if they differ. Patch version differences are tolerated.
+    func checkVersionCompatibility(daemonVersion: String) {
+        guard let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return
+        }
+        guard let (daemonMajor, daemonMinor) = parseMajorMinor(daemonVersion),
+              let (clientMajor, clientMinor) = parseMajorMinor(clientVersion) else {
+            return
+        }
+        let mismatch = daemonMajor != clientMajor || daemonMinor != clientMinor
+        if mismatch != versionMismatch {
+            versionMismatch = mismatch
+        }
+        if mismatch {
+            log.warning("Version mismatch: client \(clientVersion, privacy: .public) vs daemon \(daemonVersion, privacy: .public) — major.minor differs, features may not work correctly")
+        }
     }
 
     deinit {

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -266,6 +266,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// The version being upgraded to, if an update is in progress.
     @Published public internal(set) var updateTargetVersion: String?
 
+    /// Deadline after which `isUpdateInProgress` is considered stale.
+    /// Computed from `expectedDowntimeSeconds` (with a 2x safety buffer)
+    /// when a `service_group_update_starting` event arrives. If the update
+    /// hasn't completed by this time, auto-wake suppression expires so the
+    /// client can recover from a crashed update.
+    var updateExpiresAt: Date?
+
     /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
     /// Used to detect instance switches — if this changes, the stored actor token is stale.
     @Published public internal(set) var keyFingerprint: String?
@@ -563,6 +570,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         versionMismatch = false
         isUpdateInProgress = false
         updateTargetVersion = nil
+        updateExpiresAt = nil
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -258,6 +258,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Set automatically when `daemon_status` is received. Does not block the connection.
     @Published public internal(set) var versionMismatch: Bool = false
 
+    /// Whether a planned service group update is in progress.
+    /// Set when a `service_group_update_starting` event is received,
+    /// cleared when reconnected and `daemon_status` confirms the new version.
+    @Published public internal(set) var isUpdateInProgress: Bool = false
+
+    /// The version being upgraded to, if an update is in progress.
+    @Published public internal(set) var updateTargetVersion: String?
+
     /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
     /// Used to detect instance switches — if this changes, the stored actor token is stale.
     @Published public internal(set) var keyFingerprint: String?
@@ -553,6 +561,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         httpPort = nil
         daemonVersion = nil
         versionMismatch = false
+        isUpdateInProgress = false
+        updateTargetVersion = nil
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -344,6 +344,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when a notification delivery creates a new vellum conversation.
     public var onNotificationConversationCreated: ((NotificationConversationCreated) -> Void)?
 
+    /// Called when the daemon broadcasts that a service group update is starting.
+    public var onServiceGroupUpdateStarting: ((ServiceGroupUpdateStartingMessage) -> Void)?
+
+    /// Called when the daemon broadcasts that a service group update has completed.
+    public var onServiceGroupUpdateComplete: ((ServiceGroupUpdateCompleteMessage) -> Void)?
+
     /// Called when the server-assigned conversation ID differs from the
     /// client-local ID. Parameters: (localId, serverId).
     public var onConversationIdResolved: ((_ localId: String, _ serverId: String) -> Void)?

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -174,9 +174,17 @@ extension DaemonClient {
     /// `onConnectionStateChanged` callback when the health check reports
     /// disconnection.
     private func autoWakeIfDaemonDied() {
-        guard !isUpdateInProgress else {
-            log.info("auto-wake: skipping — planned service group update in progress")
-            return
+        if isUpdateInProgress {
+            if let expiry = updateExpiresAt, Date() >= expiry {
+                log.warning("auto-wake: planned update expired — clearing stale update state and proceeding")
+                isUpdateInProgress = false
+                updateTargetVersion = nil
+                updateExpiresAt = nil
+                httpTransport?.isUpdateInProgress = false
+            } else {
+                log.info("auto-wake: skipping — planned service group update in progress")
+                return
+            }
         }
 
         guard let wakeHandler,

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -174,6 +174,11 @@ extension DaemonClient {
     /// `onConnectionStateChanged` callback when the health check reports
     /// disconnection.
     private func autoWakeIfDaemonDied() {
+        guard !isUpdateInProgress else {
+            log.info("auto-wake: skipping — planned service group update in progress")
+            return
+        }
+
         guard let wakeHandler,
               config.transportMetadata.routeMode == .runtimeFlat
         else { return }

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -14,6 +14,17 @@ extension DaemonClient {
             if let version = status.version {
                 daemonVersion = version
                 checkVersionCompatibility(daemonVersion: version)
+                // If we were awaiting a planned update, check the outcome
+                if self.isUpdateInProgress {
+                    if version == self.updateTargetVersion {
+                        log.info("Planned update completed — now running \(version, privacy: .public)")
+                    } else {
+                        log.warning("Planned update may have rolled back — expected \(self.updateTargetVersion ?? "?", privacy: .public) but running \(version, privacy: .public)")
+                    }
+                    self.isUpdateInProgress = false
+                    self.updateTargetVersion = nil
+                    self.httpTransport?.isUpdateInProgress = false
+                }
             }
             if let newFingerprint = status.keyFingerprint {
                 let oldFingerprint = keyFingerprint
@@ -94,8 +105,16 @@ extension DaemonClient {
         case .notificationConversationCreated(let msg):
             onNotificationConversationCreated?(msg)
         case .serviceGroupUpdateStarting(let msg):
+            self.isUpdateInProgress = true
+            self.updateTargetVersion = msg.targetVersion
+            self.httpTransport?.isUpdateInProgress = true
+            log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
             onServiceGroupUpdateStarting?(msg)
         case .serviceGroupUpdateComplete(let msg):
+            self.isUpdateInProgress = false
+            self.updateTargetVersion = nil
+            self.httpTransport?.isUpdateInProgress = false
+            log.info("Service group update complete — version: \(msg.installedVersion, privacy: .public), success: \(msg.success)")
             onServiceGroupUpdateComplete?(msg)
         case .trustRulesListResponse:
             break // Handled by TrustRuleClient via GatewayHTTPClient.

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -93,6 +93,10 @@ extension DaemonClient {
             onNotificationIntent?(msg)
         case .notificationConversationCreated(let msg):
             onNotificationConversationCreated?(msg)
+        case .serviceGroupUpdateStarting(let msg):
+            onServiceGroupUpdateStarting?(msg)
+        case .serviceGroupUpdateComplete(let msg):
+            onServiceGroupUpdateComplete?(msg)
         case .trustRulesListResponse:
             break // Handled by TrustRuleClient via GatewayHTTPClient.
         case .toolPermissionSimulateResponse:

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -23,6 +23,7 @@ extension DaemonClient {
                     }
                     self.isUpdateInProgress = false
                     self.updateTargetVersion = nil
+                    self.updateExpiresAt = nil
                     self.httpTransport?.isUpdateInProgress = false
                 }
             }
@@ -107,12 +108,16 @@ extension DaemonClient {
         case .serviceGroupUpdateStarting(let msg):
             self.isUpdateInProgress = true
             self.updateTargetVersion = msg.targetVersion
+            // Allow 2x the expected downtime before expiring the suppression,
+            // so auto-wake can recover if the update process crashes.
+            self.updateExpiresAt = Date().addingTimeInterval(msg.expectedDowntimeSeconds * 2)
             self.httpTransport?.isUpdateInProgress = true
             log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
             onServiceGroupUpdateStarting?(msg)
         case .serviceGroupUpdateComplete(let msg):
             self.isUpdateInProgress = false
             self.updateTargetVersion = nil
+            self.updateExpiresAt = nil
             self.httpTransport?.isUpdateInProgress = false
             log.info("Service group update complete — version: \(msg.installedVersion, privacy: .public), success: \(msg.success)")
             onServiceGroupUpdateComplete?(msg)

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -13,6 +13,7 @@ extension DaemonClient {
             httpPort = status.httpPort.flatMap { Int(exactly: $0) }
             if let version = status.version {
                 daemonVersion = version
+                checkVersionCompatibility(daemonVersion: version)
             }
             if let newFingerprint = status.keyFingerprint {
                 let oldFingerprint = keyFingerprint

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2752,6 +2752,39 @@ public struct NotificationIntentResult: Codable, Sendable {
     }
 }
 
+/// Broadcast to connected clients when a service group update is about to begin.
+public struct ServiceGroupUpdateStarting: Codable, Sendable {
+    public let type: String
+    /// The version being upgraded to.
+    public let targetVersion: String
+    /// Estimated seconds of downtime.
+    public let expectedDowntimeSeconds: Double
+
+    public init(type: String, targetVersion: String, expectedDowntimeSeconds: Double) {
+        self.type = type
+        self.targetVersion = targetVersion
+        self.expectedDowntimeSeconds = expectedDowntimeSeconds
+    }
+}
+
+/// Broadcast to connected clients when a service group update has completed.
+public struct ServiceGroupUpdateComplete: Codable, Sendable {
+    public let type: String
+    /// The version that was installed (may differ from target if rolled back).
+    public let installedVersion: String
+    /// Whether the update succeeded or rolled back.
+    public let success: Bool
+    /// If rolled back, the version reverted to.
+    public let rolledBackToVersion: String?
+
+    public init(type: String, installedVersion: String, success: Bool, rolledBackToVersion: String? = nil) {
+        self.type = type
+        self.installedVersion = installedVersion
+        self.success = success
+        self.rolledBackToVersion = rolledBackToVersion
+    }
+}
+
 /// Server push — broadcast when a notification creates a new vellum conversation.
 public struct NotificationConversationCreated: Codable, Sendable {
     public let type: String

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -150,6 +150,10 @@ public final class HTTPTransport {
     /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
 
+    /// Set by the owning DaemonClient when a planned service group update
+    /// is in progress. Accelerates health check polling for faster reconnection.
+    var isUpdateInProgress: Bool = false
+
     /// Current reconnect backoff delay in seconds (for SSE).
     private var sseReconnectDelay: TimeInterval = 1.0
 
@@ -696,7 +700,8 @@ public final class HTTPTransport {
         healthCheckTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(nanoseconds: UInt64((self?.healthCheckInterval ?? 15.0) * 1_000_000_000))
+                    let interval = (self?.isUpdateInProgress == true) ? 2.0 : (self?.healthCheckInterval ?? 15.0)
+                    try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
                 } catch {
                     return
                 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1296,6 +1296,14 @@ public struct ConversationErrorMessage: Decodable, Sendable {
 /// Backed by generated `NotificationIntent`.
 public typealias NotificationIntentMessage = NotificationIntent
 
+/// Broadcast when a service group update is starting.
+/// Backed by generated `ServiceGroupUpdateStarting`.
+public typealias ServiceGroupUpdateStartingMessage = ServiceGroupUpdateStarting
+
+/// Broadcast when a service group update has completed.
+/// Backed by generated `ServiceGroupUpdateComplete`.
+public typealias ServiceGroupUpdateCompleteMessage = ServiceGroupUpdateComplete
+
 /// Watch session started notification from daemon.
 /// Backed by generated `WatchStarted`.
 public typealias WatchStartedMessage = WatchStarted
@@ -2215,6 +2223,8 @@ public enum ServerMessage: Decodable, Sendable {
     case hostFileRequest(HostFileRequest)
     case hostCuRequest(HostCuRequest)
     case usageUpdate(UsageUpdate)
+    case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
+    case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case pong
     case unknown(String)
 
@@ -2641,6 +2651,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
+        case "service_group_update_starting":
+            let message = try ServiceGroupUpdateStartingMessage(from: decoder)
+            self = .serviceGroupUpdateStarting(message)
+        case "service_group_update_complete":
+            let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
+            self = .serviceGroupUpdateComplete(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Define upgrade lifecycle SSE event types (`ServiceGroupUpdateStarting`, `ServiceGroupUpdateComplete`) in both TypeScript and Swift message protocols
- Add version compatibility check at connection time that logs warnings when client/daemon major.minor versions differ
- Add Docker upgrade rollback: capture running container image refs before upgrade, automatically roll back if readiness check fails
- Add `isUpdateInProgress` client state with accelerated 2s health polling during planned updates
- Suppress auto-wake during planned service group updates

## PRs merged into feature branch
- #18924: Define service group upgrade lifecycle event types in message protocol
- #18926: Add service group upgrade event types to Swift message protocol
- #18925: Log warning on client/daemon version mismatch at connection time
- #18923: Add utility to capture running Docker container image references for rollback
- #18928: Automatically roll back Docker upgrade when readiness check fails
- #18931: Add isUpdateInProgress state and accelerated health polling for planned updates
- #18949: fix: require all service image refs before returning from captureImageRefs
- #18963: fix: update captureImageRefs JSDoc to reflect all-or-nothing return semantics
- #18984: fix: suppress auto-wake during planned service group updates

## Self-review result
PASS after 2 rounds of remediation (3 fix PRs)

Part of plan: update-system-foundation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
