### PR TITLE
fix: reject non-finite --width values in avatar ascii command

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -323,7 +323,7 @@ Examples:
       }
 
       const width = parseInt(opts.width, 10);
-      if (width < 1) {
+      if (!Number.isFinite(width) || width < 1) {
         log.error(
           `Invalid width: "${opts.width}". Must be a positive integer.`,
         );


### PR DESCRIPTION
## Summary
- Adds `Number.isFinite()` check to the parsed `--width` value in the avatar ascii command
- `parseInt` returns `Infinity` for very long digit-only strings (e.g., thousands of `9`s), which passed the existing `width < 1` guard but caused hangs/crashes in the ASCII renderer
- Now rejects non-finite widths with a clean validation error

Addresses review feedback from PR #17758.

## Test plan
- [ ] `assistant avatar character ascii --width 40` renders normally
- [ ] `assistant avatar character ascii --width 0` prints error
- [ ] A width consisting of thousands of digits now prints an error instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
