### PR TITLE
fix: detect re-authed connections in OAuth polling to avoid stuck state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2509,8 +2509,10 @@ public final class SettingsStore: ObservableObject {
 
                 NSWorkspace.shared.open(authURL)
 
-                // Start polling for new connections
-                let initialCount = self.yourOwnOAuthConnectionsByApp[appId]?.count ?? 0
+                // Start polling — detect new connections OR re-authed (updated) connections
+                let existingConnections = self.yourOwnOAuthConnectionsByApp[appId] ?? []
+                let initialCount = existingConnections.count
+                let maxUpdatedAt = existingConnections.map(\.updated_at).max() ?? 0
                 self.yourOwnOAuthConnectPollingTask?.cancel()
                 self.yourOwnOAuthConnectPollingTask = Task {
                     let pollInterval: UInt64 = 3_000_000_000 // 3 seconds
@@ -2522,16 +2524,17 @@ public final class SettingsStore: ObservableObject {
                         guard !Task.isCancelled else { break }
 
                         await self.fetchYourOwnOAuthConnections(appId: appId)
-                        let currentCount = self.yourOwnOAuthConnectionsByApp[appId]?.count ?? 0
+                        let current = self.yourOwnOAuthConnectionsByApp[appId] ?? []
 
-                        if currentCount > initialCount {
-                            break
-                        }
+                        // New connection added
+                        if current.count > initialCount { break }
+
+                        // Existing connection re-authed (updated_at changed)
+                        let currentMaxUpdatedAt = current.map(\.updated_at).max() ?? 0
+                        if currentMaxUpdatedAt > maxUpdatedAt { break }
 
                         let elapsed = DispatchTime.now().uptimeNanoseconds - startTime
-                        if elapsed >= timeout {
-                            break
-                        }
+                        if elapsed >= timeout { break }
                     }
 
                     self.yourOwnOAuthConnectingAppId = nil


### PR DESCRIPTION
## Summary
- Fix stuck "Waiting for authorization" when re-authing with the same Google account
- Polling now tracks both connection count AND `updated_at` timestamps, so it detects re-authed (updated) connections in addition to new ones

The root cause: re-authing with the same account updates the existing connection row rather than creating a new one. The polling only checked `count > initialCount`, which never triggered for same-account re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
