### PR TITLE
fix: add vellum-self-knowledge to skills catalog.json

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -590,6 +590,26 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "vellum-self-knowledge",
+      "name": "vellum-self-knowledge",
+      "description": "Answer questions about Vellum, the assistant's architecture, and its current configuration including which model and provider are active",
+      "metadata": {
+        "emoji": "🪞",
+        "vellum": {
+          "display-name": "Vellum Self-Knowledge",
+          "activation-hints": [
+            "When the user asks what model the assistant is running on",
+            "When the user asks about Vellum, how the assistant works, or its architecture",
+            "When the user asks about the assistant's current configuration or settings"
+          ],
+          "avoid-when": [
+            "When the user wants to change configuration (use in-chat config instead)"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "vercel-token-setup",
       "name": "vercel-token-setup",
       "description": "Set up a Vercel API token for publishing apps using browser automation",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for model-identity-in-system-prompt.md.

**Gap:** Missing catalog.json entry for vellum-self-knowledge skill
**What was expected:** Skill discoverable via catalog system
**What was found:** No catalog.json entry despite valid SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
