### PR TITLE
fix: eliminate TOCTOU race between connectedId and isManagedAssistant in LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -229,7 +229,10 @@ enum LogExporter {
         // 3. Assistant logs — platform API for managed, local gateway for self-hosted
         let home = NSHomeDirectory()
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        let isManagedAssistant = await MainActor.run { Self.isManagedAssistant }
+        let isManagedAssistant: Bool = {
+            guard let id = connectedId else { return false }
+            return LockfileAssistant.loadByName(id)?.isManaged == true
+        }()
 
         var daemonUnreachable = false
         if isManagedAssistant, let assistantId = connectedId,


### PR DESCRIPTION
## Summary
- Fix TOCTOU race condition in `LogExporter.buildArchive` where `connectedId` (from UserDefaults) and `isManagedAssistant` (from AppDelegate cached state) were read independently, allowing inconsistency if the user switches assistants between reads
- Derive `isManagedAssistant` inline from the same `connectedId` value via `LockfileAssistant.loadByName`, making both values atomically consistent
- Removes an unnecessary `await MainActor.run` hop from the nonisolated `buildArchive` method

Addresses feedback from PR #17154.

## Test plan
- [ ] Verify managed assistant log export still routes through platform API
- [ ] Verify self-hosted assistant log export still routes through daemon gateway
- [ ] Verify switching assistants during an active export does not cause path mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
