### PR TITLE
fix: clean up orphaned conversationTextZoomLevel UserDefaults key

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -254,6 +254,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // renders EmptyView — we handle settings in the main window panel).
         UserDefaults.standard.removeObject(forKey: "NSWindow Frame com_apple_SwiftUI_Settings_window")
 
+        // Remove orphaned conversation zoom key. ConversationZoomManager was
+        // deleted (redundant with window-level ZoomManager); clean up any
+        // persisted value so it doesn't linger in UserDefaults.
+        UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
+
         // Migrate API keys from plaintext UserDefaults to credential storage
         // (Keychain in Release, file-based in DEBUG). Safe to call on every
         // launch — skips providers already present in credential storage.


### PR DESCRIPTION
## Summary
- Add UserDefaults cleanup for the orphaned `conversationTextZoomLevel` key left behind by the ConversationZoomManager removal in PR #18783
- Follows the same startup-cleanup pattern used for other legacy keys (Settings window frame, privacy keys, etc.)

## Test plan
- Verify the key is removed on launch by checking UserDefaults after startup
- Safe to run on every launch (idempotent — removeObject is a no-op if the key doesn't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
