### PR TITLE
feat: make slash command help interface-aware

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveSlash,
+  type SlashContext,
+} from "../daemon/conversation-slash.js";
+
+function makeSlashContext(
+  overrides: Partial<SlashContext> = {},
+): SlashContext {
+  return {
+    messageCount: 4,
+    inputTokens: 1024,
+    outputTokens: 256,
+    maxInputTokens: 200000,
+    model: "claude-opus-4-6",
+    provider: "anthropic",
+    estimatedCost: 0.03,
+    ...overrides,
+  };
+}
+
+async function resolveCommandsLines(context?: SlashContext): Promise<string[]> {
+  const result = await resolveSlash("/commands", context);
+  expect(result.kind).toBe("unknown");
+  if (result.kind !== "unknown") {
+    throw new Error("Expected /commands to resolve to kind=unknown");
+  }
+  return result.message.split("\n");
+}
+
+describe("resolveSlash /commands interface-aware help", () => {
+  test("renders desktop command help for macOS", async () => {
+    const lines = await resolveCommandsLines(
+      makeSlashContext({ userMessageInterface: "macos" }),
+    );
+    expect(lines).toEqual([
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/status — Show conversation status and context usage",
+      "/btw — Ask a side question while the assistant is working",
+      "/pair — Generate pairing info for connecting a mobile device",
+    ]);
+    expect(lines).not.toContain(
+      "/model — Switch the active model",
+    );
+  });
+
+  test("renders iOS command help without /pair", async () => {
+    const lines = await resolveCommandsLines(
+      makeSlashContext({ userMessageInterface: "ios" }),
+    );
+    expect(lines).toEqual([
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/status — Show conversation status and context usage",
+      "/btw — Ask a side question while the assistant is working",
+    ]);
+  });
+
+  test("keeps legacy fallback help when no interface is provided", async () => {
+    const lines = await resolveCommandsLines(makeSlashContext());
+    expect(lines).toEqual([
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/pair — Generate pairing info for connecting a mobile device",
+      "/status — Show conversation status and context usage",
+    ]);
+  });
+
+  test("keeps context-free fallback without /status", async () => {
+    const lines = await resolveCommandsLines();
+    expect(lines).toEqual([
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/pair — Generate pairing info for connecting a mobile device",
+    ]);
+  });
+});

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -182,6 +182,7 @@ function buildSlashContext(
   conversation: ProcessConversationContext,
 ): SlashContext {
   const config = getConfig();
+  const turnInterface = conversation.getTurnInterfaceContext();
   return {
     messageCount: conversation.messages.length,
     inputTokens: conversation.usageStats.inputTokens,
@@ -190,6 +191,7 @@ function buildSlashContext(
     model: config.services.inference.model,
     provider: config.services.inference.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
+    userMessageInterface: turnInterface?.userMessageInterface,
   };
 }
 

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import QRCode from "qrcode";
 
+import type { InterfaceId } from "../channels/types.js";
 import { getGatewayPort, getIngressPublicBaseUrl } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
@@ -40,6 +41,7 @@ export interface SlashContext {
   model: string;
   provider: string;
   estimatedCost: number;
+  userMessageInterface?: InterfaceId;
 }
 
 // ── Deprecated model-switching shortcuts ─────────────────────────────
@@ -124,6 +126,40 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
   return { kind: "unknown", message: lines.join("\n") };
 }
 
+function resolveCommandsList(context?: SlashContext): string[] {
+  const fallbackLines = [
+    "/commands — List all available commands",
+    "/models — List all available models",
+    "/pair — Generate pairing info for connecting a mobile device",
+  ];
+  if (context) {
+    fallbackLines.push("/status — Show conversation status and context usage");
+  }
+
+  if (!context) return fallbackLines;
+
+  if (context.userMessageInterface === "macos") {
+    return [
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/status — Show conversation status and context usage",
+      "/btw — Ask a side question while the assistant is working",
+      "/pair — Generate pairing info for connecting a mobile device",
+    ];
+  }
+
+  if (context.userMessageInterface === "ios") {
+    return [
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/status — Show conversation status and context usage",
+      "/btw — Ask a side question while the assistant is working",
+    ];
+  }
+
+  return fallbackLines;
+}
+
 /**
  * Resolve built-in slash commands (/models, /status, /commands, /pair).
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
@@ -179,17 +215,9 @@ export async function resolveSlash(
 
   // Handle /commands command
   if (trimmed === "/commands") {
-    const lines = [
-      "/commands — List all available commands",
-      "/models — List all available models",
-      "/pair — Generate pairing info for connecting a mobile device",
-    ];
-    if (context) {
-      lines.push("/status — Show conversation status and context usage");
-    }
     return {
       kind: "unknown",
-      message: lines.join("\n"),
+      message: resolveCommandsList(context).join("\n"),
     };
   }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -78,7 +78,7 @@ import {
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
-import { resolveSlash } from "./conversation-slash.js";
+import { resolveSlash, type SlashContext } from "./conversation-slash.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type {
@@ -1071,11 +1071,22 @@ export class DaemonServer {
         sourceInterface,
       );
 
-    const slashResult = await resolveSlash(content);
+    const config = getConfig();
+    const serverInterfaceCtx = conversation.getTurnInterfaceContext();
+    const slashContext: SlashContext = {
+      messageCount: conversation.getMessages().length,
+      inputTokens: conversation.usageStats.inputTokens,
+      outputTokens: conversation.usageStats.outputTokens,
+      maxInputTokens: config.contextWindow.maxInputTokens,
+      model: config.services.inference.model,
+      provider: config.services.inference.provider,
+      estimatedCost: conversation.usageStats.estimatedCost,
+      userMessageInterface: serverInterfaceCtx?.userMessageInterface,
+    };
+    const slashResult = await resolveSlash(content, slashContext);
 
     if (slashResult.kind === "unknown") {
       const serverTurnCtx = conversation.getTurnChannelContext();
-      const serverInterfaceCtx = conversation.getTurnInterfaceContext();
       const serverProvenance = provenanceFromTrustContext(
         conversation.trustContext,
       );

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1066,6 +1066,7 @@ export async function handleSendMessage(
     model: config.services.inference.model,
     provider: config.services.inference.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
+    userMessageInterface: sourceInterface,
   };
   const slashResult = await resolveSlash(rawContent, slashContext);
 


### PR DESCRIPTION
## Summary
- make daemon slash-command help vary by interface
- thread interface context into slash resolution call sites
- add focused Bun tests for  output by interface

Part of plan: unify-desktop-slash-command-ux.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
