### PR TITLE
Remove unused INFERENCE_PROVIDER_DISPLAY_NAMES from model-catalog.ts

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -41,8 +41,7 @@ export const INFERENCE_PROVIDER_API_KEY_URLS: Record<string, string> = {
   openrouter: "https://openrouter.ai/keys",
 };
 
-/** Display names for inference providers */
-export const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   anthropic: "Anthropic",
   openai: "OpenAI",
   gemini: "Google Gemini",


### PR DESCRIPTION
## Summary
- Remove dead INFERENCE_PROVIDER_DISPLAY_NAMES export from model-catalog.ts — never imported anywhere in the codebase (Swift client has its own inferenceProviderDisplayNames dictionary). The constant is kept as a module-private variable since getFullProviderCatalog() references it internally.

Part of plan: custom-infer-followups.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
