### PR TITLE
docs: document camelCase wire format for ServiceGroupUpdate Swift types

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2775,6 +2775,11 @@ public struct NotificationIntentResult: Codable, Sendable {
 }
 
 /// Broadcast to connected clients when a service group update is about to begin.
+///
+/// Wire format uses camelCase keys (matching the daemon TypeScript definition
+/// in `assistant/src/daemon/message-types/upgrades.ts`). The `JSONDecoder` in
+/// `HTTPDaemonClient` uses default key decoding (no `.convertFromSnakeCase`),
+/// so property names here must match the camelCase wire keys exactly.
 public struct ServiceGroupUpdateStarting: Codable, Sendable {
     public let type: String
     /// The version being upgraded to.
@@ -2790,6 +2795,11 @@ public struct ServiceGroupUpdateStarting: Codable, Sendable {
 }
 
 /// Broadcast to connected clients when a service group update has completed.
+///
+/// Wire format uses camelCase keys (matching the daemon TypeScript definition
+/// in `assistant/src/daemon/message-types/upgrades.ts`). The `JSONDecoder` in
+/// `HTTPDaemonClient` uses default key decoding (no `.convertFromSnakeCase`),
+/// so property names here must match the camelCase wire keys exactly.
 public struct ServiceGroupUpdateComplete: Codable, Sendable {
     public let type: String
     /// The version that was installed (may differ from target if rolled back).


### PR DESCRIPTION
## Summary
- Add documentation comments to `ServiceGroupUpdateStarting` and `ServiceGroupUpdateComplete` in `GeneratedAPITypes.swift`
- Clarifies that property names must match camelCase wire keys from the daemon TypeScript definitions in `assistant/src/daemon/message-types/upgrades.ts`
- The `JSONDecoder` in `HTTPDaemonClient` uses default key decoding (no `.convertFromSnakeCase`), so Swift property names must exactly match the camelCase keys sent by the daemon

Addresses review feedback from #18926 — the Devin bot flagged a concern about key format mismatches between the daemon and client. The daemon TypeScript definitions already use camelCase, matching the Swift structs. These comments make that invariant explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
