### PR TITLE
fix: use defer for SSE parse timing to cover all exit paths

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -854,6 +854,12 @@ public final class HTTPTransport {
     private func parseSSEData(_ data: String) {
         let byteCount = data.utf8.count
         let start = CFAbsoluteTimeGetCurrent()
+        defer {
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            if elapsed > 0.05 || byteCount > 100_000 {
+                log.warning("Slow SSE event: \(String(format: "%.1f", elapsed * 1000))ms, \(byteCount) bytes")
+            }
+        }
         var jsonString = data
         // Remap server conversation IDs to client-local conversation IDs via O(1) dictionary lookup
         if let conversationId = extractJsonStringValue(from: jsonString, key: "conversationId"),
@@ -895,11 +901,6 @@ public final class HTTPTransport {
                 let byteCount = jsonData.count
                 log.error("Failed to decode SSE event: \(error.localizedDescription), bytes: \(byteCount)")
             }
-        }
-
-        let elapsed = CFAbsoluteTimeGetCurrent() - start
-        if elapsed > 0.05 || byteCount > 100_000 {
-            log.warning("Slow SSE event: \(String(format: "%.1f", elapsed * 1000))ms, \(byteCount) bytes")
         }
     }
 


### PR DESCRIPTION
Moves the slow/large-event warning into a defer block at the top of parseSSEData() so timing and size instrumentation fires on every exit path, including early returns from shouldIgnoreHostToolRequest and UTF-8 guard failures.

Addresses feedback from #19022.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
