### PR TITLE
fix: hide Save button in managed mode when no action is possible

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -60,6 +60,7 @@ struct GoogleOAuthServiceCard: View {
             onSave: { save() },
             onReset: nil,
             showReset: false,
+            hideButtons: draftMode == "managed" && !isLoggedIn,
             managedContent: {
                 managedBody
             },

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -52,6 +52,7 @@ struct ImageGenerationServiceCard: View {
                 apiKeyText = ""
             },
             showReset: draftMode == "your-own" && isConnected,
+            hideButtons: draftMode == "managed" && !isLoggedIn,
             managedContent: {
                 if isLoggedIn {
                     modelPicker

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -110,6 +110,7 @@ struct InferenceServiceCard: View {
                 apiKeyText = ""
             },
             showReset: isConnected,
+            hideButtons: draftMode == "managed" && !isLoggedIn,
             managedContent: {
                 if isLoggedIn {
                     modelPicker

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -17,6 +17,9 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
     /// Optional reset action -- shown only in Your Own mode when `showReset` is true.
     let onReset: (() -> Void)?
     let showReset: Bool
+    /// When true, the action buttons (Save / Reset) are hidden entirely.
+    /// Callers set this for states where no user action is possible (e.g. managed mode before login).
+    var hideButtons: Bool = false
     @ViewBuilder let managedContent: () -> ManagedContent
     @ViewBuilder let yourOwnContent: () -> YourOwnContent
 
@@ -36,8 +39,10 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
                 yourOwnContent()
             }
 
-            // Action buttons
-            actionButtons
+            // Action buttons (hidden when caller signals no action is possible)
+            if !hideButtons {
+                actionButtons
+            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -96,6 +96,7 @@ struct WebSearchServiceCard: View {
             },
             showReset: draftMode == "your-own" && needsAPIKey
                 && (isPerplexity ? store.hasPerplexityKey : store.hasBraveKey),
+            hideButtons: draftMode == "managed" && (store.inferenceMode == "your-own" || !isLoggedIn),
             managedContent: {
                 if store.inferenceMode == "your-own" {
                     managedUnavailableMessage


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #18259 (Devin review comment about disabled Save button visible in managed + not-logged-in state)
- Adds `hideButtons` parameter to `ServiceModeCard` (defaults to `false`) that hides action buttons entirely when set
- All four service card consumers pass `hideButtons: true` in managed + not-logged-in states, restoring the pre-refactor behavior where no buttons were shown

## Test plan
- [ ] Open Settings, switch Inference card to Managed mode while logged out -- verify no Save button is shown
- [ ] Log in -- verify Save button appears
- [ ] Switch Image Generation card to Managed mode while logged out -- verify no Save button
- [ ] Switch Web Search card to Managed mode while on Your Own inference -- verify no Save button
- [ ] Switch Google OAuth card to Managed mode while logged out -- verify no Save button
- [ ] Switch any card to Your Own mode -- verify Save button is present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
