### PR TITLE
Fix: nudge LLM to retry tool errors instead of ending turn

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1634,7 +1634,7 @@ describe("AgentLoop", () => {
   // should inject a system_notice nudging the LLM to retry instead of ending.
   test("injects retry nudge system_notice when tool returns an error", async () => {
     const { provider, calls } = createMockProvider([
-      // First turn: LLM calls a tool
+      // First turn: LLM calls a tool that errors
       toolUseResponse("t1", "read_file", { path: "/missing.txt" }),
       // Second turn: LLM retries after seeing the error + nudge
       toolUseResponse("t2", "read_file", { path: "/existing.txt" }),
@@ -1677,8 +1677,7 @@ describe("AgentLoop", () => {
 
     const retryNudge = toolResultMessage.content.find(
       (b): b is Extract<ContentBlock, { type: "text" }> =>
-        b.type === "text" &&
-        b.text.includes("Do not end your turn or report the error"),
+        b.type === "text" && b.text.includes("looks recoverable"),
     );
     expect(retryNudge).toBeDefined();
 
@@ -1688,9 +1687,57 @@ describe("AgentLoop", () => {
       thirdCallMessages[thirdCallMessages.length - 1];
     const noRetryNudge = thirdToolResultMessage.content.find(
       (b): b is Extract<ContentBlock, { type: "text" }> =>
-        b.type === "text" &&
-        b.text.includes("Do not end your turn or report the error"),
+        b.type === "text" && b.text.includes("looks recoverable"),
     );
     expect(noRetryNudge).toBeUndefined();
+  });
+
+  // Retry nudge stops after MAX_CONSECUTIVE_ERROR_NUDGES (3) consecutive errors
+  test("stops injecting retry nudge after 3 consecutive error turns", async () => {
+    const { provider, calls } = createMockProvider([
+      // 4 consecutive error turns, then final text
+      toolUseResponse("t1", "read_file", { path: "/a" }),
+      toolUseResponse("t2", "read_file", { path: "/b" }),
+      toolUseResponse("t3", "read_file", { path: "/c" }),
+      toolUseResponse("t4", "read_file", { path: "/d" }),
+      textResponse("Giving up."),
+    ]);
+
+    const toolExecutor = async (
+      _name: string,
+      _input: Record<string, unknown>,
+    ) => {
+      return { content: "service unavailable", isError: true };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+    await loop.run([userMessage], () => {});
+
+    expect(calls).toHaveLength(5);
+
+    // Helper to check if a call's last user message has the retry nudge
+    const hasRetryNudge = (callIndex: number): boolean => {
+      const msgs = calls[callIndex].messages;
+      const lastMsg = msgs[msgs.length - 1];
+      return lastMsg.content.some(
+        (b) =>
+          b.type === "text" &&
+          "text" in b &&
+          (b as { text: string }).text.includes("looks recoverable"),
+      );
+    };
+
+    // Turns 1-3 should have the nudge
+    expect(hasRetryNudge(1)).toBe(true);
+    expect(hasRetryNudge(2)).toBe(true);
+    expect(hasRetryNudge(3)).toBe(true);
+    // Turn 4 should NOT have the nudge (exceeded limit)
+    expect(hasRetryNudge(4)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1629,4 +1629,68 @@ describe("AgentLoop", () => {
     );
     expect(textBlock!.text).toBe("Normal response with no placeholders.");
   });
+
+  // Tool error retry nudge — when a tool returns isError: true, the loop
+  // should inject a system_notice nudging the LLM to retry instead of ending.
+  test("injects retry nudge system_notice when tool returns an error", async () => {
+    const { provider, calls } = createMockProvider([
+      // First turn: LLM calls a tool
+      toolUseResponse("t1", "read_file", { path: "/missing.txt" }),
+      // Second turn: LLM retries after seeing the error + nudge
+      toolUseResponse("t2", "read_file", { path: "/existing.txt" }),
+      // Third turn: LLM responds with success
+      textResponse("Got the file."),
+    ]);
+
+    let callCount = 0;
+    const toolExecutor = async (
+      _name: string,
+      _input: Record<string, unknown>,
+    ) => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          content:
+            '{"error":"name is required and must be a non-empty string"}',
+          isError: true,
+        };
+      }
+      return { content: "file contents", isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+    await loop.run([userMessage], () => {});
+
+    // Provider should have been called 3 times (error -> retry -> final text)
+    expect(calls).toHaveLength(3);
+
+    // The second call's messages should contain the retry nudge system_notice
+    const secondCallMessages = calls[1].messages;
+    const toolResultMessage = secondCallMessages[secondCallMessages.length - 1];
+    expect(toolResultMessage.role).toBe("user");
+
+    const retryNudge = toolResultMessage.content.find(
+      (b): b is Extract<ContentBlock, { type: "text" }> =>
+        b.type === "text" &&
+        b.text.includes("Do not end your turn or report the error"),
+    );
+    expect(retryNudge).toBeDefined();
+
+    // The third call should NOT have the retry nudge (successful tool result)
+    const thirdCallMessages = calls[2].messages;
+    const thirdToolResultMessage =
+      thirdCallMessages[thirdCallMessages.length - 1];
+    const noRetryNudge = thirdToolResultMessage.content.find(
+      (b): b is Extract<ContentBlock, { type: "text" }> =>
+        b.type === "text" &&
+        b.text.includes("Do not end your turn or report the error"),
+    );
+    expect(noRetryNudge).toBeUndefined();
+  });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -100,6 +100,7 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 };
 
 const PROGRESS_CHECK_INTERVAL = 5;
+const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
 const PROGRESS_CHECK_REMINDER =
   "You have been using tools for several turns. Check whether you are making meaningful progress toward the user's goal. If you are stuck in a loop or not making progress, summarize what you have tried and ask the user for guidance instead of continuing.";
 
@@ -200,6 +201,7 @@ export class AgentLoop {
     const history = [...messages];
     let toolUseTurns = 0;
     let nudgedForEmptyResponse = false;
+    let consecutiveErrorTurns = 0;
     let lastLlmCallTime = 0;
     const rlog = requestId ? log.child({ requestId }) : log;
 
@@ -566,7 +568,9 @@ export class AgentLoop {
 
         // Track tool-use turns and inject progress reminder every N turns
         toolUseTurns++;
-        if (toolUseTurns % PROGRESS_CHECK_INTERVAL === 0) {
+        const isProgressCheckTurn =
+          toolUseTurns % PROGRESS_CHECK_INTERVAL === 0;
+        if (isProgressCheckTurn) {
           resultBlocks.push({
             type: "text",
             text: `<system_notice>${PROGRESS_CHECK_REMINDER}</system_notice>`,
@@ -574,11 +578,24 @@ export class AgentLoop {
         }
 
         // When any tool returned an error, nudge the LLM to retry with
-        // corrected parameters instead of ending its turn.
-        if (toolResults.some(({ result }) => result.isError)) {
+        // corrected parameters instead of ending its turn. Skip the nudge
+        // when the progress check fires (to avoid contradictory instructions)
+        // and after MAX_CONSECUTIVE_ERROR_NUDGES consecutive error turns
+        // (the error is likely unrecoverable at that point).
+        const hasToolError = toolResults.some(({ result }) => result.isError);
+        if (hasToolError) {
+          consecutiveErrorTurns++;
+        } else {
+          consecutiveErrorTurns = 0;
+        }
+        if (
+          hasToolError &&
+          !isProgressCheckTurn &&
+          consecutiveErrorTurns <= MAX_CONSECUTIVE_ERROR_NUDGES
+        ) {
           resultBlocks.push({
             type: "text",
-            text: "<system_notice>One or more tool calls returned an error. Do not end your turn or report the error to the user. Instead, analyze the error, fix the parameters, and retry the tool call. Only give up after multiple failed attempts.</system_notice>",
+            text: "<system_notice>One or more tool calls returned an error. If the error looks recoverable (e.g. missing or invalid parameters), fix the parameters and retry. If the error is clearly unrecoverable (e.g. a service is down, a resource does not exist, or a permission is permanently denied), report it to the user.</system_notice>",
           });
         }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -573,6 +573,15 @@ export class AgentLoop {
           });
         }
 
+        // When any tool returned an error, nudge the LLM to retry with
+        // corrected parameters instead of ending its turn.
+        if (toolResults.some(({ result }) => result.isError)) {
+          resultBlocks.push({
+            type: "text",
+            text: "<system_notice>One or more tool calls returned an error. Do not end your turn or report the error to the user. Instead, analyze the error, fix the parameters, and retry the tool call. Only give up after multiple failed attempts.</system_notice>",
+          });
+        }
+
         // Remind the LLM not to repeat text it already streamed
         if (hasTextBlock) {
           resultBlocks.push({

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -681,13 +681,24 @@ function countPersistedMessages(messages: Message[]): number {
   }).length;
 }
 
-/** A user message that contains ONLY tool_result blocks (no text or other content). */
+function isSystemNoticeBlock(block: ContentBlock): boolean {
+  if (block.type !== "text") return false;
+  const text = (block as { text?: string }).text ?? "";
+  return (
+    text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
+  );
+}
+
+/** A user message that contains ONLY tool_result blocks (no text or other content).
+ *  System notice text blocks (retry nudges, progress checks) do not count as user content. */
 function isToolResultOnly(message: Message): boolean {
   return (
     message.content.length > 0 &&
     message.content.every(
       (block) =>
-        block.type === "tool_result" || block.type === "web_search_tool_result",
+        block.type === "tool_result" ||
+        block.type === "web_search_tool_result" ||
+        isSystemNoticeBlock(block),
     )
   );
 }

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -29,6 +29,16 @@ function isToolResultBlock(
   );
 }
 
+function isSystemNoticeBlock(
+  block: ContentBlock | Record<string, unknown>,
+): boolean {
+  if (block.type !== "text") return false;
+  const text = (block as { text?: string }).text ?? "";
+  return (
+    text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
+  );
+}
+
 function isUndoableUserMessage(message: Message): boolean {
   if (message.role !== "user") return false;
   if (getSummaryFromContextMessage(message) != null) return false;
@@ -37,8 +47,9 @@ function isUndoableUserMessage(message: Message): boolean {
   // responses) are not undoable. Messages that have both tool_result and text blocks
   // (e.g. after repairHistory merges a tool_result turn with a user prompt) are still
   // undoable because they contain real user content.
+  // System notice text blocks (retry nudges, progress checks) are not user content.
   const hasNonToolResultContent = message.content.some(
-    (block) => !isToolResultBlock(block),
+    (block) => !isToolResultBlock(block) && !isSystemNoticeBlock(block),
   );
   if (!hasNonToolResultContent) return false;
   return true;

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -117,6 +117,8 @@ const ALLOWED_MIME_TYPES = new Set([
   "video/mpeg",
   // Documents
   "application/pdf",
+  "text/rtf",
+  "application/rtf",
   "text/plain",
   "text/csv",
   "text/markdown",

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -101,7 +101,11 @@ export function isLastUserMessageToolResult(conversationId: string): boolean {
       parsed.every(
         (block: Record<string, unknown>) =>
           block.type === "tool_result" ||
-          block.type === "web_search_tool_result",
+          block.type === "web_search_tool_result" ||
+          (block.type === "text" &&
+            typeof block.text === "string" &&
+            block.text.startsWith("<system_notice>") &&
+            block.text.endsWith("</system_notice>")),
       )
     ) {
       return true;


### PR DESCRIPTION
## Summary
- When a tool returns an error (e.g. `{"error":"name is required and must be a non-empty string"}`), the LLM would report the error to the user and end its turn instead of retrying
- Added a `system_notice` injection in the agent loop that fires when any tool result has `isError: true`, instructing the LLM to analyze the error, fix parameters, and retry
- The nudge only appears on turns with errors, so successful tool results are unaffected

## Test plan
- [x] Added test: `injects retry nudge system_notice when tool returns an error` — verifies the notice is present after error results and absent after successful ones
- [x] All 40 existing agent-loop tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
