### PR TITLE
fix: revert conversation-count gate on BOOTSTRAP.md

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -6,7 +6,6 @@ import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
-import { countConversations } from "../memory/conversation-queries.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
@@ -144,21 +143,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const bootstrap = readPromptFile(bootstrapPath);
   const updates = readPromptFile(updatesPath);
 
-  // Only include BOOTSTRAP.md when there are zero existing conversations
-  // (truly first-time user).  Once the user has any conversation history,
-  // bootstrap is suppressed so it doesn't re-trigger on new threads — even
-  // if the user skipped or ignored onboarding.
-  let includeBootstrap = !!bootstrap && !options?.excludeBootstrap;
-  if (includeBootstrap) {
-    try {
-      if (countConversations() > 0) {
-        includeBootstrap = false;
-      }
-    } catch {
-      // DB not ready yet (e.g. during early startup) — fall back to
-      // including bootstrap if the file exists.
-    }
-  }
+  const includeBootstrap = !!bootstrap && !options?.excludeBootstrap;
 
   // Template prompt files contain placeholder fields and meta-instructions
   // meant for the assistant to fill in during onboarding.  When included


### PR DESCRIPTION
## Summary
- Reverts the `countConversations() > 0` gate from #18887 that prevented BOOTSTRAP.md from being included in the system prompt for users with existing conversations
- Restores the original behavior: BOOTSTRAP.md is included whenever the file exists and `excludeBootstrap` isn't set

## Test plan
- [x] Type-check passes
- [x] `system-prompt.test.ts` passes (47/47)
- [ ] Verify BOOTSTRAP.md appears in context for users with existing conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
