### PR TITLE
fix: correct remaining path-B port numbers for 8 OAuth provider skill docs

### DIFF
--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Telegram, Slack, etc.)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17329) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Asana)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17328) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Discord)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17326) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Dropbox)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17327) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Figma)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17331) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (HubSpot)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17330) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Linear)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17324) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Todoist)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17325) is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #17722 which fixed port numbers for GitHub and Spotify but missed 8 other providers
- All 8 remaining path-B manual setup docs incorrectly referenced port 17322 (Slack's port) instead of each provider's assigned port from `assistant/src/oauth/provider-behaviors.ts`
- Updated Linear (17324), Todoist (17325), Discord (17326), Dropbox (17327), Asana (17328), Airtable (17329), HubSpot (17330), and Figma (17331)

## Test plan
- [x] Verified all port numbers match the `loopbackPort` values in `provider-behaviors.ts`
- [x] Confirmed no remaining stale 17322 references in any path-B docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
