### PR TITLE
feat: genericize managed OAuth flow and fix disconnect error handling

### DIFF
--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -220,7 +220,18 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        await disconnectOAuthProvider(conn.providerKey, undefined, conn.id);
+        const result = await disconnectOAuthProvider(
+          conn.providerKey,
+          undefined,
+          conn.id,
+        );
+        if (result === "error") {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Failed to clean up connection tokens. The connection was not removed.",
+            500,
+          );
+        }
 
         return Response.json({ ok: true });
       },

--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -50,7 +50,7 @@ struct OAuthProviderServiceCard: View {
 
     /// True when the user has made changes worth saving.
     private var hasChanges: Bool {
-        draftMode != store.googleOAuthMode
+        draftMode != store.managedOAuthModeFor(providerKey)
     }
 
     private var isLoggedIn: Bool {
@@ -80,15 +80,17 @@ struct OAuthProviderServiceCard: View {
             }
         )
         .onAppear {
-            draftMode = store.googleOAuthMode
-            if store.googleOAuthMode == "managed" {
-                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+            draftMode = store.managedOAuthModeFor(providerKey)
+            // Always fetch provider metadata (for display name etc.) regardless of mode
+            store.fetchYourOwnOAuthApps(providerKey: providerKey)
+            if store.managedOAuthModeFor(providerKey) == "managed" {
+                Task { await store.fetchManagedOAuthConnections(providerKey: providerKey, userId: currentUserId) }
             }
         }
-        .onChange(of: store.googleOAuthMode) { _, newValue in
+        .onChange(of: store.managedOAuthModeFor(providerKey)) { _, newValue in
             draftMode = newValue
             if newValue == "managed" {
-                Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                Task { await store.fetchManagedOAuthConnections(providerKey: providerKey, userId: currentUserId) }
             } else if newValue == "your-own" {
                 store.fetchYourOwnOAuthApps(providerKey: providerKey)
             }
@@ -135,17 +137,17 @@ struct OAuthProviderServiceCard: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             if !isLoggedIn {
                 managedLoginPrompt
-            } else if !store.googleOAuthConnections.isEmpty {
+            } else if !store.managedConnections(for: providerKey).isEmpty {
                 managedConnectionsList
-            } else if store.googleOAuthIsConnecting {
+            } else if store.managedIsConnecting(for: providerKey) {
                 managedConnectingState
             } else {
                 VButton(label: "Connect \(displayName) Account", style: .primary) {
-                    store.startGoogleOAuthConnect(userId: currentUserId)
+                    store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
                 }
             }
 
-            if let error = store.googleOAuthError {
+            if let error = store.managedError(for: providerKey) {
                 VInlineMessage(error, tone: .error)
             }
         }
@@ -163,7 +165,7 @@ struct OAuthProviderServiceCard: View {
             ) {
                 Task {
                     await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                        Task { await store.fetchGoogleOAuthConnections(userId: currentUserId) }
+                        Task { await store.fetchManagedOAuthConnections(providerKey: providerKey, userId: currentUserId) }
                     })
                 }
             }
@@ -181,13 +183,13 @@ struct OAuthProviderServiceCard: View {
 
     private var managedConnectionsList: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            ForEach(store.googleOAuthConnections, id: \.id) { entry in
-                connectionRow(for: entry)
+            ForEach(store.managedConnections(for: providerKey), id: \.id) { entry in
+                managedConnectionRow(for: entry)
             }
-            VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.googleOAuthIsConnecting) {
-                store.startGoogleOAuthConnect(userId: currentUserId)
+            VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.managedIsConnecting(for: providerKey)) {
+                store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
             }
-            if store.googleOAuthIsConnecting {
+            if store.managedIsConnecting(for: providerKey) {
                 Text("Waiting for authorization...")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
@@ -195,7 +197,7 @@ struct OAuthProviderServiceCard: View {
         }
     }
 
-    private func connectionRow(for entry: OAuthConnectionEntry) -> some View {
+    private func managedConnectionRow(for entry: OAuthConnectionEntry) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text(entry.account_label ?? "\(displayName) Account")
@@ -213,7 +215,7 @@ struct OAuthProviderServiceCard: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.systemPositiveStrong)
             VButton(label: "Disconnect", style: .danger) {
-                store.disconnectGoogleOAuthConnection(entry.id, userId: currentUserId)
+                store.disconnectManagedOAuthConnection(entry.id, providerKey: providerKey, userId: currentUserId)
             }
         }
     }
@@ -468,8 +470,8 @@ struct OAuthProviderServiceCard: View {
     // MARK: - Save
 
     private func save() {
-        if draftMode != store.googleOAuthMode {
-            store.setGoogleOAuthMode(draftMode)
+        if draftMode != store.managedOAuthModeFor(providerKey) {
+            store.setManagedOAuthMode(draftMode, providerKey: providerKey)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -199,13 +199,16 @@ public final class SettingsStore: ObservableObject {
     /// Current web search mode. Values: "managed" or "your-own".
     @Published var webSearchMode: String = "your-own"
 
-    /// Current Google OAuth mode. Values: "managed" or "your-own".
-    @Published var googleOAuthMode: String = "your-own"
-    @Published var googleOAuthConnections: [OAuthConnectionEntry] = []
-    @Published var googleOAuthIsConnecting: Bool = false
-    @Published var googleOAuthError: String? = nil
+    /// Managed OAuth mode per provider (keyed by managedServiceConfigKey). Values: "managed" or "your-own".
+    @Published var managedOAuthMode: [String: String] = [:]
+    /// Managed OAuth connections per provider (keyed by managedServiceConfigKey).
+    @Published var managedOAuthConnections: [String: [OAuthConnectionEntry]] = [:]
+    /// Whether a managed OAuth connect flow is in progress (keyed by managedServiceConfigKey).
+    @Published var managedOAuthIsConnecting: [String: Bool] = [:]
+    /// Managed OAuth errors per provider (keyed by managedServiceConfigKey).
+    @Published var managedOAuthError: [String: String] = [:]
     /// Strong reference to prevent the auth session from being deallocated mid-flow.
-    private var googleOAuthWebAuthSession: ASWebAuthenticationSession?
+    private var managedOAuthWebAuthSession: ASWebAuthenticationSession?
 
     // MARK: - Your Own OAuth State
 
@@ -2139,7 +2142,7 @@ public final class SettingsStore: ObservableObject {
         }
         if let googleOAuth = services["google-oauth"] as? [String: Any],
            let mode = googleOAuth["mode"] as? String {
-            self.googleOAuthMode = mode
+            self.managedOAuthMode["integration:google"] = mode
         }
     }
 
@@ -2192,18 +2195,21 @@ public final class SettingsStore: ObservableObject {
         scheduleRoutingSourceRefresh()
     }
 
-    func setGoogleOAuthMode(_ mode: String) {
-        googleOAuthMode = mode
+    func setManagedOAuthMode(_ mode: String, providerKey: String) {
+        managedOAuthMode[providerKey] = mode
         guard !isCurrentAssistantRemote else { return }
+        // Derive config key from provider metadata or fall back to the provider slug
+        let configKey = yourOwnProviderMeta(for: providerKey)?.platformOAuthSlug ?? providerKey
+        let serviceKey = configKey.contains(":") ? configKey : "\(configKey)-oauth"
         let existingConfig = WorkspaceConfigIO.read(from: configPath)
         var services = existingConfig["services"] as? [String: Any] ?? [:]
-        var googleOAuth = services["google-oauth"] as? [String: Any] ?? [:]
-        googleOAuth["mode"] = mode
-        services["google-oauth"] = googleOAuth
+        var svc = services[serviceKey] as? [String: Any] ?? [:]
+        svc["mode"] = mode
+        services[serviceKey] = svc
         do {
             try WorkspaceConfigIO.merge(["services": services], into: configPath)
         } catch {
-            log.error("Failed to merge workspace config for google-oauth mode: \(error)")
+            log.error("Failed to merge workspace config for \(serviceKey) mode: \(error)")
         }
         scheduleRoutingSourceRefresh()
     }
@@ -2285,46 +2291,51 @@ public final class SettingsStore: ObservableObject {
         return postBootstrapResolved
     }
 
-    func fetchGoogleOAuthConnections(userId: String? = nil) async {
-        guard googleOAuthMode == "managed" else { return }
+    func fetchManagedOAuthConnections(providerKey: String, userId: String? = nil) async {
+        guard managedOAuthMode[providerKey] == "managed" else { return }
         guard let assistantId = await resolvePlatformAssistantId(userId: userId) else { return }
+
+        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
 
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
-            googleOAuthConnections = connections.filter { $0.provider == "google" }
-            googleOAuthError = nil
+            managedOAuthConnections[providerKey] = connections.filter { $0.provider == providerSlug }
+            managedOAuthError[providerKey] = nil
         } catch {
-            log.error("Failed to fetch Google OAuth connections: \(error)")
-            googleOAuthError = error.localizedDescription
-            googleOAuthConnections = []
+            log.error("Failed to fetch managed OAuth connections for \(providerKey): \(error)")
+            managedOAuthError[providerKey] = error.localizedDescription
+            managedOAuthConnections[providerKey] = []
         }
     }
 
-    func startGoogleOAuthConnect(userId: String? = nil) {
+    func startManagedOAuthConnect(providerKey: String, userId: String? = nil) {
+        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
+
         Task {
-            googleOAuthIsConnecting = true
-            googleOAuthError = nil
-            defer { googleOAuthIsConnecting = false }
+            managedOAuthIsConnecting[providerKey] = true
+            managedOAuthError[providerKey] = nil
+            defer { managedOAuthIsConnecting[providerKey] = false }
 
             guard let assistantId = await resolvePlatformAssistantId(userId: userId) else {
-                googleOAuthError = "No connected assistant"
+                managedOAuthError[providerKey] = "No connected assistant"
                 return
             }
 
             do {
-                let response = try await PlatformOAuthService.shared.startGoogleOAuth(
+                let response = try await PlatformOAuthService.shared.startOAuthConnect(
+                    provider: providerSlug,
                     assistantId: assistantId,
-                    redirectAfterConnect: "vellum-assistant://oauth/google/callback"
+                    redirectAfterConnect: "vellum-assistant://oauth/\(providerSlug)/callback"
                 )
 
                 guard let connectURL = URL(string: response.connect_url) else {
-                    googleOAuthError = "Invalid connect URL"
+                    managedOAuthError[providerKey] = "Invalid connect URL"
                     return
                 }
 
                 let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
                     let session = ASWebAuthenticationSession(url: connectURL, callbackURLScheme: "vellum-assistant") { [weak self] callbackURL, error in
-                        self?.googleOAuthWebAuthSession = nil
+                        self?.managedOAuthWebAuthSession = nil
                         if let error {
                             continuation.resume(throwing: error)
                         } else if let callbackURL {
@@ -2335,7 +2346,7 @@ public final class SettingsStore: ObservableObject {
                     }
                     session.prefersEphemeralWebBrowserSession = false
                     session.presentationContextProvider = WebAuthPresentationContext.shared
-                    self.googleOAuthWebAuthSession = session
+                    self.managedOAuthWebAuthSession = session
                     session.start()
                 }
 
@@ -2343,31 +2354,31 @@ public final class SettingsStore: ObservableObject {
                 let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
 
                 if oauthStatus == "connected" {
-                    await fetchGoogleOAuthConnections(userId: userId)
+                    await fetchManagedOAuthConnections(providerKey: providerKey, userId: userId)
                 } else if oauthStatus == "error" {
                     let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
-                    googleOAuthError = errorCode ?? "OAuth connection failed"
+                    managedOAuthError[providerKey] = errorCode ?? "OAuth connection failed"
                 }
             } catch {
-                log.error("Google OAuth connect failed: \(error)")
-                googleOAuthError = error.localizedDescription
+                log.error("Managed OAuth connect failed for \(providerKey): \(error)")
+                managedOAuthError[providerKey] = error.localizedDescription
             }
         }
     }
 
-    func disconnectGoogleOAuthConnection(_ connectionId: String, userId: String? = nil) {
+    func disconnectManagedOAuthConnection(_ connectionId: String, providerKey: String, userId: String? = nil) {
         Task {
             guard let assistantId = await resolvePlatformAssistantId(userId: userId) else {
-                googleOAuthError = "No connected assistant"
+                managedOAuthError[providerKey] = "No connected assistant"
                 return
             }
 
             do {
                 try await PlatformOAuthService.shared.disconnectConnection(assistantId: assistantId, connectionId: connectionId)
-                await fetchGoogleOAuthConnections(userId: userId)
+                await fetchManagedOAuthConnections(providerKey: providerKey, userId: userId)
             } catch {
-                log.error("Failed to disconnect Google OAuth connection: \(error)")
-                googleOAuthError = error.localizedDescription
+                log.error("Failed to disconnect managed OAuth connection for \(providerKey): \(error)")
+                managedOAuthError[providerKey] = error.localizedDescription
             }
         }
     }
@@ -2590,6 +2601,24 @@ public final class SettingsStore: ObservableObject {
 
     func yourOwnProviderMeta(for providerKey: String) -> OAuthProviderMetadata? {
         yourOwnOAuthProviderMetadata[providerKey]
+    }
+
+    // MARK: - Managed OAuth Convenience Accessors
+
+    func managedOAuthModeFor(_ providerKey: String) -> String {
+        managedOAuthMode[providerKey] ?? "your-own"
+    }
+
+    func managedConnections(for providerKey: String) -> [OAuthConnectionEntry] {
+        managedOAuthConnections[providerKey] ?? []
+    }
+
+    func managedIsConnecting(for providerKey: String) -> Bool {
+        managedOAuthIsConnecting[providerKey] ?? false
+    }
+
+    func managedError(for providerKey: String) -> String? {
+        managedOAuthError[providerKey]
     }
 
     func setWebSearchProvider(_ provider: String) {
@@ -3065,6 +3094,14 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let dashboard_url: String?
     let client_id_placeholder: String?
     let requires_client_secret: Int
+
+    /// Derive the platform OAuth slug from provider_key (e.g. "integration:google" → "google").
+    var platformOAuthSlug: String {
+        if provider_key.hasPrefix("integration:") {
+            return String(provider_key.dropFirst("integration:".count))
+        }
+        return provider_key
+    }
 }
 
 struct YourOwnOAuthAppsResponse: Codable, Sendable {

--- a/clients/shared/App/Auth/PlatformOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformOAuthService.swift
@@ -82,9 +82,9 @@ public final class PlatformOAuthService {
 
     // MARK: - Public Methods
 
-    /// Start a Google OAuth flow for the given assistant.
-    public func startGoogleOAuth(assistantId: String, redirectAfterConnect: String? = nil) async throws -> OAuthStartResponse {
-        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/google/start/"
+    /// Start an OAuth flow for the given provider and assistant.
+    public func startOAuthConnect(provider: String, assistantId: String, redirectAfterConnect: String? = nil) async throws -> OAuthStartResponse {
+        let urlString = "\(resolvePlatformBaseURL())/v1/assistants/\(assistantId)/oauth/\(provider)/start/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -110,7 +110,7 @@ public final class PlatformOAuthService {
         let httpResponse = response as? HTTPURLResponse
         let statusCode = httpResponse?.statusCode ?? 0
 
-        log.debug("Platform request POST assistants/\(assistantId)/oauth/google/start/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(assistantId)/oauth/\(provider)/start/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired


### PR DESCRIPTION
## Summary
- Parameterize PlatformOAuthService: `startGoogleOAuth` → `startOAuthConnect(provider:)` using the slug derived from providerKey (e.g. `integration:google` → `google`)
- Refactor managed OAuth state in SettingsStore from single-provider (`googleOAuthMode`, `googleOAuthConnections`, etc.) to dictionary-keyed (`managedOAuthMode[providerKey]`, `managedOAuthConnections[providerKey]`, etc.)
- Parameterize all managed methods: `fetchManagedOAuthConnections(providerKey:)`, `startManagedOAuthConnect(providerKey:)`, `disconnectManagedOAuthConnection(_:providerKey:)`
- Update OAuthProviderServiceCard managed tab to use providerKey throughout — zero hardcoded "Google" references remain
- Fix review feedback: check `disconnectOAuthProvider` return value in DELETE /v1/oauth/connections/:id and return 500 on cleanup failure
- Fix review feedback: fetch provider metadata on appear regardless of mode (prevents "OAuth OAuth" fallback text when mode is managed)

## Original prompt
Genericize the managed OAuth flow so the card is fully decoupled from Google. Also address PR review feedback on disconnect error handling and metadata loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)