### PR TITLE
fix: restore iOS model catalog wiring

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -60,6 +60,30 @@ struct ChatContentView: View {
         return Array(all.suffix(viewModel.displayedMessageCount))
     }
 
+    private var modelPickerModels: [(id: String, name: String)] {
+        if let currentProvider = viewModel.providerCatalog.first(where: { provider in
+            provider.models.contains(where: { $0.id == viewModel.selectedModel })
+        }) {
+            return currentProvider.models.map { model in
+                (id: model.id, name: model.displayName)
+            }
+        }
+
+        var seenModelIds = Set<String>()
+        let allCatalogModels = viewModel.providerCatalog.flatMap { provider in
+            provider.models.compactMap { model -> (id: String, name: String)? in
+                guard seenModelIds.insert(model.id).inserted else { return nil }
+                return (id: model.id, name: model.displayName)
+            }
+        }
+
+        if !allCatalogModels.isEmpty {
+            return allCatalogModels
+        }
+
+        return [(id: viewModel.selectedModel, name: viewModel.selectedModel)]
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Messages area — empty state when no messages, otherwise scrollable list
@@ -299,7 +323,7 @@ struct ChatContentView: View {
     private func messageBubble(message: ChatMessage, index: Int, messages: [ChatMessage]) -> some View {
         if message.modelPicker != nil {
             ModelPickerBubble(
-                models: ModelListBubble.anthropicModels.map { (id: $0.model, name: $0.display) },
+                models: modelPickerModels,
                 selectedModelId: viewModel.selectedModel,
                 onSelect: { modelId in
                     viewModel.setModel(modelId)
@@ -311,12 +335,16 @@ struct ChatContentView: View {
                 removal: .opacity
             ))
         } else if message.modelList != nil {
-            ModelListBubble(currentModel: viewModel.selectedModel, configuredProviders: viewModel.configuredProviders)
-                .id(message.id)
-                .transition(.asymmetric(
-                    insertion: .move(edge: .bottom).combined(with: .opacity),
-                    removal: .opacity
-                ))
+            ModelListBubble(
+                currentModel: viewModel.selectedModel,
+                configuredProviders: viewModel.configuredProviders,
+                providerCatalog: viewModel.providerCatalog
+            )
+            .id(message.id)
+            .transition(.asymmetric(
+                insertion: .move(edge: .bottom).combined(with: .opacity),
+                removal: .opacity
+            ))
         } else if message.commandList != nil {
             CommandListBubble()
                 .id(message.id)


### PR DESCRIPTION
## Summary
- fix the iOS chat model picker to use the live provider catalog instead of the removed `ModelListBubble.anthropicModels` helper.
- pass `providerCatalog` into `ModelListBubble` so the iOS chat UI matches the shared model-list API and compiles again.
- Apple refs checked (2026-03-19): not applicable; this change only rewires existing shared chat state and does not adopt new platform APIs.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23277248997/job/67682766357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
