### PR TITLE
fix(macos): clamp search match index when match count decreases

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -496,6 +496,13 @@ public struct VCodeSearchBar: View {
         .onChange(of: searchQuery) { _, _ in
             currentMatchIndex = 0
         }
+        .onChange(of: matchCount) { _, newCount in
+            // Clamp currentMatchIndex when matches change (e.g. text edits reduce
+            // match count) to avoid stale display like "5 of 2".
+            if currentMatchIndex >= newCount {
+                currentMatchIndex = max(newCount - 1, 0)
+            }
+        }
     }
 
     private func goToPreviousMatch() {


### PR DESCRIPTION
## Summary
- Adds `.onChange(of: matchCount)` handler to `VCodeSearchBar` that clamps `currentMatchIndex` when match count decreases
- Prevents stale "N of M" display (e.g. "5 of 2") when text edits reduce the number of search matches
- Mirrors the existing clamping pattern used in `ChatView.swift` (lines 387-392)

Addresses review feedback from #17892.

## Test plan
- [ ] Open a file in the code viewer, search for a term with multiple matches
- [ ] Navigate to a later match (e.g. match 5 of 5)
- [ ] Edit the file to remove some occurrences of the search term
- [ ] Verify the match index clamps correctly and does not show stale values like "5 of 2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
