### PR TITLE
fix: persist selectedImageGenModel to UserDefaults as local fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -361,8 +361,14 @@ public final class SettingsStore: ObservableObject {
         let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs")
         self.hasElevenLabsKey = elevenLabsKey != nil
         self.maskedElevenLabsKey = Self.maskKey(elevenLabsKey)
-        // selectedImageGenModel is initialized with a hardcoded default and
-        // populated from the daemon's workspace config via loadServiceModes().
+        // Restore persisted image-gen model as a local fallback so the
+        // user's selection survives restarts even if the daemon is unreachable.
+        // loadServiceModes() will override with the daemon's authoritative
+        // value once it connects.
+        let storedImageGenModel = UserDefaults.standard.string(forKey: "selectedImageGenModel")
+        if let storedImageGenModel, Self.availableImageGenModels.contains(storedImageGenModel) {
+            self.selectedImageGenModel = storedImageGenModel
+        }
 
         self.cmdEnterToSend = UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool ?? false
 
@@ -841,6 +847,7 @@ public final class SettingsStore: ObservableObject {
 
     func setImageGenModel(_ model: String) {
         selectedImageGenModel = model
+        UserDefaults.standard.set(model, forKey: "selectedImageGenModel")
         Task {
             _ = await settingsClient.setImageGenModel(modelId: model)
         }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -908,6 +908,7 @@ enum LogExporter {
             "collectUsageData",
             "sendDiagnostics",
             "ttsVoiceId",
+            "selectedImageGenModel",
         ]
 
         let boolKeys = [


### PR DESCRIPTION
## Summary
- Restore UserDefaults read in SettingsStore init so the user's image-gen model selection survives app restarts even when the daemon is unreachable
- Restore UserDefaults write in setImageGenModel so selections are persisted locally alongside the async daemon write
- Re-add selectedImageGenModel to LogExporter diagnostic snapshot keys

Addresses review feedback on #18784: without a local fallback, setImageGenModel only updates in-memory state and fires a best-effort async daemon request. If the daemon write fails, the selection is silently lost on restart and the hardcoded default overwrites the assistant's real model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
