### PR TITLE
fix: use lightweight existence check instead of full attachment hydration

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -16,7 +16,7 @@ import type {
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import {
   AttachmentUploadError,
-  getAttachmentById,
+  attachmentExists,
   linkAttachmentToMessage,
   uploadAttachment,
   validateAttachmentUpload,
@@ -368,7 +368,7 @@ export async function persistUserMessage(
         // attachments uploaded separately), link it directly without
         // re-uploading. This handles the case where data is empty because
         // the attachment content lives on disk.
-        if (a.id && getAttachmentById(a.id)) {
+        if (a.id && attachmentExists(a.id)) {
           linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
           continue;
         }

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -633,6 +633,20 @@ export function getAttachmentMetadataForMessage(
 }
 
 /**
+ * Lightweight existence check — queries only the attachment ID column
+ * without reading file contents from disk.
+ */
+export function attachmentExists(attachmentId: string): boolean {
+  const db = getDb();
+  const row = db
+    .select({ id: attachments.id })
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+  return !!row;
+}
+
+/**
  * Retrieve a single attachment by ID.
  */
 export function getAttachmentById(


### PR DESCRIPTION
Addresses review feedback from PR #18992 (both Codex and Devin):
- Add `attachmentExists()` function that queries DB without reading file contents
- Replace `getAttachmentById()` call in `conversation-messaging.ts` with `attachmentExists()`
- Avoids reading potentially 100MB+ files into memory just for a truthiness check

Closes feedback from Codex and Devin reviews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
