### PR TITLE
fix: sync Swift attachment DTOs with daemon contract

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1711,16 +1711,18 @@ final class ChatViewModelTests: XCTestCase {
         // Complete with attachments
         let attachment = UserMessageAttachment(
             id: "att-1", filename: "photo.png", mimeType: "image/png",
-            data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
+            data: "iVBORw0KGgo=", sourceType: "tool_block", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.messageComplete(
-            MessageCompleteMessage(conversationId: nil, attachments: [attachment])
+            MessageCompleteMessage(conversationId: nil, attachments: [attachment], attachmentWarnings: ["Attachment was sanitized"])
         ))
 
         XCTAssertEqual(viewModel.messages.count, 1, "Should add attachments to existing message, not create new")
         XCTAssertEqual(viewModel.messages[0].attachments.count, 1)
         XCTAssertEqual(viewModel.messages[0].attachments[0].filename, "photo.png")
         XCTAssertEqual(viewModel.messages[0].attachments[0].id, "att-1")
+        XCTAssertEqual(viewModel.messages[0].attachments[0].sourceType, "tool_block")
+        XCTAssertEqual(viewModel.messages[0].attachmentWarnings, ["Attachment was sanitized"])
         XCTAssertFalse(viewModel.messages[0].isStreaming)
     }
 
@@ -1757,11 +1759,18 @@ final class ChatViewModelTests: XCTestCase {
             data: "Y29sQQ==", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
         viewModel.handleServerMessage(.generationHandoff(
-            GenerationHandoffMessage(conversationId: "sess-1", requestId: nil, queuedCount: 1, attachments: [attachment])
+            GenerationHandoffMessage(
+                conversationId: "sess-1",
+                requestId: nil,
+                queuedCount: 1,
+                attachments: [attachment],
+                attachmentWarnings: ["Generated attachment is truncated"]
+            )
         ))
 
         XCTAssertEqual(viewModel.messages[0].attachments.count, 1)
         XCTAssertEqual(viewModel.messages[0].attachments[0].filename, "output.csv")
+        XCTAssertEqual(viewModel.messages[0].attachmentWarnings, ["Generated attachment is truncated"])
         XCTAssertFalse(viewModel.messages[0].isStreaming)
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -354,13 +354,13 @@ extension ChatViewModel {
                 id: id,
                 filename: attachment.filename,
                 mimeType: attachment.mimeType,
-                sourceType: attachment.sourceType,
                 data: base64,
                 thumbnailData: thumbnailData,
                 dataLength: dataLength,
                 sizeBytes: sizeBytes,
                 thumbnailImage: thumbnailImage,
-                filePath: attachment.filePath
+                filePath: attachment.filePath,
+                sourceType: attachment.sourceType
             )
         }
     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1691,14 +1691,16 @@ public struct GenerationHandoff: Codable, Sendable {
     public let requestId: String?
     public let queuedCount: Int
     public let attachments: [UserMessageAttachment]?
+    public let attachmentWarnings: [String]?
     public let messageId: String?
 
-    public init(type: String, conversationId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
+    public init(type: String, conversationId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.requestId = requestId
         self.queuedCount = queuedCount
         self.attachments = attachments
+        self.attachmentWarnings = attachmentWarnings
         self.messageId = messageId
     }
 }
@@ -2545,12 +2547,14 @@ public struct MessageComplete: Codable, Sendable {
     public let type: String
     public let conversationId: String?
     public let attachments: [UserMessageAttachment]?
+    public let attachmentWarnings: [String]?
     public let messageId: String?
 
-    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
+    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.attachments = attachments
+        self.attachmentWarnings = attachmentWarnings
         self.messageId = messageId
     }
 }
@@ -4903,6 +4907,8 @@ public struct UserMessageAttachment: Codable, Sendable {
     public let filename: String
     public let mimeType: String
     public let data: String
+    /// Origin of the attachment on the daemon side, when known.
+    public let sourceType: String?
     public let extractedText: String?
     /// Original file size in bytes. Present when data was omitted from history_response to reduce payload size.
     public let sizeBytes: Int?
@@ -4913,11 +4919,12 @@ public struct UserMessageAttachment: Codable, Sendable {
     /// True when the attachment is file-backed and clients should hydrate via the /content endpoint.
     public let fileBacked: Bool?
 
-    public init(id: String? = nil, filename: String, mimeType: String, data: String, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil, fileBacked: Bool? = nil) {
+    public init(id: String? = nil, filename: String, mimeType: String, data: String, sourceType: String? = nil, extractedText: String? = nil, sizeBytes: Int? = nil, thumbnailData: String? = nil, filePath: String? = nil, fileBacked: Bool? = nil) {
         self.id = id
         self.filename = filename
         self.mimeType = mimeType
         self.data = data
+        self.sourceType = sourceType
         self.extractedText = extractedText
         self.sizeBytes = sizeBytes
         self.thumbnailData = thumbnailData

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -673,8 +673,8 @@ extension AssistantThinkingDelta {
 public typealias MessageCompleteMessage = MessageComplete
 
 extension MessageComplete {
-    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
-        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, messageId: messageId)
+    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
+        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId)
     }
 }
 
@@ -840,8 +840,8 @@ public struct GenerationCancelledMessage: Decodable, Sendable {
 public typealias GenerationHandoffMessage = GenerationHandoff
 
 extension GenerationHandoff {
-    public init(conversationId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
-        self.init(type: "generation_handoff", conversationId: conversationId, requestId: requestId, queuedCount: queuedCount, attachments: attachments, messageId: messageId)
+    public init(conversationId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
+        self.init(type: "generation_handoff", conversationId: conversationId, requestId: requestId, queuedCount: queuedCount, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId)
     }
 }
 


### PR DESCRIPTION
## Summary
- sync the manually maintained Swift message DTOs with the daemon contract so attachment source metadata and attachment warnings are available again in client code
- fix the assistant attachment mapping call site in ChatViewModel+MessageHandling.swift and extend chat tests to cover the restored fields
- Apple refs checked (2026-03-19): no new Apple APIs were introduced; local iOS verification was limited because this machine lacks the iOS 26.2 simulator platform

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23281725966/job/67696492065

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
