### PR TITLE
fix: warn and strip deprecated rateLimit.maxTokensPerSession from user configs

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -119,6 +119,66 @@ function deleteNestedKey(
 }
 
 /**
+ * Deprecated config fields that have been removed. Each entry maps a
+ * dot-separated path to the deprecation message shown to the user.
+ */
+const DEPRECATED_FIELDS: Record<string, string> = {
+  "rateLimit.maxTokensPerSession":
+    "rateLimit.maxTokensPerSession has been removed and is no longer enforced. " +
+    "Per-session token budget tracking is no longer supported. " +
+    "The field will be removed from your config file.",
+};
+
+/**
+ * Check for deprecated config fields, log a warning for each one found,
+ * and strip them from both the in-memory object and the on-disk config file
+ * so the warning is only emitted once.
+ */
+function warnAndStripDeprecatedFields(
+  fileConfig: Record<string, unknown>,
+  configPath: string,
+): void {
+  const found: string[] = [];
+  for (const dotPath of Object.keys(DEPRECATED_FIELDS)) {
+    if (getNestedValue(fileConfig, dotPath) !== undefined) {
+      log.warn(DEPRECATED_FIELDS[dotPath]);
+      found.push(dotPath);
+    }
+  }
+
+  if (found.length === 0) return;
+
+  // Strip from the in-memory object so Zod never sees them
+  for (const dotPath of found) {
+    deleteNestedKeyByDotPath(fileConfig, dotPath);
+  }
+
+  // Persist the cleaned config to disk so the warning doesn't repeat
+  try {
+    if (existsSync(configPath)) {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (raw != null && typeof raw === "object" && !Array.isArray(raw)) {
+        for (const dotPath of found) {
+          deleteNestedKeyByDotPath(raw as Record<string, unknown>, dotPath);
+        }
+        writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n");
+      }
+    }
+  } catch {
+    // Best-effort — if the file can't be rewritten, the warning will repeat
+    // on next load, which is acceptable.
+  }
+}
+
+function deleteNestedKeyByDotPath(
+  obj: Record<string, unknown>,
+  dotPath: string,
+): void {
+  const keys = dotPath.split(".");
+  deleteNestedKey(obj, keys);
+}
+
+/**
  * Deep-merge missing keys from `defaults` into `target`.
  * Only adds keys that do not already exist in `target`; never overwrites.
  * Returns true if any key was added.
@@ -223,6 +283,10 @@ export function loadConfig(): AssistantConfig {
     } else {
       configFileExisted = false;
     }
+
+    // Warn about and strip deprecated config fields so users know their
+    // settings are no longer honored rather than silently dropping them.
+    warnAndStripDeprecatedFields(fileConfig, configPath);
 
     // Validate and apply defaults via Zod schema
     const config = validateWithSchema(fileConfig);


### PR DESCRIPTION
## Summary
- Add deprecation warning when `rateLimit.maxTokensPerSession` is found in a user's config file
- Auto-strip the deprecated field from both in-memory config and on-disk config.json
- Introduce a generic `DEPRECATED_FIELDS` registry and `warnAndStripDeprecatedFields` helper for future deprecations
- Addresses backwards compatibility feedback from PR #18272

## Test plan
- [ ] Verify a config file with `rateLimit.maxTokensPerSession` set logs a warning on startup
- [ ] Verify the field is removed from the config file after the warning
- [ ] Verify configs without the field load normally with no warnings

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
