### PR TITLE
fix: clarify tautological doc comment on ConversationModel.conversationId

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -10,7 +10,7 @@ struct ConversationModel: Identifiable, Hashable {
     var title: String
     let createdAt: Date
     /// Daemon conversation ID for restored conversations. Nil for new, unsaved conversations.
-    /// Mutable so it can be backfilled when the daemon assigns a conversation to a new conversation.
+    /// Mutable so it can be backfilled when the daemon assigns a session ID to a new conversation.
     var conversationId: String?
     var isArchived: Bool
     var isPinned: Bool


### PR DESCRIPTION
## Summary
- Fixes tautological doc comment flagged in PR #17713 review: "assigns a conversation to a new conversation" -> "assigns a session ID to a new conversation"
- The mechanical thread->conversation rename collapsed two distinct concepts (session ID vs conversation) into a redundant phrase
- The user-facing string issues from the same review were already addressed in PRs #18249 and #18313

## Test plan
- [ ] Verify the doc comment accurately describes the `conversationId` property's mutability rationale
- [ ] No runtime behavior changes — comment-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
