### PR TITLE
fix: capture assistant ID before await in API key revocation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -793,6 +793,11 @@ struct SettingsDeveloperTab: View {
         isRevokingApiKey = true
         defer { isRevokingApiKey = false }
 
+        // Capture assistant ID before the await so local credential cleanup
+        // targets the same assistant the remote DELETE was issued against,
+        // even if the user switches assistants while the request is in flight.
+        let targetAssistantId = selectedAssistantId
+
         let body: [String: String] = ["type": "credential", "name": "vellum:assistant_api_key"]
         do {
             let response = try await GatewayHTTPClient.delete(
@@ -806,7 +811,7 @@ struct SettingsDeveloperTab: View {
                 #else
                 let credStorage = KeychainCredentialStorage()
                 #endif
-                let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: selectedAssistantId)
+                let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: targetAssistantId)
                 _ = credStorage.delete(account: credentialAccount)
 
                 showRevokeStatus("Assistant API key revoked", isError: false)


### PR DESCRIPTION
## Summary
- Fixes a race condition in `revokeAssistantApiKey()` where `selectedAssistantId` was read after the async network DELETE, meaning if the user switched assistants during the in-flight request, the local credential cleanup would target the wrong assistant
- Captures `selectedAssistantId` into a local `targetAssistantId` before the `await` boundary, ensuring the remote revoke and local cache deletion always target the same assistant

Addresses review feedback from PR #18773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
