### PR TITLE
fix: fall back to local keychain mask in Inference card, include daemon masks in isConnected

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -51,7 +51,11 @@ struct InferenceServiceCard: View {
     // MARK: - Computed State
 
     private var isConnected: Bool {
-        isCustomProviderEnabled ? store.hasKeyForProvider(effectiveProvider) : store.hasKey
+        let daemonHasMaskedKey = !(store.providerMaskedKeys[effectiveProvider] ?? "").isEmpty
+        if isCustomProviderEnabled {
+            return store.hasKeyForProvider(effectiveProvider) || daemonHasMaskedKey
+        }
+        return store.hasKey || daemonHasMaskedKey
     }
 
     private var isLoggedIn: Bool {
@@ -264,8 +268,15 @@ struct InferenceServiceCard: View {
 
     private var apiKeyField: some View {
         let currentMask: String = {
-            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
-                return masked
+            // Prefer daemon-reported masks when available (authoritative for
+            // remote/managed contexts), but fall back to local keychain masks
+            // so onboarding-written keys render immediately before daemon sync.
+            if let daemonMask = store.providerMaskedKeys[effectiveProvider], !daemonMask.isEmpty {
+                return daemonMask
+            }
+            let localMask = store.maskedKeyForProvider(effectiveProvider)
+            if !localMask.isEmpty {
+                return localMask
             }
             return ""
         }()


### PR DESCRIPTION
## Summary
- `isConnected` now also checks daemon-reported masked keys, so remote/managed contexts where keys aren't in the local Keychain still show as connected
- `currentMask` falls back to local Keychain mask via `maskedKeyForProvider()` when the daemon hasn't reported a mask yet, so onboarding-written keys render immediately before daemon sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
