### PR TITLE
fix: give compact pill gallery demo its own selection state

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct NavigationGallerySection: View {
     @State private var segmentSelection = 0
     @State private var pillSelection = "active"
+    @State private var compactPillSelection = "preview"
     @State private var selectedTab = 0
 
     private let segmentItems = ["All", "Active", "Archived", "Drafts"]
@@ -89,7 +90,7 @@ struct NavigationGallerySection: View {
                             (label: "Preview", tag: "preview"),
                             (label: "Source", tag: "source"),
                         ],
-                        selection: $pillSelection,
+                        selection: $compactPillSelection,
                         style: .pill,
                         size: .compact
                     )


### PR DESCRIPTION
## Summary
- Add dedicated `compactPillSelection` state variable for the compact pill gallery example
- The compact pill was sharing `pillSelection` (initialized to `"active"`) with the regular pill, but uses tags `"preview"`/`"source"` -- so it rendered with no initial selection and interacting with either demo deselected the other
- Addresses review feedback from PR #17953

## Test plan
- [ ] Open the Gallery > Navigation section
- [ ] Verify the compact pill control starts with "Preview" selected
- [ ] Interact with the compact pill and confirm the regular pill above is unaffected, and vice versa

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
