### PR TITLE
fix: gate hasNewKey on your-own mode to prevent false-dirty Save state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -87,7 +87,7 @@ struct InferenceServiceCard: View {
             return false
         }
         let modeChanged = draftMode != store.inferenceMode
-        let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasNewKey = draftMode == "your-own" && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let modelChanged = draftModel != initialModel
         let providerChanged = isCustomProviderEnabled && draftProvider != initialProvider
         return modeChanged || hasNewKey || modelChanged || providerChanged


### PR DESCRIPTION
## Summary
- Fixes false-dirty Save button state in InferenceServiceCard when switching from your-own to managed mode with a non-empty API key
- The `hasChanges` computed property now gates `hasNewKey` on `draftMode == "your-own"`, matching the existing save guard
- Addresses review feedback from PR #17987

## Test plan
- [ ] In Settings, type an API key in your-own mode
- [ ] Switch to managed mode
- [ ] Verify the Save button is disabled (no actionable changes)
- [ ] Switch back to your-own mode
- [ ] Verify the Save button re-enables (key text is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
