### PR TITLE
fix: complete getProviderKeyAsync migration for remaining files

### DIFF
--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -56,6 +56,8 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "anthropic" ? "fake-anthropic-key" : null,
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "anthropic" ? "fake-anthropic-key" : undefined,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -40,6 +40,8 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "anthropic" ? "fake-anthropic-key" : null,
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "anthropic" ? "fake-anthropic-key" : undefined,
 }));
 
 import { claudeCodeTool } from "../tools/claude-code/claude-code.js";

--- a/assistant/src/__tests__/swarm-conversation-integration.test.ts
+++ b/assistant/src/__tests__/swarm-conversation-integration.test.ts
@@ -70,6 +70,7 @@ const mockTestProvider = {
 let mockAnthropicKey: string | undefined = "test-api-key";
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => mockAnthropicKey,
+  getProviderKeyAsync: async () => mockAnthropicKey,
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -81,6 +81,7 @@ const mockProvider = {
 };
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => "test-api-key",
+  getProviderKeyAsync: async () => "test-api-key",
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -76,6 +76,7 @@ const mockProvider = {
 };
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => "test-api-key",
+  getProviderKeyAsync: async () => "test-api-key",
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -4,7 +4,7 @@ import {
   getKeyframesForAsset,
   getMediaAssetById,
 } from "../../../../memory/media-store.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -31,7 +31,7 @@ export async function run(
 
   let openaiApiKey: string | undefined;
   if (includeAudio && (!transcriptionMode || transcriptionMode === "api")) {
-    openaiApiKey = (await getSecureKeyAsync("openai")) ?? undefined;
+    openaiApiKey = await getProviderKeyAsync("openai");
   }
 
   const options: PreprocessOptions = {

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -7,7 +7,7 @@
 
 import { resolveModelIntent } from "../providers/model-intents.js";
 import type { ModelIntent } from "../providers/types.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type {
   SwarmWorkerBackend,
@@ -29,8 +29,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
     name: "claude_code",
 
     async isAvailable(): Promise<boolean> {
-      const apiKey =
-        (await getSecureKeyAsync("anthropic")) ?? process.env.ANTHROPIC_API_KEY;
+      const apiKey = await getProviderKeyAsync("anthropic");
       return !!apiKey;
     },
 
@@ -39,9 +38,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
       const stderrLines: string[] = [];
       try {
         const { query } = await import("@anthropic-ai/claude-agent-sdk");
-        const apiKey =
-          (await getSecureKeyAsync("anthropic")) ??
-          process.env.ANTHROPIC_API_KEY;
+        const apiKey = await getProviderKeyAsync("anthropic");
         if (!apiKey) {
           return {
             success: false,

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -4,7 +4,7 @@ import {
 } from "../../commands/cc-command-registry.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import type { WorkerProfile } from "../../swarm/worker-backend.js";
 import { getProfilePolicy } from "../../swarm/worker-backend.js";
 import { getLogger } from "../../util/logger.js";
@@ -203,8 +203,7 @@ export const claudeCodeTool: Tool = {
     const profilePolicy = getProfilePolicy(profileName);
 
     // Validate API key
-    const apiKey =
-      (await getSecureKeyAsync("anthropic")) ?? process.env.ANTHROPIC_API_KEY;
+    const apiKey = await getProviderKeyAsync("anthropic");
     if (!apiKey) {
       return {
         content:

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -26,6 +26,11 @@ mock.module("../../../security/secure-keys.js", () => ({
     if (provider === "perplexity") return mockPerplexitySecureKey;
     return undefined;
   },
+  getProviderKeyAsync: async (provider: string) => {
+    if (provider === "brave") return mockBraveSecureKey;
+    if (provider === "perplexity") return mockPerplexitySecureKey;
+    return undefined;
+  },
 }));
 
 mock.module("../../../util/logger.js", () => ({


### PR DESCRIPTION
## Summary
- Migrate `getSecureKeyAsync(...) ?? process.env.X` patterns to `getProviderKeyAsync(...)` in `backend-claude-code.ts`, `claude-code.ts`, and `extract-keyframes.ts`
- Add `getProviderKeyAsync` to test mocks in 6 test files that replace the `secure-keys.js` module via `mock.module`, preventing undefined function errors at runtime

Addresses review feedback from #17912.

## Test plan
- [ ] Verify `web-search.test.ts` passes with the updated mock
- [ ] Verify `claude-code-tool-profiles.test.ts` passes with the updated mock
- [ ] Verify `claude-code-skill-regression.test.ts` passes with the updated mock
- [ ] Verify `swarm-recursion.test.ts` passes with the updated mock
- [ ] Verify `swarm-tool.test.ts` passes with the updated mock
- [ ] Verify `swarm-conversation-integration.test.ts` passes with the updated mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
