### PR TITLE
fix: clear assistant API key from daemon secrets on logout

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -191,7 +191,7 @@ extension AppDelegate {
             if !isCurrentAssistantManaged && !isCurrentAssistantRemote && hasSetupDaemon {
                 let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials()
                 if !cleared {
-                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale platform identity state")
+                    log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed credential state")
                     daemonClient.disconnect()
                     assistantCli.stop(name: connectedAssistantId)
                 }

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -338,13 +338,15 @@ public final class LocalAssistantBootstrapService {
         }
     }
 
-    /// Clears platform identity credentials from the daemon's secret store
-    /// by issuing `DELETE /v1/secrets` for each vellum-namespaced credential.
+    /// Clears platform identity credentials and the assistant API key from
+    /// the daemon's secret store by issuing `DELETE /v1/secrets` for each
+    /// vellum-namespaced credential.
     ///
     /// Returns `true` if all credentials were successfully cleared (or didn't exist).
     @discardableResult
     public static func clearDaemonCredentials() async -> Bool {
         let credentialNames = [
+            "vellum:assistant_api_key",
             "vellum:platform_assistant_id",
             "vellum:platform_base_url",
             "vellum:platform_organization_id",
@@ -369,9 +371,9 @@ public final class LocalAssistantBootstrapService {
             }
         }
         if allCleared {
-            log.info("All platform identity credentials cleared from daemon")
+            log.info("All managed credentials cleared from daemon")
         } else {
-            log.warning("Some platform identity credentials could not be cleared from daemon")
+            log.warning("Some managed credentials could not be cleared from daemon")
         }
         return allCleared
     }


### PR DESCRIPTION
## Summary
- Restore `vellum:assistant_api_key` to the `clearDaemonCredentials()` deletion list so managed proxy cannot remain usable after logout
- Update doc comments and log messages to reflect the broader credential scope

Addresses review feedback on #18771: logout was leaving the assistant API key in the daemon's in-memory secret store, which meant managed inference could continue working (and billing) after sign-out.

## Test plan
- [ ] Log in with a platform account, verify managed inference works
- [ ] Log out, verify managed inference stops (assistant API key is cleared from daemon)
- [ ] Log back in, verify managed inference resumes (key is re-provisioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
