### PR TITLE
fix: prevent double onComplete and disk I/O in ReauthView body

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -11,10 +11,7 @@ struct ReauthView: View {
 
     @State private var showContent = false
     @State private var didComplete = false
-
-    private var hasNonManagedAssistant: Bool {
-        LockfileAssistant.loadAll().contains { !$0.isManaged }
-    }
+    @State private var hasNonManagedAssistant = false
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -86,6 +83,7 @@ struct ReauthView: View {
                         if let nonManaged = LockfileAssistant.loadAll().first(where: { !$0.isManaged }) {
                             UserDefaults.standard.set(nonManaged.assistantId, forKey: "connectedAssistantId")
                         }
+                        didComplete = true
                         onComplete()
                     }
                     .accessibilityLabel("Skip")
@@ -113,6 +111,8 @@ struct ReauthView: View {
             }
         }
         .task {
+            hasNonManagedAssistant = LockfileAssistant.loadAll().contains { !$0.isManaged }
+
             // If already authenticated (e.g. macOS state restoration), skip
             // straight to the app. No redundant checkSession() — callers
             // (startAuthenticatedFlow, performLogout) have already resolved


### PR DESCRIPTION
## Summary
- Fix Skip button to set `didComplete = true` before calling `onComplete()`, preventing double invocation if `authManager.isAuthenticated` later becomes true (e.g. background session refresh)
- Move `hasNonManagedAssistant` from a computed property (disk I/O on every render) to a `@State` property computed once in `.task`, complying with `clients/AGENTS.md` rule that view bodies must be lightweight

Addresses review feedback on #17950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
