### PR TITLE
fix: suppress 'API key not set' toast on logout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -665,6 +665,7 @@ struct MainWindowView: View {
                     ErrorToastOverlay(
                         errorManager: viewModel.errorManager,
                         hasAPIKey: windowState.hasAPIKey,
+                        isAuthenticated: authManager.isAuthenticated,
                         onOpenSettings: { windowState.selection = .panel(.settings) },
                         onRetryConversationError: { viewModel.retryAfterConversationError() },
                         onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
@@ -673,7 +674,7 @@ struct MainWindowView: View {
                         onRetryLastMessage: { viewModel.retryLastMessage() },
                         onDismissError: { viewModel.dismissError() }
                     )
-                } else if !windowState.hasAPIKey {
+                } else if !windowState.hasAPIKey && authManager.isAuthenticated {
                     ChatConversationErrorToast(
                         message: "API key not set. Add one in Settings to start chatting.",
                         icon: .keyRound,
@@ -998,6 +999,7 @@ struct MainWindowView: View {
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
+    let isAuthenticated: Bool
     let onOpenSettings: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -1008,7 +1010,7 @@ private struct ErrorToastOverlay: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
-            if !hasAPIKey {
+            if !hasAPIKey && isAuthenticated {
                 ChatConversationErrorToast(
                     message: "API key not set. Add one in Settings to start chatting.",
                     icon: .keyRound,


### PR DESCRIPTION
## Summary
- When logging out, two toasts were shown: a bottom "Logged out" success toast and a top "API key not set" error toast
- The top toast was triggered because `hasAPIKey` becomes false when `isAuthenticated` flips to false during logout
- Gate the "API key not set" toast on `isAuthenticated` so it only shows when the user is logged in but hasn't configured an API key

## Original prompt
Remove the top "API key not set" error toast that appears when logging out. The bottom VToast already shows "Logged out. You can log in again from Settings." — the top error toast is redundant and confusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
