### PR TITLE
fix: update stale migration 009 references to 010

### DIFF
--- a/assistant/src/__tests__/app-store-dir-names.test.ts
+++ b/assistant/src/__tests__/app-store-dir-names.test.ts
@@ -1,0 +1,428 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock getDataDir to use a temp directory
+// ---------------------------------------------------------------------------
+
+let testDataDir: string;
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDataDir,
+  getProjectDir: () => testDataDir,
+}));
+
+// Re-import app-store after mocking so it uses our temp dir
+const {
+  slugify,
+  generateAppDirName,
+  validateDirName,
+  resolveAppDir,
+  getAppDirPath,
+  getAppsDir,
+  createApp,
+  getApp,
+  updateApp,
+  deleteApp,
+} = await import("../memory/app-store.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshTempDir(): string {
+  return join(
+    tmpdir(),
+    `vellum-app-dir-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+function makeAppParams(name: string) {
+  return {
+    name,
+    schemaJson: "{}",
+    htmlDefinition: "<h1>Hello</h1>",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  testDataDir = freshTempDir();
+  mkdirSync(join(testDataDir, "apps"), { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(testDataDir)) {
+    rmSync(testDataDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// slugify()
+// ---------------------------------------------------------------------------
+
+describe("slugify()", () => {
+  test("normal names", () => {
+    expect(slugify("My Cool App")).toBe("my-cool-app");
+  });
+
+  test("special characters are replaced with hyphens", () => {
+    expect(slugify("hello@world!#$%")).toBe("hello-world");
+  });
+
+  test("unicode characters are replaced", () => {
+    expect(slugify("café résumé")).toBe("caf-r-sum");
+  });
+
+  test("emoji-only names produce fallback slug", () => {
+    const result = slugify("🚀🎉");
+    expect(result).toMatch(/^app-[a-f0-9]{8}$/);
+  });
+
+  test("empty string produces fallback slug", () => {
+    const result = slugify("");
+    expect(result).toMatch(/^app-[a-f0-9]{8}$/);
+  });
+
+  test("very long names are truncated to 60 chars", () => {
+    const longName = "a".repeat(100);
+    const result = slugify(longName);
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result).toBe("a".repeat(60));
+  });
+
+  test("truncation removes trailing hyphens", () => {
+    // Create a name where position 60 lands on a hyphen sequence
+    const name = "a".repeat(58) + "--bbb";
+    const result = slugify(name);
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result).not.toMatch(/-$/);
+  });
+
+  test("names with only hyphens produce fallback slug", () => {
+    const result = slugify("---");
+    expect(result).toMatch(/^app-[a-f0-9]{8}$/);
+  });
+
+  test("leading and trailing hyphens are stripped", () => {
+    expect(slugify("-hello-world-")).toBe("hello-world");
+  });
+
+  test("consecutive hyphens are collapsed", () => {
+    expect(slugify("hello---world")).toBe("hello-world");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateAppDirName()
+// ---------------------------------------------------------------------------
+
+describe("generateAppDirName()", () => {
+  test("returns base slug when no collision", () => {
+    const result = generateAppDirName("My App", new Set());
+    expect(result).toBe("my-app");
+  });
+
+  test("appends -2 on first collision", () => {
+    const result = generateAppDirName("My App", new Set(["my-app"]));
+    expect(result).toBe("my-app-2");
+  });
+
+  test("escalates numeric suffix on multiple collisions", () => {
+    const existing = new Set(["my-app", "my-app-2", "my-app-3"]);
+    const result = generateAppDirName("My App", existing);
+    expect(result).toBe("my-app-4");
+  });
+
+  test("collision with truncated names still deduplicates", () => {
+    const longName = "a".repeat(100);
+    const base = slugify(longName);
+    const existing = new Set([base]);
+    const result = generateAppDirName(longName, existing);
+    expect(result).toBe(`${base}-2`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createApp() — directory named after slug
+// ---------------------------------------------------------------------------
+
+describe("createApp()", () => {
+  test("directory is named after slug, not UUID", () => {
+    const app = createApp(makeAppParams("My Test App"));
+    const appsDir = getAppsDir();
+
+    // dirName should be the slug
+    expect(app.dirName).toBe("my-test-app");
+
+    // JSON file should be named after slug
+    expect(existsSync(join(appsDir, "my-test-app.json"))).toBe(true);
+
+    // Directory should be named after slug
+    expect(existsSync(join(appsDir, "my-test-app"))).toBe(true);
+
+    // UUID-named files should NOT exist
+    expect(existsSync(join(appsDir, `${app.id}.json`))).toBe(false);
+  });
+
+  test("dirName is persisted in JSON", () => {
+    const app = createApp(makeAppParams("Slug Test"));
+    const appsDir = getAppsDir();
+    const jsonPath = join(appsDir, "slug-test.json");
+    const persisted = JSON.parse(readFileSync(jsonPath, "utf-8"));
+    expect(persisted.dirName).toBe("slug-test");
+    expect(persisted.id).toBe(app.id);
+  });
+
+  test("index.html is in the slugified directory", () => {
+    createApp(makeAppParams("Html App"));
+    const appsDir = getAppsDir();
+    const indexPath = join(appsDir, "html-app", "index.html");
+    expect(existsSync(indexPath)).toBe(true);
+    expect(readFileSync(indexPath, "utf-8")).toBe("<h1>Hello</h1>");
+  });
+
+  test("deduplicates dirNames across multiple creates", () => {
+    const app1 = createApp(makeAppParams("Duplicate"));
+    const app2 = createApp(makeAppParams("Duplicate"));
+    expect(app1.dirName).toBe("duplicate");
+    expect(app2.dirName).toBe("duplicate-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createApp() + updateApp() — frozen dirName invariant
+// ---------------------------------------------------------------------------
+
+describe("frozen dirName invariant", () => {
+  test("renaming an app does NOT change its directory name", () => {
+    const app = createApp(makeAppParams("Original Name"));
+    const appsDir = getAppsDir();
+
+    expect(app.dirName).toBe("original-name");
+    expect(existsSync(join(appsDir, "original-name.json"))).toBe(true);
+
+    // Rename the app
+    const updated = updateApp(app.id, { name: "New Name" });
+    expect(updated.name).toBe("New Name");
+
+    // Directory and files should still be at original slug
+    expect(existsSync(join(appsDir, "original-name.json"))).toBe(true);
+    expect(existsSync(join(appsDir, "original-name"))).toBe(true);
+
+    // New name slug should NOT exist as files
+    expect(existsSync(join(appsDir, "new-name.json"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getApp() — lookup by UUID with slugified dirs
+// ---------------------------------------------------------------------------
+
+describe("getApp()", () => {
+  test("lookup by UUID works with slugified dirs", () => {
+    const created = createApp(makeAppParams("Lookup App"));
+    const fetched = getApp(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+    expect(fetched!.name).toBe("Lookup App");
+    expect(fetched!.htmlDefinition).toBe("<h1>Hello</h1>");
+  });
+
+  test("backward compat: works when JSON has no dirName (uses id as fallback)", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    // Write a JSON file with no dirName, using the UUID as the filename
+    const appData = {
+      id: fakeId,
+      name: "Legacy App",
+      schemaJson: "{}",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify(appData, null, 2),
+    );
+
+    // Create directory with index.html
+    const appDir = join(appsDir, fakeId);
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, "index.html"), "<p>legacy</p>", "utf-8");
+
+    const fetched = getApp(fakeId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(fakeId);
+    expect(fetched!.name).toBe("Legacy App");
+    expect(fetched!.htmlDefinition).toBe("<p>legacy</p>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteApp() — cleans up slugified files
+// ---------------------------------------------------------------------------
+
+describe("deleteApp()", () => {
+  test("cleans up slugified directory, JSON, and preview files", () => {
+    const app = createApp({
+      ...makeAppParams("Delete Me"),
+      preview: "base64-preview-data",
+    });
+    const appsDir = getAppsDir();
+
+    // Verify files exist before deletion
+    expect(existsSync(join(appsDir, "delete-me.json"))).toBe(true);
+    expect(existsSync(join(appsDir, "delete-me"))).toBe(true);
+    expect(existsSync(join(appsDir, "delete-me.preview"))).toBe(true);
+
+    deleteApp(app.id);
+
+    // All files should be gone
+    expect(existsSync(join(appsDir, "delete-me.json"))).toBe(false);
+    expect(existsSync(join(appsDir, "delete-me"))).toBe(false);
+    expect(existsSync(join(appsDir, "delete-me.preview"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAppDir() — validation rejects malicious dirName values
+// When a JSON file has an invalid dirName, resolveAppDir defensively falls
+// back to using the app ID instead of the malicious dirName. The
+// validateDirName() call inside the try/catch causes the invalid entry to
+// be skipped, and the function returns the safe fallback.
+// ---------------------------------------------------------------------------
+
+describe("resolveAppDir() validation", () => {
+  test("falls back to id when dirName contains path traversal (..)", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify({ id: fakeId, name: "Evil", dirName: "../etc" }),
+    );
+
+    // Should NOT use the malicious dirName — falls back to id
+    const result = resolveAppDir(fakeId);
+    expect(result.dirName).toBe(fakeId);
+    expect(result.appDir).toBe(join(appsDir, fakeId));
+  });
+
+  test("falls back to id when dirName contains forward slash", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa";
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify({ id: fakeId, name: "Evil", dirName: "foo/bar" }),
+    );
+
+    const result = resolveAppDir(fakeId);
+    expect(result.dirName).toBe(fakeId);
+  });
+
+  test("falls back to id when dirName contains backslash", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb";
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify({ id: fakeId, name: "Evil", dirName: "foo\\bar" }),
+    );
+
+    const result = resolveAppDir(fakeId);
+    expect(result.dirName).toBe(fakeId);
+  });
+
+  test("falls back to id when dirName is empty string", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "eeeeeeee-ffff-aaaa-bbbb-cccccccccccc";
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify({ id: fakeId, name: "Evil", dirName: "" }),
+    );
+
+    // Empty string is falsy, so validateDirName is not called.
+    // `parsed.dirName ?? id` with nullish coalescing: "" is not nullish,
+    // so dirName = "". The function returns "" as dirName.
+    const result = resolveAppDir(fakeId);
+    // Empty dirName is falsy, so the conditional `if (parsed.dirName)` is false,
+    // meaning it won't call validateDirName. The dirName "" is used as-is.
+    expect(result.dirName).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDirName() — direct unit tests
+// ---------------------------------------------------------------------------
+
+describe("validateDirName()", () => {
+  test("accepts valid slug names", () => {
+    expect(() => validateDirName("my-cool-app")).not.toThrow();
+    expect(() => validateDirName("app-123")).not.toThrow();
+  });
+
+  test("rejects git pathspec metacharacters", () => {
+    expect(() => validateDirName("app*")).toThrow("git pathspec");
+    expect(() => validateDirName("app?")).toThrow("git pathspec");
+    expect(() => validateDirName("app[0]")).toThrow("git pathspec");
+    expect(() => validateDirName("app:foo")).toThrow("git pathspec");
+    expect(() => validateDirName("app(1)")).toThrow("git pathspec");
+  });
+
+  test("rejects path traversal", () => {
+    expect(() => validateDirName("..")).toThrow("Invalid dirName");
+    expect(() => validateDirName("foo/bar")).toThrow("Invalid dirName");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAppDirPath() — returns correct path
+// ---------------------------------------------------------------------------
+
+describe("getAppDirPath()", () => {
+  test("returns correct path for slugified apps", () => {
+    const app = createApp(makeAppParams("Path Test"));
+    const appsDir = getAppsDir();
+    const result = getAppDirPath(app.id);
+    expect(result).toBe(join(appsDir, "path-test"));
+  });
+
+  test("returns correct path for legacy apps (no dirName)", () => {
+    const appsDir = getAppsDir();
+    const fakeId = "11111111-2222-3333-4444-555555555555";
+    // Write a legacy JSON with no dirName
+    writeFileSync(
+      join(appsDir, `${fakeId}.json`),
+      JSON.stringify({ id: fakeId, name: "Legacy" }),
+    );
+
+    const result = getAppDirPath(fakeId);
+    expect(result).toBe(join(appsDir, fakeId));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard test: no file outside app-store.ts constructs getAppsDir() + appId
+// (Note: the primary guard test is in app-dir-path-guard.test.ts; this is
+//  a complementary check that we can import and use the guard-relevant
+//  functions without issues.)
+// ---------------------------------------------------------------------------
+
+describe("guard: getAppsDir + appId path construction", () => {
+  test("app-dir-path-guard.test.ts exists and covers this concern", () => {
+    // This is a meta-test to ensure the guard test file is present
+    expect(existsSync(join(__dirname, "app-dir-path-guard.test.ts"))).toBe(
+      true,
+    );
+  });
+});

--- a/assistant/src/__tests__/app-store-dir-names.test.ts
+++ b/assistant/src/__tests__/app-store-dir-names.test.ts
@@ -351,13 +351,11 @@ describe("resolveAppDir() validation", () => {
       JSON.stringify({ id: fakeId, name: "Evil", dirName: "" }),
     );
 
-    // Empty string is falsy, so validateDirName is not called.
-    // `parsed.dirName ?? id` with nullish coalescing: "" is not nullish,
-    // so dirName = "". The function returns "" as dirName.
+    // Empty string is falsy, so `parsed.dirName || id` falls back to the app ID.
+    // This prevents appDir from resolving to the apps root directory.
     const result = resolveAppDir(fakeId);
-    // Empty dirName is falsy, so the conditional `if (parsed.dirName)` is false,
-    // meaning it won't call validateDirName. The dirName "" is used as-is.
-    expect(result.dirName).toBe("");
+    expect(result.dirName).toBe(fakeId);
+    expect(result.appDir).toBe(join(appsDir, fakeId));
   });
 });
 

--- a/assistant/src/__tests__/workspace-migration-010-app-dir-rename.test.ts
+++ b/assistant/src/__tests__/workspace-migration-010-app-dir-rename.test.ts
@@ -1,0 +1,275 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { appDirRenameMigration } from "../workspace/migrations/010-app-dir-rename.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let appsDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-010-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  appsDir = join(workspaceDir, "data", "apps");
+  mkdirSync(appsDir, { recursive: true });
+}
+
+function writeAppJson(filename: string, data: Record<string, unknown>): void {
+  writeFileSync(join(appsDir, filename), JSON.stringify(data, null, 2));
+}
+
+function readAppJson(filename: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(appsDir, filename), "utf-8"));
+}
+
+function createUuidApp(
+  id: string,
+  name: string,
+  opts?: { preview?: string; indexHtml?: string },
+): void {
+  // JSON file at {id}.json
+  writeAppJson(`${id}.json`, { id, name, schemaJson: "{}" });
+
+  // App directory at {id}/
+  const appDir = join(appsDir, id);
+  mkdirSync(appDir, { recursive: true });
+  writeFileSync(
+    join(appDir, "index.html"),
+    opts?.indexHtml ?? `<h1>${name}</h1>`,
+    "utf-8",
+  );
+
+  // Preview file at {id}.preview
+  if (opts?.preview) {
+    writeFileSync(join(appsDir, `${id}.preview`), opts.preview, "utf-8");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("010-app-dir-rename migration", () => {
+  test("renames UUID-named app files/dirs to slugified names with dirName in JSON", () => {
+    const id = "aaaaaaaa-1111-2222-3333-444444444444";
+    createUuidApp(id, "My Cool App", { preview: "preview-data" });
+
+    appDirRenameMigration.run(workspaceDir);
+
+    // Old files should be gone
+    expect(existsSync(join(appsDir, `${id}.json`))).toBe(false);
+    expect(existsSync(join(appsDir, id))).toBe(false);
+    expect(existsSync(join(appsDir, `${id}.preview`))).toBe(false);
+
+    // New files should exist
+    expect(existsSync(join(appsDir, "my-cool-app.json"))).toBe(true);
+    expect(existsSync(join(appsDir, "my-cool-app"))).toBe(true);
+    expect(existsSync(join(appsDir, "my-cool-app.preview"))).toBe(true);
+
+    // JSON should have dirName set
+    const json = readAppJson("my-cool-app.json");
+    expect(json.dirName).toBe("my-cool-app");
+    expect(json.id).toBe(id);
+
+    // index.html should be in the new directory
+    expect(
+      readFileSync(join(appsDir, "my-cool-app", "index.html"), "utf-8"),
+    ).toBe("<h1>My Cool App</h1>");
+
+    // Preview content preserved
+    expect(readFileSync(join(appsDir, "my-cool-app.preview"), "utf-8")).toBe(
+      "preview-data",
+    );
+  });
+
+  test("idempotency: running migration again produces no errors or changes", () => {
+    const id = "bbbbbbbb-1111-2222-3333-444444444444";
+    createUuidApp(id, "Idempotent App");
+
+    // Run twice
+    appDirRenameMigration.run(workspaceDir);
+    const jsonAfterFirst = readAppJson("idempotent-app.json");
+
+    appDirRenameMigration.run(workspaceDir);
+    const jsonAfterSecond = readAppJson("idempotent-app.json");
+
+    expect(jsonAfterSecond).toEqual(jsonAfterFirst);
+    expect(existsSync(join(appsDir, "idempotent-app"))).toBe(true);
+  });
+
+  test("partial-rename recovery: JSON has dirName but files still at UUID", () => {
+    const id = "cccccccc-1111-2222-3333-444444444444";
+    const dirName = "partial-app";
+
+    // Simulate crash: JSON was updated with dirName but files weren't renamed
+    writeAppJson(`${id}.json`, {
+      id,
+      name: "Partial App",
+      dirName,
+      schemaJson: "{}",
+    });
+    // Files still at UUID locations
+    mkdirSync(join(appsDir, id), { recursive: true });
+    writeFileSync(join(appsDir, id, "index.html"), "<h1>Partial</h1>", "utf-8");
+    writeFileSync(join(appsDir, `${id}.preview`), "partial-preview", "utf-8");
+
+    appDirRenameMigration.run(workspaceDir);
+
+    // UUID files should be gone, dirName files should exist
+    expect(existsSync(join(appsDir, `${id}.json`))).toBe(false);
+    expect(existsSync(join(appsDir, id))).toBe(false);
+    expect(existsSync(join(appsDir, `${id}.preview`))).toBe(false);
+
+    expect(existsSync(join(appsDir, `${dirName}.json`))).toBe(true);
+    expect(existsSync(join(appsDir, dirName))).toBe(true);
+    expect(existsSync(join(appsDir, `${dirName}.preview`))).toBe(true);
+
+    const json = readAppJson(`${dirName}.json`);
+    expect(json.dirName).toBe(dirName);
+  });
+
+  test("missing directories: JSON exists but no app dir — still sets dirName and renames JSON", () => {
+    const id = "dddddddd-1111-2222-3333-444444444444";
+    // JSON exists but no corresponding directory
+    writeAppJson(`${id}.json`, { id, name: "No Dir App", schemaJson: "{}" });
+
+    appDirRenameMigration.run(workspaceDir);
+
+    // Old JSON gone
+    expect(existsSync(join(appsDir, `${id}.json`))).toBe(false);
+
+    // New JSON and directory created
+    expect(existsSync(join(appsDir, "no-dir-app.json"))).toBe(true);
+    expect(existsSync(join(appsDir, "no-dir-app"))).toBe(true);
+
+    const json = readAppJson("no-dir-app.json");
+    expect(json.dirName).toBe("no-dir-app");
+  });
+
+  test("missing preview files produce no error, JSON and dir still renamed", () => {
+    const id = "eeeeeeee-1111-2222-3333-444444444444";
+    // Create app without preview
+    writeAppJson(`${id}.json`, {
+      id,
+      name: "No Preview",
+      schemaJson: "{}",
+    });
+    mkdirSync(join(appsDir, id), { recursive: true });
+    writeFileSync(
+      join(appsDir, id, "index.html"),
+      "<h1>No Preview</h1>",
+      "utf-8",
+    );
+
+    appDirRenameMigration.run(workspaceDir);
+
+    expect(existsSync(join(appsDir, "no-preview.json"))).toBe(true);
+    expect(existsSync(join(appsDir, "no-preview"))).toBe(true);
+    expect(existsSync(join(appsDir, "no-preview.preview"))).toBe(false);
+  });
+
+  test("duplicate names after slugification get numeric suffixes", () => {
+    const id1 = "ffffffff-1111-2222-3333-444444444444";
+    const id2 = "gggggggg-1111-2222-3333-444444444444";
+    createUuidApp(id1, "Same Name");
+    createUuidApp(id2, "Same Name");
+
+    appDirRenameMigration.run(workspaceDir);
+
+    // Both should exist with deduped names
+    const jsonFiles = readdirSync(appsDir)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+
+    // One should be "same-name.json", the other "same-name-2.json"
+    expect(jsonFiles).toContain("same-name.json");
+    expect(jsonFiles).toContain("same-name-2.json");
+
+    // Both should have dirName set
+    const json1 = readAppJson("same-name.json");
+    const json2 = readAppJson("same-name-2.json");
+    expect(json1.dirName).toBe("same-name");
+    expect(json2.dirName).toBe("same-name-2");
+
+    // Both directories should exist
+    expect(existsSync(join(appsDir, "same-name"))).toBe(true);
+    expect(existsSync(join(appsDir, "same-name-2"))).toBe(true);
+  });
+
+  test("emoji-only app names get fallback slug", () => {
+    const id = "hhhhhhhh-1111-2222-3333-444444444444";
+    writeAppJson(`${id}.json`, { id, name: "🚀🎉", schemaJson: "{}" });
+    mkdirSync(join(appsDir, id), { recursive: true });
+    writeFileSync(join(appsDir, id, "index.html"), "<h1>Emoji</h1>", "utf-8");
+
+    appDirRenameMigration.run(workspaceDir);
+
+    // Old files should be gone
+    expect(existsSync(join(appsDir, `${id}.json`))).toBe(false);
+
+    // Find the new JSON file (has app- prefix fallback)
+    const jsonFiles = readdirSync(appsDir).filter(
+      (f) => f.endsWith(".json") && f !== `${id}.json`,
+    );
+    expect(jsonFiles.length).toBe(1);
+    expect(jsonFiles[0]).toMatch(/^app-[a-f0-9]{8}\.json$/);
+
+    const json = readAppJson(jsonFiles[0]);
+    expect(json.dirName).toMatch(/^app-[a-f0-9]{8}$/);
+    expect(json.id).toBe(id);
+  });
+
+  test("empty app name falls back to 'untitled' slug", () => {
+    const id = "iiiiiiii-1111-2222-3333-444444444444";
+    // name is absent — migration defaults to "untitled"
+    writeAppJson(`${id}.json`, { id, schemaJson: "{}" });
+    mkdirSync(join(appsDir, id), { recursive: true });
+    writeFileSync(join(appsDir, id, "index.html"), "<h1>No Name</h1>", "utf-8");
+
+    appDirRenameMigration.run(workspaceDir);
+
+    expect(existsSync(join(appsDir, "untitled.json"))).toBe(true);
+    const json = readAppJson("untitled.json");
+    expect(json.dirName).toBe("untitled");
+  });
+
+  test("no-op when apps directory does not exist", () => {
+    // Remove the apps directory
+    rmSync(appsDir, { recursive: true, force: true });
+
+    // Should not throw
+    expect(() => appDirRenameMigration.run(workspaceDir)).not.toThrow();
+  });
+
+  test("no-op when apps directory is empty", () => {
+    expect(() => appDirRenameMigration.run(workspaceDir)).not.toThrow();
+  });
+});

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -11,7 +11,7 @@
  * Reuses WorkspaceGitService for all git operations (mutex, circuit breaker,
  * lazy init, etc.).
  *
- * NOTE: After the 009-app-dir-rename migration, git pathspecs use dirName
+ * NOTE: After the 010-app-dir-rename migration, git pathspecs use dirName
  * (slug) instead of appId (UUID). History queries will only return commits
  * made after the migration rename. Commits before the migration used UUID-
  * based paths and are not visible through the current slug-based pathspecs.
@@ -197,7 +197,7 @@ export async function commitAppTurnChanges(
  * Scopes `git log` to files belonging to this app using dirName-based
  * pathspecs: {dirName}.json, {dirName}/.
  *
- * Note: After the 009 migration, only commits made after the rename are
+ * Note: After the 010 migration, only commits made after the rename are
  * visible. Pre-migration commits used UUID-based paths.
  */
 export async function getAppHistory(

--- a/assistant/src/workspace/migrations/010-app-dir-rename.ts
+++ b/assistant/src/workspace/migrations/010-app-dir-rename.ts
@@ -1,5 +1,5 @@
 /**
- * Workspace migration 009: Rename UUID-based app directories and files to
+ * Workspace migration 010: Rename UUID-based app directories and files to
  * human-readable slugified names.
  *
  * Inline slugify + dedup logic (not imported from app-store) so the migration
@@ -145,7 +145,7 @@ export const appDirRenameMigration: WorkspaceMigration = {
       const gitDir = join(appsDir, ".git");
       if (existsSync(gitDir)) {
         execSync(
-          "git add -A && git commit -m 'Migration 009: rename app dirs to slugified names' --allow-empty",
+          "git add -A && git commit -m 'Migration 010: rename app dirs to slugified names' --allow-empty",
           {
             cwd: appsDir,
             stdio: "ignore",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for human-readable-app-dirs.md.

**Gap:** Stale 009 references in migration file and app-git-service.ts
**What was expected:** Consistent use of 010 after renumbering
**What was found:** JSDoc, commit message string, and comments still said 009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
