### PR TITLE
fix: use full file path as identity key for HighlightedTextView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -53,6 +53,12 @@ struct FileContentView: View {
     var isEditable: Bool = false
     var showReadOnlyBadge: Bool = false
     var onTextChange: ((String) -> Void)? = nil
+    /// Unique identity for the file, used to force SwiftUI to recreate the
+    /// HighlightedTextView when the underlying file changes. Defaults to
+    /// `fileName`, but callers should pass a full path when the display name
+    /// alone is not unique (e.g. files with the same basename in different
+    /// directories).
+    var fileIdentity: String? = nil
 
     private func syncViewMode() {
         let modes = availableViewModes(for: fileName, mimeType: mimeType)
@@ -96,7 +102,7 @@ struct FileContentView: View {
                     isEditable: isEditable,
                     onTextChange: onTextChange
                 )
-                .id(fileName)
+                .id(fileIdentity ?? fileName)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .preview:
                 MarkdownPreviewView(content: content)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -726,7 +726,8 @@ private struct WorkspaceFileViewer: View {
                     showReadOnlyBadge: readOnly,
                     onTextChange: { newValue in
                         state.isDirty = newValue != state.originalContent
-                    }
+                    },
+                    fileIdentity: detail.path
                 )
             } else {
                 FileContentHeaderBar(


### PR DESCRIPTION
## Summary
- Fixes a bug where switching between files with the same basename in different directories did not reset editing state in the file viewer
- The `.id(fileName)` modifier on `HighlightedTextView` used the leaf filename which is not unique across directories
- Added an optional `fileIdentity` parameter to `FileContentView` that defaults to `fileName`, used in the `.id()` modifier
- Updated the `WorkspacePanel` call site to pass `detail.path` as `fileIdentity` for a unique identity

## Test plan
- Open workspace panel
- Navigate to a file (e.g. `dirA/config.json`), enter editing mode
- Navigate to a different file with the same basename in a different directory (e.g. `dirB/config.json`)
- Verify that the editing state is reset (syntax-highlighted view, not plain TextEditor)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
