### PR TITLE
fix: sync viewMode binding when available modes change in FileContentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -47,9 +47,15 @@ struct FileContentView: View {
     var showReadOnlyBadge: Bool = false
     var onTextChange: ((String) -> Void)? = nil
 
+    private func syncViewMode() {
+        let modes = availableViewModes(for: fileName, mimeType: mimeType)
+        if !modes.contains(viewMode) {
+            viewMode = modes.first ?? .source
+        }
+    }
+
     var body: some View {
         let modes = availableViewModes(for: fileName, mimeType: mimeType)
-        let effectiveMode = modes.contains(viewMode) ? viewMode : (modes.first ?? .source)
 
         VStack(alignment: .leading, spacing: 0) {
             FileContentHeaderBar(
@@ -75,7 +81,7 @@ struct FileContentView: View {
 
             Divider().background(VColor.borderBase)
 
-            switch effectiveMode {
+            switch viewMode {
             case .source:
                 HighlightedTextView(
                     text: isEditable ? $content : .constant(content),
@@ -93,6 +99,9 @@ struct FileContentView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
+        .onAppear { syncViewMode() }
+        .onChange(of: fileName) { syncViewMode() }
+        .onChange(of: mimeType) { syncViewMode() }
     }
 }
 


### PR DESCRIPTION
## Summary
- Address review feedback from PR #17631 where `effectiveMode` was computed locally but never written back to `state.viewMode`, leaving the `VSegmentedControl` binding stale
- Replace the `effectiveMode` pattern with a `syncViewMode()` helper called from `.onAppear` and `.onChange(of:)` modifiers on `fileName` and `mimeType`
- The segmented control now stays in sync with the actual rendered content without mutating state during view body evaluation
- Fixes the scenario where renaming a file (e.g. `.json` to `.md`) would leave the toggle showing no selected tab

## Test plan
- [ ] Open a markdown file in the workspace viewer and verify the Preview/Source toggle works
- [ ] Rename a file to change its extension (e.g. rename a .json file to .md) and verify the view mode toggle updates correctly
- [ ] Verify no "Publishing changes from within view updates" runtime warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
