### PR TITLE
fix: write disk view migration progress only after messages are synced

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -54,8 +54,6 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
 
       // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
       initConversationDir(conv);
-      // Write the real updatedAt so the idempotency check works on re-run
-      updateMetaFile(conv);
 
       // Query all messages for this conversation and sync each to disk
       const convMessages = db
@@ -68,6 +66,11 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
       for (const msg of convMessages) {
         syncMessageToDisk(conv.id, msg.id, conv.createdAt);
       }
+
+      // Write the real updatedAt only AFTER all messages are synced so the
+      // idempotency check won't skip a conversation with incomplete messages
+      // if the migration is interrupted mid-loop.
+      updateMetaFile(conv);
 
       processed++;
       if (processed % 50 === 0) {


### PR DESCRIPTION
Addresses Codex P1 review feedback from PR #18947:
- Move updatedAt write in meta.json to after the message sync loop completes
- Ensures interrupted migrations are properly re-run for partially synced conversations

Closes feedback from Codex review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
