### PR TITLE
fix: decouple sendDiagnostics from collectUsageData in non-migration read sites

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -158,7 +158,6 @@ struct SettingsDeveloperTab: View {
 
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
                 ?? true
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -264,7 +264,6 @@ public final class SettingsStore: ObservableObject {
     /// performance metrics. Defaults to `true`. Controls Sentry independently from usage analytics.
     @Published var sendDiagnostics: Bool = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
         ?? UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool
-        ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
         ?? true
 
     /// Whether the user has opted in to sharing anonymized usage analytics (e.g. token counts,

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -221,7 +221,6 @@ import os
     private nonisolated static func restartSentryInline() {
         guard !SentrySDK.isEnabled else { return }
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-            ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
             ?? true
         guard sendDiagnostics else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
@@ -256,7 +255,6 @@ extension MetricKitManager: MXMetricManagerSubscriber {
 
             // Only send to Sentry if sendDiagnostics is enabled.
             let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
-                ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
                 ?? true
             guard sendDiagnostics else { continue }
 


### PR DESCRIPTION
## Summary
- Remove `collectUsageData` fallback from `sendDiagnostics` resolution in MetricKitManager, SettingsDeveloperTab, and SettingsStore
- The fallback is retained only in the two migration/early-launch sites (AppDelegate.applicationDidFinishLaunching and syncPrivacyConfig) where it is needed to honor legacy opt-outs before migration writes explicit values
- After syncPrivacyConfig runs, `sendDiagnostics` is always explicitly set in UserDefaults, so post-migration read sites should not fall back to `collectUsageData`
- Addresses review feedback from PR #17784: the two privacy toggles (analytics vs diagnostics) should be independent

## Test plan
- [ ] Verify Sentry is enabled by default when neither key is set
- [ ] Verify turning off "Share Analytics" does not affect "Share Diagnostics" state
- [ ] Verify legacy users who had collectUsageData=false still get Sentry disabled on first launch (via the AppDelegate fallback) and then get explicit sendDiagnostics=false written by syncPrivacyConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
