### PR TITLE
fix: harden update-in-progress state across transport lifecycle

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -91,6 +91,13 @@ extension DaemonClient {
 
         self.httpTransport = transport
 
+        // Propagate update-in-progress state to the new transport so
+        // accelerated health-check polling survives transport recreation
+        // (e.g. auto-wake reconnect during a planned update).
+        if isUpdateInProgress {
+            transport.isUpdateInProgress = true
+        }
+
         do {
             try await transport.connect()
             isAuthenticated = true  // HTTP transport uses bearer token, no additional auth needed
@@ -180,7 +187,7 @@ extension DaemonClient {
                 isUpdateInProgress = false
                 updateTargetVersion = nil
                 updateExpiresAt = nil
-                httpTransport?.isUpdateInProgress = false
+                httpTransport?.setUpdateInProgress(false)
             } else {
                 log.info("auto-wake: skipping — planned service group update in progress")
                 return

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -24,7 +24,7 @@ extension DaemonClient {
                     self.isUpdateInProgress = false
                     self.updateTargetVersion = nil
                     self.updateExpiresAt = nil
-                    self.httpTransport?.isUpdateInProgress = false
+                    self.httpTransport?.setUpdateInProgress(false)
                 }
             }
             if let newFingerprint = status.keyFingerprint {
@@ -111,14 +111,14 @@ extension DaemonClient {
             // Allow 2x the expected downtime before expiring the suppression,
             // so auto-wake can recover if the update process crashes.
             self.updateExpiresAt = Date().addingTimeInterval(msg.expectedDowntimeSeconds * 2)
-            self.httpTransport?.isUpdateInProgress = true
+            self.httpTransport?.setUpdateInProgress(true)
             log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
             onServiceGroupUpdateStarting?(msg)
         case .serviceGroupUpdateComplete(let msg):
             self.isUpdateInProgress = false
             self.updateTargetVersion = nil
             self.updateExpiresAt = nil
-            self.httpTransport?.isUpdateInProgress = false
+            self.httpTransport?.setUpdateInProgress(false)
             log.info("Service group update complete — version: \(msg.installedVersion, privacy: .public), success: \(msg.success)")
             onServiceGroupUpdateComplete?(msg)
         case .trustRulesListResponse:

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -152,7 +152,20 @@ public final class HTTPTransport {
 
     /// Set by the owning DaemonClient when a planned service group update
     /// is in progress. Accelerates health check polling for faster reconnection.
+    /// Use `setUpdateInProgress(_:)` to restart the health-check loop when
+    /// the flag transitions to `true`, avoiding a stale 15s sleep.
     var isUpdateInProgress: Bool = false
+
+    /// Update the in-progress flag and restart the health-check loop when
+    /// transitioning to `true`. This avoids waiting out a stale 15s sleep
+    /// before the accelerated 2s polling kicks in.
+    func setUpdateInProgress(_ value: Bool) {
+        let wasInProgress = isUpdateInProgress
+        isUpdateInProgress = value
+        if value && !wasInProgress && healthCheckTask != nil {
+            startHealthCheckLoop()
+        }
+    }
 
     /// Current reconnect backoff delay in seconds (for SSE).
     private var sseReconnectDelay: TimeInterval = 1.0
@@ -682,6 +695,12 @@ public final class HTTPTransport {
                 throw HTTPTransportError.healthCheckFailed
             }
             log.info("Health check passed for \(self.baseURL, privacy: .public)")
+            // When the daemon comes back during a planned update, reset the
+            // SSE reconnect backoff so the event stream reconnects quickly
+            // instead of waiting up to 30s of exponential backoff.
+            if isUpdateInProgress {
+                sseReconnectDelay = 1.0
+            }
             setConnected(true)
         } catch let error as HTTPTransportError {
             setConnected(false)


### PR DESCRIPTION
## Summary
- Propagate `isUpdateInProgress` to new `HTTPTransport` instances created during reconnect, so accelerated 2s polling survives transport recreation
- Add `setUpdateInProgress()` that restarts the health-check loop when the flag transitions to `true`, so the client does not wait out a stale 15s sleep
- Reset SSE reconnect backoff (`sseReconnectDelay`) when health check passes during a planned update, so the event stream reconnects in ~1s instead of up to 30s

Addresses review feedback from #18931.

## Test plan
- [ ] Trigger a service group update and verify health-check polling immediately switches to 2s (no stale 15s wait)
- [ ] Verify that when the daemon comes back after a planned update, SSE reconnects within ~1s (not 30s backoff)
- [ ] Confirm that auto-wake reconnect during a planned update preserves 2s polling on the new transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
