### PR TITLE
fix: surface fallback error view when daemon retry fails with unexpected error

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -960,13 +960,21 @@ struct MainWindowView: View {
                     restart: true
                 )
             } catch let error as AssistantCli.CLIError {
-                if case .daemonStartupFailed(let startupError) = error {
-                    appDelegate.daemonStartupError = startupError
-                    daemonStartupError = startupError
-                    MetricKitManager.reportDaemonStartupFailure(startupError)
+                let startupError: DaemonStartupError
+                if case .daemonStartupFailed(let parsed) = error {
+                    startupError = parsed
+                } else {
+                    startupError = DaemonStartupError(category: "UNKNOWN", message: error.localizedDescription, detail: nil)
                 }
+                appDelegate.daemonStartupError = startupError
+                daemonStartupError = startupError
+                MetricKitManager.reportDaemonStartupFailure(startupError)
                 return
             } catch {
+                let startupError = DaemonStartupError(category: "UNKNOWN", message: error.localizedDescription, detail: nil)
+                appDelegate.daemonStartupError = startupError
+                daemonStartupError = startupError
+                MetricKitManager.reportDaemonStartupFailure(startupError)
                 return
             }
             // Reconnect the daemon client after a successful restart


### PR DESCRIPTION
## Summary
- Fix the generic catch block in `retryDaemonStartup()` that silently returned on unexpected errors, leaving users stuck on an infinite loading skeleton with no way to recover
- Both catch blocks now create a fallback `DaemonStartupError` (category: `UNKNOWN`) and set it on both `appDelegate` and the local state so the error view is shown
- Also fixed the `CLIError` catch for non-`daemonStartupFailed` variants (e.g. `binaryNotFound`, `executionFailed`) which had the same silent-return bug
- The `stop()` blocking concern from the second review comment is already resolved in the current codebase (`stop()` is fire-and-forget via SIGTERM, no `waitUntilExit`)

Addresses feedback from #17812

## Test plan
- [ ] Trigger a daemon startup failure (e.g., corrupt binary, port conflict) and verify the error view appears with retry/send-logs buttons
- [ ] Trigger a non-CLIError failure during retry and verify the fallback UNKNOWN error view appears instead of infinite loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
