### PR TITLE
fix: add routing source refresh to Google OAuth mode setter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2186,6 +2186,7 @@ public final class SettingsStore: ObservableObject {
         } catch {
             log.error("Failed to merge workspace config for google-oauth mode: \(error)")
         }
+        scheduleRoutingSourceRefresh()
     }
 
     // MARK: - Google OAuth Connections


### PR DESCRIPTION
## Summary
- Add missing `scheduleRoutingSourceRefresh()` call in `setGoogleOAuthMode()` to match the pattern used by `setInferenceMode()`, `setImageGenMode()`, and `setWebSearchMode()`
- Without this call, switching Google OAuth mode would not trigger a routing source refresh, unlike all other service mode setters

Addresses review feedback from PR #18507.

## Test plan
- [x] Verified the fix matches the pattern of all other mode setters in SettingsStore
- [x] Confirmed the first review comment (default value) was already addressed on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
