### PR TITLE
fix: keep LLM inspector response pane visible

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -11,6 +11,8 @@ struct MessageInspectorView: View {
     let onBack: () -> Void
 
     private let llmContextClient: any LLMContextClientProtocol = LLMContextClient()
+    private let inspectorPaneMinHeight: CGFloat = 420
+    private let inspectorPaneChromeHeight: CGFloat = 44
 
     @State private var response: LLMContextResponse?
     @State private var isLoading = true
@@ -217,21 +219,31 @@ struct MessageInspectorView: View {
             )
 
             if isExpanded {
-                HStack(alignment: .top, spacing: VSpacing.lg) {
-                    jsonSection(
-                        title: "Request",
-                        formattedText: formattedJSON["\(entry.id)-request"] ?? ""
-                    )
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                GeometryReader { proxy in
+                    // Constrain both panes to the visible row width so very wide
+                    // request JSON cannot push the sibling response pane offscreen.
+                    let columnWidth = max((proxy.size.width - VSpacing.lg) / 2, 0)
 
-                    jsonSection(
-                        title: "Response",
-                        formattedText: formattedJSON["\(entry.id)-response"] ?? ""
-                    )
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    HStack(alignment: .top, spacing: VSpacing.lg) {
+                        jsonSection(
+                            title: "Request",
+                            formattedText: formattedJSON["\(entry.id)-request"] ?? ""
+                        )
+                        .frame(width: columnWidth, alignment: .topLeading)
+
+                        jsonSection(
+                            title: "Response",
+                            formattedText: formattedJSON["\(entry.id)-response"] ?? ""
+                        )
+                        .frame(width: columnWidth, alignment: .topLeading)
+                    }
+                    .frame(width: proxy.size.width, alignment: .leading)
                 }
+                .frame(
+                    minHeight: inspectorPaneMinHeight + inspectorPaneChromeHeight,
+                    alignment: .topLeading
+                )
                 .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, alignment: .leading)
                 .background(VColor.surfaceOverlay.opacity(0.5))
                 .clipShape(
                     UnevenRoundedRectangle(
@@ -271,14 +283,18 @@ struct MessageInspectorView: View {
             }
 
             ScrollView([.horizontal, .vertical]) {
-                Text(formattedText)
+                Text(verbatim: formattedText)
                     .font(VFont.mono)
                     .foregroundColor(VColor.contentDefault)
                     .textSelection(.enabled)
                     .padding(VSpacing.sm)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
-            .frame(maxWidth: .infinity, minHeight: 420, alignment: .topLeading)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: inspectorPaneMinHeight,
+                alignment: .topLeading
+            )
             .background(VColor.surfaceBase)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .overlay(


### PR DESCRIPTION
## Summary
- constrain the request and response panes in the LLM context inspector to the visible row width so oversized request JSON cannot push the response viewer offscreen
- render the raw payload text verbatim to avoid any SwiftUI string interpretation while inspecting stored JSON logs

## Original prompt
The response isn't showing up here - can you fix?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
