### PR TITLE
fix: sync origin channel and tool-result messages to conversation disk view

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -642,12 +642,21 @@ export async function handleMessageComplete(
       assistantMessageInterface:
         deps.turnInterfaceContext.assistantMessageInterface,
     };
-    await addMessage(
+    const toolResultMsg = await addMessage(
       deps.ctx.conversationId,
       "user",
       JSON.stringify(toolResultBlocks),
       toolResultMetadata,
     );
+    // Sync tool-result user message to disk view
+    const convForToolResult = getConversation(deps.ctx.conversationId);
+    if (convForToolResult) {
+      syncMessageToDisk(
+        deps.ctx.conversationId,
+        toolResultMsg.id,
+        convForToolResult.createdAt,
+      );
+    }
     for (const id of state.pendingToolResults.keys()) {
       state.persistedToolUseIds.add(id);
     }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -28,7 +28,10 @@ import {
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../memory/conversation-crud.js";
-import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
+import {
+  syncMessageToDisk,
+  updateMetaFile,
+} from "../memory/conversation-disk-view.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -354,6 +357,14 @@ export async function persistUserMessage(
         ctx.conversationId,
         turnIfCtx.userMessageInterface,
       );
+    }
+
+    // Rewrite meta.json so the on-disk metadata reflects the origin channel
+    if (turnCtx || turnIfCtx) {
+      const convForMeta = getConversation(ctx.conversationId);
+      if (convForMeta) {
+        updateMetaFile(convForMeta);
+      }
     }
 
     if (!persistedUserMessage.id) {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -35,12 +35,14 @@ import {
 } from "../memory/canonical-guardian-store.js";
 import {
   addMessage,
+  getConversation,
   getConversationMemoryScopeId,
   getConversationType,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
 } from "../memory/conversation-crud.js";
+import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
@@ -1137,6 +1139,21 @@ export class DaemonServer {
           log.warn(
             { err, conversationId },
             "Failed to set origin interface (best-effort)",
+          );
+        }
+      }
+
+      // Rewrite meta.json so the on-disk metadata reflects the origin channel
+      if (serverTurnCtx || serverInterfaceCtx) {
+        try {
+          const convForMeta = getConversation(conversationId);
+          if (convForMeta) {
+            updateMetaFile(convForMeta);
+          }
+        } catch (err) {
+          log.warn(
+            { err, conversationId },
+            "Failed to update disk meta (best-effort)",
           );
         }
       }


### PR DESCRIPTION
Addresses review feedback from PR #18943:
- Update meta.json when origin channel is established after conversation creation
- Sync tool-result user messages to disk JSONL alongside assistant messages

Closes feedback from Codex review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
