### PR TITLE
fix: validate provider input at PUT /v1/model route boundary

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -13,6 +13,7 @@
  * DELETE /v1/messages/queued/:id        — delete queued message
  */
 
+import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import {
   getModelInfo,
   type ModelSetContext,
@@ -27,6 +28,8 @@ import { deleteQueuedMessage } from "../../daemon/handlers/conversations.js";
 import { getRequestLogsByMessageId } from "../../memory/llm-request-log-store.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+
+const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
 
 // ---------------------------------------------------------------------------
 // Dependency interfaces
@@ -75,6 +78,17 @@ export function conversationQueryRouteDefinitions(
           return httpError(
             "BAD_REQUEST",
             "Missing required field: modelId",
+            400,
+          );
+        }
+        if (
+          body.provider !== undefined &&
+          (typeof body.provider !== "string" ||
+            !validProviderSet.has(body.provider))
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            `Invalid provider "${body.provider}". Valid providers: ${[...validProviderSet].join(", ")}`,
             400,
           );
         }


### PR DESCRIPTION
## Summary
- Validates the `provider` field in `PUT /v1/model` at the route boundary before passing it to `setModel()`
- Invalid or unknown provider values now return `400 BAD_REQUEST` instead of falling through to `setModel()` where they would throw and be caught as `500 INTERNAL_ERROR`
- Uses the canonical `VALID_INFERENCE_PROVIDERS` list from the services schema for validation

Addresses P2 feedback from PR #18801: provider input from client payloads was not type-checked at the route boundary, causing invalid inputs to be misclassified as server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
