### PR TITLE
fix: handle transform/pipe wrappers in config schema CLI

### DIFF
--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -117,32 +117,60 @@ describe("getSchemaAtPath", () => {
       "memory.segmentation",
     );
     expect(result).not.toBeNull();
-    // Unwrap to check it has targetTokens and overlapTokens
-    let schema: any = result;
-    while (schema && !schema.shape) {
-      const inner = schema._zod?.def?.innerType;
-      if (!inner) break;
-      schema = inner;
-    }
-    expect(schema.shape).toBeDefined();
-    expect(schema.shape.targetTokens).toBeDefined();
-    expect(schema.shape.overlapTokens).toBeDefined();
+    // Verify we can produce JSON Schema with the expected properties
+    const jsonSchema = z.toJSONSchema(result!, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties.targetTokens).toBeDefined();
+    expect(properties.overlapTokens).toBeDefined();
   });
 
   test("navigates through .default() wrappers (calls → object schema)", () => {
     const result = getSchemaAtPath(AssistantConfigSchema, "calls");
     expect(result).not.toBeNull();
-    // Unwrap to check it has shape (it's a ZodDefault wrapping ZodObject)
-    let schema: any = result;
-    while (schema && !schema.shape) {
-      const inner = schema._zod?.def?.innerType;
-      if (!inner) break;
-      schema = inner;
-    }
-    expect(schema.shape).toBeDefined();
-    expect(schema.shape.enabled).toBeDefined();
-    expect(schema.shape.voice).toBeDefined();
-    expect(schema.shape.safety).toBeDefined();
+    // Verify we can produce JSON Schema with the expected properties
+    const jsonSchema = z.toJSONSchema(result!, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties.enabled).toBeDefined();
+    expect(properties.voice).toBeDefined();
+    expect(properties.safety).toBeDefined();
+  });
+
+  test("navigates through .transform() wrappers (ingress → object schema)", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "ingress");
+    expect(result).not.toBeNull();
+    // ingress uses .transform() which creates a pipe — getSchemaAtPath
+    // must unwrap through the pipe to reach the input object shape
+    const jsonSchema = z.toJSONSchema(result!, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties.enabled).toBeDefined();
+    expect(properties.webhook).toBeDefined();
+    expect(properties.rateLimit).toBeDefined();
+  });
+
+  test("navigates nested path through .transform() wrapper (ingress.webhook)", () => {
+    const result = getSchemaAtPath(AssistantConfigSchema, "ingress.webhook");
+    expect(result).not.toBeNull();
+    const jsonSchema = z.toJSONSchema(result!, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties.secret).toBeDefined();
+    expect(properties.timeoutMs).toBeDefined();
+    expect(properties.maxRetries).toBeDefined();
   });
 
   test("returns null for non-existent top-level path", () => {
@@ -170,6 +198,7 @@ describe("z.toJSONSchema integration", () => {
   test("full schema produces valid JSON Schema with type object and properties", () => {
     const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
       unrepresentable: "any",
+      io: "input",
     }) as Record<string, unknown>;
     expect(jsonSchema.type).toBe("object");
     const properties = jsonSchema.properties as Record<string, unknown>;
@@ -184,11 +213,27 @@ describe("z.toJSONSchema integration", () => {
     expect(properties.sandbox).toBeDefined();
   });
 
+  test("full schema emits real properties for transformed fields (ingress)", () => {
+    const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
+      unrepresentable: "any",
+      io: "input",
+    }) as Record<string, unknown>;
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    const ingress = properties.ingress as Record<string, unknown>;
+    // Without io: "input", transforms produce empty {} — verify we get real content
+    expect(ingress.properties).toBeDefined();
+    const ingressProps = ingress.properties as Record<string, unknown>;
+    expect(ingressProps.enabled).toBeDefined();
+    expect(ingressProps.webhook).toBeDefined();
+    expect(ingressProps.rateLimit).toBeDefined();
+  });
+
   test("sub-schema at calls produces JSON Schema with expected properties", () => {
     const callsSchema = getSchemaAtPath(AssistantConfigSchema, "calls");
     expect(callsSchema).not.toBeNull();
     const jsonSchema = z.toJSONSchema(callsSchema!, {
       unrepresentable: "any",
+      io: "input",
     }) as Record<string, unknown>;
     const properties = jsonSchema.properties as
       | Record<string, unknown>
@@ -204,6 +249,7 @@ describe("z.toJSONSchema integration", () => {
     expect(maxTokensSchema).not.toBeNull();
     const jsonSchema = z.toJSONSchema(maxTokensSchema!, {
       unrepresentable: "any",
+      io: "input",
     }) as Record<string, unknown>;
     expect(jsonSchema.type).toBe("integer");
   });
@@ -216,6 +262,7 @@ describe("z.toJSONSchema integration", () => {
     expect(segSchema).not.toBeNull();
     const jsonSchema = z.toJSONSchema(segSchema!, {
       unrepresentable: "any",
+      io: "input",
     }) as Record<string, unknown>;
     expect(jsonSchema.type).toBe("object");
     const properties = jsonSchema.properties as

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -152,6 +152,7 @@ Examples:
       if (!path) {
         const jsonSchema = z.toJSONSchema(AssistantConfigSchema, {
           unrepresentable: "any",
+          io: "input",
         });
         log.info(JSON.stringify(jsonSchema, null, 2));
         return;
@@ -165,6 +166,7 @@ Examples:
 
       const jsonSchema = z.toJSONSchema(subSchema, {
         unrepresentable: "any",
+        io: "input",
       });
       log.info(JSON.stringify(jsonSchema, null, 2));
     });

--- a/assistant/src/config/schema-utils.ts
+++ b/assistant/src/config/schema-utils.ts
@@ -1,8 +1,34 @@
 import type { z } from "zod";
 
 /**
+ * Unwrap a Zod schema to reach its inner object shape, handling:
+ * - default/optional/nullable wrappers (innerType)
+ * - pipe/transform wrappers (in — the input side)
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function unwrapToShape(schema: any): any {
+  let current = schema;
+  while (current && !current.shape) {
+    const def = current._zod?.def;
+    if (!def) break;
+    // Pipe/transform: follow the input side to get the pre-transform schema
+    if (def.type === "pipe" && def.in) {
+      current = def.in;
+      continue;
+    }
+    // Default/optional/nullable: follow innerType
+    if (def.innerType) {
+      current = def.innerType;
+      continue;
+    }
+    break;
+  }
+  return current;
+}
+
+/**
  * Navigate a Zod schema by dotted path, unwrapping wrapper types
- * (default, optional, nullable) to reach inner object shapes.
+ * (default, optional, nullable, pipe/transform) to reach inner object shapes.
  * Returns the Zod schema at the given path, or null if the path is invalid.
  */
 export function getSchemaAtPath(
@@ -13,12 +39,7 @@ export function getSchemaAtPath(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let current: any = schema;
   for (const key of keys) {
-    // Unwrap default/optional/nullable wrappers to find inner object shape
-    while (current && !current.shape) {
-      const inner = current._zod?.def?.innerType;
-      if (!inner) break;
-      current = inner;
-    }
+    current = unwrapToShape(current);
     if (!current || !current.shape) return null;
     current = current.shape[key];
     if (!current) return null;


### PR DESCRIPTION
## Summary
- Update `getSchemaAtPath` to unwrap Zod v4 pipe/transform wrappers by following `def.in` (the input side), in addition to `def.innerType` for default/optional/nullable
- Add `io: 'input'` to all `z.toJSONSchema` calls so transformed schemas emit their real properties instead of empty `{}`
- Add tests for navigating through transform wrappers (`ingress`, `ingress.webhook`) and verifying ingress produces real JSON Schema output
- Remove direct `_zod.def.innerType` usage from test assertions in favor of JSON Schema output checks

Addresses review feedback from PR #17854.

## Test plan
- [ ] Existing config-schema-cmd tests continue to pass
- [ ] New tests verify `ingress` and `ingress.webhook` paths resolve correctly through transform wrappers
- [ ] New test verifies full schema JSON output includes real ingress properties (not empty `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
