### PR TITLE
fix: ModelListBubble uses hardcoded model constants instead of daemon catalog

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -164,7 +164,9 @@ struct ChatContentView: View {
     private func messageBubble(message: ChatMessage, index: Int, messages: [ChatMessage]) -> some View {
         if message.modelPicker != nil {
             ModelPickerBubble(
-                models: ModelListBubble.anthropicModels.map { (id: $0.model, name: $0.display) },
+                models: viewModel.providerCatalog
+                    .first { $0.id == "anthropic" }
+                    .map { $0.models.map { (id: $0.id, name: $0.displayName) } } ?? [],
                 selectedModelId: viewModel.selectedModel,
                 onSelect: { modelId in
                     viewModel.setModel(modelId)
@@ -176,7 +178,7 @@ struct ChatContentView: View {
                 removal: .opacity
             ))
         } else if message.modelList != nil {
-            ModelListBubble(currentModel: viewModel.selectedModel, configuredProviders: viewModel.configuredProviders)
+            ModelListBubble(currentModel: viewModel.selectedModel, configuredProviders: viewModel.configuredProviders, providerCatalog: viewModel.providerCatalog)
                 .id(message.id)
                 .transition(.asymmetric(
                     insertion: .move(edge: .bottom).combined(with: .opacity),

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -26,6 +26,7 @@ struct ChatView: View {
     var selectedModel: String = ""
     var catalogModels: [(id: String, name: String)] = []
     var configuredProviders: Set<String> = []
+    var providerCatalog: [ProviderCatalogEntry] = []
     let assistantActivityPhase: String
     let assistantActivityAnchor: String
     let assistantActivityReason: String?
@@ -226,6 +227,7 @@ struct ChatView: View {
                             selectedModel: selectedModel,
                             catalogModels: catalogModels,
                             configuredProviders: configuredProviders,
+                            providerCatalog: providerCatalog,
                             activeSubagents: activeSubagents,
                             dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                             onConfirmationAllow: onConfirmationAllow,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -81,6 +81,7 @@ struct MessageListView: View {
     let selectedModel: String
     let catalogModels: [(id: String, name: String)]
     let configuredProviders: Set<String>
+    let providerCatalog: [ProviderCatalogEntry]
     let activeSubagents: [SubagentInfo]
     let dismissedDocumentSurfaceIds: Set<String>
     let onConfirmationAllow: (String) -> Void
@@ -731,7 +732,8 @@ struct MessageListView: View {
                             subagentDetailStore: subagentDetailStore,
                             selectedModel: selectedModel,
                             catalogModels: catalogModels,
-                            configuredProviders: configuredProviders
+                            configuredProviders: configuredProviders,
+                            providerCatalog: providerCatalog
                         )
                         .equatable()
                     }
@@ -1311,6 +1313,8 @@ private struct MessageCellView: View, Equatable {
             && lhs.catalogModels.count == rhs.catalogModels.count
             && zip(lhs.catalogModels, rhs.catalogModels).allSatisfy({ $0.id == $1.id && $0.name == $1.name })
             && lhs.configuredProviders == rhs.configuredProviders
+            && lhs.providerCatalog.count == rhs.providerCatalog.count
+            && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.models.count == $1.models.count })
     }
 
     let message: ChatMessage
@@ -1354,6 +1358,7 @@ private struct MessageCellView: View, Equatable {
     let selectedModel: String
     let catalogModels: [(id: String, name: String)]
     let configuredProviders: Set<String>
+    let providerCatalog: [ProviderCatalogEntry]
 
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
@@ -1368,7 +1373,7 @@ private struct MessageCellView: View, Equatable {
     }
 
     private func modelListView(for msg: ChatMessage) -> some View {
-        ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders)
+        ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders, providerCatalog: providerCatalog)
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -648,6 +648,7 @@ struct ActiveChatViewWrapper: View {
             selectedModel: settingsStore.selectedModel,
             catalogModels: settingsStore.dynamicProviderModels("anthropic").map { (id: $0.id, name: $0.displayName) },
             configuredProviders: settingsStore.configuredProviders,
+            providerCatalog: settingsStore.providerCatalog,
             assistantActivityPhase: viewModel.assistantActivityPhase,
             assistantActivityAnchor: viewModel.assistantActivityAnchor,
             assistantActivityReason: viewModel.assistantActivityReason,

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -78,5 +78,7 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var selectedModel: String = "claude-opus-4-6"
     /// Set of provider keys with configured API keys, updated via `model_info` messages.
     @Published public var configuredProviders: Set<String> = ["anthropic"]
+    /// Full provider catalog from daemon, updated via `model_info` messages.
+    @Published public var providerCatalog: [ProviderCatalogEntry] = []
 
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1979,6 +1979,9 @@ extension ChatViewModel {
             if let providers = msg.configuredProviders {
                 configuredProviders = Set(providers)
             }
+            if let allProviders = msg.allProviders, !allProviders.isEmpty {
+                providerCatalog = allProviders
+            }
 
         case .memoryStatus(let status):
             // Log degradation state so developers can diagnose memory issues

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -313,6 +313,11 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.configuredProviders }
         set { messageManager.configuredProviders = newValue }
     }
+    /// Full provider catalog from daemon, updated via `model_info` messages.
+    public var providerCatalog: [ProviderCatalogEntry] {
+        get { messageManager.providerCatalog }
+        set { messageManager.providerCatalog = newValue }
+    }
 
     // MARK: - Forwarding properties — ChatAttachmentManager
 
@@ -1146,6 +1151,9 @@ public final class ChatViewModel: ObservableObject {
                 if let providers = info?.configuredProviders {
                     self.configuredProviders = Set(providers)
                 }
+                if let allProviders = info?.allProviders, !allProviders.isEmpty {
+                    self.providerCatalog = allProviders
+                }
             }
         }
 
@@ -1713,6 +1721,9 @@ public final class ChatViewModel: ObservableObject {
             }
             if let providers = info?.configuredProviders {
                 self.configuredProviders = Set(providers)
+            }
+            if let allProviders = info?.allProviders, !allProviders.isEmpty {
+                self.providerCatalog = allProviders
             }
         }
     }
@@ -2837,6 +2848,9 @@ public final class ChatViewModel: ObservableObject {
                 }
                 if let providers = info?.configuredProviders {
                     self.configuredProviders = Set(providers)
+                }
+                if let allProviders = info?.allProviders, !allProviders.isEmpty {
+                    self.providerCatalog = allProviders
                 }
             }
         }

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -9,42 +9,33 @@ public struct ModelListBubble: View {
     }
 
     struct ModelEntry: Identifiable {
-        let id: String // shortcut command
+        let id: String
         let displayName: String
         let isCurrent: Bool
     }
 
     let currentModel: String
     let configuredProviders: Set<String>
-
-    /// Anthropic model shortcuts, exposed for use by ModelPickerBubble on iOS.
-    public static let anthropicModels: [(cmd: String, model: String, display: String)] = [
-        ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
-        ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
-        ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
-    ]
-
-    private static let providerGroups: [(key: String, name: String, models: [(cmd: String, model: String, display: String)])] = [
-        ("anthropic", "Anthropic", anthropicModels),
-    ]
+    let providerCatalog: [ProviderCatalogEntry]
 
     private var groups: [ProviderGroup] {
-        Self.providerGroups.map { provider in
-            let hasKey = configuredProviders.contains(provider.key)
+        providerCatalog.map { provider in
+            let hasKey = configuredProviders.contains(provider.id)
             let entries = provider.models.map { m in
                 ModelEntry(
-                    id: m.cmd,
-                    displayName: m.display,
-                    isCurrent: currentModel == m.model
+                    id: m.id,
+                    displayName: m.displayName,
+                    isCurrent: currentModel == m.id
                 )
             }
-            return ProviderGroup(id: provider.key, name: provider.name, hasKey: hasKey, models: entries)
+            return ProviderGroup(id: provider.id, name: provider.displayName, hasKey: hasKey, models: entries)
         }
     }
 
-    public init(currentModel: String, configuredProviders: Set<String>) {
+    public init(currentModel: String, configuredProviders: Set<String>, providerCatalog: [ProviderCatalogEntry]) {
         self.currentModel = currentModel
         self.configuredProviders = configuredProviders
+        self.providerCatalog = providerCatalog
     }
 
     public var body: some View {
@@ -88,7 +79,7 @@ public struct ModelListBubble: View {
 
                         Spacer()
 
-                        Text("/\(model.id)")
+                        Text(model.id)
                             .font(VFont.monoSmall)
                             .foregroundColor(VColor.contentTertiary)
                     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-key-ux.md.

**Gap:** ModelListBubble.swift retains hardcoded static model constants
**What was expected:** All hardcoded provider/model constants should use daemon-driven data
**What was found:** ModelListBubble.swift has hardcoded anthropicModels and providerGroups statics, bypassing the daemon catalog

- Removed `static let anthropicModels` and `static let providerGroups` from ModelListBubble
- ModelListBubble now accepts `providerCatalog: [ProviderCatalogEntry]` and renders all providers dynamically
- Added `providerCatalog` to shared ChatMessageManager/ChatViewModel, populated from `model_info` responses
- Updated all callers (macOS MessageListView/ChatView/PanelCoordinator, iOS ChatContentView)
- iOS ModelPickerBubble now derives models from catalog instead of hardcoded statics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
