### PR TITLE
fix: seed iOS providerCatalog, deepen Equatable check, fix footer text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1361,7 +1361,7 @@ private struct MessageCellView: View, Equatable {
             && zip(lhs.catalogModels, rhs.catalogModels).allSatisfy({ $0.id == $1.id && $0.name == $1.name })
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.providerCatalog.count == rhs.providerCatalog.count
-            && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.models.count == $1.models.count })
+            && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName && $0.models.count == $1.models.count && zip($0.models, $1.models).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName }) })
     }
 
     let message: ChatMessage

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -404,36 +404,9 @@ public final class SettingsStore: ObservableObject {
         // Load service modes (inference, image-generation) from workspace config
         loadServiceModes()
 
-        // Seed provider catalog with inline defaults so the UI has data before
+        // Seed provider catalog with shared defaults so the UI has data before
         // the first daemon fetch completes.
-        providerCatalog = [
-            ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
-                CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
-                CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-                CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-            ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
-            ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
-                CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
-                CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
-                CatalogModel(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
-                CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
-            ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys", apiKeyPlaceholder: "sk-proj-..."),
-            ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
-                CatalogModel(id: "gemini-3-flash", displayName: "Gemini 3 Flash"),
-                CatalogModel(id: "gemini-3-pro", displayName: "Gemini 3 Pro"),
-            ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey", apiKeyPlaceholder: "AIza..."),
-            ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
-                CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
-                CatalogModel(id: "mistral", displayName: "Mistral"),
-            ], defaultModel: "llama3.2"),
-            ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
-                CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
-            ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
-            ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
-                CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
-                CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
-            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
-        ]
+        providerCatalog = ProviderCatalogEntry.defaultCatalog
 
         // When enabledSince was defaulted to "now" (no value on disk),
         // persist it immediately so subsequent loads produce the same

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -79,8 +79,44 @@ public final class ChatMessageManager: ObservableObject {
     /// Set of provider keys with configured API keys, updated via `model_info` messages.
     @Published public var configuredProviders: Set<String> = ["anthropic"]
     /// Full provider catalog from daemon, updated via `model_info` messages.
-    @Published public var providerCatalog: [ProviderCatalogEntry] = []
+    /// Seeded with inline defaults so the UI has data before the first daemon fetch completes.
+    @Published public var providerCatalog: [ProviderCatalogEntry] = ProviderCatalogEntry.defaultCatalog
     /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x"), updated via `model_info` messages.
     @Published public var providerMaskedKeys: [String: String] = [:]
 
+}
+
+// MARK: - Default Provider Catalog
+
+extension ProviderCatalogEntry {
+    /// Inline seed data shared by ChatMessageManager and SettingsStore so the
+    /// model picker / model list has data before the first daemon fetch completes.
+    public static let defaultCatalog: [ProviderCatalogEntry] = [
+        ProviderCatalogEntry(id: "anthropic", displayName: "Anthropic", models: [
+            CatalogModel(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
+            CatalogModel(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+            CatalogModel(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
+        ], defaultModel: "claude-opus-4-6", apiKeyUrl: "https://console.anthropic.com/settings/keys", apiKeyPlaceholder: "sk-ant-api03-..."),
+        ProviderCatalogEntry(id: "openai", displayName: "OpenAI", models: [
+            CatalogModel(id: "gpt-5.4", displayName: "GPT-5.4"),
+            CatalogModel(id: "gpt-5.2", displayName: "GPT-5.2"),
+            CatalogModel(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
+            CatalogModel(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
+        ], defaultModel: "gpt-5.4", apiKeyUrl: "https://platform.openai.com/api-keys", apiKeyPlaceholder: "sk-proj-..."),
+        ProviderCatalogEntry(id: "gemini", displayName: "Google Gemini", models: [
+            CatalogModel(id: "gemini-3-flash", displayName: "Gemini 3 Flash"),
+            CatalogModel(id: "gemini-3-pro", displayName: "Gemini 3 Pro"),
+        ], defaultModel: "gemini-3-flash", apiKeyUrl: "https://aistudio.google.com/apikey", apiKeyPlaceholder: "AIza..."),
+        ProviderCatalogEntry(id: "ollama", displayName: "Ollama", models: [
+            CatalogModel(id: "llama3.2", displayName: "Llama 3.2"),
+            CatalogModel(id: "mistral", displayName: "Mistral"),
+        ], defaultModel: "llama3.2"),
+        ProviderCatalogEntry(id: "fireworks", displayName: "Fireworks", models: [
+            CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
+        ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
+        ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
+            CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
+            CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
+        ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
+    ]
 }

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -89,7 +89,7 @@ public struct ModelListBubble: View {
             }
 
             // Footer
-            Text("Switch with /shortcut or `keys set <provider> <key>` to add a provider.")
+            Text("Switch with /model <id> or `keys set <provider> <key>` to add a provider.")
                 .font(VFont.small)
                 .foregroundColor(VColor.contentTertiary)
                 .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
## Summary
Addresses three review comments from PR #19021:

- **Seed iOS providerCatalog**: `ChatMessageManager.providerCatalog` was initialized to `[]`, causing the model picker/list to render with no models on iOS until the daemon responded. Extracted the seed data from `SettingsStore` into a shared `ProviderCatalogEntry.defaultCatalog` constant and used it in both places, eliminating duplication.
- **Deepen Equatable check**: `MessageCellView` equality only compared provider IDs and model counts, missing changes to model IDs or display names. Now compares individual model `id` and `displayName` within each provider so the UI re-renders when model data changes.
- **Fix footer text**: Updated "Switch with /shortcut" to "Switch with /model <id>" since the displayed values are now full model identifiers, not slash shortcuts.

## Test plan
- [ ] Verify iOS model picker shows seeded models immediately on launch (before daemon fetch)
- [ ] Verify macOS model list re-renders when model names change without count changes
- [ ] Verify footer text matches the model switching UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
