### PR TITLE
fix: derive default file viewer mode from MIME type instead of extension only

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -18,6 +18,13 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
     return [.source]
 }
 
+/// Returns the preferred default view mode for a file based on its name and MIME type.
+/// Unlike `availableViewModes`, this picks the single best initial mode rather than listing all options.
+func defaultViewMode(for fileName: String, mimeType: String) -> FileViewMode {
+    let modes = availableViewModes(for: fileName, mimeType: mimeType)
+    return modes.first ?? .source
+}
+
 func viewModeLabel(_ mode: FileViewMode) -> String {
     switch mode {
     case .source: return "Source"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -45,12 +45,7 @@ final class WorkspaceBrowserState {
 
     func loadFile(path targetPath: String, using workspaceClient: any WorkspaceClientProtocol) async {
         selectedFilePath = targetPath
-        let ext = (targetPath as NSString).pathExtension.lowercased()
-        if ext == "md" || ext == "markdown" {
-            viewMode = .preview
-        } else {
-            viewMode = .source
-        }
+        viewMode = .source
         isLoadingFile = true
         selectedFileDetail = nil
         isDirty = false
@@ -65,6 +60,11 @@ final class WorkspaceBrowserState {
             isDirty = false
             isSaving = false
             isLoadingFile = false
+
+            // Default view mode using both file name and MIME type from the response
+            if let detail {
+                viewMode = defaultViewMode(for: detail.name, mimeType: detail.mimeType)
+            }
         }
         fileLoadTask = task
     }


### PR DESCRIPTION
## Summary
- Move view mode defaulting in `loadFile` to after `fetchWorkspaceFile` returns, so the MIME type from the response is available
- Add `defaultViewMode(for:mimeType:)` helper in `SharedFileViewerComponents.swift` that delegates to `availableViewModes` to pick the best initial mode
- Fixes inconsistency where files recognized as markdown by MIME type (e.g. extensionless docs served as `text/markdown`) still opened in Source mode

Addresses review feedback from PR #17929.

## Test plan
- [ ] Open a markdown file with `.md` extension — should default to Preview mode
- [ ] Open a file served as `text/markdown` MIME type but without `.md` extension — should now default to Preview mode (previously opened in Source mode)
- [ ] Open a non-markdown text file — should default to Source mode
- [ ] Verify the segmented control still allows switching between available modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
