### PR TITLE
refactor: reuse btw sidechain for titles

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -348,6 +348,7 @@ describe("POST /v1/btw", () => {
 
     // Options: tool_choice must be "none"
     expect(options!.config!.tool_choice).toEqual({ type: "none" });
+    expect(options!.config!.modelIntent).toBe("latency-optimized");
   });
 
   // -- No persistence --

--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockRunBtwSidechain = mock(async () => ({
+  text: "Project kickoff",
+  hadTextDeltas: true,
+  response: {
+    content: [{ type: "text", text: "Project kickoff" }],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  },
+}));
+
+const mockGetConversation = mock(
+  (_conversationId: string) =>
+    ({
+      title: "Generating title...",
+      isAutoTitle: 1,
+    }) as {
+      title: string;
+      isAutoTitle: number;
+    },
+);
+const mockGetMessages = mock(() => [
+  { role: "user", content: "first message" },
+  { role: "assistant", content: "first reply" },
+  { role: "user", content: "follow-up" },
+]);
+const mockUpdateConversationTitle = mock(() => {});
+const mockGetConfiguredProvider = mock(async () => null);
+const mockGetConfig = mock(() => ({
+  daemon: {
+    titleGenerationMaxTokens: 37,
+  },
+}));
+
+mock.module("../runtime/btw-sidechain.js", () => ({
+  runBtwSidechain: mockRunBtwSidechain,
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversation: mockGetConversation,
+  getMessages: mockGetMessages,
+  updateConversationTitle: mockUpdateConversationTitle,
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: mockGetConfiguredProvider,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: mockGetConfig,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  generateAndPersistConversationTitle,
+  regenerateConversationTitle,
+} from "../memory/conversation-title-service.js";
+
+describe("conversation-title-service", () => {
+  beforeEach(() => {
+    mockRunBtwSidechain.mockClear();
+    mockGetConversation.mockClear();
+    mockGetMessages.mockClear();
+    mockUpdateConversationTitle.mockClear();
+    mockGetConfiguredProvider.mockClear();
+    mockGetConfig.mockClear();
+  });
+
+  test("uses the BTW side-chain helper for initial title generation", async () => {
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("provider.sendMessage should not be called directly");
+      }),
+    };
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "Help me plan the kickoff",
+    });
+
+    expect(result).toEqual({ title: "Project kickoff", updated: true });
+    expect(mockRunBtwSidechain).toHaveBeenCalledTimes(1);
+    expect(mockRunBtwSidechain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider,
+        maxTokens: 37,
+        modelIntent: "latency-optimized",
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Project kickoff",
+      1,
+    );
+  });
+
+  test("uses the BTW side-chain helper for title regeneration", async () => {
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("provider.sendMessage should not be called directly");
+      }),
+    };
+
+    const result = await regenerateConversationTitle({
+      conversationId: "conv-1",
+      provider,
+    });
+
+    expect(result).toEqual({ title: "Project kickoff", updated: true });
+    expect(mockRunBtwSidechain).toHaveBeenCalledTimes(1);
+    expect(mockRunBtwSidechain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider,
+        maxTokens: 37,
+        modelIntent: "latency-optimized",
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Project kickoff",
+      1,
+    );
+  });
+});

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -10,6 +10,7 @@
 import { getConfig } from "../config/loader.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
