### PR TITLE
feat: add apiKeyUrl to provider catalog entries

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -247,6 +247,7 @@ export interface ModelInfo {
     displayName: string;
     models: Array<{ id: string; displayName: string }>;
     defaultModel: string;
+    apiKeyUrl?: string;
   }>;
   maskedKeys?: Record<string, string>;
 }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -32,6 +32,15 @@ export const PROVIDER_MODEL_CATALOG: Record<string, CatalogModel[]> = {
   ],
 };
 
+/** API key management URLs for inference providers (omit providers that don't require keys). */
+export const INFERENCE_PROVIDER_API_KEY_URLS: Record<string, string> = {
+  anthropic: "https://console.anthropic.com/settings/keys",
+  openai: "https://platform.openai.com/api-keys",
+  gemini: "https://aistudio.google.com/apikey",
+  fireworks: "https://fireworks.ai/account/api-keys",
+  openrouter: "https://openrouter.ai/keys",
+};
+
 /** Display names for inference providers */
 export const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   anthropic: "Anthropic",
@@ -47,6 +56,7 @@ export interface ProviderCatalogEntry {
   displayName: string;
   models: CatalogModel[];
   defaultModel: string;
+  apiKeyUrl?: string;
 }
 
 /** Build the full provider catalog with metadata for each inference provider. */
@@ -56,6 +66,7 @@ export function getFullProviderCatalog(): ProviderCatalogEntry[] {
     displayName: INFERENCE_PROVIDER_DISPLAY_NAMES[id] ?? id,
     models,
     defaultModel: models[0]?.id ?? "",
+    apiKeyUrl: INFERENCE_PROVIDER_API_KEY_URLS[id],
   }));
 }
 


### PR DESCRIPTION
## Summary
- Add `apiKeyUrl` optional field to `ProviderCatalogEntry` interface
- Add `INFERENCE_PROVIDER_API_KEY_URLS` constant with URLs for Anthropic, OpenAI, Gemini, Fireworks, and OpenRouter
- Wire `apiKeyUrl` into `getFullProviderCatalog()` and the `ModelInfo` message type

Part of plan: onboard-custom-provider.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
