### PR TITLE
feat: use per-provider API key placeholder, VDropdown in onboarding, update copy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -77,8 +77,8 @@ struct APIKeyEntryStepView: View {
             .padding(.bottom, VSpacing.md)
 
         Text(isCustomProviderEnabled
-            ? "Since you skipped creating an account,\nyou\u{2019}ll need to bring your own API key\nfor a model provider."
-            : "Since you skipped creating an account,\nwe\u{2019}ll need your Anthropic API key.")
+            ? "Enter an API key to connect your model provider."
+            : "Enter your Anthropic API key to get started.")
             .font(VFont.buttonLarge)
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
@@ -176,15 +176,14 @@ struct APIKeyEntryStepView: View {
             Text("Provider")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            Picker("", selection: $state.selectedProvider) {
-                ForEach(providerCatalog, id: \.id) { entry in
-                    Text(entry.displayName).tag(entry.id)
+            VDropdown(
+                placeholder: "Select a provider\u{2026}",
+                selection: $state.selectedProvider,
+                options: providerCatalog.map { entry in
+                    (label: entry.displayName, value: entry.id)
                 }
-            }
-            .pickerStyle(.menu)
-            .labelsHidden()
+            )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Model Picker
@@ -194,15 +193,14 @@ struct APIKeyEntryStepView: View {
             Text("Model")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            Picker("", selection: $selectedModel) {
-                ForEach(currentProviderEntry?.models ?? [], id: \.id) { model in
-                    Text(model.displayName).tag(model.id)
+            VDropdown(
+                placeholder: "Select a model\u{2026}",
+                selection: $selectedModel,
+                options: (currentProviderEntry?.models ?? []).map { model in
+                    (label: model.displayName, value: model.id)
                 }
-            }
-            .pickerStyle(.menu)
-            .labelsHidden()
+            )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - API Key Field
@@ -228,9 +226,7 @@ struct APIKeyEntryStepView: View {
                     }
             } else {
                 SecureField(
-                    isCustomProviderEnabled
-                        ? (state.selectedProvider == "anthropic" ? "sk-ant-\u{2026}" : "Enter your \(providerDisplayName) API key")
-                        : "sk-ant-\u{2026}",
+                    currentProviderEntry?.apiKeyPlaceholder ?? "Enter your API key",
                     text: $apiKey
                 )
                     .textFieldStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -221,18 +221,25 @@ struct InferenceServiceCard: View {
             }
             return ""
         }()
+        let placeholder: String = {
+            if !currentMask.isEmpty {
+                return currentMask
+            }
+            if let providerPlaceholder = store.dynamicProviderApiKeyPlaceholder(effectiveProvider), !providerPlaceholder.isEmpty {
+                return providerPlaceholder
+            }
+            return "Enter your API key"
+        }()
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text(isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            SecureField(
-                !currentMask.isEmpty ? currentMask : "Enter your API key",
-                text: $apiKeyText
-            )
+            SecureField(placeholder, text: $apiKeyText)
                 .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
                 .disabled(store.apiKeySaving)
+                .frame(maxWidth: 400)
 
             if let error = store.apiKeySaveError {
                 Text(error)


### PR DESCRIPTION
## Summary
- Inference card: use per-provider apiKeyPlaceholder as fallback when no masked key exists, constrain SecureField to maxWidth 400
- Onboarding: replace hardcoded sk-ant placeholder with catalog lookup via currentProviderEntry.apiKeyPlaceholder
- Onboarding: replace native Picker dropdowns with VDropdown component for visual consistency
- Onboarding: update subtitle copy to be more concise and action-oriented

Part of plan: provider-apikey-placeholder.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
