### PR TITLE
refactor: consolidate provider catalog into single PROVIDER_CATALOG array

### DIFF
--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -6,7 +6,7 @@ import QRCode from "qrcode";
 
 import { getGatewayPort, getIngressPublicBaseUrl } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
-import { getFullProviderCatalog } from "../providers/model-catalog.js";
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
 import { getLocalIPv4 } from "../util/network-info.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -54,7 +54,7 @@ async function resolveModelList(): Promise<SlashResolution> {
     id: provider,
     displayName: providerName,
     models,
-  } of getFullProviderCatalog()) {
+  } of PROVIDER_CATALOG) {
     const hasKey = configuredProviders.has(provider);
     const status = hasKey ? "✓" : "✗";
     lines.push(`**${providerName}** ${status}`);

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -7,9 +7,8 @@ import { setServiceField } from "../../config/raw-config-utils.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
 import {
-  getFullProviderCatalog,
   isModelInCatalog,
-  PROVIDER_MODEL_CATALOG,
+  PROVIDER_CATALOG,
 } from "../../providers/model-catalog.js";
 import { getProviderDefaultModel } from "../../providers/model-intents.js";
 import {
@@ -28,10 +27,10 @@ import {
   log,
 } from "./shared.js";
 
-/** Reverse lookup: model ID → provider, derived from PROVIDER_MODEL_CATALOG. */
+/** Reverse lookup: model ID → provider, derived from PROVIDER_CATALOG. */
 export const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
-  Object.entries(PROVIDER_MODEL_CATALOG).flatMap(([provider, models]) =>
-    models.map(({ id }) => [id, provider]),
+  PROVIDER_CATALOG.flatMap((provider) =>
+    provider.models.map(({ id }) => [id, provider.id]),
   ),
 );
 
@@ -63,8 +62,8 @@ export async function getModelInfo(): Promise<ModelInfo> {
     model: config.services.inference.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
-    availableModels: PROVIDER_MODEL_CATALOG[provider],
-    allProviders: getFullProviderCatalog(),
+    availableModels: PROVIDER_CATALOG.find((p) => p.id === provider)?.models,
+    allProviders: PROVIDER_CATALOG,
     maskedKeys,
   };
 }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -3,62 +3,6 @@ export interface CatalogModel {
   displayName: string;
 }
 
-export const PROVIDER_MODEL_CATALOG: Record<string, CatalogModel[]> = {
-  anthropic: [
-    { id: "claude-opus-4-6", displayName: "Claude Opus 4.6" },
-    { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
-    { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
-  ],
-  openai: [
-    { id: "gpt-5.4", displayName: "GPT-5.4" },
-    { id: "gpt-5.2", displayName: "GPT-5.2" },
-    { id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
-    { id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano" },
-  ],
-  gemini: [
-    { id: "gemini-3-flash", displayName: "Gemini 3 Flash" },
-    { id: "gemini-3-pro", displayName: "Gemini 3 Pro" },
-  ],
-  ollama: [
-    { id: "llama3.2", displayName: "Llama 3.2" },
-    { id: "mistral", displayName: "Mistral" },
-  ],
-  fireworks: [
-    { id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5" },
-  ],
-  openrouter: [
-    { id: "x-ai/grok-4", displayName: "Grok 4" },
-    { id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta" },
-  ],
-};
-
-/** API key management URLs for inference providers (omit providers that don't require keys). */
-export const INFERENCE_PROVIDER_API_KEY_URLS: Record<string, string> = {
-  anthropic: "https://console.anthropic.com/settings/keys",
-  openai: "https://platform.openai.com/api-keys",
-  gemini: "https://aistudio.google.com/apikey",
-  fireworks: "https://fireworks.ai/account/api-keys",
-  openrouter: "https://openrouter.ai/keys",
-};
-
-/** API key placeholder patterns for inference providers (omit providers that don't require keys). */
-export const INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS: Record<string, string> = {
-  anthropic: "sk-ant-api03-...",
-  openai: "sk-proj-...",
-  gemini: "AIza...",
-  fireworks: "fw_...",
-  openrouter: "sk-or-v1-...",
-};
-
-const INFERENCE_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  anthropic: "Anthropic",
-  openai: "OpenAI",
-  gemini: "Google Gemini",
-  ollama: "Ollama",
-  fireworks: "Fireworks",
-  openrouter: "OpenRouter",
-};
-
 export interface ProviderCatalogEntry {
   id: string;
   displayName: string;
@@ -68,20 +12,81 @@ export interface ProviderCatalogEntry {
   apiKeyPlaceholder?: string;
 }
 
-/** Build the full provider catalog with metadata for each inference provider. */
-export function getFullProviderCatalog(): ProviderCatalogEntry[] {
-  return Object.entries(PROVIDER_MODEL_CATALOG).map(([id, models]) => ({
-    id,
-    displayName: INFERENCE_PROVIDER_DISPLAY_NAMES[id] ?? id,
-    models,
-    defaultModel: models[0]?.id ?? "",
-    apiKeyUrl: INFERENCE_PROVIDER_API_KEY_URLS[id],
-    apiKeyPlaceholder: INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS[id],
-  }));
-}
+/** Single source of truth for all inference provider metadata and models. */
+export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
+  {
+    id: "anthropic",
+    displayName: "Anthropic",
+    models: [
+      { id: "claude-opus-4-6", displayName: "Claude Opus 4.6" },
+      { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
+      { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
+    ],
+    defaultModel: "claude-opus-4-6",
+    apiKeyUrl: "https://console.anthropic.com/settings/keys",
+    apiKeyPlaceholder: "sk-ant-api03-...",
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    models: [
+      { id: "gpt-5.4", displayName: "GPT-5.4" },
+      { id: "gpt-5.2", displayName: "GPT-5.2" },
+      { id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
+      { id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano" },
+    ],
+    defaultModel: "gpt-5.4",
+    apiKeyUrl: "https://platform.openai.com/api-keys",
+    apiKeyPlaceholder: "sk-proj-...",
+  },
+  {
+    id: "gemini",
+    displayName: "Google Gemini",
+    models: [
+      { id: "gemini-3-flash", displayName: "Gemini 3 Flash" },
+      { id: "gemini-3-pro", displayName: "Gemini 3 Pro" },
+    ],
+    defaultModel: "gemini-3-flash",
+    apiKeyUrl: "https://aistudio.google.com/apikey",
+    apiKeyPlaceholder: "AIza...",
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama",
+    models: [
+      { id: "llama3.2", displayName: "Llama 3.2" },
+      { id: "mistral", displayName: "Mistral" },
+    ],
+    defaultModel: "llama3.2",
+  },
+  {
+    id: "fireworks",
+    displayName: "Fireworks",
+    models: [
+      {
+        id: "accounts/fireworks/models/kimi-k2p5",
+        displayName: "Kimi K2.5",
+      },
+    ],
+    defaultModel: "accounts/fireworks/models/kimi-k2p5",
+    apiKeyUrl: "https://fireworks.ai/account/api-keys",
+    apiKeyPlaceholder: "fw_...",
+  },
+  {
+    id: "openrouter",
+    displayName: "OpenRouter",
+    models: [
+      { id: "x-ai/grok-4", displayName: "Grok 4" },
+      { id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta" },
+    ],
+    defaultModel: "x-ai/grok-4",
+    apiKeyUrl: "https://openrouter.ai/keys",
+    apiKeyPlaceholder: "sk-or-v1-...",
+  },
+];
 
-/** Check if a model ID is in the catalog for a given provider */
+/** Check if a model ID is in the catalog for a given provider. */
 export function isModelInCatalog(provider: string, modelId: string): boolean {
-  const catalog = PROVIDER_MODEL_CATALOG[provider];
-  return catalog?.some((m) => m.id === modelId) ?? false;
+  const entry = PROVIDER_CATALOG.find((p) => p.id === provider);
+  return entry?.models.some((m) => m.id === modelId) ?? false;
 }


### PR DESCRIPTION
## Summary
- Replaced 4 parallel `Record<string, ...>` dicts (`PROVIDER_MODEL_CATALOG`, `INFERENCE_PROVIDER_DISPLAY_NAMES`, `INFERENCE_PROVIDER_API_KEY_URLS`, `INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS`) and `getFullProviderCatalog()` with a single `PROVIDER_CATALOG: ProviderCatalogEntry[]` array
- Updated consumers in `conversation-slash.ts` and `config-model.ts` to use the unified array directly
- No wire-format changes — `ProviderCatalogEntry` interface is unchanged, so Swift clients are unaffected

## Original prompt
Consolidate multiple arrays and untyped dicts (`PROVIDER_MODEL_CATALOG`, `INFERENCE_PROVIDER_DISPLAY_NAMES`, `INFERENCE_PROVIDER_API_KEY_URLS`, `INFERENCE_PROVIDER_API_KEY_PLACEHOLDERS`) into a single `PROVIDER_CATALOG` array of `ProviderCatalogEntry` objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
