### PR TITLE
Add vellum-self-knowledge skill for model identity and system introspection

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -590,6 +590,26 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "vellum-self-knowledge",
+      "name": "vellum-self-knowledge",
+      "description": "Answer questions about Vellum, the assistant's architecture, and its current configuration including which model and provider are active",
+      "metadata": {
+        "emoji": "🪞",
+        "vellum": {
+          "display-name": "Vellum Self-Knowledge",
+          "activation-hints": [
+            "When the user asks what model the assistant is running on",
+            "When the user asks about Vellum, how the assistant works, or its architecture",
+            "When the user asks about the assistant's current configuration or settings"
+          ],
+          "avoid-when": [
+            "When the user wants to change configuration (use in-chat config instead)"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "vercel-token-setup",
       "name": "vercel-token-setup",
       "description": "Set up a Vercel API token for publishing apps using browser automation",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vellum-self-knowledge
 description: Answer questions about Vellum, the assistant's architecture, and its current configuration including which model and provider are active
+compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🪞"
   vellum:
@@ -15,11 +16,11 @@ metadata:
 
 ## What is Vellum
 
-Vellum is a personal AI assistant platform that runs as a local daemon on the user's machine. It supports multiple LLM providers (Anthropic, OpenAI, Gemini, Ollama, Fireworks, OpenRouter) and is accessible via a macOS desktop app, voice calls, and messaging channels like Telegram.
+Vellum is a personal AI assistant platform that runs as a local background service on the user's machine. It supports multiple LLM providers (Anthropic, OpenAI, Gemini, Ollama, Fireworks, OpenRouter) and is accessible via a macOS desktop app, voice calls, and messaging channels like Telegram.
 
 ## Architecture at a Glance
 
-The assistant runs as a daemon HTTP server. Conversations are managed by a coordinator that delegates to an AgentLoop, which sends messages to the configured LLM provider and executes tools. The system prompt is composed from workspace files (IDENTITY.md, SOUL.md, USER.md) plus dynamic context. Skills extend capabilities via lazy-loaded instruction sets.
+The assistant runs as a local HTTP server. Conversations are managed by a coordinator that delegates to an AgentLoop, which sends messages to the configured LLM provider and executes tools. The system prompt is composed from workspace files (IDENTITY.md, SOUL.md, USER.md) plus dynamic context. Skills extend capabilities via lazy-loaded instruction sets.
 
 ## Configuration System
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -35,6 +35,16 @@ Consult these reference files for detailed knowledge on specific topics. Read th
 
 - `references/inference.md` — Model identity, provider details, model catalog, and how inference routing works. **Read this when asked what model you are or about inference configuration.**
 
+## Self-Info Script
+
+To determine what model and provider you are currently running as, run:
+
+```bash
+bun run {baseDir}/scripts/self-info.ts
+```
+
+**Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
+
 ## Critical Rule
 
-Never guess or hallucinate information about yourself. If unsure, consult the relevant reference file or run the self-info script.
+Never guess or hallucinate information about yourself. If unsure, consult the relevant reference file or run the self-info script above.

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -29,7 +29,7 @@ Config is stored in `config.json` in the workspace directory. Use the CLI to int
 - **Set a value**: `assistant config set <key> <value>`
 - **Search config**: `assistant config list --search <query>`
 
-## Reference Files
+## When to Consult References
 
 Consult these reference files for detailed knowledge on specific topics. Read the relevant file before answering questions in that domain.
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: vellum-self-knowledge
+description: Answer questions about Vellum, the assistant's architecture, and its current configuration including which model and provider are active
+metadata:
+  emoji: "🪞"
+  vellum:
+    display-name: "Vellum Self-Knowledge"
+    activation-hints:
+      - "When the user asks what model the assistant is running on"
+      - "When the user asks about Vellum, how the assistant works, or its architecture"
+      - "When the user asks about the assistant's current configuration or settings"
+    avoid-when:
+      - "When the user wants to change configuration (use in-chat config instead)"
+---
+
+## What is Vellum
+
+Vellum is a personal AI assistant platform that runs as a local daemon on the user's machine. It supports multiple LLM providers (Anthropic, OpenAI, Gemini, Ollama, Fireworks, OpenRouter) and is accessible via a macOS desktop app, voice calls, and messaging channels like Telegram.
+
+## Architecture at a Glance
+
+The assistant runs as a daemon HTTP server. Conversations are managed by a coordinator that delegates to an AgentLoop, which sends messages to the configured LLM provider and executes tools. The system prompt is composed from workspace files (IDENTITY.md, SOUL.md, USER.md) plus dynamic context. Skills extend capabilities via lazy-loaded instruction sets.
+
+## Configuration System
+
+Config is stored in `config.json` in the workspace directory. Use the CLI to interact with it:
+
+- **Read a value**: `assistant config get <key>`
+- **Set a value**: `assistant config set <key> <value>`
+- **Search config**: `assistant config list --search <query>`
+
+## Reference Files
+
+Consult these reference files for detailed knowledge on specific topics. Read the relevant file before answering questions in that domain.
+
+- `references/inference.md` — Model identity, provider details, model catalog, and how inference routing works. **Read this when asked what model you are or about inference configuration.**
+
+## Critical Rule
+
+Never guess or hallucinate information about yourself. If unsure, consult the relevant reference file or run the self-info script.

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -2,11 +2,7 @@
 
 ## Current Model Identity
 
-To determine what model and provider you are currently running as, run the self-info script:
-
-```bash
-bun run {baseDir}/scripts/self-info.ts
-```
+To determine what model and provider you are currently running as, run the self-info script command shown in SKILL.md above.
 
 The script returns JSON with the current model ID, display name, provider, and provider display name. **Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
 

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -59,6 +59,6 @@ assistant config get services.inference.provider
 
 ## How Inference Routing Works
 
-The daemon initializes a provider registry on startup, with a primary provider from config and fallback providers ordered by `providerOrder`. When a request is made, the primary provider is used first; if it fails, fallbacks are tried in order.
+The assistant initializes a provider registry on startup, with a primary provider from config and fallback providers ordered by `providerOrder`. When a request is made, the primary provider is used first; if it fails, fallbacks are tried in order.
 
 Model intents (`latency-optimized`, `quality-optimized`, `vision-optimized`) can select different models within the same provider, allowing the system to route to a faster or more capable model depending on the task without switching providers.

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -1,0 +1,68 @@
+# Inference Reference
+
+## Current Model Identity
+
+To determine what model and provider you are currently running as, run the self-info script:
+
+```bash
+bun run {baseDir}/scripts/self-info.ts
+```
+
+The script returns JSON with the current model ID, display name, provider, and provider display name. **Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
+
+Example output:
+
+```json
+{
+  "ok": true,
+  "model": { "id": "gpt-5.2", "displayName": "GPT-5.2" },
+  "provider": { "id": "openai", "displayName": "OpenAI" },
+  "mode": "your-own",
+  "summary": "You are running as GPT-5.2 via OpenAI (your-own API key)."
+}
+```
+
+## Model Catalog
+
+All known models by provider, so you can interpret model IDs from config:
+
+| Provider | Model ID | Display Name |
+|----------|----------|--------------|
+| Anthropic | `claude-opus-4-6` | Claude Opus 4.6 |
+| Anthropic | `claude-sonnet-4-6` | Claude Sonnet 4.6 |
+| Anthropic | `claude-haiku-4-5-20251001` | Claude Haiku 4.5 |
+| OpenAI | `gpt-5.2` | GPT-5.2 |
+| OpenAI | `gpt-5.4` | GPT-5.4 |
+| OpenAI | `gpt-5.4-nano` | GPT-5.4 Nano |
+| Google Gemini | `gemini-3-flash` | Gemini 3 Flash |
+| Google Gemini | `gemini-3-pro` | Gemini 3 Pro |
+| Ollama | `llama3.2` | Llama 3.2 |
+| Ollama | `mistral` | Mistral |
+| Fireworks | `accounts/fireworks/models/kimi-k2p5` | Kimi K2.5 |
+| OpenRouter | `x-ai/grok-4` | Grok 4 |
+| OpenRouter | `x-ai/grok-4.20-beta` | Grok 4.20 Beta |
+
+## Inference Configuration
+
+Relevant config paths and what they control:
+
+| Config Path | Description |
+|-------------|-------------|
+| `services.inference.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
+| `services.inference.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
+| `services.inference.mode` | `"your-own"` (user's API key) vs `"managed"` (platform proxy) |
+| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"` |
+| `thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
+
+Read any of these with `assistant config get <path>`, e.g.:
+
+```bash
+assistant config get services.inference.model
+assistant config get services.inference.provider
+```
+
+## How Inference Routing Works
+
+The daemon initializes a provider registry on startup, with a primary provider from config and fallback providers ordered by `providerOrder`. When a request is made, the primary provider is used first; if it fails, fallbacks are tried in order.
+
+Model intents (`latency-optimized`, `quality-optimized`, `vision-optimized`) can select different models within the same provider, allowing the system to route to a faster or more capable model depending on the task without switching providers.

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+/**
+ * CLI for vellum-self-knowledge skill: `bun run scripts/self-info.ts`
+ *
+ * Queries the current inference configuration and returns structured JSON
+ * with the active model, provider, and mode.
+ */
+
+// ---------------------------------------------------------------------------
+// Display name mappings (mirrors model-catalog.ts)
+// ---------------------------------------------------------------------------
+
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  "claude-opus-4-6": "Claude Opus 4.6",
+  "claude-sonnet-4-6": "Claude Sonnet 4.6",
+  "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+  "gpt-5.2": "GPT-5.2",
+  "gpt-5.4": "GPT-5.4",
+  "gpt-5.4-nano": "GPT-5.4 Nano",
+  "gemini-3-flash": "Gemini 3 Flash",
+  "gemini-3-pro": "Gemini 3 Pro",
+  "llama3.2": "Llama 3.2",
+  mistral: "Mistral",
+  "accounts/fireworks/models/kimi-k2p5": "Kimi K2.5",
+  "x-ai/grok-4": "Grok 4",
+  "x-ai/grok-4.20-beta": "Grok 4.20 Beta",
+};
+
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  gemini: "Google Gemini",
+  ollama: "Ollama",
+  fireworks: "Fireworks",
+  openrouter: "OpenRouter",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function output(data: unknown): void {
+  process.stdout.write(JSON.stringify(data) + "\n");
+}
+
+function outputError(message: string, code = 1): void {
+  output({ ok: false, error: message });
+  process.exitCode = code;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  try {
+    const proc = Bun.spawn(["assistant", "config", "get", "services.inference"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      outputError(`Failed to read inference config: ${stderr.trim() || "unknown error"}`);
+      return;
+    }
+
+    const config = JSON.parse(stdout.trim()) as {
+      model?: string;
+      provider?: string;
+      mode?: string;
+    };
+
+    const modelId = config.model ?? "unknown";
+    const providerId = config.provider ?? "unknown";
+    const mode = config.mode ?? "unknown";
+
+    const modelDisplayName = MODEL_DISPLAY_NAMES[modelId] ?? modelId;
+    const providerDisplayName = PROVIDER_DISPLAY_NAMES[providerId] ?? providerId;
+
+    const modeLabel = mode === "your-own" ? "your-own API key" : mode === "managed" ? "managed platform proxy" : mode;
+
+    output({
+      ok: true,
+      model: { id: modelId, displayName: modelDisplayName },
+      provider: { id: providerId, displayName: providerDisplayName },
+      mode,
+      summary: `You are running as ${modelDisplayName} via ${providerDisplayName} (${modeLabel}).`,
+    });
+  } catch (err) {
+    outputError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+main();

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -68,11 +68,25 @@ async function main(): Promise<void> {
       return;
     }
 
-    const config = JSON.parse(stdout.trim()) as {
-      model?: string;
-      provider?: string;
-      mode?: string;
-    };
+    const raw = stdout.trim();
+
+    // When the inference config hasn't been explicitly set, the CLI returns
+    // the literal string "(not set)". Fall back to sensible defaults rather
+    // than crashing with a cryptic JSON-parse error.
+    let config: { model?: string; provider?: string; mode?: string };
+    if (raw === "(not set)" || raw === "") {
+      config = {
+        model: "claude-opus-4-6",
+        provider: "anthropic",
+        mode: "unknown",
+      };
+    } else {
+      config = JSON.parse(raw) as {
+        model?: string;
+        provider?: string;
+        mode?: string;
+      };
+    }
 
     const modelId = config.model ?? "unknown";
     const providerId = config.provider ?? "unknown";


### PR DESCRIPTION
## Summary
- Create `vellum-self-knowledge` skill that gives the assistant reliable knowledge about what model it's running on, what Vellum is, how the assistant works, and its current configuration
- SKILL.md acts as a concise routing hub; detailed knowledge lives in `references/inference.md` for progressive disclosure
- Includes `scripts/self-info.ts` that queries live config to report current model/provider

## PRs merged into feature branch
- #18981: Add vellum-self-knowledge skill for model identity and system introspection
- #18986: fix: move {baseDir} script command to SKILL.md where substitution works
- #18985: fix: rename duplicate Reference Files heading in SKILL.md
- #18987: fix: handle (not set) config response in self-info script
- #18995: fix: add vellum-self-knowledge to skills catalog.json

## Self-review result
PASS (after 2 remediation rounds fixing 4 gaps: baseDir substitution, duplicate heading, not-set handling, catalog entry)

Part of plan: model-identity-in-system-prompt.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
