### PR TITLE
Fix iOS Build CI failure

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -80,6 +80,36 @@ private struct PersistedConversation: Codable {
         case legacySessionId = "sessionId"
     }
 
+    init(
+        id: UUID,
+        title: String,
+        createdAt: Date,
+        lastActivityAt: Date? = nil,
+        isArchived: Bool? = nil,
+        isPinned: Bool? = nil,
+        displayOrder: Int? = nil,
+        isPrivate: Bool? = nil,
+        conversationId: String? = nil,
+        scheduleJobId: String? = nil,
+        hasUnseenLatestAssistantMessage: Bool? = nil,
+        latestAssistantMessageAt: Date? = nil,
+        lastSeenAssistantMessageAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.lastActivityAt = lastActivityAt
+        self.isArchived = isArchived
+        self.isPinned = isPinned
+        self.displayOrder = displayOrder
+        self.isPrivate = isPrivate
+        self.conversationId = conversationId
+        self.scheduleJobId = scheduleJobId
+        self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
+        self.latestAssistantMessageAt = latestAssistantMessageAt
+        self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)


### PR DESCRIPTION
## Summary
- restore an explicit memberwise initializer for PersistedConversation so the custom Codable decoder does not remove the initializer used by the save paths
- keep the change scoped to the specific job from https://github.com/vellum-ai/vellum-assistant/actions/runs/23280798503/job/67693741197
- Apple refs checked (2026-03-19): Swift memberwise initializer behavior for structs with custom initializers

## Verification
- swiftc -typecheck on a minimal Codable reproduction covering both CI-failing PersistedConversation(...) call shapes
- cd clients/ios && ./build.sh test (blocked locally: no iPhone simulator installed)
- xcodebuild build -project vellum-assistant-ios.xcodeproj -scheme VellumAssistantIOS -destination generic/platform=iOS Simulator -configuration Debug CODE_SIGNING_ALLOWED=NO (blocked locally: iOS 26.2 platform not installed)

## CI job
- Job: https://github.com/vellum-ai/vellum-assistant/actions/runs/23280798503/job/67693741197
- Workflow: CI Main iOS Build
- Failed step: Build & test

## Original prompt
$ci https://github.com/vellum-ai/vellum-assistant/actions/runs/23280798503/job/67693741197
