### PR TITLE
fix: update test fixtures for base64 disk round-trip and registry tool count

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -549,7 +549,7 @@ describe("attachment reuse across conversation lifecycles", () => {
   test("attachment uploaded in conversation A is retrievable by ID without any conversation reference", async () => {
     const convA = createConversation("Conversation A");
     const msgA = await addMessage(convA.id, "assistant", "Here is a file");
-    const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
+    const stored = uploadAttachment("report.pdf", "application/pdf", "JVBERA==");
     linkAttachmentToMessage(msgA.id, stored.id, 0);
 
     // Create a completely separate conversation
@@ -561,7 +561,7 @@ describe("attachment reuse across conversation lifecycles", () => {
     expect(fetched).not.toBeNull();
     expect(fetched!.id).toBe(stored.id);
     expect(fetched!.originalFilename).toBe("report.pdf");
-    expect(fetched!.dataBase64).toBe("JVBER");
+    expect(fetched!.dataBase64).toBe("JVBERA==");
   });
 
   test("attachment can be linked to messages in different conversations", async () => {

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -109,7 +109,7 @@ describe("tool registry dynamic-tools tools", () => {
 
 describe("tool manifest", () => {
   test("eager module tool names list contains expected count", () => {
-    expect(eagerModuleToolNames.length).toBe(11);
+    expect(eagerModuleToolNames.length).toBe(9);
   });
 
   test("explicit tools list includes memory and credential tools", () => {

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -116,7 +116,7 @@ describe("Runtime attachment metadata", () => {
     );
 
     // Upload and link an attachment using "self" as the assistantId
-    const stored = uploadAttachment("chart.png", "image/png", "iVBOR");
+    const stored = uploadAttachment("chart.png", "image/png", "iVBORw==");
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     const res = await fetch(
@@ -181,7 +181,7 @@ describe("Runtime attachment metadata", () => {
   });
 
   test("GET /attachments/:id returns attachment with payload", async () => {
-    const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
+    const stored = uploadAttachment("report.pdf", "application/pdf", "JVBERA==");
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,
@@ -201,7 +201,7 @@ describe("Runtime attachment metadata", () => {
     expect(body.filename).toBe("report.pdf");
     expect(body.mimeType).toBe("application/pdf");
     expect(body.kind).toBe("document");
-    expect(body.data).toBe("JVBER");
+    expect(body.data).toBe("JVBERA==");
     expect(body.sizeBytes).toBeGreaterThan(0);
   });
 

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -330,7 +330,7 @@ describe("getAttachmentsForMessage", () => {
 
   test("returns attachments linked to a message", async () => {
     const msgId = await createMessage("assistant", "Here is a chart");
-    const stored = uploadAttachment("chart.png", "image/png", "iVBOR");
+    const stored = uploadAttachment("chart.png", "image/png", "iVBORw==");
     linkAttachmentToMessage(msgId, stored.id, 0);
 
     const result = getAttachmentsForMessage(msgId);
@@ -338,7 +338,7 @@ describe("getAttachmentsForMessage", () => {
     expect(result[0].id).toBe(stored.id);
     expect(result[0].originalFilename).toBe("chart.png");
     expect(result[0].mimeType).toBe("image/png");
-    expect(result[0].dataBase64).toBe("iVBOR");
+    expect(result[0].dataBase64).toBe("iVBORw==");
   });
 
   test("returns empty array when no attachments are linked", () => {


### PR DESCRIPTION
## Summary
- Use properly padded base64 test fixtures (`JVBERA==`, `iVBORw==`) so they round-trip correctly through the file-backed attachment storage (decode to binary on disk → re-encode to base64 on read).
- Update `eagerModuleToolNames` expected count from 11 to 9 after `asset_search` and `asset_materialize` were removed from the tool manifest.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23273903106/job/67672590132

🤖 Generated with [Claude Code](https://claude.com/claude-code)