### PR TITLE
fix: align tombstone handling in provider-specific save methods with saveAPIKey pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -671,7 +671,9 @@ public final class SettingsStore: ObservableObject {
         guard !trimmed.isEmpty else { return }
         braveKeySaveError = nil
         APIKeyManager.setKey(trimmed, for: "brave")
-        removeDeletionTombstone(type: "api_key", name: "brave")
+        // Remove any stale deletion tombstone eagerly — the user's intent is to
+        // save a new key, so any prior clear is superseded.
+        let hadTombstone = removeDeletionTombstone(type: "api_key", name: "brave")
         hasBraveKey = true
         maskedBraveKey = Self.maskKey(trimmed)
         Task {
@@ -684,6 +686,11 @@ public final class SettingsStore: ObservableObject {
                     APIKeyManager.deleteKey(for: "brave")
                     hasBraveKey = false
                     maskedBraveKey = ""
+                    // Restore the deletion tombstone if one existed before we
+                    // removed it, so pending offline clears are not lost.
+                    if hadTombstone {
+                        addDeletionTombstone(type: "api_key", name: "brave")
+                    }
                 }
             }
         }
@@ -703,7 +710,9 @@ public final class SettingsStore: ObservableObject {
         guard !trimmed.isEmpty else { return }
         perplexityKeySaveError = nil
         APIKeyManager.setKey(trimmed, for: "perplexity")
-        removeDeletionTombstone(type: "api_key", name: "perplexity")
+        // Remove any stale deletion tombstone eagerly — the user's intent is to
+        // save a new key, so any prior clear is superseded.
+        let hadTombstone = removeDeletionTombstone(type: "api_key", name: "perplexity")
         hasPerplexityKey = true
         maskedPerplexityKey = Self.maskKey(trimmed)
         Task {
@@ -716,6 +725,11 @@ public final class SettingsStore: ObservableObject {
                     APIKeyManager.deleteKey(for: "perplexity")
                     hasPerplexityKey = false
                     maskedPerplexityKey = ""
+                    // Restore the deletion tombstone if one existed before we
+                    // removed it, so pending offline clears are not lost.
+                    if hadTombstone {
+                        addDeletionTombstone(type: "api_key", name: "perplexity")
+                    }
                 }
             }
         }
@@ -735,7 +749,9 @@ public final class SettingsStore: ObservableObject {
         guard !trimmed.isEmpty else { return }
         imageGenKeySaveError = nil
         APIKeyManager.setKey(trimmed, for: "gemini")
-        removeDeletionTombstone(type: "api_key", name: "gemini")
+        // Remove any stale deletion tombstone eagerly — the user's intent is to
+        // save a new key, so any prior clear is superseded.
+        let hadTombstone = removeDeletionTombstone(type: "api_key", name: "gemini")
         hasImageGenKey = true
         maskedImageGenKey = Self.maskKey(trimmed)
         Task {
@@ -748,6 +764,11 @@ public final class SettingsStore: ObservableObject {
                     APIKeyManager.deleteKey(for: "gemini")
                     hasImageGenKey = false
                     maskedImageGenKey = ""
+                    // Restore the deletion tombstone if one existed before we
+                    // removed it, so pending offline clears are not lost.
+                    if hadTombstone {
+                        addDeletionTombstone(type: "api_key", name: "gemini")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Align saveBraveKey, savePerplexityKey, and saveImageGenKey with the hadTombstone pattern established by saveAPIKey and saveInferenceAPIKey
- Capture the return value of removeDeletionTombstone and only restore the tombstone on non-transient validation failure if one existed before the save attempt
- Prevents spurious deletion tombstones from wiping valid daemon keys on reconnect

Addresses review feedback from PR #19058 (Devin comment about inconsistent tombstone handling across provider-specific save methods).

## Test plan
- [ ] Verify saveBraveKey, savePerplexityKey, saveImageGenKey now match the saveAPIKey/saveInferenceAPIKey tombstone pattern
- [ ] Confirm no tombstone is created on validation failure when no prior tombstone existed
- [ ] Confirm tombstone is restored on validation failure when a prior tombstone did exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
