### PR TITLE
fix: use standard Logger subsystem in image decode timing

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -901,7 +901,7 @@ public struct ToolCallData: Identifiable, Equatable {
         let image = NSImage(data: data)
         let elapsed = CFAbsoluteTimeGetCurrent() - start
         if elapsed > 0.05 {
-            Logger(subsystem: Bundle.main.bundleIdentifier ?? "vellum", category: "ToolCallData")
+            Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ToolCallData")
                 .warning("Image decode took \(String(format: "%.1f", elapsed * 1000))ms, base64 size \(base64String.count)")
         }
         return image
@@ -913,7 +913,7 @@ public struct ToolCallData: Identifiable, Equatable {
         let image = UIImage(data: data)
         let elapsed = CFAbsoluteTimeGetCurrent() - start
         if elapsed > 0.05 {
-            Logger(subsystem: Bundle.main.bundleIdentifier ?? "vellum", category: "ToolCallData")
+            Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ToolCallData")
                 .warning("Image decode took \(String(format: "%.1f", elapsed * 1000))ms, base64 size \(base64String.count)")
         }
         return image


### PR DESCRIPTION
Follow-up to #19024. Changes Logger fallback subsystem from "vellum" to "com.vellum.vellum-assistant" to match codebase convention.

Closes #19024 review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
