### PR TITLE
fix: unarchive conversation when explicitly navigated to via search

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -819,9 +819,16 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     /// Select a conversation by conversation ID, fetching it on-demand from the server if not locally available.
     /// Returns `true` if the conversation was found (or fetched) and selected, `false` on failure.
+    /// If the conversation is archived, it is automatically unarchived since the caller
+    /// explicitly navigated to it (e.g. via command palette search).
     func selectConversationByConversationIdAsync(_ conversationId: String) async -> Bool {
         // Fast path: already loaded locally
         if selectConversationByConversationId(conversationId) {
+            // Unarchive if needed — the user explicitly navigated to this conversation,
+            // so it should appear in the sidebar alongside being selected.
+            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
+                unarchiveConversation(id: match.id)
+            }
             return true
         }
 
@@ -833,6 +840,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Re-check after await — another code path (e.g. SSE conversation-list response)
         // may have inserted this conversation while we were waiting on the network.
         if selectConversationByConversationId(conversationId) {
+            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
+                unarchiveConversation(id: match.id)
+            }
             return true
         }
 
@@ -841,12 +851,21 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return false
         }
 
+        // The user explicitly navigated to this conversation, so clear its archived
+        // state. Without this, the conversation would be selected (chat view renders)
+        // but invisible in the sidebar because visibleConversations filters out archived items.
+        if isConversationArchived(conversation.id) {
+            var archived = archivedConversationIds
+            archived.remove(conversation.id)
+            archivedConversationIds = archived
+        }
+
         let effectiveCreatedAt = conversation.createdAt ?? conversation.updatedAt
         let conversationModel = ConversationModel(
             title: conversation.title,
             createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
             conversationId: conversation.id,
-            isArchived: isConversationArchived(conversation.id),
+            isArchived: false,
             isPinned: conversation.isPinned ?? false,
             pinnedOrder: (conversation.isPinned ?? false) ? conversation.displayOrder.map { Int($0) } : nil,
             displayOrder: conversation.displayOrder.map { Int($0) },


### PR DESCRIPTION
## Summary
- When a user navigates to a conversation via command palette search (`selectConversationByConversationIdAsync`), any archived conversation is now automatically unarchived
- Handles all three code paths: fast path (locally loaded), re-check path (inserted during network fetch), and slow path (newly fetched from server)
- Addresses the Devin review comment on #17718 that identified archived conversations being selected but not visible in the sidebar

## Test plan
- [x] Verify that searching for an archived conversation via command palette unarchives it and makes it visible in the sidebar
- [x] Verify that non-archived conversations continue to work normally
- [x] Verify that the fast path, re-check path, and slow path all handle unarchiving correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
