### PR TITLE
fix: persist anthropic provider in managed mode save path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -295,9 +295,10 @@ struct InferenceServiceCard: View {
         }
 
         // Persist provider if changed and flag is on
-        if isCustomProviderEnabled && draftProvider != initialProvider {
-            store.setInferenceProvider(draftProvider)
-            initialProvider = draftProvider
+        let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
+        if isCustomProviderEnabled && persistProvider != initialProvider {
+            store.setInferenceProvider(persistProvider)
+            initialProvider = persistProvider
         }
 
         // Persist API key if entered and in your-own mode.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-mode-model-reset.md.

**Gap:** Provider persistence in performSave doesn't account for managed mode
**What was expected:** When saving in managed mode, the provider persisted to config should be anthropic
**What was found:** performSave() persisted draftProvider (e.g. openai) regardless of mode

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
