### PR TITLE
fix: add secure-keys guard allowlist entries for masked key display

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -252,6 +252,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
       "cli/commands/avatar.ts", // CLI avatar generation API key lookup
       "config/bundled-skills/slack/tools/shared.ts", // Slack skill bot token lookup
+      "daemon/conversation-process.ts", // masked provider key display
+      "daemon/handlers/config-model.ts", // masked provider key display
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `daemon/conversation-process.ts` and `daemon/handlers/config-model.ts` to the secure-keys import guard allowlist
- Both files only use `getMaskedProviderKey` (read-only masked display), not plaintext secret access

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23274208792/job/67673561756

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
