### PR TITLE
fix: remove unused sourceConversationId param from upsertContactChannel

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -145,7 +145,6 @@ export function upsertContactChannel(params: {
   policy?: string;
   status?: string;
   inviteId?: string;
-  sourceConversationId?: string;
   verifiedAt?: number;
   verifiedVia?: string;
   role?: ContactRole;


### PR DESCRIPTION
## Summary
- Removes the unused `sourceConversationId` parameter from the `upsertContactChannel` function signature in `contacts-write.ts`
- This parameter was never referenced in the function body and no caller passes it
- Dead code cleanup per AGENTS.md policy, addressing review feedback from PR #18069

## Test plan
- [x] Verified no callers pass `sourceConversationId` to `upsertContactChannel`
- [x] Verified the parameter is not referenced anywhere in the function body
- [x] Change is a pure dead-code removal with no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
