### PR TITLE
fix: sort imports in conversation-messaging.ts

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -15,8 +15,8 @@ import type {
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import {
-  AttachmentUploadError,
   attachmentExists,
+  AttachmentUploadError,
   linkAttachmentToMessage,
   uploadAttachment,
   validateAttachmentUpload,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-messaging.ts` by sorting named imports alphabetically

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23275636190/job/67677945101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
