### PR TITLE
fix: normalize draftProvider in managed mode to prevent stuck Save button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -95,7 +95,8 @@ struct InferenceServiceCard: View {
         let modeChanged = draftMode != store.inferenceMode
         let hasNewKey = draftMode == "your-own" && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let modelChanged = draftModel != initialModel
-        let providerChanged = isCustomProviderEnabled && draftProvider != initialProvider
+        let effectiveDraftProvider = draftMode == "managed" ? "anthropic" : draftProvider
+        let providerChanged = isCustomProviderEnabled && effectiveDraftProvider != initialProvider
         return modeChanged || hasNewKey || modelChanged || providerChanged
     }
 
@@ -400,6 +401,11 @@ struct InferenceServiceCard: View {
         if isCustomProviderEnabled && (persistProvider != initialProvider || modeChanged) {
             store.setInferenceProvider(persistProvider)
             initialProvider = persistProvider
+        }
+        // Normalize draftProvider to match what was persisted so hasChanges
+        // (which compares draftProvider against initialProvider) stays in sync.
+        if isCustomProviderEnabled && draftProvider != persistProvider {
+            draftProvider = persistProvider
         }
 
         // Persist API key if entered and in your-own mode.


### PR DESCRIPTION
## Summary
- Fixes Save button staying enabled indefinitely after saving in managed mode when draftProvider differs from the persisted anthropic provider
- `hasChanges` now resolves the effective provider using the same logic as `performSave` (managed mode -> anthropic)
- `performSave` normalizes `draftProvider` to match `persistProvider` after saving, keeping UI state consistent

Addresses review feedback from PR #19013.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