+import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
 import {
@@ -129,30 +130,16 @@ export async function generateAndPersistConversationTitle(
 
   const config = getConfig();
   const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
-  const timeoutSignal = AbortSignal.timeout(10_000);
-  const combinedSignal = signal
-    ? AbortSignal.any([signal, timeoutSignal])
-    : timeoutSignal;
-
-  const response = await provider.sendMessage(
-    [{ role: "user", content: [{ type: "text", text: prompt }] }],
-    [],
-    undefined,
-    {
-      config: {
-        max_tokens: config.daemon.titleGenerationMaxTokens,
-        modelIntent: "latency-optimized",
-      },
-      signal: combinedSignal,
-    },
-  );
-  const textBlock = response.content.find((b) => b.type === "text");
-  if (textBlock && textBlock.type === "text") {
-    let title = normalizeTitle(textBlock.text);
-    if (!title) {
-      title = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-    }
-
+  const result = await runBtwSidechain({
+    content: prompt,
+    provider,
+    maxTokens: config.daemon.titleGenerationMaxTokens,
+    modelIntent: "latency-optimized",
+    signal,
+    timeoutMs: 10_000,
+  });
+  const title = normalizeTitle(result.text);
+  if (title) {
     // Re-check replaceability before persisting (race guard)
     const current = getConversation(conversationId);
     if (current && !isReplaceableTitle(current.title)) {
@@ -246,31 +233,16 @@ export async function regenerateConversationTitle(
 
   const prompt = buildRegenerationPrompt(recentMessages);
   const config = getConfig();
-  const timeoutSignal = AbortSignal.timeout(10_000);
-  const combinedSignal = signal
-    ? AbortSignal.any([signal, timeoutSignal])
-    : timeoutSignal;
-
-  const response = await provider.sendMessage(
-    [{ role: "user", content: [{ type: "text", text: prompt }] }],
-    [],
-    undefined,
-    {
-      config: {
-        max_tokens: config.daemon.titleGenerationMaxTokens,
-        modelIntent: "latency-optimized",
-      },
-      signal: combinedSignal,
-    },
-  );
-
-  const textBlock = response.content.find((b) => b.type === "text");
-  if (textBlock && textBlock.type === "text") {
-    const title = normalizeTitle(textBlock.text);
-    if (!title) {
-      return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
-    }
-
+  const result = await runBtwSidechain({
+    content: prompt,
+    provider,
+    maxTokens: config.daemon.titleGenerationMaxTokens,
+    modelIntent: "latency-optimized",
+    signal,
+    timeoutMs: 10_000,
+  });
+  const title = normalizeTitle(result.text);
+  if (title) {
     // Re-check isAutoTitle before persisting (race guard against manual rename)
     const current = getConversation(conversationId);
     if (!current || !current.isAutoTitle) {

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -1,0 +1,101 @@
+import { buildToolDefinitions } from "../daemon/conversation-tool-setup.js";
+import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import {
+  createTimeout,
+  extractAllText,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import type {
+  Message,
+  ModelIntent,
+  Provider,
+  ProviderEvent,
+  ProviderResponse,
+  ToolDefinition,
+} from "../providers/types.js";
+
+export interface BtwSidechainConversationLike {
+  provider: Provider;
+  systemPrompt: string;
+  hasSystemPromptOverride?: boolean;
+  getMessages(): Message[];
+}
+
+export interface RunBtwSidechainParams {
+  content: string;
+  conversation?: BtwSidechainConversationLike;
+  provider?: Provider;
+  messages?: Message[];
+  systemPrompt?: string;
+  tools?: ToolDefinition[];
+  maxTokens?: number;
+  modelIntent?: ModelIntent;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  onEvent?: (event: ProviderEvent) => void;
+}
+
+export interface RunBtwSidechainResult {
+  text: string;
+  hadTextDeltas: boolean;
+  response: ProviderResponse;
+}
+
+/**
+ * Run an ephemeral BTW-style side-chain LLM call.
+ *
+ * This mirrors the /v1/btw route behavior: no message persistence, tool_choice
+ * forced to none, latency-optimized by default, and the standard system prompt
+ * with BOOTSTRAP.md excluded unless an explicit system prompt override exists.
+ */
+export async function runBtwSidechain(
+  params: RunBtwSidechainParams,
+): Promise<RunBtwSidechainResult> {
+  const trimmedContent = params.content.trim();
+  const provider = params.provider ?? params.conversation?.provider;
+  if (!provider) {
+    throw new Error("BTW side-chain requires a provider");
+  }
+
+  const tools = params.tools ?? buildToolDefinitions();
+  const history = params.messages ?? params.conversation?.getMessages() ?? [];
+  const messages = [...history, userMessage(trimmedContent)];
+  const systemPrompt =
+    params.systemPrompt ??
+    (params.conversation?.hasSystemPromptOverride
+      ? params.conversation.systemPrompt
+      : buildSystemPrompt({ excludeBootstrap: true }));
+
+  const { signal: timeoutSignal, cleanup } = createTimeout(
+    params.timeoutMs ?? 30_000,
+  );
+  const combinedSignal = params.signal
+    ? AbortSignal.any([params.signal, timeoutSignal])
+    : timeoutSignal;
+
+  let collectedText = "";
+  let hadTextDeltas = false;
+
+  try {
+    const response = await provider.sendMessage(messages, tools, systemPrompt, {
+      config: {
+        max_tokens: params.maxTokens ?? 1024,
+        tool_choice: { type: "none" },
+        modelIntent: params.modelIntent ?? "latency-optimized",
+      },
+      onEvent: (event) => {
+        if (event.type === "text_delta") {
+          hadTextDeltas = true;
+          collectedText += event.text;
+        }
+        params.onEvent?.(event);
+      },
+      signal: combinedSignal,
+    });
+
+    const text = collectedText.trim() || extractAllText(response).trim();
+    return { text, hadTextDeltas, response };
+  } finally {
+    cleanup();
+  }
+}

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -14,17 +14,12 @@
 
 import { existsSync, readFileSync } from "node:fs";
 
-import { buildToolDefinitions } from "../../daemon/conversation-tool-setup.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
-import { buildSystemPrompt } from "../../prompts/system-prompt.js";
-import {
-  createTimeout,
-  userMessage,
-} from "../../providers/provider-send-message.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import type { AuthContext } from "../auth/types.js";
+import { runBtwSidechain } from "../btw-sidechain.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import type { SendMessageDeps } from "../http-types.js";
@@ -159,73 +154,42 @@ async function handleBtw(
   const conversation =
     await deps.sendMessageDeps.getOrCreateConversation(conversationId);
 
-  const messages = [...conversation.getMessages(), userMessage(trimmedContent)];
-  const tools = buildToolDefinitions();
-  const { signal: timeoutSignal, cleanup: cleanupTimeout } =
-    createTimeout(30_000);
-
-  // Combine the timeout signal with the request's abort signal so that
-  // disconnection or timeout both cancel the provider call.
-  const combinedController = new AbortController();
-  const onTimeoutAbort = () => combinedController.abort();
-  const onRequestAbort = () => combinedController.abort();
-  timeoutSignal.addEventListener("abort", onTimeoutAbort, { once: true });
-  req.signal.addEventListener("abort", onRequestAbort, { once: true });
-  const combinedSignal = combinedController.signal;
-
   const encoder = new TextEncoder();
 
   const stream = new ReadableStream({
     start(controller) {
       (async () => {
         try {
-          // Preserve any conversation-specific systemPromptOverride so
-          // side-chain responses match the active conversation contract.  Only
-          // fall back to a fresh prompt (excluding BOOTSTRAP.md) for
-          // default conversations where no override was provided.
-          const systemPrompt = conversation.hasSystemPromptOverride
-            ? conversation.systemPrompt
-            : buildSystemPrompt({ excludeBootstrap: true });
-
           const isIntroRequest = conversationKey === IDENTITY_INTRO_KEY;
-          let textDeltaCount = 0;
-          let collectedText = "";
-          await conversation.provider.sendMessage(
-            messages,
-            tools,
-            systemPrompt,
-            {
-              config: {
-                max_tokens: 1024,
-                tool_choice: { type: "none" },
-                modelIntent: "latency-optimized",
-              },
-              onEvent: (event) => {
-                if (event.type === "text_delta") {
-                  textDeltaCount++;
-                  if (isIntroRequest) collectedText += event.text;
-                  controller.enqueue(
-                    encoder.encode(
-                      `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
-                    ),
-                  );
-                }
-              },
-              signal: combinedSignal,
+          const result = await runBtwSidechain({
+            content: trimmedContent,
+            conversation,
+            signal: req.signal,
+            onEvent: (event) => {
+              if (event.type === "text_delta") {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
+                  ),
+                );
+              }
             },
-          );
+          });
 
-          if (textDeltaCount === 0) {
+          if (!result.hadTextDeltas) {
             log.warn(
-              { conversationKey, messageCount: messages.length },
+              {
+                conversationKey,
+                messageCount: conversation.getMessages().length + 1,
+              },
               "btw side-chain completed with no text deltas",
             );
           }
 
           // Cache the generated identity intro for subsequent requests.
-          if (isIntroRequest && collectedText.trim()) {
+          if (isIntroRequest && result.text) {
             try {
-              setCachedIntro(collectedText.trim());
+              setCachedIntro(result.text);
               log.debug("Cached identity intro text");
             } catch {
               // Non-fatal — next request will regenerate.
@@ -249,10 +213,6 @@ async function handleBtw(
           } catch {
             /* stream already closed */
           }
-        } finally {
-          cleanupTimeout();
-          timeoutSignal.removeEventListener("abort", onTimeoutAbort);
-          req.signal.removeEventListener("abort", onRequestAbort);
         }
       })();
     },


### PR DESCRIPTION
## Summary
- add a shared BTW side-chain runner so ephemeral UI and title generation use the same non-persistent path
- route conversation title generation and regeneration through that helper with latency-optimized intent
- add focused coverage for the title path and assert the BTW route keeps using latency-optimized intent

## Testing
- cd assistant && bun test src/__tests__/btw-routes.test.ts
- cd assistant && bun test src/__tests__/conversation-title-service.test.ts

## Notes
- `cd assistant && bunx tsc --noEmit` is currently blocked by a pre-existing `packages/ces-contracts` `zod/v4` resolution issue in this workspace.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
