### PR TITLE
feat: add performance logging to image decoding

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 #if os(macOS)
 import AppKit
 #elseif os(iOS)
@@ -896,12 +897,26 @@ public struct ToolCallData: Identifiable, Equatable {
     #if os(macOS)
     public static func decodeImage(from base64String: String?) -> NSImage? {
         guard let base64String, let data = Data(base64Encoded: base64String) else { return nil }
-        return NSImage(data: data)
+        let start = CFAbsoluteTimeGetCurrent()
+        let image = NSImage(data: data)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        if elapsed > 0.05 {
+            Logger(subsystem: Bundle.main.bundleIdentifier ?? "vellum", category: "ToolCallData")
+                .warning("Image decode took \(String(format: "%.1f", elapsed * 1000))ms, base64 size \(base64String.count)")
+        }
+        return image
     }
     #elseif os(iOS)
     public static func decodeImage(from base64String: String?) -> UIImage? {
         guard let base64String, let data = Data(base64Encoded: base64String) else { return nil }
-        return UIImage(data: data)
+        let start = CFAbsoluteTimeGetCurrent()
+        let image = UIImage(data: data)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        if elapsed > 0.05 {
+            Logger(subsystem: Bundle.main.bundleIdentifier ?? "vellum", category: "ToolCallData")
+                .warning("Image decode took \(String(format: "%.1f", elapsed * 1000))ms, base64 size \(base64String.count)")
+        }
+        return image
     }
     #else
     #error("Unsupported platform")


### PR DESCRIPTION
## Summary
- Add timing instrumentation to `ToolCallData.decodeImage()` in `ChatMessage.swift`
- Logs a warning when image decoding takes >50ms, including elapsed time and base64 size
- Helps diagnose main-thread freezes caused by decoding large images inline

## Original prompt
Add image decode timing logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
