### PR TITLE
fix: align web-search test mock config structure with production code

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -16,16 +16,13 @@ mock.module("../../registry.js", () => ({
 
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
-    webSearchProvider: mockWebSearchProvider,
+    services: {
+      "web-search": { provider: mockWebSearchProvider },
+    },
   }),
 }));
 
 mock.module("../../../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (provider: string) => {
-    if (provider === "brave") return mockBraveSecureKey;
-    if (provider === "perplexity") return mockPerplexitySecureKey;
-    return undefined;
-  },
   getProviderKeyAsync: async (provider: string) => {
     if (provider === "brave") return mockBraveSecureKey;
     if (provider === "perplexity") return mockPerplexitySecureKey;


### PR DESCRIPTION
## Summary
- Fix config mock in `web-search.test.ts` to return `{ services: { "web-search": { provider } } }` matching the real `AssistantConfig.services` schema, instead of the incorrect `{ webSearchProvider }` flat structure
- Remove dead `getSecureKeyAsync` mock export -- production `web-search.ts` only imports `getProviderKeyAsync`

Addresses review feedback from PR #18365.

## Test plan
- [ ] Verify `bun test assistant/src/tools/network/__tests__/web-search.test.ts` passes with the corrected mock structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
