### PR TITLE
fix(macos): cache line count in ToolCallChip to avoid per-render string splitting

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -17,6 +17,9 @@ public struct ToolCallChip: View {
     /// Cached formatted input — computed once on first expand to avoid re-running
     /// `formatAllToolInput` on every SwiftUI render pass.
     @State private var cachedInputFull: String?
+    /// Cached line count for the result text — avoids O(n) `components(separatedBy:)`
+    /// array allocation on every SwiftUI render pass when the chip is expanded.
+    @State private var cachedResultLineCount: Int?
 
     /// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
     static func parseExitCode(from result: String) -> Int? {
@@ -30,6 +33,15 @@ public struct ToolCallChip: View {
             return nil
         }
         return Int(matched[numRange])
+    }
+
+    /// Count lines in a string without allocating an intermediate array.
+    static func countLines(in text: String) -> Int {
+        var count = 1
+        for byte in text.utf8 where byte == UInt8(ascii: "\n") {
+            count += 1
+        }
+        return count
     }
 
     /// Human-readable explanation for common exit codes.
@@ -206,7 +218,7 @@ public struct ToolCallChip: View {
                                         .foregroundColor(VColor.contentSecondary)
                                 }
                             } else {
-                                let lineCount = result.components(separatedBy: "\n").count
+                                let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
                                 if lineCount > 500 {
                                     ScrollView {
                                         Text(result)
@@ -241,6 +253,10 @@ public struct ToolCallChip: View {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
                     }
+                    // Cache the result line count so subsequent renders are O(1).
+                    if cachedResultLineCount == nil, let result = toolCall.result {
+                        cachedResultLineCount = Self.countLines(in: result)
+                    }
                     // Trigger on-demand rehydration when expanding truncated content.
                     onRehydrate?()
                 }
@@ -263,11 +279,16 @@ public struct ToolCallChip: View {
             // `resolvedInputFull` returns the formatted input on the very first
             // render of the expanded section — avoiding a visible flash/pop-in
             // for lazy-loaded history tool calls where `.onAppear` fires too late.
-            if newValue, cachedInputFull == nil {
-                if let dict = toolCall.inputRawDict {
-                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
-                } else if !toolCall.inputFull.isEmpty {
-                    cachedInputFull = toolCall.inputFull
+            if newValue {
+                if cachedInputFull == nil {
+                    if let dict = toolCall.inputRawDict {
+                        cachedInputFull = ToolCallData.formatAllToolInput(dict)
+                    } else if !toolCall.inputFull.isEmpty {
+                        cachedInputFull = toolCall.inputFull
+                    }
+                }
+                if cachedResultLineCount == nil, let result = toolCall.result {
+                    cachedResultLineCount = Self.countLines(in: result)
                 }
             }
         }
@@ -275,6 +296,9 @@ public struct ToolCallChip: View {
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.
             cachedInputFull = nil
+        }
+        .onChange(of: toolCall.result) {
+            cachedResultLineCount = nil
         }
     }
 }


### PR DESCRIPTION
Addresses Codex feedback from PR #18954. The line count computation via `components(separatedBy:)` was running inside the view body on every re-render. This caches the result in a `@State` property and uses a lightweight UTF-8 newline counter (O(1) memory) as fallback, avoiding the O(n) array allocation on each render pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
