### PR TITLE
Reduce redundant transcript bottom repins

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -557,7 +557,13 @@ struct MessageListView: View {
             // button flash) and does not reflect actual scroll position.
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard !Task.isCancelled else { return }
-            if anchorMessageId == nil && !hasReceivedScrollEvent {
+            if anchorMessageId == nil
+                && !hasReceivedScrollEvent
+                && MessageListBottomAnchorPolicy.needsRepin(
+                    anchorMinY: anchorTracker.lastMinY,
+                    viewportHeight: scrollViewportHeight
+                )
+            {
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 log.debug("Scroll restore: stage 2 (200ms) — retrying scrollTo")
             } else {
@@ -902,8 +908,14 @@ struct MessageListView: View {
                     if elapsed > 0.25 {
                         scrollTracking.isPinningDuringExpansion = false
                         updateAvatarFollower(anchorY: scrollTracking.lastTailAnchorY)
-                    } else {
+                    } else if MessageListBottomAnchorPolicy.needsRepin(
+                        anchorMinY: minY,
+                        viewportHeight: scrollViewportHeight
+                    ) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    } else {
+                        // Keep the pinning window alive, but don't issue a redundant
+                        // scrollTo once the bottom anchor is already back in view.
                     }
                 } else if scrollTracking.isPinningDuringExpansion {
                     // User scrolled away during the pinning window — still clear
@@ -1065,11 +1077,16 @@ struct MessageListView: View {
                             // If the task was cancelled during the sleep (user scrolled up), do not fire trailing-edge scroll.
                             guard !Task.isCancelled else { return }
                             if isNearBottom && !isSuppressingBottomScroll {
-                                if isLastMessageStreaming {
-                                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                                } else {
-                                    withAnimation(VAnimation.fast) {
+                                if MessageListBottomAnchorPolicy.needsRepin(
+                                    anchorMinY: anchorTracker.lastMinY,
+                                    viewportHeight: scrollViewportHeight
+                                ) {
+                                    if isLastMessageStreaming {
                                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                    } else {
+                                        withAnimation(VAnimation.fast) {
+                                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                        }
                                     }
                                 }
                             }
@@ -1152,7 +1169,12 @@ struct MessageListView: View {
                         // Pin to bottom without animation to avoid visual bounce.
                         // Skip when an anchor is pending (deep-link / notification)
                         // to avoid yanking the viewport away from the target message.
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        if MessageListBottomAnchorPolicy.needsRepin(
+                            anchorMinY: anchorTracker.lastMinY,
+                            viewportHeight: scrollViewportHeight
+                        ) {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
                     }
                     // If not near bottom or anchor is set, preserve viewport.
                 }
@@ -1654,6 +1676,22 @@ private struct AnchorMinYKey: PreferenceKey {
         // Use min so sibling views in the LazyVStack (which report the default
         // value of .infinity) don't overwrite the anchor's actual Y position.
         value = min(value, nextValue())
+    }
+}
+
+/// Centralizes the "do we still need to scroll?" check for bottom-pinning
+/// paths so expansion/streaming guards stop once the tail anchor re-enters
+/// the viewport.
+enum MessageListBottomAnchorPolicy {
+    static let repinTolerance: CGFloat = 2
+
+    static func needsRepin(
+        anchorMinY: CGFloat,
+        viewportHeight: CGFloat,
+        tolerance: CGFloat = repinTolerance
+    ) -> Bool {
+        guard anchorMinY.isFinite, viewportHeight.isFinite else { return true }
+        return anchorMinY > viewportHeight + tolerance
     }
 }
 

--- a/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class MessageListBottomAnchorPolicyTests: XCTestCase {
+    func testNeedsRepinWhenAnchorFallsBelowViewport() {
+        XCTAssertTrue(
+            MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: 540,
+                viewportHeight: 500
+            )
+        )
+    }
+
+    func testDoesNotRepinWhenAnchorAlreadyWithinTolerance() {
+        XCTAssertFalse(
+            MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: 500.5,
+                viewportHeight: 500
+            )
+        )
+        XCTAssertFalse(
+            MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: 502,
+                viewportHeight: 500
+            )
+        )
+    }
+
+    func testUnknownGeometryDefaultsToRepin() {
+        XCTAssertTrue(
+            MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: .infinity,
+                viewportHeight: 500
+            )
+        )
+        XCTAssertTrue(
+            MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: 500,
+                viewportHeight: .infinity
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- centralize the chat bottom-anchor repin check so restore, expansion, streaming, and resize paths stop once the tail anchor is already visible
- avoid redundant transcript `scrollTo` retries that were likely feeding scroll-triggered render churn in image-heavy conversations
- add focused macOS tests for the bottom-anchor repin policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)