### PR TITLE
Add missing routing refresh to setInferenceProvider and fix tombstone restoration on key validation failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -824,6 +824,7 @@ public final class SettingsStore: ObservableObject {
                 if !result.isTransient {
                     // Definitive validation failure — revert optimistic local state
                     APIKeyManager.deleteKey(for: provider)
+                    addDeletionTombstone(type: "api_key", name: provider)
                 }
             }
         }
@@ -2365,6 +2366,7 @@ public final class SettingsStore: ObservableObject {
         } catch {
             log.error("Failed to persist inference provider: \(error.localizedDescription)")
         }
+        scheduleRoutingSourceRefresh()
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the


### PR DESCRIPTION
## Summary
- Add scheduleRoutingSourceRefresh() call to setInferenceProvider, matching the pattern used by setWebSearchProvider and other analogous methods
- Restore deletion tombstone in saveInferenceAPIKey when validation fails definitively, preventing stale keys on daemon after offline clear + failed re-save

Part of plan: custom-infer-followups.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
