### PR TITLE
fix: update tests to expect hydrated attachment content from disk

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -52,7 +52,7 @@ import {
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, rawGet, resetDb } from "../memory/db.js";
 
 initializeDb();
 
@@ -103,12 +103,20 @@ describe("uploadAttachment", () => {
     expect(content.toString()).toBe("hello");
   });
 
-  test("stores empty dataBase64 in DB row", () => {
+  test("stores empty dataBase64 in DB row but hydrates on read", () => {
     const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
-    const row = getAttachmentById(stored.id);
 
+    // The raw DB row stores empty dataBase64 since content is on disk
+    const rawRow = rawGet<{ data_base64: string }>(
+      "SELECT data_base64 FROM attachments WHERE id = ?",
+      stored.id,
+    );
+    expect(rawRow!.data_base64).toBe("");
+
+    // But getAttachmentById hydrates from disk
+    const row = getAttachmentById(stored.id);
     expect(row).not.toBeNull();
-    expect(row!.dataBase64).toBe("");
+    expect(row!.dataBase64).toBe("dGVzdA==");
   });
 
   test("classifies image MIME as image kind", () => {
@@ -334,15 +342,15 @@ describe("deleteAttachment", () => {
 describe("getAttachmentsByIds", () => {
   beforeEach(resetTables);
 
-  test("returns matching attachments with empty dataBase64", () => {
+  test("returns matching attachments with hydrated dataBase64", () => {
     const a = uploadAttachment("a.txt", "text/plain", "AAAA");
     const b = uploadAttachment("b.txt", "text/plain", "BBBB");
 
     const results = getAttachmentsByIds([a.id, b.id]);
     expect(results).toHaveLength(2);
-    // dataBase64 is always empty since content is on disk
-    expect(results[0].dataBase64).toBe("");
-    expect(results[1].dataBase64).toBe("");
+    // dataBase64 is hydrated from on-disk files
+    expect(results[0].dataBase64).toBe("AAAA");
+    expect(results[1].dataBase64).toBe("BBBB");
   });
 
   test("returns empty array for empty IDs list", () => {
@@ -364,15 +372,15 @@ describe("getAttachmentsByIds", () => {
 describe("getAttachmentById", () => {
   beforeEach(resetTables);
 
-  test("returns attachment with empty dataBase64 when found", () => {
+  test("returns attachment with hydrated dataBase64 when found", () => {
     const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
     const result = getAttachmentById(stored.id);
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(stored.id);
     expect(result!.originalFilename).toBe("report.pdf");
-    // dataBase64 is empty; content is on disk
-    expect(result!.dataBase64).toBe("");
+    // dataBase64 is hydrated from on-disk file (round-trips via binary)
+    expect(result!.dataBase64).toBe("JVBE");
   });
 
   test("returns null for nonexistent ID", () => {
@@ -399,8 +407,8 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     expect(linked).toHaveLength(1);
     expect(linked[0].id).toBe(stored.id);
     expect(linked[0].originalFilename).toBe("chart.png");
-    // dataBase64 is empty; content is on disk
-    expect(linked[0].dataBase64).toBe("");
+    // dataBase64 is hydrated from on-disk file
+    expect(linked[0].dataBase64).toBe("iVBORw0K");
   });
 
   test("returns attachments in position order", async () => {


### PR DESCRIPTION
## Summary

Fixes test assertions that expected empty `dataBase64` after the always-file-backed migration. Since `getAttachmentsByIds` now hydrates content from disk (landed in #18980), these tests were failing:

- **attachments-store.test.ts**: 4 tests updated — assertions now expect hydrated base64 content instead of empty strings. The "stores empty dataBase64 in DB row" test now verifies both the raw DB row (empty) and the hydrated read (populated).
- **conversation-store.test.ts**: 1 test updated — fixed base64 round-trip expectation (`"JVBER"` -> `"JVBE"` after binary round-trip).
- **server-history-render.test.ts**: 1 test updated — fixed base64 round-trip expectation (`"iVBOR"` -> `"iVBO"`).

**Gap:** resolveAttachments returns empty data after always-file-backed migration
**Root cause:** Tests were written to expect the pre-hydration behavior where `dataBase64` was always empty
**Fix:** Updated test expectations to match the hydrated behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
