### PR TITLE
fix: reset localBootstrapDidComplete before ensureLocalAssistantApiKey in onSignIn and switchAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -463,6 +463,10 @@ extension AppDelegate {
         if !isCurrentAssistantManaged {
             ensureActorCredentials()
         }
+        // Reset before provisioning so a stale flag from a previous
+        // bootstrap cycle doesn't cause awaitLocalBootstrapCompleted
+        // to skip the wait. Mirrors the reset in proceedToApp().
+        localBootstrapDidComplete = false
         ensureLocalAssistantApiKey()
 
         // 6. Sync locally-stored API keys to the new daemon. The daemon may

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -356,6 +356,10 @@ struct SettingsPanel: View {
                 if !(AppDelegate.shared?.isCurrentAssistantManaged ?? false) {
                     AppDelegate.shared?.ensureActorCredentials()
                 }
+                // Reset before provisioning so a stale flag from a previous
+                // bootstrap cycle doesn't cause awaitLocalBootstrapCompleted
+                // to skip the wait. Mirrors the reset in proceedToApp().
+                AppDelegate.shared?.localBootstrapDidComplete = false
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
             })
         case .modelsAndServices:


### PR DESCRIPTION
## Summary
- Adds `localBootstrapDidComplete = false` reset before `ensureLocalAssistantApiKey()` in the Settings sign-in handler and `performSwitchAssistant`, matching the existing pattern in `proceedToApp()`
- Prevents a stale `localBootstrapDidComplete` flag from causing `awaitLocalBootstrapCompleted` to skip waiting if a future code path depends on it after these flows

Addresses review feedback from #17958.

## Test plan
- [x] Verified the reset is consistent with the `proceedToApp()` pattern at AppDelegate.swift:374-377
- [ ] Manual: Sign out from Settings, sign back in — verify actor credentials bootstrap completes normally
- [ ] Manual: Switch assistant via lockfile — verify credential bootstrap completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
