### PR TITLE
fix: link existing attachments even when data is empty

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -16,6 +16,7 @@ import type {
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import {
   AttachmentUploadError,
+  getAttachmentById,
   linkAttachmentToMessage,
   uploadAttachment,
   validateAttachmentUpload,
@@ -362,8 +363,18 @@ export async function persistUserMessage(
     // Index user attachments in the attachments table for later retrieval.
     for (let i = 0; i < attachments.length; i++) {
       const a = attachments[i];
-      if (!a.data) continue;
       try {
+        // If the attachment already exists in the store (e.g. file-backed
+        // attachments uploaded separately), link it directly without
+        // re-uploading. This handles the case where data is empty because
+        // the attachment content lives on disk.
+        if (a.id && getAttachmentById(a.id)) {
+          linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
+          continue;
+        }
+
+        if (!a.data) continue;
+
         const validation = validateAttachmentUpload(a.filename, a.mimeType);
         if (!validation.ok) {
           log.warn(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-disk-view.md.

**Gap:** Attachment linking skipped due to empty data field
**What was expected:** Attachments should be linked to messages even when data is empty
**What was found:** `if (!a.data) continue;` skips all attachments after file-backed migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
