### PR TITLE
fix: add cancel button for stuck OAuth connect flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -333,19 +333,23 @@ struct GoogleOAuthServiceCard: View {
 
             // Connect button
             HStack(spacing: VSpacing.sm) {
-                VButton(
-                    label: store.yourOwnOAuthConnectingAppId == app.id ? "Connecting..." : "Connect Account",
-                    leftIcon: "lucide-log-in",
-                    style: .outlined,
-                    isDisabled: store.yourOwnOAuthConnectingAppId == app.id
-                ) {
-                    store.startYourOwnOAuthConnect(appId: app.id)
-                }
                 if store.yourOwnOAuthConnectingAppId == app.id {
+                    VButton(label: "Cancel", leftIcon: "lucide-x", style: .outlined) {
+                        store.cancelYourOwnOAuthConnect()
+                    }
                     VBusyIndicator(size: 8, color: VColor.contentTertiary)
                     Text("Waiting for authorization...")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
+                } else {
+                    VButton(
+                        label: "Connect Account",
+                        leftIcon: "lucide-log-in",
+                        style: .outlined,
+                        isDisabled: store.yourOwnOAuthConnectingAppId != nil
+                    ) {
+                        store.startYourOwnOAuthConnect(appId: app.id)
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2473,6 +2473,12 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
+    func cancelYourOwnOAuthConnect() {
+        yourOwnOAuthConnectPollingTask?.cancel()
+        yourOwnOAuthConnectPollingTask = nil
+        yourOwnOAuthConnectingAppId = nil
+    }
+
     func startYourOwnOAuthConnect(appId: String) {
         yourOwnOAuthConnectingAppId = appId
         yourOwnOAuthError = nil


### PR DESCRIPTION
## Summary
- Add `cancelYourOwnOAuthConnect()` method to SettingsStore that cancels the polling task and clears connecting state
- Replace the disabled "Connecting..." button with a "Cancel" button while an OAuth flow is in progress
- Other app cards' Connect buttons are disabled while one flow is active (prevents concurrent flows)

## Original prompt
Fix the stuck "Waiting for authorization" state in the Your Own Google OAuth tab. When the user closes the browser or cancels the OAuth flow, the UI stays stuck showing "Waiting for authorization..." with no way to cancel. Convert the connect button into a Cancel button while connecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
