### PR TITLE
fix: guard upsertApp rollback delete against concurrent writers (#17656)

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -278,7 +278,14 @@ export async function upsertApp(
     if (!stored) {
       // Roll back the just-inserted row to avoid an orphaned app pointing
       // at a non-existent client_secret in secure storage.
-      db.delete(oauthApps).where(eq(oauthApps.id, id)).run();
+      //
+      // Guard: only delete if updatedAt still matches our insertion timestamp.
+      // A concurrent upsertApp call may have observed this row, successfully
+      // stored the secret, and updated the row — deleting it would orphan that
+      // caller's valid reference.
+      db.delete(oauthApps)
+        .where(and(eq(oauthApps.id, id), eq(oauthApps.updatedAt, now)))
+        .run();
       throw new Error("Failed to store client_secret in secure storage");
     }
   }


### PR DESCRIPTION
## Summary
- Add updatedAt guard to the rollback delete in upsertApp to prevent a race condition where a failed secret-storage write could delete a row that a concurrent caller has already validated
- When two upsertApp calls race on the same (providerKey, clientId), call A can insert a row, call B can observe it and successfully store the secret, and then call A can fail and roll back — deleting call B's valid row. The fix checks updatedAt === insertion timestamp before deleting.

## Original PR
Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/17656

## Test plan
- [x] Existing test "throws when setSecureKeyAsync returns false" still passes (rollback still works in non-race case since updatedAt matches)
- [ ] CI passes lint, type-check, and existing oauth-store tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
