### PR TITLE
refactor: fix session→conversation in skill-management TOOLS.json

### DIFF
--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "scaffold_managed_skill",
-      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated session due to file-watcher eviction - continue normally.",
+      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {
@@ -54,7 +54,7 @@
     },
     {
       "name": "delete_managed_skill",
-      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated session due to file-watcher eviction - continue normally.",
+      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Updated two occurrences of "recreated session" to "recreated conversation" in `assistant/src/config/bundled-skills/skill-management/TOOLS.json`
- Addresses review feedback from PR #17970, which renamed session/thread terminology to conversation throughout the codebase but missed the tool descriptions in TOOLS.json
- The `scaffold_managed_skill` and `delete_managed_skill` tool descriptions both referenced "recreated session due to file-watcher eviction" — now consistently say "recreated conversation"

## Test plan
- [x] Verified both occurrences in TOOLS.json are updated
- [x] No other files in the codebase contain "recreated session"
- [x] JSON is valid and well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
