### PR TITLE
feat: add GPT-5.4 Mini to model catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -12,6 +12,7 @@ export const PROVIDER_MODEL_CATALOG: Record<string, CatalogModel[]> = {
   openai: [
     { id: "gpt-5.4", displayName: "GPT-5.4" },
     { id: "gpt-5.2", displayName: "GPT-5.2" },
+    { id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
     { id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano" },
   ],
   gemini: [

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -25,6 +25,7 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   },
   openai: {
     "gpt-5.4": { inputPer1M: 2.5, outputPer1M: 15 },
+    "gpt-5.4-mini": { inputPer1M: 0.5, outputPer1M: 3 },
     "gpt-5.4-nano": { inputPer1M: 0.2, outputPer1M: 1.25 },
     "gpt-5.2": { inputPer1M: 1.75, outputPer1M: 14 },
     "gpt-4o": { inputPer1M: 2.5, outputPer1M: 10 },

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -85,6 +85,7 @@ public final class SettingsStore: ObservableObject {
         "openai": [
             ("gpt-5.4", "GPT-5.4"),
             ("gpt-5.2", "GPT-5.2"),
+            ("gpt-5.4-mini", "GPT-5.4 Mini"),
             ("gpt-5.4-nano", "GPT-5.4 Nano"),
         ],
         "gemini": [


### PR DESCRIPTION
## Summary
- Add GPT-5.4 Mini (gpt-5.4-mini) to the OpenAI model catalog, pricing table, and macOS client model picker

## Original prompt
Add GPT-5.4 Mini (gpt-5.4-mini) to this list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
