### PR TITLE
refactor: move custom-inference-provider flag from assistant to macos scope

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -381,7 +381,6 @@ struct SettingsPanel: View {
             InferenceServiceCard(
                 store: store,
                 authManager: authManager,
-                assistantFeatureFlagStore: assistantFeatureFlagStore,
                 apiKeyText: $apiKeyText,
                 showToast: showToast
             )

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -16,13 +16,7 @@ struct APIKeyEntryStepView: View {
     // MARK: - Feature Flag
 
     private var isCustomProviderEnabled: Bool {
-        let config = WorkspaceConfigIO.read()
-        guard let featureFlags = config["feature_flags"] as? [String: Any],
-              let customProvider = featureFlags["custom-inference-provider"] as? [String: Any],
-              let enabled = customProvider["enabled"] as? Bool else {
-            return false  // default is false per the registry
-        }
-        return enabled
+        MacOSClientFeatureFlagManager.shared.isEnabled("custom_inference_provider_enabled")
     }
 
     // MARK: - Provider Catalog

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -15,7 +15,6 @@ import VellumAssistantShared
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
-    @ObservedObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
     @Binding var apiKeyText: String
     var showToast: ((String, ToastInfo.Style) -> Void)?
 
@@ -32,10 +31,8 @@ struct InferenceServiceCard: View {
 
     // MARK: - Feature Flag
 
-    private static let customInferenceProviderFlagKey = "feature_flags.custom-inference-provider.enabled"
-
     private var isCustomProviderEnabled: Bool {
-        assistantFeatureFlagStore.isEnabled(Self.customInferenceProviderFlagKey)
+        MacOSClientFeatureFlagManager.shared.isEnabled("custom_inference_provider_enabled")
     }
 
     // MARK: - Provider Helpers

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -27,8 +27,8 @@
     },
     {
       "id": "custom-inference-provider",
-      "scope": "assistant",
-      "key": "feature_flags.custom-inference-provider.enabled",
+      "scope": "macos",
+      "key": "custom_inference_provider_enabled",
       "label": "Custom Inference Provider",
       "description": "Allow selecting a specific LLM provider and model for inference in Your Own mode",
       "defaultEnabled": false


### PR DESCRIPTION
## Summary
- Change `custom-inference-provider` feature flag from `scope: "assistant"` to `scope: "macos"` with key `custom_inference_provider_enabled`
- Switch `InferenceServiceCard` from `AssistantFeatureFlagStore` to `MacOSClientFeatureFlagManager` and remove unused `assistantFeatureFlagStore` property
- Switch `APIKeyEntryStepView` from raw workspace config parsing to `MacOSClientFeatureFlagManager`

## Original prompt
Move the `custom-inference-provider` feature flag from assistant scope to macOS scope. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
