### PR TITLE
fix: reset model to Anthropic default when switching inference to Managed mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -151,6 +151,15 @@ struct InferenceServiceCard: View {
             }
             apiKeyText = ""
         }
+        .onChange(of: draftMode) { _, newMode in
+            if newMode == "managed" && isCustomProviderEnabled {
+                let anthropicModels = SettingsStore.inferenceProviderModels["anthropic"] ?? []
+                let isCurrentModelAnthropic = anthropicModels.contains { $0.id == store.selectedModel }
+                if !isCurrentModelAnthropic {
+                    store.selectedModel = SettingsStore.inferenceProviderDefaultModel["anthropic"] ?? "claude-opus-4-6"
+                }
+            }
+        }
         .alert("Heads up", isPresented: $showWebSearchAlert) {
             Button("Go Back", role: .cancel) {}
             Button("Continue") { performSave() }
@@ -254,13 +263,14 @@ struct InferenceServiceCard: View {
 
     /// Per-provider catalog model dropdown (flag on).
     private var providerModelPicker: some View {
-        VDropdown(
+        let provider = draftMode == "managed" ? "anthropic" : draftProvider
+        return VDropdown(
             placeholder: "Select a model\u{2026}",
             selection: Binding(
                 get: { store.selectedModel },
                 set: { store.selectedModel = $0 }
             ),
-            options: (SettingsStore.inferenceProviderModels[draftProvider] ?? []).map { model in
+            options: (SettingsStore.inferenceProviderModels[provider] ?? []).map { model in
                 (label: model.displayName, value: model.id)
             }
         )
@@ -309,7 +319,8 @@ struct InferenceServiceCard: View {
 
         // Persist model selection
         if isCustomProviderEnabled {
-            store.setModel(store.selectedModel, provider: draftProvider)
+            let saveProvider = draftMode == "managed" ? "anthropic" : draftProvider
+            store.setModel(store.selectedModel, provider: saveProvider)
         } else {
             store.setModel(store.selectedModel)
         }


### PR DESCRIPTION
## Summary
- When switching from Your Own to Managed mode on the Inference card, reset the selected model to an Anthropic default if the current model is not in the Anthropic catalog
- Fix the provider model picker to show Anthropic models (not the Your Own provider's models) when in Managed mode
- Fix performSave() to persist the model with provider anthropic when in Managed mode

Part of plan: managed-mode-model-reset.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
