### PR TITLE
feat: add search bar to filter feature flags by name, label, or description

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -75,6 +75,8 @@ struct SettingsDeveloperTab: View {
     @State private var sentryDismissTask: Task<Void, Never>?
     @State private var isSentryEnabled: Bool = true
 
+    @State private var featureFlagSearchText: String = ""
+
     @State private var platformUrlText: String = ""
     @FocusState private var isPlatformUrlFocused: Bool
 
@@ -889,8 +891,21 @@ struct SettingsDeveloperTab: View {
         return (fromAssistant + fromMacOS).sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
     }
 
+    private var filteredUnifiedFlags: [UnifiedFeatureFlag] {
+        if featureFlagSearchText.isEmpty {
+            return unifiedFlags
+        }
+        return unifiedFlags.filter { flag in
+            flag.label.localizedCaseInsensitiveContains(featureFlagSearchText) ||
+            flag.description.localizedCaseInsensitiveContains(featureFlagSearchText) ||
+            flag.key.localizedCaseInsensitiveContains(featureFlagSearchText)
+        }
+    }
+
     private var featureFlagSection: some View {
         SettingsCard(title: "Feature Flags", subtitle: "Toggle feature flags for the assistant and macOS app.") {
+            VSearchBar(placeholder: "Search flags...", text: $featureFlagSearchText)
+
             if isLoadingAssistantFlags {
                 HStack {
                     Spacer()
@@ -914,8 +929,12 @@ struct SettingsDeveloperTab: View {
                 Text("No feature flags available.")
                     .font(VFont.body)
                     .foregroundColor(VColor.contentTertiary)
+            } else if filteredUnifiedFlags.isEmpty && !featureFlagSearchText.isEmpty {
+                Text("No flags matching \"\(featureFlagSearchText)\"")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentTertiary)
             } else {
-                ForEach(unifiedFlags) { flag in
+                ForEach(filteredUnifiedFlags) { flag in
                     unifiedFlagRow(flag: flag)
                 }
             }


### PR DESCRIPTION
## Summary
- Add VSearchBar at top of Feature Flags card for live filtering
- Filters by flag label, key, or description (case-insensitive)
- Shows 'No flags matching...' message when search has no results

Part of plan: unified-feature-flags-ui.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
