### PR TITLE
fix: add auth guards for inference mode sync in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -138,25 +138,50 @@ struct InferenceServiceCard: View {
             draftProvider = store.selectedInferenceProvider
             initialProvider = store.selectedInferenceProvider
 
-            // If the user logged out while on another tab, the persisted
-            // inference mode may still be "managed". Reset both the draft
-            // and the persisted mode so the daemon doesn't attempt managed-
-            // proxy routing while unauthenticated.
+            // If the user is not authenticated and the persisted mode is
+            // "managed", reset the draft so the UI shows "your-own".
+            // When auth is still loading (startup), only reset the draft —
+            // the persisted mode is preserved so it can be restored when
+            // auth completes. When auth is confirmed absent, also persist
+            // the reset so the daemon doesn't attempt managed-proxy routing.
             if !isLoggedIn && draftMode == "managed" {
                 draftMode = "your-own"
-                store.setInferenceMode("your-own")
+                if !authManager.isLoading {
+                    store.setInferenceMode("your-own")
+                }
             }
         }
         .onChange(of: store.inferenceMode) { _, newValue in
-            // Sync draft when external changes arrive (e.g. daemon reload)
-            draftMode = newValue
+            // Sync draft when external changes arrive (e.g. daemon reload),
+            // but guard against adopting managed mode while unauthenticated.
+            if newValue == "managed" && !isLoggedIn {
+                draftMode = "your-own"
+            } else {
+                draftMode = newValue
+            }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            // When the user logs out while this card is mounted, reset
-            // both the draft and the persisted mode so the daemon doesn't
-            // attempt managed-proxy routing while unauthenticated.
             if !isAuthenticated && draftMode == "managed" {
+                // When the user logs out while this card is mounted, reset
+                // both the draft and the persisted mode so the daemon doesn't
+                // attempt managed-proxy routing while unauthenticated.
                 draftMode = "your-own"
+                store.setInferenceMode("your-own")
+            } else if isAuthenticated && store.inferenceMode == "managed" {
+                // When auth becomes available (e.g. startup transition from
+                // loading to authenticated), restore the persisted managed
+                // mode that onAppear may have temporarily overridden.
+                draftMode = "managed"
+            }
+        }
+        .onChange(of: authManager.isLoading) { _, isLoading in
+            // When auth finishes loading without authenticating, persist
+            // the mode reset that onAppear deferred during the loading
+            // state. Without this, the persisted mode stays "managed"
+            // while the UI shows "your-own" — pressing Save for unrelated
+            // edits would not trigger a mode change since draftMode already
+            // equals the visual state.
+            if !isLoading && !isLoggedIn && store.inferenceMode == "managed" {
                 store.setInferenceMode("your-own")
             }
         }


### PR DESCRIPTION
## Summary
- Adds auth guard to `onChange(of: store.inferenceMode)` to prevent adopting managed mode while unauthenticated (fixes view/selector inconsistency reported by Devin review on #17998)
- Adds login-restoration path in `onChange(of: authManager.isAuthenticated)` to restore managed draft when auth becomes available after startup loading (fixes premature mode override reported by Codex review on #17998)
- Defers persisted mode reset during auth loading state in `onAppear` and adds `onChange(of: authManager.isLoading)` to persist the reset when auth settles as unauthenticated

## Test plan
- [ ] Verify managed mode displays correctly when logged in
- [ ] Verify managed mode resets to your-own on logout while card is mounted
- [ ] Verify managed mode resets to your-own when navigating to settings after logging out on another tab
- [ ] Verify managed mode is restored after startup auth loading completes successfully
- [ ] Verify daemon reload setting managed mode while unauthenticated does not leak into draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
