### PR TITLE
fix: clear expansion pin flag on expiry regardless of scroll position

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -912,6 +912,14 @@ struct MessageListView: View {
                     } else {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
+                } else if scrollTracking.isPinningDuringExpansion {
+                    // User scrolled away during the pinning window — still clear
+                    // the flag once expired so avatar follower updates resume.
+                    let elapsed = CFAbsoluteTimeGetCurrent() - scrollTracking.expansionPinStartTime
+                    if elapsed > 0.25 {
+                        scrollTracking.isPinningDuringExpansion = false
+                        updateAvatarFollower(anchorY: scrollTracking.lastTailAnchorY)
+                    }
                 }
                 os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
             }


### PR DESCRIPTION
Adds a secondary expiration check that clears isPinningDuringExpansion after 250ms even when the user has scrolled away from the bottom, preventing stale avatar follower suppression. Still uses inline wall-clock check (no Task) to avoid the original infinite layout loop.

Addresses feedback from #19027.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
