### PR TITLE
fix: update app-builder-tool-scripts tests for dirName path resolution

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -66,6 +66,11 @@ const mockStore = makeMockStore();
 mock.module("../memory/app-store.js", () => ({
   ...mockStore,
   getAppsDir: () => "/tmp/test-apps",
+  getAppDirPath: (appId: string) => `/tmp/test-apps/${appId}`,
+  resolveAppDir: (id: string) => ({
+    dirName: id,
+    appDir: `/tmp/test-apps/${id}`,
+  }),
   isMultifileApp: (app: AppDefinition) => app.formatVersion === 2,
 }));
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for human-readable-app-dirs.md.

**Gap:** app-builder-tool-scripts.test.ts broken by resolveAppDir scanning non-existent mock directory
**What was expected:** Tests should handle the new directory scanning in resolveAppDir
**What was found:** Mocked apps directory didn't exist on disk, causing ENOENT in readdirSync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
