### PR TITLE
fix: pass missing argument to getLogger() in attachments-store

### DIFF
--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -528,7 +528,7 @@ export function getAttachmentsByIds(
         try {
           dataBase64 = readFileSync(row.filePath).toString("base64");
         } catch (err: unknown) {
-          const log = getLogger();
+          const log = getLogger("attachments-store");
           log.warn(
             `Failed to read file-backed attachment ${id} from ${row.filePath}: ${err instanceof Error ? err.message : String(err)}`,
           );


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error in `attachments-store.ts` — `getLogger()` was called without the required `name` argument, causing CI type-check to fail.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23274673592/job/67675007668

🤖 Generated with [Claude Code](https://claude.com/claude-code)