### PR TITLE
fix: guard syncChannels same-contact path against overwriting blocked status (#17647)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -295,21 +295,28 @@ function syncChannels(
       .get();
 
     if (existing) {
+      // Preserve guardian blocks: if the channel is blocked, do not overwrite
+      // its status/policy — mirrors the guard in the cross-contact reassignment
+      // path so a blocked channel cannot be unblocked via a same-contact sync.
+      const isBlocked = existing.status === "blocked";
+
       const updateSet: Record<string, unknown> = {};
       if (ch.isPrimary !== undefined) updateSet.isPrimary = ch.isPrimary;
       if (ch.externalUserId !== undefined)
         updateSet.externalUserId = ch.externalUserId;
       if (ch.externalChatId !== undefined)
         updateSet.externalChatId = ch.externalChatId;
-      if (ch.status !== undefined) updateSet.status = ch.status;
-      if (ch.policy !== undefined) updateSet.policy = ch.policy;
+      if (!isBlocked) {
+        if (ch.status !== undefined) updateSet.status = ch.status;
+        if (ch.policy !== undefined) updateSet.policy = ch.policy;
+        if (ch.revokedReason !== undefined)
+          updateSet.revokedReason = ch.revokedReason;
+        if (ch.blockedReason !== undefined)
+          updateSet.blockedReason = ch.blockedReason;
+      }
       if (ch.verifiedAt !== undefined) updateSet.verifiedAt = ch.verifiedAt;
       if (ch.verifiedVia !== undefined) updateSet.verifiedVia = ch.verifiedVia;
       if (ch.inviteId !== undefined) updateSet.inviteId = ch.inviteId;
-      if (ch.revokedReason !== undefined)
-        updateSet.revokedReason = ch.revokedReason;
-      if (ch.blockedReason !== undefined)
-        updateSet.blockedReason = ch.blockedReason;
 
       if (Object.keys(updateSet).length > 0) {
         updateSet.updatedAt = now;


### PR DESCRIPTION
## Summary
- Add isBlocked guard to the existing-channel path in syncChannels to prevent overwriting blocked status/policy during same-contact updates
- Mirrors the guard already present in the conflicting-channel (cross-contact reassignment) path
- Addresses review feedback from #17647 noting the asymmetry between the two code paths

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/17647

## Test plan
- [ ] Verify that a blocked channel on a contact cannot have its status overwritten by a subsequent upsertContact call with status active
- [ ] Verify that non-blocked channels can still have their status updated normally
- [ ] Verify the conflicting-channel path still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
