### PR TITLE
fix: stop scroll-disrupting attachment warning deltas and image dedup

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -77,7 +77,6 @@ import {
 } from "./conversation-agent-loop-handlers.js";
 import {
   approveHostAttachmentRead,
-  formatAttachmentWarnings,
   resolveAssistantAttachments,
 } from "./conversation-attachments.js";
 import {
@@ -1578,17 +1577,6 @@ export async function runAgentLoopImpl(
 
       ctx.lastAssistantAttachments = assistantAttachments;
       ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
-
-      const warningText = formatAttachmentWarnings(
-        attachmentResult.directiveWarnings,
-      );
-      if (warningText) {
-        onEvent({
-          type: "assistant_text_delta",
-          text: warningText,
-          conversationId: ctx.conversationId,
-        });
-      }
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -108,12 +108,6 @@ export async function approveHostAttachmentRead(
   return isAllowDecision(response.decision);
 }
 
-export function formatAttachmentWarnings(warnings: string[]): string | null {
-  if (warnings.length === 0) return null;
-  const lines = warnings.map((warning) => `Attachment warning: ${warning}`);
-  return `\n\n${lines.join("\n")}`;
-}
-
 export interface AttachmentResolutionResult {
   assistantAttachments: AssistantAttachmentDraft[];
   emittedAttachments: UserMessageAttachment[];

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -389,8 +389,8 @@ struct ChatBubble: View {
                         .foregroundColor(isUser ? VColor.contentSecondary : VColor.contentSecondary)
                 }
 
-                // Skip image attachments when they all come from tool calls shown inline
-                if !partitioned.images.isEmpty && partitioned.images.count != inlineToolCallImageCount {
+                // Skip image attachments when tool calls already display images inline
+                if !partitioned.images.isEmpty && inlineToolCallImageCount == 0 {
                     attachmentImageGrid(partitioned.images)
                 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -247,9 +247,9 @@ extension ChatBubble {
         }
 
         // Attachments are not part of contentOrder but must still be rendered
-        // Skip image attachments when they all come from tool calls shown inline
+        // Skip image attachments when tool calls already display images inline
         let partitioned = partitionedAttachments
-        if !partitioned.images.isEmpty && partitioned.images.count != inlineToolCallImageCount {
+        if !partitioned.images.isEmpty && inlineToolCallImageCount == 0 {
             attachmentImageGrid(partitioned.images)
         }
         if !partitioned.videos.isEmpty {


### PR DESCRIPTION
## Summary
- Stop emitting attachment warnings as `assistant_text_delta` events after the response completes — these late text deltas triggered `streamingScrollTrigger` auto-scroll, yanking the viewport to the bottom while the user was reading
- Fix image attachment dedup: a multi-image tool call sets `cachedImage` on 1 tool call but generates N attachments, so the old count-equality check always failed — now suppresses the attachment grid entirely when inline tool call images exist
- Remove dead `formatAttachmentWarnings` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)