### PR TITLE
fix: address PR #19054 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -38,16 +38,20 @@ extension EnvironmentValues {
         if isVisible != newVisible { isVisible = newVisible }
     }
 
-    func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) {
-        guard storedViewportHeight != height else { return }
+    /// Returns `true` when the viewport height actually changed, so callers
+    /// can refresh any state tied to the visible geometry.
+    @discardableResult
+    func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
+        guard storedViewportHeight != height else { return false }
         storedViewportHeight = height
         // Don't recompute visibility before the anchor position has been
         // measured — lastMinY starts at .infinity, and .infinity <= height + 20
         // evaluates to false, incorrectly flipping isVisible to false and
         // flashing the "Scroll to latest" button on short conversations.
-        guard lastMinY.isFinite else { return }
+        guard lastMinY.isFinite else { return true }
         let newVisible = lastMinY >= -20 && lastMinY <= height + 20
         if isVisible != newVisible { isVisible = newVisible }
+        return true
     }
 }
 
@@ -894,7 +898,15 @@ struct MessageListView: View {
             }
             .onPreferenceChange(ScrollViewportHeightKey.self) { height in
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
-                anchorTracker.updateViewport(height: height, storedViewportHeight: &scrollViewportHeight)
+                let viewportChanged = anchorTracker.updateViewport(
+                    height: height,
+                    storedViewportHeight: &scrollViewportHeight
+                )
+                if viewportChanged, scrollTracking.lastTailAnchorY.isFinite {
+                    // Reconcile the avatar follower on resize so a hidden target
+                    // is refreshed before a later visibility transition reveals it.
+                    updateAvatarFollower(anchorY: scrollTracking.lastTailAnchorY)
+                }
                 os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
             }
             .transaction { $0.disablesAnimations = true }

--- a/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
@@ -80,4 +80,38 @@ final class ConversationAvatarFollowerTests: XCTestCase {
             )
         )
     }
+
+    @MainActor
+    func testViewportChangeRecomputesVisibility() {
+        let tracker = AnchorVisibilityTracker()
+        tracker.lastMinY = 520
+        tracker.isVisible = false
+        var storedViewportHeight: CGFloat = 500
+
+        let changed = tracker.updateViewport(
+            height: 540,
+            storedViewportHeight: &storedViewportHeight
+        )
+
+        XCTAssertTrue(changed)
+        XCTAssertEqual(storedViewportHeight, 540)
+        XCTAssertTrue(tracker.isVisible)
+    }
+
+    @MainActor
+    func testViewportChangeNoOpsWhenHeightIsUnchanged() {
+        let tracker = AnchorVisibilityTracker()
+        tracker.lastMinY = 520
+        tracker.isVisible = false
+        var storedViewportHeight: CGFloat = 540
+
+        let changed = tracker.updateViewport(
+            height: 540,
+            storedViewportHeight: &storedViewportHeight
+        )
+
+        XCTAssertFalse(changed)
+        XCTAssertEqual(storedViewportHeight, 540)
+        XCTAssertFalse(tracker.isVisible)
+    }
 }


### PR DESCRIPTION
## Summary
- address bot review feedback from #19054
- keep avatar target tracking correct while the anchor remains off-screen
- preserve the extracted helper structure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
