### PR TITLE
fix: decode both sessionId and conversationId keys for cross-version compat

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -69,14 +69,52 @@ private struct PersistedConversation: Codable {
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
 
-    // Map conversationId to the legacy "sessionId" JSON key so that
-    // existing UserDefaults data (encoded before the rename) decodes
-    // correctly on upgrade instead of silently dropping all cached
-    // conversations.
+    // Decode both the legacy "sessionId" key and the current "conversationId"
+    // key so UserDefaults data written by any version (pre-rename, intermediate,
+    // or current) is read correctly.  Encoding always uses "conversationId".
     enum CodingKeys: String, CodingKey {
         case id, title, createdAt, lastActivityAt, isArchived, isPinned, displayOrder, isPrivate
-        case conversationId = "sessionId"
+        case conversationId
         case scheduleJobId, hasUnseenLatestAssistantMessage, latestAssistantMessageAt, lastSeenAssistantMessageAt
+        // Legacy key used before the session-to-conversation rename.
+        case legacySessionId = "sessionId"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        lastActivityAt = try container.decodeIfPresent(Date.self, forKey: .lastActivityAt)
+        isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived)
+        isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned)
+        displayOrder = try container.decodeIfPresent(Int.self, forKey: .displayOrder)
+        isPrivate = try container.decodeIfPresent(Bool.self, forKey: .isPrivate)
+        // Try the current key first, fall back to the legacy key.
+        conversationId = try container.decodeIfPresent(String.self, forKey: .conversationId)
+            ?? container.decodeIfPresent(String.self, forKey: .legacySessionId)
+        scheduleJobId = try container.decodeIfPresent(String.self, forKey: .scheduleJobId)
+        hasUnseenLatestAssistantMessage = try container.decodeIfPresent(Bool.self, forKey: .hasUnseenLatestAssistantMessage)
+        latestAssistantMessageAt = try container.decodeIfPresent(Date.self, forKey: .latestAssistantMessageAt)
+        lastSeenAssistantMessageAt = try container.decodeIfPresent(Date.self, forKey: .lastSeenAssistantMessageAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encodeIfPresent(lastActivityAt, forKey: .lastActivityAt)
+        try container.encodeIfPresent(isArchived, forKey: .isArchived)
+        try container.encodeIfPresent(isPinned, forKey: .isPinned)
+        try container.encodeIfPresent(displayOrder, forKey: .displayOrder)
+        try container.encodeIfPresent(isPrivate, forKey: .isPrivate)
+        // Always encode under the current "conversationId" key.
+        try container.encodeIfPresent(conversationId, forKey: .conversationId)
+        try container.encodeIfPresent(scheduleJobId, forKey: .scheduleJobId)
+        try container.encodeIfPresent(hasUnseenLatestAssistantMessage, forKey: .hasUnseenLatestAssistantMessage)
+        try container.encodeIfPresent(latestAssistantMessageAt, forKey: .latestAssistantMessageAt)
+        try container.encodeIfPresent(lastSeenAssistantMessageAt, forKey: .lastSeenAssistantMessageAt)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -8,6 +8,8 @@ import Combine
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
 // Legacy UserDefaults key preserved from the session-to-conversation rename.
 private let archivedConversationsKey = "archivedSessionIds"
+// Intermediate builds may have written under this key before the compat fix.
+private let archivedConversationsNewKey = "archivedConversationIds"
 
 // MARK: - Conversation Client Protocol
 
@@ -1853,10 +1855,20 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     private var archivedConversationIds: Set<String> {
         get {
-            Set(UserDefaults.standard.stringArray(forKey: archivedConversationsKey) ?? [])
+            let legacy = Set(UserDefaults.standard.stringArray(forKey: archivedConversationsKey) ?? [])
+            let newer = Set(UserDefaults.standard.stringArray(forKey: archivedConversationsNewKey) ?? [])
+            let merged = legacy.union(newer)
+            // Migrate: consolidate into the canonical key and remove the intermediate key.
+            if !newer.isEmpty {
+                UserDefaults.standard.set(Array(merged), forKey: archivedConversationsKey)
+                UserDefaults.standard.removeObject(forKey: archivedConversationsNewKey)
+            }
+            return merged
         }
         set {
             UserDefaults.standard.set(Array(newValue), forKey: archivedConversationsKey)
+            // Clean up the intermediate key if it exists.
+            UserDefaults.standard.removeObject(forKey: archivedConversationsNewKey)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add custom Codable init/encode to PersistedConversation (iOS) so both the legacy `sessionId` and current `conversationId` JSON keys are decoded, preventing data loss for users who ran intermediate builds
- Merge both `archivedSessionIds` and `archivedConversationIds` UserDefaults keys in ConversationManager (macOS) so archived state survives mixed-version transitions
- Addresses review feedback from PR #17776

## Test plan
- [ ] Verify iOS connected-mode cache decodes correctly for data written under either `sessionId` or `conversationId` key
- [ ] Verify macOS archived conversations remain archived after upgrade regardless of which UserDefaults key was used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
