### PR TITLE
fix: address PR #19080 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -221,26 +221,18 @@ struct MessageInspectorView: View {
             )
 
             if isExpanded {
-                GeometryReader { proxy in
-                    // Constrain both panes to the visible row width so very wide
-                    // request JSON cannot push the sibling response pane offscreen.
-                    let columnWidth = max((proxy.size.width - VSpacing.lg) / 2, 0)
+                HStack(alignment: .top, spacing: VSpacing.lg) {
+                    jsonSection(
+                        title: "Request",
+                        formattedText: formattedJSON["\(entry.id)-request"] ?? ""
+                    )
 
-                    HStack(alignment: .top, spacing: VSpacing.lg) {
-                        jsonSection(
-                            title: "Request",
-                            formattedText: formattedJSON["\(entry.id)-request"] ?? ""
-                        )
-                        .frame(width: columnWidth, alignment: .topLeading)
-
-                        jsonSection(
-                            title: "Response",
-                            formattedText: formattedJSON["\(entry.id)-response"] ?? ""
-                        )
-                        .frame(width: columnWidth, alignment: .topLeading)
-                    }
-                    .frame(width: proxy.size.width, alignment: .leading)
+                    jsonSection(
+                        title: "Response",
+                        formattedText: formattedJSON["\(entry.id)-response"] ?? ""
+                    )
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(
                     minHeight: payloadViewportHeight + payloadSectionChromeHeight,
                     alignment: .topLeading


### PR DESCRIPTION
## Summary\n- address bot review feedback from #19080\n- keep the response pane visible without a greedy expanded log layout\n- preserve the current inspector UX\n\nApple refs checked (2026-03-19): existing SwiftUI flexible layout patterns in the macOS client.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
