### PR TITLE
fix: remove unused dynamicProviderApiKeyUrl from SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -978,10 +978,6 @@ public final class SettingsStore: ObservableObject {
         providerCatalog.first { $0.id == provider }?.defaultModel ?? ""
     }
 
-    func dynamicProviderApiKeyUrl(_ provider: String) -> String? {
-        providerCatalog.first { $0.id == provider }?.apiKeyUrl
-    }
-
     func dynamicProviderApiKeyPlaceholder(_ provider: String) -> String? {
         providerCatalog.first { $0.id == provider }?.apiKeyPlaceholder
     }


### PR DESCRIPTION
## Summary
- Remove the `dynamicProviderApiKeyUrl(_:)` method from `SettingsStore.swift` — it was introduced in PR #19048 but has no callers anywhere in the codebase
- Per the repo's dead code removal policy in AGENTS.md, unused code should be proactively removed

Addresses review feedback on #19048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
