### PR TITLE
feat: use colored pills for feature flag default value indicators

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1021,9 +1021,14 @@ struct SettingsDeveloperTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
-                Text("Default: \(flag.defaultEnabled ? "On" : "Off")")
-                    .font(VFont.small)
-                    .foregroundColor(VColor.contentTertiary)
+                HStack(spacing: VSpacing.xxs) {
+                    Text("Default:")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.contentTertiary)
+                    VBadge(label: flag.defaultEnabled ? "On" : "Off",
+                           tone: flag.defaultEnabled ? .danger : .neutral,
+                           emphasis: .subtle)
+                }
             }
             Spacer()
             VToggle(isOn: flagBinding)


### PR DESCRIPTION
## Summary
- Replace plain "Default: On/Off" text with VBadge pills for better visual distinction
- Default On uses red (.danger) pill to draw attention to flags enabled by default
- Default Off uses grey (.neutral) pill for a subdued indicator

## Original prompt
Make default On/Off more obvious using small chips/pills — grey for Off and red for On

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
