### PR TITLE
feat: add gateway proxy routes for OAuth app and connection management

### DIFF
--- a/gateway/src/http/routes/oauth-apps-proxy.ts
+++ b/gateway/src/http/routes/oauth-apps-proxy.ts
@@ -1,0 +1,129 @@
+/**
+ * Gateway proxy endpoints for OAuth app and connection management routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("oauth-apps-proxy");
+
+export function createOAuthAppsProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error(
+          { path: upstreamPath, duration },
+          "OAuth apps proxy upstream timed out",
+        );
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, path: upstreamPath, duration },
+        "OAuth apps proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth apps proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "OAuth apps proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  }
+
+  return {
+    async handleListApps(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/oauth/apps", new URL(req.url).search);
+    },
+
+    async handleCreateApp(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/oauth/apps", "");
+    },
+
+    async handleDeleteApp(req: Request, appId: string): Promise<Response> {
+      return proxyToRuntime(req, `/v1/oauth/apps/${appId}`, "");
+    },
+
+    async handleListConnections(
+      req: Request,
+      appId: string,
+    ): Promise<Response> {
+      return proxyToRuntime(req, `/v1/oauth/apps/${appId}/connections`, "");
+    },
+
+    async handleDeleteConnection(
+      req: Request,
+      connectionId: string,
+    ): Promise<Response> {
+      return proxyToRuntime(req, `/v1/oauth/connections/${connectionId}`, "");
+    },
+
+    async handleConnect(req: Request, appId: string): Promise<Response> {
+      return proxyToRuntime(req, `/v1/oauth/apps/${appId}/connect`, "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -50,6 +50,7 @@ import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-c
 import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
 import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
+import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
@@ -266,6 +267,7 @@ async function main() {
     createContactsControlPlaneProxyHandler(config);
   const twilioControlPlaneProxy = createTwilioControlPlaneProxyHandler(config);
   const slackControlPlaneProxy = createSlackControlPlaneProxyHandler(config);
+  const oauthAppsProxy = createOAuthAppsProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
@@ -647,6 +649,46 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => slackControlPlaneProxy.handleShareToSlack(req),
+    },
+
+    // ── OAuth apps ──
+    {
+      path: "/v1/oauth/apps",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => oauthAppsProxy.handleListApps(req),
+    },
+    {
+      path: "/v1/oauth/apps",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => oauthAppsProxy.handleCreateApp(req),
+    },
+    {
+      path: /^\/v1\/oauth\/apps\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) => oauthAppsProxy.handleDeleteApp(req, params[0]),
+    },
+    {
+      path: /^\/v1\/oauth\/apps\/([^/]+)\/connections$/,
+      method: "GET",
+      auth: "edge",
+      handler: (req, params) =>
+        oauthAppsProxy.handleListConnections(req, params[0]),
+    },
+    {
+      path: /^\/v1\/oauth\/connections\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) =>
+        oauthAppsProxy.handleDeleteConnection(req, params[0]),
+    },
+    {
+      path: /^\/v1\/oauth\/apps\/([^/]+)\/connect$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req, params) => oauthAppsProxy.handleConnect(req, params[0]),
     },
 
     // ── Channel readiness ──


### PR DESCRIPTION
## Summary
- Add gateway proxy handler for six OAuth app/connection management endpoints
- Follow the existing twilio-control-plane-proxy pattern for proxying to runtime
- Register routes with edge auth in gateway route table

Part of plan: your-own-google-oauth.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
