### PR TITLE
fix: force your-own inference mode when user provides API key during onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -271,7 +271,7 @@ struct APIKeyEntryStepView: View {
             if providerRequiresKey {
                 APIKeyManager.setKey(trimmed, for: state.selectedProvider)
             }
-            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own")
+            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true)
             // Persist provider + model
             let existingConfig = WorkspaceConfigIO.read()
             var services = existingConfig["services"] as? [String: Any] ?? [:]
@@ -286,9 +286,10 @@ struct APIKeyEntryStepView: View {
             guard !trimmed.isEmpty else { return }
             APIKeyManager.setKey(trimmed, for: "anthropic")
 
-            // Set service modes to "your-own" for any services that don't already
-            // have a mode configured (first-time BYOK onboarding).
-            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own")
+            // Force service modes to "your-own" — the user explicitly chose to
+            // provide their own API key, which should override any mode that the
+            // managed bootstrap may have set asynchronously before this point.
+            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true)
 
             saveModelToConfig("claude-opus-4-6")
             state.advance()


### PR DESCRIPTION
## Summary
- Fix race condition where managed bootstrap could set inference mode to `managed` before the user completes API key onboarding, leaving the user stuck on managed mode despite explicitly providing their own key
- Both onboarding paths (custom provider and legacy Anthropic) now call `initializeServiceDefaults(defaultMode: "your-own", force: true)` to ensure the user's explicit API key choice is respected

Addresses review feedback from PR #17880.

## Test plan
- [ ] Start fresh onboarding with a managed account (authenticated)
- [ ] Verify that choosing API key onboarding correctly sets inference mode to `your-own` even if managed bootstrap ran first
- [ ] Verify that managed users who don't enter an API key still get `managed` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
