### PR TITLE
fix: pass error message context to retry handler to target correct message

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -218,7 +218,7 @@ struct ChatContentView: View {
                 onSurfaceRefetch: { surfaceId, conversationId in
                     viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
                 },
-                onRetryConversationError: message.isError ? { viewModel.retryAfterConversationError() } : nil
+                onRetryConversationError: message.isError ? { viewModel.retryAfterConversationError(messageId: message.id) } : nil
             )
             .id(message.id)
             .transition(.asymmetric(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -55,7 +55,8 @@ struct ChatView: View {
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
     /// Called when the user taps "Retry" on an inline conversation error.
-    var onRetryConversationError: (() -> Void)?
+    /// Receives the error message's ID so the handler can validate the retry target.
+    var onRetryConversationError: ((UUID) -> Void)?
     var subagentDetailStore: SubagentDetailStore
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -116,7 +116,8 @@ struct MessageListView: View {
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
     /// Called when the user taps "Retry" on an inline conversation error.
-    var onRetryConversationError: (() -> Void)?
+    /// Receives the error message's ID so the handler can validate the retry target.
+    var onRetryConversationError: ((UUID) -> Void)?
     var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Credits Exhausted (inline banner)
@@ -1371,7 +1372,8 @@ private struct MessageCellView: View, Equatable {
     /// Called when the user taps "Retry" on a per-message send failure.
     var onRetryFailedMessage: ((UUID) -> Void)?
     /// Called when the user taps "Retry" on an inline conversation error.
-    var onRetryConversationError: (() -> Void)?
+    /// Receives the error message's ID so the handler can validate the retry target.
+    var onRetryConversationError: ((UUID) -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
     var onModelPickerSelect: ((UUID, String) -> Void)?
@@ -1525,7 +1527,7 @@ private struct MessageCellView: View, Equatable {
                 onTemporaryAllow: onTemporaryAllow,
                 activeConfirmationRequestId: activePendingRequestId,
                 onRetryFailedMessage: onRetryFailedMessage,
-                onRetryConversationError: message.isError ? onRetryConversationError : nil,
+                onRetryConversationError: message.isError ? { onRetryConversationError?(message.id) } : nil,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -702,8 +702,8 @@ struct ActiveChatViewWrapper: View {
             onRetryFailedMessage: { messageId in
                 viewModel.retryFailedMessage(id: messageId)
             },
-            onRetryConversationError: {
-                viewModel.retryAfterConversationError()
+            onRetryConversationError: { messageId in
+                viewModel.retryAfterConversationError(messageId: messageId)
             },
             subagentDetailStore: viewModel.subagentDetailStore,
             resolveHttpPort: daemonClient.httpPortResolver,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2201,7 +2201,23 @@ public final class ChatViewModel: ObservableObject {
     /// Retry the last message after a conversation error, if the error is retryable.
     /// The error may live on the view model (toast path) or on the last inline error
     /// message (inline card path, where `conversationError` was already cleared).
-    public func retryAfterConversationError() {
+    ///
+    /// When `messageId` is provided (inline card path), the method validates that no
+    /// successful messages follow the target error — preventing the retry button on
+    /// an older error card from regenerating a newer, perfectly good response.
+    public func retryAfterConversationError(messageId: UUID? = nil) {
+        // When a specific message triggered the retry, validate that it is still
+        // at the tail of the conversation so the retry targets the correct turn.
+        if let messageId {
+            guard let targetIndex = messages.firstIndex(where: { $0.id == messageId }) else { return }
+            let target = messages[targetIndex]
+            guard target.isError else { return }
+            // Bail if any non-error messages follow — the conversation has moved on.
+            let hasSuccessfulFollowup = messages.suffix(from: messages.index(after: targetIndex))
+                .contains(where: { !$0.isError })
+            if hasSuccessfulFollowup { return }
+        }
+
         let error = conversationError ?? messages.last(where: { $0.isError })?.conversationError
         guard let error, error.isRetryable else { return }
         guard conversationId != nil else { return }


### PR DESCRIPTION
Updates retryAfterConversationError() to accept the specific error message, preventing the retry button on older error cards from regenerating the wrong (latest) message. Retry buttons remain visible on all error cards but now target the correct error.

Addresses feedback from #19038.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
