### PR TITLE
Add access count sorting for memories

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -347,6 +347,40 @@ describe("Memory Item Routes", () => {
       expect(body.items[1].id).toBe("i1");
     });
 
+    test("supports sort by accessCount descending", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+      });
+      insertItem({
+        id: "i2",
+        kind: "preference",
+        subject: "s2",
+        statement: "st2",
+      });
+
+      getDb()
+        .update(memoryItems)
+        .set({ accessCount: 2 })
+        .where(eq(memoryItems.id, "i1"))
+        .run();
+      getDb()
+        .update(memoryItems)
+        .set({ accessCount: 7 })
+        .where(eq(memoryItems.id, "i2"))
+        .run();
+
+      const ctx = makeCtx({ sort: "accessCount", order: "desc" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+      };
+      expect(body.items[0].id).toBe("i2");
+      expect(body.items[1].id).toBe("i1");
+    });
+
     test("rejects invalid kind filter", async () => {
       const ctx = makeCtx({ kind: "bogus" });
       const res = await handler(ctx);

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -37,6 +37,7 @@ type MemoryItemKind = (typeof VALID_KINDS)[number];
 const VALID_SORT_FIELDS = [
   "lastSeenAt",
   "importance",
+  "accessCount",
   "kind",
   "firstSeenAt",
 ] as const;
@@ -46,6 +47,7 @@ type SortField = (typeof VALID_SORT_FIELDS)[number];
 const SORT_COLUMN_MAP = {
   lastSeenAt: memoryItems.lastSeenAt,
   importance: memoryItems.importance,
+  accessCount: memoryItems.accessCount,
   kind: memoryItems.kind,
   firstSeenAt: memoryItems.firstSeenAt,
 } as const;

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -7,19 +7,21 @@ private enum MemorySortOption: String, CaseIterable {
     case newest = "Newest"
     case oldest = "Oldest"
     case importance = "Importance"
+    case accessCount = "Access Count"
     case kind = "Kind"
 
     var sortField: String {
         switch self {
         case .newest, .oldest: return "lastSeenAt"
         case .importance: return "importance"
+        case .accessCount: return "accessCount"
         case .kind: return "kind"
         }
     }
 
     var sortOrder: String {
         switch self {
-        case .newest, .importance: return "desc"
+        case .newest, .importance, .accessCount: return "desc"
         case .oldest, .kind: return "asc"
         }
     }
@@ -218,4 +220,3 @@ struct MemoriesPanel: View {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- Add an `Access Count` sort option to the macOS memories panel so users can order memories by how often they have been used.
- Allow the memory-items API to accept `sort=accessCount` and cover the new server-side ordering path with a regression test.
- Apple refs checked (2026-03-19): https://developer.apple.com/documentation/swiftui/picker, https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:) 

## Original prompt
Add the ability to sort by access count

🤖 Generated with [Claude Code](https://claude.com/claude-code)