### PR TITLE
fix: use valid icon token and align Swift types with normalized API response

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -351,7 +351,7 @@ struct OAuthProviderServiceCard: View {
                 } else {
                     VButton(
                         label: "Connect Account",
-                        leftIcon: "lucide-log-in",
+                        leftIcon: "lucide-external-link",
                         style: .outlined,
                         isDisabled: store.yourOwnOAuthConnectingAppId != nil
                     ) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3079,9 +3079,9 @@ struct YourOwnOAuthConnection: Codable, Identifiable, Sendable {
     let id: String
     let provider_key: String
     let account_info: String?
-    let granted_scopes: String
+    let granted_scopes: [String]
     let status: String
-    let has_refresh_token: Int
+    let has_refresh_token: Bool
     let expires_at: Int?
     let created_at: Int
     let updated_at: Int


### PR DESCRIPTION
## Summary
- Replace `lucide-log-in` (not in IconTokens) with `lucide-external-link` on the Connect Account button to avoid puzzle icon fallback
- Update `YourOwnOAuthConnection` Swift type: `granted_scopes` from `String` to `[String]`, `has_refresh_token` from `Int` to `Bool` — matching the already-normalized API response from `parseGrantedScopes()` and `normalizeHasRefreshToken()`

## Original prompt
Fix the two remaining open review issues: invalid icon token on connect button and mismatched Swift types for normalized API fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
