### PR TITLE
fix(macos): repopulate cached line count when result changes while expanded

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -298,7 +298,11 @@ public struct ToolCallChip: View {
             cachedInputFull = nil
         }
         .onChange(of: toolCall.result) {
-            cachedResultLineCount = nil
+            if isExpanded, let result = toolCall.result {
+                cachedResultLineCount = Self.countLines(in: result)
+            } else {
+                cachedResultLineCount = nil
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses Devin review feedback from PR #19006:
- When result changes while expanded, repopulate cache instead of just invalidating
- Prevents fallthrough to uncached O(n) line count computation after result changes

Closes feedback from Devin review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
