### PR TITLE
fix: address PR #18803 review feedback for SettingsStore provider handling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -818,8 +818,11 @@ public final class SettingsStore: ObservableObject {
         // Persist locally first
         APIKeyManager.setKey(trimmed, for: provider)
 
-        // Remove any stale deletion tombstone
-        removeDeletionTombstone(type: "api_key", name: provider)
+        // Remove any stale deletion tombstone eagerly — the user's intent is to
+        // save a new key, so any prior clear is superseded. Deferring this until
+        // after async validation creates a race: if the daemon reconnects before
+        // validation completes, replayDeletionTombstones would DELETE the new key.
+        let hadTombstone = removeDeletionTombstone(type: "api_key", name: provider)
 
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: provider, value: trimmed)
@@ -833,7 +836,11 @@ public final class SettingsStore: ObservableObject {
                 if !result.isTransient {
                     // Definitive validation failure — revert optimistic local state
                     APIKeyManager.deleteKey(for: provider)
-                    addDeletionTombstone(type: "api_key", name: provider)
+                    // Restore the deletion tombstone if one existed before we
+                    // removed it, so pending offline clears are not lost.
+                    if hadTombstone {
+                        addDeletionTombstone(type: "api_key", name: provider)
+                    }
                 }
             }
         }
@@ -2102,8 +2109,14 @@ public final class SettingsStore: ObservableObject {
         guard let services = config["services"] as? [String: Any] else { return }
         if let inference = services["inference"] as? [String: Any] {
             if let mode = inference["mode"] as? String { self.inferenceMode = mode }
-            if let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
-            if let model = inference["model"] as? String { self.selectedModel = model }
+            // Only apply local config provider/model as a fallback when the daemon
+            // hasn't yet reported an authoritative value. Once the daemon responds
+            // via applyModelInfoResponse, its values take precedence over local
+            // config which may be stale (especially for remote assistants).
+            if lastDaemonProvider == nil,
+               let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
+            if lastDaemonProvider == nil,
+               let model = inference["model"] as? String { self.selectedModel = model }
         }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -8,7 +8,7 @@ final class MockSettingsClient: SettingsClientProtocol {
 
     var fetchVercelConfigCallCount = 0
     var fetchModelInfoCallCount = 0
-    var setModelCalls: [String] = []
+    var setModelCalls: [(model: String, provider: String?)] = []
     var setImageGenModelCalls: [String] = []
     var fetchTelegramConfigCallCount = 0
     var setTelegramConfigCalls: [(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?)] = []
@@ -39,7 +39,7 @@ final class MockSettingsClient: SettingsClientProtocol {
     }
 
     func setModel(model: String, provider: String? = nil) async -> ModelInfoMessage? {
-        setModelCalls.append(model)
+        setModelCalls.append((model: model, provider: provider))
         return setModelResponse
     }
 


### PR DESCRIPTION
## Summary
- Fix tombstone lifecycle bug in `saveInferenceAPIKey`: was unconditionally adding tombstones on validation failure instead of conditionally restoring pre-existing ones (matching `saveAPIKey` pattern)
- Update `MockSettingsClient.setModelCalls` from `[String]` to `[(model: String, provider: String?)]` so tests can verify provider is passed through
- Guard `loadServiceModes()` from overwriting daemon-authoritative `selectedInferenceProvider`/`selectedModel` with stale local config after reconnect

## Test plan
- [ ] Verify `saveInferenceAPIKey` tombstone behavior: clear key while offline, attempt save with invalid key, confirm tombstone is restored
- [ ] Verify `loadServiceModes` doesn't clobber daemon provider after reconnect
- [ ] Verify mock captures provider in `setModelCalls` tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
