### PR TITLE
Change default conversation retention to unlimited

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -186,7 +186,7 @@ describe("AssistantConfigSchema", () => {
       enabled: true,
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
-      conversationRetentionDays: 90,
+      conversationRetentionDays: 0,
     });
   });
 

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -68,8 +68,10 @@ export const MemoryCleanupConfigSchema = z
       .nonnegative(
         "memory.cleanup.conversationRetentionDays must be non-negative",
       )
-      .default(90)
-      .describe("Number of days to retain conversation data before cleanup"),
+      .default(0)
+      .describe(
+        "Number of days to retain conversation data before cleanup (0 disables pruning)",
+      ),
   })
   .describe("Automatic memory cleanup and garbage collection settings");
 


### PR DESCRIPTION
## Summary
- change the default conversation cleanup retention from 90 days to unlimited by setting `conversationRetentionDays` to `0`
- clarify in the schema docs that `0` disables pruning
- update the config schema test to match the new default

## Original prompt
Change the default to unlimited and also change my config to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)