### PR TITLE
fix: start breathing animation fresh on resume when post-entry delay was interrupted

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -90,6 +90,11 @@ class AvatarLayerView: NSView {
     private var configEntryAnimationEnabled: Bool = false
     private var hasPlayedEntry: Bool = false
 
+    /// Whether the post-entry animations (breathing, blink, twitch) have been started
+    /// after the entry animation delay. Used by `resumeAnimations()` to decide whether
+    /// to start breathing fresh vs resume an existing animation.
+    private var postEntryAnimationsStarted: Bool = false
+
     /// Whether configure() has set up entry animation state (closed eyes, drop transform)
     /// that needs to be cleaned up if the entry animation never fires.
     private var entrySetupPending: Bool = false
@@ -466,6 +471,17 @@ class AvatarLayerView: NSView {
         animationsActive = true
         if configBlinkEnabled { startBlinkTimer() }
         startTwitchTimer()
+
+        // If the entry animation played but the post-entry delay was cancelled
+        // before breathing/blink/twitch could start (e.g. window lost focus during
+        // the 1.1s post-entry delay), start them fresh now instead of trying to
+        // resume a non-existent breathing animation.
+        if hasPlayedEntry && !postEntryAnimationsStarted {
+            postEntryAnimationsStarted = true
+            if configBreathingEnabled { startBreathing() }
+            return
+        }
+
         if configBreathingEnabled {
             let pausedTime = bodyLayer.timeOffset
             bodyLayer.speed = 1
@@ -571,6 +587,7 @@ class AvatarLayerView: NSView {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard let self, self.animationsActive else { return }
+                self.postEntryAnimationsStarted = true
                 if self.configBlinkEnabled { self.startBlinkTimer() }
                 if self.configBreathingEnabled { self.startBreathing() }
                 self.startTwitchTimer()


### PR DESCRIPTION
## Summary
- Fixes a regression from PR #17708 where cancelling `postEntryTask` in `pauseAnimations()` could permanently prevent breathing animation from starting
- Adds `postEntryAnimationsStarted` flag to track whether the post-entry animations (breathing, blink, twitch) have been started after the entry animation delay
- When `resumeAnimations()` is called and post-entry animations haven't started yet, starts breathing fresh instead of trying to resume a non-existent animation

Addresses review feedback from PR #17708.

## Test plan
- [ ] Verify avatar entry animation still plays correctly with the drop-bounce and eye reveal
- [ ] Verify breathing, blink, and twitch animations start after the post-entry delay under normal conditions
- [ ] Verify that if the window loses focus during the 1.1s post-entry delay, breathing animation starts correctly when focus returns
- [ ] Verify that pause/resume after breathing is already running still works (layer timing resume path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
