### PR TITLE
fix: break up MainWindowView core layout type checking

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -490,317 +490,367 @@ struct MainWindowView: View {
 
     /// Core layout extracted to break up type-checker complexity.
     private var coreLayoutView: some View {
+        applyWorkspaceNotificationModifiers(
+            to: applyConversationSelectionModifiers(
+                to: applyLifecycleModifiers(
+                    to: coreLayoutDecoratedView
+                )
+            )
+        )
+        // Hover->pending-deletion invariant is now owned by
+        // SidebarInteractionState.setConversationHover(conversationId:hovering:)
+    }
+
+    private var coreLayoutGeometryView: some View {
         GeometryReader { geometry in
             coreLayoutContent(geometry: geometry)
         }
-        .frame(minWidth: 800, minHeight: 600)
-        .overlay(alignment: .top) {
-            if zoomManager.showZoomIndicator {
-                ZoomIndicatorView(percentage: zoomManager.zoomPercentage)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .padding(.top, 40)
-                    .shadow(color: VColor.auxBlack.opacity(0.15), radius: 8, y: 2)
-            }
-        }
-        .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
-        .overlay(alignment: .top) {
-            Group {
-                if let viewModel = conversationManager.activeViewModel {
-                    ErrorToastOverlay(
-                        errorManager: viewModel.errorManager,
-                        hasAPIKey: windowState.hasAPIKey,
-                        needsInferenceApiKey: windowState.needsInferenceApiKey,
-                        onOpenModelsAndServices: {
-                            settingsStore.pendingSettingsTab = .modelsAndServices
-                            windowState.selection = .panel(.settings)
-                        },
-                        onRetryConversationError: { viewModel.retryAfterConversationError() },
-                        onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
-                        onDismissConversationError: { viewModel.dismissConversationError() },
-                        onSendAnyway: { viewModel.sendAnyway() },
-                        onRetryLastMessage: { viewModel.retryLastMessage() },
-                        onDismissError: { viewModel.dismissError() }
-                    )
-                } else if windowState.needsInferenceApiKey {
-                    ChatConversationErrorToast(
-                        message: "Add an API key to start chatting.",
-                        icon: .keyRound,
-                        accentColor: VColor.systemMidStrong,
-                        actionLabel: "Open Settings",
-                        onAction: {
-                            settingsStore.pendingSettingsTab = .modelsAndServices
-                            windowState.selection = .panel(.settings)
-                        }
-                    )
-                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-                    .padding(.top, VSpacing.sm)
-                    .animation(VAnimation.fast, value: windowState.needsInferenceApiKey)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-        }
-        .overlay(alignment: .bottom) {
-            if let toast = windowState.toastInfo {
-                VToast(
-                    message: toast.message,
-                    style: toast.style == .success ? .success : toast.style == .warning ? .warning : .error,
-                    copyableDetail: toast.copyableDetail,
-                    primaryAction: toast.primaryAction,
-                    onDismiss: { windowState.dismissToast() }
-                )
-                .padding(.horizontal, VSpacing.xl)
-                .padding(.bottom, VSpacing.xl)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-        }
-        .animation(VAnimation.standard, value: windowState.toastInfo != nil)
-        .overlay {
-            JITPermissionView(manager: jitPermissionManager)
-        }
-        .onAppear {
-            // Reset stale chat-dock state for users upgrading from older versions.
-            // Without this, isAppChatOpen could remain persisted as true with
-            // no UI to disable it, leaving panels stuck in split mode.
-            isAppChatOpen = false
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
-            windowState.refreshInferenceApiKeyStatus()
-            selectedConversationId = conversationManager.activeConversationId
-            // Initialize persistent conversation tracking on launch
-            if let activeId = conversationManager.activeConversationId {
-                windowState.persistentConversationId = activeId
-            }
-            daemonClient.startSSE()
-            // Sync initial daemon startup error state
-            daemonStartupError = AppDelegate.shared?.daemonStartupError
-        }
-        .task {
-            guard let appDelegate = AppDelegate.shared else { return }
-            for await error in appDelegate.$daemonStartupError.values {
-                daemonStartupError = error
-            }
-        }
-        .onDisappear {
-            sharing.errorDismissTask?.cancel()
-            sharing.errorDismissTask = nil
-            sharing.credentialPollTimer?.invalidate()
-            sharing.credentialPollTimer = nil
-            sharing.pendingPublish = nil
-            if let handler = sharing.previousVercelHandler {
-                daemonClient.onVercelApiConfigResponse = handler
-                sharing.previousVercelHandler = nil
-            }
-            daemonClient.stopSSE()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
-            windowState.refreshInferenceApiKeyStatus()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .inferenceConfigDidChange)) { _ in
-            windowState.refreshInferenceApiKeyStatus()
-        }
-        .onReceive(daemonClient.$isConnected) { connected in
-            windowState.refreshAPIKeyStatus(isConnected: connected, isAuthenticated: authManager.isAuthenticated)
-            windowState.refreshInferenceApiKeyStatus()
+    }
 
-            // Fallback for fresh users with 0 conversations: dismiss skeleton after a
-            // short delay once the daemon is connected. Only applies during initial load.
-            guard connected, showDaemonLoading else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                guard showDaemonLoading else { return }
-                withAnimation(VAnimation.standard) {
-                    showDaemonLoading = false
+    private var coreLayoutDecoratedView: some View {
+        coreLayoutGeometryView
+            .frame(minWidth: 800, minHeight: 600)
+            .overlay(alignment: .top) { zoomIndicatorOverlay }
+            .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
+            .overlay(alignment: .top) { coreLayoutErrorOverlay }
+            .overlay(alignment: .bottom) { windowToastOverlay }
+            .animation(VAnimation.standard, value: windowState.toastInfo != nil)
+            .overlay { JITPermissionView(manager: jitPermissionManager) }
+    }
+
+    @ViewBuilder
+    private var zoomIndicatorOverlay: some View {
+        if zoomManager.showZoomIndicator {
+            ZoomIndicatorView(percentage: zoomManager.zoomPercentage)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .padding(.top, 40)
+                .shadow(color: VColor.auxBlack.opacity(0.15), radius: 8, y: 2)
+        }
+    }
+
+    @ViewBuilder
+    private var coreLayoutErrorOverlay: some View {
+        Group {
+            if let viewModel = conversationManager.activeViewModel {
+                ErrorToastOverlay(
+                    errorManager: viewModel.errorManager,
+                    hasAPIKey: windowState.hasAPIKey,
+                    needsInferenceApiKey: windowState.needsInferenceApiKey,
+                    onOpenModelsAndServices: {
+                        settingsStore.pendingSettingsTab = .modelsAndServices
+                        windowState.selection = .panel(.settings)
+                    },
+                    onRetryConversationError: { viewModel.retryAfterConversationError() },
+                    onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
+                    onDismissConversationError: { viewModel.dismissConversationError() },
+                    onSendAnyway: { viewModel.sendAnyway() },
+                    onRetryLastMessage: { viewModel.retryLastMessage() },
+                    onDismissError: { viewModel.dismissError() }
+                )
+            } else if windowState.needsInferenceApiKey {
+                ChatConversationErrorToast(
+                    message: "Add an API key to start chatting.",
+                    icon: .keyRound,
+                    accentColor: VColor.systemMidStrong,
+                    actionLabel: "Open Settings",
+                    onAction: {
+                        settingsStore.pendingSettingsTab = .modelsAndServices
+                        windowState.selection = .panel(.settings)
+                    }
+                )
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                .padding(.top, VSpacing.sm)
+                .animation(VAnimation.fast, value: windowState.needsInferenceApiKey)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private var windowToastOverlay: some View {
+        if let toast = windowState.toastInfo {
+            VToast(
+                message: toast.message,
+                style: toast.style == .success ? .success : toast.style == .warning ? .warning : .error,
+                copyableDetail: toast.copyableDetail,
+                primaryAction: toast.primaryAction,
+                onDismiss: { windowState.dismissToast() }
+            )
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.bottom, VSpacing.xl)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+
+    private func applyLifecycleModifiers<Content: View>(to content: Content) -> some View {
+        content
+            .onAppear { handleCoreLayoutAppear() }
+            .task { await observeDaemonStartupErrors() }
+            .onDisappear { handleCoreLayoutDisappear() }
+            .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
+                refreshWindowAPIStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .inferenceConfigDidChange)) { _ in
+                windowState.refreshInferenceApiKeyStatus()
+            }
+            .onReceive(daemonClient.$isConnected) { connected in
+                handleDaemonConnectionChange(connected)
+            }
+            .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+                refreshWindowAPIStatus(isConnected: daemonClient.isConnected, isAuthenticated: isAuthenticated)
+            }
+            .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
+                if !isEmpty && showDaemonLoading {
+                    withAnimation(VAnimation.standard) {
+                        showDaemonLoading = false
+                    }
                 }
             }
-        }
-        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-            windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected, isAuthenticated: isAuthenticated)
-            windowState.refreshInferenceApiKeyStatus()
-        }
-        .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
-            // Dismiss skeleton when conversations arrive from daemon
-            if !isEmpty && showDaemonLoading {
-                withAnimation(VAnimation.standard) {
-                    showDaemonLoading = false
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                conversationManager.markActiveConversationSeenIfNeeded()
+            }
+    }
+
+    private func applyConversationSelectionModifiers<Content: View>(to content: Content) -> some View {
+        content
+            .onChange(of: selectedConversationId) { _, newId in
+                if let newId {
+                    conversationManager.selectConversation(id: newId)
                 }
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            conversationManager.markActiveConversationSeenIfNeeded()
-        }
-        .onChange(of: selectedConversationId) { _, newId in
-            if let newId = newId {
-                conversationManager.selectConversation(id: newId)
+            .onChange(of: conversationManager.activeConversationId) { oldId, newId in
+                handleActiveConversationIdChange(oldId: oldId, newId: newId)
             }
-        }
-        .onChange(of: conversationManager.activeConversationId) { oldId, newId in
-            // Sync activeConversationId changes back to selectedConversationId to keep sidebar selection in sync
-            selectedConversationId = newId
-            // Always sync persistentConversationId so the sidebar highlights the
-            // correct conversation — even when an overlay (.panel, .app) is active.
-            // Without this, archiving the active conversation while viewing a panel
-            // leaves persistentConversationId pointing at the archived (invisible) conversation
-            // and the sidebar shows no active highlight.
-            // Clear it when entering draft mode (nil) so no conversation appears active.
-            windowState.persistentConversationId = newId
-            if case .panel(.intelligence) = windowState.selection {
-                windowState.selection = nil
+    }
+
+    private func applyWorkspaceNotificationModifiers<Content: View>(to content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
+                handleOpenDynamicWorkspace(notification)
             }
-            // Clear subagent detail panel on conversation switch
-            windowState.selectedSubagentId = nil
-            // Clear stale activeSurfaceId on the old conversation and sync the new one
-            if let oldId {
-                conversationManager.clearActiveSurface(conversationId: oldId)
+            .onReceive(NotificationCenter.default.publisher(for: .shareAppCloud)) { notification in
+                guard let appId = notification.userInfo?["appId"] as? String else { return }
+                bundleAndShare(appId: appId)
             }
-            conversationManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
-            conversationManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
-            // Consume any buffered deep-link message now that a conversation is active.
-            // Mirrors the iOS pattern (ChatTabView.onAppear, ConversationListView.onAppear)
-            // where consumeDeepLinkIfNeeded() is called when the view model becomes
-            // visible. Without this, deep links arriving before the window/conversation is
-            // fully initialized are silently dropped on macOS.
-            conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
-            if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
-                // Full message from daemon live event (AppDelegate path)
-                windowState.activeDynamicSurface = msg
-                windowState.activeDynamicParsedSurface = Surface.from(msg)
-                if let path = notification.userInfo?["userAppsDirectoryPath"] as? String, !path.isEmpty {
-                    windowState.activeDynamicUserAppsDirectory = URL(fileURLWithPath: path, isDirectory: true)
-                } else {
-                    let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
-                    windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
+            .onReceive(NotificationCenter.default.publisher(for: .pinApp)) { notification in
+                handlePinAppNotification(notification, isPinned: true)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .unpinApp)) { notification in
+                handlePinAppNotification(notification, isPinned: false)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .queryAppPinState)) { notification in
+                handleQueryAppPinState(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in
+                handleOpenDocumentEditor(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
+                if let updated = notification.userInfo?["surface"] as? Surface,
+                   updated.id == windowState.activeDynamicSurface?.surfaceId {
+                    windowState.activeDynamicParsedSurface = updated
                 }
-                // Determine the app ID from the surface if available
-                if let surface = windowState.activeDynamicParsedSurface,
-                   case .dynamicPage(let dpData) = surface.data,
-                   let appId = dpData.appId {
-                    // Open in view-only mode; user can enter edit mode
-                    // via the Edit button in the toolbar.
-                    windowState.selection = .app(appId)
-                } else {
-                    windowState.selection = .app(msg.surfaceId)
-                }
-            } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
-                // Lightweight ref from inline surface click — the daemon will
-                // send a fresh ui_surface_show via SSE with the full payload.
-                // Use the real appId for the app_open_request when available,
-                // because surfaceId is a daemon-generated identifier
-                // (e.g. "app-open-<uuid>") that doesn't match any real app.
-                let reopenId = ref.appId ?? ref.surfaceId
-                windowState.selection = .app(reopenId)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .requestAppPreview)) { notification in
+                handleRequestAppPreview(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .dismissDynamicWorkspace)) { notification in
+                handleDismissDynamicWorkspace(notification)
+            }
+    }
+
+    private func handleCoreLayoutAppear() {
+        // Reset stale chat-dock state for users upgrading from older versions.
+        // Without this, isAppChatOpen could remain persisted as true with
+        // no UI to disable it, leaving panels stuck in split mode.
+        isAppChatOpen = false
+        refreshWindowAPIStatus(isConnected: daemonClient.isConnected, isAuthenticated: authManager.isAuthenticated)
+        selectedConversationId = conversationManager.activeConversationId
+        if let activeId = conversationManager.activeConversationId {
+            windowState.persistentConversationId = activeId
+        }
+        daemonClient.startSSE()
+        daemonStartupError = AppDelegate.shared?.daemonStartupError
+    }
+
+    private func observeDaemonStartupErrors() async {
+        guard let appDelegate = AppDelegate.shared else { return }
+        for await error in appDelegate.$daemonStartupError.values {
+            daemonStartupError = error
+        }
+    }
+
+    private func handleCoreLayoutDisappear() {
+        sharing.errorDismissTask?.cancel()
+        sharing.errorDismissTask = nil
+        sharing.credentialPollTimer?.invalidate()
+        sharing.credentialPollTimer = nil
+        sharing.pendingPublish = nil
+        if let handler = sharing.previousVercelHandler {
+            daemonClient.onVercelApiConfigResponse = handler
+            sharing.previousVercelHandler = nil
+        }
+        daemonClient.stopSSE()
+    }
+
+    private func refreshWindowAPIStatus(isConnected: Bool, isAuthenticated: Bool) {
+        windowState.refreshAPIKeyStatus(isConnected: isConnected, isAuthenticated: isAuthenticated)
+        windowState.refreshInferenceApiKeyStatus()
+    }
+
+    private func handleDaemonConnectionChange(_ connected: Bool) {
+        refreshWindowAPIStatus(isConnected: connected, isAuthenticated: authManager.isAuthenticated)
+
+        // Fallback for fresh users with 0 conversations: dismiss skeleton after a
+        // short delay once the daemon is connected. Only applies during initial load.
+        guard connected, showDaemonLoading else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            guard showDaemonLoading else { return }
+            withAnimation(VAnimation.standard) {
+                showDaemonLoading = false
+            }
+        }
+    }
+
+    private func handleActiveConversationIdChange(oldId: UUID?, newId: UUID?) {
+        // Sync activeConversationId changes back to selectedConversationId to keep sidebar selection in sync
+        selectedConversationId = newId
+        // Always sync persistentConversationId so the sidebar highlights the
+        // correct conversation — even when an overlay (.panel, .app) is active.
+        // Without this, archiving the active conversation while viewing a panel
+        // leaves persistentConversationId pointing at the archived (invisible) conversation
+        // and the sidebar shows no active highlight.
+        // Clear it when entering draft mode (nil) so no conversation appears active.
+        windowState.persistentConversationId = newId
+        if case .panel(.intelligence) = windowState.selection {
+            windowState.selection = nil
+        }
+        windowState.selectedSubagentId = nil
+        if let oldId {
+            conversationManager.clearActiveSurface(conversationId: oldId)
+        }
+        conversationManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
+        conversationManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
+        conversationManager.activeViewModel?.consumeDeepLinkIfNeeded()
+    }
+
+    private func handleOpenDynamicWorkspace(_ notification: Notification) {
+        if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
+            // Full message from daemon live event (AppDelegate path)
+            windowState.activeDynamicSurface = msg
+            windowState.activeDynamicParsedSurface = Surface.from(msg)
+            if let path = notification.userInfo?["userAppsDirectoryPath"] as? String, !path.isEmpty {
+                windowState.activeDynamicUserAppsDirectory = URL(fileURLWithPath: path, isDirectory: true)
+            } else {
                 let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
                 windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
-                Task { await AppsClient.openAppAndDispatchSurface(id: reopenId, daemonClient: daemonClient) }
             }
+            if let surface = windowState.activeDynamicParsedSurface,
+               case .dynamicPage(let dpData) = surface.data,
+               let appId = dpData.appId {
+                windowState.selection = .app(appId)
+            } else {
+                windowState.selection = .app(msg.surfaceId)
+            }
+        } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
+            // Lightweight ref from inline surface click — the daemon will
+            // send a fresh ui_surface_show via SSE with the full payload.
+            let reopenId = ref.appId ?? ref.surfaceId
+            windowState.selection = .app(reopenId)
+            let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+            windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
+            Task { await AppsClient.openAppAndDispatchSurface(id: reopenId, daemonClient: daemonClient) }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .shareAppCloud)) { notification in
-            guard let appId = notification.userInfo?["appId"] as? String else { return }
-            bundleAndShare(appId: appId)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .pinApp)) { notification in
-            guard let appId = notification.userInfo?["appId"] as? String else { return }
+    }
+
+    private func handlePinAppNotification(_ notification: Notification, isPinned: Bool) {
+        guard let appId = notification.userInfo?["appId"] as? String else { return }
+        if isPinned {
             appListManager.pinApp(id: appId)
-            NotificationCenter.default.post(
-                name: Notification.Name("MainWindow.appPinStateChanged"),
-                object: nil,
-                userInfo: ["appId": appId, "isPinned": true]
-            )
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .unpinApp)) { notification in
-            guard let appId = notification.userInfo?["appId"] as? String else { return }
+        } else {
             appListManager.unpinApp(id: appId)
-            NotificationCenter.default.post(
-                name: Notification.Name("MainWindow.appPinStateChanged"),
-                object: nil,
-                userInfo: ["appId": appId, "isPinned": false]
+        }
+        NotificationCenter.default.post(
+            name: Notification.Name("MainWindow.appPinStateChanged"),
+            object: nil,
+            userInfo: ["appId": appId, "isPinned": isPinned]
+        )
+    }
+
+    private func handleQueryAppPinState(_ notification: Notification) {
+        guard let appId = notification.userInfo?["appId"] as? String else { return }
+        let pinned = appListManager.apps.first(where: { $0.id == appId })?.isPinned ?? false
+        NotificationCenter.default.post(
+            name: Notification.Name("MainWindow.appPinStateChanged"),
+            object: nil,
+            userInfo: ["appId": appId, "isPinned": pinned]
+        )
+    }
+
+    private func handleOpenDocumentEditor(_ notification: Notification) {
+        guard let surfaceId = notification.userInfo?["documentSurfaceId"] as? String else { return }
+        if documentManager.hasActiveDocument && documentManager.surfaceId == surfaceId {
+            windowState.selection = .panel(.documentEditor)
+            return
+        }
+
+        Task {
+            guard let response = await DocumentClient().fetchDocument(surfaceId: surfaceId) else { return }
+            guard response.success else {
+                windowState.showToast(
+                    message: "Failed to load document\(response.error.map { ": \($0)" } ?? "")",
+                    style: .error
+                )
+                return
+            }
+            documentManager.createDocument(
+                surfaceId: response.surfaceId,
+                conversationId: response.conversationId,
+                title: response.title,
+                initialContent: response.content
             )
+            windowState.selection = .panel(.documentEditor)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .queryAppPinState)) { notification in
-            guard let appId = notification.userInfo?["appId"] as? String else { return }
-            let pinned = appListManager.apps.first(where: { $0.id == appId })?.isPinned ?? false
-            NotificationCenter.default.post(
-                name: Notification.Name("MainWindow.appPinStateChanged"),
-                object: nil,
-                userInfo: ["appId": appId, "isPinned": pinned]
-            )
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openDocumentEditor)) { notification in
-            guard let surfaceId = notification.userInfo?["documentSurfaceId"] as? String else { return }
-            if documentManager.hasActiveDocument && documentManager.surfaceId == surfaceId {
-                // Document already in memory — just show the panel
-                windowState.selection = .panel(.documentEditor)
-            } else {
-                Task {
-                    guard let response = await DocumentClient().fetchDocument(surfaceId: surfaceId) else { return }
-                    guard response.success else {
-                        windowState.showToast(
-                            message: "Failed to load document\(response.error.map { ": \($0)" } ?? "")",
-                            style: .error
-                        )
-                        return
-                    }
-                    documentManager.createDocument(
-                        surfaceId: response.surfaceId,
-                        conversationId: response.conversationId,
-                        title: response.title,
-                        initialContent: response.content
-                    )
-                    windowState.selection = .panel(.documentEditor)
-                }
+    }
+
+    private func handleRequestAppPreview(_ notification: Notification) {
+        guard let appId = notification.userInfo?["appId"] as? String else { return }
+        let html = notification.userInfo?["html"] as? String
+        Task { @MainActor in
+            let response = await AppsClient().fetchAppPreview(appId: appId)
+            if let base64 = response?.preview, !base64.isEmpty {
+                NotificationCenter.default.post(
+                    name: .appPreviewImageCaptured,
+                    object: nil,
+                    userInfo: ["appId": appId, "previewImage": base64]
+                )
+            } else if let html,
+                      let base64 = await OffscreenPreviewCapture.capture(html: html) {
+                _ = await AppsClient().updateAppPreview(appId: appId, preview: base64)
+                NotificationCenter.default.post(
+                    name: .appPreviewImageCaptured,
+                    object: nil,
+                    userInfo: ["appId": appId, "previewImage": base64]
+                )
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .updateDynamicWorkspace)) { notification in
-            if let updated = notification.userInfo?["surface"] as? Surface,
-               updated.id == windowState.activeDynamicSurface?.surfaceId {
-                windowState.activeDynamicParsedSurface = updated
+    }
+
+    private func handleDismissDynamicWorkspace(_ notification: Notification) {
+        if let surfaceId = notification.userInfo?["surfaceId"] as? String {
+            if windowState.activeDynamicSurface?.surfaceId == surfaceId {
+                sharing.showSharePicker = false
+                windowState.closeDynamicPanel()
             }
+            return
         }
-        .onReceive(NotificationCenter.default.publisher(for: .requestAppPreview)) { notification in
-            guard let appId = notification.userInfo?["appId"] as? String else { return }
-            let html = notification.userInfo?["html"] as? String
-            Task { @MainActor in
-                let response = await AppsClient().fetchAppPreview(appId: appId)
-                if let base64 = response?.preview, !base64.isEmpty {
-                    NotificationCenter.default.post(
-                        name: .appPreviewImageCaptured,
-                        object: nil,
-                        userInfo: ["appId": appId, "previewImage": base64]
-                    )
-                } else if let html = html {
-                    // No stored preview — capture one via offscreen WKWebView
-                    if let base64 = await OffscreenPreviewCapture.capture(html: html) {
-                        _ = await AppsClient().updateAppPreview(appId: appId, preview: base64)
-                        NotificationCenter.default.post(
-                            name: .appPreviewImageCaptured,
-                            object: nil,
-                            userInfo: ["appId": appId, "previewImage": base64]
-                        )
-                    }
-                }
-            }
+
+        if case .app = windowState.selection {
+            sharing.showSharePicker = false
+            windowState.closeDynamicPanel()
+        } else if case .appEditing = windowState.selection {
+            sharing.showSharePicker = false
+            windowState.closeDynamicPanel()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .dismissDynamicWorkspace)) { notification in
-            // If a specific surfaceId was dismissed, only clear if it matches.
-            if let surfaceId = notification.userInfo?["surfaceId"] as? String {
-                if windowState.activeDynamicSurface?.surfaceId == surfaceId {
-                    sharing.showSharePicker = false
-                    windowState.closeDynamicPanel()
-                }
-            } else {
-                // Bulk dismiss (dismissAll) — only clear if currently showing an app workspace.
-                // Avoid kicking the user out of unrelated panels (Settings, Agent, etc.).
-                if case .app = windowState.selection {
-                    sharing.showSharePicker = false
-                    windowState.closeDynamicPanel()
-                } else if case .appEditing = windowState.selection {
-                    sharing.showSharePicker = false
-                    windowState.closeDynamicPanel()
-                }
-            }
-        }
-        // Hover→pending-deletion invariant is now owned by
-        // SidebarInteractionState.setConversationHover(conversationId:hovering:)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- break the MainWindowView core layout into smaller geometry, overlay, and modifier helpers so Swift can type-check the macOS window shell again
- keep the existing notification wiring and state synchronization behavior while moving the heavy modifier closures into named handlers
- Apple refs checked (2026-03-19): [GeometryReader](https://developer.apple.com/documentation/swiftui/geometryreader), [View body](https://developer.apple.com/documentation/swiftui/view/body-8kl5o), [ViewBuilder](https://developer.apple.com/documentation/swiftui/viewbuilder)

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift:493:9: error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
 491 |     /// Core layout extracted to break up type-checker complexity.
 492 |     private var coreLayoutView: some View {
 493 |         GeometryReader { geometry in
     |         `- error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
 494 |             coreLayoutContent(geometry: geometry)
 495 |         }
[3/6] Compiling VellumAssistantLib MainWindowView.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
