### PR TITLE
fix: chat model picker hardcodes anthropic instead of selected provider

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -646,7 +646,7 @@ struct ActiveChatViewWrapper: View {
                 settingsStore.setModel(modelId)
             },
             selectedModel: settingsStore.selectedModel,
-            catalogModels: settingsStore.dynamicProviderModels("anthropic").map { (id: $0.id, name: $0.displayName) },
+            catalogModels: settingsStore.dynamicProviderModels(settingsStore.selectedInferenceProvider).map { (id: $0.id, name: $0.displayName) },
             configuredProviders: settingsStore.configuredProviders,
             assistantActivityPhase: viewModel.assistantActivityPhase,
             assistantActivityAnchor: viewModel.assistantActivityAnchor,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-key-ux.md.

**Gap:** Chat model picker in PanelCoordinator hardcodes "anthropic" instead of using selected provider
**What was expected:** The chat model picker should display models for the currently active inference provider
**What was found:** PanelCoordinator.swift hardcodes dynamicProviderModels("anthropic") so the in-chat model picker always shows Anthropic models

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
