### PR TITLE
fix: ensure DB migrations run before workspace disk view backfill

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -142,7 +142,6 @@ export async function runDaemon(): Promise<void> {
     await initLogfire();
 
     ensureDataDir();
-    await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
 
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the
@@ -150,14 +149,16 @@ export async function runDaemon(): Promise<void> {
     const signingKey = loadOrCreateSigningKey();
     initAuthSigningKey(signingKey);
 
-    log.info("Daemon startup: migrations complete");
-
     seedInterfaceFiles();
 
     log.info("Daemon startup: installing templates and initializing DB");
     installTemplates();
     ensurePromptFiles();
 
+    // DB must be initialized before workspace migrations because some
+    // workspace migrations (e.g. 009-backfill-conversation-disk-view)
+    // depend on DB migrations having run (e.g. the inline-attachment-to-disk
+    // backfill that populates attachment filePaths).
     initializeDb();
     // Seed well-known OAuth provider configurations (insert-if-not-exists)
     seedOAuthProviders();
@@ -173,6 +174,9 @@ export async function runDaemon(): Promise<void> {
       );
     }
     log.info("Daemon startup: DB initialized");
+
+    await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
+    log.info("Daemon startup: workspace migrations complete");
 
     // Purge private (temporary) conversations from the previous daemon run.
     // These are ephemeral by design and should not survive daemon restarts.

--- a/assistant/src/workspace/migrations/002-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/002-backfill-installation-id.ts
@@ -16,8 +16,8 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
   run(_workspaceDir: string): void {
     // a. Read existing installation ID from SQLite, or generate a new one.
-    //    On fresh installs the memory_checkpoints table may not exist yet
-    //    (workspace migrations run before initializeDb), so treat errors as null.
+    //    On fresh installs the memory_checkpoints table may not exist yet,
+    //    so treat errors as null.
     let existingId: string | null = null;
     try {
       existingId = getMemoryCheckpoint("telemetry:installation_id");


### PR DESCRIPTION
## Summary
- Workspace migration 009 (backfill-conversation-disk-view) reads attachment `filePath` from the DB, but those are populated by DB migration 83 (backfill-inline-attachments-to-disk)
- The previous startup ordering in `lifecycle.ts` ran `runWorkspaceMigrations()` before `initializeDb()`, causing workspace migration 009 to see `NULL` filePaths for old inline attachments
- Moved `initializeDb()` before `runWorkspaceMigrations()` so DB schema + migrations complete first
- Updated stale comment in workspace migration 002 that referenced the old ordering

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] Workspace migration runner tests pass
- [x] Conversation disk view tests pass
- [x] Conversation disk view integration tests pass
- [x] Lifecycle docs guard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
