### PR TITLE
fix: move model picker above API key input in Inference card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -121,11 +121,11 @@ struct InferenceServiceCard: View {
                         providerPicker
                     }
 
-                    // API Key field
-                    apiKeyField
-
                     // Model picker
                     modelPicker
+
+                    // API Key field
+                    apiKeyField
                 }
             }
         )


### PR DESCRIPTION
## Summary
- Reorder Inference card "Your Own" fields: Provider → Model → API Key (was Provider → API Key → Model)
- Matches the order used in onboarding (PR #19159)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
