### PR TITLE
fix: restore connectedOrganizationId during self-hosted logout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -163,8 +163,9 @@ extension AppDelegate {
 
     @objc public func performLogout() {
         Task {
-            // Capture assistant ID before logout clears it from UserDefaults
+            // Capture assistant/org IDs before logout clears them from UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            let connectedOrganizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
 
             // Capture managed status before logout clears UserDefaults
             let wasManaged = isCurrentAssistantManaged
@@ -232,11 +233,15 @@ extension AppDelegate {
                 // Self-hosted (local or remote): clear auth state but keep the
                 // app running. The user can sign in again from Settings > General.
 
-                // Restore connectedAssistantId — authManager.logout() clears it
-                // from UserDefaults, but the app stays running in this path and
-                // subsystems (avatar, gateway resolution, API key sync) need it.
+                // Restore connectedAssistantId and connectedOrganizationId —
+                // authManager.logout() clears both from UserDefaults, but the
+                // app stays running in this path and subsystems (avatar, gateway
+                // resolution, API key sync, Sentry tagging, billing) need them.
                 if let connectedAssistantId {
                     UserDefaults.standard.set(connectedAssistantId, forKey: "connectedAssistantId")
+                }
+                if let connectedOrganizationId {
+                    UserDefaults.standard.set(connectedOrganizationId, forKey: "connectedOrganizationId")
                 }
 
                 actorTokenBootstrapTask?.cancel()


### PR DESCRIPTION
## Summary
- Captures `connectedOrganizationId` from UserDefaults before `authManager.logout()` clears it
- Restores it alongside `connectedAssistantId` in the non-managed (self-hosted) logout path
- Prevents loss of organization context for Sentry tagging, billing service, gateway headers, and settings panel after logout on self-hosted assistants

Addresses review feedback from PR #17949: https://github.com/vellum-ai/vellum-assistant/pull/17949#discussion_r2943229417

## Test plan
- [ ] Log out from a self-hosted (local) assistant
- [ ] Verify `connectedOrganizationId` persists in UserDefaults after logout
- [ ] Verify Sentry org tag remains set
- [ ] Verify billing tab visibility is unaffected after re-sign-in
- [ ] Log in again from Settings > General and verify full bootstrap completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
