### PR TITLE
fix: use monotonic time and coalesce probes in stall detector

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -20,6 +20,7 @@ final class MainThreadStallDetector {
 
     private let queue = DispatchQueue(label: "com.vellum.stall-detector", qos: .utility)
     private var timer: DispatchSourceTimer?
+    private var probeInFlight = false
 
     private init() {}
 
@@ -35,11 +36,18 @@ final class MainThreadStallDetector {
     }
 
     private func ping() {
-        let scheduled = CFAbsoluteTimeGetCurrent()
+        guard !probeInFlight else { return }
+        probeInFlight = true
+        let scheduledNanos = DispatchTime.now().uptimeNanoseconds
         DispatchQueue.main.async { [weak self] in
-            let delay = CFAbsoluteTimeGetCurrent() - scheduled
+            guard let self else { return }
+            self.queue.async {
+                self.probeInFlight = false
+            }
+            let delayNanos = DispatchTime.now().uptimeNanoseconds - scheduledNanos
+            let delay = Double(delayNanos) / 1_000_000_000
             if delay > 1.0 {
-                self?.log.warning("Main thread stall detected: \(String(format: "%.1f", delay))s delay")
+                self.log.warning("Main thread stall detected: \(String(format: "%.1f", delay))s delay")
             }
         }
     }


### PR DESCRIPTION
Follow-up to #19025. Switches from CFAbsoluteTimeGetCurrent to monotonic DispatchTime and adds in-flight probe tracking to prevent queue buildup during stalls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
