### PR TITLE
feat: expose display metadata in CLI oauth provider commands

### DIFF
--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -51,6 +51,11 @@ function parseProviderRow(row: ReturnType<typeof getProvider>) {
   if (!row) return row;
   return {
     ...row,
+    displayName: row.displayName ?? null,
+    description: row.description ?? null,
+    dashboardUrl: row.dashboardUrl ?? null,
+    clientIdPlaceholder: row.clientIdPlaceholder ?? null,
+    requiresClientSecret: row.requiresClientSecret ?? 1,
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
     extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
@@ -203,6 +208,14 @@ Examples:
       "--ping-url <url>",
       "Health-check endpoint URL for token validation",
     )
+    .option("--display-name <name>", "Display name for the provider")
+    .option("--description <text>", "Short description")
+    .option("--dashboard-url <url>", "Developer console URL")
+    .option("--client-id-placeholder <text>", "Placeholder for client ID field")
+    .option(
+      "--no-client-secret",
+      "Set requires_client_secret to false (default is true)",
+    )
     .addHelpText(
       "after",
       `
@@ -220,6 +233,12 @@ Arguments (via options):
   --ping-url            Optional URL for a lightweight health-check endpoint.
                         Used by "connections ping" to validate that a stored token
                         is still functional (e.g. "https://api.example.com/user").
+  --display-name        Optional human-readable display name for the provider.
+  --description         Optional short description of the provider.
+  --dashboard-url       Optional URL to the provider's developer console / dashboard.
+  --client-id-placeholder  Optional placeholder text for the client ID input field.
+  --no-client-secret    If set, marks the provider as not requiring a client secret
+                        (sets requires_client_secret to 0). Default is true (1).
 
 Registers a new OAuth provider configuration in the local store. This is
 used for custom integrations not covered by the built-in provider seeds.
@@ -253,6 +272,11 @@ Examples:
           tokenAuthMethod?: string;
           callbackTransport?: string;
           pingUrl?: string;
+          displayName?: string;
+          description?: string;
+          dashboardUrl?: string;
+          clientIdPlaceholder?: string;
+          clientSecret: boolean;
         },
         cmd: Command,
       ) => {
@@ -268,6 +292,11 @@ Examples:
             tokenEndpointAuthMethod: opts.tokenAuthMethod,
             callbackTransport: opts.callbackTransport,
             pingUrl: opts.pingUrl,
+            displayName: opts.displayName,
+            description: opts.description,
+            dashboardUrl: opts.dashboardUrl,
+            clientIdPlaceholder: opts.clientIdPlaceholder,
+            requiresClientSecret: opts.clientSecret ? 1 : 0,
           });
 
           writeOutput(cmd, parseProviderRow(row));

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -148,6 +148,11 @@ export function registerProvider(params: {
   extraParams?: Record<string, string>;
   callbackTransport?: string;
   managedServiceConfigKey?: string;
+  displayName?: string;
+  description?: string;
+  dashboardUrl?: string;
+  clientIdPlaceholder?: string;
+  requiresClientSecret?: number;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -170,6 +175,11 @@ export function registerProvider(params: {
     callbackTransport: params.callbackTransport ?? null,
     pingUrl: params.pingUrl ?? null,
     managedServiceConfigKey: params.managedServiceConfigKey ?? null,
+    displayName: params.displayName ?? null,
+    description: params.description ?? null,
+    dashboardUrl: params.dashboardUrl ?? null,
+    clientIdPlaceholder: params.clientIdPlaceholder ?? null,
+    requiresClientSecret: params.requiresClientSecret ?? 1,
     createdAt: now,
     updatedAt: now,
   };
@@ -303,8 +313,7 @@ export function getApp(id: string): OAuthAppRow | undefined {
 export async function getAppClientSecret(
   appOrId: OAuthAppRow | string,
 ): Promise<string | undefined> {
-  const app =
-    typeof appOrId === "string" ? getApp(appOrId) : appOrId;
+  const app = typeof appOrId === "string" ? getApp(appOrId) : appOrId;
   if (!app) return undefined;
   return getSecureKeyAsync(app.clientSecretCredentialPath);
 }


### PR DESCRIPTION
## Summary
- Add display metadata fields (`displayName`, `description`, `dashboardUrl`, `clientIdPlaceholder`, `requiresClientSecret`) to CLI list/get output for oauth providers
- Add `--display-name`, `--description`, `--dashboard-url`, `--client-id-placeholder`, `--no-client-secret` flags to register command
- Update `registerProvider()` in oauth-store to accept and persist new fields

Part of plan: oauth-provider-display-metadata.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
