### PR TITLE
Fix underline VSegmentedControl layout by removing internal Spacer

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -65,8 +65,8 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
                 .accessibilityLabel(item.label)
                 .accessibilityAddTraits(selection == item.tag ? .isSelected : [])
             }
-            Spacer()
         }
+        .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, VSpacing.sm)
     }
 


### PR DESCRIPTION
## Summary
- Remove the internal `Spacer()` from VSegmentedControl's underline style body that caused it to greedily consume horizontal space
- Add `.fixedSize(horizontal: true, vertical: false)` so the underline style sizes itself based on content, matching the pill style's intrinsic sizing behavior
- Addresses Devin review feedback on PR #17948 about the underline style's Spacer competing with parent layout spacers

## Context
PR #17948 switched file viewer toggles from pill to underline style. A review flagged that the underline style's internal `Spacer()` inside its `HStack` competed with the parent header bar's `Spacer()`, potentially truncating filename text. While subsequent PRs (#18080) reverted the file viewer to pill style, the underlying component issue remained: the underline style was greedy by default, which is unexpected component behavior.

## Test plan
- [ ] Verify gallery design system preview renders underline segments correctly (intrinsically sized)
- [ ] Verify VSidePanel pinned content with underline tabs still renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
