### PR TITLE
fix: require activity for computer_use_observe

### DIFF
--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -474,6 +474,7 @@ export const computerUseObserveTool: Tool = {
         properties: {
           activity: activityProperty,
         },
+        required: ["activity"],
       },
     };
   },


### PR DESCRIPTION
## Summary
- require `activity` in the core `computer_use_observe` schema so it matches the bundled computer-use skill manifest
- fix the manifest regression that was failing in GitHub Actions for the stable test suite

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23281350542/job/67695357991

🤖 Generated with [Claude Code](https://claude.com/claude-code)