### PR TITLE
fix: harden Docker upgrade rollback ordering and error handling

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -213,18 +213,10 @@ async function upgradeDocker(
     `🔄 Upgrading Docker assistant '${instanceName}' to ${versionTag}...\n`,
   );
 
-  console.log("📦 Pulling new Docker images...");
-  await exec("docker", ["pull", imageTags.assistant]);
-  await exec("docker", ["pull", imageTags.gateway]);
-  await exec("docker", ["pull", imageTags["credential-executor"]]);
-  console.log("✅ Docker images pulled\n");
-
-  console.log("💾 Capturing existing container environment...");
-  const capturedEnv = await captureContainerEnv(res.assistantContainer);
-  console.log(
-    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
-  );
-
+  // Capture rollback state from existing containers BEFORE pulling new
+  // images or stopping anything.  captureImageRefs uses the immutable
+  // image digest ({{.Image}}), but capturing first keeps the intent
+  // explicit and avoids relying on container-inspect ordering subtleties.
   console.log("📸 Capturing current image references for rollback...");
   const previousImageRefs = await captureImageRefs(res);
   if (previousImageRefs) {
@@ -234,6 +226,18 @@ async function upgradeDocker(
   } else {
     console.log("   No existing containers found (fresh install)\n");
   }
+
+  console.log("💾 Capturing existing container environment...");
+  const capturedEnv = await captureContainerEnv(res.assistantContainer);
+  console.log(
+    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
+  );
+
+  console.log("📦 Pulling new Docker images...");
+  await exec("docker", ["pull", imageTags.assistant]);
+  await exec("docker", ["pull", imageTags.gateway]);
+  await exec("docker", ["pull", imageTags["credential-executor"]]);
+  console.log("✅ Docker images pulled\n");
 
   console.log("🛑 Stopping existing containers...");
   await stopContainers(res);
@@ -296,28 +300,38 @@ async function upgradeDocker(
 
     if (previousImageRefs) {
       console.log(`\n🔄 Rolling back to previous images...`);
-      await stopContainers(res);
+      try {
+        await stopContainers(res);
 
-      await startContainers(
-        {
-          extraAssistantEnv,
-          gatewayPort,
-          imageTags: previousImageRefs,
-          instanceName,
-          res,
-        },
-        (msg) => console.log(msg),
-      );
-
-      const rollbackReady = await waitForReady(entry.runtimeUrl);
-      if (rollbackReady) {
-        console.log(
-          `\n⚠️  Rolled back to previous version. Upgrade to ${versionTag} failed.`,
+        await startContainers(
+          {
+            extraAssistantEnv,
+            gatewayPort,
+            imageTags: previousImageRefs,
+            instanceName,
+            res,
+          },
+          (msg) => console.log(msg),
         );
-      } else {
+
+        const rollbackReady = await waitForReady(entry.runtimeUrl);
+        if (rollbackReady) {
+          console.log(
+            `\n⚠️  Rolled back to previous version. Upgrade to ${versionTag} failed.`,
+          );
+        } else {
+          console.error(
+            `\n❌ Rollback also failed. Manual intervention required.`,
+          );
+          console.log(
+            `   Check logs with: docker logs -f ${res.assistantContainer}`,
+          );
+        }
+      } catch (rollbackErr) {
         console.error(
-          `\n❌ Rollback also failed. Manual intervention required.`,
+          `\n❌ Rollback failed: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
         );
+        console.error(`   Manual intervention required.`);
         console.log(
           `   Check logs with: docker logs -f ${res.assistantContainer}`,
         );


### PR DESCRIPTION
## Summary
- Move image ref capture before `docker pull` so rollback state is captured before any local image state changes
- Wrap rollback `startContainers` + `waitForReady` in try-catch so docker failures during rollback produce a user-friendly error instead of an unhandled exception crash

Addresses review feedback from #18928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
