### PR TITLE
fix: add Task.isCancelled guards to SkillsStore fetch methods

### DIFF
--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -362,13 +362,16 @@ public final class SkillsStore: ObservableObject {
 
     public func fetchSkillDetail(skillId: String) {
         skillDetailTask?.cancel()
+        if currentDetailSkillId != skillId {
+            selectedSkillDetail = nil
+        }
         currentDetailSkillId = skillId
         isLoadingSkillDetail = true
         skillDetailError = nil
-        selectedSkillDetail = nil
 
         skillDetailTask = Task {
             let result = await skillsClient.fetchSkillDetail(skillId: skillId)
+            guard !Task.isCancelled else { return }
             guard self.currentDetailSkillId == skillId else { return }
             if let result {
                 selectedSkillDetail = result
@@ -383,13 +386,16 @@ public final class SkillsStore: ObservableObject {
 
     public func fetchSkillFiles(skillId: String) {
         skillFilesTask?.cancel()
+        if currentFilesSkillId != skillId {
+            selectedSkillFiles = nil
+        }
         currentFilesSkillId = skillId
         isLoadingSkillFiles = true
         skillFilesError = nil
-        selectedSkillFiles = nil
 
         skillFilesTask = Task {
             let result = await skillsClient.fetchSkillFiles(skillId: skillId)
+            guard !Task.isCancelled else { return }
             guard self.currentFilesSkillId == skillId else { return }
             if let result {
                 selectedSkillFiles = result


### PR DESCRIPTION
## Summary
- Add `guard !Task.isCancelled else { return }` after `await` in both `fetchSkillDetail` and `fetchSkillFiles` to prevent cancelled tasks from incorrectly setting error state when the same `skillId` is re-fetched
- Only nil out `selectedSkillDetail`/`selectedSkillFiles` when fetching a *different* skill, avoiding UI flicker on same-skill refreshes

Addresses review feedback on #17734.

## Test plan
- [ ] Navigate rapidly between skills in the skills list and verify the detail/files always match the selected skill
- [ ] Re-fetch the same skill and verify no error flash or content flicker occurs
- [ ] Navigate away while a fetch is in-flight and verify no stale data appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
