### PR TITLE
fix: update attachment warning test to match text delta removal

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1419,12 +1419,14 @@ describe("Conversation host attachment directives", () => {
         ),
       ).toBe(true);
 
+      // Attachment warnings are no longer emitted as assistant_text_delta events
+      // (see 9d39e70ae). They are only stored on ctx.lastAttachmentWarnings.
       const warningDelta = events.find(
         (e) =>
           e.type === "assistant_text_delta" &&
           e.text.includes("Attachment warning:"),
       );
-      expect(warningDelta).toBeDefined();
+      expect(warningDelta).toBeUndefined();
       const completion = events.find((e) => e.type === "message_complete");
       expect(completion).toBeDefined();
     } finally {


### PR DESCRIPTION
## Summary
- Updated the `"host attachment denial is non-fatal and emits warning text"` test in `conversation-queue.test.ts` to no longer expect an `assistant_text_delta` event for attachment warnings
- Commit 9d39e70ae intentionally stopped emitting these deltas, but the test was not updated, causing CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23275936611/job/67678877880

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
