### PR TITLE
fix: scope getFilePathBySourcePath query to current conversation

### DIFF
--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -73,7 +73,7 @@ export async function run(
         // Fallback: if the source path is outside the sandbox (e.g. an image
         // attached from ~/Desktop), check if the attachment store has a
         // workspace-internal copy stored under its original source_path.
-        const storedPath = getFilePathBySourcePath(filePath);
+        const storedPath = getFilePathBySourcePath(filePath, context.conversationId);
         if (!storedPath) {
           errors.push(pathCheck.error);
           continue;

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -317,10 +317,18 @@ export function getSourcePathsForAttachments(
  * Returns the workspace-internal file path if found, or null otherwise.
  * Useful as a fallback when the original source_path is outside the sandbox.
  */
-export function getFilePathBySourcePath(sourcePath: string): string | null {
+export function getFilePathBySourcePath(
+  sourcePath: string,
+  conversationId: string,
+): string | null {
   const row = rawGet<{ file_path: string | null }>(
-    "SELECT file_path FROM attachments WHERE source_path = ? ORDER BY created_at DESC LIMIT 1",
+    `SELECT a.file_path FROM attachments a
+     JOIN message_attachments ma ON ma.attachment_id = a.id
+     JOIN messages m ON m.id = ma.message_id
+     WHERE a.source_path = ? AND m.conversation_id = ?
+     ORDER BY a.created_at DESC LIMIT 1`,
     sourcePath,
+    conversationId,
   );
   return row?.file_path ?? null;
 }


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #19010:
- Add conversationId parameter to getFilePathBySourcePath
- Join through message_attachments/messages to scope lookup to current conversation
- Prevents cross-conversation attachment leakage when same source path is reused

Closes feedback from Codex and Devin reviews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
