### PR TITLE
refactor: centralize shared chat slash command classification

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -361,6 +361,7 @@ public final class ChatViewModel: ObservableObject {
 
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol
+    private let settingsClient: any SettingsClientProtocol
     private let surfaceClient: any SurfaceClientProtocol = SurfaceClient()
     private let conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient()
     let interactionClient: any InteractionClientProtocol
@@ -901,8 +902,14 @@ public final class ChatViewModel: ObservableObject {
     /// Set via the onPageChanged callback when the user navigates within a multi-page app.
     public var currentPage: String?
 
-    public init(daemonClient: any DaemonClientProtocol, interactionClient: any InteractionClientProtocol = InteractionClient(), onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil) {
+    public init(
+        daemonClient: any DaemonClientProtocol,
+        settingsClient: any SettingsClientProtocol = SettingsClient(),
+        interactionClient: any InteractionClientProtocol = InteractionClient(),
+        onToolCallsComplete: ((_ toolCalls: [ToolCallData]) -> Void)? = nil
+    ) {
         self.daemonClient = daemonClient
+        self.settingsClient = settingsClient
         self.interactionClient = interactionClient
         self.onToolCallsComplete = onToolCallsComplete
 
@@ -1137,10 +1144,12 @@ public final class ChatViewModel: ObservableObject {
         // `confirmation_state_changed` events for all resolution paths.
         // No client-side pessimistic denial is needed.
 
-        // When "/model" or "/models" is sent, refresh model state so the picker/table has fresh data
-        if (text == "/model" || text == "/models") && !hasSkillInvocation {
+        // Refresh model state only for slash commands that explicitly opt in.
+        let shouldRefreshModelMetadata = !hasSkillInvocation
+            && ChatSlashCommandCatalog.shouldRefreshModelMetadata(forRawInput: text)
+        if shouldRefreshModelMetadata {
             Task {
-                let info = await SettingsClient().fetchModelInfo()
+                let info = await self.settingsClient.fetchModelInfo()
                 if let model = info?.model {
                     self.selectedModel = model
                 }
@@ -1157,7 +1166,7 @@ public final class ChatViewModel: ObservableObject {
         }
 
         // Fire auto-title callback on the first user message (skip slash commands
-        // like /model so the conversation title isn't set to a command string)
+        // so the conversation title isn't set to a command token)
         if !rawText.isEmpty, !rawText.hasPrefix("/"), let callback = onFirstUserMessage {
             onFirstUserMessage = nil
             callback(rawText)
@@ -1217,8 +1226,8 @@ public final class ChatViewModel: ObservableObject {
         let attachments = pendingAttachments
         pendingAttachments = []
 
-        let isModelCommand = text == "/model" || text == "/models" || text.hasPrefix("/model ")
-        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !isModelCommand
+        let hasSlashCommandToken = ChatSlashCommandCatalog.normalizedCommandName(from: text) != nil
+        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !hasSlashCommandToken
 
         let willBeQueued = isSending && conversationId != nil
         var queuedMessageId: UUID?

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatViewModelSlashCommandTests: XCTestCase {
+
+    private final class StubSettingsClient: SettingsClientProtocol {
+        var fetchModelInfoCallCount = 0
+        var modelInfoResponse: ModelInfoMessage?
+
+        func fetchVercelConfig() async -> VercelApiConfigResponseMessage? { nil }
+
+        func fetchModelInfo() async -> ModelInfoMessage? {
+            fetchModelInfoCallCount += 1
+            return modelInfoResponse
+        }
+
+        func setModel(model: String, provider: String?) async -> ModelInfoMessage? { nil }
+
+        func setImageGenModel(modelId: String) async -> ModelInfoMessage? { nil }
+
+        func fetchTelegramConfig() async -> TelegramConfigResponseMessage? { nil }
+
+        func setTelegramConfig(
+            action: String,
+            botToken: String?,
+            commands: [TelegramConfigRequestCommand]?
+        ) async -> TelegramConfigResponseMessage? { nil }
+
+        func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool { false }
+
+        func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage? { nil }
+    }
+
+    private var daemonClient: MockDaemonClient!
+    private var settingsClient: StubSettingsClient!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        settingsClient = StubSettingsClient()
+        viewModel = ChatViewModel(
+            daemonClient: daemonClient,
+            settingsClient: settingsClient
+        )
+        viewModel.conversationId = "sess-1"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        settingsClient = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    func testCommandsAndStatusBypassWorkspaceRefinementWhenSurfaceIsActive() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
+
+        viewModel.inputText = "/commands"
+        viewModel.sendMessage()
+
+        XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/commands")
+
+        viewModel.inputText = "/status"
+        viewModel.sendMessage()
+
+        XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[1].text, "/status")
+    }
+
+    func testModelsRefreshesMetadataButDeprecatedModelDoesNot() async {
+        settingsClient.modelInfoResponse = ModelInfoMessage(
+            type: "model_info",
+            model: "test-model",
+            provider: "test-provider",
+            configuredProviders: ["test-provider"]
+        )
+
+        viewModel.inputText = "/models"
+        viewModel.sendMessage()
+
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
+
+        viewModel.inputText = "/model"
+        viewModel.sendMessage()
+
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
+    }
+
+    func testDeprecatedModelStillBypassesWorkspaceRefinementAndSends() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
+
+        viewModel.inputText = "/model"
+        viewModel.sendMessage()
+
+        XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/model")
+    }
+}


### PR DESCRIPTION
## Summary
- replace stale ad hoc  checks in ChatViewModel with shared catalog helpers
- make recognized slash commands bypass workspace-refinement routing consistently
- add focused shared tests for slash command send-path behavior

Part of plan: unify-desktop-slash-command-ux.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
