### PR TITLE
fix: address PR #19046 review feedback

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1450,8 +1450,8 @@ describe("Conversation host attachment directives", () => {
         ),
       ).toBe(true);
 
-      // Attachment warnings are no longer emitted as assistant_text_delta events
-      // (see 9d39e70ae). They are only stored on ctx.lastAttachmentWarnings.
+      // Attachment warnings are surfaced on the completion payload instead of
+      // being emitted as late assistant_text_delta events.
       const warningDelta = events.find(
         (e) =>
           e.type === "assistant_text_delta" &&
@@ -1460,6 +1460,8 @@ describe("Conversation host attachment directives", () => {
       expect(warningDelta).toBeUndefined();
       const completion = events.find((e) => e.type === "message_complete");
       expect(completion).toBeDefined();
+      expect((completion as { attachmentWarnings?: string[] }).attachmentWarnings)
+        .toEqual(expect.arrayContaining([expect.stringContaining("access denied by user")]));
     } finally {
       rmSync(hostPath, { force: true });
     }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1625,6 +1625,9 @@ export async function runAgentLoopImpl(
           ...(emittedAttachments.length > 0
             ? { attachments: emittedAttachments }
             : {}),
+          ...(ctx.lastAttachmentWarnings.length > 0
+            ? { attachmentWarnings: ctx.lastAttachmentWarnings }
+            : {}),
           ...(state.lastAssistantMessageId
             ? { messageId: state.lastAssistantMessageId }
             : {}),
@@ -1644,6 +1647,9 @@ export async function runAgentLoopImpl(
           conversationId: ctx.conversationId,
           ...(emittedAttachments.length > 0
             ? { attachments: emittedAttachments }
+            : {}),
+          ...(ctx.lastAttachmentWarnings.length > 0
+            ? { attachmentWarnings: ctx.lastAttachmentWarnings }
             : {}),
           ...(state.lastAssistantMessageId
             ? { messageId: state.lastAssistantMessageId }

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -254,6 +254,7 @@ export async function resolveAssistantAttachments(
         filename: draft.filename,
         mimeType: draft.mimeType,
         data: omitData ? "" : draft.dataBase64,
+        sourceType: draft.sourceType,
         ...(omitData ? { sizeBytes: draft.sizeBytes } : {}),
         fileBacked: true,
         ...(thumbnailData ? { thumbnailData } : {}),
@@ -265,6 +266,7 @@ export async function resolveAssistantAttachments(
         filename: draft.filename,
         mimeType: draft.mimeType,
         data: draft.dataBase64,
+        sourceType: draft.sourceType,
       });
     }
   }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -232,6 +232,7 @@ export interface GenerationHandoff {
   requestId?: string;
   queuedCount: number;
   attachments?: UserMessageAttachment[];
+  attachmentWarnings?: string[];
   /** Database ID of the persisted assistant message, if any. */
   messageId?: string;
 }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -183,6 +183,7 @@ export interface MessageComplete {
   type: "message_complete";
   conversationId?: string;
   attachments?: UserMessageAttachment[];
+  attachmentWarnings?: string[];
   /** Database ID of the persisted assistant message, if any. */
   messageId?: string;
 }

--- a/assistant/src/daemon/message-types/shared.ts
+++ b/assistant/src/daemon/message-types/shared.ts
@@ -34,6 +34,8 @@ export interface UserMessageAttachment {
   filename: string;
   mimeType: string;
   data: string;
+  /** Origin of the attachment on the daemon side, when known. */
+  sourceType?: "sandbox_file" | "host_file" | "tool_block";
   extractedText?: string;
   /** Original file size in bytes. Present when data was omitted from history_response to reduce payload size. */
   sizeBytes?: number;

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -152,7 +152,8 @@ struct ChatBubble: View {
 
     /// Whether the text/attachment bubble should be rendered.
     /// Tool calls for assistant messages render outside the bubble as separate chips,
-    /// so only show the bubble when there's actual text or attachment content.
+    /// so only show the bubble when there's actual text, attachment content, or
+    /// attachment warnings to show.
     ///
     /// NOTE: When inline surfaces are present, the bubble is intentionally hidden
     /// even if the message also contains text. This is by design — the assistant's
@@ -167,7 +168,7 @@ struct ChatBubble: View {
             let allCompleted = visibleSurfaces.allSatisfy { $0.completionState != nil }
             if !allCompleted { return false }
         }
-        return hasText || !message.attachments.isEmpty
+        return hasText || !message.attachments.isEmpty || !message.attachmentWarnings.isEmpty
     }
 
     var body: some View {
@@ -203,6 +204,10 @@ struct ChatBubble: View {
                         if let documentToolCall = message.toolCalls.first(where: { $0.toolName == "document_create" && $0.isComplete }) {
                             documentWidget(for: documentToolCall)
                         }
+                    }
+
+                    if !hasInterleavedContent {
+                        attachmentWarningBanners(message.attachmentWarnings)
                     }
 
                     // Media embeds rendered below the text, preserving source order
@@ -389,9 +394,9 @@ struct ChatBubble: View {
                         .foregroundColor(isUser ? VColor.contentSecondary : VColor.contentSecondary)
                 }
 
-                // Skip image attachments when tool calls already display images inline
-                if !partitioned.images.isEmpty && inlineToolCallImageCount == 0 {
-                    attachmentImageGrid(partitioned.images)
+                let visibleImages = visibleAttachmentImages(partitioned.images)
+                if !visibleImages.isEmpty {
+                    attachmentImageGrid(visibleImages)
                 }
 
                 if !partitioned.videos.isEmpty {
@@ -545,4 +550,3 @@ private struct ConditionalCompositingGroup: ViewModifier {
         }
     }
 }
-

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -276,11 +276,39 @@ extension ChatBubble {
     }
 
     /// Number of tool calls in this message that have inline cached images.
-    /// Used to suppress the corresponding image attachments from the attachment
-    /// grid — only when the count matches (i.e. all image attachments come from
-    /// tool calls), so unrelated image attachments still render normally.
+    /// Used to suppress the corresponding tool-block image attachments from the
+    /// attachment grid only when inline tool previews are actually rendered.
     var inlineToolCallImageCount: Int {
         message.toolCalls.filter { $0.cachedImage != nil }.count
+    }
+
+    /// Returns the image attachments that should still render in the attachment grid.
+    /// When inline tool previews are visible, the matching tool-block images are
+    /// hidden so we do not duplicate the same image twice. Non-tool images remain.
+    func visibleAttachmentImages(_ images: [ChatAttachment]) -> [ChatAttachment] {
+        guard shouldRenderToolProgressInline, inlineToolCallImageCount > 0 else {
+            return images
+        }
+
+        var remainingInlineToolImages = inlineToolCallImageCount
+        return images.filter { attachment in
+            guard attachment.sourceType == "tool_block", remainingInlineToolImages > 0 else {
+                return true
+            }
+            remainingInlineToolImages -= 1
+            return false
+        }
+    }
+
+    @ViewBuilder
+    func attachmentWarningBanners(_ warnings: [String]) -> some View {
+        if !warnings.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(Array(warnings.enumerated()), id: \.offset) { _, warning in
+                    VInlineMessage(warning, tone: .warning)
+                }
+            }
+        }
     }
 
     /// Renders cached images from completed tool calls inline below the

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -246,11 +246,13 @@ extension ChatBubble {
             }
         }
 
-        // Attachments are not part of contentOrder but must still be rendered
-        // Skip image attachments when tool calls already display images inline
+        // Attachments are not part of contentOrder but must still be rendered.
+        // Hide only the tool-block image attachments that are already shown
+        // inline by completed tool calls; keep directive/host images visible.
         let partitioned = partitionedAttachments
-        if !partitioned.images.isEmpty && inlineToolCallImageCount == 0 {
-            attachmentImageGrid(partitioned.images)
+        let visibleImages = visibleAttachmentImages(partitioned.images)
+        if !visibleImages.isEmpty {
+            attachmentImageGrid(visibleImages)
         }
         if !partitioned.videos.isEmpty {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -266,5 +268,6 @@ extension ChatBubble {
                 }
             }
         }
+        attachmentWarningBanners(message.attachmentWarnings)
     }
 }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1430,6 +1430,8 @@ public struct ChatAttachment: Identifiable {
     public let id: String
     public let filename: String
     public let mimeType: String
+    /// Origin of the attachment on the daemon side, when known.
+    public let sourceType: String?
     /// Base64-encoded file data. Empty when the attachment was too large to embed
     /// in the history_response — use ``fetchData(port:)`` to load it lazily.
     /// Mutable so it can be nil'd out after the daemon has persisted the data,
@@ -1464,10 +1466,11 @@ public struct ChatAttachment: Identifiable {
     public var isLazyLoad: Bool { data.isEmpty && sizeBytes != nil }
 
     #if os(macOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?, filePath: String? = nil) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: NSImage?, filePath: String? = nil, sourceType: String? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
+        self.sourceType = sourceType
         self.data = data
         self.thumbnailData = thumbnailData
         self.dataLength = dataLength
@@ -1476,10 +1479,11 @@ public struct ChatAttachment: Identifiable {
         self.filePath = filePath
     }
     #elseif os(iOS)
-    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?, filePath: String? = nil) {
+    public init(id: String, filename: String, mimeType: String, data: String, thumbnailData: Data?, dataLength: Int, sizeBytes: Int? = nil, thumbnailImage: UIImage?, filePath: String? = nil, sourceType: String? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
+        self.sourceType = sourceType
         self.data = data
         self.thumbnailData = thumbnailData
         self.dataLength = dataLength
@@ -1629,6 +1633,7 @@ public struct ChatMessage: Identifiable, Equatable {
         && lhs.conversationError == rhs.conversationError
         && lhs.toolCalls == rhs.toolCalls
         && lhs.attachments.count == rhs.attachments.count
+        && lhs.attachmentWarnings == rhs.attachmentWarnings
         && lhs.inlineSurfaces == rhs.inlineSurfaces
         && lhs.confirmation?.state == rhs.confirmation?.state
         && lhs.guardianDecision?.state == rhs.guardianDecision?.state
@@ -1653,6 +1658,7 @@ public struct ChatMessage: Identifiable, Equatable {
     public var modelList: ModelListData?
     public var commandList: CommandListData?
     public var attachments: [ChatAttachment]
+    public var attachmentWarnings: [String]
     public var toolCalls: [ToolCallData]
     public var inlineSurfaces: [InlineSurfaceData]
     /// Streaming code preview from tool input generation (e.g. app_create HTML).
@@ -1690,7 +1696,7 @@ public struct ChatMessage: Identifiable, Equatable {
         textSegments.joined(separator: "\n")
     }
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false, conversationError: ConversationError? = nil) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], attachmentWarnings: [String] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false, conversationError: ConversationError? = nil) {
         self.id = id
         self.role = role
         self.textSegments = text.isEmpty ? [] : [text]
@@ -1702,6 +1708,7 @@ public struct ChatMessage: Identifiable, Equatable {
         self.guardianDecision = guardianDecision
         self.skillInvocation = skillInvocation
         self.attachments = attachments
+        self.attachmentWarnings = attachmentWarnings
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
         self.isError = isError

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -354,6 +354,7 @@ extension ChatViewModel {
                 id: id,
                 filename: attachment.filename,
                 mimeType: attachment.mimeType,
+                sourceType: attachment.sourceType,
                 data: base64,
                 thumbnailData: thumbnailData,
                 dataLength: dataLength,
@@ -375,6 +376,21 @@ extension ChatViewModel {
             messages[index].attachments.append(contentsOf: chatAttachments)
         } else {
             let msg = ChatMessage(role: .assistant, text: "", attachments: chatAttachments)
+            currentAssistantMessageId = msg.id
+            messages.append(msg)
+        }
+    }
+
+    /// Ingest attachment warnings from a completion/handoff event into the
+    /// current or new assistant message.
+    func ingestAssistantAttachmentWarnings(_ warnings: [String]?) {
+        guard let warnings, !warnings.isEmpty else { return }
+
+        if let existingId = currentAssistantMessageId,
+           let index = messages.firstIndex(where: { $0.id == existingId }) {
+            messages[index].attachmentWarnings.append(contentsOf: warnings)
+        } else {
+            let msg = ChatMessage(role: .assistant, text: "", attachmentWarnings: warnings)
             currentAssistantMessageId = msg.id
             messages.append(msg)
         }
@@ -711,6 +727,7 @@ extension ChatViewModel {
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             if !wasRefinement {
                 ingestAssistantAttachments(complete.attachments)
+                ingestAssistantAttachmentWarnings(complete.attachmentWarnings)
             }
             if pendingVoiceMessage {
                 pendingVoiceMessage = false
@@ -1003,6 +1020,7 @@ extension ChatViewModel {
             flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
+            ingestAssistantAttachmentWarnings(handoff.attachmentWarnings)
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -115,6 +115,14 @@ public struct MessageBubbleView: View {
                     }
                 }
 
+                if !message.attachmentWarnings.isEmpty {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        ForEach(Array(message.attachmentWarnings.enumerated()), id: \.offset) { _, warning in
+                            VInlineMessage(warning, tone: .warning)
+                        }
+                    }
+                }
+
                 // Offline-pending indicator: shown when the message is buffered
                 // locally awaiting daemon reconnect. Replaces the streaming dots.
                 if message.status == .pendingOffline {
@@ -304,6 +312,5 @@ public struct MessageBubbleView: View {
         return 1.0 + 0.4 * sin(normalized * 2 * .pi)
     }
 }
-
 
 


### PR DESCRIPTION
## Summary\n- address bot review feedback from #19046\n- preserve attachment warning visibility without reviving the scroll regression\n- avoid hiding legitimate non-inline images when inline tool previews exist
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
