### PR TITLE
fix: persist ttsVoiceId to UserDefaults so voice selection survives app restart

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -299,6 +299,7 @@ extension AppDelegate {
         daemonClient.onClientSettingsUpdate = { msg in
             if msg.key == "ttsVoiceId" {
                 OpenAIVoiceService.overrideVoiceId = msg.value
+                UserDefaults.standard.set(msg.value, forKey: msg.key)
             } else if msg.key == "voiceConversationTimeoutSeconds" {
                 VoiceModeManager.conversationTimeoutOverride = Int(msg.value)
             } else {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -907,6 +907,7 @@ enum LogExporter {
             "windowZoomLevel",
             "collectUsageData",
             "sendDiagnostics",
+            "ttsVoiceId",
         ]
 
         let boolKeys = [


### PR DESCRIPTION
## Summary
- Write `ttsVoiceId` to UserDefaults in addition to the in-memory override when receiving `client_settings_update`, so the user's voice selection persists across app restarts
- Re-add `ttsVoiceId` to LogExporter diagnostics snapshot keys for support/debug visibility

Addresses review feedback from #18781.

## Test plan
- [ ] Change TTS voice via settings
- [ ] Quit and relaunch the app
- [ ] Verify the selected voice is preserved (not reset to default Amelia)
- [ ] Verify ttsVoiceId appears in diagnostic log exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
