### PR TITLE
fix: add apiKeyPlaceholder to ModelInfo wire type

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -248,6 +248,7 @@ export interface ModelInfo {
     models: Array<{ id: string; displayName: string }>;
     defaultModel: string;
     apiKeyUrl?: string;
+    apiKeyPlaceholder?: string;
   }>;
   maskedKeys?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for provider-apikey-placeholder.md.

**Gap:** Stale wire-protocol type
**What was expected:** ModelInfo.allProviders inline type should include apiKeyPlaceholder
**What was found:** The field was missing from the type definition despite being sent at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
