### PR TITLE
feat: add display metadata columns to oauth_providers table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -85,6 +85,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateOAuthAppsClientSecretPath,
+  migrateOAuthProvidersDisplayMetadata,
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingUrl,
   migrateReminderRoutingIntent,
@@ -465,6 +466,9 @@ export function initializeDb(): void {
 
   // 81. Add managed_service_config_key column to oauth_providers
   migrateOAuthProvidersManagedServiceConfigKey(database);
+
+  // 81b. Add display metadata columns to oauth_providers (display_name, description, dashboard_url, etc.)
+  migrateOAuthProvidersDisplayMetadata(database);
 
   // 82. Add message_id column to llm_request_logs for per-message LLM context lookup
   migrateLlmRequestLogMessageId(database);

--- a/assistant/src/memory/migrations/182-oauth-providers-display-metadata.ts
+++ b/assistant/src/memory/migrations/182-oauth-providers-display-metadata.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersDisplayMetadata(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const columns = [
+    "display_name TEXT",
+    "description TEXT",
+    "dashboard_url TEXT",
+    "client_id_placeholder TEXT",
+    "requires_client_secret INTEGER NOT NULL DEFAULT 1",
+  ];
+  for (const col of columns) {
+    try {
+      raw.exec(`ALTER TABLE oauth_providers ADD COLUMN ${col}`);
+    } catch {
+      // Column already exists — nothing to do.
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -123,6 +123,7 @@ export { migrateOAuthProvidersManagedServiceConfigKey } from "./178-oauth-provid
 export { migrateLlmRequestLogMessageId } from "./179-llm-request-log-message-id.js";
 export { migrateBackfillInlineAttachmentsToDisk } from "./180-backfill-inline-attachments-to-disk.js";
 export { migrateRenameThreadStartersCheckpoints } from "./181-rename-thread-starters-checkpoints.js";
+export { migrateOAuthProvidersDisplayMetadata } from "./182-oauth-providers-display-metadata.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -19,6 +19,11 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   callbackTransport: text("callback_transport"),
   pingUrl: text("ping_url"),
   managedServiceConfigKey: text("managed_service_config_key"),
+  displayName: text("display_name"),
+  description: text("description"),
+  dashboardUrl: text("dashboard_url"),
+  clientIdPlaceholder: text("client_id_placeholder"),
+  requiresClientSecret: integer("requires_client_secret").notNull().default(1),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });


### PR DESCRIPTION
## Summary
- Add migration 182 with five new columns: display_name, description, dashboard_url, client_id_placeholder, requires_client_secret
- Update Drizzle schema to match
- Register migration in db-init

Part of plan: oauth-provider-display-metadata.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
