### PR TITLE
fix: make OAuth app CRUD methods async to show loading/error states

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -88,7 +88,7 @@ struct GoogleOAuthServiceCard: View {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
                 if let app = appToDelete {
-                    store.deleteYourOwnOAuthApp(id: app.id)
+                    Task { await store.deleteYourOwnOAuthApp(id: app.id) }
                     appToDelete = nil
                 }
             }
@@ -101,7 +101,7 @@ struct GoogleOAuthServiceCard: View {
             Button("Cancel", role: .cancel) {}
             Button("Disconnect", role: .destructive) {
                 if let conn = disconnectConnection, let appId = disconnectAppId {
-                    store.disconnectYourOwnOAuthConnection(id: conn.id, appId: appId)
+                    Task { await store.disconnectYourOwnOAuthConnection(id: conn.id, appId: appId) }
                     disconnectConnection = nil
                     disconnectAppId = nil
                 }
@@ -388,9 +388,11 @@ struct GoogleOAuthServiceCard: View {
                     isDisabled: createAppClientId.isEmpty || createAppClientSecret.isEmpty || createAppIsSubmitting
                 ) {
                     createAppIsSubmitting = true
-                    store.createYourOwnOAuthApp(clientId: createAppClientId, clientSecret: createAppClientSecret)
-                    createAppIsSubmitting = false
-                    showCreateAppSheet = false
+                    Task {
+                        await store.createYourOwnOAuthApp(clientId: createAppClientId, clientSecret: createAppClientSecret)
+                        createAppIsSubmitting = false
+                        showCreateAppSheet = false
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2395,7 +2395,7 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func createYourOwnOAuthApp(clientId: String, clientSecret: String) {
+    func createYourOwnOAuthApp(clientId: String, clientSecret: String) async {
         yourOwnOAuthError = nil
         var body: [String: Any] = [
             "provider_key": "integration:google",
@@ -2404,74 +2404,68 @@ public final class SettingsStore: ObservableObject {
         // Set via subscript to avoid pre-commit secret detection on the literal key.
         let secretKey = "client" + "_secret"
         body[secretKey] = clientSecret
-        Task {
-            do {
-                let response = try await GatewayHTTPClient.post(path: "oauth/apps", json: body, timeout: 10)
-                if response.isSuccess {
-                    self.fetchYourOwnOAuthApps()
+        do {
+            let response = try await GatewayHTTPClient.post(path: "oauth/apps", json: body, timeout: 10)
+            if response.isSuccess {
+                self.fetchYourOwnOAuthApps()
+            } else {
+                let errorMsg: String
+                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                   let msg = json["error"] as? String {
+                    errorMsg = msg
                 } else {
-                    let errorMsg: String
-                    if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                       let msg = json["error"] as? String {
-                        errorMsg = msg
-                    } else {
-                        errorMsg = "HTTP \(response.statusCode)"
-                    }
-                    self.yourOwnOAuthError = "Failed to create app: \(errorMsg)"
+                    errorMsg = "HTTP \(response.statusCode)"
                 }
-            } catch {
-                log.error("Failed to create Your Own OAuth app: \(error)")
-                self.yourOwnOAuthError = "Failed to create app: \(error.localizedDescription)"
+                self.yourOwnOAuthError = "Failed to create app: \(errorMsg)"
             }
+        } catch {
+            log.error("Failed to create Your Own OAuth app: \(error)")
+            self.yourOwnOAuthError = "Failed to create app: \(error.localizedDescription)"
         }
     }
 
-    func deleteYourOwnOAuthApp(id: String) {
+    func deleteYourOwnOAuthApp(id: String) async {
         yourOwnOAuthError = nil
-        Task {
-            do {
-                let response = try await GatewayHTTPClient.delete(path: "oauth/apps/\(id)", timeout: 10)
-                if response.isSuccess {
-                    self.yourOwnOAuthApps.removeAll { $0.id == id }
-                    self.yourOwnOAuthConnectionsByApp.removeValue(forKey: id)
+        do {
+            let response = try await GatewayHTTPClient.delete(path: "oauth/apps/\(id)", timeout: 10)
+            if response.isSuccess {
+                self.yourOwnOAuthApps.removeAll { $0.id == id }
+                self.yourOwnOAuthConnectionsByApp.removeValue(forKey: id)
+            } else {
+                let errorMsg: String
+                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                   let msg = json["error"] as? String {
+                    errorMsg = msg
                 } else {
-                    let errorMsg: String
-                    if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                       let msg = json["error"] as? String {
-                        errorMsg = msg
-                    } else {
-                        errorMsg = "HTTP \(response.statusCode)"
-                    }
-                    self.yourOwnOAuthError = "Failed to delete app: \(errorMsg)"
+                    errorMsg = "HTTP \(response.statusCode)"
                 }
-            } catch {
-                log.error("Failed to delete Your Own OAuth app: \(error)")
-                self.yourOwnOAuthError = "Failed to delete app: \(error.localizedDescription)"
+                self.yourOwnOAuthError = "Failed to delete app: \(errorMsg)"
             }
+        } catch {
+            log.error("Failed to delete Your Own OAuth app: \(error)")
+            self.yourOwnOAuthError = "Failed to delete app: \(error.localizedDescription)"
         }
     }
 
-    func disconnectYourOwnOAuthConnection(id: String, appId: String) {
+    func disconnectYourOwnOAuthConnection(id: String, appId: String) async {
         yourOwnOAuthError = nil
-        Task {
-            do {
-                let response = try await GatewayHTTPClient.delete(path: "oauth/connections/\(id)", timeout: 10)
-                if response.isSuccess {
-                    await self.fetchYourOwnOAuthConnections(appId: appId)
+        do {
+            let response = try await GatewayHTTPClient.delete(path: "oauth/connections/\(id)", timeout: 10)
+            if response.isSuccess {
+                await self.fetchYourOwnOAuthConnections(appId: appId)
+            } else {
+                let errorMsg: String
+                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                   let msg = json["error"] as? String {
+                    errorMsg = msg
                 } else {
-                    let errorMsg: String
-                    if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                       let msg = json["error"] as? String {
-                        errorMsg = msg
-                    } else {
-                        errorMsg = "HTTP \(response.statusCode)"
-                    }
-                    self.yourOwnOAuthError = "Failed to disconnect: \(errorMsg)"
+                    errorMsg = "HTTP \(response.statusCode)"
                 }
-            } catch {
-                log.error("Failed to disconnect Your Own OAuth connection: \(error)")
-                self.yourOwnOAuthError = "Failed to disconnect: \(error.localizedDescription)"
+                self.yourOwnOAuthError = "Failed to disconnect: \(errorMsg)"
             }
+        } catch {
+            log.error("Failed to disconnect Your Own OAuth connection: \(error)")
+            self.yourOwnOAuthError = "Failed to disconnect: \(error.localizedDescription)"
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for your-own-google-oauth.md.

**Gap:** Create app sheet dismisses before async operation completes
**What was expected:** Modal should stay open showing "Creating..." until API completes
**What was found:** Non-async method returns immediately, sheet dismisses before request

Changes:
- Made `createYourOwnOAuthApp`, `deleteYourOwnOAuthApp`, and `disconnectYourOwnOAuthConnection` in SettingsStore async by removing internal `Task {}` wrappers
- Updated GoogleOAuthServiceCard create button to use `Task { await ... }` so the sheet stays open during the API call and shows "Creating..." state
- Updated delete and disconnect alert buttons for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
