### PR TITLE
fix: add trailing slash tolerance to gateway OAuth regex routes

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -665,27 +665,27 @@ async function main() {
       handler: (req) => oauthAppsProxy.handleCreateApp(req),
     },
     {
-      path: /^\/v1\/oauth\/apps\/([^/]+)$/,
+      path: /^\/v1\/oauth\/apps\/([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) => oauthAppsProxy.handleDeleteApp(req, params[0]),
     },
     {
-      path: /^\/v1\/oauth\/apps\/([^/]+)\/connections$/,
+      path: /^\/v1\/oauth\/apps\/([^/]+)\/connections\/?$/,
       method: "GET",
       auth: "edge",
       handler: (req, params) =>
         oauthAppsProxy.handleListConnections(req, params[0]),
     },
     {
-      path: /^\/v1\/oauth\/connections\/([^/]+)$/,
+      path: /^\/v1\/oauth\/connections\/([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) =>
         oauthAppsProxy.handleDeleteConnection(req, params[0]),
     },
     {
-      path: /^\/v1\/oauth\/apps\/([^/]+)\/connect$/,
+      path: /^\/v1\/oauth\/apps\/([^/]+)\/connect\/?$/,
       method: "POST",
       auth: "edge",
       handler: (req, params) => oauthAppsProxy.handleConnect(req, params[0]),


### PR DESCRIPTION
## Summary

Fixes gap identified during plan review for your-own-google-oauth.md.

**Gap:** Gateway regex routes miss trailing slashes from GatewayHTTPClient
**What was expected:** Routes should match Swift client requests that include trailing slashes
**What was found:** Regex patterns anchored with `$` without optional slash, causing mismatches

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
