### PR TITLE
fix: resolve workspace config path from connected assistant, persist onboarding inference selection to hatched workspace

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -268,6 +268,7 @@ struct APIKeyEntryStepView: View {
         if isCustomProviderEnabled {
             let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !providerRequiresKey || !trimmed.isEmpty else { return }
+            state.selectedModel = selectedModel
             if providerRequiresKey {
                 APIKeyManager.setKey(trimmed, for: state.selectedProvider)
             }
@@ -284,6 +285,8 @@ struct APIKeyEntryStepView: View {
         } else {
             let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }
+            state.selectedProvider = "anthropic"
+            state.selectedModel = "claude-opus-4-6"
             APIKeyManager.setKey(trimmed, for: "anthropic")
 
             // Force service modes to "your-own" — the user explicitly chose to

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -208,6 +208,8 @@ struct APIKeyStepView: View {
 
         if isAuthenticated {
             // Authenticated user selecting Local: skip API key, advance to consent step
+            state.selectedProvider = "anthropic"
+            state.selectedModel = "claude-opus-4-6"
             saveModelToConfig("claude-opus-4-6")
             state.skippedAPIKeyEntry = true
             state.advance(by: 2)

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -192,6 +192,30 @@ struct HatchingStepView: View {
         state.resetForRetry()
     }
 
+    /// Persist the onboarding-selected inference provider/model into the
+    /// newly hatched assistant workspace config. This ensures first-launch
+    /// selections survive instance-scoped workspaces.
+    private func persistOnboardingInferenceSelectionToHatchedWorkspace() {
+        guard !state.selectedProvider.isEmpty, !state.selectedModel.isEmpty else { return }
+        guard let workspaceDir = LockfileAssistant.loadLatest()?.workspaceDir else { return }
+        let configPath = URL(fileURLWithPath: workspaceDir).appendingPathComponent("config.json").path
+        WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true, into: configPath)
+
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var services = existingConfig["services"] as? [String: Any] ?? [:]
+        var inference = services["inference"] as? [String: Any] ?? [:]
+        inference["provider"] = state.selectedProvider
+        inference["model"] = state.selectedModel
+        services["inference"] = inference
+
+        do {
+            try WorkspaceConfigIO.merge(["services": services], into: configPath)
+            log.info("Persisted onboarding inference selection to hatched workspace config at \(configPath, privacy: .public)")
+        } catch {
+            log.error("Failed to persist onboarding inference selection to hatched workspace config: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     /// Called when the CLI process finishes successfully or when the success
     /// sentinel is detected in CLI output. Saves the random avatar (for
     /// non-pairing flows) then signals completion after a brief delay.
@@ -209,6 +233,8 @@ struct HatchingStepView: View {
            let image = hatchAvatarImage {
             AvatarAppearanceManager.shared.saveAvatar(image, bodyShape: hatchBody, eyeStyle: hatchEyes, color: hatchColor)
         }
+
+        persistOnboardingInferenceSelectionToHatchedWorkspace()
 
         // Brief delay so the user sees the waking animation before transition.
         // Stored as a cancellable Task so it's cleaned up if the view disappears.

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 /// Utility for reading and writing the workspace configuration file at
 /// `~/.vellum/workspace/config.json`.
@@ -13,6 +14,28 @@ public enum WorkspaceConfigIO {
         return "\(home)/.vellum/workspace/config.json"
     }()
 
+    private static let connectedAssistantIdDefaultsKey = "connectedAssistantId"
+
+    /// Resolve the workspace config path for the currently connected assistant.
+    ///
+    /// Resolution order:
+    /// 1. Explicit `path` argument (tests/overrides)
+    /// 2. Connected assistant workspace from lockfile (`instanceDir`/`baseDataDir`)
+    /// 3. Legacy default `~/.vellum/workspace/config.json`
+    private static func resolvePath(_ path: String? = nil) -> String {
+        if let path, !path.isEmpty {
+            return path
+        }
+        guard let assistantId = UserDefaults.standard.string(forKey: connectedAssistantIdDefaultsKey),
+              !assistantId.isEmpty,
+              let assistant = LockfileAssistant.loadByName(assistantId),
+              let workspaceDir = assistant.workspaceDir,
+              !workspaceDir.isEmpty else {
+            return defaultPath
+        }
+        return URL(fileURLWithPath: workspaceDir).appendingPathComponent("config.json").path
+    }
+
     /// Reads the workspace config and returns the top-level dictionary.
     ///
     /// Returns an empty dictionary when the file is missing, empty,
@@ -20,7 +43,7 @@ public enum WorkspaceConfigIO {
     ///
     /// - Parameter path: Override the file path (useful for testing).
     public static func read(from path: String? = nil) -> [String: Any] {
-        let filePath = path ?? defaultPath
+        let filePath = resolvePath(path)
 
         guard FileManager.default.fileExists(atPath: filePath) else {
             return [:]
@@ -54,7 +77,7 @@ public enum WorkspaceConfigIO {
     ///   - path: Override the file path (useful for testing).
     /// - Throws: If serialisation or filesystem operations fail.
     public static func merge(_ values: [String: Any], into path: String? = nil) throws {
-        let filePath = path ?? defaultPath
+        let filePath = resolvePath(path)
         let fileURL = URL(fileURLWithPath: filePath)
         let directory = fileURL.deletingLastPathComponent()
 


### PR DESCRIPTION
## Summary
- `WorkspaceConfigIO` now resolves the config path from the connected assistant's lockfile entry instead of always using the hardcoded `~/.vellum/workspace/config.json` default — fixes mismatch between where the Swift client writes config and where the daemon reads it
- After hatching completes, `persistOnboardingInferenceSelectionToHatchedWorkspace()` writes the user's provider/model selection to the hatched assistant's workspace config
- Sync `state.selectedModel` and `state.selectedProvider` in all onboarding save paths so `HatchingStepView` can read them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
