### PR TITLE
fix: log managed logout HTTP errors instead of silently discarding

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -175,7 +175,14 @@ extension AppDelegate {
                     self?.mainWindow?.windowState.showToast(message: msg, style: style)
                 }
             } else {
-                await authManager.logout()
+                // Managed: user is redirected to the reauth screen regardless of
+                // HTTP outcome, so we don't toast. Log the error for diagnostics —
+                // the local session is always cleared and the stale server session
+                // will expire naturally or be replaced on re-login.
+                let logoutError = await authManager.logout()
+                if let logoutError {
+                    log.warning("Managed logout HTTP request failed (local session cleared): \(logoutError, privacy: .public)")
+                }
             }
 
             // Clear platform identity credentials from the running daemon (local assistants only).


### PR DESCRIPTION
## Summary
- Capture the return value from `authManager.logout()` in the managed logout path instead of discarding it
- Log a warning when the managed logout HTTP request fails, providing visibility into server-side session invalidation failures
- Add clarifying comment explaining why toasting is skipped for managed users (redirected to reauth screen)

Addresses feedback from automated review on #18427 about managed logout silently swallowing HTTP errors.

## Test plan
- [ ] Verify managed logout still works normally (happy path)
- [ ] Verify that if the server is unreachable during managed logout, a warning is logged and the user is still redirected to the reauth screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
