### PR TITLE
fix: prevent force-init from overwriting user-selected google-oauth mode

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -117,9 +117,15 @@ public enum WorkspaceConfigIO {
         }
     }
 
-    /// All known service keys. Add new services here to automatically include
-    /// them in `initializeServiceDefaults`.
-    static let serviceKeys = ["inference", "image-generation", "web-search", "google-oauth"]
+    /// Service keys whose mode can be force-overwritten during bootstrap.
+    static let forcibleServiceKeys = ["inference", "image-generation", "web-search"]
+
+    /// Service keys whose mode is only set when missing (never force-overwritten).
+    /// Google OAuth mode is user-selected and must survive app restarts.
+    static let initOnlyServiceKeys = ["google-oauth"]
+
+    /// All known service keys (union of forcible + init-only).
+    static let serviceKeys: [String] = forcibleServiceKeys + initOnlyServiceKeys
 
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").
@@ -127,18 +133,28 @@ public enum WorkspaceConfigIO {
     ///
     /// - Parameters:
     ///   - mode: The service mode to set (e.g. "managed", "your-own").
-    ///   - force: When `true`, overwrites existing modes unconditionally. Use this
-    ///     for the managed bootstrap path where daemon-materialized schema defaults
-    ///     ("your-own") must be replaced with the correct managed mode.
+    ///   - force: When `true`, overwrites existing modes unconditionally for
+    ///     forcible services (inference, image-generation, web-search). Init-only
+    ///     services (google-oauth) are always set only when missing, regardless
+    ///     of this flag.
     ///   - path: Override the file path (useful for testing).
     public static func initializeServiceDefaults(defaultMode mode: String, force: Bool = false, into path: String? = nil) {
         let existingConfig = read(from: path)
         var services = existingConfig["services"] as? [String: Any] ?? [:]
         var changed = false
 
-        for key in serviceKeys {
+        for key in forcibleServiceKeys {
             var service = services[key] as? [String: Any] ?? [:]
             if force || service["mode"] == nil {
+                service["mode"] = mode
+                services[key] = service
+                changed = true
+            }
+        }
+
+        for key in initOnlyServiceKeys {
+            var service = services[key] as? [String: Any] ?? [:]
+            if service["mode"] == nil {
                 service["mode"] = mode
                 services[key] = service
                 changed = true


### PR DESCRIPTION
## Summary
- Fixes a regression from PR #18513 where the loop refactor applied the `force` flag to `google-oauth`, causing user-selected Google OAuth mode to be reset on every managed bootstrap
- Splits `serviceKeys` into `forcibleServiceKeys` and `initOnlyServiceKeys` arrays with separate iteration logic
- `google-oauth` mode is now only set when missing (never force-overwritten), matching pre-refactor behavior

## Test plan
- [ ] Verify that setting Google OAuth mode persists across app restarts
- [ ] Verify that inference/image-generation/web-search modes still respect force initialization during managed bootstrap
- [ ] Verify onboarding flows still correctly initialize all service modes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
