### PR TITLE
fix: use draftModel pattern to prevent spurious Save button on daemon model refresh

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -20,6 +20,8 @@ struct InferenceServiceCard: View {
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
+    /// Local draft of the model selection — only persisted on Save.
+    @State private var draftModel: String = ""
     /// Snapshot of the model at card appear — used to detect model-only changes.
     @State private var initialModel: String = ""
     /// Whether to show the web search impact confirmation alert.
@@ -81,12 +83,12 @@ struct InferenceServiceCard: View {
             return false
         }
         // A valid model must be selected to save.
-        if store.selectedModel.isEmpty {
+        if draftModel.isEmpty {
             return false
         }
         let modeChanged = draftMode != store.inferenceMode
         let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let modelChanged = store.selectedModel != initialModel
+        let modelChanged = draftModel != initialModel
         let providerChanged = isCustomProviderEnabled && draftProvider != initialProvider
         return modeChanged || hasNewKey || modelChanged || providerChanged
     }
@@ -131,6 +133,7 @@ struct InferenceServiceCard: View {
         )
         .onAppear {
             draftMode = store.inferenceMode
+            draftModel = store.selectedModel
             initialModel = store.selectedModel
             draftProvider = store.selectedInferenceProvider
             initialProvider = store.selectedInferenceProvider
@@ -143,21 +146,26 @@ struct InferenceServiceCard: View {
             draftProvider = newValue
             initialProvider = newValue
         }
+        .onChange(of: store.selectedModel) { _, newValue in
+            // Sync draft & baseline when external changes arrive (e.g. daemon model info refresh)
+            draftModel = newValue
+            initialModel = newValue
+        }
         .onChange(of: draftProvider) { _, newProvider in
             if isCustomProviderEnabled {
                 let defaultModel = store.dynamicProviderDefaultModel(newProvider)
                 let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""
-                store.selectedModel = defaultModel.isEmpty ? fallback : defaultModel
+                draftModel = defaultModel.isEmpty ? fallback : defaultModel
             }
             apiKeyText = ""
         }
         .onChange(of: draftMode) { _, newMode in
             if newMode == "managed" && isCustomProviderEnabled {
                 let anthropicModels = store.dynamicProviderModels("anthropic")
-                let isCurrentModelAnthropic = anthropicModels.contains { $0.id == store.selectedModel }
+                let isCurrentModelAnthropic = anthropicModels.contains { $0.id == draftModel }
                 if !isCurrentModelAnthropic {
                     let defaultModel = store.dynamicProviderDefaultModel("anthropic")
-                    store.selectedModel = defaultModel.isEmpty ? "claude-opus-4-6" : defaultModel
+                    draftModel = defaultModel.isEmpty ? "claude-opus-4-6" : defaultModel
                 }
             }
         }
@@ -268,10 +276,7 @@ struct InferenceServiceCard: View {
     private var defaultModelPicker: some View {
         VDropdown(
             placeholder: "Select a model\u{2026}",
-            selection: Binding(
-                get: { store.selectedModel },
-                set: { store.selectedModel = $0 }
-            ),
+            selection: $draftModel,
             options: store.dynamicProviderModels("anthropic").map { model in
                 (label: model.displayName, value: model.id)
             }
@@ -283,10 +288,7 @@ struct InferenceServiceCard: View {
         let provider = draftMode == "managed" ? "anthropic" : draftProvider
         return VDropdown(
             placeholder: "Select a model\u{2026}",
-            selection: Binding(
-                get: { store.selectedModel },
-                set: { store.selectedModel = $0 }
-            ),
+            selection: $draftModel,
             options: store.dynamicProviderModels(provider).map { model in
                 (label: model.displayName, value: model.id)
             }
@@ -339,12 +341,13 @@ struct InferenceServiceCard: View {
         }
 
         // Persist model selection
+        store.selectedModel = draftModel
         if isCustomProviderEnabled {
             let saveProvider = draftMode == "managed" ? "anthropic" : draftProvider
-            store.setModel(store.selectedModel, provider: saveProvider)
+            store.setModel(draftModel, provider: saveProvider)
         } else {
-            store.setModel(store.selectedModel)
+            store.setModel(draftModel)
         }
-        initialModel = store.selectedModel
+        initialModel = draftModel
     }
 }


### PR DESCRIPTION
## Summary
- Introduces `draftModel` @State variable for model selection, matching the existing `draftMode`/`draftProvider` pattern
- Model picker dropdowns now bind to `draftModel` instead of `store.selectedModel` directly
- Adds `.onChange(of: store.selectedModel)` handler that syncs both `draftModel` and `initialModel` when daemon updates arrive
- `hasChanges` now compares `draftModel != initialModel`, so only user-initiated model changes enable the Save button
- On save, `draftModel` is applied to `store.selectedModel` and `initialModel` is reset

Fixes the bug where `store.selectedModel` being updated by daemon model info responses (after view appeared) would spuriously enable the Save button.

Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/17981

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
