### PR TITLE
fix: align self-info fallback mode with schema default

### DIFF
--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
       config = {
         model: "claude-opus-4-6",
         provider: "anthropic",
-        mode: "unknown",
+        mode: "your-own",
       };
     } else {
       config = JSON.parse(raw) as {


### PR DESCRIPTION
## Summary
- Changed the fallback `mode` in `self-info.ts` from `"unknown"` to `"your-own"` to match the canonical schema default in `assistant/src/config/schemas/services.ts`
- When inference config is unset (`"(not set)"`), the script now correctly reports the mode as `"your-own API key"` instead of the misleading `"unknown"`

## Test plan
- [ ] Verify self-info script output when inference config is not set shows "your-own API key" mode
- [ ] Verify self-info script output when inference config is explicitly set still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
