### PR TITLE
Fix logout error message leaking into login/reauth screens

### DIFF
--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -139,9 +139,6 @@ struct DaemonConnectionSection: View {
                     Button("Log Out", role: .destructive) {
                         Task {
                             await authManager.logout()
-                            // Clear any stale error from a failed logout HTTP request so it
-                            // doesn't appear inline next to the login button on iOS.
-                            authManager.errorMessage = nil
                         }
                     }
                 } else {

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -177,9 +177,6 @@ struct AccountSection: View {
                 Button("Log Out", role: .destructive) {
                     Task {
                         await authManager.logout()
-                        // Clear any stale error from a failed logout HTTP request so it
-                        // doesn't appear inline next to the login button on iOS.
-                        authManager.errorMessage = nil
                     }
                 }
             } else {

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -307,7 +307,6 @@ extension AppDelegate {
                 hasSetupDaemon = false
                 UserDefaults.standard.removeObject(forKey: "managedServiceModesInitialized")
                 showAuthWindow(reusingWindow: detachedWindow)
-                authManager.errorMessage = nil
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AuthManager+LogoutToast.swift
+++ b/clients/macos/vellum-assistant/App/AuthManager+LogoutToast.swift
@@ -2,14 +2,12 @@ import VellumAssistantShared
 
 extension AuthManager {
     /// Performs logout, showing an error toast on HTTP failure or a success toast on clean logout.
-    /// Clears `errorMessage` after toasting so inline displays don't double-show.
     func logoutWithToast(
         showToast: @escaping (String, ToastInfo.Style) -> Void
     ) async {
-        await logout()
-        if let error = errorMessage {
+        let error = await logout()
+        if let error {
             showToast(error, .error)
-            errorMessage = nil
         } else {
             showToast("Logged out. You can log in again from Settings.", .success)
         }

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -170,13 +170,21 @@ public final class AuthManager {
         }
     }
 
-    public func logout() async {
+    /// Logs out by deleting the server session, clearing local tokens and
+    /// persisted identifiers, and transitioning to `.unauthenticated`.
+    ///
+    /// Returns the error description if the HTTP DELETE to the session endpoint
+    /// fails (e.g. server unreachable). The local cleanup always proceeds
+    /// regardless. Does **not** set `errorMessage` — callers that need to
+    /// surface the error (e.g. via a toast) should inspect the return value.
+    @discardableResult
+    public func logout() async -> String? {
+        var logoutError: String?
         do {
             _ = try await authService.logout()
-            errorMessage = nil
         } catch {
             log.error("Logout request failed: baseURL=\(self.authService.baseURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            errorMessage = error.localizedDescription
+            logoutError = error.localizedDescription
         }
         await SessionTokenManager.deleteTokenAsync()
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
@@ -184,6 +192,7 @@ public final class AuthManager {
         UserDefaults.standard.removeObject(forKey: "managed_assistant_id")
         UserDefaults.standard.removeObject(forKey: "managed_platform_base_url")
         state = .unauthenticated
+        return logoutError
     }
 
     private func generateCodeVerifier() -> String {


### PR DESCRIPTION
## Summary
- Change `AuthManager.logout()` to return the error string via `@discardableResult` instead of setting `errorMessage`, preventing logout HTTP errors from leaking into login/reauth screen error displays
- Update `logoutWithToast` to use the return value instead of reading `errorMessage`
- Remove now-unnecessary manual `errorMessage = nil` cleanup from iOS `SettingsView`, `ConnectionSettingsSection`, and macOS `AppDelegate+AuthLifecycle`

Addresses review feedback from #18423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
