### PR TITLE
fix: disable Save when no model selected, update mask per provider, move mask to placeholder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -83,6 +83,10 @@ struct InferenceServiceCard: View {
         if draftMode == "managed" && !isLoggedIn {
             return false
         }
+        // A valid model must be selected to save.
+        if store.selectedModel.isEmpty {
+            return false
+        }
         let modeChanged = draftMode != store.inferenceMode
         let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let modelChanged = store.selectedModel != initialModel
@@ -214,17 +218,18 @@ struct InferenceServiceCard: View {
     // MARK: - API Key Field
 
     private var apiKeyField: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        let currentMask: String = {
+            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
+                return masked
+            }
+            return ""
+        }()
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text(isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
-                Text(masked)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.contentTertiary)
-            }
             SecureField(
-                isConnected ? "Enter a new key to replace the existing one" : "Enter your API key",
+                !currentMask.isEmpty ? currentMask : "Enter your API key",
                 text: $apiKeyText
             )
                 .vInputStyle()


### PR DESCRIPTION
## Summary
- Disable Save button when no model is selected (empty selectedModel)
- Move the masked API key from a label above the input to the SecureField placeholder text
- Mask now reactively updates per provider when switching providers in Your Own mode

Part of plan: infer-card-fixes.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
