### PR TITLE
fix: handle bidirectional model reset and force-persist on inference mode switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -230,6 +230,15 @@ struct InferenceServiceCard: View {
                     let defaultModel = store.dynamicProviderDefaultModel("anthropic")
                     draftModel = defaultModel.isEmpty ? "claude-opus-4-6" : defaultModel
                 }
+            } else if newMode == "your-own" && isCustomProviderEnabled {
+                let providerModels = store.dynamicProviderModels(draftProvider)
+                let isCurrentModelValid = providerModels.contains { $0.id == draftModel }
+                if !isCurrentModelValid {
+                    let defaultModel = store.dynamicProviderDefaultModel(draftProvider)
+                    draftModel = defaultModel.isEmpty
+                        ? (providerModels.first?.id ?? "")
+                        : defaultModel
+                }
             }
         }
         .alert("Heads up", isPresented: $showWebSearchAlert) {
@@ -374,14 +383,21 @@ struct InferenceServiceCard: View {
     private func performSave() {
         store.apiKeySaveError = nil
 
+        // Detect mode change before persisting so downstream logic can
+        // force-persist provider/model even when IDs happen to match.
+        let modeChanged = draftMode != store.inferenceMode
+
         // Persist mode if changed
-        if draftMode != store.inferenceMode {
+        if modeChanged {
             store.setInferenceMode(draftMode)
         }
 
-        // Persist provider if changed and flag is on
+        // Persist provider if changed and flag is on. Also re-persist when
+        // the mode changed — switching between managed and your-own implies
+        // a provider change even if the resolved provider ID happens to
+        // match initialProvider (ensures config stays consistent).
         let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
-        if isCustomProviderEnabled && persistProvider != initialProvider {
+        if isCustomProviderEnabled && (persistProvider != initialProvider || modeChanged) {
             store.setInferenceProvider(persistProvider)
             initialProvider = persistProvider
         }
@@ -406,13 +422,15 @@ struct InferenceServiceCard: View {
             }
         }
 
-        // Persist model selection
+        // Persist model selection. Force-send to daemon when the mode
+        // changed so the model+provider pair is always re-persisted,
+        // even if IDs happen to match the daemon's cached state.
         store.selectedModel = draftModel
         if isCustomProviderEnabled {
             let saveProvider = draftMode == "managed" ? "anthropic" : draftProvider
-            store.setModel(draftModel, provider: saveProvider)
+            store.setModel(draftModel, provider: saveProvider, force: modeChanged)
         } else {
-            store.setModel(draftModel)
+            store.setModel(draftModel, force: modeChanged)
         }
         initialModel = draftModel
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2796,11 +2796,15 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Model Actions
 
-    func setModel(_ model: String, provider: String? = nil) {
-        // Skip if neither model nor provider changed
-        let modelUnchanged = model == lastDaemonModel
-        let providerUnchanged = provider == nil || provider == lastDaemonProvider
-        guard !modelUnchanged || !providerUnchanged else { return }
+    func setModel(_ model: String, provider: String? = nil, force: Bool = false) {
+        // Skip if neither model nor provider changed (unless forced,
+        // e.g. after an inference-mode switch that requires re-persisting
+        // the model+provider pair even when IDs haven't changed).
+        if !force {
+            let modelUnchanged = model == lastDaemonModel
+            let providerUnchanged = provider == nil || provider == lastDaemonProvider
+            guard !modelUnchanged || !providerUnchanged else { return }
+        }
         lastDaemonModel = model
         if let provider { lastDaemonProvider = provider }
         Task {


### PR DESCRIPTION
## Summary
- Add reverse-direction model reset when switching from Managed back to Your Own mode, preventing invalid model+provider combinations (e.g., Anthropic model ID paired with OpenAI provider)
- Add `force` parameter to `SettingsStore.setModel()` to bypass the short-circuit guard when the inference mode changes, ensuring the model+provider pair is always re-persisted to the daemon
- Re-persist the provider via `setInferenceProvider()` on mode changes even when the resolved provider ID matches `initialProvider`

Addresses review feedback on #19004.

## Test plan
- [ ] Enable `custom-inference-provider` flag
- [ ] Set Your Own mode with a non-Anthropic provider (e.g., OpenAI) and a non-Anthropic model
- [ ] Switch to Managed mode -- verify model resets to an Anthropic default
- [ ] Switch back to Your Own -- verify model resets to the Your Own provider's default (not the Anthropic model)
- [ ] Save in both directions and verify config has correct model+provider pairing
- [ ] Round-trip Managed -> Your Own -> Managed and save -- verify no stale provider in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
