### PR TITLE
fix: show neutral empty state while skill files are loading

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -31,8 +31,12 @@ struct AgentPanelContent: View {
     }
 
     /// Whether any files in the selected skill are viewable (non-binary with content).
+    /// Defaults to `true` when file metadata hasn't loaded yet so the empty state
+    /// shows the neutral "Select a file to view" instead of the misleading
+    /// "No viewable files" during loading.
     private var hasViewableFiles: Bool {
-        skillsManager.selectedSkillFiles?.files.contains { !$0.isBinary && $0.content != nil } ?? false
+        guard let files = skillsManager.selectedSkillFiles else { return true }
+        return files.files.contains { !$0.isBinary && $0.content != nil }
     }
 
     private var hasActiveSearch: Bool { !normalizedSkillQuery.isEmpty }


### PR DESCRIPTION
## Summary
- Fixed `hasViewableFiles` in `AgentPanel.swift` to default to `true` when `selectedSkillFiles` is `nil` (during loading), so the file viewer shows the neutral "Select a file to view" message instead of the misleading "No viewable files" while the request is in flight.
- Addresses review feedback from PR #17748: the prior `?? false` fallback caused a brief flash of "No viewable files" on every skill open because `fetchSkillFiles` sets `selectedSkillFiles = nil` while the request is in flight.

## Test plan
- [ ] Open a skill detail view and verify the empty state says "Select a file to view" during loading
- [ ] Open a skill that has only binary files and verify "No viewable files" appears after loading completes
- [ ] Open a skill with text files and verify a file is auto-selected after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
