### PR TITLE
fix: use local draftModel in ImageGenerationServiceCard to prevent unsaved state mutation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -16,6 +16,8 @@ struct ImageGenerationServiceCard: View {
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
+    /// Local draft of the model selection — only persisted on Save.
+    @State private var draftModel: String = ""
     /// Snapshot of the model at card appear — used to detect model-only changes.
     @State private var initialModel: String = ""
 
@@ -35,7 +37,7 @@ struct ImageGenerationServiceCard: View {
         }
         let modeChanged = draftMode != store.imageGenMode
         let hasNewKey = !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let modelChanged = store.selectedImageGenModel != initialModel
+        let modelChanged = draftModel != initialModel
         return modeChanged || hasNewKey || modelChanged
     }
 
@@ -85,11 +87,17 @@ struct ImageGenerationServiceCard: View {
         )
         .onAppear {
             draftMode = store.imageGenMode
+            draftModel = store.selectedImageGenModel
             initialModel = store.selectedImageGenModel
         }
         .onChange(of: store.imageGenMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload)
             draftMode = newValue
+        }
+        .onChange(of: store.selectedImageGenModel) { _, newValue in
+            // Sync draft & baseline when external changes arrive (e.g. daemon model info refresh)
+            draftModel = newValue
+            initialModel = newValue
         }
     }
 
@@ -125,10 +133,7 @@ struct ImageGenerationServiceCard: View {
                 .foregroundColor(VColor.contentSecondary)
             VDropdown(
                 placeholder: "Select a model\u{2026}",
-                selection: Binding(
-                    get: { store.selectedImageGenModel },
-                    set: { store.selectedImageGenModel = $0 }
-                ),
+                selection: $draftModel,
                 options: SettingsStore.availableImageGenModels.map { model in
                     (label: SettingsStore.imageGenModelDisplayNames[model] ?? model, value: model)
                 }
@@ -152,7 +157,7 @@ struct ImageGenerationServiceCard: View {
         }
 
         // Persist model selection
-        store.setImageGenModel(store.selectedImageGenModel)
-        initialModel = store.selectedImageGenModel
+        store.setImageGenModel(draftModel)
+        initialModel = draftModel
     }
 }


### PR DESCRIPTION
## Summary
- Adds a local `draftModel` `@State` variable to `ImageGenerationServiceCard`, matching the pattern used by `InferenceServiceCard`
- The model picker now writes to `draftModel` instead of `store.selectedImageGenModel`, preventing unsaved changes from leaking into the store
- `hasChanges` compares `draftModel` vs `initialModel` instead of reading from the store
- `save()` persists `draftModel` to the store via `setImageGenModel()`
- Added `.onChange(of: store.selectedImageGenModel)` to sync the draft when external changes arrive (e.g. daemon model info refresh)

Addresses feedback from PR #18258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
