### PR TITLE
fix: invalidate cursor rects when configPokeEnabled changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -165,8 +165,16 @@ class AvatarLayerView: NSView {
                    entryAnimationEnabled: Bool = false) {
         configBreathingEnabled = breathingEnabled
         configBlinkEnabled = blinkEnabled
+        let pokeChanged = configPokeEnabled != pokeEnabled
         configPokeEnabled = pokeEnabled
         configEntryAnimationEnabled = entryAnimationEnabled
+
+        // When pokeEnabled changes, AppKit won't re-invoke resetCursorRects()
+        // on its own (the frame hasn't changed), so we must explicitly ask it
+        // to re-query cursor rects for this view.
+        if pokeChanged {
+            window?.invalidateCursorRects(for: self)
+        }
 
         // Recovery: if entry was set up but entryAnimationEnabled was turned off
         // (e.g. SwiftUI re-rendered with entryAnimationEnabled=false before


### PR DESCRIPTION
## Summary
- Adds `window?.invalidateCursorRects(for: self)` call in `configure()` when `pokeEnabled` changes, so AppKit re-invokes `resetCursorRects()` and the cursor correctly updates between pointing-hand and default arrow
- Addresses review feedback from PR #17698

## Test plan
- [ ] Toggle `pokeEnabled` dynamically and verify cursor changes from pointing-hand to default arrow and vice versa
- [ ] Verify no regressions in normal avatar hover behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
