### PR TITLE
fix: reject deprecated model shortcut commands instead of passing through to LLM

### DIFF
--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -42,6 +42,21 @@ export interface SlashContext {
   estimatedCost: number;
 }
 
+// ── Deprecated model-switching shortcuts ─────────────────────────────
+
+/**
+ * Former provider shortcut commands that switched models. These are now
+ * removed — model switching lives in Settings. We reject them explicitly
+ * so they don't fall through to the LLM as passthrough text.
+ */
+const DEPRECATED_MODEL_SHORTCUTS = new Set([
+  "opus",
+  "sonnet",
+  "haiku",
+  "grok-beta",
+  "grok-multi",
+]);
+
 // ── /models command ──────────────────────────────────────────────────
 
 async function resolveModelList(): Promise<SlashResolution> {
@@ -117,7 +132,7 @@ export async function resolveSlash(
   content: string,
   context?: SlashContext,
 ): Promise<SlashResolution> {
-  // Handle deprecated /model command — direct users to Settings
+  // Handle deprecated model-switching commands — direct users to Settings
   const trimmed = content.trim();
   if (
     trimmed === "/model" ||
@@ -127,6 +142,18 @@ export async function resolveSlash(
       kind: "unknown",
       message:
         "The `/model` command has been removed. Use **Settings → Models & Services** to change your model and provider.",
+    };
+  }
+
+  // Reject deprecated provider shortcut commands (/opus, /sonnet, /haiku, etc.)
+  const shortcutMatch = trimmed.match(/^\/([a-z0-9-]+)(\s|$)/i);
+  if (
+    shortcutMatch &&
+    DEPRECATED_MODEL_SHORTCUTS.has(shortcutMatch[1].toLowerCase())
+  ) {
+    return {
+      kind: "unknown",
+      message: `The \`/${shortcutMatch[1]}\` shortcut has been removed. Use **Settings → Models & Services** to change your model and provider.`,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add explicit rejection for deprecated provider shortcut slash commands (`/opus`, `/sonnet`, `/haiku`, `/grok-beta`, `/grok-multi`)
- These commands now return a clear deprecation message directing users to Settings, instead of silently falling through to the LLM as passthrough text
- Addresses review feedback on PR #19059

## Test plan
- [ ] Type `/opus`, `/sonnet`, `/haiku`, `/grok-beta`, `/grok-multi` in a conversation and verify each returns the deprecation message
- [ ] Verify `/models`, `/status`, `/commands`, `/pair` still work normally
- [ ] Verify unknown slash commands still pass through to the LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
