### PR TITLE
Deduplicate conversation timeout values from PR #18779 review

### DIFF
--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -4,6 +4,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../../../config/loader.js";
+import { VALID_CONVERSATION_TIMEOUTS } from "../../../../config/schemas/elevenlabs.js";
 import { normalizeActivationKey } from "../../../../daemon/handlers/config-voice.js";
 import type {
   ToolContext,
@@ -29,7 +30,7 @@ type VoiceSettingName = keyof typeof VOICE_SETTINGS;
 
 const VALID_SETTINGS = Object.keys(VOICE_SETTINGS) as VoiceSettingName[];
 
-const VALID_TIMEOUTS = [5, 10, 15, 30, 60];
+const VALID_TIMEOUTS: readonly number[] = VALID_CONVERSATION_TIMEOUTS;
 
 const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
   activation_key: "PTT activation key",

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -38,6 +38,7 @@ export type { ElevenLabsConfig } from "./schemas/elevenlabs.js";
 export {
   DEFAULT_ELEVENLABS_VOICE_ID,
   ElevenLabsConfigSchema,
+  VALID_CONVERSATION_TIMEOUTS,
 } from "./schemas/elevenlabs.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";

--- a/assistant/src/config/schemas/elevenlabs.ts
+++ b/assistant/src/config/schemas/elevenlabs.ts
@@ -5,6 +5,9 @@ import { z } from "zod";
 // Mirrored in: clients/macos/.../OpenAIVoiceService.swift (defaultVoiceId)
 export const DEFAULT_ELEVENLABS_VOICE_ID = "ZF6FPAbjXT4488VcRRnw";
 
+/** Valid conversation timeout values (seconds). Shared with voice-config-update tool. */
+export const VALID_CONVERSATION_TIMEOUTS = [5, 10, 15, 30, 60] as const;
+
 export const ElevenLabsConfigSchema = z
   .object({
     voiceId: z
@@ -46,10 +49,15 @@ export const ElevenLabsConfigSchema = z
       .number({
         error: "elevenlabs.conversationTimeoutSeconds must be a number",
       })
-      .refine((v) => [5, 10, 15, 30, 60].includes(v), {
-        message:
-          "elevenlabs.conversationTimeoutSeconds must be one of: 5, 10, 15, 30, 60",
-      })
+      .refine(
+        (v) =>
+          VALID_CONVERSATION_TIMEOUTS.includes(
+            v as (typeof VALID_CONVERSATION_TIMEOUTS)[number],
+          ),
+        {
+          message: `elevenlabs.conversationTimeoutSeconds must be one of: ${VALID_CONVERSATION_TIMEOUTS.join(", ")}`,
+        },
+      )
       .default(30)
       .describe("Seconds of silence before voice conversation auto-ends"),
   })


### PR DESCRIPTION
## Summary
- Extract duplicated `[5, 10, 15, 30, 60]` conversation timeout values into a shared `VALID_CONVERSATION_TIMEOUTS` constant in `elevenlabs.ts` schema
- Import and use the shared constant in `voice-config-update.ts` instead of a local duplicate
- Export the constant from the `schema.ts` barrel file

Addresses review feedback on #18779 (Devin flagged duplicated valid timeout values between schema and tool).

## Test plan
- [ ] Verify the schema validation still accepts the same set of timeout values
- [ ] Verify voice-config-update tool validation uses the shared constant

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
