### PR TITLE
fix: gate "API key not set" toast on inference service mode, not auth state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -65,6 +65,7 @@ public final class MainWindowState: ObservableObject {
     @Published var activeDynamicParsedSurface: Surface?
     @Published var activeDynamicUserAppsDirectory: URL?
     @Published var hasAPIKey: Bool
+    @Published var needsInferenceApiKey: Bool = false
     @Published var workspaceComposerExpanded = false
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
@@ -138,6 +139,7 @@ public final class MainWindowState: ObservableObject {
         self.layoutConfig = LayoutConfigStore.load()
         self.navigationHistoryCancellable = navigationHistory.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
+        refreshInferenceApiKeyStatus()
     }
 
     // MARK: - Selection Helpers
@@ -234,6 +236,29 @@ public final class MainWindowState: ObservableObject {
 
     func refreshAPIKeyStatus(isConnected: Bool, isAuthenticated: Bool) {
         hasAPIKey = APIKeyManager.hasAnyKey() || isConnected || isAuthenticated
+    }
+
+    /// Re-evaluates whether the "API key not set" toast should appear based on
+    /// the workspace config's inference service mode and the selected provider's
+    /// API key presence.
+    ///
+    /// `needsInferenceApiKey` is `true` only when:
+    /// - `services.inference.mode` is `"your-own"`, AND
+    /// - the configured provider (defaulting to `"anthropic"`) has no API key set.
+    ///
+    /// In all other cases (mode is `"managed"`, config is missing/unreadable,
+    /// or the provider has a key), it is `false`.
+    func refreshInferenceApiKeyStatus() {
+        let config = WorkspaceConfigIO.read()
+        guard let services = config["services"] as? [String: Any],
+              let inference = services["inference"] as? [String: Any],
+              let mode = inference["mode"] as? String,
+              mode == "your-own" else {
+            needsInferenceApiKey = false
+            return
+        }
+        let provider = (inference["provider"] as? String) ?? "anthropic"
+        needsInferenceApiKey = APIKeyManager.getKey(for: provider) == nil
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -665,7 +665,7 @@ struct MainWindowView: View {
                     ErrorToastOverlay(
                         errorManager: viewModel.errorManager,
                         hasAPIKey: windowState.hasAPIKey,
-                        isAuthenticated: authManager.isAuthenticated,
+                        needsInferenceApiKey: windowState.needsInferenceApiKey,
                         onOpenSettings: { windowState.selection = .panel(.settings) },
                         onRetryConversationError: { viewModel.retryAfterConversationError() },
                         onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
@@ -674,7 +674,7 @@ struct MainWindowView: View {
                         onRetryLastMessage: { viewModel.retryLastMessage() },
                         onDismissError: { viewModel.dismissError() }
                     )
-                } else if !windowState.hasAPIKey && authManager.isAuthenticated {
+                } else if windowState.needsInferenceApiKey {
                     ChatConversationErrorToast(
                         message: "API key not set. Add one in Settings to start chatting.",
                         icon: .keyRound,
@@ -713,6 +713,7 @@ struct MainWindowView: View {
             // no UI to disable it, leaving panels stuck in split mode.
             isAppChatOpen = false
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
+            windowState.refreshInferenceApiKeyStatus()
             selectedConversationId = conversationManager.activeConversationId
             // Initialize persistent conversation tracking on launch
             if let activeId = conversationManager.activeConversationId {
@@ -742,9 +743,11 @@ struct MainWindowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
+            windowState.refreshInferenceApiKeyStatus()
         }
         .onReceive(daemonClient.$isConnected) { connected in
             windowState.refreshAPIKeyStatus(isConnected: connected, isAuthenticated: authManager.isAuthenticated)
+            windowState.refreshInferenceApiKeyStatus()
 
             // Fallback for fresh users with 0 conversations: dismiss skeleton after a
             // short delay once the daemon is connected. Only applies during initial load.
@@ -758,6 +761,7 @@ struct MainWindowView: View {
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: isAuthenticated)
+            windowState.refreshInferenceApiKeyStatus()
         }
         .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
             // Dismiss skeleton when conversations arrive from daemon
@@ -999,7 +1003,7 @@ struct MainWindowView: View {
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
-    let isAuthenticated: Bool
+    let needsInferenceApiKey: Bool
     let onOpenSettings: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -1010,7 +1014,7 @@ private struct ErrorToastOverlay: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
-            if !hasAPIKey && isAuthenticated {
+            if needsInferenceApiKey {
                 ChatConversationErrorToast(
                     message: "API key not set. Add one in Settings to start chatting.",
                     icon: .keyRound,


### PR DESCRIPTION
## Summary
- Replace `isAuthenticated` gate on the "API key not set" toast with a service-mode-aware check
- Add `needsInferenceApiKey` property to `MainWindowState` that reads `services.inference.mode` from workspace config
- Toast only shows when mode is "your-own" and the selected provider's API key is missing — regardless of login state

Part of plan: api-key-toast-service-mode.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
