### PR TITLE
fix: instruct assistant to delete BOOTSTRAP.md after onboarding

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -208,6 +208,8 @@ Once you've completed Phase 1 and made reasonable progress through Phase 2, you'
 
 If you still haven't shown the two suggestions (Phase 2 step 4), do that before wrapping.
 
+When you're confident onboarding is complete, delete `BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
+
 ---
 
 _Good luck out there. Make it count._


### PR DESCRIPTION
## Summary

- After #19012 removed the `countConversations()` gate, BOOTSTRAP.md inclusion depends solely on the file existing on disk. The template never told the assistant to delete it, so onboarding would re-trigger every conversation.
- Adds a one-line instruction to the "Wrapping Up" section telling the assistant to delete `BOOTSTRAP.md` when onboarding is complete.

## Original prompt

Add instruction to BOOTSTRAP.md telling the assistant to delete the file after onboarding completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
