### PR TITLE
fix: clear messages.jsonl before retry in disk view migration

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { asc, eq } from "drizzle-orm";
@@ -54,6 +54,17 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
 
       // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
       initConversationDir(conv);
+
+      // Clear stale data from any previous interrupted run so the append-only
+      // syncMessageToDisk calls below don't produce duplicates.
+      const messagesPath = join(dirPath, "messages.jsonl");
+      if (existsSync(messagesPath)) {
+        rmSync(messagesPath);
+      }
+      const attachDir = join(dirPath, "attachments");
+      if (existsSync(attachDir)) {
+        rmSync(attachDir, { recursive: true, force: true });
+      }
 
       // Query all messages for this conversation and sync each to disk
       const convMessages = db


### PR DESCRIPTION
Follow-up to #19028. Ensures idempotent migration by clearing messages.jsonl (and attachments/) before re-syncing messages when the migration retries an interrupted conversation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
