### PR TITLE
fix: clear stale daemonStartupError on successful hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -375,6 +375,9 @@ extension AppDelegate {
                     // Pass the selected assistant ID so the gateway starts
                     // with the correct default assistant (not a random name).
                     let assistantName = assistant?.assistantId
+                    // Clear any stale startup error from a previous hatch attempt
+                    // so a successful hatch doesn't leave a non-nil error in app state.
+                    self.daemonStartupError = nil
                     do {
                         try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
                     } catch let error as AssistantCli.CLIError {


### PR DESCRIPTION
## Summary
- Clear `daemonStartupError` before each hatch attempt so a successful hatch resets any stale error from a prior failure
- Addresses review feedback on PR #17775: the error was set on failure but never cleared when the primary hatch path succeeded, leaving a stale non-nil error in app state that could cause the UI to show an incorrect persistent startup failure

## Test plan
- [ ] Verify that after a transient hatch failure followed by a successful retry, `daemonStartupError` is nil
- [ ] Verify that after a successful first hatch, `daemonStartupError` remains nil
- [ ] Verify that after a permanent hatch failure, `daemonStartupError` is still populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
