### PR TITLE
fix: reset bodyLayer.speed before starting breathing on interrupted post-entry resume

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -478,7 +478,12 @@ class AvatarLayerView: NSView {
         // resume a non-existent breathing animation.
         if hasPlayedEntry && !postEntryAnimationsStarted {
             postEntryAnimationsStarted = true
-            if configBreathingEnabled { startBreathing() }
+            if configBreathingEnabled {
+                bodyLayer.speed = 1
+                bodyLayer.timeOffset = 0
+                bodyLayer.beginTime = 0
+                startBreathing()
+            }
             return
         }
 


### PR DESCRIPTION
## Summary
- Fixes a bug from PR #19097 where the early-return path in `resumeAnimations()` called `startBreathing()` without first resetting `bodyLayer.speed` from 0 to 1
- When the window loses focus during the 1.1s post-entry delay, `pauseAnimations()` sets `bodyLayer.speed = 0`. On resume, the new breathing animation was attached to a still-paused layer and never visually played
- Now resets `bodyLayer.speed = 1`, `timeOffset = 0`, and `beginTime = 0` before calling `startBreathing()` in the early-return path

Addresses review feedback from PR #19097.

## Test plan
- [ ] Verify that if the window loses focus during the 1.1s post-entry delay, breathing animation starts correctly when focus returns
- [ ] Verify breathing, blink, and twitch animations still start after the post-entry delay under normal conditions
- [ ] Verify that pause/resume after breathing is already running still works (layer timing resume path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
