### PR TITLE
fix: address PR #19205 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -856,18 +856,18 @@ struct MainWindowView: View {
     @ViewBuilder
     private func coreLayoutContent(geometry: GeometryProxy) -> some View {
         coreLayoutBase(geometry: geometry)
-            .ignoresSafeArea(edges: .top)
-            .background(VColor.surfaceBase.ignoresSafeArea())
-            .frame(width: geometry.size.width / zoomManager.zoomLevel,
-                   height: geometry.size.height / zoomManager.zoomLevel)
-            .scaleEffect(zoomManager.zoomLevel, anchor: .topLeading)
-            .frame(width: geometry.size.width, height: geometry.size.height, alignment: .topLeading)
             .overlay { preferencesDismissLayer }
             .overlay { conversationActionsDismissLayer }
             .overlay(alignment: .topLeading) { conversationActionsDrawerLayer }
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
             .overlay { conversationSwitcherDismissLayer }
             .overlay(alignment: .topLeading) { conversationSwitcherDrawerLayer }
+            .ignoresSafeArea(edges: .top)
+            .background(VColor.surfaceBase.ignoresSafeArea())
+            .frame(width: geometry.size.width / zoomManager.zoomLevel,
+                   height: geometry.size.height / zoomManager.zoomLevel)
+            .scaleEffect(zoomManager.zoomLevel, anchor: .topLeading)
+            .frame(width: geometry.size.width, height: geometry.size.height, alignment: .topLeading)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary\n- address bot review feedback from #19205\n- keep overlay drawers inside the zoomed coordinate space\n- preserve the type-checker simplification
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
