### PR TITLE
fix: sort imports in workspace migration 012 test

### DIFF
--- a/assistant/src/__tests__/workspace-migration-012-rename-conversation-disk-view-dirs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-012-rename-conversation-disk-view-dirs.test.ts
@@ -2,8 +2,8 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";


### PR DESCRIPTION
## Summary
- sort the `node:fs` imports in the workspace migration 012 test so the lint job passes again
- keep the fix scoped to the single file reported by the failing CI job

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23281564467/job/67696001971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
