### PR TITLE
fix: use DAEMON_INTERNAL_ASSISTANT_ID constant instead of hardcoded 'self' string

### DIFF
--- a/assistant/src/runtime/auth/credential-service.ts
+++ b/assistant/src/runtime/auth/credential-service.ts
@@ -31,6 +31,7 @@ import {
   createActorTokenRecord,
   revokeByDeviceBinding as revokeActorTokensByDevice,
 } from "../actor-token-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getExternalAssistantId } from "./external-assistant-id.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { hashToken, mintToken } from "./token-service.js";
@@ -107,7 +108,8 @@ function mintAccessToken(guardianPrincipalId: string): {
   expiresAt: number;
   issuedAt: number;
 } {
-  const externalAssistantId = getExternalAssistantId() ?? "self";
+  const externalAssistantId =
+    getExternalAssistantId() ?? DAEMON_INTERNAL_ASSISTANT_ID;
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
 
   const token = mintToken({

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -97,6 +97,7 @@ mock.module("../version.js", () => ({
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { UsageEvent } from "../usage/types.js";
 import { UsageTelemetryReporter } from "./usage-telemetry-reporter.js";
 
@@ -434,7 +435,7 @@ describe("UsageTelemetryReporter", () => {
     expect(body.user_id).toBeUndefined();
   });
 
-  test("assistant_id falls back to 'self' when getExternalAssistantId returns undefined", async () => {
+  test("assistant_id falls back to DAEMON_INTERNAL_ASSISTANT_ID when getExternalAssistantId returns undefined", async () => {
     mockGetExternalAssistantId.mockReturnValue(undefined);
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
@@ -450,7 +451,7 @@ describe("UsageTelemetryReporter", () => {
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
     expect(body.installation_id).toBe("test-device-id");
-    expect(body.assistant_id).toBe("self");
+    expect(body.assistant_id).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
   });
 
   test("turn events are included in the events array with type discriminator", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -23,6 +23,7 @@ import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
@@ -187,7 +188,8 @@ export class UsageTelemetryReporter {
         ),
       ];
 
-      const assistantId = getExternalAssistantId() ?? "self";
+      const assistantId =
+        getExternalAssistantId() ?? DAEMON_INTERNAL_ASSISTANT_ID;
       const organizationId = getPlatformOrganizationId() || undefined;
       const userId = getPlatformUserId() || undefined;
       const payload = {


### PR DESCRIPTION
## Summary
- Replace hardcoded `"self"` fallback with `DAEMON_INTERNAL_ASSISTANT_ID` constant in `usage-telemetry-reporter.ts` and `credential-service.ts`
- Addresses review feedback from PR #17793 about using the canonical constant instead of magic strings when falling back for external assistant ID resolution
- Both files now import and use `DAEMON_INTERNAL_ASSISTANT_ID` from `assistant-scope.ts`, making the intent explicit and searchable
- Updated test assertions to use the constant as well

## Test plan
- [ ] Verify `usage-telemetry-reporter.test.ts` passes with updated assertion using `DAEMON_INTERNAL_ASSISTANT_ID`
- [ ] Confirm no other hardcoded `"self"` fallbacks remain for `getExternalAssistantId()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
