### PR TITLE
fix: guard resolveAppDir against empty-string dirName

### DIFF
--- a/assistant/src/__tests__/app-store-dir-names.test.ts
+++ b/assistant/src/__tests__/app-store-dir-names.test.ts
@@ -351,13 +351,11 @@ describe("resolveAppDir() validation", () => {
       JSON.stringify({ id: fakeId, name: "Evil", dirName: "" }),
     );
 
-    // Empty string is falsy, so validateDirName is not called.
-    // `parsed.dirName ?? id` with nullish coalescing: "" is not nullish,
-    // so dirName = "". The function returns "" as dirName.
+    // Empty string is falsy, so `parsed.dirName || id` falls back to the app ID.
+    // This prevents appDir from resolving to the apps root directory.
     const result = resolveAppDir(fakeId);
-    // Empty dirName is falsy, so the conditional `if (parsed.dirName)` is false,
-    // meaning it won't call validateDirName. The dirName "" is used as-is.
-    expect(result.dirName).toBe("");
+    expect(result.dirName).toBe(fakeId);
+    expect(result.appDir).toBe(join(appsDir, fakeId));
   });
 });
 

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -212,7 +212,7 @@ export function resolveAppDir(id: string): {
       const raw = readFileSync(filePath, "utf-8");
       const parsed = JSON.parse(raw) as { id?: string; dirName?: string };
       if (parsed.id === id) {
-        const dirName = parsed.dirName ?? id;
+        const dirName = parsed.dirName || id;
         if (parsed.dirName) {
           validateDirName(dirName);
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for human-readable-app-dirs.md.

**Gap:** Empty-string dirName causes deleteApp to wipe the entire apps directory
**What was expected:** Empty dirName should fall back to app ID
**What was found:** Nullish coalescing allowed empty string through, resulting in appDir = getAppsDir()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
