### PR TITLE
fix: include QDRANT_HTTP_PORT in ENV_VALIDATION error categorization

### DIFF
--- a/assistant/src/daemon/startup-error.ts
+++ b/assistant/src/daemon/startup-error.ts
@@ -104,6 +104,7 @@ export function categorizeDaemonError(err: unknown): DaemonStartupError {
     message.startsWith("Invalid RUNTIME_HTTP_PORT") ||
     message.startsWith("Invalid integer for GATEWAY_PORT") ||
     message.startsWith("Invalid integer for RUNTIME_HTTP_PORT") ||
+    message.startsWith("Invalid integer for QDRANT_HTTP_PORT") ||
     /\benv\b.*\bvalidat/i.test(message) ||
     /\bvalidat.*\benv\b/i.test(message)
   ) {


### PR DESCRIPTION
## Summary
- Adds missing `QDRANT_HTTP_PORT` int() error prefix to ENV_VALIDATION categorization in `startup-error.ts`
- Fixes regression from PR #17815 where narrowing `startsWith("Invalid ")` catch-all missed this env var
- Without this fix, invalid QDRANT_HTTP_PORT values produce generic UNKNOWN errors instead of ENV_VALIDATION

## Test plan
- [ ] Verify that setting `QDRANT_HTTP_PORT=abc` produces an ENV_VALIDATION categorized error, not UNKNOWN
- [ ] Verify existing GATEWAY_PORT and RUNTIME_HTTP_PORT error categorization still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
