### PR TITLE
fix: getMaskedProviderKey leaks full key for short keys

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -211,7 +211,7 @@ export async function getMaskedProviderKey(
   const maxVisible = Math.max(1, key.length - minHidden);
   const prefixLen = Math.min(10, maxVisible);
   const suffixLen = Math.min(4, Math.max(0, maxVisible - prefixLen));
-  return `${key.slice(0, prefixLen)}...${key.slice(-suffixLen || undefined)}`;
+  return `${key.slice(0, prefixLen)}...${suffixLen > 0 ? key.slice(-suffixLen) : ""}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-key-ux.md.

**Gap:** getMaskedProviderKey leaks full API key for short keys
**What was expected:** The masking function should always hide at least 3 characters
**What was found:** When suffixLen is 0 (keys <= 13 chars), `-0 || undefined` causes `key.slice(undefined)` which returns the full key

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
