### PR TITLE
fix: bump updatedAt in existing-row secret path so rollback guard detects concurrent writers (#19091)

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -270,6 +270,14 @@ export async function upsertApp(
       if (!stored) {
         throw new Error("Failed to store client_secret in secure storage");
       }
+      // Bump updatedAt so the rollback guard in the new-row insertion path
+      // can detect that a concurrent caller has claimed this row. Without
+      // this, a concurrent inserter's rollback DELETE would still match on
+      // the original updatedAt and delete the row we just validated.
+      db.update(oauthApps)
+        .set({ updatedAt: Date.now() })
+        .where(eq(oauthApps.id, existingRow.id))
+        .run();
     }
     if (clientSecretCredentialPath) {
       db.update(oauthApps)


### PR DESCRIPTION
## Summary
- In `upsertApp`, the existing-row + `clientSecretValue` path stored the secret but did not update `updatedAt` on the DB row
- This made the rollback guard (`eq(oauthApps.updatedAt, now)`) ineffective: a concurrent inserter's rollback DELETE would still match the original timestamp and delete the row, orphaning the secret the concurrent caller just stored
- The fix bumps `updatedAt` after a successful `setSecureKeyAsync` in the existing-row path, so the guard can detect the concurrent modification

## Original PR
Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/19091

## Test plan
- [x] Existing tests still pass (the rollback guard logic is unchanged for the non-race case)
- [ ] CI passes lint, type-check, and existing oauth-store tests

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
