### PR TITLE
fix: persist voice conversation timeout to UserDefaults from daemon handler

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -302,6 +302,9 @@ extension AppDelegate {
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             } else if msg.key == "voiceConversationTimeoutSeconds" {
                 let parsed = Int(msg.value)
+                if let parsed {
+                    UserDefaults.standard.set(parsed, forKey: msg.key)
+                }
                 Task { @MainActor in
                     VoiceModeManager.conversationTimeoutOverride = parsed
                 }


### PR DESCRIPTION
## Summary
- Persist `voiceConversationTimeoutSeconds` to UserDefaults in the `client_settings_update` handler, matching the pattern already used for `ttsVoiceId`
- Store as `Int` (not `String`) so it is compatible with `@AppStorage` in VoiceSettingsView and the `as? Int` cast in VoiceModeManager
- Addresses review feedback on #18793 about the UserDefaults fallback being ineffective

## Test plan
- [ ] Set a non-default conversation timeout via daemon (e.g. 10s)
- [ ] Quit and relaunch the app
- [ ] Verify voice mode uses the persisted timeout before daemon reconnects
- [ ] Verify the Settings UI reflects the daemon-set value after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
