### PR TITLE
fix: gate reauth screen to managed assistants only

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -46,11 +46,11 @@ extension AppDelegate {
             return
         }
 
-        let hasAssistants = lockfileHasAssistants()
+        let hasManagedAssistants = LockfileAssistant.loadAll().contains { $0.isManaged }
         let authView: AnyView
 
-        if hasAssistants {
-            // Returning user with existing assistant — show clean sign-in, not full onboarding
+        if hasManagedAssistants {
+            // Returning managed user — show clean sign-in, not full onboarding
             authView = AnyView(ReauthView(
                 authManager: authManager,
                 onComplete: { [weak self] in
@@ -58,8 +58,8 @@ extension AppDelegate {
                 }
             ))
         } else {
-            // No assistants — show full onboarding (shouldn't normally happen via this path,
-            // but included as a safety net)
+            // No managed assistants — show full onboarding which includes
+            // skip/authless flows for local and remote assistant setups
             OnboardingState.clearPersistedState()
             let state = OnboardingState()
             state.shouldPersist = false


### PR DESCRIPTION
## Summary
- Changes `showAuthWindow()` to check for managed assistants specifically (not just any assistants) before routing to `ReauthView`
- Non-managed (local/remote) lockfile entries now correctly show the full `OnboardingFlowView` which includes skip and authless API-key flows
- Addresses feedback from PR #17911 where the `lockfileHasAssistants()` check was too broad and could lock users out of non-managed assistants

## Test plan
- [ ] Verify managed assistant logout still shows ReauthView with "Welcome Back" sign-in screen
- [ ] Verify local-only assistant logout shows full OnboardingFlowView (not ReauthView)
- [ ] Verify mixed setup (managed + local assistants) shows ReauthView with Skip button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
