### PR TITLE
feat: add apiKeyPlaceholder to provider catalog and ModelInfo API

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -41,6 +41,15 @@ export const INFERENCE_PROVIDER_API_KEY_URLS: Record<string, string> = {
   openrouter: "https://openrouter.ai/keys",
 };
 
+/** API key placeholder patterns for inference providers (omit providers that don't require keys). */
+export const INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS: Record<string, string> = {
+  anthropic: "sk-ant-api03-...",
+  openai: "sk-proj-...",
+  gemini: "AIza...",
+  fireworks: "fw_...",
+  openrouter: "sk-or-v1-...",
+};
+
 const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   anthropic: "Anthropic",
   openai: "OpenAI",
@@ -56,6 +65,7 @@ export interface ProviderCatalogEntry {
   models: CatalogModel[];
   defaultModel: string;
   apiKeyUrl?: string;
+  apiKeyPlaceholder?: string;
 }
 
 /** Build the full provider catalog with metadata for each inference provider. */
@@ -66,6 +76,7 @@ export function getFullProviderCatalog(): ProviderCatalogEntry[] {
     models,
     defaultModel: models[0]?.id ?? "",
     apiKeyUrl: INFERENCE_PROVIDER_API_KEY_URLS[id],
+    apiKeyPlaceholder: INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS[id],
   }));
 }
 


### PR DESCRIPTION
## Summary
- Add INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS map with per-provider key prefix patterns (anthropic, openai, gemini, fireworks, openrouter)
- Add apiKeyPlaceholder optional field to ProviderCatalogEntry interface
- Include apiKeyPlaceholder in getFullProviderCatalog() output, flowing through GET /v1/model allProviders

Part of plan: provider-apikey-placeholder.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
