### PR TITLE
feat: add apiKeyPlaceholder to Swift ProviderCatalogEntry and inline catalogs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -27,28 +27,28 @@ struct APIKeyEntryStepView: View {
                 CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
                 CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
                 CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys"),
+            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
             ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
                 CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
                 CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
                 CatalogModel(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
                 CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
-            ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys"),
+            ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys", apiKeyPlaceholder: "sk-proj-..."),
             ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
                 CatalogModel(id: "gemini-3-flash", displayName: "Gemini 3 Flash"),
                 CatalogModel(id: "gemini-3-pro", displayName: "Gemini 3 Pro"),
-            ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey"),
+            ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey", apiKeyPlaceholder: "AIza..."),
             ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
                 CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
                 CatalogModel(id: "mistral", displayName: "Mistral"),
             ], defaultModel: "llama3.2"),
             ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
                 CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
-            ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys"),
+            ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
             ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
                 CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
                 CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
-            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys"),
+            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
         ]
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -404,28 +404,28 @@ public final class SettingsStore: ObservableObject {
                 CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
                 CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
                 CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys"),
+            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
             ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
                 CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
                 CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
                 CatalogModel(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
                 CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
-            ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys"),
+            ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys", apiKeyPlaceholder: "sk-proj-..."),
             ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
                 CatalogModel(id: "gemini-3-flash", displayName: "Gemini 3 Flash"),
                 CatalogModel(id: "gemini-3-pro", displayName: "Gemini 3 Pro"),
-            ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey"),
+            ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey", apiKeyPlaceholder: "AIza..."),
             ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
                 CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
                 CatalogModel(id: "mistral", displayName: "Mistral"),
             ], defaultModel: "llama3.2"),
             ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
                 CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
-            ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys"),
+            ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
             ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
                 CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
                 CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
-            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys"),
+            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
         ]
 
         // When enabledSince was defaulted to "now" (no value on disk),
@@ -965,6 +965,10 @@ public final class SettingsStore: ObservableObject {
 
     func dynamicProviderApiKeyUrl(_ provider: String) -> String? {
         providerCatalog.first { $0.id == provider }?.apiKeyUrl
+    }
+
+    func dynamicProviderApiKeyPlaceholder(_ provider: String) -> String? {
+        providerCatalog.first { $0.id == provider }?.apiKeyPlaceholder
     }
 
     // MARK: - Telegram Integration Actions

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2677,13 +2677,15 @@ public struct ProviderCatalogEntry: Codable, Sendable {
     public let models: [CatalogModel]
     public let defaultModel: String
     public let apiKeyUrl: String?
+    public let apiKeyPlaceholder: String?
 
-    public init(id: String, displayName: String, models: [CatalogModel], defaultModel: String, apiKeyUrl: String? = nil) {
+    public init(id: String, displayName: String, models: [CatalogModel], defaultModel: String, apiKeyUrl: String? = nil, apiKeyPlaceholder: String? = nil) {
         self.id = id
         self.displayName = displayName
         self.models = models
         self.defaultModel = defaultModel
         self.apiKeyUrl = apiKeyUrl
+        self.apiKeyPlaceholder = apiKeyPlaceholder
     }
 }
 


### PR DESCRIPTION
## Summary
- Add apiKeyPlaceholder: String? to ProviderCatalogEntry in GeneratedAPITypes.swift
- Update inline seed catalogs in SettingsStore and APIKeyEntryStepView with per-provider placeholders
- Add dynamicProviderApiKeyPlaceholder() helper to SettingsStore

Part of plan: provider-apikey-placeholder.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
