### PR TITLE
fix: restore isVideo guard for size-based data omission

### DIFF
--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -250,8 +250,10 @@ export async function resolveAssistantAttachments(
       }
       linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       const isVideo = draft.mimeType.startsWith("video/");
-      // All attachments are file-backed; omit large data from the event payload
-      const omitData = draft.dataBase64.length > MAX_INLINE_B64_SIZE;
+      // Only omit data for videos — they have an end-to-end lazy-load path
+      // via /v1/attachments/:id/content. Other types (images, PDFs) still need
+      // inline data for thumbnails, preview, and file-save in the client.
+      const omitData = isVideo && draft.dataBase64.length > MAX_INLINE_B64_SIZE;
 
       // Generate and persist a thumbnail for video attachments.
       let thumbnailData: string | undefined;


### PR DESCRIPTION
Addresses review feedback from PR #19005 (both Codex and Devin):
- Restore the isVideo condition for size-based data omission
- Only video attachments have lazy-load support in the client (InlineVideoAttachmentView)
- Without this guard, large images/PDFs render as non-functional file chips

Closes feedback from Codex and Devin reviews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
