### PR TITLE
fix: apply size-based data omission for all large attachments, not just videos

### DIFF
--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -251,7 +251,7 @@ export async function resolveAssistantAttachments(
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       const isVideo = draft.mimeType.startsWith("video/");
       // All attachments are file-backed; omit large data from the event payload
-      const omitData = isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
+      const omitData = draft.dataBase64.length > MAX_INLINE_B64_SIZE;
 
       // Generate and persist a thumbnail for video attachments.
       let thumbnailData: string | undefined;


### PR DESCRIPTION
Addresses feedback from PR #18940 (comment 3). The omitData logic was only suppressing large payloads for video attachments. This fix extends it to all attachment types exceeding the size threshold, preventing 100+ MB base64 blobs from being emitted inline in message_complete/generation_handoff events.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
