### PR TITLE
fix: preserve UserDefaults API keys when credential store write fails during migration

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -68,10 +68,14 @@ enum APIKeyManager {
             if let udValue = UserDefaults.standard.string(forKey: udKey),
                !udValue.isEmpty,
                storage.get(account: udKey) == nil {
-                _ = storage.set(account: udKey, value: udValue)
+                // Only remove from UserDefaults if the credential store
+                // write succeeds. A transient Keychain/file failure should
+                // not destroy the user's only copy of the key.
+                guard storage.set(account: udKey, value: udValue) else { continue }
             }
-            // Always remove from UserDefaults regardless — keys should not
-            // remain in the plaintext plist after migration.
+            // Safe to remove: either the key was successfully migrated,
+            // the credential store already had a value, or UserDefaults
+            // had no value to preserve.
             UserDefaults.standard.removeObject(forKey: udKey)
         }
     }


### PR DESCRIPTION
## Summary
- Fix `APIKeyManager.migrateFromUserDefaults()` to only remove UserDefaults keys after confirming the credential store write succeeded
- Previously, a transient Keychain/file write failure would permanently erase the user's only stored API key since the UserDefaults removal was unconditional
- Uses `guard storage.set(...) else { continue }` to skip the cleanup when the write fails, preserving the key for a future migration retry

Addresses review feedback from #18780.

## Test plan
- [ ] Verify migration succeeds normally: UserDefaults key is moved to credential store and removed from UserDefaults
- [ ] Verify that if credential store write fails, the UserDefaults key is preserved (not deleted)
- [ ] Verify idempotency: running migration twice when credential store already has the key still cleans up UserDefaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
