### PR TITLE
fix: move model picker above API key input in onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -91,11 +91,11 @@ struct APIKeyEntryStepView: View {
                 if isCustomProviderEnabled {
                     providerPicker
 
+                    modelPicker
+
                     if providerRequiresKey {
                         apiKeyField
                     }
-
-                    modelPicker
 
                     OnboardingButton(
                         title: "Continue",


### PR DESCRIPTION
## Summary
- Reorder onboarding fields: Provider → Model → API Key (was Provider → API Key → Model)

## Original prompt
In APIKeyEntryStepView.swift, move the model picker to be above the API key field and below the provider picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
