### PR TITLE
fix: validate provider keys on cache hit and avoid eager base64 decode in indexer

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -203,15 +203,6 @@ function getCachedOrCreate<T extends EmbeddingBackend>(
   return instance;
 }
 
-/** Check if a backend instance already exists in the cache. */
-function getCached(
-  provider: string,
-  model: string,
-  extras?: string[],
-): EmbeddingBackend | undefined {
-  return backendCache.get(cacheKey(provider, model, extras));
-}
-
 function geminiCacheExtras(config: AssistantConfig): string[] {
   const extras: string[] = [];
   if (config.memory.embeddings.geminiTaskType) {
@@ -259,9 +250,6 @@ export async function selectEmbeddingBackend(
     };
   }
   if (requested === "ollama") {
-    // Check cache first to avoid unnecessary async key fetch on cache hits
-    const cached = getCached("ollama", config.memory.embeddings.ollamaModel);
-    if (cached) return { backend: cached, reason: null };
     const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
     return {
       backend: getCachedOrCreate(
@@ -298,12 +286,6 @@ export async function selectEmbeddingBackend(
           reason: null,
         };
       case "openai": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedOpenai = getCached(
-          "openai",
-          config.memory.embeddings.openaiModel,
-        );
-        if (cachedOpenai) return { backend: cachedOpenai, reason: null };
         const openaiKey = await getProviderKeyAsync("openai");
         if (!openaiKey) continue;
         return {
@@ -320,13 +302,6 @@ export async function selectEmbeddingBackend(
         };
       }
       case "gemini": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedGemini = getCached(
-          "gemini",
-          config.memory.embeddings.geminiModel,
-          geminiCacheExtras(config),
-        );
-        if (cachedGemini) return { backend: cachedGemini, reason: null };
         const geminiKey = await getProviderKeyAsync("gemini");
         if (!geminiKey) continue;
         return {
@@ -348,12 +323,6 @@ export async function selectEmbeddingBackend(
         };
       }
       case "ollama": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedOllama = getCached(
-          "ollama",
-          config.memory.embeddings.ollamaModel,
-        );
-        if (cachedOllama) return { backend: cachedOllama, reason: null };
         if (!(await isOllamaConfigured(config))) continue;
         const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
         return {
@@ -570,15 +539,6 @@ async function selectFallbackBackends(
     if (provider === exclude) continue;
     switch (provider) {
       case "openai": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedOpenai = getCached(
-          "openai",
-          config.memory.embeddings.openaiModel,
-        );
-        if (cachedOpenai) {
-          backends.push(cachedOpenai);
-          break;
-        }
         const openaiKey = await getProviderKeyAsync("openai");
         if (openaiKey) {
           backends.push(
@@ -596,16 +556,6 @@ async function selectFallbackBackends(
         break;
       }
       case "gemini": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedGemini = getCached(
-          "gemini",
-          config.memory.embeddings.geminiModel,
-          geminiCacheExtras(config),
-        );
-        if (cachedGemini) {
-          backends.push(cachedGemini);
-          break;
-        }
         const geminiKey = await getProviderKeyAsync("gemini");
         if (geminiKey) {
           backends.push(
@@ -628,15 +578,6 @@ async function selectFallbackBackends(
         break;
       }
       case "ollama": {
-        // Check cache first to avoid unnecessary async key fetch on cache hits
-        const cachedOllama = getCached(
-          "ollama",
-          config.memory.embeddings.ollamaModel,
-        );
-        if (cachedOllama) {
-          backends.push(cachedOllama);
-          break;
-        }
         if (await isOllamaConfigured(config)) {
           const ollamaKey = (await getProviderKeyAsync("ollama")) ?? undefined;
           backends.push(

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -9,7 +9,7 @@ import { getDb } from "./db.js";
 import { selectedBackendSupportsMultimodal } from "./embedding-backend.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
 import {
-  extractMediaBlocks,
+  extractMediaBlockMeta,
   extractTextFromStoredMessageContent,
 } from "./message-content.js";
 import { memorySegments } from "./schema.js";
@@ -71,16 +71,18 @@ export async function indexMessageNow(
     input.role === "user" ||
     (input.role === "assistant" && config.extraction.extractFromAssistant);
   // Check if the message has any image blocks before probing the backend.
-  // extractMediaBlocks is synchronous and cheap, while
-  // selectedBackendSupportsMultimodal requires async key resolution that
-  // would add unnecessary latency for text-only messages.
-  const candidateMediaBlocks = extractMediaBlocks(input.content).filter(
+  // extractMediaBlockMeta is synchronous and lightweight — it detects image
+  // blocks without decoding base64 data into Buffers, avoiding CPU/memory
+  // overhead for messages on non-multimodal backends.
+  // selectedBackendSupportsMultimodal requires async key resolution, so we
+  // skip it entirely for text-only messages.
+  const candidateMediaMeta = extractMediaBlockMeta(input.content).filter(
     (b) => b.type === "image",
   );
   const mediaBlocks =
-    candidateMediaBlocks.length > 0 &&
+    candidateMediaMeta.length > 0 &&
     (await selectedBackendSupportsMultimodal(getConfig()))
-      ? candidateMediaBlocks
+      ? candidateMediaMeta
       : [];
 
   // Wrap all segment inserts and job enqueues in a single transaction so they


### PR DESCRIPTION
## Summary
- Remove `getCached()` early-return shortcut that bypassed API key validation, causing stale cached backends to be returned after key deletion instead of falling through to the next provider
- Replace `extractMediaBlocks` with `extractMediaBlockMeta` in indexer to avoid eagerly decoding base64 image payloads into Buffers before confirming the backend supports multimodal embeddings
- Delete the now-unused `getCached()` helper function

## Test plan
- [ ] Verify embedding backend selection falls through correctly when API key is removed while daemon is running
- [ ] Verify text-only messages do not trigger base64 decode overhead
- [ ] Verify image messages still enqueue embed_attachment jobs when multimodal backend is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
