### PR TITLE
fix: graceful /model deprecation and cleanup of stale references

### DIFF
--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -2,7 +2,7 @@
  * Tests for slash command interception in the POST /v1/messages handler.
  *
  * Validates that:
- * - Built-in slash commands (/status, /model, /commands) are intercepted and
+ * - Built-in slash commands (/status, /models, /commands) are intercepted and
  *   do NOT trigger the agent loop.
  * - Regular messages pass through to the agent loop unchanged.
  */
@@ -122,12 +122,7 @@ mock.module("../daemon/conversation-process.js", () => ({
     configuredProviders: ["anthropic", "ollama"],
   }),
   isModelSlashCommand: (content: string) => {
-    const trimmed = content.trim();
-    return (
-      trimmed === "/model" ||
-      trimmed === "/models" ||
-      trimmed.startsWith("/model ")
-    );
+    return content.trim() === "/models";
   },
 }));
 

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -49,14 +49,9 @@ export async function buildModelInfoEvent(): Promise<ServerMessage> {
   return { type: "model_info", ...(await getModelInfo()) };
 }
 
-/** True when the trimmed content is a /model or /models slash command. */
+/** True when the trimmed content is the /models slash command. */
 export function isModelSlashCommand(content: string): boolean {
-  const trimmed = content.trim();
-  return (
-    trimmed === "/model" ||
-    trimmed === "/models" ||
-    trimmed.startsWith("/model ")
-  );
+  return content.trim() === "/models";
 }
 
 // ── Context Interface ────────────────────────────────────────────────

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -144,8 +144,21 @@ export async function resolveSlash(
   content: string,
   context?: SlashContext,
 ): Promise<SlashResolution> {
+  // Handle deprecated /model command — direct users to Settings
+  const trimmed = content.trim();
+  if (
+    trimmed === "/model" ||
+    (trimmed.startsWith("/model ") && trimmed !== "/models")
+  ) {
+    return {
+      kind: "unknown",
+      message:
+        "The `/model` command has been removed. Use **Settings → Models & Services** to change your model and provider.",
+    };
+  }
+
   // Handle /models command (read-only listing)
-  if (content.trim() === "/models") {
+  if (trimmed === "/models") {
     return await resolveModelList();
   }
 
@@ -154,7 +167,7 @@ export async function resolveSlash(
   if (pairResult) return pairResult;
 
   // Handle /status command
-  if (content.trim() === "/status") {
+  if (trimmed === "/status") {
     if (!context) {
       return {
         kind: "unknown",
@@ -165,7 +178,7 @@ export async function resolveSlash(
   }
 
   // Handle /commands command
-  if (content.trim() === "/commands") {
+  if (trimmed === "/commands") {
     const lines = [
       "/commands — List all available commands",
       "/models — List all available models",

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -456,9 +456,7 @@ extension ChatViewModel {
         } else {
             // No existing assistant message — create a new one (first text delta)
             var msg = ChatMessage(role: .assistant, text: buffered, isStreaming: true)
-            if currentTurnUserText == "/model" {
-                msg.modelPicker = ModelPickerData()
-            } else if currentTurnUserText == "/models" {
+            if currentTurnUserText == "/models" {
                 msg.modelList = ModelListData()
             } else if currentTurnUserText == "/commands" {
                 msg.commandList = CommandListData()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2849,17 +2849,14 @@ public final class ChatViewModel: ObservableObject {
             activeSubagents.append(info)
         }
 
-        // Tag assistant messages that follow "/model" or "/models" user messages
-        // so the client renders the picker/table UI instead of plain text.
+        // Tag assistant messages that follow "/models" user messages
+        // so the client renders the table UI instead of plain text.
         var hasModelCommand = false
         for i in chatMessages.indices {
             guard chatMessages[i].role == .user,
                   i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant else { continue }
             let userText = chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if userText == "/model" {
-                chatMessages[i + 1].modelPicker = ModelPickerData()
-                hasModelCommand = true
-            } else if userText == "/models" {
+            if userText == "/models" {
                 chatMessages[i + 1].modelList = ModelListData()
                 hasModelCommand = true
             } else if userText == "/commands" {

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -8,7 +8,6 @@ public struct CommandListBubble: View {
 
     private let commands: [CommandEntry] = [
         CommandEntry(id: "/commands", description: "Show this list"),
-        CommandEntry(id: "/model", description: "Show or switch the current model"),
         CommandEntry(id: "/models", description: "List all available models"),
     ]
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for custom-infer-followups.md.

- Add deprecation handler for /model in resolveSlash — returns helpful message instead of passing through to LLM
- Remove model picker overlay logic for /model from Swift client (ChatViewModel, ChatViewModel+MessageHandling)
- Remove /model entry from CommandListBubble
- Simplify isModelSlashCommand to only match /models
- Update test comment and mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
