### PR TITLE
fix: add syntax color tokens to design system gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -38,6 +38,41 @@ struct TokensGallerySection: View {
                 }
             }
 
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    Text("Syntax Colors")
+                        .font(VFont.headline)
+                        .foregroundColor(VColor.contentDefault)
+
+                    let syntaxTokens: [(String, Color)] = [
+                        ("syntaxString", VColor.syntaxString),
+                        ("syntaxNumber", VColor.syntaxNumber),
+                        ("syntaxKeyword", VColor.syntaxKeyword),
+                        ("syntaxComment", VColor.syntaxComment),
+                        ("syntaxType", VColor.syntaxType),
+                        ("syntaxProperty", VColor.syntaxProperty),
+                        ("syntaxLink", VColor.syntaxLink),
+                    ]
+
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: VSpacing.md), count: 3), spacing: VSpacing.md) {
+                        ForEach(syntaxTokens, id: \.0) { name, color in
+                            VStack(spacing: VSpacing.xs) {
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .fill(color)
+                                    .frame(height: 40)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: VRadius.sm)
+                                            .stroke(VColor.borderBase, lineWidth: 1)
+                                    )
+                                Text(name)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.contentSecondary)
+                            }
+                        }
+                    }
+                }
+            }
+
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
             // MARK: - Typography


### PR DESCRIPTION
## Summary
- Add a "Syntax Colors" subsection to TokensGallerySection showing all 7 VColor.syntax* tokens (syntaxString, syntaxNumber, syntaxKeyword, syntaxComment, syntaxType, syntaxProperty, syntaxLink)
- Tokens render as adaptive swatches in a 3-column grid, responding to light/dark mode appearance
- Addresses review feedback from PR #17798 which noted the gallery was not updated when syntax color tokens were added to ColorTokens.swift

## Test plan
- [ ] Open the design system gallery in DEBUG builds and verify the new "Syntax Colors" card appears under Colors
- [ ] Toggle light/dark mode to confirm swatches adapt correctly
- [ ] Verify all 7 syntax tokens are displayed with correct names
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
