### PR TITLE
fix: address PR #19067 review feedback

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -90,6 +90,10 @@ function resetTables() {
   db.run("DELETE FROM conversations");
 }
 
+function getLegacyConversationDirName(id: string, createdAtMs: number): string {
+  return `${id}_${new Date(createdAtMs).toISOString().replace(/:/g, "-")}`;
+}
+
 // ---------------------------------------------------------------------------
 // getConversationDirName
 // ---------------------------------------------------------------------------
@@ -213,6 +217,29 @@ describe("updateMetaFile", () => {
     expect(meta.updatedAt).toBe(new Date(updated).toISOString());
 
     rmSync(dirPath, { recursive: true, force: true });
+  });
+
+  test("reuses legacy directory names when the new directory does not exist", () => {
+    const created = Date.now();
+    const legacyDirName = getLegacyConversationDirName("conv-legacy", created);
+    const legacyDirPath = join(conversationsDir, legacyDirName);
+    mkdirSync(legacyDirPath, { recursive: true });
+
+    updateMetaFile({
+      id: "conv-legacy",
+      title: "Legacy",
+      createdAt: created,
+      updatedAt: created + 1234,
+      conversationType: "standard",
+      originChannel: "desktop",
+    });
+
+    expect(existsSync(join(legacyDirPath, "meta.json"))).toBe(true);
+    expect(existsSync(getConversationDirPath("conv-legacy", created))).toBe(
+      false,
+    );
+
+    rmSync(legacyDirPath, { recursive: true, force: true });
   });
 });
 
@@ -466,6 +493,37 @@ describe("syncMessageToDisk", () => {
 
     rmSync(dirPath, { recursive: true, force: true });
   });
