### PR TITLE
fix: avoid Source-view flash when opening Preview-default files

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -45,7 +45,6 @@ final class WorkspaceBrowserState {
 
     func loadFile(path targetPath: String, using workspaceClient: any WorkspaceClientProtocol) async {
         selectedFilePath = targetPath
-        viewMode = .source
         isLoadingFile = true
         selectedFileDetail = nil
         isDirty = false


### PR DESCRIPTION
## Summary
- Remove the eager `viewMode = .source` reset in `loadFile()` that ran before the async file detail fetch
- The correct default view mode is already derived from the MIME type once the file detail loads (via `defaultViewMode()`)
- This prevents a visible flash of Source view when opening markdown files that should default to Preview

Addresses review feedback from #17931: the tab reorder (Preview first) was not fully effective because `loadFile()` always reset to `.source` before the file detail was available.

## Test plan
- [ ] Open a markdown file in the workspace panel and verify it opens directly in Preview mode without a brief flash of Source view
- [ ] Open a non-markdown text file and verify it still opens in Source mode
- [ ] Switch between files and verify view mode is set correctly each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
