### PR TITLE
fix: dispatch voice timeout override to @MainActor in settings callback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -301,7 +301,10 @@ extension AppDelegate {
                 OpenAIVoiceService.overrideVoiceId = msg.value
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             } else if msg.key == "voiceConversationTimeoutSeconds" {
-                VoiceModeManager.conversationTimeoutOverride = Int(msg.value)
+                let parsed = Int(msg.value)
+                Task { @MainActor in
+                    VoiceModeManager.conversationTimeoutOverride = parsed
+                }
             } else {
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             }


### PR DESCRIPTION
## Summary
- Wrap `VoiceModeManager.conversationTimeoutOverride` assignment in `Task { @MainActor in }` inside `onClientSettingsUpdate`
- `VoiceModeManager` is `@MainActor`-isolated, so accessing its static var from a non-main-actor context is a concurrency violation
- Follows the same pattern used by other callbacks in the file (e.g., `onNavigateSettings`, `onAvatarUpdated`)

## Test plan
- Verify voice conversation timeout setting changes from daemon still apply correctly
- Confirm no strict concurrency warnings related to this code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
