### PR TITLE
fix: convert OAuth app timestamp from ms to seconds in formattedDate

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -460,7 +460,7 @@ struct OAuthProviderServiceCard: View {
     }
 
     private func formattedDate(_ timestamp: Int) -> String {
-        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0)
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .none


### PR DESCRIPTION
## Summary
- Fix timestamp interpretation bug in `OAuthProviderServiceCard.formattedDate()`
- The backend stores timestamps using JavaScript's `Date.now()` which returns epoch milliseconds
- The Swift code was passing the raw value to `Date(timeIntervalSince1970:)` which expects seconds
- This caused OAuth app creation dates to display as dates ~54,000 years in the future
- Fixed by dividing by 1000.0, matching the convention used everywhere else in the codebase

Addresses review feedback from PR #19082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
