### PR TITLE
fix: use containerization-aware base dir for device ID persistence

### DIFF
--- a/assistant/src/__tests__/workspace-migration-seed-device-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-seed-device-id.test.ts
@@ -10,7 +10,7 @@ const writeFileSyncFn = mock(
   (_path: string, _data: string, _opts?: object) => {},
 );
 const mkdirSyncFn = mock((_path: string, _opts?: object) => {});
-const getBaseDataDirFn = mock((): string | undefined => undefined);
+const getDeviceIdBaseDirFn = mock((): string => "/mock-home");
 
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
@@ -23,12 +23,8 @@ mock.module("node:fs", () => ({
   mkdirSync: mkdirSyncFn,
 }));
 
-mock.module("node:os", () => ({
-  homedir: () => "/mock-home",
-}));
-
-mock.module("../config/env-registry.js", () => ({
-  getBaseDataDir: getBaseDataDirFn,
+mock.module("../util/device-id.js", () => ({
+  getDeviceIdBaseDir: getDeviceIdBaseDirFn,
 }));
 
 // Import after mocking
@@ -67,7 +63,7 @@ describe("003-seed-device-id migration", () => {
     readFileSyncFn.mockClear();
     writeFileSyncFn.mockClear();
     mkdirSyncFn.mockClear();
-    getBaseDataDirFn.mockReturnValue(undefined);
+    getDeviceIdBaseDirFn.mockReturnValue("/mock-home");
   });
 
   test("no-op when device.json already has a deviceId", () => {
@@ -269,9 +265,9 @@ describe("003-seed-device-id migration", () => {
     expect(parsed.deviceId).toBe("install-legacy");
   });
 
-  test("respects BASE_DATA_DIR override", () => {
+  test("respects BASE_DATA_DIR override via getDeviceIdBaseDir", () => {
     const customBase = "/custom-base";
-    getBaseDataDirFn.mockReturnValue(customBase);
+    getDeviceIdBaseDirFn.mockReturnValue(customBase);
 
     const customLockPath = `${customBase}/.vellum.lock.json`;
     const customDevicePath = `${customBase}/.vellum/device.json`;

--- a/assistant/src/util/device-id.ts
+++ b/assistant/src/util/device-id.ts
@@ -1,9 +1,16 @@
 /**
  * Device ID resolver.
  *
- * Reads or creates a stable per-device UUID stored in ~/.vellum/device.json.
- * The file is a JSON object (`{ "deviceId": "<uuid>" }`) extensible for
- * future per-device metadata.
+ * Reads or creates a stable per-device UUID stored in device.json under the
+ * Vellum config directory. The file is a JSON object (`{ "deviceId": "<uuid>" }`)
+ * extensible for future per-device metadata.
+ *
+ * Path resolution:
+ *   - Containerized (IS_CONTAINERIZED=true): uses BASE_DATA_DIR, which maps to a
+ *     persistent volume. Each container is effectively its own "device."
+ *   - Local (single or multi-instance): uses homedir() so all instances on the
+ *     same machine share a single device ID, even when BASE_DATA_DIR is set to
+ *     an instance-scoped directory.
  *
  * The value is cached in memory after the first successful read/write.
  * Falls back to a generated UUID if the file cannot be read or written.
@@ -14,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("device-id");
@@ -21,11 +29,26 @@ const log = getLogger("device-id");
 let cached: string | undefined;
 
 /**
+ * Resolve the base directory for device.json.
+ *
+ * In containerized environments, BASE_DATA_DIR points to a persistent volume
+ * and homedir() is ephemeral, so we must use BASE_DATA_DIR.
+ * In local environments (including multi-instance), homedir() is stable and
+ * shared across instances, giving a true per-machine device ID.
+ */
+export function getDeviceIdBaseDir(): string {
+  if (getIsContainerized()) {
+    return getBaseDataDir() || homedir();
+  }
+  return homedir();
+}
+
+/**
  * Get the stable device ID for this machine.
  *
  * Resolution order:
  *   1. Cached in-memory value (populated on first call)
- *   2. `deviceId` field from ~/.vellum/device.json
+ *   2. `deviceId` field from device.json
  *   3. Generate a new UUID, persist it to device.json, and return it
  *
  * On any read/write error the generated UUID is still cached so the
@@ -36,7 +59,7 @@ export function getDeviceId(): string {
     return cached;
   }
 
-  const vellumDir = join(homedir(), ".vellum");
+  const vellumDir = join(getDeviceIdBaseDir(), ".vellum");
   const filePath = join(vellumDir, "device.json");
   const generated = randomUUID();
 

--- a/assistant/src/workspace/migrations/003-seed-device-id.ts
+++ b/assistant/src/workspace/migrations/003-seed-device-id.ts
@@ -1,16 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { getBaseDataDir } from "../../config/env-registry.js";
+import { getDeviceIdBaseDir } from "../../util/device-id.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const seedDeviceIdMigration: WorkspaceMigration = {
   id: "003-seed-device-id",
   description:
-    "Seed ~/.vellum/device.json deviceId from the most recent lockfile installationId for continuity",
+    "Seed device.json deviceId from the most recent lockfile installationId for continuity",
   run(_workspaceDir: string): void {
-    const base = getBaseDataDir() || homedir();
+    const base = getDeviceIdBaseDir();
     const vellumDir = join(base, ".vellum");
     const devicePath = join(vellumDir, "device.json");
 


### PR DESCRIPTION
## Summary
- Introduces `getDeviceIdBaseDir()` in `device-id.ts` that uses `BASE_DATA_DIR` when `IS_CONTAINERIZED=true` (persistent volume) and `homedir()` otherwise (per-machine identity)
- Updates `003-seed-device-id` migration to use `getDeviceIdBaseDir()` instead of `getBaseDataDir() || homedir()`, ensuring path consistency with `getDeviceId()`
- Updates migration tests to mock the new shared helper

## Test plan
- [ ] Verify containerized environments use `BASE_DATA_DIR` for device.json persistence
- [ ] Verify local multi-instance setups share a single device ID via `homedir()`
- [ ] Confirm migration and `getDeviceId()` resolve to the same path in all environments

Addresses review feedback from PR #17742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
