### PR TITLE
fix: add force flag to rmSync in disk view migration

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -59,7 +59,7 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
       // syncMessageToDisk calls below don't produce duplicates.
       const messagesPath = join(dirPath, "messages.jsonl");
       if (existsSync(messagesPath)) {
-        rmSync(messagesPath);
+        rmSync(messagesPath, { force: true });
       }
       const attachDir = join(dirPath, "attachments");
       if (existsSync(attachDir)) {


### PR DESCRIPTION
Adds `{ force: true }` to the `rmSync(messagesPath)` call in the disk view migration so that unlink errors (permissions, race conditions, symlink mismatches) don't throw and abort daemon startup. Keeps the migration idempotent and best-effort.

Addresses feedback from #19042.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
