### PR TITLE
fix: remove hard-coded provider display names from API key toast

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -66,9 +66,6 @@ public final class MainWindowState: ObservableObject {
     @Published var activeDynamicUserAppsDirectory: URL?
     @Published var hasAPIKey: Bool
     @Published var needsInferenceApiKey: Bool = false
-    /// Display name of the inference provider that needs an API key (e.g. "Anthropic").
-    /// Only meaningful when `needsInferenceApiKey` is `true`.
-    @Published var inferenceProviderDisplayName: String = ""
     @Published var workspaceComposerExpanded = false
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
@@ -251,15 +248,6 @@ public final class MainWindowState: ObservableObject {
     ///
     /// In all other cases (mode is `"managed"`, config is missing/unreadable,
     /// or the provider has a key), it is `false`.
-    private static let providerDisplayNames: [String: String] = [
-        "anthropic": "Anthropic",
-        "openai": "OpenAI",
-        "gemini": "Google Gemini",
-        "fireworks": "Fireworks",
-        "perplexity": "Perplexity",
-        "ollama": "Ollama",
-    ]
-
     func refreshInferenceApiKeyStatus() {
         let config = WorkspaceConfigIO.read()
         guard let services = config["services"] as? [String: Any],
@@ -271,7 +259,6 @@ public final class MainWindowState: ObservableObject {
         }
         let provider = (inference["provider"] as? String) ?? "anthropic"
         needsInferenceApiKey = APIKeyManager.getKey(for: provider) == nil
-        inferenceProviderDisplayName = Self.providerDisplayNames[provider] ?? provider.capitalized
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -666,7 +666,6 @@ struct MainWindowView: View {
                         errorManager: viewModel.errorManager,
                         hasAPIKey: windowState.hasAPIKey,
                         needsInferenceApiKey: windowState.needsInferenceApiKey,
-                        inferenceProviderDisplayName: windowState.inferenceProviderDisplayName,
                         onOpenModelsAndServices: {
                             settingsStore.pendingSettingsTab = .modelsAndServices
                             windowState.selection = .panel(.settings)
@@ -680,7 +679,7 @@ struct MainWindowView: View {
                     )
                 } else if windowState.needsInferenceApiKey {
                     ChatConversationErrorToast(
-                        message: "Add your \(windowState.inferenceProviderDisplayName) API key to start chatting.",
+                        message: "Add an API key to start chatting.",
                         icon: .keyRound,
                         accentColor: VColor.systemMidStrong,
                         actionLabel: "Open Settings",
@@ -1014,7 +1013,6 @@ private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
     let needsInferenceApiKey: Bool
-    let inferenceProviderDisplayName: String
     let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -1027,7 +1025,7 @@ private struct ErrorToastOverlay: View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
             if needsInferenceApiKey {
                 ChatConversationErrorToast(
-                    message: "Add your \(inferenceProviderDisplayName) API key to start chatting.",
+                    message: "Add an API key to start chatting.",
                     icon: .keyRound,
                     accentColor: VColor.systemMidStrong,
                     actionLabel: "Open Settings",


### PR DESCRIPTION
## Summary
- Remove the hard-coded `providerDisplayNames` map and `inferenceProviderDisplayName` property from `MainWindowState`
- Simplify toast copy to "Add an API key to start chatting." — the "Open Settings" button navigates directly to Models & Services where the provider context is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
