### PR TITLE
fix: persist inference mode reset to your-own on logout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -134,10 +134,28 @@ struct InferenceServiceCard: View {
             initialModel = store.selectedModel
             draftProvider = store.selectedInferenceProvider
             initialProvider = store.selectedInferenceProvider
+
+            // If the user logged out while on another tab, the persisted
+            // inference mode may still be "managed". Reset both the draft
+            // and the persisted mode so the daemon doesn't attempt managed-
+            // proxy routing while unauthenticated.
+            if !isLoggedIn && draftMode == "managed" {
+                draftMode = "your-own"
+                store.setInferenceMode("your-own")
+            }
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
+        }
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            // When the user logs out while this card is mounted, reset
+            // both the draft and the persisted mode so the daemon doesn't
+            // attempt managed-proxy routing while unauthenticated.
+            if !isAuthenticated && draftMode == "managed" {
+                draftMode = "your-own"
+                store.setInferenceMode("your-own")
+            }
         }
         .onChange(of: store.selectedInferenceProvider) { _, newValue in
             draftProvider = newValue


### PR DESCRIPTION
## Summary
- Fixes gap where logout did not persist the inference mode reset from "managed" to "your-own"
- Adds `onAppear` guard to handle the common flow (user logs out from General tab, later opens Models & Services)
- Adds `onChange(of: authManager.isAuthenticated)` handler to handle the edge case where the card is already mounted during logout
- Both paths now call `store.setInferenceMode("your-own")` to persist the change, not just update the UI draft

Addresses review feedback from PR #17992.

## Test plan
- [ ] Log in, set inference mode to Managed, log out from General tab
- [ ] Open Models & Services tab — verify inference mode shows "Your Own" (not "Managed")
- [ ] Verify workspace config file has inference mode set to "your-own"
- [ ] Log in, set to Managed, switch to Models & Services tab, then log out — verify mode resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
