### PR TITLE
Revert "fix: restore targeted risk escalation for mutating assistant/vellum subcommands"

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -144,7 +144,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "du",
   "df",
   "assistant",
-  "vellum",
 ]);
 
 // High-risk shell programs / patterns
@@ -196,32 +195,6 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "ls-tree",
   "cat-file",
   "reflog",
-]);
-
-// Mutating assistant/vellum CLI subcommands that should be escalated to Medium
-// risk. Most assistant/vellum subcommands are read-only and stay Low risk.
-// This mirrors the git subcommand pattern — only known mutating operations
-// get escalated.
-const MEDIUM_RISK_CLI_SUBCOMMANDS = new Set([
-  "credentials",
-  "config",
-  "bash",
-  "trust",
-  "autonomy",
-  "contacts",
-  "mcp",
-  "keys",
-  "wake",
-  "sleep",
-  "hatch",
-  "retire",
-  "clean",
-  "setup",
-  "upgrade",
-  "recover",
-  "login",
-  "use",
-  "pair",
 ]);
 
 // Commands that wrap another program — the real program appears as the first
@@ -711,17 +684,6 @@ async function classifyRiskUncached(
         }
         // Non-read-only git commands are medium
         maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (prog === "vellum" || prog === "assistant") {
-        const subcommand = firstPositionalArg(seg.args);
-        if (subcommand && MEDIUM_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
-          // Known mutating subcommands are medium
-          maxRisk = RiskLevel.Medium;
-          continue;
-        }
-        // Read-only / unknown subcommands stay at current risk
         continue;
       }
 


### PR DESCRIPTION
Reverts vellum-ai/vellum-assistant#18982

the auto-address review feedback (`/check-reviews-and-swarm`) is driving me fucking crazy. sorry for this PR guys
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
