### PR TITLE
fix: update app-routes-csp tests for dirName path resolution

### DIFF
--- a/assistant/src/__tests__/app-routes-csp.test.ts
+++ b/assistant/src/__tests__/app-routes-csp.test.ts
@@ -37,6 +37,7 @@ const apps = new Map<string, typeof legacyApp | typeof multifileApp>([
 mock.module("../memory/app-store.js", () => ({
   getApp: (id: string) => apps.get(id) ?? null,
   getAppsDir: () => "/fake/apps",
+  getAppDirPath: (appId: string) => `/fake/apps/${appId}`,
   isMultifileApp: (app: Record<string, unknown>) => app.formatVersion === 2,
 }));
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for human-readable-app-dirs.md.

**Gap:** app-routes-csp.test.ts broken by resolveAppDir scanning the directory
**What was expected:** Tests should handle the new directory scanning in resolveAppDir
**What was found:** Mocked getAppsDir returned non-existent path, causing ENOENT in readdirSync
**Fix:** Added `getAppDirPath` to the app-store mock so app-routes uses the mock directly instead of calling through `resolveAppDir` which tries to scan the filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
