### PR TITLE
fix: make attachment file hydration opt-in and log read failures

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -559,7 +559,10 @@ export async function runDaemon(): Promise<void> {
           server.getConversationForMessages(conversationId),
         assistantEventHub,
         resolveAttachments: (attachmentIds) => {
-          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const resolved = attachmentsStore.getAttachmentsByIds(
+            attachmentIds,
+            { hydrateFileData: true },
+          );
           const sourcePaths =
             attachmentsStore.getSourcePathsForAttachments(attachmentIds);
           return resolved.map((a) => ({
@@ -657,7 +660,10 @@ export async function runDaemon(): Promise<void> {
       getOrCreateConversation: (conversationId, _transport) =>
         server.getConversationForMessages(conversationId),
       resolveAttachments: (attachmentIds) => {
-        const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+        const resolved = attachmentsStore.getAttachmentsByIds(
+          attachmentIds,
+          { hydrateFileData: true },
+        );
         const sourcePaths =
           attachmentsStore.getSourcePathsForAttachments(attachmentIds);
         return resolved.map((a) => ({

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -964,7 +964,10 @@ export class DaemonServer {
 
     const attachments = attachmentIds
       ? (() => {
-          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
+          const resolved = attachmentsStore.getAttachmentsByIds(
+            attachmentIds,
+            { hydrateFileData: true },
+          );
           const sourcePaths =
             attachmentsStore.getSourcePathsForAttachments(attachmentIds);
           return resolved.map((a) => ({

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -11,6 +11,7 @@ import { basename, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { getDb, rawAll, rawGet, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
@@ -508,9 +509,11 @@ export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
 
 export function getAttachmentsByIds(
   ids: string[],
+  options?: { hydrateFileData?: boolean },
 ): Array<StoredAttachment & { dataBase64: string }> {
   if (ids.length === 0) return [];
   const db = getDb();
+  const hydrateFileData = options?.hydrateFileData ?? false;
   const results: Array<StoredAttachment & { dataBase64: string }> = [];
   for (const id of ids) {
     const row = db
@@ -520,12 +523,17 @@ export function getAttachmentsByIds(
       .get();
     if (row) {
       // File-backed attachments store data on disk with dataBase64 = "".
-      // Hydrate base64 from disk so callers get actual content.
+      // Only hydrate base64 from disk when callers explicitly opt in,
+      // to avoid eagerly reading large files for validation-only paths.
       let dataBase64 = row.dataBase64;
-      if (!dataBase64 && row.filePath) {
+      if (hydrateFileData && !dataBase64 && row.filePath) {
         try {
           dataBase64 = readFileSync(row.filePath).toString("base64");
-        } catch {
+        } catch (err: unknown) {
+          const log = getLogger();
+          log.warn(
+            `Failed to read file-backed attachment ${id} from ${row.filePath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
           dataBase64 = "";
         }
       }
@@ -583,7 +591,7 @@ export function getAttachmentsForMessage(
   const ids = links
     .map((l) => l.attachmentId)
     .filter((id): id is string => id != null);
-  return getAttachmentsByIds(ids);
+  return getAttachmentsByIds(ids, { hydrateFileData: true });
 }
 
 /**
@@ -631,8 +639,9 @@ export function getAttachmentMetadataForMessage(
  */
 export function getAttachmentById(
   attachmentId: string,
+  options?: { hydrateFileData?: boolean },
 ): (StoredAttachment & { dataBase64: string }) | null {
-  const results = getAttachmentsByIds([attachmentId]);
+  const results = getAttachmentsByIds([attachmentId], options);
   return results[0] ?? null;
 }
 

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -128,7 +128,9 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
 }
 
 function handleGetAttachment(attachmentId: string): Response {
-  const attachment = attachmentsStore.getAttachmentById(attachmentId);
+  const attachment = attachmentsStore.getAttachmentById(attachmentId, {
+    hydrateFileData: true,
+  });
   if (!attachment) {
     return httpError("NOT_FOUND", "Attachment not found", 404);
   }
@@ -158,7 +160,9 @@ export function handleGetAttachmentContent(
   attachmentId: string,
   req: Request,
 ): Response {
-  const attachment = attachmentsStore.getAttachmentById(attachmentId);
+  const attachment = attachmentsStore.getAttachmentById(attachmentId, {
+    hydrateFileData: true,
+  });
   if (!attachment) {
     return httpError("NOT_FOUND", "Attachment not found", 404);
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -397,7 +397,9 @@ export function handleListMessages(
         msgAttachments = linked.map((a) => {
           const isFileBacked = fileBackedIds.has(a.id);
           if (a.mimeType.startsWith("image/")) {
-            const full = attachmentsStore.getAttachmentById(a.id);
+            const full = attachmentsStore.getAttachmentById(a.id, {
+              hydrateFileData: true,
+            });
             return {
               id: a.id,
               filename: a.originalFilename,


### PR DESCRIPTION
Addresses feedback from PR #18980:
- Add `hydrateFileData` option to `getAttachmentsByIds` (default: `false`) so validation-only callers don't eagerly read large files from disk
- Update `getAttachmentById` to pass through the option
- Update `resolveAttachments` callers in lifecycle.ts and server.ts to opt-in to hydration
- Update content-serving callers in attachment-routes.ts and conversation-routes.ts to opt-in
- `getAttachmentsForMessage` (used for message display) always hydrates
- Add warning log when file-backed attachment read fails instead of silently returning empty string
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
