### PR TITLE
fix: sync vellum-self-knowledge catalog entry with SKILL.md frontmatter

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -596,7 +596,15 @@
       "metadata": {
         "emoji": "🪞",
         "vellum": {
-          "display-name": "Vellum Self-Knowledge"
+          "display-name": "Vellum Self-Knowledge",
+          "activation-hints": [
+            "When the user asks what model the assistant is running on",
+            "When the user asks about Vellum, how the assistant works, or its architecture",
+            "When the user asks about the assistant's current configuration or settings"
+          ],
+          "avoid-when": [
+            "When the user wants to change configuration (use in-chat config instead)"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vellum-self-knowledge
 description: Answer questions about Vellum, the assistant's architecture, and its current configuration including which model and provider are active
+compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🪞"
   vellum:


### PR DESCRIPTION
## Summary
- Added missing `compatibility` field to `skills/vellum-self-knowledge/SKILL.md` frontmatter to match all other skills
- Regenerated `skills/catalog.json` to sync with SKILL.md, restoring `activation-hints` and `avoid-when` metadata that were accidentally stripped in #19240

Addresses review feedback on #18995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
