### PR TITLE
Refactor attachment storage into conversation-local directories

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -556,7 +556,7 @@ sequenceDiagram
     Daemon->>DiskView: syncMessageToDisk(convId, msgId, createdAtMs)
     DiskView->>DiskView: flattenContentBlocks(content)
     DiskView->>FS: append JSONL record to messages.jsonl
-    DiskView->>FS: write attachment files to attachments/
+    DiskView->>FS: reference files already materialized in attachments/
 
     Note over CRUD,FS: Conversation update (CRUD layer)
     CRUD->>CRUD: UPDATE conversation row
@@ -580,7 +580,7 @@ Message content (stored as JSON `ContentBlock[]` in the DB) is flattened for the
 
 ### Attachment Projection
 
-When a message with attachments is synced, each attachment's binary content is decoded from the DB and written to the `attachments/` subdirectory using the original filename. Filename collisions are resolved by appending a numeric suffix (e.g., `photo-2.png`, `photo-3.png`). The resolved filenames are recorded in the JSONL record's `attachments` array.
+Attachments are materialized into `conversations/<conversation>/attachments/` as soon as they are linked to a message. During disk-view sync, the JSONL record reuses those filenames directly and only falls back to materializing legacy rows that have not been projected yet. Filename collisions are still resolved by appending a numeric suffix (e.g., `photo-2.png`, `photo-3.png`).
 
 ### Backfill Migration
 

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -52,7 +52,7 @@ import {
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
-import { getDb, initializeDb, rawGet, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, rawGet, rawRun, resetDb } from "../memory/db.js";
 
 initializeDb();
 
@@ -74,7 +74,7 @@ function resetTables() {
 }
 
 // ---------------------------------------------------------------------------
-// uploadAttachment — always writes to disk
+// uploadAttachment — stages until linked
 // ---------------------------------------------------------------------------
 
 describe("uploadAttachment", () => {
@@ -91,29 +91,24 @@ describe("uploadAttachment", () => {
     expect(stored.createdAt).toBeGreaterThan(0);
   });
 
-  test("always writes file to disk", () => {
+  test("keeps uploads staged until linked", () => {
     const stored = uploadAttachment("small.txt", "text/plain", "aGVsbG8=");
     const filePath = getFilePathForAttachment(stored.id);
 
-    expect(filePath).toBeTruthy();
-    expect(existsSync(filePath!)).toBe(true);
-
-    // The on-disk file should contain the decoded bytes
-    const content = readFileSync(filePath!);
-    expect(content.toString()).toBe("hello");
+    expect(filePath).toBeNull();
+    expect(getAttachmentContent(stored.id)?.toString()).toBe("hello");
   });
 
-  test("stores empty dataBase64 in DB row but hydrates on read", () => {
+  test("stores base64 in the DB row until linked", () => {
     const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
 
-    // The raw DB row stores empty dataBase64 since content is on disk
+    // Staged uploads keep the payload inline until they are attached to a message.
     const rawRow = rawGet<{ data_base64: string }>(
       "SELECT data_base64 FROM attachments WHERE id = ?",
       stored.id,
     );
-    expect(rawRow!.data_base64).toBe("");
+    expect(rawRow!.data_base64).toBe("dGVzdA==");
 
-    // But getAttachmentById hydrates from disk
     const row = getAttachmentById(stored.id, { hydrateFileData: true });
     expect(row).not.toBeNull();
     expect(row!.dataBase64).toBe("dGVzdA==");
@@ -141,7 +136,7 @@ describe("uploadAttachment", () => {
     expect(stored.sizeBytes).toBe(5);
   });
 
-  test("deduplicates by content hash", () => {
+  test("does not deduplicate identical uploads before linking", () => {
     const first = uploadAttachment(
       "photo.png",
       "image/png",
@@ -152,10 +147,10 @@ describe("uploadAttachment", () => {
       "image/png",
       "iVBORw0KGgoAAAANSUh",
     );
-    expect(second.id).toBe(first.id);
+    expect(second.id).not.toBe(first.id);
   });
 
-  test("deduplicates even when filenames differ", () => {
+  test("does not deduplicate identical content when filenames differ", () => {
     const first = uploadAttachment(
       "original.png",
       "image/png",
@@ -166,7 +161,7 @@ describe("uploadAttachment", () => {
       "image/png",
       "DUPECONTENT123",
     );
-    expect(second.id).toBe(first.id);
+    expect(second.id).not.toBe(first.id);
   });
 
   test("does not deduplicate different content", () => {
@@ -210,13 +205,13 @@ describe("uploadAttachment", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getAttachmentContent — always reads from disk
+// getAttachmentContent — staged inline or materialized on disk
 // ---------------------------------------------------------------------------
 
 describe("getAttachmentContent", () => {
   beforeEach(resetTables);
 
-  test("reads content from on-disk file", () => {
+  test("returns staged content before the attachment is linked", () => {
     const stored = uploadAttachment("hello.txt", "text/plain", "aGVsbG8=");
     const content = getAttachmentContent(stored.id);
 
@@ -229,8 +224,11 @@ describe("getAttachmentContent", () => {
     expect(content).toBeNull();
   });
 
-  test("returns null when on-disk file is missing (ENOENT)", () => {
+  test("returns null when a materialized on-disk file is missing (ENOENT)", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "assistant", "File");
     const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
 
     // Remove the file to simulate ENOENT
@@ -282,10 +280,18 @@ describe("deleteAttachment", () => {
     expect(fetched).toBeNull();
   });
 
-  test("cleans up on-disk file when deleting", () => {
+  test("cleans up on-disk file when deleting", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "assistant", "cleanup");
     const stored = uploadAttachment("cleanup.txt", "text/plain", "dGVzdA==");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
     expect(existsSync(filePath!)).toBe(true);
+
+    rawRun(
+      "DELETE FROM message_attachments WHERE attachment_id = ?",
+      stored.id,
+    );
 
     deleteAttachment(stored.id);
     expect(existsSync(filePath!)).toBe(false);
@@ -301,13 +307,9 @@ describe("deleteAttachment", () => {
     const msg1 = await addMessage(conv.id, "user", "First upload");
     const msg2 = await addMessage(conv.id, "user", "Duplicate upload");
 
-    // Dedup: both uploads return the same attachment row
     const first = uploadAttachment("photo.png", "image/png", "SHAREDCONTENT1");
-    const second = uploadAttachment("photo.png", "image/png", "SHAREDCONTENT1");
-    expect(second.id).toBe(first.id);
-
     linkAttachmentToMessage(msg1.id, first.id, 0);
-    linkAttachmentToMessage(msg2.id, second.id, 0);
+    linkAttachmentToMessage(msg2.id, first.id, 0);
 
     // Delete should return still_referenced and NOT remove the attachment row
     const result = deleteAttachment(first.id);
@@ -348,7 +350,6 @@ describe("getAttachmentsByIds", () => {
 
     const results = getAttachmentsByIds([a.id, b.id], { hydrateFileData: true });
     expect(results).toHaveLength(2);
-    // dataBase64 is hydrated from on-disk files
     expect(results[0].dataBase64).toBe("AAAA");
     expect(results[1].dataBase64).toBe("BBBB");
   });
@@ -379,8 +380,7 @@ describe("getAttachmentById", () => {
     expect(result).not.toBeNull();
     expect(result!.id).toBe(stored.id);
     expect(result!.originalFilename).toBe("report.pdf");
-    // dataBase64 is hydrated from on-disk file (round-trips via binary)
-    expect(result!.dataBase64).toBe("JVBE");
+    expect(result!.dataBase64).toBe("JVBER");
   });
 
   test("returns null for nonexistent ID", () => {
@@ -407,8 +407,8 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     expect(linked).toHaveLength(1);
     expect(linked[0].id).toBe(stored.id);
     expect(linked[0].originalFilename).toBe("chart.png");
-    // dataBase64 is hydrated from on-disk file
     expect(linked[0].dataBase64).toBe("iVBORw0K");
+    expect(getFilePathForAttachment(stored.id)).toContain("/conversations/");
   });
 
   test("returns attachments in position order", async () => {
@@ -450,10 +450,18 @@ describe("deleteOrphanAttachments", () => {
     expect(removed).toBe(1);
   });
 
-  test("cleans up on-disk files when removing orphans", () => {
+  test("cleans up on-disk files when removing orphaned materialized attachments", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "assistant", "Orphan me");
     const stored = uploadAttachment("orphan.txt", "text/plain", "ZGF0YQ==");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
     expect(existsSync(filePath!)).toBe(true);
+
+    rawRun(
+      "DELETE FROM message_attachments WHERE attachment_id = ?",
+      stored.id,
+    );
 
     deleteOrphanAttachments([stored.id]);
     expect(existsSync(filePath!)).toBe(false);

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -55,6 +55,11 @@ mock.module("../permissions/trust-store.js", () => ({
 }));
 
 mock.module("../permissions/types.js", () => ({
+  RiskLevel: {
+    Low: "low",
+    Medium: "medium",
+    High: "high",
+  },
   isAllowDecision: () => true,
 }));
 

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -564,7 +564,7 @@ describe("attachment reuse across conversation lifecycles", () => {
     expect(fetched!.dataBase64).toBe("JVBERA==");
   });
 
-  test("attachment can be linked to messages in different conversations", async () => {
+  test("re-linking an attachment across conversations creates a conversation-local row", async () => {
     const convA = createConversation("Conversation A");
     const convB = createConversation("Conversation B");
 
@@ -576,17 +576,17 @@ describe("attachment reuse across conversation lifecycles", () => {
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
 
-    // Both messages see the attachment
+    // Both messages see the attachment, but each conversation keeps its own row.
     const linkedA = getAttachmentsForMessage(msgA.id);
     expect(linkedA).toHaveLength(1);
     expect(linkedA[0].id).toBe(stored.id);
 
     const linkedB = getAttachmentsForMessage(msgB.id);
     expect(linkedB).toHaveLength(1);
-    expect(linkedB[0].id).toBe(stored.id);
+    expect(linkedB[0].id).not.toBe(stored.id);
   });
 
-  test("deleting conversation A does not orphan attachment reused in conversation B", async () => {
+  test("deleting conversation A does not remove the copied attachment in conversation B", async () => {
     const convA = createConversation("Conversation A");
     const convB = createConversation("Conversation B");
 
@@ -600,33 +600,33 @@ describe("attachment reuse across conversation lifecycles", () => {
     const stored = uploadAttachment("chart.png", "image/png", "AAAA");
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
+    const linkedB = getAttachmentsForMessage(msgB.id);
+    expect(linkedB).toHaveLength(1);
 
     // Delete conversation A's exchange
     deleteLastExchange(convA.id);
 
-    // Attachment survives because convB still references it
-    const fetched = getAttachmentById(stored.id);
+    // Conversation B keeps its own attachment row and file.
+    const fetched = getAttachmentById(linkedB[0].id);
     expect(fetched).not.toBeNull();
 
     // convB's message still has the attachment linked
-    const linkedB = getAttachmentsForMessage(msgB.id);
-    expect(linkedB).toHaveLength(1);
-    expect(linkedB[0].id).toBe(stored.id);
+    const linkedBAfterDelete = getAttachmentsForMessage(msgB.id);
+    expect(linkedBAfterDelete).toHaveLength(1);
+    expect(linkedBAfterDelete[0].id).toBe(linkedB[0].id);
   });
 
-  test("content-hash dedup works across conversations", async () => {
+  test("identical uploads remain distinct across conversations", async () => {
     const convA = createConversation("Conversation A");
     const convB = createConversation("Conversation B");
 
     await addMessage(convA.id, "user", "upload in A");
     await addMessage(convB.id, "user", "upload in B");
 
-    // Same content uploaded in two different conversation contexts
     const first = uploadAttachment("photo.png", "image/png", "DEDUPCROSS");
     const second = uploadAttachment("photo.png", "image/png", "DEDUPCROSS");
 
-    // Dedup returns the same attachment row
-    expect(second.id).toBe(first.id);
+    expect(second.id).not.toBe(first.id);
   });
 });
 
@@ -664,7 +664,7 @@ describe("no private-conversation attachment visibility boundary", () => {
     expect(fetched!.originalFilename).toBe("secret.pdf");
   });
 
-  test("attachment from private conversation can be linked to a standard conversation message", async () => {
+  test("attachment from a private conversation is copied when linked into a standard conversation", async () => {
     const privateConv = createConversation({
       title: "Private",
       conversationType: "private",
@@ -695,7 +695,7 @@ describe("no private-conversation attachment visibility boundary", () => {
 
     const linkedStandard = getAttachmentsForMessage(standardMsg.id);
     expect(linkedStandard).toHaveLength(1);
-    expect(linkedStandard[0].id).toBe(stored.id);
+    expect(linkedStandard[0].id).not.toBe(stored.id);
   });
 
   test("getAttachmentsForMessage returns private conversation attachments", async () => {
@@ -712,7 +712,7 @@ describe("no private-conversation attachment visibility boundary", () => {
     expect(linked[0].id).toBe(stored.id);
   });
 
-  test("content-hash dedup works across private and standard conversations", () => {
+  test("identical uploads remain distinct across private and standard conversations", () => {
     createConversation({ title: "Private", conversationType: "private" });
     createConversation({ title: "Standard", conversationType: "standard" });
 
@@ -728,8 +728,7 @@ describe("no private-conversation attachment visibility boundary", () => {
       "CROSSCONVERSATION",
     );
 
-    // Dedup returns the same row — no conversation-type isolation
-    expect(fromStandard.id).toBe(fromPrivate.id);
+    expect(fromStandard.id).not.toBe(fromPrivate.id);
   });
 
   test("clearAll removes attachments from both private and standard conversations", async () => {

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -81,6 +81,23 @@ const mockAttachments: Array<{
 let mockAttachmentIdCounter = 0;
 
 mock.module("../memory/attachments-store.js", () => ({
+  attachFileBackedAttachmentToMessage: (
+    _messageId: string,
+    _position: number,
+    filename: string,
+    mimeType: string,
+    _filePath: string,
+    sizeBytes: number,
+  ) => {
+    const att = {
+      id: `att-${++mockAttachmentIdCounter}`,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes,
+    };
+    mockAttachments.push(att);
+    return att;
+  },
   uploadFileBackedAttachment: (
     filename: string,
     mimeType: string,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -721,16 +721,6 @@ export async function handleMessageComplete(
   );
   state.lastAssistantMessageId = assistantMsg.id;
 
-  // Sync assistant message to disk view
-  const convForDisk = getConversation(deps.ctx.conversationId);
-  if (convForDisk) {
-    syncMessageToDisk(
-      deps.ctx.conversationId,
-      assistantMsg.id,
-      convForDisk.createdAt,
-    );
-  }
-
   // Backfill message_id on all LLM request logs from this turn.
   // The agent loop is single-threaded per conversation, so all rows with
   // message_id IS NULL belong to the current turn.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -43,6 +43,7 @@ import {
   updateConversationContextWindow,
   updateConversationTitle,
 } from "../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
@@ -1538,10 +1539,22 @@ export async function runAgentLoopImpl(
       conversationId: ctx.conversationId,
     });
 
+    const syncLastAssistantMessageToDisk = (): void => {
+      if (!state.lastAssistantMessageId) return;
+      const convForDisk = getConversation(ctx.conversationId);
+      if (!convForDisk) return;
+      syncMessageToDisk(
+        ctx.conversationId,
+        state.lastAssistantMessageId,
+        convForDisk.createdAt,
+      );
+    };
+
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
     // so the client can re-enable the UI without delay.
     if (abortController.signal.aborted) {
+      syncLastAssistantMessageToDisk();
       ctx.emitActivityState("idle", "generation_cancelled", "global", reqId);
       ctx.traceEmitter.emit(
         "generation_cancelled",
@@ -1577,6 +1590,7 @@ export async function runAgentLoopImpl(
 
       ctx.lastAssistantAttachments = assistantAttachments;
       ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
+      syncLastAssistantMessageToDisk();
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -1,12 +1,8 @@
 import {
+  attachInlineAttachmentToMessage,
   AttachmentUploadError,
   getFilePathForAttachment,
-  linkAttachmentToMessage,
-  MAX_UPLOAD_BYTES,
   setAttachmentThumbnail,
-  uploadAttachment,
-  uploadFileBackedAttachment,
-  writeAttachmentToDisk,
 } from "../memory/attachments-store.js";
 import {
   check,
@@ -208,27 +204,14 @@ export async function resolveAssistantAttachments(
       const draft = assistantAttachments[i];
       let stored;
       try {
-        // uploadAttachment always writes to disk now. For oversized files
-        // that exceed the upload limit, use the file-backed path which
-        // bypasses the size check.
-        if (draft.sizeBytes > MAX_UPLOAD_BYTES) {
-          const diskFilePath = writeAttachmentToDisk(
-            draft.dataBase64,
-            draft.filename,
-          );
-          stored = uploadFileBackedAttachment(
-            draft.filename,
-            draft.mimeType,
-            diskFilePath,
-            draft.sizeBytes,
-          );
-        } else {
-          stored = uploadAttachment(
-            draft.filename,
-            draft.mimeType,
-            draft.dataBase64,
-          );
-        }
+        stored = attachInlineAttachmentToMessage(
+          lastAssistantMessageId,
+          i,
+          draft.filename,
+          draft.mimeType,
+          draft.dataBase64,
+          { skipSizeLimit: true },
+        );
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
           log.warn(
@@ -242,7 +225,6 @@ export async function resolveAssistantAttachments(
         }
         throw err;
       }
-      linkAttachmentToMessage(lastAssistantMessageId, stored.id, i);
       const isVideo = draft.mimeType.startsWith("video/");
       // Only omit data for videos — they have an end-to-end lazy-load path
       // via /v1/attachments/:id/content. Other types (images, PDFs) still need

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -15,10 +15,10 @@ import type {
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import {
+  attachInlineAttachmentToMessage,
   attachmentExists,
   AttachmentUploadError,
   linkAttachmentToMessage,
-  uploadAttachment,
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
 import {
@@ -394,8 +394,14 @@ export async function persistUserMessage(
           );
           continue;
         }
-        const stored = uploadAttachment(a.filename, a.mimeType, a.data);
-        linkAttachmentToMessage(persistedUserMessage.id, stored.id, i);
+        attachInlineAttachmentToMessage(
+          persistedUserMessage.id,
+          i,
+          a.filename,
+          a.mimeType,
+          a.data,
+          { sourcePath: a.filePath },
+        );
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
           log.warn(

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -4,8 +4,7 @@ import * as path from "node:path";
 import { v4 as uuid } from "uuid";
 
 import {
-  linkAttachmentToMessage,
-  uploadFileBackedAttachment,
+  attachFileBackedAttachmentToMessage,
 } from "../../memory/attachments-store.js";
 import {
   addMessage,
@@ -620,23 +619,6 @@ export async function finalizeAndPublishRecording(params: {
     const ext = filename.split(".").pop()?.toLowerCase();
     const mimeType = (ext && RECORDING_MIME_TYPES.get(ext)) || "video/mp4";
 
-    // Store as file-backed attachment (avoids reading large files into memory)
-    const attachment = uploadFileBackedAttachment(
-      filename,
-      mimeType,
-      resolvedPath,
-      sizeBytes,
-    );
-    log.info(
-      {
-        recordingId,
-        attachmentId: attachment.id,
-        sizeBytes,
-        filePath: resolvedPath,
-      },
-      "Created attachment for standalone recording",
-    );
-
     // Always create a new assistant message for the recording attachment.
     // Reusing the last assistant message would attach the recording to an
     // unrelated older message after reload.
@@ -652,7 +634,23 @@ export async function finalizeAndPublishRecording(params: {
       "Created assistant message for recording attachment",
     );
 
-    linkAttachmentToMessage(messageId, attachment.id, 0);
+    const attachment = attachFileBackedAttachmentToMessage(
+      messageId,
+      0,
+      filename,
+      mimeType,
+      resolvedPath,
+      sizeBytes,
+    );
+    log.info(
+      {
+        recordingId,
+        attachmentId: attachment.id,
+        sizeBytes,
+        filePath: resolvedPath,
+      },
+      "Created attachment for standalone recording",
+    );
     log.info(
       { recordingId, messageId, attachmentId: attachment.id },
       "Linked recording attachment to assistant message",

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1,18 +1,26 @@
 /**
  * Assistant-owned attachment storage.
  *
- * All attachments are stored on disk; the database row references the
- * on-disk file path. Provides upload, delete, and message-linkage operations.
+ * Attachments uploaded ahead of message persistence are staged in the database.
+ * Once linked to a message, the canonical file is materialized directly into
+ * that conversation's attachments/ directory and the database row points there.
  */
 
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
 
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
 import { getDb, rawAll, rawGet, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
 
@@ -45,6 +53,257 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function getConversationDirName(
+  conversationId: string,
+  createdAtMs: number,
+): string {
+  const isoDate = new Date(createdAtMs).toISOString().replace(/:/g, "-");
+  return `${conversationId}_${isoDate}`;
+}
+
+function getConversationAttachmentsDirPath(
+  conversationId: string,
+  createdAtMs: number,
+): string {
+  return join(
+    getConversationsDir(),
+    getConversationDirName(conversationId, createdAtMs),
+    "attachments",
+  );
+}
+
+function resolveUniqueFilename(dir: string, filename: string): string {
+  const sanitized = basename(filename);
+  const existingPath = join(dir, sanitized);
+  if (!existsSync(existingPath)) return sanitized;
+
+  const ext = extname(sanitized);
+  const base = basename(sanitized, ext);
+  let counter = 2;
+  let candidate = `${base}-${counter}${ext}`;
+  while (existsSync(join(dir, candidate))) {
+    counter++;
+    candidate = `${base}-${counter}${ext}`;
+  }
+  return candidate;
+}
+
+function computeSizeBytesFromBase64(dataBase64: string): number {
+  const padding = dataBase64.endsWith("==")
+    ? 2
+    : dataBase64.endsWith("=")
+      ? 1
+      : 0;
+  return Math.max(0, Math.floor((dataBase64.length * 3) / 4) - padding);
+}
+
+interface AttachmentRow {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  dataBase64: string;
+  contentHash: string | null;
+  thumbnailBase64: string | null;
+  filePath: string | null;
+  createdAt: number;
+  sourcePath: string | null;
+}
+
+function getAttachmentRow(attachmentId: string): AttachmentRow | null {
+  return (
+    rawGet<AttachmentRow>(
+      `SELECT
+         id,
+         original_filename AS originalFilename,
+         mime_type AS mimeType,
+         size_bytes AS sizeBytes,
+         kind,
+         data_base64 AS dataBase64,
+         content_hash AS contentHash,
+         thumbnail_base64 AS thumbnailBase64,
+         file_path AS filePath,
+         created_at AS createdAt,
+         source_path AS sourcePath
+       FROM attachments
+       WHERE id = ?`,
+      attachmentId,
+    ) ?? null
+  );
+}
+
+function getMessageConversationContext(
+  messageId: string,
+): { conversationId: string; conversationCreatedAt: number } | null {
+  return (
+    rawGet<{ conversationId: string; conversationCreatedAt: number }>(
+      `SELECT
+         m.conversation_id AS conversationId,
+         c.created_at AS conversationCreatedAt
+       FROM messages m
+       JOIN conversations c ON c.id = m.conversation_id
+       WHERE m.id = ?`,
+      messageId,
+    ) ?? null
+  );
+}
+
+function listLinkedConversationIds(attachmentId: string): string[] {
+  return rawAll<{ conversationId: string }>(
+    `SELECT DISTINCT m.conversation_id AS conversationId
+     FROM message_attachments ma
+     JOIN messages m ON m.id = ma.message_id
+     WHERE ma.attachment_id = ?`,
+    attachmentId,
+  ).map((row) => row.conversationId);
+}
+
+function cloneAttachmentRow(row: AttachmentRow): AttachmentRow {
+  const clonedId = uuid();
+  const db = getDb();
+  const now = Date.now();
+
+  db.insert(attachments)
+    .values({
+      id: clonedId,
+      originalFilename: row.originalFilename,
+      mimeType: row.mimeType,
+      sizeBytes: row.sizeBytes,
+      kind: row.kind,
+      dataBase64: row.dataBase64,
+      contentHash: null,
+      thumbnailBase64: row.thumbnailBase64,
+      filePath: row.filePath,
+      createdAt: now,
+    })
+    .run();
+
+  if (row.sourcePath) {
+    rawRun(
+      `UPDATE attachments SET source_path = ? WHERE id = ?`,
+      row.sourcePath,
+      clonedId,
+    );
+  }
+
+  return {
+    ...row,
+    id: clonedId,
+    createdAt: now,
+  };
+}
+
+function insertMessageAttachmentLink(
+  messageId: string,
+  attachmentId: string,
+  position: number,
+): void {
+  const db = getDb();
+  db.insert(messageAttachments)
+    .values({
+      id: uuid(),
+      messageId,
+      attachmentId,
+      position,
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+function persistAttachmentFilePath(
+  attachmentId: string,
+  targetPath: string,
+  sourcePath?: string | null,
+): void {
+  if (sourcePath) {
+    rawRun(
+      `UPDATE attachments
+       SET file_path = ?, data_base64 = '', source_path = COALESCE(source_path, ?)
+       WHERE id = ?`,
+      targetPath,
+      sourcePath,
+      attachmentId,
+    );
+    return;
+  }
+
+  rawRun(
+    `UPDATE attachments SET file_path = ?, data_base64 = '' WHERE id = ?`,
+    targetPath,
+    attachmentId,
+  );
+}
+
+function materializeAttachmentIntoConversation(
+  row: AttachmentRow,
+  conversationId: string,
+  conversationCreatedAt: number,
+): void {
+  const attachDir = getConversationAttachmentsDirPath(
+    conversationId,
+    conversationCreatedAt,
+  );
+  mkdirSync(attachDir, { recursive: true });
+
+  if (row.filePath && existsSync(row.filePath) && dirname(row.filePath) === attachDir) {
+    if (row.dataBase64) {
+      rawRun(`UPDATE attachments SET data_base64 = '' WHERE id = ?`, row.id);
+    }
+    return;
+  }
+
+  const resolvedName = resolveUniqueFilename(attachDir, row.originalFilename);
+  const targetPath = join(attachDir, resolvedName);
+
+  let sourcePath = row.sourcePath;
+  if (row.dataBase64) {
+    writeFileSync(targetPath, Buffer.from(row.dataBase64, "base64"));
+  } else {
+    const readablePath = [row.filePath, row.sourcePath].find(
+      (path): path is string => !!path && existsSync(path),
+    );
+    if (!readablePath) return;
+
+    if (!sourcePath && readablePath !== row.filePath) {
+      sourcePath = readablePath;
+    } else if (
+      !sourcePath &&
+      readablePath === row.filePath &&
+      dirname(readablePath) !== attachDir
+    ) {
+      sourcePath = readablePath;
+    }
+
+    copyFileSync(readablePath, targetPath);
+  }
+
+  persistAttachmentFilePath(row.id, targetPath, sourcePath);
+}
+
+function scopeAttachmentToConversation(
+  attachmentId: string,
+  conversationId: string,
+  conversationCreatedAt: number,
+): string {
+  let row = getAttachmentRow(attachmentId);
+  if (!row) {
+    throw new Error(`Attachment not found: ${attachmentId}`);
+  }
+
+  const linkedConversationIds = listLinkedConversationIds(attachmentId);
+  if (linkedConversationIds.some((id) => id !== conversationId)) {
+    row = cloneAttachmentRow(row);
+  }
+
+  materializeAttachmentIntoConversation(
+    row,
+    conversationId,
+    conversationCreatedAt,
+  );
+  return row.id;
+}
+
 // ---------------------------------------------------------------------------
 // Size and encoding limits
 // ---------------------------------------------------------------------------
@@ -53,8 +312,8 @@ function formatBytes(bytes: number): string {
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 /**
- * Write decoded base64 data to disk under the workspace attachments directory.
- * Returns the absolute file path of the written file.
+ * Legacy helper kept for historical backfills that still need to materialize
+ * old attachment rows from inline base64 data.
  */
 export function writeAttachmentToDisk(
   dataBase64: string,
@@ -211,14 +470,6 @@ export function validateAttachmentUpload(
   return { ok: true };
 }
 
-/**
- * Compute a content hash for deduplication. Uses Bun.hash (wyhash) for speed,
- * encoded as base-36 for compact storage.
- */
-function computeContentHash(dataBase64: string): string {
-  return Bun.hash(dataBase64).toString(36);
-}
-
 // ---------------------------------------------------------------------------
 // File-backed attachment storage (avoids reading large files into memory)
 // ---------------------------------------------------------------------------
@@ -254,6 +505,8 @@ export function uploadFileBackedAttachment(
       createdAt: now,
     })
     .run();
+
+  rawRun(`UPDATE attachments SET source_path = ? WHERE id = ?`, filePath, id);
 
   return {
     id,
@@ -340,17 +593,17 @@ export function getFilePathBySourcePath(
  * Returns null if the attachment does not exist or the file is missing.
  */
 export function getAttachmentContent(attachmentId: string): Buffer | null {
-  const db = getDb();
-  const row = db
-    .select({ filePath: attachments.filePath })
-    .from(attachments)
-    .where(eq(attachments.id, attachmentId))
-    .get();
-
-  if (!row?.filePath) return null;
+  const row = getAttachmentRow(attachmentId);
+  if (!row) return null;
 
   try {
-    return readFileSync(row.filePath);
+    if (row.filePath) {
+      return readFileSync(row.filePath);
+    }
+    if (row.dataBase64) {
+      return Buffer.from(row.dataBase64, "base64");
+    }
+    return null;
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && err.code === "ENOENT") {
       return null;
@@ -359,27 +612,16 @@ export function getAttachmentContent(attachmentId: string): Buffer | null {
   }
 }
 
-export function uploadAttachment(
-  filename: string,
-  mimeType: string,
+function validateAttachmentPayload(
   dataBase64: string,
-  sourcePath?: string,
-): StoredAttachment {
+  options?: { skipSizeLimit?: boolean },
+): number {
   if (!isValidBase64(dataBase64)) {
     throw new AttachmentUploadError("Invalid base64 encoding");
   }
 
-  const padding = dataBase64.endsWith("==")
-    ? 2
-    : dataBase64.endsWith("=")
-      ? 1
-      : 0;
-  const sizeBytes = Math.max(
-    0,
-    Math.floor((dataBase64.length * 3) / 4) - padding,
-  );
-
-  if (sizeBytes > MAX_UPLOAD_BYTES) {
+  const sizeBytes = computeSizeBytesFromBase64(dataBase64);
+  if (!options?.skipSizeLimit && sizeBytes > MAX_UPLOAD_BYTES) {
     throw new AttachmentUploadError(
       `Attachment too large: ${formatBytes(sizeBytes)} exceeds ${formatBytes(
         MAX_UPLOAD_BYTES,
@@ -387,41 +629,20 @@ export function uploadAttachment(
     );
   }
 
+  return sizeBytes;
+}
+
+export function uploadAttachment(
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+  sourcePath?: string,
+): StoredAttachment {
+  const sizeBytes = validateAttachmentPayload(dataBase64);
+
   const db = getDb();
-  const contentHash = computeContentHash(dataBase64);
-
-  // Dedup: if an attachment with the same content already exists, return it
-  // instead of storing a duplicate.
-  const existing = db
-    .select({
-      id: attachments.id,
-      originalFilename: attachments.originalFilename,
-      mimeType: attachments.mimeType,
-      sizeBytes: attachments.sizeBytes,
-      kind: attachments.kind,
-      thumbnailBase64: attachments.thumbnailBase64,
-      createdAt: attachments.createdAt,
-    })
-    .from(attachments)
-    .where(eq(attachments.contentHash, contentHash))
-    .get();
-
-  if (existing) {
-    if (sourcePath) {
-      rawRun(
-        `UPDATE attachments SET source_path = ? WHERE id = ?`,
-        sourcePath,
-        existing.id,
-      );
-    }
-    return existing;
-  }
-
   const now = Date.now();
   const kind = classifyKind(mimeType);
-
-  // Always write to disk
-  const filePath = writeAttachmentToDisk(dataBase64, filename);
 
   const record = {
     id: uuid(),
@@ -429,9 +650,9 @@ export function uploadAttachment(
     mimeType,
     sizeBytes,
     kind,
-    dataBase64: "",
-    filePath,
-    contentHash,
+    dataBase64,
+    filePath: null,
+    contentHash: null,
     createdAt: now,
   };
 
@@ -453,6 +674,126 @@ export function uploadAttachment(
     kind,
     thumbnailBase64: null,
     createdAt: now,
+  };
+}
+
+export function attachInlineAttachmentToMessage(
+  messageId: string,
+  position: number,
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+  options?: { sourcePath?: string; skipSizeLimit?: boolean },
+): StoredAttachment {
+  const sizeBytes = validateAttachmentPayload(dataBase64, {
+    skipSizeLimit: options?.skipSizeLimit,
+  });
+  const ctx = getMessageConversationContext(messageId);
+  if (!ctx) {
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  const attachDir = getConversationAttachmentsDirPath(
+    ctx.conversationId,
+    ctx.conversationCreatedAt,
+  );
+  mkdirSync(attachDir, { recursive: true });
+  const resolvedName = resolveUniqueFilename(attachDir, filename);
+  const targetPath = join(attachDir, resolvedName);
+  writeFileSync(targetPath, Buffer.from(dataBase64, "base64"));
+
+  const now = Date.now();
+  const id = uuid();
+  const kind = classifyKind(mimeType);
+  const db = getDb();
+
+  db.insert(attachments)
+    .values({
+      id,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes,
+      kind,
+      dataBase64: "",
+      filePath: targetPath,
+      contentHash: null,
+      createdAt: now,
+    })
+    .run();
+
+  if (options?.sourcePath) {
+    rawRun(
+      `UPDATE attachments SET source_path = ? WHERE id = ?`,
+      options.sourcePath,
+      id,
+    );
+  }
+
+  insertMessageAttachmentLink(messageId, id, position);
+
+  return {
+    id,
+    originalFilename: filename,
+    mimeType,
+    sizeBytes,
+    kind,
+    thumbnailBase64: null,
+    createdAt: now,
+  };
+}
+
+export function attachFileBackedAttachmentToMessage(
+  messageId: string,
+  position: number,
+  filename: string,
+  mimeType: string,
+  sourceFilePath: string,
+  sizeBytes: number,
+): StoredAttachment & { filePath: string } {
+  const ctx = getMessageConversationContext(messageId);
+  if (!ctx) {
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  const attachDir = getConversationAttachmentsDirPath(
+    ctx.conversationId,
+    ctx.conversationCreatedAt,
+  );
+  mkdirSync(attachDir, { recursive: true });
+  const resolvedName = resolveUniqueFilename(attachDir, filename);
+  const targetPath = join(attachDir, resolvedName);
+  copyFileSync(sourceFilePath, targetPath);
+
+  const now = Date.now();
+  const id = uuid();
+  const kind = classifyKind(mimeType);
+  const db = getDb();
+
+  db.insert(attachments)
+    .values({
+      id,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes,
+      kind,
+      dataBase64: "",
+      filePath: targetPath,
+      createdAt: now,
+    })
+    .run();
+
+  rawRun(`UPDATE attachments SET source_path = ? WHERE id = ?`, sourceFilePath, id);
+  insertMessageAttachmentLink(messageId, id, position);
+
+  return {
+    id,
+    originalFilename: filename,
+    mimeType,
+    sizeBytes,
+    kind,
+    thumbnailBase64: null,
+    createdAt: now,
+    filePath: targetPath,
   };
 }
 
@@ -485,9 +826,8 @@ export function deleteAttachment(attachmentId: string): DeleteAttachmentResult {
 
   if (!existing) return "not_found";
 
-  // With content-hash deduplication, multiple messages may reference the same
-  // attachment row. Only delete the attachment (and cascade its links) when no
-  // message_attachments rows still point to it.
+  // An attachment row can still be shared by multiple messages inside the same
+  // conversation. Only delete it when no remaining links point to the row.
   const refCount = db
     .select({ id: messageAttachments.id })
     .from(messageAttachments)
@@ -562,17 +902,19 @@ export function linkAttachmentToMessage(
   messageId: string,
   attachmentId: string,
   position: number,
-): void {
-  const db = getDb();
-  db.insert(messageAttachments)
-    .values({
-      id: uuid(),
-      messageId,
-      attachmentId,
-      position,
-      createdAt: Date.now(),
-    })
-    .run();
+): string {
+  const ctx = getMessageConversationContext(messageId);
+  if (!ctx) {
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  const scopedAttachmentId = scopeAttachmentToConversation(
+    attachmentId,
+    ctx.conversationId,
+    ctx.conversationCreatedAt,
+  );
+  insertMessageAttachmentLink(messageId, scopedAttachmentId, position);
+  return scopedAttachmentId;
 }
 
 /**

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -17,12 +17,13 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, extname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import {
   getAttachmentContent,
+  getFilePathForAttachment,
   getAttachmentMetadataForMessage,
 } from "./attachments-store.js";
 import { getMessageById } from "./conversation-crud.js";
@@ -219,8 +220,8 @@ export function resolveUniqueFilename(dir: string, filename: string): string {
 }
 
 /**
- * Write an attachment's content to the conversation's attachments/ subdirectory.
- * Returns the resolved filename (after collision handling), or null on failure.
+ * Ensure an attachment is present in the conversation's attachments/
+ * subdirectory and return the filename recorded in the disk view.
  */
 function writeAttachmentFile(
   conversationDirPath: string,
@@ -230,6 +231,15 @@ function writeAttachmentFile(
   try {
     const attachDir = join(conversationDirPath, "attachments");
     mkdirSync(attachDir, { recursive: true });
+
+    const existingPath = getFilePathForAttachment(attachmentId);
+    if (
+      existingPath &&
+      existsSync(existingPath) &&
+      dirname(existingPath) === attachDir
+    ) {
+      return basename(existingPath);
+    }
 
     const content = getAttachmentContent(attachmentId);
     if (!content) return null;
@@ -253,7 +263,8 @@ function writeAttachmentFile(
 /**
  * Read a message and its attachments from DB, flatten content, and append
  * a JSONL line to `messages.jsonl` in the conversation's disk-view directory.
- * Also copies attachment files to the `attachments/` subdirectory.
+ * Attachment filenames are recorded from the conversation's attachments/
+ * subdirectory, materializing legacy rows there only when needed.
  *
  * Requires `createdAtMs` of the conversation to resolve the directory path.
  */


### PR DESCRIPTION
## Summary
- Move canonical attachment storage into each conversation's `attachments/` directory and materialize files when they are linked to a message
- Clone attachment rows on cross-conversation reuse so each conversation keeps its own attachment-scoped file path
- Sync assistant messages to the disk view only after assistant attachments are resolved so filenames are written immediately

## Notes
- No migration was added because this storage layout has not rolled out to users yet

## Original prompt
> Instead of writing attachments data/attachments/ let's only write them to conversations/<conversation>/attachments/ and make sure they're written immediately
>
> Don't bother adding a migration for this one - this hasn't rolled out to users yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)