### PR TITLE
fix: forward maskedKeys from SSE model_info events to settings store

### DIFF
--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -80,5 +80,7 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var configuredProviders: Set<String> = ["anthropic"]
     /// Full provider catalog from daemon, updated via `model_info` messages.
     @Published public var providerCatalog: [ProviderCatalogEntry] = []
+    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x"), updated via `model_info` messages.
+    @Published public var providerMaskedKeys: [String: String] = [:]
 
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1982,6 +1982,9 @@ extension ChatViewModel {
             if let allProviders = msg.allProviders, !allProviders.isEmpty {
                 providerCatalog = allProviders
             }
+            if let maskedKeys = msg.maskedKeys {
+                providerMaskedKeys = maskedKeys
+            }
 
         case .memoryStatus(let status):
             // Log degradation state so developers can diagnose memory issues

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -318,6 +318,11 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.providerCatalog }
         set { messageManager.providerCatalog = newValue }
     }
+    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x"), updated via `model_info` messages.
+    public var providerMaskedKeys: [String: String] {
+        get { messageManager.providerMaskedKeys }
+        set { messageManager.providerMaskedKeys = newValue }
+    }
 
     // MARK: - Forwarding properties — ChatAttachmentManager
 
@@ -1154,6 +1159,9 @@ public final class ChatViewModel: ObservableObject {
                 if let allProviders = info?.allProviders, !allProviders.isEmpty {
                     self.providerCatalog = allProviders
                 }
+                if let maskedKeys = info?.maskedKeys {
+                    self.providerMaskedKeys = maskedKeys
+                }
             }
         }
 
@@ -1724,6 +1732,9 @@ public final class ChatViewModel: ObservableObject {
             }
             if let allProviders = info?.allProviders, !allProviders.isEmpty {
                 self.providerCatalog = allProviders
+            }
+            if let maskedKeys = info?.maskedKeys {
+                self.providerMaskedKeys = maskedKeys
             }
         }
     }
@@ -2851,6 +2862,9 @@ public final class ChatViewModel: ObservableObject {
                 }
                 if let allProviders = info?.allProviders, !allProviders.isEmpty {
                     self.providerCatalog = allProviders
+                }
+                if let maskedKeys = info?.maskedKeys {
+                    self.providerMaskedKeys = maskedKeys
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inference-key-ux.md.

**Gap:** SSE model_info handler does not forward maskedKeys
**What was expected:** maskedKeys from SSE events should update the settings store
**What was found:** Only providerCatalog was forwarded, maskedKeys was missing

- Added `providerMaskedKeys` property to `ChatMessageManager` following the `providerCatalog` pattern
- Added forwarding computed property to `ChatViewModel`
- Added `maskedKeys` forwarding in the `.modelInfo` SSE handler in `ChatViewModel+MessageHandling.swift`
- Also added `maskedKeys` forwarding in the 3 other REST response locations in `ChatViewModel.swift` for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
