### PR TITLE
fix: inline deprecated getFileBackedAttachmentIds and remove dead function

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -312,21 +312,6 @@ export function getSourcePathsForAttachments(
 }
 
 /**
- * Returns the subset of `attachmentIds` that are file-backed.
- *
- * Since all attachments are now stored on disk, this simply returns a
- * Set containing every input ID — no database query is needed.
- *
- * @deprecated All attachments are file-backed. Callers should assume
- * `fileBacked: true` unconditionally and avoid calling this function.
- */
-export function getFileBackedAttachmentIds(
-  attachmentIds: string[],
-): Set<string> {
-  return new Set(attachmentIds);
-}
-
-/**
  * Return the raw binary content for an attachment by reading from its
  * on-disk file path.
  *

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -389,13 +389,7 @@ export function handleListMessages(
       // generate thumbnails for inline display on history restore.
       const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
       if (linked.length > 0) {
-        // Batch-fetch file-backed status for all attachments in one query
-        // instead of issuing a separate query per attachment.
-        const fileBackedIds = attachmentsStore.getFileBackedAttachmentIds(
-          linked.map((a) => a.id),
-        );
         msgAttachments = linked.map((a) => {
-          const isFileBacked = fileBackedIds.has(a.id);
           if (a.mimeType.startsWith("image/")) {
             const full = attachmentsStore.getAttachmentById(a.id);
             return {
@@ -408,7 +402,7 @@ export function handleListMessages(
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),
-              ...(isFileBacked ? { fileBacked: true } : {}),
+              fileBacked: true,
             };
           }
           return {
@@ -418,7 +412,7 @@ export function handleListMessages(
             sizeBytes: a.sizeBytes,
             kind: a.kind,
             ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
-            ...(isFileBacked ? { fileBacked: true } : {}),
+            fileBacked: true,
           };
         });
       }


### PR DESCRIPTION
Addresses feedback from PR #18988. All attachments are now file-backed, so getFileBackedAttachmentIds was a trivial passthrough. Inlines the logic at the single caller in conversation-routes.ts and removes the deprecated function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
