### PR TITLE
fix: read inference model from workspace config in loadServiceModes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2103,6 +2103,7 @@ public final class SettingsStore: ObservableObject {
         if let inference = services["inference"] as? [String: Any] {
             if let mode = inference["mode"] as? String { self.inferenceMode = mode }
             if let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
+            if let model = inference["model"] as? String { self.selectedModel = model }
         }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {


### PR DESCRIPTION
## Summary
- `loadServiceModes()` was reading `inference.mode` and `inference.provider` from workspace config but not `inference.model`, causing the model selected during onboarding to be lost when opening Models & Services
- Add `if let model = inference["model"] as? String { self.selectedModel = model }` to close the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
