### PR TITLE
fix: update user-facing footer text from session→conversation restoration

### DIFF
--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -56,7 +56,7 @@ struct PrivateConversationsSection: View {
                 } header: {
                     Text("Private Conversations")
                 } footer: {
-                    Text("These conversations are not included in your regular chat history and are excluded from session restoration.")
+                    Text("These conversations are not included in your regular chat history and are excluded from conversation restoration.")
                 }
             }
 


### PR DESCRIPTION
## Summary
- Update user-facing footer text in `PrivateConversationsSection.swift` from "session restoration" to "conversation restoration"
- This was the last remaining instance of "session restoration" in the codebase — the doc comment was updated in PR #17844 but this `Text()` view was missed
- Addresses review feedback from #17844

## Test plan
- [ ] Verify the footer text in the Private Conversations section on iOS reads "conversation restoration" instead of "session restoration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
