### PR TITLE
fix: scope BOOTSTRAP.md deletion instruction to workspace path

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -208,7 +208,7 @@ Once you've completed Phase 1 and made reasonable progress through Phase 2, you'
 
 If you still haven't shown the two suggestions (Phase 2 step 4), do that before wrapping.
 
-When you're confident onboarding is complete, delete `BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
+When you're confident onboarding is complete, delete `~/.vellum/workspace/BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
 
 ---
 


### PR DESCRIPTION
Follow-up to #19026. Updates the onboarding cleanup instruction to reference the workspace-scoped path (`~/.vellum/workspace/BOOTSTRAP.md`) rather than a bare filename, preventing accidental deletion of unrelated files if the working directory changed during Phase 1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
