### PR TITLE
fix: align workspace path tests with timestamp-first conversation dirs

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { getConversationDirName } from "../memory/conversation-disk-view.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -198,6 +199,13 @@ function makeConversation(): Conversation {
   );
 }
 
+const conversationDirName = getConversationDirName(
+  "conv-1",
+  Date.parse("2026-03-19T12:00:00.000Z"),
+);
+const conversationPath = `conversations/${conversationDirName}/`;
+const conversationAttachmentsPath = `${conversationPath}attachments/`;
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -226,10 +234,10 @@ describe("Conversation workspace cache state", () => {
       "</workspace_top_level>",
     );
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
+      `Current conversation folder: ${conversationPath}`,
     );
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+      `Attachment files: ${conversationAttachmentsPath}`,
     );
   });
 

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { getConversationDirName } from "../memory/conversation-disk-view.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -278,6 +279,13 @@ function messageText(message: Message): string {
     .join("\n");
 }
 
+const conversationDirName = getConversationDirName(
+  "conv-1",
+  Date.parse("2026-03-19T12:00:00.000Z"),
+);
+const conversationPath = `conversations/${conversationDirName}/`;
+const conversationAttachmentsPath = `${conversationPath}attachments/`;
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -313,12 +321,8 @@ describe("Conversation workspace injection", () => {
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     const text = messageText(runtimeUser);
     expect(text).toContain("Root: /tmp");
-    expect(text).toContain(
-      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
-    );
-    expect(text).toContain(
-      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
-    );
+    expect(text).toContain(`Current conversation folder: ${conversationPath}`);
+    expect(text).toContain(`Attachment files: ${conversationAttachmentsPath}`);
   });
 
   test("workspace context is prepended before user text", async () => {

--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -133,16 +133,16 @@ describe("renderWorkspaceTopLevelContext", () => {
     };
 
     const result = renderWorkspaceTopLevelContext(snapshot, {
-      currentConversationPath: "conversations/conv-1_2026-03-19T12-00-00.000Z/",
+      currentConversationPath: "conversations/2026-03-19T12-00-00.000Z_conv-1/",
       currentConversationAttachmentsPath:
-        "conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+        "conversations/2026-03-19T12-00-00.000Z_conv-1/attachments/",
     });
 
     expect(result).toContain(
-      "Current conversation folder: conversations/conv-1_2026-03-19T12-00-00.000Z/",
+      "Current conversation folder: conversations/2026-03-19T12-00-00.000Z_conv-1/",
     );
     expect(result).toContain(
-      "Attachment files: conversations/conv-1_2026-03-19T12-00-00.000Z/attachments/",
+      "Attachment files: conversations/2026-03-19T12-00-00.000Z_conv-1/attachments/",
     );
   });
 });


### PR DESCRIPTION
## Summary
- align stale workspace-context tests with the timestamp-first conversation disk-view directory format
- derive expected conversation paths from `getConversationDirName()` in workspace tests so future naming changes stay in sync
- update the renderer fixture strings to match the current conversation attachment path format

## Original prompt
https://github.com/vellum-ai/vellum-assistant/actions/runs/23276887389/job/67681698296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
