### PR TITLE
fix: sort conversation disk view imports for lint

### DIFF
--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -23,8 +23,8 @@ import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import {
   getAttachmentContent,
-  getFilePathForAttachment,
   getAttachmentMetadataForMessage,
+  getFilePathForAttachment,
 } from "./attachments-store.js";
 import { getMessageById } from "./conversation-crud.js";
 


### PR DESCRIPTION
## Summary
- sort the `conversation-disk-view` attachment imports to satisfy `simple-import-sort`
- keep the change scoped to the single file flagged by the failing lint job

## Original prompt
[$do](/Users/sidd/vocify/claude-skills/skills/do/SKILL.md) Fix this lint issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23277205551/job/67682636349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
