### PR TITLE
feat: make GPT-5.4 the default OpenAI model

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -159,7 +159,7 @@ mock.module("../providers/registry.js", () => {
     getDefaultModel: (providerName: string) => {
       const defaults: Record<string, string> = {
         anthropic: "claude-opus-4-6",
-        openai: "gpt-5.2",
+        openai: "gpt-5.4",
         gemini: "gemini-3-flash",
         ollama: "llama3.2",
         fireworks: "accounts/fireworks/models/kimi-k2p5",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -10,8 +10,8 @@ export const PROVIDER_MODEL_CATALOG: Record<string, CatalogModel[]> = {
     { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
   ],
   openai: [
-    { id: "gpt-5.2", displayName: "GPT-5.2" },
     { id: "gpt-5.4", displayName: "GPT-5.4" },
+    { id: "gpt-5.2", displayName: "GPT-5.2" },
     { id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano" },
   ],
   gemini: [

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -2,7 +2,7 @@ import type { ModelIntent } from "./types.js";
 
 export const PROVIDER_DEFAULT_MODELS = {
   anthropic: "claude-opus-4-6",
-  openai: "gpt-5.2",
+  openai: "gpt-5.4",
   gemini: "gemini-3-flash",
   ollama: "llama3.2",
   fireworks: "accounts/fireworks/models/kimi-k2p5",

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -83,8 +83,8 @@ public final class SettingsStore: ObservableObject {
             ("claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
         ],
         "openai": [
-            ("gpt-5.2", "GPT-5.2"),
             ("gpt-5.4", "GPT-5.4"),
+            ("gpt-5.2", "GPT-5.2"),
             ("gpt-5.4-nano", "GPT-5.4 Nano"),
         ],
         "gemini": [
@@ -106,7 +106,7 @@ public final class SettingsStore: ObservableObject {
     /// Default model per provider (first entry from the catalog).
     static let inferenceProviderDefaultModel: [String: String] = [
         "anthropic": "claude-opus-4-6",
-        "openai": "gpt-5.2",
+        "openai": "gpt-5.4",
         "gemini": "gemini-3-flash",
         "ollama": "llama3.2",
         "fireworks": "accounts/fireworks/models/kimi-k2p5",


### PR DESCRIPTION
## Summary
- Change the default OpenAI model from GPT-5.2 to GPT-5.4 across the model catalog, model intents, macOS client settings, and test fixtures
- Reorder the OpenAI model catalog so GPT-5.4 appears first (catalog ordering drives the default in `getFullProviderCatalog()`)

## Original prompt
Make GPT-5.4 the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)