### PR TITLE
feat: show default value for each feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -992,6 +992,9 @@ struct SettingsDeveloperTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
+                Text("Default: \(flag.defaultEnabled ? "On" : "Off")")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
             }
             Spacer()
             VToggle(isOn: flagBinding)


### PR DESCRIPTION
## Summary
- Add 'Default: On/Off' text below each flag's description
- Uses VFont.small (10pt) in contentTertiary color for unobtrusive metadata display

Part of plan: unified-feature-flags-ui.md (PR 3 of 4)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
