### PR TITLE
feat: add scope indicator badges to unified feature flag rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -984,9 +984,14 @@ struct SettingsDeveloperTab: View {
         )
         return HStack {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(flag.label)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
+                HStack(spacing: VSpacing.xs) {
+                    Text(flag.label)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
+                           tone: flag.scope == .assistant ? .accent : .neutral,
+                           emphasis: .subtle)
+                }
                 if !flag.description.isEmpty {
                     Text(flag.description)
                         .font(VFont.caption)


### PR DESCRIPTION
## Summary
- Add VBadge scope indicators next to each flag label: blue 'Assistant' or gray 'macOS'
- Uses the design system VBadge component with .subtle emphasis

Part of plan: unified-feature-flags-ui.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
