### PR TITLE
feat: use daemon provider catalog as single source of truth, show masked keys and success toast

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
     let onMicrophoneToggle: () -> Void
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var selectedModel: String = ""
+    var catalogModels: [(id: String, name: String)] = []
     var configuredProviders: Set<String> = []
     let assistantActivityPhase: String
     let assistantActivityAnchor: String
@@ -223,6 +224,7 @@ struct ChatView: View {
                             assistantActivityReason: assistantActivityReason,
                             assistantStatusText: assistantStatusText,
                             selectedModel: selectedModel,
+                            catalogModels: catalogModels,
                             configuredProviders: configuredProviders,
                             activeSubagents: activeSubagents,
                             dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -79,6 +79,7 @@ struct MessageListView: View {
     let assistantActivityReason: String?
     let assistantStatusText: String?
     let selectedModel: String
+    let catalogModels: [(id: String, name: String)]
     let configuredProviders: Set<String>
     let activeSubagents: [SubagentInfo]
     let dismissedDocumentSurfaceIds: Set<String>
@@ -729,6 +730,7 @@ struct MessageListView: View {
                             onModelPickerSelect: onModelPickerSelect,
                             subagentDetailStore: subagentDetailStore,
                             selectedModel: selectedModel,
+                            catalogModels: catalogModels,
                             configuredProviders: configuredProviders
                         )
                         .equatable()
@@ -1306,6 +1308,8 @@ private struct MessageCellView: View, Equatable {
             && lhs.activeSurfaceId == rhs.activeSurfaceId
             && lhs.isHighlighted == rhs.isHighlighted
             && lhs.selectedModel == rhs.selectedModel
+            && lhs.catalogModels.count == rhs.catalogModels.count
+            && zip(lhs.catalogModels, rhs.catalogModels).allSatisfy({ $0.id == $1.id && $0.name == $1.name })
             && lhs.configuredProviders == rhs.configuredProviders
     }
 
@@ -1348,15 +1352,14 @@ private struct MessageCellView: View, Equatable {
     var onModelPickerSelect: ((UUID, String) -> Void)?
     var subagentDetailStore: SubagentDetailStore
     let selectedModel: String
+    let catalogModels: [(id: String, name: String)]
     let configuredProviders: Set<String>
 
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private func modelPickerView(for msg: ChatMessage) -> some View {
         ModelPickerBubble(
-            models: SettingsStore.availableModels.map { id in
-                (id: id, name: SettingsStore.modelDisplayNames[id] ?? id)
-            },
+            models: catalogModels,
             selectedModelId: selectedModel,
             onSelect: { modelId in
                 onModelPickerSelect?(msg.id, modelId)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -646,6 +646,7 @@ struct ActiveChatViewWrapper: View {
                 settingsStore.setModel(modelId)
             },
             selectedModel: settingsStore.selectedModel,
+            catalogModels: settingsStore.dynamicProviderModels("anthropic").map { (id: $0.id, name: $0.displayName) },
             configuredProviders: settingsStore.configuredProviders,
             assistantActivityPhase: viewModel.assistantActivityPhase,
             assistantActivityAnchor: viewModel.assistantActivityAnchor,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -46,7 +46,7 @@ struct InferenceServiceCard: View {
     }
 
     private var providerDisplayName: String {
-        SettingsStore.inferenceProviderDisplayNames[effectiveProvider] ?? effectiveProvider
+        store.dynamicProviderDisplayName(effectiveProvider)
     }
 
     // MARK: - Computed State
@@ -144,10 +144,9 @@ struct InferenceServiceCard: View {
         }
         .onChange(of: draftProvider) { _, newProvider in
             if isCustomProviderEnabled {
-                let defaultModel = SettingsStore.inferenceProviderDefaultModel[newProvider]
-                    ?? SettingsStore.inferenceProviderModels[newProvider]?.first?.id
-                    ?? ""
-                store.selectedModel = defaultModel
+                let defaultModel = store.dynamicProviderDefaultModel(newProvider)
+                let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""
+                store.selectedModel = defaultModel.isEmpty ? fallback : defaultModel
             }
             apiKeyText = ""
         }
@@ -195,8 +194,8 @@ struct InferenceServiceCard: View {
             VDropdown(
                 placeholder: "Select a provider\u{2026}",
                 selection: $draftProvider,
-                options: SettingsStore.inferenceProviders.map { provider in
-                    (label: SettingsStore.inferenceProviderDisplayNames[provider] ?? provider, value: provider)
+                options: store.dynamicProviderIds.map { provider in
+                    (label: store.dynamicProviderDisplayName(provider), value: provider)
                 }
             )
         }
@@ -209,7 +208,15 @@ struct InferenceServiceCard: View {
             Text(isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            SecureField("Enter your API key", text: $apiKeyText)
+            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
+                Text(masked)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            SecureField(
+                isConnected ? "Enter a new key to replace the existing one" : "Enter your API key",
+                text: $apiKeyText
+            )
                 .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
@@ -238,7 +245,7 @@ struct InferenceServiceCard: View {
         }
     }
 
-    /// Hardcoded Anthropic-only model dropdown (flag off, backward compat).
+    /// Anthropic-only model dropdown (flag off, backward compat).
     private var defaultModelPicker: some View {
         VDropdown(
             placeholder: "Select a model\u{2026}",
@@ -246,8 +253,8 @@ struct InferenceServiceCard: View {
                 get: { store.selectedModel },
                 set: { store.selectedModel = $0 }
             ),
-            options: SettingsStore.availableModels.map { model in
-                (label: SettingsStore.modelDisplayNames[model] ?? model, value: model)
+            options: store.dynamicProviderModels("anthropic").map { model in
+                (label: model.displayName, value: model.id)
             }
         )
     }
@@ -260,7 +267,7 @@ struct InferenceServiceCard: View {
                 get: { store.selectedModel },
                 set: { store.selectedModel = $0 }
             ),
-            options: (SettingsStore.inferenceProviderModels[draftProvider] ?? []).map { model in
+            options: store.dynamicProviderModels(draftProvider).map { model in
                 (label: model.displayName, value: model.id)
             }
         )
@@ -296,13 +303,16 @@ struct InferenceServiceCard: View {
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if draftMode == "your-own" && !trimmedKey.isEmpty {
             let keyTextBinding = $apiKeyText
+            let displayName = providerDisplayName
             if isCustomProviderEnabled {
                 store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: {
                     keyTextBinding.wrappedValue = ""
+                    showToast?("\(displayName) API key saved", .success)
                 })
             } else {
                 store.saveAPIKey(trimmedKey, onSuccess: {
                     keyTextBinding.wrappedValue = ""
+                    showToast?("API key saved", .success)
                 })
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -46,72 +46,14 @@ public final class SettingsStore: ObservableObject {
     @Published var configuredProviders: Set<String> = ["ollama"]
     @Published var selectedImageGenModel: String = "gemini-3.1-flash-image-preview"
 
-    static let availableModels: [String] = [
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
-        "claude-haiku-4-5-20251001",
-    ]
-
-    static let modelDisplayNames: [String: String] = [
-        "claude-opus-4-6": "Claude Opus 4.6",
-        "claude-sonnet-4-6": "Claude Sonnet 4.6",
-        "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
-    ]
-
     // MARK: - Inference Provider Selection
 
     @Published var selectedInferenceProvider: String = "anthropic"
-    @Published var inferenceAvailableModels: [CatalogModel] = []
 
-    static let inferenceProviders: [String] = [
-        "anthropic", "openai", "gemini", "ollama", "fireworks", "openrouter",
-    ]
-    static let inferenceProviderDisplayNames: [String: String] = [
-        "anthropic": "Anthropic",
-        "openai": "OpenAI",
-        "gemini": "Google Gemini",
-        "ollama": "Ollama",
-        "fireworks": "Fireworks",
-        "openrouter": "OpenRouter",
-    ]
-    /// Client-side model catalog for immediate UI updates on provider change.
-    /// Mirrors PROVIDER_MODEL_CATALOG on the daemon.
-    static let inferenceProviderModels: [String: [(id: String, displayName: String)]] = [
-        "anthropic": [
-            ("claude-opus-4-6", "Claude Opus 4.6"),
-            ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
-            ("claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
-        ],
-        "openai": [
-            ("gpt-5.2", "GPT-5.2"),
-            ("gpt-5.4", "GPT-5.4"),
-            ("gpt-5.4-nano", "GPT-5.4 Nano"),
-        ],
-        "gemini": [
-            ("gemini-3-flash", "Gemini 3 Flash"),
-            ("gemini-3-pro", "Gemini 3 Pro"),
-        ],
-        "ollama": [
-            ("llama3.2", "Llama 3.2"),
-            ("mistral", "Mistral"),
-        ],
-        "fireworks": [
-            ("accounts/fireworks/models/kimi-k2p5", "Kimi K2.5"),
-        ],
-        "openrouter": [
-            ("x-ai/grok-4", "Grok 4"),
-            ("x-ai/grok-4.20-beta", "Grok 4.20 Beta"),
-        ],
-    ]
-    /// Default model per provider (first entry from the catalog).
-    static let inferenceProviderDefaultModel: [String: String] = [
-        "anthropic": "claude-opus-4-6",
-        "openai": "gpt-5.2",
-        "gemini": "gemini-3-flash",
-        "ollama": "llama3.2",
-        "fireworks": "accounts/fireworks/models/kimi-k2p5",
-        "openrouter": "x-ai/grok-4",
-    ]
+    /// Full provider catalog from daemon. Seeded with inline defaults for pre-fetch rendering.
+    @Published var providerCatalog: [ProviderCatalogEntry] = []
+    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x").
+    @Published var providerMaskedKeys: [String: String] = [:]
 
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
@@ -446,6 +388,36 @@ public final class SettingsStore: ObservableObject {
         // Load service modes (inference, image-generation) from workspace config
         loadServiceModes()
 
+        // Seed provider catalog with inline defaults so the UI has data before
+        // the first daemon fetch completes.
+        providerCatalog = [
+            ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
+                CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
+                CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+                CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
+            ], defaultModel: "claude-opus-4-6"),
+            ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
+                CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
+                CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
+                CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
+            ], defaultModel: "gpt-5.2"),
+            ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
+                CatalogModel(id: "gemini-3-flash", displayName: "Gemini 3 Flash"),
+                CatalogModel(id: "gemini-3-pro", displayName: "Gemini 3 Pro"),
+            ], defaultModel: "gemini-3-flash"),
+            ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
+                CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
+                CatalogModel(id: "mistral", displayName: "Mistral"),
+            ], defaultModel: "llama3.2"),
+            ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
+                CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
+            ], defaultModel: "accounts/fireworks/models/kimi-k2p5"),
+            ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
+                CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
+                CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
+            ], defaultModel: "x-ai/grok-4"),
+        ]
+
         // When enabledSince was defaulted to "now" (no value on disk),
         // persist it immediately so subsequent loads produce the same
         // deterministic timestamp instead of advancing each time.
@@ -673,6 +645,7 @@ public final class SettingsStore: ObservableObject {
             if result.success {
                 scheduleRoutingSourceRefresh()
                 onSuccess?()
+                refreshModelInfo()
             } else if let error = result.error {
                 apiKeySaveError = error
                 if !result.isTransient {
@@ -700,6 +673,7 @@ public final class SettingsStore: ObservableObject {
         hasKey = false
         maskedKey = ""
         scheduleRoutingSourceRefresh()
+        refreshModelInfo()
     }
 
     func saveBraveKey(_ raw: String) {
@@ -822,6 +796,7 @@ public final class SettingsStore: ObservableObject {
         deleteKeyFromDaemon(provider: provider)
         refreshAPIKeyState()
         scheduleRoutingSourceRefresh()
+        refreshModelInfo()
     }
 
     func saveInferenceAPIKey(_ raw: String, provider: String, onSuccess: (() -> Void)? = nil) {
@@ -842,6 +817,7 @@ public final class SettingsStore: ObservableObject {
             if result.success {
                 scheduleRoutingSourceRefresh()
                 onSuccess?()
+                refreshModelInfo()
             } else if let error = result.error {
                 apiKeySaveError = error
                 if !result.isTransient {
@@ -950,9 +926,30 @@ public final class SettingsStore: ObservableObject {
         if let providers = response.configuredProviders {
             self.configuredProviders = Set(providers)
         }
-        if let models = response.availableModels {
-            self.inferenceAvailableModels = models
+        if let allProviders = response.allProviders, !allProviders.isEmpty {
+            self.providerCatalog = allProviders
         }
+        if let maskedKeys = response.maskedKeys {
+            self.providerMaskedKeys = maskedKeys
+        }
+    }
+
+    // MARK: - Dynamic Provider Catalog Helpers
+
+    var dynamicProviderIds: [String] {
+        providerCatalog.map(\.id)
+    }
+
+    func dynamicProviderDisplayName(_ provider: String) -> String {
+        providerCatalog.first { $0.id == provider }?.displayName ?? provider
+    }
+
+    func dynamicProviderModels(_ provider: String) -> [CatalogModel] {
+        providerCatalog.first { $0.id == provider }?.models ?? []
+    }
+
+    func dynamicProviderDefaultModel(_ provider: String) -> String {
+        providerCatalog.first { $0.id == provider }?.defaultModel ?? ""
     }
 
     // MARK: - Telegram Integration Actions

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2671,19 +2671,37 @@ public struct CatalogModel: Codable, Sendable {
     }
 }
 
+public struct ProviderCatalogEntry: Codable, Sendable {
+    public let id: String
+    public let displayName: String
+    public let models: [CatalogModel]
+    public let defaultModel: String
+
+    public init(id: String, displayName: String, models: [CatalogModel], defaultModel: String) {
+        self.id = id
+        self.displayName = displayName
+        self.models = models
+        self.defaultModel = defaultModel
+    }
+}
+
 public struct ModelInfo: Codable, Sendable {
     public let type: String
     public let model: String
     public let provider: String
     public let configuredProviders: [String]?
     public let availableModels: [CatalogModel]?
+    public let allProviders: [ProviderCatalogEntry]?
+    public let maskedKeys: [String: String]?
 
-    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil, availableModels: [CatalogModel]? = nil) {
+    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil, availableModels: [CatalogModel]? = nil, allProviders: [ProviderCatalogEntry]? = nil, maskedKeys: [String: String]? = nil) {
         self.type = type
         self.model = model
         self.provider = provider
         self.configuredProviders = configuredProviders
         self.availableModels = availableModels
+        self.allProviders = allProviders
+        self.maskedKeys = maskedKeys
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace six hardcoded static catalog constants in SettingsStore with dynamic `providerCatalog` and `providerMaskedKeys` from daemon
- Add masked key display above SecureField when a key is stored
- Add success toast after saving API keys
- Switch all provider/model dropdowns to use daemon-driven data
- Update MessageListView model picker to use dynamic data

Part of plan: inference-key-ux.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
