### PR TITLE
refactor: remove legacy session_id Sentry tag from daemon and macOS client

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -121,7 +121,6 @@ export function setSentryOrganizationId(
 const CONVERSATION_TAG_KEYS = [
   "assistant_id",
   "conversation_id",
-  "session_id",
   "message_count",
   "user_identifier",
 ] as const;
@@ -148,9 +147,6 @@ export function setSentryConversationContext(
 ): void {
   Sentry.setTag("assistant_id", ctx.assistantId);
   Sentry.setTag("conversation_id", ctx.conversationId);
-  // session_id mirrors conversation_id — downstream Sentry dashboards and
-  // alerts may still filter by the legacy tag name.
-  Sentry.setTag("session_id", ctx.conversationId);
   Sentry.setTag("message_count", String(ctx.messageCount));
   if (ctx.userIdentifier) {
     Sentry.setTag("user_identifier", ctx.userIdentifier);

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -97,12 +97,10 @@ enum LogExporter {
             if let activeConversation = conversationManager?.activeConversation {
                 extra["conversation_title"] = activeConversation.title
                 if let conversationId = activeConversation.conversationId {
-                    tags["session_id"] = conversationId
-                    // conversation_id mirrors session_id — the daemon tags its
-                    // Sentry events with both names for the same value. Setting
-                    // it here enables cross-project search: find the daemon error
-                    // that corresponds to a macOS log report by querying
-                    // conversation_id in the vellum-assistant-brain Sentry project.
+                    // Setting conversation_id enables cross-project search: find
+                    // the daemon error that corresponds to a macOS log report by
+                    // querying conversation_id in the vellum-assistant-brain
+                    // Sentry project.
                     // For conversation-scoped exports, conversation_id was already set
                     // to the reported conversation's ID above — don't overwrite it with
                     // the active conversation's ID.


### PR DESCRIPTION
## Summary
- Remove the legacy `session_id` Sentry tag from the daemon's `setSentryConversationContext` in `instrument.ts` — it was a duplicate of `conversation_id`
- Remove `session_id` from the macOS `LogExporter.swift` — it existed solely to match the daemon's tag for cross-project search, which already works via `conversation_id`
- Update comments to reflect the simplified tag set

Addresses review feedback from PR #17865 which noted that `session_id` was left unchanged when `thread_title` was renamed to `conversation_title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
