### PR TITLE
fix: use variableLength for menu bar status item

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -23,7 +23,7 @@ extension AppDelegate {
         // Set saved position to right side of menu bar (visible area, right of notch)
         UserDefaults.standard.set(1200, forKey: "NSStatusItem Preferred Position VellumMenuBar")
 
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.autosaveName = "VellumMenuBar"
         statusItem.isVisible = true
         if let button = statusItem.button {


### PR DESCRIPTION
## Summary
- Switch the macOS menu bar status item from `squareLength` to `variableLength` so the grey capsule background fits tightly around the avatar icon instead of being padded to a fixed square

## Original prompt
lets try switching to NSStatusItem.variableLength

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