+
+  test("appends to a legacy directory when that is the only existing path", async () => {
+    const conv = createConversation("Legacy Attach Test");
+    const createdAt = conv.createdAt;
+    const newDirPath = getConversationDirPath(conv.id, createdAt);
+    rmSync(newDirPath, { recursive: true, force: true });
+    const legacyDirPath = join(
+      conversationsDir,
+      getLegacyConversationDirName(conv.id, createdAt),
+    );
+    mkdirSync(legacyDirPath, { recursive: true });
+
+    const msg = await addMessage(conv.id, "user", "Legacy path", undefined, {
+      skipIndexing: true,
+    });
+
+    const att = uploadAttachment("legacy.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(msg.id, att.id, 0);
+
+    syncMessageToDisk(conv.id, msg.id, createdAt);
+
+    expect(
+      existsSync(join(legacyDirPath, "messages.jsonl")),
+    ).toBe(true);
+    expect(existsSync(join(newDirPath, "messages.jsonl"))).toBe(false);
+    expect(existsSync(join(legacyDirPath, "attachments", "legacy.png"))).toBe(
+      true,
+    );
+
+    rmSync(legacyDirPath, { recursive: true, force: true });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -493,6 +551,22 @@ describe("removeConversationDir", () => {
   test("handles non-existent directory gracefully", () => {
     // Should not throw
     removeConversationDir("nonexistent", Date.now());
+  });
+
+  test("removes both new-format and legacy directories when both exist", () => {
+    const created = Date.now();
+    const newDirPath = getConversationDirPath("conv-both", created);
+    const legacyDirPath = join(
+      conversationsDir,
+      getLegacyConversationDirName("conv-both", created),
+    );
+    mkdirSync(newDirPath, { recursive: true });
+    mkdirSync(legacyDirPath, { recursive: true });
+
+    removeConversationDir("conv-both", created);
+
+    expect(existsSync(newDirPath)).toBe(false);
+    expect(existsSync(legacyDirPath)).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/workspace-migration-012-rename-conversation-disk-view-dirs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-012-rename-conversation-disk-view-dirs.test.ts
@@ -1,0 +1,77 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { renameConversationDiskViewDirsMigration } from "../workspace/migrations/012-rename-conversation-disk-view-dirs.js";
+
+function freshWorkspace(): { workspaceDir: string; conversationsDir: string } {
+  const workspaceDir = mkdtempSync(
+    join(tmpdir(), `vellum-migration-012-test-${Date.now()}-`),
+  );
+  const conversationsDir = join(workspaceDir, "conversations");
+  mkdirSync(conversationsDir, { recursive: true });
+  return { workspaceDir, conversationsDir };
+}
+
+function legacyConversationDirName(
+  conversationId: string,
+  createdAtMs: number,
+): string {
+  return `${conversationId}_${new Date(createdAtMs).toISOString().replace(/:/g, "-")}`;
+}
+
+describe("012-rename-conversation-disk-view-dirs migration", () => {
+  test("renames legacy conversation directories to timestamp-first names", () => {
+    const { workspaceDir, conversationsDir } = freshWorkspace();
+    try {
+      const createdAt = Date.parse("2026-03-18T14:23:00.000Z");
+      const legacyName = legacyConversationDirName("conv-123", createdAt);
+      const legacyDir = join(conversationsDir, legacyName);
+      mkdirSync(legacyDir, { recursive: true });
+      writeFileSync(join(legacyDir, "meta.json"), "{\"ok\":true}\n", "utf-8");
+
+      renameConversationDiskViewDirsMigration.run(workspaceDir);
+
+      const newName = `2026-03-18T14-23-00.000Z_conv-123`;
+      const newDir = join(conversationsDir, newName);
+      expect(existsSync(legacyDir)).toBe(false);
+      expect(existsSync(newDir)).toBe(true);
+      expect(readFileSync(join(newDir, "meta.json"), "utf-8")).toContain(
+        "\"ok\":true",
+      );
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("is idempotent and ignores non-matching entries", () => {
+    const { workspaceDir, conversationsDir } = freshWorkspace();
+    try {
+      const createdAt = Date.parse("2026-03-18T15:00:00.000Z");
+      const legacyName = legacyConversationDirName("conv-456", createdAt);
+      mkdirSync(join(conversationsDir, legacyName), { recursive: true });
+      mkdirSync(join(conversationsDir, "already-new"), { recursive: true });
+      mkdirSync(join(conversationsDir, "random-folder"), { recursive: true });
+
+      renameConversationDiskViewDirsMigration.run(workspaceDir);
+      renameConversationDiskViewDirsMigration.run(workspaceDir);
+
+      const names = readdirSync(conversationsDir).sort();
+      expect(names).toContain("2026-03-18T15-00-00.000Z_conv-456");
+      expect(names).toContain("already-new");
+      expect(names).toContain("random-folder");
+      expect(names).not.toContain(legacyName);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -38,6 +38,13 @@ function getConversationDirTimestamp(createdAtMs: number): string {
   return new Date(createdAtMs).toISOString().replace(/:/g, "-");
 }
 
+function getLegacyConversationDirName(
+  id: string,
+  createdAtMs: number,
+): string {
+  return `${id}_${getConversationDirTimestamp(createdAtMs)}`;
+}
+
 /**
  * Build a filesystem-safe directory name for a conversation.
  * Format: `{isoDate}_{id}` where colons in the ISO date are replaced with
@@ -60,6 +67,26 @@ export function getConversationDirPath(
   return join(getConversationsDir(), getConversationDirName(id, createdAtMs));
 }
 
+function getLegacyConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  return join(
+    getConversationsDir(),
+    getLegacyConversationDirName(id, createdAtMs),
+  );
+}
+
+function resolveConversationDirPath(id: string, createdAtMs: number): string {
+  const dirPath = getConversationDirPath(id, createdAtMs);
+  if (existsSync(dirPath)) return dirPath;
+
+  const legacyDirPath = getLegacyConversationDirPath(id, createdAtMs);
+  if (existsSync(legacyDirPath)) return legacyDirPath;
+
+  return dirPath;
+}
+
 // ---------------------------------------------------------------------------
 // Write operations
 // ---------------------------------------------------------------------------
@@ -75,7 +102,7 @@ export function initConversationDir(conv: {
   originChannel: string | null;
 }): void {
   try {
-    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const dirPath = resolveConversationDirPath(conv.id, conv.createdAt);
     mkdirSync(dirPath, { recursive: true });
 
     const meta = {
@@ -111,7 +138,7 @@ export function updateMetaFile(conv: {
   originChannel: string | null;
 }): void {
   try {
-    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const dirPath = resolveConversationDirPath(conv.id, conv.createdAt);
 
     const meta = {
       id: conv.id,
@@ -286,7 +313,7 @@ export function syncMessageToDisk(
       return;
     }
 
-    const dirPath = getConversationDirPath(conversationId, createdAtMs);
+    const dirPath = resolveConversationDirPath(conversationId, createdAtMs);
     const { content, toolCalls, toolResults } = flattenContentBlocks(
       message.content,
     );
@@ -338,8 +365,13 @@ export function syncMessageToDisk(
  */
 export function removeConversationDir(id: string, createdAtMs: number): void {
   try {
-    const dirPath = getConversationDirPath(id, createdAtMs);
-    rmSync(dirPath, { recursive: true, force: true });
+    const dirPaths = new Set([
+      getConversationDirPath(id, createdAtMs),
+      getLegacyConversationDirPath(id, createdAtMs),
+    ]);
+    for (const dirPath of dirPaths) {
+      rmSync(dirPath, { recursive: true, force: true });
+    }
   } catch (err) {
     log.warn({ err, conversationId: id }, "Failed to remove conversation dir");
   }

--- a/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
+++ b/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
@@ -1,0 +1,64 @@
+/**
+ * Workspace migration 012: Rename legacy conversation disk-view directories
+ * from `{conversationId}_{timestamp}` to `{timestamp}_{conversationId}`.
+ *
+ * Idempotent and conservative:
+ * - skips directories that already use the new format
+ * - skips non-matching directories
+ * - leaves an existing target directory alone rather than clobbering it
+ * - continues past per-directory rename failures
+ */
+
+import { existsSync, readdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const LEGACY_CONVERSATION_DIR_PATTERN =
+  /^(.*)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z)$/;
+
+function parseLegacyConversationDirName(
+  dirName: string,
+): { conversationId: string; timestamp: string } | null {
+  const match = dirName.match(LEGACY_CONVERSATION_DIR_PATTERN);
+  if (!match) return null;
+
+  return {
+    conversationId: match[1],
+    timestamp: match[2],
+  };
+}
+
+export const renameConversationDiskViewDirsMigration: WorkspaceMigration = {
+  id: "012-rename-conversation-disk-view-dirs",
+  description:
+    "Rename legacy conversation disk-view directories to timestamp-first names",
+
+  run(workspaceDir: string): void {
+    const conversationsDir = join(workspaceDir, "conversations");
+    if (!existsSync(conversationsDir)) return;
+
+    const entries = readdirSync(conversationsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const dirName of entries) {
+      const parsed = parseLegacyConversationDirName(dirName);
+      if (!parsed) continue;
+
+      const sourcePath = join(conversationsDir, dirName);
+      const targetName = `${parsed.timestamp}_${parsed.conversationId}`;
+      const targetPath = join(conversationsDir, targetName);
+
+      if (sourcePath === targetPath) continue;
+      if (existsSync(targetPath)) continue;
+
+      try {
+        renameSync(sourcePath, targetPath);
+      } catch {
+        // Best-effort: leave the old directory in place if a single rename fails.
+      }
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -8,6 +8,7 @@ import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-st
 import { backfillConversationDiskViewMigration } from "./009-backfill-conversation-disk-view.js";
 import { appDirRenameMigration } from "./010-app-dir-rename.js";
 import { backfillInstallationIdMigration } from "./011-backfill-installation-id.js";
+import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
@@ -25,4 +26,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillConversationDiskViewMigration,
   appDirRenameMigration,
   backfillInstallationIdMigration,
+  renameConversationDiskViewDirsMigration,
 ];


### PR DESCRIPTION
## Summary\n- address bot review feedback from #19067\n- add backward-compatible handling for timestamp-first conversation disk-view directories\n- include the required workspace migration for existing workspaces
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
