### PR TITLE
fix: address PR #17779 review — remove stale breadcrumb, parse DAEMON_ERROR on exit 0

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -131,7 +131,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Structured error from the most recent daemon startup failure.
     /// Populated by `setupDaemonClient()` when `hatch()` throws a
-    /// `CLIError.daemonStartupFailed`. Read by the UI (PR 3) to show a
+    /// `CLIError.daemonStartupFailed`. Read by the UI to show a
     /// contextual error view instead of a generic failure message.
     @Published var daemonStartupError: DaemonStartupError?
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -173,6 +173,14 @@ final class AssistantCli {
             throw CLIError.daemonStartupFailed(Self.parseDaemonStartupError(from: stderr))
         }
 
+        // The CLI can exit 0 even when the daemon had a startup failure
+        // (e.g. it logged a warning and continued). Check stderr for the
+        // DAEMON_ERROR sentinel so these failures still surface.
+        if let startupError = Self.parseDaemonStartupErrorIfPresent(from: stderr) {
+            log.error("CLI hatch exited 0 but daemon reported startup error [\(startupError.category, privacy: .public)]: \(startupError.message, privacy: .private)")
+            throw CLIError.daemonStartupFailed(startupError)
+        }
+
         log.info("CLI hatch completed successfully")
     }
 
@@ -588,6 +596,25 @@ final class AssistantCli {
         // Fallback for old daemon binaries that don't emit DAEMON_ERROR.
         let fallbackMessage = String(stderr.suffix(500))
         return DaemonStartupError(category: "UNKNOWN", message: fallbackMessage, detail: nil)
+    }
+
+    /// Parse a `DaemonStartupError` from stderr only if the `DAEMON_ERROR:`
+    /// sentinel is present. Returns `nil` when no marker is found — used for
+    /// the exit-0 path where we don't want to fabricate an UNKNOWN error.
+    private static func parseDaemonStartupErrorIfPresent(from stderr: String) -> DaemonStartupError? {
+        let lines = stderr.components(separatedBy: .newlines)
+        guard let markerLine = lines.last(where: { $0.hasPrefix("DAEMON_ERROR:") }) else {
+            return nil
+        }
+        let jsonString = String(markerLine.dropFirst("DAEMON_ERROR:".count))
+        guard let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let category = json["error"] as? String ?? "UNKNOWN"
+        let message = json["message"] as? String ?? "Unknown startup error"
+        let detail = json["detail"] as? String
+        return DaemonStartupError(category: category, message: message, detail: detail)
     }
 
     /// Send SIGTERM to a process identified by a PID file. Does not wait for


### PR DESCRIPTION
## Summary
- Remove stale "(PR 3)" breadcrumb comment from `AppDelegate.swift` docstring per AGENTS.md convention against refactoring-history markers
- Parse `DAEMON_ERROR:` sentinel from stderr even when hatch CLI exits with status 0, since the CLI can succeed while the daemon itself had a startup failure — without this, those failures were silently dropped and never reported to Sentry

Addresses review feedback on #17779.

## Test plan
- [x] Swift build passes (verified via pre-push hook)
- [ ] Verify hatch with exit 0 + DAEMON_ERROR in stderr surfaces the error to AppDelegate
- [ ] Verify hatch with exit 0 and no DAEMON_ERROR sentinel proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
