### PR TITLE
Remove dead notifyOnComplete plumbing from quick input

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -387,13 +387,11 @@ extension AppDelegate {
             ?? (PermissionManager.screenRecordingStatus() != .granted)
 
         let window = QuickInputWindow()
-        window.onSubmit = { [weak self, weak window] message, imageData in
-            let notify = window?.notifyOnComplete ?? false
-            self?.handleQuickInputSubmit(message, imageData: imageData, notifyOnComplete: notify)
+        window.onSubmit = { [weak self] message, imageData in
+            self?.handleQuickInputSubmit(message, imageData: imageData)
         }
-        window.onSubmitToConversation = { [weak self, weak window] message, imageData in
-            let notify = window?.notifyOnComplete ?? false
-            self?.handleQuickInputSubmitToConversation(message, imageData: imageData, notifyOnComplete: notify)
+        window.onSubmitToConversation = { [weak self] message, imageData in
+            self?.handleQuickInputSubmitToConversation(message, imageData: imageData)
         }
         window.onSelectConversation = { [weak self] conversationId in
             self?.handleQuickInputSelectConversation(conversationId)
@@ -436,13 +434,11 @@ extension AppDelegate {
             guard let self else { return }
 
             let window = QuickInputWindow()
-            window.onSubmit = { [weak self, weak window] message, imgData in
-                let notify = window?.notifyOnComplete ?? false
-                self?.handleQuickInputSubmit(message, imageData: imgData, notifyOnComplete: notify)
+            window.onSubmit = { [weak self] message, imgData in
+                self?.handleQuickInputSubmit(message, imageData: imgData)
             }
-            window.onSubmitToConversation = { [weak self, weak window] message, imgData in
-                let notify = window?.notifyOnComplete ?? false
-                self?.handleQuickInputSubmitToConversation(message, imageData: imgData, notifyOnComplete: notify)
+            window.onSubmitToConversation = { [weak self] message, imgData in
+                self?.handleQuickInputSubmitToConversation(message, imageData: imgData)
             }
             window.onSelectConversation = { [weak self] conversationId in
                 self?.handleQuickInputSelectConversation(conversationId)
@@ -465,7 +461,7 @@ extension AppDelegate {
         selectionWindow.show()
     }
 
-    func handleQuickInputSubmit(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+    func handleQuickInputSubmit(_ message: String, imageData: Data?) {
         // Ensure mainWindow exists so we can get a ChatViewModel.
         // Never show it — quick input is fire-and-forget.
         ensureMainWindowExists()
@@ -492,7 +488,7 @@ extension AppDelegate {
         }
     }
 
-    func handleQuickInputSubmitToConversation(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+    func handleQuickInputSubmitToConversation(_ message: String, imageData: Data?) {
         guard let mainWindow else { return }
         if let viewModel = mainWindow.activeViewModel {
             if let imageData {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -16,7 +16,6 @@ struct QuickInputView: View {
     let onRemoveAttachment: (() -> Void)?
     let onAllowScreenRecording: (() -> Void)?
     let onMicrophoneToggle: (() -> Void)?
-    let onNotificationToggle: (() -> Void)?
     let recentConversations: [QuickInputConversation]
     let attachedImage: NSImage?
     let showScreenPermissionPrompt: Bool
@@ -35,7 +34,6 @@ struct QuickInputView: View {
         onRemoveAttachment: (() -> Void)? = nil,
         onAllowScreenRecording: (() -> Void)? = nil,
         onMicrophoneToggle: (() -> Void)? = nil,
-        onNotificationToggle: (() -> Void)? = nil,
         recentConversations: [QuickInputConversation] = [],
         attachedImage: NSImage? = nil,
         showScreenPermissionPrompt: Bool = false
@@ -48,7 +46,6 @@ struct QuickInputView: View {
         self.onRemoveAttachment = onRemoveAttachment
         self.onAllowScreenRecording = onAllowScreenRecording
         self.onMicrophoneToggle = onMicrophoneToggle
-        self.onNotificationToggle = onNotificationToggle
         self.recentConversations = recentConversations
         self.attachedImage = attachedImage
         self.showScreenPermissionPrompt = showScreenPermissionPrompt
@@ -144,15 +141,6 @@ struct QuickInputView: View {
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
                 .fixedSize()
-
-                // Notification toggle
-                Button(action: { onNotificationToggle?() }) {
-                    VIconView(.bell, size: 14)
-                        .foregroundColor(textModel.notifyOnComplete ? VColor.contentSecondary : VColor.contentTertiary)
-                        .frame(width: 32, height: 32)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(textModel.notifyOnComplete ? "Notifications on" : "Notifications off")
 
                 // Screenshot button
                 if attachedImage == nil {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -18,8 +18,6 @@ final class QuickInputTextModel: ObservableObject {
     /// When set, the user has selected an existing conversation to continue.
     @Published var selectedConversationId: UUID?
     @Published var selectedConversationTitle: String?
-    /// Whether to send a notification when the assistant response completes.
-    @Published var notifyOnComplete: Bool = UserDefaults.standard.object(forKey: "quickInputNotifyOnComplete") as? Bool ?? true
 }
 
 /// A borderless, floating NSPanel that hosts the Quick Input text field.
@@ -45,17 +43,12 @@ final class QuickInputWindow {
     var onSubmitToConversation: ((String, Data?) -> Void)?
     /// Callback invoked when the user taps the microphone button.
     var onMicrophoneToggle: (() -> Void)?
-    /// Callback invoked when the user toggles the notification bell.
-    var onNotificationToggle: (() -> Void)?
     /// Callback invoked when the user selects an existing conversation (navigates to it).
     var onSelectConversation: ((UUID) -> Void)?
     /// Recent conversations to show in the dropdown.
     var recentConversations: [QuickInputConversation] = []
     /// When true, show a screen recording permission prompt below the bar.
     var showScreenPermissionPrompt = false
-
-    /// Whether to send a notification when the assistant response completes.
-    var notifyOnComplete: Bool { textModel.notifyOnComplete }
 
     /// Shared text model for voice input injection.
     private let textModel = QuickInputTextModel()
@@ -196,11 +189,6 @@ final class QuickInputWindow {
                 self?.dismiss()
             },
             onMicrophoneToggle: onMicrophoneToggle,
-            onNotificationToggle: { [weak self] in
-                guard let self else { return }
-                self.textModel.notifyOnComplete.toggle()
-                UserDefaults.standard.set(self.textModel.notifyOnComplete, forKey: "quickInputNotifyOnComplete")
-            },
             recentConversations: recentConversations,
             attachedImage: attachedImage,
             showScreenPermissionPrompt: showScreenPermissionPrompt


### PR DESCRIPTION
## Summary
- Remove unused `notifyOnComplete` parameter from `handleQuickInputSubmit` and `handleQuickInputSubmitToConversation`
- Remove `notifyOnComplete` property from `QuickInputTextModel` and `QuickInputWindow`
- Remove `onNotificationToggle` callback and bell toggle UI from `QuickInputView`
- Remove `quickInputNotifyOnComplete` UserDefaults key persistence

Follows up on PR #18782 which removed `setupQuickInputNotification` but left the flag, toggle, and persistence as dead code. The bell toggle was non-functional since the notification setup was removed.

## Test plan
- [ ] Quick input bar opens without the bell toggle button
- [ ] Quick input submit to new chat works without notification parameter
- [ ] Quick input submit to existing conversation works without notification parameter
- [ ] Screen capture + quick input flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
