### PR TITLE
fix: make conversation disk-view folders timestamp-first

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -520,11 +520,11 @@ The conversation disk view projects conversation metadata, messages, and attachm
 
 ### Directory Layout
 
-Each conversation is projected to a directory named `{id}_{isoDate}`:
+Each conversation is projected to a directory named `{isoDate}_{id}`:
 
 ```
 ~/.vellum/workspace/conversations/
-  abc123_2025-01-15T10-30-00.000Z/
+  2025-01-15T10-30-00.000Z_abc123/
     meta.json             # Conversation metadata (id, title, type, channel, timestamps)
     messages.jsonl        # Flattened message log (one JSON object per line)
     attachments/          # Decoded attachment files (original filenames, collision-safe)

--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -124,6 +124,9 @@ describe("createConversation → disk view", () => {
 
     const dirPath = getConversationDirPath(conv.id, conv.createdAt);
     expect(existsSync(dirPath)).toBe(true);
+    expect(readdirSync(conversationsDir)).toEqual([
+      `${new Date(conv.createdAt).toISOString().replace(/:/g, "-")}_${conv.id}`,
+    ]);
 
     const metaPath = join(dirPath, "meta.json");
     expect(existsSync(metaPath)).toBe(true);

--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -99,14 +99,14 @@ describe("getConversationDirName", () => {
     // 2026-03-18T14:23:00.000Z
     const ts = new Date("2026-03-18T14:23:00.000Z").getTime();
     const name = getConversationDirName("abc123", ts);
-    expect(name).toBe("abc123_2026-03-18T14-23-00.000Z");
+    expect(name).toBe("2026-03-18T14-23-00.000Z_abc123");
     // No colons in the name (safe for Windows/macOS/Linux)
     expect(name).not.toContain(":");
   });
 
   test("handles epoch zero", () => {
     const name = getConversationDirName("conv0", 0);
-    expect(name).toBe("conv0_1970-01-01T00-00-00.000Z");
+    expect(name).toBe("1970-01-01T00-00-00.000Z_conv0");
   });
 });
 
@@ -119,7 +119,7 @@ describe("getConversationDirPath", () => {
     const ts = Date.now();
     const dirPath = getConversationDirPath("test-id", ts);
     expect(dirPath.startsWith(conversationsDir)).toBe(true);
-    expect(dirPath).toContain("test-id_");
+    expect(dirPath).toContain("_test-id");
   });
 });
 

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -33,17 +33,20 @@ const log = getLogger("conversation-disk-view");
 // Directory helpers
 // ---------------------------------------------------------------------------
 
+function getConversationDirTimestamp(createdAtMs: number): string {
+  return new Date(createdAtMs).toISOString().replace(/:/g, "-");
+}
+
 /**
  * Build a filesystem-safe directory name for a conversation.
- * Format: `{id}_{isoDate}` where colons in the ISO date are replaced with
+ * Format: `{isoDate}_{id}` where colons in the ISO date are replaced with
  * hyphens so the name is valid on all platforms (Windows forbids colons).
  */
 export function getConversationDirName(
   id: string,
   createdAtMs: number,
 ): string {
-  const isoDate = new Date(createdAtMs).toISOString().replace(/:/g, "-");
-  return `${id}_${isoDate}`;
+  return `${getConversationDirTimestamp(createdAtMs)}_${id}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- switch conversation disk-view folder names from `id_timestamp` to `timestamp_id`
- update disk-view tests to assert the new folder naming convention
- refresh the architecture doc example for the on-disk conversation layout

## Original prompt
[$do](/Users/sidd/vocify/claude-skills/skills/do/SKILL.md) Let's reverse the order of the conversation folder name so the timestamp comes first, then the id

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
