### PR TITLE
fix: local assistants always use workspace config for provider/model, refresh masked keys after key replay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -318,6 +318,7 @@ struct InferenceServiceCard: View {
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
             SecureField(placeholder, text: $apiKeyText)
+                .id("inference-api-key-\(effectiveProvider)-\(placeholder)")
                 .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1200,6 +1200,10 @@ public final class SettingsStore: ObservableObject {
             }
 
             replayDeletionTombstones()
+            // Re-fetch model info after reconnect-time key replay so maskedKeys
+            // can reflect newly synced provider secrets.
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            refreshModelInfo()
         }
     }
 
@@ -2117,14 +2121,18 @@ public final class SettingsStore: ObservableObject {
         guard let services = config["services"] as? [String: Any] else { return }
         if let inference = services["inference"] as? [String: Any] {
             if let mode = inference["mode"] as? String { self.inferenceMode = mode }
-            // Only apply local config provider/model as a fallback when the daemon
-            // hasn't yet reported an authoritative value. Once the daemon responds
-            // via applyModelInfoResponse, its values take precedence over local
-            // config which may be stale (especially for remote assistants).
-            if lastDaemonProvider == nil,
-               let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
-            if lastDaemonProvider == nil,
-               let model = inference["model"] as? String { self.selectedModel = model }
+            // Local assistants should always reflect persisted workspace config.
+            // Remote assistants may not have local workspace state, so retain
+            // daemon-reported provider/model once available.
+            if !isCurrentAssistantRemote {
+                if let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
+                if let model = inference["model"] as? String { self.selectedModel = model }
+            } else {
+                if lastDaemonProvider == nil,
+                   let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
+                if lastDaemonProvider == nil,
+                   let model = inference["model"] as? String { self.selectedModel = model }
+            }
         }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {


### PR DESCRIPTION
## Summary
- `loadServiceModes()`: local assistants now always apply provider/model from workspace config (source of truth), removing the `lastDaemonProvider == nil` guard that blocked config values after the daemon reported stale defaults. Remote assistants still defer to daemon-reported values.
- Add delayed `refreshModelInfo()` after reconnect-time key replay so masked keys reflect newly synced provider secrets
- Add `.id()` modifier to SecureField to force SwiftUI to recreate it when provider/placeholder changes, preventing stale placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
