### PR TITLE
Fix app git history tests for slug-based dirs

### DIFF
--- a/assistant/src/__tests__/app-git-history.test.ts
+++ b/assistant/src/__tests__/app-git-history.test.ts
@@ -14,7 +14,7 @@ mock.module("../util/platform.js", () => ({
 }));
 
 // Re-import after mocking so modules use our temp dir
-const { createApp, updateApp, getAppsDir } =
+const { createApp, updateApp, getAppDirPath } =
   await import("../memory/app-store.js");
 const {
   getAppHistory,
@@ -147,7 +147,7 @@ describe("App Git History", () => {
 
     // Current file should show new content
     const currentContent = readFileSync(
-      join(getAppsDir(), app.id, "index.html"),
+      join(getAppDirPath(app.id), "index.html"),
       "utf-8",
     );
     expect(currentContent).toContain("version two");
@@ -169,7 +169,7 @@ describe("App Git History", () => {
 
     // Verify current content is "new content"
     let current = readFileSync(
-      join(getAppsDir(), app.id, "index.html"),
+      join(getAppDirPath(app.id), "index.html"),
       "utf-8",
     );
     expect(current).toContain("new content");
@@ -178,7 +178,7 @@ describe("App Git History", () => {
     await restoreAppVersion(app.id, originalHash);
 
     // Verify content is restored
-    current = readFileSync(join(getAppsDir(), app.id, "index.html"), "utf-8");
+    current = readFileSync(join(getAppDirPath(app.id), "index.html"), "utf-8");
     expect(current).toContain("original content");
 
     // Verify a restore commit was created


### PR DESCRIPTION
## Summary
- update app git history tests to use getAppDirPath(app.id) instead of the legacy UUID-based path
- keep the test assertions aligned with the slug-based app directory invariant enforced by app-store

## Original prompt
Fix this test issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23278413251/job/67686293344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
