### PR TITLE
fix: sort imports in media-generate-image.ts

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -4,13 +4,13 @@ import {
   type ImageGenCredentials,
   mapGeminiError,
 } from "../../../../media/gemini-image-service.js";
+import { getFilePathBySourcePath } from "../../../../memory/attachments-store.js";
 import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
 import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
-import { getFilePathBySourcePath } from "../../../../memory/attachments-store.js";
 import { sandboxPolicy } from "../../../../tools/shared/filesystem/path-policy.js";
 import type {
   ToolContext,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `media-generate-image.ts` by sorting the `memory/attachments-store` import to its correct alphabetical position

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23274673592/job/67675007680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
