### PR TITLE
fix: resolve Swift build errors from premature sourceType/attachmentWarnings references

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -742,6 +742,7 @@ struct ActiveChatViewWrapper: View {
                 viewModel?.inputText = starter.prompt
             },
             onFetchConversationStarters: { [weak viewModel] in viewModel?.fetchConversationStarters() },
+            isInteractionEnabled: inspectorMessageId == nil,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,
@@ -759,7 +760,6 @@ struct ActiveChatViewWrapper: View {
             loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
             isBootstrapping: isBootstrapping,
             isBootstrapTimedOut: isBootstrapTimedOut,
-            isInteractionEnabled: inspectorMessageId == nil,
             onBootstrapSendLogs: {
                 AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
             }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -354,7 +354,6 @@ extension ChatViewModel {
                 id: id,
                 filename: attachment.filename,
                 mimeType: attachment.mimeType,
-                sourceType: attachment.sourceType,
                 data: base64,
                 thumbnailData: thumbnailData,
                 dataLength: dataLength,
@@ -727,7 +726,6 @@ extension ChatViewModel {
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             if !wasRefinement {
                 ingestAssistantAttachments(complete.attachments)
-                ingestAssistantAttachmentWarnings(complete.attachmentWarnings)
             }
             if pendingVoiceMessage {
                 pendingVoiceMessage = false
@@ -1020,7 +1018,6 @@ extension ChatViewModel {
             flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
-            ingestAssistantAttachmentWarnings(handoff.attachmentWarnings)
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {


### PR DESCRIPTION
## Summary
- Remove `sourceType` from `ChatAttachment` constructor call in `ChatViewModel+MessageHandling.swift` — `UserMessageAttachment` (generated type) does not have a `sourceType` field yet
- Remove `ingestAssistantAttachmentWarnings` calls for `MessageComplete` and `GenerationHandoff` completions — neither generated type has an `attachmentWarnings` field yet
- Fix `isInteractionEnabled` parameter ordering in `PanelCoordinator.swift` — must precede `anchorMessageId` to match `ChatView` property declaration order

## Original prompt
fix them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
