### PR TITLE
fix: align upgrade log message with captureImageRefs null semantics

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -232,7 +232,9 @@ async function upgradeDocker(
       `   Captured refs for ${Object.keys(previousImageRefs).length} service(s)\n`,
     );
   } else {
-    console.log("   No existing containers found (fresh install)\n");
+    console.log(
+      "   Could not capture all container refs (fresh install or partial deployment)\n",
+    );
   }
 
   console.log("🛑 Stopping existing containers...");


### PR DESCRIPTION
## Summary
- Updates the log message in `upgrade.ts` when `captureImageRefs` returns null to reflect that null can mean either a fresh install or a partial deployment, not just a fresh install.
- Addresses review feedback from PR #18963 where the JSDoc was updated to document all-or-nothing return semantics but the call site log message was not updated to match.

## Test plan
- [ ] Verify the log message is accurate when `captureImageRefs` returns null in both fresh install and partial deployment scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
