### PR TITLE
fix: guard provider-change model reset to user-initiated selections in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -30,6 +30,8 @@ struct InferenceServiceCard: View {
     @State private var draftProvider: String = "anthropic"
     /// Snapshot of the provider at card appear — used to detect provider changes.
     @State private var initialProvider: String = ""
+    /// Guards against provider-change side-effects during initial load.
+    @State private var didInitialSync = false
 
     // MARK: - Feature Flag
 
@@ -142,6 +144,7 @@ struct InferenceServiceCard: View {
             initialModel = store.selectedModel
             draftProvider = store.selectedInferenceProvider
             initialProvider = store.selectedInferenceProvider
+            didInitialSync = true
 
             // If the user is not authenticated and the persisted mode is
             // "managed", reset the draft so the UI shows "your-own".
@@ -191,8 +194,13 @@ struct InferenceServiceCard: View {
             }
         }
         .onChange(of: store.selectedInferenceProvider) { _, newValue in
+            // Sync draft & baseline when the daemon reports a provider
+            // update. Also refresh the model baseline so hasChanges does
+            // not flag a stale diff against the old provider's model.
             draftProvider = newValue
             initialProvider = newValue
+            draftModel = store.selectedModel
+            initialModel = store.selectedModel
         }
         .onChange(of: store.selectedModel) { _, newValue in
             // Sync draft & baseline when external changes arrive (e.g. daemon model info refresh)
@@ -200,6 +208,13 @@ struct InferenceServiceCard: View {
             initialModel = newValue
         }
         .onChange(of: draftProvider) { _, newProvider in
+            // Only reset the model and API key text for user-initiated
+            // provider changes. Skip during initial load (onAppear sets
+            // draftProvider before didInitialSync is true) and during
+            // external store syncs (onChange of store.selectedInferenceProvider
+            // updates both draftProvider and initialProvider together, so
+            // they will match).
+            guard didInitialSync, newProvider != initialProvider else { return }
             if isCustomProviderEnabled {
                 let defaultModel = store.dynamicProviderDefaultModel(newProvider)
                 let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""


### PR DESCRIPTION
## Summary
- Adds a `didInitialSync` flag to prevent `onChange(of: draftProvider)` from resetting the model during initial load
- Guards the handler with `newProvider != initialProvider` so daemon-driven provider syncs (which update both `draftProvider` and `initialProvider` together) are also skipped
- Updates `onChange(of: store.selectedInferenceProvider)` to sync model baselines alongside provider baselines, preventing stale `hasChanges` state after daemon updates
- Addresses review feedback from PR #18817

## Test plan
- [ ] Open Settings with a saved non-default provider + custom model, verify model is not overwritten on load
- [ ] Switch providers in the picker, verify model resets to provider default (desired user-initiated behavior)
- [ ] Verify daemon provider refresh does not cause spurious model changes or false-dirty Save button

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
