### PR TITLE
fix: handle missing conversations table in migration 009

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -22,11 +22,22 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
   run(_workspaceDir: string): void {
     const db = getDb();
 
-    const allConversations = db
-      .select()
-      .from(conversations)
-      .orderBy(asc(conversations.createdAt))
-      .all();
+    // On a fresh install the conversations table may not exist yet (DB schema
+    // migrations run after workspace migrations). Nothing to backfill in that
+    // case, so bail out gracefully.
+    let allConversations: (typeof conversations.$inferSelect)[];
+    try {
+      allConversations = db
+        .select()
+        .from(conversations)
+        .orderBy(asc(conversations.createdAt))
+        .all();
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message.includes("no such table")) {
+        return;
+      }
+      throw e;
+    }
 
     const total = allConversations.length;
     let processed = 0;
@@ -43,7 +54,9 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
           if (existing.updatedAt === expectedUpdatedAt) {
             processed++;
             if (processed % 50 === 0) {
-              log.info(`Backfilled ${processed}/${total} conversations to disk`);
+              log.info(
+                `Backfilled ${processed}/${total} conversations to disk`,
+              );
             }
             continue;
           }


### PR DESCRIPTION
## Summary
- On a fresh install, workspace migration 009 (`backfill-conversation-disk-view`) crashes with `SQLiteError: no such table: conversations` because workspace migrations run before DB schema migrations create the table.
- This prevents the daemon from starting entirely — the app shows a timeout screen and never connects.
- Wraps the query in a try/catch that returns early on "no such table", since there's nothing to backfill on a fresh database anyway.

## Test plan
- [ ] Fresh install: delete `~/.vellum/workspace/` and `~/.vellum.lock.json`, relaunch app, verify daemon starts successfully
- [ ] Existing install: verify migration is skipped (already checkpointed) and daemon starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
