### PR TITLE
fix: refresh API key toast on config changes, improve copy and nav

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -18,6 +18,7 @@ extension Notification.Name {
     static let requestAppPreview = Notification.Name("MainWindow.requestAppPreview")
     static let assistantFeatureFlagDidChange = Notification.Name("assistantFeatureFlagDidChange")
     static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
+    static let inferenceConfigDidChange = Notification.Name("SettingsStore.inferenceConfigDidChange")
 }
 
 /// Manages API keys using CredentialStorage (Keychain in Release, file-based

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -66,6 +66,9 @@ public final class MainWindowState: ObservableObject {
     @Published var activeDynamicUserAppsDirectory: URL?
     @Published var hasAPIKey: Bool
     @Published var needsInferenceApiKey: Bool = false
+    /// Display name of the inference provider that needs an API key (e.g. "Anthropic").
+    /// Only meaningful when `needsInferenceApiKey` is `true`.
+    @Published var inferenceProviderDisplayName: String = ""
     @Published var workspaceComposerExpanded = false
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
@@ -248,6 +251,15 @@ public final class MainWindowState: ObservableObject {
     ///
     /// In all other cases (mode is `"managed"`, config is missing/unreadable,
     /// or the provider has a key), it is `false`.
+    private static let providerDisplayNames: [String: String] = [
+        "anthropic": "Anthropic",
+        "openai": "OpenAI",
+        "gemini": "Google Gemini",
+        "fireworks": "Fireworks",
+        "perplexity": "Perplexity",
+        "ollama": "Ollama",
+    ]
+
     func refreshInferenceApiKeyStatus() {
         let config = WorkspaceConfigIO.read()
         guard let services = config["services"] as? [String: Any],
@@ -259,6 +271,7 @@ public final class MainWindowState: ObservableObject {
         }
         let provider = (inference["provider"] as? String) ?? "anthropic"
         needsInferenceApiKey = APIKeyManager.getKey(for: provider) == nil
+        inferenceProviderDisplayName = Self.providerDisplayNames[provider] ?? provider.capitalized
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -666,7 +666,11 @@ struct MainWindowView: View {
                         errorManager: viewModel.errorManager,
                         hasAPIKey: windowState.hasAPIKey,
                         needsInferenceApiKey: windowState.needsInferenceApiKey,
-                        onOpenSettings: { windowState.selection = .panel(.settings) },
+                        inferenceProviderDisplayName: windowState.inferenceProviderDisplayName,
+                        onOpenModelsAndServices: {
+                            settingsStore.pendingSettingsTab = .modelsAndServices
+                            windowState.selection = .panel(.settings)
+                        },
                         onRetryConversationError: { viewModel.retryAfterConversationError() },
                         onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
                         onDismissConversationError: { viewModel.dismissConversationError() },
@@ -676,15 +680,18 @@ struct MainWindowView: View {
                     )
                 } else if windowState.needsInferenceApiKey {
                     ChatConversationErrorToast(
-                        message: "API key not set. Add one in Settings to start chatting.",
+                        message: "Add your \(windowState.inferenceProviderDisplayName) API key to start chatting.",
                         icon: .keyRound,
                         accentColor: VColor.systemMidStrong,
                         actionLabel: "Open Settings",
-                        onAction: { windowState.selection = .panel(.settings) }
+                        onAction: {
+                            settingsStore.pendingSettingsTab = .modelsAndServices
+                            windowState.selection = .panel(.settings)
+                        }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
                     .padding(.top, VSpacing.sm)
-                    .animation(VAnimation.fast, value: windowState.hasAPIKey)
+                    .animation(VAnimation.fast, value: windowState.needsInferenceApiKey)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .center)
@@ -743,6 +750,9 @@ struct MainWindowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
+            windowState.refreshInferenceApiKeyStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .inferenceConfigDidChange)) { _ in
             windowState.refreshInferenceApiKeyStatus()
         }
         .onReceive(daemonClient.$isConnected) { connected in
@@ -1004,7 +1014,8 @@ private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
     let needsInferenceApiKey: Bool
-    let onOpenSettings: () -> Void
+    let inferenceProviderDisplayName: String
+    let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
     let onDismissConversationError: () -> Void
@@ -1016,11 +1027,11 @@ private struct ErrorToastOverlay: View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
             if needsInferenceApiKey {
                 ChatConversationErrorToast(
-                    message: "API key not set. Add one in Settings to start chatting.",
+                    message: "Add your \(inferenceProviderDisplayName) API key to start chatting.",
                     icon: .keyRound,
                     accentColor: VColor.systemMidStrong,
                     actionLabel: "Open Settings",
-                    onAction: onOpenSettings
+                    onAction: onOpenModelsAndServices
                 )
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
@@ -1047,7 +1058,7 @@ private struct ErrorToastOverlay: View {
             }
         }
         .padding(.top, VSpacing.sm)
-        .animation(VAnimation.fast, value: hasAPIKey)
+        .animation(VAnimation.fast, value: needsInferenceApiKey)
         .animation(VAnimation.fast, value: errorManager.conversationError != nil)
         .animation(VAnimation.fast, value: errorManager.errorText != nil)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2138,6 +2138,7 @@ public final class SettingsStore: ObservableObject {
             log.error("Failed to merge workspace config for inference mode: \(error)")
         }
         scheduleRoutingSourceRefresh()
+        NotificationCenter.default.post(name: .inferenceConfigDidChange, object: nil)
     }
 
     func setImageGenMode(_ mode: String) {
@@ -2578,6 +2579,7 @@ public final class SettingsStore: ObservableObject {
             log.error("Failed to persist inference provider: \(error.localizedDescription)")
         }
         scheduleRoutingSourceRefresh()
+        NotificationCenter.default.post(name: .inferenceConfigDidChange, object: nil)
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the


### PR DESCRIPTION
## Summary
- Post `.inferenceConfigDidChange` notification from `setInferenceMode()` and `setInferenceProvider()` so the "API key not set" toast updates reactively when the user changes inference config in Settings
- Fix animation triggers to key on `needsInferenceApiKey` instead of the now-unrelated `hasAPIKey`
- Navigate to Models & Services tab when tapping "Open Settings" on the toast
- Show provider-specific copy: "Add your Anthropic API key to start chatting." (dynamically uses the configured provider name)

Fixes gaps from self-review of api-key-toast-service-mode.md plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
