### PR TITLE
fix: dock icon falls back to character traits when avatar PNG missing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -324,6 +324,7 @@ final class AvatarAppearanceManager {
             characterColor = nil
             cachedFallbackAvatar = nil
             cachedFullFallbackAvatar = nil
+            updateDockIcon()
             return
         }
         characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
@@ -331,6 +332,7 @@ final class AvatarAppearanceManager {
         characterColor = AvatarColor(rawValue: components.color)
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
+        updateDockIcon()
     }
 
     // MARK: - File Watching
@@ -480,12 +482,18 @@ final class AvatarAppearanceManager {
     static let avatarDidChangeNotification = Notification.Name("AvatarAppearanceManager.avatarDidChange")
 
     /// Updates the application dock icon to match the current avatar.
-    /// When a custom avatar exists, renders it inside a macOS-style squircle mask.
-    /// When cleared, reverts to the default bundle icon.
+    /// Uses the custom avatar PNG when available, falls back to a character
+    /// avatar rendered from saved traits, then reverts to the default bundle icon.
     private func updateDockIcon() {
         NotificationCenter.default.post(name: Self.avatarDidChangeNotification, object: nil)
 
-        guard let avatar = customAvatarImage else {
+        // Prefer custom avatar PNG, then character avatar from saved traits.
+        let avatar: NSImage
+        if let custom = customAvatarImage {
+            avatar = custom
+        } else if let body = characterBodyShape, let eyes = characterEyeStyle, let color = characterColor {
+            avatar = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color, size: 512)
+        } else {
             NSApplication.shared.applicationIconImage = nil
             NSApp.dockTile.display()
             return


### PR DESCRIPTION
## Summary
- Updates `updateDockIcon()` to fall back to `AvatarCompositor.render()` from saved character traits when `customAvatarImage` is nil, matching the existing fallback behavior in `chatAvatarImage` and `fullAvatarImage`
- Calls `updateDockIcon()` from `loadAvatarComponents()` so the dock icon updates immediately when traits change via the file watcher

Addresses review feedback from #17114 — both the Devin and Codex bot comments noted that the dock icon did not reflect character traits when the avatar PNG was missing.

## Test plan
- [ ] Verify dock icon shows character avatar when `avatar-image.png` is deleted but `character-traits.json` exists
- [ ] Verify dock icon updates when character traits change via file watcher
- [ ] Verify dock icon still shows custom avatar PNG when both PNG and traits exist
- [ ] Verify dock icon reverts to default bundle icon when neither PNG nor traits exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
