### PR TITLE
fix: guard against null/undefined in categorizeDaemonError

### DIFF
--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -27,6 +27,14 @@ const DAEMON_ERROR_PREFIX = "DAEMON_ERROR:";
  * Inspect an error and return a categorized {@link DaemonStartupError}.
  */
 export function categorizeDaemonError(err: unknown): DaemonStartupError {
+  if (err == null) {
+    return {
+      error: "UNKNOWN",
+      message: String(err),
+      detail: "An unexpected error occurred during startup.",
+    };
+  }
+
   const code = (err as { code?: string }).code ?? "";
   const name = (err as { name?: string }).name ?? "";
   const message =


### PR DESCRIPTION
## Summary
- Add null guard at the top of `categorizeDaemonError` to handle `null`/`undefined` errors safely
- Prevents `TypeError` when a startup path rejects with a nullish value
- Returns a safe `UNKNOWN` category with the stringified value instead of crashing

Addresses review feedback from PR #17765.

## Test plan
- [x] Verified that passing `null` or `undefined` to `categorizeDaemonError` now returns an `UNKNOWN` error instead of throwing a `TypeError`
- [x] Existing error categorization logic is unchanged for non-nullish values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
