### PR TITLE
feat: add performance logging to SSE event parsing

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -852,6 +852,8 @@ public final class HTTPTransport {
     }
 
     private func parseSSEData(_ data: String) {
+        let byteCount = data.utf8.count
+        let start = CFAbsoluteTimeGetCurrent()
         var jsonString = data
         // Remap server conversation IDs to client-local conversation IDs via O(1) dictionary lookup
         if let conversationId = extractJsonStringValue(from: jsonString, key: "conversationId"),
@@ -893,6 +895,11 @@ public final class HTTPTransport {
                 let byteCount = jsonData.count
                 log.error("Failed to decode SSE event: \(error.localizedDescription), bytes: \(byteCount)")
             }
+        }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        if elapsed > 0.05 || byteCount > 100_000 {
+            log.warning("Slow SSE event: \(String(format: "%.1f", elapsed * 1000))ms, \(byteCount) bytes")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add timing + payload size instrumentation to `parseSSEData()` in `HTTPDaemonClient.swift`
- Logs a warning when SSE event processing takes >50ms or the payload exceeds 100KB
- Helps diagnose main-thread freezes caused by large SSE payloads (e.g. base64 image data)

## Original prompt
Add SSE event processing timing and payload size logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)