### PR TITLE
fix: clean command removes per-repo SPM module cache

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -354,6 +354,7 @@ case "$CMD" in
         echo "Cleaning..."
         rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
         rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin"
+        rm -rf "$SPM_MODULE_CACHE"
         echo "Done."
         exit 0
         ;;


### PR DESCRIPTION
## Summary
- Add removal of per-repo SPM module cache to the `clean` command in `clients/macos/build.sh`
- Ensures `./build.sh clean` removes stale PCH artifacts under `/tmp/spm-module-cache/`

Addresses review feedback from PR #18852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
