### PR TITLE
fix: pass hydrateFileData option in attachment tests

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -114,7 +114,7 @@ describe("uploadAttachment", () => {
     expect(rawRow!.data_base64).toBe("");
 
     // But getAttachmentById hydrates from disk
-    const row = getAttachmentById(stored.id);
+    const row = getAttachmentById(stored.id, { hydrateFileData: true });
     expect(row).not.toBeNull();
     expect(row!.dataBase64).toBe("dGVzdA==");
   });
@@ -346,7 +346,7 @@ describe("getAttachmentsByIds", () => {
     const a = uploadAttachment("a.txt", "text/plain", "AAAA");
     const b = uploadAttachment("b.txt", "text/plain", "BBBB");
 
-    const results = getAttachmentsByIds([a.id, b.id]);
+    const results = getAttachmentsByIds([a.id, b.id], { hydrateFileData: true });
     expect(results).toHaveLength(2);
     // dataBase64 is hydrated from on-disk files
     expect(results[0].dataBase64).toBe("AAAA");
@@ -374,7 +374,7 @@ describe("getAttachmentById", () => {
 
   test("returns attachment with hydrated dataBase64 when found", () => {
     const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
-    const result = getAttachmentById(stored.id);
+    const result = getAttachmentById(stored.id, { hydrateFileData: true });
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(stored.id);

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -557,7 +557,7 @@ describe("attachment reuse across conversation lifecycles", () => {
     await addMessage(convB.id, "user", "hello");
 
     // The attachment is retrievable by ID regardless of which conversation is active.
-    const fetched = getAttachmentById(stored.id);
+    const fetched = getAttachmentById(stored.id, { hydrateFileData: true });
     expect(fetched).not.toBeNull();
     expect(fetched!.id).toBe(stored.id);
     expect(fetched!.originalFilename).toBe("report.pdf");


### PR DESCRIPTION
## Summary
- Fix 4 failing tests in `attachments-store.test.ts` and `conversation-store.test.ts` that expect `dataBase64` to be hydrated from on-disk files but don't pass `{ hydrateFileData: true }` to `getAttachmentById` / `getAttachmentsByIds`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23274673592/job/67675007632

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
