### PR TITLE
fix: extract checkpoint key rename from migration 174 into separate migration 181

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -99,6 +99,7 @@ import {
   migrateRenameSequenceEnrollmentsThreadIdColumn,
   migrateRenameSequenceStepsReplyKey,
   migrateRenameSourceSessionIdColumn,
+  migrateRenameThreadStartersCheckpoints,
   migrateRenameThreadStartersTable,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
@@ -449,6 +450,9 @@ export function initializeDb(): void {
 
   // 77. Rename thread_starters → conversation_starters table and indexes
   migrateRenameThreadStartersTable(database);
+
+  // 77b. Rename checkpoint keys from thread_starters: → conversation_starters: prefix
+  migrateRenameThreadStartersCheckpoints(database);
 
   // 78. Lifecycle events table for app_open / hatch telemetry
   createLifecycleEventsTable(database);

--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -40,13 +40,6 @@ export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
       raw.exec(
         /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
       );
-
-      // Migrate checkpoint keys from old thread_starters: prefix to
-      // conversation_starters: so existing checkpoint data is found by
-      // the renamed code paths and unnecessary re-generation is avoided.
-      raw.exec(
-        /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
-      );
     },
   );
 }

--- a/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
+++ b/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
@@ -1,0 +1,31 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Rename checkpoint keys from the old `thread_starters:` prefix to
+ * `conversation_starters:` so that the renamed code paths in
+ * `conversation-starters-cadence.ts` and `conversation-starters.ts`
+ * find existing generation state and avoid unnecessary re-generation.
+ *
+ * This was originally appended to migration 174, but that migration
+ * had already shipped with its own checkpoint key
+ * (`migration_rename_thread_starters_table_v1`), so `withCrashRecovery`
+ * would skip the entire body for users who had already run it. Moving
+ * the checkpoint-key rewrite into its own migration with an independent
+ * checkpoint key ensures it runs for all users.
+ */
+export function migrateRenameThreadStartersCheckpoints(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_thread_starters_checkpoints_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      raw.exec(
+        /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
+      );
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -122,6 +122,7 @@ export { migrateCreateTraceEventsTable } from "./177-create-trace-events-table.j
 export { migrateOAuthProvidersManagedServiceConfigKey } from "./178-oauth-providers-managed-service-config-key.js";
 export { migrateLlmRequestLogMessageId } from "./179-llm-request-log-message-id.js";
 export { migrateBackfillInlineAttachmentsToDisk } from "./180-backfill-inline-attachments-to-disk.js";
+export { migrateRenameThreadStartersCheckpoints } from "./181-rename-thread-starters-checkpoints.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -234,6 +234,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64",
   },
+  {
+    key: "migration_rename_thread_starters_checkpoints_v1",
+    version: 35,
+    dependsOn: ["migration_rename_thread_starters_table_v1"],
+    description:
+      "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
- Extracted the `UPDATE memory_checkpoints SET key = replace(...)` statement from migration 174 into a new migration 181
- Migration 174 had already shipped with checkpoint key `migration_rename_thread_starters_table_v1`, so `withCrashRecovery` would skip the entire body (including the newly added UPDATE) for users who already ran it
- The new migration 181 uses its own checkpoint key (`migration_rename_thread_starters_checkpoints_v1`) and declares `dependsOn: ["migration_rename_thread_starters_table_v1"]`
- This ensures the `thread_starters:*` checkpoint keys are renamed to `conversation_starters:*` for all users, preventing unnecessary re-generation of conversation starters

## Test plan
- [x] Verify migration 174 is reverted to its pre-PR-18090 state (no checkpoint UPDATE)
- [x] Verify new migration 181 has its own `withCrashRecovery` with independent key
- [x] Verify registry entry uses correct version (35) and dependency
- [x] Verify db-init.ts calls the new migration after migration 174

Addresses review feedback on #18090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
