### PR TITLE
fix: update seed-providers comment to reflect userinfoUrl reclassification

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -5,10 +5,10 @@ import { seedProviders } from "./oauth-store.js";
  *
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authUrl, tokenUrl,
- * tokenEndpointAuthMethod, extraParams, callbackTransport, pingUrl,
- * managedServiceConfigKey) are
+ * tokenEndpointAuthMethod, userinfoUrl, extraParams, callbackTransport,
+ * pingUrl, managedServiceConfigKey) are
  * overwritten on subsequent startups — user-customizable
- * fields (defaultScopes, scopePolicy, userinfoUrl, baseUrl) are only
+ * fields (defaultScopes, scopePolicy, baseUrl) are only
  * written on initial insert and preserved across restarts.
  *
  * Code-side behavioral fields (identityVerifier, injectionTemplates,


### PR DESCRIPTION
## Summary
- Moved `userinfoUrl` from the user-customizable field list to the implementation field list in the JSDoc comment in `seed-providers.ts`
- Addresses the stale comment identified in the review of #17692: the code was updated to treat `userinfoUrl` as an implementation field (overwritten on re-seed), but the doc comment was not updated to match

## Test plan
- No behavioral change -- comment-only fix
- Verify the comment now matches the `onConflictDoUpdate` set in `oauth-store.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
