### PR TITLE
fix: send full privacy state on each sync to prevent dropped toggle changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -9,7 +9,10 @@ struct SettingsPrivacyTab: View {
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
 
     /// Tracks the in-flight privacy sync task so rapid toggles cancel the
-    /// previous write and only the latest value reaches the daemon.
+    /// previous write and only the latest values reach the daemon.
+    /// A single task suffices because `syncPrivacyConfig()` always sends
+    /// both current store values, so cancelling one toggle's task cannot
+    /// silently drop the other toggle's change.
     @State private var privacySyncTask: Task<Void, Never>?
 
     var body: some View {
@@ -34,7 +37,7 @@ struct SettingsPrivacyTab: View {
                     get: { store.collectUsageData },
                     set: { newValue in
                         store.collectUsageData = newValue
-                        syncPrivacyConfig(collectUsageData: newValue)
+                        syncPrivacyConfig()
                     }
                 ))
             }
@@ -60,7 +63,7 @@ struct SettingsPrivacyTab: View {
                         } else {
                             MetricKitManager.closeSentry()
                         }
-                        syncPrivacyConfig(sendDiagnostics: newValue)
+                        syncPrivacyConfig()
                     }
                 ))
             }
@@ -69,13 +72,18 @@ struct SettingsPrivacyTab: View {
 
     // MARK: - Privacy Config Sync
 
-    /// Syncs a privacy config change to the daemon, cancelling any in-flight
-    /// sync so that only the latest toggle value wins when the user toggles
-    /// rapidly.
-    private func syncPrivacyConfig(collectUsageData: Bool? = nil, sendDiagnostics: Bool? = nil) {
+    /// Syncs the full privacy config to the daemon, cancelling any in-flight
+    /// sync so that only the latest state wins when the user toggles rapidly.
+    ///
+    /// Always sends **both** current store values so that cancelling one
+    /// toggle's in-flight task cannot silently drop the other toggle's change.
+    private func syncPrivacyConfig() {
         privacySyncTask?.cancel()
         privacySyncTask = Task {
-            try? await featureFlagClient.setPrivacyConfig(collectUsageData: collectUsageData, sendDiagnostics: sendDiagnostics)
+            try? await featureFlagClient.setPrivacyConfig(
+                collectUsageData: store.collectUsageData,
+                sendDiagnostics: store.sendDiagnostics
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Addresses review feedback from #17780 where the shared `privacySyncTask` could silently drop one toggle's daemon sync when both privacy toggles are changed in quick succession
- Changed `syncPrivacyConfig()` to always send both current store values (`collectUsageData` and `sendDiagnostics`) instead of only the changed field, so cancelling one in-flight task cannot lose the other toggle's change

## Test plan
- [ ] Toggle "Share Analytics" and immediately toggle "Share Diagnostics" -- verify both changes reach the daemon
- [ ] Toggle a single setting rapidly -- verify only the final value is synced
- [ ] Verify no regression in normal single-toggle usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
