### PR TITLE
fix: address review feedback from PR #16249

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -1088,6 +1088,7 @@ export async function startInviteCall(
       callMode: "invite",
       inviteFriendName: friendName,
       inviteGuardianName: guardianName,
+      initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
 


### PR DESCRIPTION
## Summary
- Restore `initiatedFromConversationId: conversationId` in `startInviteCall` that was accidentally removed in PR #16249
- Without this field, invite call sessions default to `initiatedFromConversationId: null`, causing them to be misclassified as inbound calls in `relay-setup-router.ts`, `guardian-action-followup-executor.ts`, and `relay-server.ts`

Address reviewer feedback from https://github.com/vellum-ai/vellum-assistant/pull/16249

## Test plan
- [x] Existing test at `relay-server.test.ts:4088-4096` continues to pass (it creates sessions directly with `initiatedFromConversationId` set)
- [ ] Verify invite calls are correctly classified as outbound

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
