### PR TITLE
Make showToast non-optional in settings login views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -48,7 +48,7 @@ struct SettingsPanel: View {
     @ObservedObject var conversationManager: ConversationManager
     var authManager: AuthManager
     @ObservedObject var assistantFeatureFlagStore: AssistantFeatureFlagStore
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
 
     // MARK: - Init
@@ -60,7 +60,7 @@ struct SettingsPanel: View {
         conversationManager: ConversationManager,
         authManager: AuthManager,
         assistantFeatureFlagStore: AssistantFeatureFlagStore,
-        showToast: ((String, ToastInfo.Style) -> Void)? = nil,
+        showToast: @escaping (String, ToastInfo.Style) -> Void,
         featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
     ) {
         self.onClose = onClose

--- a/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GoogleOAuthServiceCard.swift
@@ -10,7 +10,7 @@ import VellumAssistantShared
 struct GoogleOAuthServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -151,16 +151,9 @@ struct GoogleOAuthServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    if let showToast {
-                        await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                            Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
-                        })
-                    } else {
-                        await authManager.startWorkOSLogin()
-                        if authManager.isAuthenticated {
-                            await store.fetchGoogleOAuthConnections(userId: currentUserId)
-                        }
-                    }
+                    await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                        Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                    })
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -12,7 +12,7 @@ struct ImageGenerationServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     @Binding var apiKeyText: String
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -115,11 +115,7 @@ struct ImageGenerationServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    if let showToast {
-                        await authManager.loginWithToast(showToast: showToast)
-                    } else {
-                        await authManager.startWorkOSLogin()
-                    }
+                    await authManager.loginWithToast(showToast: showToast)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -16,7 +16,7 @@ struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     @Binding var apiKeyText: String
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -237,11 +237,7 @@ struct InferenceServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    if let showToast {
-                        await authManager.loginWithToast(showToast: showToast)
-                    } else {
-                        await authManager.startWorkOSLogin()
-                    }
+                    await authManager.loginWithToast(showToast: showToast)
                 }
             }
         }
@@ -374,12 +370,12 @@ struct InferenceServiceCard: View {
             if isCustomProviderEnabled {
                 store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: {
                     keyTextBinding.wrappedValue = ""
-                    showToast?("\(displayName) API key saved", .success)
+                    showToast("\(displayName) API key saved", .success)
                 })
             } else {
                 store.saveAPIKey(trimmedKey, onSuccess: {
                     keyTextBinding.wrappedValue = ""
-                    showToast?("API key saved", .success)
+                    showToast("API key saved", .success)
                 })
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -8,7 +8,7 @@ struct SettingsGeneralTab: View {
     var daemonClient: DaemonClient?
     var authManager: AuthManager
     var onClose: () -> Void
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
     var onSignIn: (() -> Void)?
 
     @State private var showingPairingQR: Bool = false
@@ -101,12 +101,7 @@ struct SettingsGeneralTab: View {
                     isDisabled: authManager.isSubmitting
                 ) {
                     Task {
-                        if let showToast {
-                            await authManager.loginWithToast(showToast: showToast, onSuccess: { onSignIn?() })
-                        } else {
-                            await authManager.startWorkOSLogin()
-                            if authManager.isAuthenticated { onSignIn?() }
-                        }
+                        await authManager.loginWithToast(showToast: showToast, onSuccess: { onSignIn?() })
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -15,7 +15,7 @@ struct WebSearchServiceCard: View {
     var authManager: AuthManager
     @Binding var perplexityKeyText: String
     @Binding var braveKeyText: String
-    var showToast: ((String, ToastInfo.Style) -> Void)?
+    var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
     @State private var draftMode: String = "your-own"
@@ -166,11 +166,7 @@ struct WebSearchServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    if let showToast {
-                        await authManager.loginWithToast(showToast: showToast)
-                    } else {
-                        await authManager.startWorkOSLogin()
-                    }
+                    await authManager.loginWithToast(showToast: showToast)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Make `showToast` non-optional in `SettingsPanel`, `SettingsGeneralTab`, `InferenceServiceCard`, `ImageGenerationServiceCard`, `WebSearchServiceCard`, and `GoogleOAuthServiceCard`
- Remove dead `else` fallback branches that called `startWorkOSLogin()` directly without error feedback
- Remove optional chaining (`showToast?()`) now that the type is non-optional
- All callers already provide a non-nil `showToast`, so the optional contract was misleading and the nil path was unreachable dead code that silently swallowed login errors

Addresses review feedback on #18312.

## Test plan
- [ ] Verify settings panel still renders and login buttons work in managed and your-own modes
- [ ] Verify login error toasts appear when login fails (e.g. network error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
