### PR TITLE
fix: refresh dock label on avatar reload after reconnect/switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -251,15 +251,25 @@ final class AvatarAppearanceManager {
         updateDockIcon()
     }
 
-    /// Reloads the custom avatar from disk. Called when the daemon notifies
-    /// that the avatar image has been regenerated (via `avatar_updated` event).
-    /// Invalidates all cached images so SwiftUI views pick up the new avatar.
+    /// Reloads the custom avatar from disk and refreshes the assistant name.
+    /// Called when the daemon notifies that the avatar image has been
+    /// regenerated (via `avatar_updated` event), after reconnection
+    /// (`proceedToApp`), and after assistant switches.
+    /// Invalidates all cached images so SwiftUI views pick up the new avatar,
+    /// and re-reads the identity so the dock label reflects the current assistant.
     func reloadAvatar() {
+        assistantName = AssistantDisplayName.resolve(
+            IdentityInfo.load()?.name,
+            fallback: "V"
+        )
         cachedChatAvatar = nil
         cachedFallbackAvatar = nil
+        cachedFallbackName = nil
         cachedFullFallbackAvatar = nil
+        cachedFullFallbackName = nil
         loadCustomAvatar()
         loadAvatarComponents()
+        updateDockLabel()
     }
 
     /// Clears all cached avatar state and resets the dock icon to the default


### PR DESCRIPTION
## Summary
- Fix dock label staying stuck at "Vellum" after assistant switch or reconnect
- `reloadAvatar()` now re-reads `assistantName` from `IdentityInfo.load()` and calls `updateDockLabel()`
- Also invalidates `cachedFallbackName` and `cachedFullFallbackName` so initial-letter avatars update correctly

Addresses feedback from PR #17805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
