### PR TITLE
fix: stabilize conversation starter pagination by reordering before offset/limit

### DIFF
--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -123,8 +123,10 @@ function handleListConversationStarters(url: URL): Response {
 
   const db = getDb();
 
-  // Fetch chips (ranked by model, newest batch first)
-  const rawItems = db
+  // Fetch all chips (ranked by model, newest batch first), apply diversity
+  // reordering, then paginate. Reordering must happen before offset/limit so
+  // that paginated results are stable across pages.
+  const allItems = db
     .select({
       id: conversationStarters.id,
       label: conversationStarters.label,
@@ -143,20 +145,16 @@ function handleListConversationStarters(url: URL): Response {
       desc(conversationStarters.generationBatch),
       desc(conversationStarters.createdAt),
     )
-    .limit(limitParam)
-    .offset(offsetParam)
     .all();
 
-  const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM conversation_starters WHERE scope_id = ? AND card_type = 'chip'`,
-    scopeId,
-  );
-  const total = countRow?.c ?? 0;
+  const total = allItems.length;
 
-  // If starters exist, return them immediately.
+  // If starters exist, reorder for category diversity then paginate.
   if (total > 0) {
+    const ordered = orderStrongestFirst(allItems);
+    const page = ordered.slice(offsetParam, offsetParam + limitParam);
     return Response.json({
-      starters: orderStrongestFirst(rawItems),
+      starters: page,
       total,
       status: "ready",
     });


### PR DESCRIPTION
## Summary
- Fetch all conversation starters from DB without limit/offset, apply `orderStrongestFirst` diversity reordering, then slice the result with `offset` and `limit` in JS
- Previously, SQL-level OFFSET was applied before the diversity reordering, making paginated results unstable (items could appear on multiple pages or be skipped entirely)
- Derive total count from `allItems.length` instead of a separate COUNT query, since we already fetch all rows

Addresses review feedback from PR #18103 (Codex bot P2: "Preserve pagination order when re-ranking starters").

## Test plan
- [ ] Verify conversation starters still load correctly on the empty conversation page
- [ ] With >4 starters, verify `limit=2&offset=0` and `limit=2&offset=2` return disjoint sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
