### PR TITLE
fix: add legacy alias for integrations/oauth/start endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -437,6 +437,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // OAuth / integrations
   { endpoint: "oauth/start", scopes: ["settings.write"] },
+  { endpoint: "integrations/oauth/start", scopes: ["settings.write"] }, // legacy alias
   { endpoint: "oauth/apps", scopes: ["settings.read"] },
   { endpoint: "oauth/apps.create", scopes: ["settings.write"] },
   { endpoint: "oauth/apps.delete", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -656,6 +656,20 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
         return handleOAuthConnectStart(body);
       },
     },
+    // Legacy alias for oauth/start (kept for backwards compatibility with
+    // older clients and platform proxy routes)
+    {
+      endpoint: "integrations/oauth/start",
+      method: "POST",
+      policyKey: "integrations/oauth/start",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          service?: string;
+          requestedScopes?: string[];
+        };
+        return handleOAuthConnectStart(body);
+      },
+    },
 
     // Workspace files (list/read -- distinct from workspace-routes.ts tree/file)
     {


### PR DESCRIPTION
## Summary
- Adds a legacy route alias `integrations/oauth/start` alongside the new `oauth/start` endpoint introduced in #19065
- Adds the corresponding auth policy entry for the legacy path
- Ensures backwards compatibility for older clients and platform proxy routes during mixed-version deployments

Addresses review feedback from #19065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
