### PR TITLE
fix: prevent traits/PNG desync by rendering avatar into memory before disk writes

### DIFF
--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -25,37 +25,56 @@ export type TraitsSyncResult =
     };
 
 /**
- * Renders avatar-image.png and character-ascii.txt from the given traits,
- * writing each file atomically.  Does NOT touch character-traits.json.
- *
- * Returns `true` if the ASCII sidecar was also written successfully.
+ * Renders avatar PNG and ASCII art into memory without touching the filesystem.
+ * Call this before any disk writes so a render failure leaves all files untouched.
  */
-function renderAndWriteAvatarFiles(
-  traits: CharacterTraits,
-  avatarDir: string,
-): boolean {
-  const pngPath = join(avatarDir, "avatar-image.png");
-
-  // Render PNG first so we fail before writing anything to disk.
-  // Trait ID validation has already been performed by the caller.
+function renderAvatarBuffers(traits: CharacterTraits): {
+  pngBuffer: Buffer;
+  asciiArt: string | null;
+} {
   const pngBuffer = renderCharacterPng(
     traits.bodyShape,
     traits.eyeStyle,
     traits.color,
   );
-  const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
-  writeFileSync(pngTmp, pngBuffer);
-  renameSync(pngTmp, pngPath);
 
-  // Render and write ASCII art — isolated so a failure here doesn't cause
-  // the primary operation to report failure.
+  let asciiArt: string | null = null;
   try {
-    const asciiPath = join(avatarDir, "character-ascii.txt");
-    const asciiArt = renderCharacterAscii(
+    asciiArt = renderCharacterAscii(
       traits.bodyShape,
       traits.eyeStyle,
       traits.color,
     );
+  } catch (asciiErr) {
+    log.warn(
+      { err: asciiErr },
+      "Failed to render ASCII art — will still write PNG and traits",
+    );
+  }
+
+  return { pngBuffer, asciiArt };
+}
+
+/**
+ * Writes pre-rendered avatar files (PNG + optional ASCII) to disk atomically.
+ * Returns `true` if the ASCII sidecar was also written successfully.
+ */
+function writeAvatarFiles(
+  avatarDir: string,
+  pngBuffer: Buffer,
+  asciiArt: string | null,
+): boolean {
+  const pngPath = join(avatarDir, "avatar-image.png");
+  const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
+  writeFileSync(pngTmp, pngBuffer);
+  renameSync(pngTmp, pngPath);
+
+  if (asciiArt == null) {
+    return false;
+  }
+
+  try {
+    const asciiPath = join(avatarDir, "character-ascii.txt");
     const asciiTmp = `${asciiPath}.${randomUUID()}.tmp`;
     writeFileSync(asciiTmp, asciiArt);
     renameSync(asciiTmp, asciiPath);
@@ -74,8 +93,10 @@ function renderAndWriteAvatarFiles(
  * character-ascii.txt in one atomic operation.  Accepts the trait values
  * directly so callers don't need to touch the filesystem first.
  *
- * Validates trait IDs against the component set, then renders the PNG before
- * writing the traits file so that if rendering fails, neither file is modified.
+ * Validates trait IDs against the component set, then renders into memory
+ * before any disk writes.  Writes the traits file first, then the rendered
+ * avatar files, so a render failure leaves all files untouched and a disk
+ * failure after traits are written never leaves the PNG ahead of the traits.
  */
 export function writeTraitsAndRenderAvatar(
   traits: CharacterTraits,
@@ -129,15 +150,20 @@ export function writeTraitsAndRenderAvatar(
   try {
     mkdirSync(avatarDir, { recursive: true });
 
-    // Render avatar files first — trait IDs are already validated above,
-    // so errors here are genuine render failures (disk I/O, Resvg, etc.).
-    const asciiWritten = renderAndWriteAvatarFiles(traits, avatarDir);
+    // Phase 1: Render everything into memory — no disk writes yet.
+    // If rendering fails, all files remain untouched.
+    const { pngBuffer, asciiArt } = renderAvatarBuffers(traits);
 
-    // Write traits file atomically (after successful render)
+    // Phase 2: Write traits file atomically first.
     const traitsJson = JSON.stringify(traits, null, 2);
     const traitsTmp = `${traitsPath}.${randomUUID()}.tmp`;
     writeFileSync(traitsTmp, traitsJson);
     renameSync(traitsTmp, traitsPath);
+
+    // Phase 3: Write rendered avatar files to disk.
+    // Traits are already committed, so a failure here leaves traits ahead of
+    // the PNG — acceptable because the next render call will reconcile them.
+    const asciiWritten = writeAvatarFiles(avatarDir, pngBuffer, asciiArt);
 
     log.info(
       {


### PR DESCRIPTION
## Summary
- Splits `renderAndWriteAvatarFiles()` into two functions: `renderAvatarBuffers()` (pure render, no disk I/O) and `writeAvatarFiles()` (writes pre-rendered buffers to disk)
- Restructures `writeTraitsAndRenderAvatar()` into three explicit phases: render to memory, write traits, write avatar files
- Fixes a consistency bug where a traits write failure after avatar files were already written would leave `avatar-image.png` reflecting new traits while `character-traits.json` still held old values

Addresses review feedback from #17741.

## Test plan
- [ ] Verify `POST /v1/avatar/render-from-traits` with valid JSON body still works
- [ ] Verify sending invalid trait IDs returns error without modifying any files
- [ ] Verify `assistant avatar character update` CLI still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
