### PR TITLE
fix: address review feedback on migration 002

### DIFF
--- a/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const existsSyncFn = mock((_path: string): boolean => false);
+const readFileSyncFn = mock((_path: string, _enc: string): string => "");
+const writeFileSyncFn = mock((_path: string, _data: string): void => undefined);
+const randomUUIDFn = mock((): string => "generated-uuid-1234");
+const getMemoryCheckpointFn = mock((_key: string): string | null => null);
+const deleteMemoryCheckpointFn = mock((_key: string): void => undefined);
+const getExternalAssistantIdFn = mock((): string | undefined => "my-assistant");
+const homedirFn = mock((): string => "/mock-home");
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs", () => ({
+  existsSync: existsSyncFn,
+  readFileSync: readFileSyncFn,
+  writeFileSync: writeFileSyncFn,
+}));
+
+mock.module("node:crypto", () => ({
+  randomUUID: randomUUIDFn,
+}));
+
+mock.module("node:os", () => ({
+  homedir: homedirFn,
+}));
+
+mock.module("../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: getMemoryCheckpointFn,
+  deleteMemoryCheckpoint: deleteMemoryCheckpointFn,
+}));
+
+mock.module("../runtime/auth/external-assistant-id.js", () => ({
+  getExternalAssistantId: getExternalAssistantIdFn,
+}));
+
+// Import after mocking
+import { backfillInstallationIdMigration } from "../workspace/migrations/010-backfill-installation-id.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE = "/mock-home";
+const LOCK_PATH = `${BASE}/.vellum.lock.json`;
+const LEGACY_LOCK_PATH = `${BASE}/.vellum.lockfile.json`;
+const WORKSPACE_DIR = `${BASE}/.vellum/workspace`;
+
+function makeLockfile(assistants: Array<Record<string, unknown>>): string {
+  return JSON.stringify({ assistants });
+}
+
+function setupFs(fileContents: Record<string, string>): void {
+  existsSyncFn.mockImplementation((path: string) => path in fileContents);
+  readFileSyncFn.mockImplementation((path: string, _enc: string) => {
+    if (path in fileContents) return fileContents[path];
+    throw new Error(`ENOENT: ${path}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("010-backfill-installation-id migration", () => {
+  beforeEach(() => {
+    existsSyncFn.mockClear();
+    readFileSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+    randomUUIDFn.mockClear();
+    getMemoryCheckpointFn.mockClear();
+    deleteMemoryCheckpointFn.mockClear();
+    getExternalAssistantIdFn.mockClear();
+    homedirFn.mockClear();
+
+    // Defaults
+    homedirFn.mockReturnValue("/mock-home");
+    getExternalAssistantIdFn.mockReturnValue("my-assistant");
+    getMemoryCheckpointFn.mockReturnValue(null);
+    randomUUIDFn.mockReturnValue("generated-uuid-1234");
+    delete process.env.BASE_DATA_DIR;
+  });
+
+  test("no-op when no lockfile exists", () => {
+    setupFs({});
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when lockfile has no assistants array", () => {
+    setupFs({
+      [LOCK_PATH]: JSON.stringify({ version: 1 }),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when lockfile is malformed JSON", () => {
+    setupFs({
+      [LOCK_PATH]: "{{not json",
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when lockfile is an array", () => {
+    setupFs({
+      [LOCK_PATH]: JSON.stringify([1, 2, 3]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no matching assistant entry found", () => {
+    getExternalAssistantIdFn.mockReturnValue("my-assistant");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([
+        { assistantId: "other-assistant", installationId: undefined },
+      ]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("backfills installationId from SQLite checkpoint", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-install-id");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    expect(path).toBe(LOCK_PATH);
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("sqlite-install-id");
+  });
+
+  test("generates new UUID when no SQLite checkpoint exists", () => {
+    getMemoryCheckpointFn.mockReturnValue(null);
+    randomUUIDFn.mockReturnValue("new-uuid-5678");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("new-uuid-5678");
+  });
+
+  test("generates new UUID when SQLite table does not exist", () => {
+    getMemoryCheckpointFn.mockImplementation(() => {
+      throw new Error("no such table: memory_checkpoints");
+    });
+    randomUUIDFn.mockReturnValue("fallback-uuid");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("fallback-uuid");
+  });
+
+  test("skips lockfile write when entry already has installationId", () => {
+    setupFs({
+      [LOCK_PATH]: makeLockfile([
+        { assistantId: "my-assistant", installationId: "existing-id" },
+      ]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("cleans up SQLite checkpoint when entry already has installationId", () => {
+    setupFs({
+      [LOCK_PATH]: makeLockfile([
+        { assistantId: "my-assistant", installationId: "existing-id" },
+      ]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(deleteMemoryCheckpointFn).toHaveBeenCalledWith(
+      "telemetry:installation_id",
+    );
+  });
+
+  test("cleans up SQLite checkpoint after writing lockfile", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(deleteMemoryCheckpointFn).toHaveBeenCalledWith(
+      "telemetry:installation_id",
+    );
+  });
+
+  test("handles deleteMemoryCheckpoint throwing gracefully", () => {
+    deleteMemoryCheckpointFn.mockImplementation(() => {
+      throw new Error("no such table");
+    });
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    // Should not throw
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("reads from legacy .vellum.lockfile.json when primary is absent", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+    setupFs({
+      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    expect(path).toBe(LEGACY_LOCK_PATH);
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("sqlite-id");
+  });
+
+  test("prefers primary lockfile over legacy when both exist", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+    setupFs({
+      [LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [path] = writeFileSyncFn.mock.calls[0] as [string, string];
+    expect(path).toBe(LOCK_PATH);
+  });
+
+  test("falls through to legacy lockfile when primary is malformed", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+    setupFs({
+      [LOCK_PATH]: "{{not json",
+      [LEGACY_LOCK_PATH]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    expect(path).toBe(LEGACY_LOCK_PATH);
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("sqlite-id");
+  });
+
+  test("respects BASE_DATA_DIR environment variable", () => {
+    process.env.BASE_DATA_DIR = "/custom-base";
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+
+    const customLockPath = "/custom-base/.vellum.lock.json";
+    setupFs({
+      [customLockPath]: makeLockfile([{ assistantId: "my-assistant" }]),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [path] = writeFileSyncFn.mock.calls[0] as [string, string];
+    expect(path).toBe(customLockPath);
+  });
+
+  test("preserves other assistants in lockfile when writing", () => {
+    getMemoryCheckpointFn.mockReturnValue("sqlite-id");
+    setupFs({
+      [LOCK_PATH]: JSON.stringify({
+        assistants: [
+          { assistantId: "other-assistant", installationId: "other-id" },
+          { assistantId: "my-assistant" },
+        ],
+      }),
+    });
+
+    backfillInstallationIdMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const [, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(data);
+    expect(parsed.assistants[0].installationId).toBe("other-id");
+    expect(parsed.assistants[1].installationId).toBe("sqlite-id");
+  });
+
+  test("has migration id 010-backfill-installation-id", () => {
+    expect(backfillInstallationIdMigration.id).toBe(
+      "010-backfill-installation-id",
+    );
+  });
+});

--- a/assistant/src/workspace/migrations/010-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/010-backfill-installation-id.ts
@@ -11,7 +11,7 @@ import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id
 import type { WorkspaceMigration } from "./types.js";
 
 export const backfillInstallationIdMigration: WorkspaceMigration = {
-  id: "002-backfill-installation-id",
+  id: "010-backfill-installation-id",
   description:
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
   run(_workspaceDir: string): void {
@@ -26,19 +26,30 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
     }
     const installationId = existingId || randomUUID();
 
-    // b. Read the lockfile from the standard path
+    // b. Read the lockfile — check both the current and legacy lockfile paths
+    //    to support installs that haven't migrated the filename yet.
     const base = process.env.BASE_DATA_DIR?.trim() || homedir();
-    const lockPath = join(base, ".vellum.lock.json");
-    if (!existsSync(lockPath)) return;
+    const lockCandidates = [
+      join(base, ".vellum.lock.json"),
+      join(base, ".vellum.lockfile.json"),
+    ];
 
-    let lockData: Record<string, unknown>;
-    try {
-      const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
-      lockData = raw as Record<string, unknown>;
-    } catch {
-      return;
+    let lockPath: string | undefined;
+    let lockData: Record<string, unknown> | undefined;
+    for (const candidate of lockCandidates) {
+      if (!existsSync(candidate)) continue;
+      try {
+        const raw = JSON.parse(readFileSync(candidate, "utf-8"));
+        if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+          lockPath = candidate;
+          lockData = raw as Record<string, unknown>;
+          break;
+        }
+      } catch {
+        // Malformed — try next candidate.
+      }
     }
+    if (!lockPath || !lockData) return;
 
     // c. Find the assistant entry that corresponds to this daemon instance
     const assistants = lockData.assistants as

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,5 +1,4 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
-import { backfillInstallationIdMigration } from "./002-backfill-installation-id.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
@@ -7,6 +6,7 @@ import { servicesConfigMigration } from "./006-services-config.js";
 import { webSearchProviderRenameMigration } from "./007-web-search-provider-rename.js";
 import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-steps.js";
 import { backfillConversationDiskViewMigration } from "./009-backfill-conversation-disk-view.js";
+import { backfillInstallationIdMigration } from "./010-backfill-installation-id.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -15,7 +15,6 @@ import type { WorkspaceMigration } from "./types.js";
  */
 export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
-  backfillInstallationIdMigration,
   seedDeviceIdMigration,
   extractCollectUsageDataMigration,
   addSendDiagnosticsMigration,
@@ -23,4 +22,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   webSearchProviderRenameMigration,
   voiceTimeoutAndMaxStepsMigration,
   backfillConversationDiskViewMigration,
+  backfillInstallationIdMigration,
 ];


### PR DESCRIPTION
## Summary
- Moves `backfillInstallationIdMigration` from position 2 (between 001 and 003) to the end of the `WORKSPACE_MIGRATIONS` registry, renaming from `002` to `010` to comply with the append-only invariant documented in both `registry.ts` and `AGENTS.md`
- Adds legacy `.vellum.lockfile.json` path support so the migration works on installs that still use the old lockfile name (matching the pattern in `003-seed-device-id.ts`)
- Adds `workspace-migration-backfill-installation-id.test.ts` with comprehensive test coverage for all code paths

Addresses review feedback from PR #17759.

## Test plan
- [x] New test file covers: no-op cases, SQLite checkpoint recovery, UUID fallback, idempotent skip, legacy lockfile support, malformed lockfile fallback, BASE_DATA_DIR override, multi-assistant preservation
- [x] Migration is idempotent — users who already ran the old `002` ID will safely re-run under `010` (existing installationId check at step d)
- [x] Pre-commit hooks pass (lint, format, type-check, secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
