### PR TITLE
feat: sync macOS slash picker with shared command catalog

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -12,14 +12,32 @@ struct SlashCommand: Identifiable {
     let name: String
     let description: String
     let icon: String
+    let selectionBehavior: ChatSlashCommandSelectionBehavior
 
-    static let all: [SlashCommand] = [
-        SlashCommand(name: "commands", description: "List all available commands", icon: "terminal"),
-        SlashCommand(name: "model", description: "Switch the active model", icon: "cpu"),
-        SlashCommand(name: "models", description: "List all available models", icon: "list.bullet"),
-        SlashCommand(name: "status", description: "Show session status and context usage", icon: "info.circle"),
-        SlashCommand(name: "btw", description: "Ask a side question while the assistant is working", icon: "bubble.left.and.text.bubble.right"),
-    ]
+    static let all: [SlashCommand] = ChatSlashCommandCatalog.commands(
+        for: .macos,
+        surface: .picker
+    ).map(SlashCommand.init(descriptor:))
+
+    init(descriptor: ChatSlashCommandDescriptor) {
+        self.name = descriptor.name
+        self.description = descriptor.description
+        self.icon = descriptor.icon
+        self.selectionBehavior = descriptor.selectionBehavior
+    }
+
+    var selectedInputText: String {
+        switch selectionBehavior {
+        case .autoSend:
+            "/\(name)"
+        case .insertTrailingSpace:
+            "/\(name) "
+        }
+    }
+
+    var shouldAutoSendOnSelect: Bool {
+        selectionBehavior == .autoSend
+    }
 }
 
 // MARK: - Slash Navigation
@@ -86,11 +104,8 @@ extension ComposerView {
     func selectSlashCommand(_ command: SlashCommand) {
         withAnimation(VAnimation.fast) { showSlashMenu = false }
         slashSelectedIndex = 0
-        if command.name == "btw" {
-            inputText = "/\(command.name) "
-            // Don't auto-send — user needs to type the question
-        } else {
-            inputText = "/\(command.name)"
+        inputText = command.selectedInputText
+        if command.shouldAutoSendOnSelect {
             onSend()
         }
     }

--- a/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
@@ -1,0 +1,30 @@
+#if os(macOS)
+import XCTest
+@testable import VellumAssistantLib
+
+final class ComposerSlashCommandPickerTests: XCTestCase {
+
+    func testPickerCommandsMatchSharedCatalogOrder() {
+        XCTAssertEqual(
+            SlashCommand.all.map(\.name),
+            ["commands", "models", "status", "btw", "pair"]
+        )
+    }
+
+    func testDeprecatedModelCommandIsNotInPickerCommands() {
+        XCTAssertFalse(SlashCommand.all.contains(where: { $0.name == "model" }))
+    }
+
+    func testBtwSelectionInsertsTrailingSpaceWithoutAutoSend() {
+        let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "btw" }))
+        XCTAssertEqual(command.selectedInputText, "/btw ")
+        XCTAssertFalse(command.shouldAutoSendOnSelect)
+    }
+
+    func testPairSelectionAutoSendsWithoutTrailingSpace() {
+        let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "pair" }))
+        XCTAssertEqual(command.selectedInputText, "/pair")
+        XCTAssertTrue(command.shouldAutoSendOnSelect)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- drive the macOS composer slash list from the shared catalog
- preserve descriptor-driven selection behavior for auto-send vs trailing-space insert
- add focused picker tests for inventory and selection semantics

Part of plan: unify-desktop-slash-command-ux.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
