### PR TITLE
fix: remove confusing resolveAppDir alias in executors.ts

### DIFF
--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -541,10 +541,8 @@ export async function executeAppGenerateIcon(
   // destroying an existing icon if generation fails.
   const { existsSync, renameSync, unlinkSync } = await import("node:fs");
   const { join } = await import("node:path");
-  const { getAppDirPath: resolveAppDir } =
-    await import("../../memory/app-store.js");
-  const iconPath = join(resolveAppDir(input.app_id), "icon.png");
-  const tempPath = join(resolveAppDir(input.app_id), "icon.tmp.png");
+  const iconPath = join(getAppDirPath(input.app_id), "icon.png");
+  const tempPath = join(getAppDirPath(input.app_id), "icon.tmp.png");
 
   // Temporarily move existing icon aside so generateAppIcon doesn't skip
   if (existsSync(iconPath)) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for human-readable-app-dirs.md.

**Gap:** `getAppDirPath` aliased as `resolveAppDir`, shadowing the real `resolveAppDir` export
**What was expected:** Clear, unambiguous imports
**What was found:** Local alias shadows a different function with a different return type

- Removed the dynamic import with confusing alias in `executeAppGenerateIcon`
- Uses the already-imported `getAppDirPath` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
