### PR TITLE
Fix truncated message ID in LLM context inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -87,9 +87,11 @@ struct MessageInspectorView: View {
                         .foregroundColor(VColor.contentSecondary)
                 }
 
-                Text(shortMessageId)
+                Text(messageId)
                     .font(VFont.monoSmall)
                     .foregroundColor(VColor.contentTertiary)
+                    .multilineTextAlignment(.trailing)
+                    .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
             }
         }
@@ -290,13 +292,6 @@ struct MessageInspectorView: View {
     }
 
     // MARK: - Helpers
-
-    private var shortMessageId: String {
-        if messageId.count > 12 {
-            return String(messageId.prefix(12)) + "..."
-        }
-        return messageId
-    }
 
     private var skeletonColumn: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- show the full message ID in the macOS LLM Context Inspector header instead of truncating it to 12 characters
- let the identifier wrap on the trailing edge so the full value stays readable in narrower layouts
- Apple refs checked (2026-03-19): SwiftUI fixedSize(horizontal:vertical:), lineLimit

## Original prompt
This shouldn't be truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
