### PR TITLE
feat: render command help bubble from shared slash catalog

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -309,7 +309,7 @@ struct ChatContentView: View {
                 removal: .opacity
             ))
         } else if message.commandList != nil {
-            CommandListBubble()
+            CommandListBubble(platform: .ios)
                 .id(message.id)
                 .transition(.asymmetric(
                     insertion: .move(edge: .bottom).combined(with: .opacity),

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1503,7 +1503,7 @@ private struct MessageCellView: View, Equatable {
             modelListView(for: message)
                 .id(message.id)
         } else if message.commandList != nil {
-            CommandListBubble()
+            CommandListBubble(platform: .macos)
                 .id(message.id)
         } else if let guardianDecision = message.guardianDecision {
             GuardianDecisionBubble(

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -6,12 +6,17 @@ public struct CommandListBubble: View {
         let description: String
     }
 
-    private let commands: [CommandEntry] = [
-        CommandEntry(id: "/commands", description: "Show this list"),
-        CommandEntry(id: "/models", description: "List all available models"),
-    ]
+    private let platform: ChatSlashCommandPlatform
 
-    public init() {}
+    private var commands: [CommandEntry] {
+        ChatSlashCommandCatalog.commands(for: platform, surface: .helpBubble).map {
+            CommandEntry(id: $0.slashName, description: $0.description)
+        }
+    }
+
+    public init(platform: ChatSlashCommandPlatform) {
+        self.platform = platform
+    }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Summary
- drive the command help bubble from the shared slash command catalog
- make the bubble platform-aware for macOS vs iOS command visibility
- update the existing macOS and iOS bubble call sites to pass platform context

Part of plan: unify-desktop-slash-command-ux.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
