### PR TITLE
fix: revert BOOTSTRAP.md to bare filename for auto-allow and multi-instance compat

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -208,7 +208,7 @@ Once you've completed Phase 1 and made reasonable progress through Phase 2, you'
 
 If you still haven't shown the two suggestions (Phase 2 step 4), do that before wrapping.
 
-When you're confident onboarding is complete, delete `~/.vellum/workspace/BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
+When you're confident onboarding is complete, delete `BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
 
 ---
 


### PR DESCRIPTION
Reverts the BOOTSTRAP.md deletion instruction to use bare filename `BOOTSTRAP.md` instead of hardcoded `~/.vellum/workspace/BOOTSTRAP.md`. The hardcoded path broke the auto-allow permission rule (rm with / is high-risk) and violated the multi-instance path invariant.

Addresses feedback from #19041.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
