### PR TITLE
Add conversation disk-view paths to workspace context

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -79,6 +79,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getMessages: () => [],
   getConversation: () => ({
     id: "conv-1",
+    createdAt: Date.parse("2026-03-19T12:00:00.000Z"),
     contextSummary: null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null,
@@ -223,6 +224,12 @@ describe("Conversation workspace cache state", () => {
     );
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
       "</workspace_top_level>",
+    );
+    expect(conversation.getWorkspaceTopLevelContext()!).toContain(
+      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
+    );
+    expect(conversation.getWorkspaceTopLevelContext()!).toContain(
+      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
     );
   });
 

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -115,6 +115,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getMessages: () => [],
   getConversation: () => ({
     id: "conv-1",
+    createdAt: Date.parse("2026-03-19T12:00:00.000Z"),
     contextSummary: null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null,
@@ -312,6 +313,12 @@ describe("Conversation workspace injection", () => {
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     const text = messageText(runtimeUser);
     expect(text).toContain("Root: /tmp");
+    expect(text).toContain(
+      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
+    );
+    expect(text).toContain(
+      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+    );
   });
 
   test("workspace context is prepended before user text", async () => {

--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -123,4 +123,26 @@ describe("renderWorkspaceTopLevelContext", () => {
     expect(result).toContain("Directories: ");
     expect(result).toContain("Files: a.txt, b.txt");
   });
+
+  test("renders current conversation and attachment paths when provided", () => {
+    const snapshot: TopLevelSnapshot = {
+      rootPath: "/sandbox",
+      directories: ["src"],
+      files: ["package.json"],
+      truncated: false,
+    };
+
+    const result = renderWorkspaceTopLevelContext(snapshot, {
+      currentConversationPath: "conversations/conv-1_2026-03-19T12-00-00.000Z/",
+      currentConversationAttachmentsPath:
+        "conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+    });
+
+    expect(result).toContain(
+      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
+    );
+    expect(result).toContain(
+      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+    );
+  });
 });

--- a/assistant/src/daemon/conversation-workspace.ts
+++ b/assistant/src/daemon/conversation-workspace.ts
@@ -1,3 +1,5 @@
+import { getConversation } from "../memory/conversation-crud.js";
+import { getConversationDirName } from "../memory/conversation-disk-view.js";
 import { renderWorkspaceTopLevelContext } from "../workspace/top-level-renderer.js";
 import { scanTopLevelDirectories } from "../workspace/top-level-scanner.js";
 
@@ -5,6 +7,7 @@ import { scanTopLevelDirectories } from "../workspace/top-level-scanner.js";
  * Subset of Conversation state that workspace context helpers need.
  */
 export interface WorkspaceConversationContext {
+  conversationId: string;
   workingDir: string;
   workspaceTopLevelContext: string | null;
   workspaceTopLevelDirty: boolean;
@@ -17,6 +20,16 @@ export function refreshWorkspaceTopLevelContextIfNeeded(
   if (!ctx.workspaceTopLevelDirty && ctx.workspaceTopLevelContext != null)
     return;
   const snapshot = scanTopLevelDirectories(ctx.workingDir);
-  ctx.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot);
+  const conversation = getConversation(ctx.conversationId);
+  const currentConversationPath =
+    conversation && typeof conversation.createdAt === "number"
+      ? `conversations/${getConversationDirName(conversation.id, conversation.createdAt)}/`
+      : null;
+  ctx.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot, {
+    currentConversationPath,
+    currentConversationAttachmentsPath: currentConversationPath
+      ? `${currentConversationPath}attachments/`
+      : null,
+  });
   ctx.workspaceTopLevelDirty = false;
 }

--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -1,5 +1,10 @@
 import type { TopLevelSnapshot } from "./top-level-scanner.js";
 
+export interface WorkspaceTopLevelRenderOptions {
+  currentConversationPath?: string | null;
+  currentConversationAttachmentsPath?: string | null;
+}
+
 /**
  * Render a workspace top-level snapshot into a compact XML-like block
  * suitable for injection into user messages.
@@ -8,11 +13,18 @@ import type { TopLevelSnapshot } from "./top-level-scanner.js";
  */
 export function renderWorkspaceTopLevelContext(
   snapshot: TopLevelSnapshot,
+  options: WorkspaceTopLevelRenderOptions = {},
 ): string {
   const lines: string[] = ["<workspace_top_level>"];
   lines.push(`Root: ${snapshot.rootPath}`);
   lines.push(`Directories: ${snapshot.directories.join(", ")}`);
   lines.push(`Files: ${snapshot.files.join(", ")}`);
+  if (options.currentConversationPath) {
+    lines.push(`Current conversation folder: ${options.currentConversationPath}`);
+  }
+  if (options.currentConversationAttachmentsPath) {
+    lines.push(`Attachment files: ${options.currentConversationAttachmentsPath}`);
+  }
   if (snapshot.truncated) {
     lines.push("(list truncated — more entries exist)");
   }


### PR DESCRIPTION
## Summary
- include the current conversation's disk-view folder in the injected `<workspace_top_level>` context block
- add an explicit attachment path for that conversation so the assistant knows where to look for conversation files
- cover the new prompt text in renderer and workspace injection tests

## Original prompt
In the injected user context message, let's add the worksapce local path to the folder of the current conversation (e.g. `conversations/<conversation>/`) and note that attachments can be found at `conversations/<conversation>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
