### PR TITLE
feat: expand GET /v1/model with full provider catalog and masked keys

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -17,6 +17,7 @@ import type {
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import { VALID_INFERENCE_PROVIDERS } from "../config/schemas/services.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
 import {
   addMessage,
@@ -26,10 +27,14 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
-import { PROVIDER_MODEL_CATALOG } from "../providers/model-catalog.js";
+import {
+  getFullProviderCatalog,
+  PROVIDER_MODEL_CATALOG,
+} from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
+import { getMaskedProviderKey } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
@@ -54,12 +59,21 @@ const log = getLogger("conversation-process");
 export async function buildModelInfoEvent(): Promise<ServerMessage> {
   const config = getConfig();
   const provider = config.services.inference.provider;
+
+  const maskedKeys: Record<string, string> = {};
+  for (const p of VALID_INFERENCE_PROVIDERS) {
+    const masked = await getMaskedProviderKey(p);
+    if (masked) maskedKeys[p] = masked;
+  }
+
   return {
     type: "model_info",
     model: config.services.inference.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
     availableModels: PROVIDER_MODEL_CATALOG[provider],
+    allProviders: getFullProviderCatalog(),
+    maskedKeys,
   };
 }
 

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -5,7 +5,9 @@ import {
 } from "../../config/loader.js";
 import { setServiceField } from "../../config/raw-config-utils.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
+import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
 import {
+  getFullProviderCatalog,
   isModelInCatalog,
   PROVIDER_MODEL_CATALOG,
 } from "../../providers/model-catalog.js";
@@ -15,6 +17,7 @@ import {
   isProviderAvailable,
 } from "../../providers/provider-availability.js";
 import { initializeProviders } from "../../providers/registry.js";
+import { getMaskedProviderKey } from "../../security/secure-keys.js";
 import { MODEL_TO_PROVIDER } from "../conversation-slash.js";
 import type {
   ImageGenModelSetRequest,
@@ -35,17 +38,28 @@ export interface ModelInfo {
   provider: string;
   configuredProviders?: string[];
   availableModels?: Array<{ id: string; displayName: string }>;
+  allProviders?: ProviderCatalogEntry[];
+  maskedKeys?: Record<string, string>;
 }
 
 /** Return current model configuration. */
 export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
   const provider = config.services.inference.provider;
+
+  const maskedKeys: Record<string, string> = {};
+  for (const p of VALID_INFERENCE_PROVIDERS) {
+    const masked = await getMaskedProviderKey(p);
+    if (masked) maskedKeys[p] = masked;
+  }
+
   return {
     model: config.services.inference.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
     availableModels: PROVIDER_MODEL_CATALOG[provider],
+    allProviders: getFullProviderCatalog(),
+    maskedKeys,
   };
 }
 
@@ -159,11 +173,20 @@ export async function setModel(
   ctx.updateConfigFingerprint();
 
   const newProvider = config.services.inference.provider;
+
+  const setMaskedKeys: Record<string, string> = {};
+  for (const p of VALID_INFERENCE_PROVIDERS) {
+    const masked = await getMaskedProviderKey(p);
+    if (masked) setMaskedKeys[p] = masked;
+  }
+
   return {
     model: config.services.inference.model,
     provider: newProvider,
     configuredProviders: await getConfiguredProviders(),
     availableModels: PROVIDER_MODEL_CATALOG[newProvider],
+    allProviders: getFullProviderCatalog(),
+    maskedKeys: setMaskedKeys,
   };
 }
 

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -242,6 +242,13 @@ export interface ModelInfo {
   provider: string;
   configuredProviders?: string[];
   availableModels?: Array<{ id: string; displayName: string }>;
+  allProviders?: Array<{
+    id: string;
+    displayName: string;
+    models: Array<{ id: string; displayName: string }>;
+    defaultModel: string;
+  }>;
+  maskedKeys?: Record<string, string>;
 }
 
 export interface HistoryResponseToolCall {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -41,6 +41,23 @@ export const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   openrouter: "OpenRouter",
 };
 
+export interface ProviderCatalogEntry {
+  id: string;
+  displayName: string;
+  models: CatalogModel[];
+  defaultModel: string;
+}
+
+/** Build the full provider catalog with metadata for each inference provider. */
+export function getFullProviderCatalog(): ProviderCatalogEntry[] {
+  return Object.entries(PROVIDER_MODEL_CATALOG).map(([id, models]) => ({
+    id,
+    displayName: INFERENCE_PROVIDER_DISPLAY_NAMES[id] ?? id,
+    models,
+    defaultModel: models[0]?.id ?? "",
+  }));
+}
+
 /** Check if a model ID is in the catalog for a given provider */
 export function isModelInCatalog(provider: string, modelId: string): boolean {
   const catalog = PROVIDER_MODEL_CATALOG[provider];

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -194,6 +194,27 @@ export async function getProviderKeyAsync(
 }
 
 // ---------------------------------------------------------------------------
+// Masked provider key — for safe display in client UIs
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieve a provider API key and return a masked version suitable for
+ * display. Shows the first 10 characters and last 4, with `...` in between,
+ * always hiding at least 3 characters. Returns `null` if no key is stored.
+ */
+export async function getMaskedProviderKey(
+  provider: string,
+): Promise<string | null> {
+  const key = await getProviderKeyAsync(provider);
+  if (!key || key.length === 0) return null;
+  const minHidden = 3;
+  const maxVisible = Math.max(1, key.length - minHidden);
+  const prefixLen = Math.min(10, maxVisible);
+  const suffixLen = Math.min(4, Math.max(0, maxVisible - prefixLen));
+  return `${key.slice(0, prefixLen)}...${key.slice(-suffixLen || undefined)}`;
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `getMaskedProviderKey()` to retrieve and mask stored provider API keys
- Add `getFullProviderCatalog()` to expose full provider metadata (id, displayName, models, defaultModel)
- Expand `ModelInfo` in both REST and SSE paths with `allProviders` and `maskedKeys` fields

Part of plan: inference-key-ux.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/18999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
