### PR TITLE
fix: restore legacy privacy key guards in OnboardingState init

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -123,6 +123,18 @@ final class OnboardingState {
         if currentStep > maxStep {
             currentStep = maxStep
         }
+
+        // Opt in to usage data and diagnostics by default for new users.
+        // Also check legacy keys so we don't override an existing opt-out from
+        // users who haven't yet been migrated by syncPrivacyConfig().
+        if UserDefaults.standard.object(forKey: "collectUsageData") == nil
+            && UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
+            UserDefaults.standard.set(true, forKey: "collectUsageData")
+        }
+        if UserDefaults.standard.object(forKey: "sendDiagnostics") == nil
+            && UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
+            UserDefaults.standard.set(true, forKey: "sendDiagnostics")
+        }
     }
 
     func advance(by steps: Int = 1) {


### PR DESCRIPTION
## Summary
- Restores the legacy privacy key guards (`collectUsageDataEnabled`, `sendPerformanceReports`) in `OnboardingState.init()` that were removed in PR #17787
- `OnboardingState` is instantiated in the auth-gate path (`showAuthWindow`) for users who already have assistants, so `init` can run before `syncPrivacyConfig()` migration completes
- Without the legacy guards, existing opt-outs (e.g. `collectUsageDataEnabled = false`) would be silently overridden by the canonical default writes

## Test plan
- [x] Verified `OnboardingState()` is instantiated in `AppDelegate+AuthLifecycle.swift` (auth-gate path), confirming init runs for existing users
- [x] Legacy key guard prevents canonical key from being written when a legacy opt-out exists
- [x] New users (no keys at all) still get opted in by default
- [x] No change for users already migrated to canonical keys

Addresses review feedback from PR #17787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
