### PR TITLE
docs: fix privacy note to say conversations are excluded from log exports

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -536,7 +536,7 @@ Each conversation is projected to a directory named `{id}_{isoDate}`:
 
 The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
 
-> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/` and are included in diagnostic log exports ("Send logs to Vellum"). The export applies a binary-file heuristic (skipping null-byte files) and a cumulative size cap, so large binary attachments are typically excluded, but text-based conversation metadata (`meta.json`) and message logs (`messages.jsonl`) will be included. Users should be aware that diagnostic exports may contain conversation content.
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/` and are **excluded** from diagnostic log exports ("Send logs to Vellum") via the `WORKSPACE_SKIP_DIRS` filter in `log-export-routes.ts`. Conversation metadata, message logs, and attachments are not sent to Vellum when users export logs.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
Addresses review feedback from PR #19009 (both Codex and Devin):
- Correct the privacy note in integrations.md to say conversations are EXCLUDED (not included)
- The same PR that added the note also added conversations to WORKSPACE_SKIP_DIRS

Closes feedback from Codex and Devin reviews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
