### PR TITLE
feat: include provider display metadata in GET /v1/oauth/apps response

### DIFF
--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -45,7 +45,20 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           (row) => row.providerKey === providerKey,
         );
 
+        const providerRow = getProvider(providerKey);
+        const provider = providerRow
+          ? {
+              provider_key: providerRow.providerKey,
+              display_name: providerRow.displayName ?? null,
+              description: providerRow.description ?? null,
+              dashboard_url: providerRow.dashboardUrl ?? null,
+              client_id_placeholder: providerRow.clientIdPlaceholder ?? null,
+              requires_client_secret: providerRow.requiresClientSecret ?? 1,
+            }
+          : null;
+
         return Response.json({
+          provider,
           apps: filtered.map((row) => ({
             id: row.id,
             provider_key: row.providerKey,


### PR DESCRIPTION
## Summary
- Enrich GET /v1/oauth/apps response with provider display metadata (display_name, description, dashboard_url, etc.)
- No new endpoints needed — existing gateway proxy forwards the enriched response
- Backward compatible: apps array unchanged, provider object is additive

Part of plan: oauth-provider-display-metadata.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
