### PR TITLE
fix: align VEmptyState accessibility condition with button rendering logic (#17687)

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
@@ -48,7 +48,7 @@ public struct VEmptyState: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: action != nil ? .contain : .ignore)
+        .accessibilityElement(children: actionLabel != nil && action != nil ? .contain : .ignore)
         .accessibilityLabel("\(title). \(subtitle ?? "")")
     }
 }


### PR DESCRIPTION
## Summary
- Aligns the `.accessibilityElement(children:)` condition in `VEmptyState` with the button rendering condition
- Previously checked only `action != nil`; now checks `actionLabel != nil && action != nil` to match the `if let actionLabel, let action` guard on line 41
- Prevents VoiceOver from treating the empty state as a container with navigable children when no button is actually rendered

## Original PR
Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/17687

## Test plan
- [ ] Verify VoiceOver announces VEmptyState as a single element when no action button is present
- [ ] Verify VoiceOver allows navigating into VEmptyState children when an action button is present
- [ ] Confirm no regression in existing callers of VEmptyState

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
