### PR TITLE
fix: add sendPerformanceReports legacy fallback in syncPrivacyConfig and SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -486,10 +486,12 @@ extension AppDelegate {
             let collectUsageData = canonicalCollectUsageData ?? legacyCollectUsageData
             let hasExplicitCollectUsageData = collectUsageData != nil
 
+            let legacySendDiagnostics = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
             let canonicalSendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-            // Fall back to legacy collectUsageData keys so users who opted
-            // out via the old master switch keep Sentry disabled.
-            let sendDiagnostics = canonicalSendDiagnostics ?? collectUsageData
+            // Fall back to the legacy sendPerformanceReports key first, then
+            // to legacy collectUsageData keys so users who opted out via the
+            // old master switch keep Sentry disabled.
+            let sendDiagnostics = canonicalSendDiagnostics ?? legacySendDiagnostics ?? collectUsageData
             let hasExplicitSendDiagnostics = sendDiagnostics != nil
 
             // Apply Sentry state based on sendDiagnostics (default true when absent)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -263,6 +263,7 @@ public final class SettingsStore: ObservableObject {
     /// Whether the user has opted in to sending crash reports, error diagnostics, and
     /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
     @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
+        ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
         ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
         ?? true
 


### PR DESCRIPTION
## Summary
- Adds `sendPerformanceReports` legacy key fallback in `syncPrivacyConfig()` so the value is migrated to the canonical `sendDiagnostics` key before the legacy key is deleted
- Adds `sendPerformanceReports` legacy key fallback in `SettingsStore.sendDiagnostics` initializer so early reads before sync also respect legacy opt-outs
- Addresses review feedback from #17785 about asymmetric legacy fallback handling between the two privacy keys

## Test plan
- [x] Verify new users (no keys present) still get opted in by default
- [x] Verify users with canonical `sendDiagnostics` set are unaffected
- [x] Verify users with only legacy `sendPerformanceReports` opt-out have it migrated correctly
- [x] Verify `SettingsStore` reflects legacy opt-out even before `syncPrivacyConfig()` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
