### PR TITLE
fix: wire selectedModel to OnboardingState to prevent provider/model desync

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -10,7 +10,6 @@ struct APIKeyEntryStepView: View {
     @State private var isEditing = false
     @State private var showTitle = false
     @State private var showContent = false
-    @State private var selectedModel: String = "claude-opus-4-6"
     @FocusState private var keyFieldFocused: Bool
 
     // MARK: - Feature Flag
@@ -163,7 +162,7 @@ struct APIKeyEntryStepView: View {
         }
         .onChange(of: state.selectedProvider) { _, newProvider in
             if let entry = providerCatalog.first(where: { $0.id == newProvider }) {
-                selectedModel = entry.defaultModel
+                state.selectedModel = entry.defaultModel
             }
             apiKey = ""
             hasExistingKey = false
@@ -197,7 +196,7 @@ struct APIKeyEntryStepView: View {
                 .foregroundColor(VColor.contentSecondary)
             VDropdown(
                 placeholder: "Select a model\u{2026}",
-                selection: $selectedModel,
+                selection: $state.selectedModel,
                 options: (currentProviderEntry?.models ?? []).map { model in
                     (label: model.displayName, value: model.id)
                 }
@@ -270,7 +269,6 @@ struct APIKeyEntryStepView: View {
         if isCustomProviderEnabled {
             let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !providerRequiresKey || !trimmed.isEmpty else { return }
-            state.selectedModel = selectedModel
             if providerRequiresKey {
                 APIKeyManager.setKey(trimmed, for: state.selectedProvider)
             }
@@ -280,7 +278,7 @@ struct APIKeyEntryStepView: View {
             var services = existingConfig["services"] as? [String: Any] ?? [:]
             var inference = services["inference"] as? [String: Any] ?? [:]
             inference["provider"] = state.selectedProvider
-            inference["model"] = selectedModel
+            inference["model"] = state.selectedModel
             services["inference"] = inference
             try? WorkspaceConfigIO.merge(["services": services])
             state.advance()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -179,6 +179,7 @@ final class OnboardingState {
         APIKeyManager.deleteKey(for: "anthropic")
 
         selectedProvider = "anthropic"
+        selectedModel = "claude-opus-4-6"
 
         // Reset cloud credentials (in-memory only; not persisted)
         cloudProvider = "local"


### PR DESCRIPTION
## Summary
- Moved `selectedModel` from local `@State` in `APIKeyEntryStepView` to `state.selectedModel` on `OnboardingState`, eliminating the provider/model desync that occurred when navigating back/forward between onboarding steps
- The root cause: `.id(state.currentStep)` on the parent view forces view identity changes on step transitions, destroying and recreating the view. Local `@State` reinitializes to its default (`claude-opus-4-6`), but `state.selectedProvider` (on `@Observable OnboardingState`) persists -- creating an invalid provider/model combination
- Also reset `selectedModel` to `claude-opus-4-6` in `resetForRetry()` to match the provider reset
- Removed the now-unnecessary `state.selectedModel = selectedModel` assignment in `saveAndHatch()` since they are the same property

Addresses review feedback from PR #19063.

## Test plan
- [ ] Open onboarding with custom provider feature flag enabled
- [ ] Select OpenAI provider, verify model picker shows GPT models with GPT-5.4 selected
- [ ] Press Back, then return to step 2 -- verify OpenAI is still selected and model is GPT-5.4 (not claude-opus-4-6)
- [ ] Press Continue and verify config written has matching provider/model
- [ ] Test resetForRetry resets both provider and model to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
