### PR TITLE
fix: add accessibility label to OAuth app delete button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -312,6 +312,7 @@ struct OAuthProviderServiceCard: View {
                             .foregroundColor(VColor.systemNegativeStrong)
                     }
                     .buttonStyle(.borderless)
+                    .accessibilityLabel("Delete OAuth App")
                     .transition(.opacity.animation(VAnimation.fast))
                 }
             }


### PR DESCRIPTION
## Summary
- Add missing `.accessibilityLabel("Delete OAuth App")` to the icon-only trash button in `OAuthProviderServiceCard.swift`
- Addresses review feedback from PR #19094 about AGENTS.md accessibility rule violations
- The other two review comments from #19094 (async create flow, plus button accessibility) were already resolved by PRs #19111 and #19244

## Test plan
- [ ] Verify the trash button on OAuth app cards has proper VoiceOver accessibility label
- [ ] Confirm no other icon-only buttons in this file are missing accessibility labels

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
