### PR TITLE
feat: redesign credits exhausted banner

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -200,41 +200,93 @@ struct ChatConversationErrorToast: View {
 
 // MARK: - Credits Exhausted Banner
 
-/// Styled inline error banner shown when the user's credits are exhausted.
-/// Displays a clear message and an "Add Funds" CTA button.
+/// Inline banner shown when the user's credits are exhausted.
+/// Uses a warm, encouraging tone with a visual gauge and clear CTA.
 struct CreditsExhaustedBanner: View {
     let onAddFunds: () -> Void
     let onDismiss: () -> Void
 
     var body: some View {
-        VStack(spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
-                VIconView(.creditCard, size: 16)
-                    .foregroundColor(VColor.systemNegativeStrong)
-                Text("You've run out of credits")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.contentEmphasized)
-                Spacer()
-                Button {
-                    onDismiss()
-                } label: {
-                    VIconView(.x, size: 14)
-                        .foregroundColor(VColor.contentTertiary)
+        VStack(spacing: 0) {
+            // Top section: gauge + message
+            VStack(spacing: VSpacing.md) {
+                // Header row with dismiss
+                HStack {
+                    Spacer()
+                    Button {
+                        onDismiss()
+                    } label: {
+                        VIconView(.x, size: 12)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss")
+
+                // Empty gauge indicator
+                creditsGauge
+
+                // Message
+                VStack(spacing: VSpacing.xs) {
+                    Text("Your balance has run out")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentEmphasized)
+                    Text("Add funds to pick up where you left off.")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                }
             }
-            Text("Add funds to continue using the assistant.")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            VButton(label: "Add Funds", style: .primary) {
-                onAddFunds()
+            .padding(.top, VSpacing.sm)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.bottom, VSpacing.lg)
+
+            // Divider
+            Rectangle()
+                .fill(VColor.borderBase)
+                .frame(height: 1)
+
+            // CTA section
+            HStack {
+                VButton(label: "Add Funds", style: .primary, isFullWidth: true) {
+                    onAddFunds()
+                }
             }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
         }
-        .padding(VSpacing.lg)
-        .background(VColor.systemNegativeWeak.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .background(VColor.surfaceActive)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .strokeBorder(VColor.borderBase, lineWidth: 1)
+        )
         .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    // MARK: - Credits Gauge
+
+    /// Visual gauge showing an empty credits state — a horizontal bar
+    /// that's fully depleted with a small amber indicator at the empty end.
+    private var creditsGauge: some View {
+        VStack(spacing: VSpacing.xs) {
+            ZStack(alignment: .leading) {
+                // Track
+                Capsule()
+                    .fill(VColor.contentTertiary.opacity(0.3))
+                    .frame(height: 6)
+
+                // Empty fill (small indicator showing "0")
+                Capsule()
+                    .fill(VColor.systemMidStrong)
+                    .frame(width: 8, height: 6)
+            }
+            .frame(maxWidth: .infinity)
+
+            // Label
+            Text("$0.00 remaining")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced alarming red (`systemNegativeWeak`) banner with a themed card using `surfaceActive` background and `borderBase` border that blends with both light and dark modes
- Added a visual gauge indicator showing depleted balance state with an amber dot and "$0.00 remaining" label
- Updated copy from punitive "You've run out of credits" to friendlier "Your balance has run out" / "Add funds to pick up where you left off"
- Restructured layout into a two-zone card (info section + divider + full-width CTA) with larger corner radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
