### PR TITLE
Restore composer suggestion after clearing input

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -115,6 +115,16 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testClearingInputRestoresExistingSuggestion() {
+        viewModel.suggestion = "Summarize the last response"
+
+        viewModel.inputText = "Something else"
+        XCTAssertEqual(viewModel.suggestion, "Summarize the last response")
+
+        viewModel.inputText = ""
+        XCTAssertEqual(viewModel.suggestion, "Summarize the last response")
+    }
+
     func testSendMessageRecordsInMockClient() throws {
         viewModel.conversationId = "sess-abc"
         viewModel.inputText = "Test"

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -108,6 +108,16 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorText)
     }
 
+    func testClearingInputRestoresExistingSuggestion() {
+        viewModel.suggestion = "Summarize the last response"
+
+        viewModel.inputText = "Something else"
+        XCTAssertEqual(viewModel.suggestion, "Summarize the last response")
+
+        viewModel.inputText = ""
+        XCTAssertEqual(viewModel.suggestion, "Summarize the last response")
+    }
+
     func testSendMessageDoesNotPrematurelyDenyPendingConfirmationForExplicitApprovePhrase() {
         viewModel.conversationId = "sess-1"
         var confirmation = ToolConfirmationData(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -178,16 +178,7 @@ public final class ChatViewModel: ObservableObject {
     }
     public var inputText: String {
         get { messageManager.inputText }
-        set {
-            let oldValue = messageManager.inputText
-            let oldSuggestion = messageManager.suggestion
-            messageManager.inputText = newValue
-            guard newValue != oldValue else { return }
-            if let oldSuggestion, !oldSuggestion.hasPrefix(newValue) {
-                messageManager.suggestion = nil
-                pendingSuggestionRequestId = nil
-            }
-        }
+        set { messageManager.inputText = newValue }
     }
     public var isThinking: Bool {
         get { messageManager.isThinking }


### PR DESCRIPTION
## Summary
- preserve the current follow-up suggestion while the user edits the composer
- let the existing composer ghost-text logic show that suggestion again when the input is cleared
- add macOS and iOS regression tests for the shared chat view-model behavior

## Testing
- Test Suite 'Selected tests' started at 2026-03-19 03:29:57.997.
Test Suite 'vellum-assistantPackageTests.xctest' started at 2026-03-19 03:29:57.998.
Test Suite 'ChatViewModelTests' started at 2026-03-19 03:29:57.998.
Test Case '-[vellum_assistantTests.ChatViewModelTests testClearingInputRestoresExistingSuggestion]' started.
Test Case '-[vellum_assistantTests.ChatViewModelTests testClearingInputRestoresExistingSuggestion]' passed (0.002 seconds).
Test Suite 'ChatViewModelTests' passed at 2026-03-19 03:29:58.000.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.003) seconds
Test Suite 'vellum-assistantPackageTests.xctest' passed at 2026-03-19 03:29:58.000.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.003) seconds
Test Suite 'Selected tests' passed at 2026-03-19 03:29:58.000.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.003) seconds
◇ Test run started.
↳ Testing Library Version: 1501
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
- Test Suite 'Selected tests' started at 2026-03-19 03:29:58.767.
Test Suite 'vellum-assistantPackageTests.xctest' started at 2026-03-19 03:29:58.768.
Test Suite 'ChatViewModelIOSTests' started at 2026-03-19 03:29:58.768.
Test Case '-[VellumAssistantIOSTests.ChatViewModelIOSTests testClearingInputRestoresExistingSuggestion]' started.
Test Case '-[VellumAssistantIOSTests.ChatViewModelIOSTests testClearingInputRestoresExistingSuggestion]' passed (0.002 seconds).
Test Suite 'ChatViewModelIOSTests' passed at 2026-03-19 03:29:58.770.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'vellum-assistantPackageTests.xctest' passed at 2026-03-19 03:29:58.770.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'Selected tests' passed at 2026-03-19 03:29:58.770.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.003) seconds
◇ Test run started.
↳ Testing Library Version: 1501
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
