### PR TITLE
docs: fix disk view documentation accuracy and update ARCHITECTURE.md diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -273,10 +273,8 @@ subgraph "Text Q&A Session"
             PROXY_APPROVAL["ApprovalCallback<br/>→ PermissionPrompter"]
         end
 
-        subgraph "Asset Tools"
-            ASSET_SEARCH["asset_search<br/>cross-conversation metadata query"]
-            ASSET_MATERIALIZE["asset_materialize<br/>decode + write to sandbox"]
-            VISIBILITY_POLICY["MediaVisibilityPolicy<br/>private conversation gate"]
+        subgraph "Conversation Disk View"
+            DISK_VIEW["conversation-disk-view.ts<br/>init, sync, remove, flatten"]
         end
 
     end
@@ -475,13 +473,9 @@ subgraph "Text Q&A Session"
     SESSION_MGR -->|"CES RPC<br/>(stdio/socket)"| CES_PROCESS
     CES_PROCESS -->|"credential<br/>materialization"| CES_GRANTS
 
-    %% Asset tools data flow
-    SESSION_MGR -->|"tool_use"| ASSET_SEARCH
-    SESSION_MGR -->|"tool_use"| ASSET_MATERIALIZE
-    ASSET_SEARCH --> DB_ATTACH
-    ASSET_SEARCH --> VISIBILITY_POLICY
-    ASSET_MATERIALIZE --> DB_ATTACH
-    ASSET_MATERIALIZE --> VISIBILITY_POLICY
+    %% Conversation disk view data flow
+    CONV_STORE -->|"init / update / remove"| DISK_VIEW
+    SESSION_MGR -->|"syncMessageToDisk"| DISK_VIEW
 
     %% Local storage
     APP_SUPPORT --- SESSION_LOGS

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -534,32 +534,36 @@ Each conversation is projected to a directory named `{id}_{isoDate}`:
 
 ### Write-Through Sync
 
-Disk writes happen as a write-through side effect of DB operations — whenever a conversation is created, updated, or receives a new message, the corresponding disk-view files are updated in lockstep. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
+The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
+
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/` and are included in diagnostic log exports ("Send logs to Vellum"). The export applies a binary-file heuristic (skipping null-byte files) and a cumulative size cap, so large binary attachments are typically excluded, but text-based conversation metadata (`meta.json`) and message logs (`messages.jsonl`) will be included. Users should be aware that diagnostic exports may contain conversation content.
 
 ```mermaid
 sequenceDiagram
     participant CRUD as conversation-crud.ts
+    participant Daemon as conversation-messaging.ts
     participant DiskView as conversation-disk-view.ts
     participant FS as Filesystem
 
-    Note over CRUD,FS: Conversation creation
+    Note over CRUD,FS: Conversation creation (CRUD layer)
     CRUD->>CRUD: INSERT conversation row
     CRUD->>DiskView: initConversationDir(conv)
     DiskView->>FS: mkdir + write meta.json
 
-    Note over CRUD,FS: Message insertion
+    Note over Daemon,FS: Message insertion (daemon layer)
+    Daemon->>CRUD: addMessage(convId, role, content)
     CRUD->>CRUD: INSERT message row
-    CRUD->>DiskView: syncMessageToDisk(convId, msgId, createdAtMs)
+    Daemon->>DiskView: syncMessageToDisk(convId, msgId, createdAtMs)
     DiskView->>DiskView: flattenContentBlocks(content)
     DiskView->>FS: append JSONL record to messages.jsonl
     DiskView->>FS: write attachment files to attachments/
 
-    Note over CRUD,FS: Conversation update (title change, etc.)
+    Note over CRUD,FS: Conversation update (CRUD layer)
     CRUD->>CRUD: UPDATE conversation row
     CRUD->>DiskView: updateMetaFile(conv)
     DiskView->>FS: rewrite meta.json
 
-    Note over CRUD,FS: Conversation deletion
+    Note over CRUD,FS: Conversation deletion (CRUD layer)
     CRUD->>CRUD: DELETE conversation row
     CRUD->>DiskView: removeConversationDir(id, createdAtMs)
     DiskView->>FS: rm -rf conversation directory
@@ -587,7 +591,8 @@ Existing conversations created before the disk view was introduced are backfille
 | File                                                                  | Role                                                                    |
 | --------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `assistant/src/memory/conversation-disk-view.ts`                     | Disk view module — init, update, sync, remove, content flattening       |
-| `assistant/src/memory/conversation-crud.ts`                          | DB CRUD layer — calls disk-view functions as write-through side effects |
+| `assistant/src/memory/conversation-crud.ts`                          | DB CRUD layer — calls init, update, and remove disk-view functions (not message sync) |
+| `assistant/src/daemon/conversation-messaging.ts`                     | Daemon messaging pipeline — calls `syncMessageToDisk` after message insertion |
 | `assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts` | Backfill migration for pre-existing conversations                       |
 
 ---

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -444,6 +444,7 @@ const WORKSPACE_SKIP_DIRS = new Set([
   "embedding-models",
   "data/qdrant",
   "data/attachments",
+  "conversations",
 ]);
 
 /** Files at the workspace root to skip (already covered by sanitized fields). */


### PR DESCRIPTION
## Summary
Addresses feedback from PR #18991:
- **Correct lockstep sync claim** (P2): Updated integrations.md to accurately describe that `syncMessageToDisk` is called at the daemon level (`conversation-messaging.ts`), not from the CRUD `addMessage()` function. Updated the sequence diagram to show the daemon as a separate participant.
- **Update ARCHITECTURE.md Mermaid diagram**: Replaced the stale "Asset Tools" subgraph (referencing deleted `asset_search`, `asset_materialize`, `MediaVisibilityPolicy`) with a "Conversation Disk View" subgraph referencing `conversation-disk-view.ts`. Updated connections to show CONV_STORE and SESSION_MGR linking to DISK_VIEW.
- **Privacy: exclude conversations from exports**: Added `conversations` to `WORKSPACE_SKIP_DIRS` in `log-export-routes.ts` so conversation history and attachments are not included in diagnostic log exports. Added a privacy note in the docs.

## Test plan
- [ ] Verify ARCHITECTURE.md Mermaid diagram renders correctly
- [ ] Verify integrations.md sequence diagram renders correctly
- [ ] Verify diagnostic exports no longer include `workspace/conversations/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
