### PR TITLE
refactor: move integrations/oauth/start endpoint to oauth/start

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -436,7 +436,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "dictation", scopes: ["chat.write"] },
 
   // OAuth / integrations
-  { endpoint: "integrations/oauth/start", scopes: ["settings.write"] },
+  { endpoint: "oauth/start", scopes: ["settings.write"] },
 
   // Ingress config
   { endpoint: "integrations/ingress/config:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -645,9 +645,9 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
 
     // OAuth connect
     {
-      endpoint: "integrations/oauth/start",
+      endpoint: "oauth/start",
       method: "POST",
-      policyKey: "integrations/oauth/start",
+      policyKey: "oauth/start",
       handler: async ({ req }) => {
         const body = (await req.json()) as {
           service?: string;

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -461,7 +461,7 @@ public final class HTTPTransport {
             return ("/v1/tools/simulate-permission", nil)
         // Integrations
         case .integrationsOAuthStart:
-            return ("/v1/integrations/oauth/start", nil)
+            return ("/v1/oauth/start", nil)
         case .integrationsVercelConfig:
             return ("/v1/integrations/vercel/config", nil)
         case .integrationsIngressConfig:
@@ -595,7 +595,7 @@ public final class HTTPTransport {
             return ("\(prefix)/tools/simulate-permission/", nil)
         // Integrations
         case .integrationsOAuthStart:
-            return ("\(prefix)/integrations/oauth/start/", nil)
+            return ("\(prefix)/oauth/start/", nil)
         case .integrationsVercelConfig:
             return ("\(prefix)/integrations/vercel/config/", nil)
         case .integrationsIngressConfig:


### PR DESCRIPTION
## Summary
- Migrate the BYO OAuth connect start endpoint from `integrations/oauth/start` to `oauth/start`
- Update runtime route, auth policy, and Swift client to use the new path
- Prepares a clean `oauth/` namespace for upcoming OAuth app CRUD endpoints

Part of plan: your-own-google-oauth.md (PR 0 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
