### PR TITLE
fix: restore backfill-installation-id migration to original position and ID

### DIFF
--- a/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
@@ -41,7 +41,7 @@ mock.module("../runtime/auth/external-assistant-id.js", () => ({
 }));
 
 // Import after mocking
-import { backfillInstallationIdMigration } from "../workspace/migrations/011-backfill-installation-id.js";
+import { backfillInstallationIdMigration } from "../workspace/migrations/002-backfill-installation-id.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -68,7 +68,7 @@ function setupFs(fileContents: Record<string, string>): void {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("011-backfill-installation-id migration", () => {
+describe("002-backfill-installation-id migration", () => {
   beforeEach(() => {
     existsSyncFn.mockClear();
     readFileSyncFn.mockClear();
@@ -320,9 +320,9 @@ describe("011-backfill-installation-id migration", () => {
     expect(parsed.assistants[1].installationId).toBe("sqlite-id");
   });
 
-  test("has migration id 011-backfill-installation-id", () => {
+  test("has migration id 002-backfill-installation-id", () => {
     expect(backfillInstallationIdMigration.id).toBe(
-      "011-backfill-installation-id",
+      "002-backfill-installation-id",
     );
   });
 });

--- a/assistant/src/workspace/migrations/002-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/002-backfill-installation-id.ts
@@ -11,7 +11,7 @@ import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id
 import type { WorkspaceMigration } from "./types.js";
 
 export const backfillInstallationIdMigration: WorkspaceMigration = {
-  id: "011-backfill-installation-id",
+  id: "002-backfill-installation-id",
   description:
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
   run(_workspaceDir: string): void {

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,4 +1,5 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
+import { backfillInstallationIdMigration } from "./002-backfill-installation-id.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
@@ -7,7 +8,6 @@ import { webSearchProviderRenameMigration } from "./007-web-search-provider-rena
 import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-steps.js";
 import { backfillConversationDiskViewMigration } from "./009-backfill-conversation-disk-view.js";
 import { appDirRenameMigration } from "./010-app-dir-rename.js";
-import { backfillInstallationIdMigration } from "./011-backfill-installation-id.js";
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -17,6 +17,7 @@ import type { WorkspaceMigration } from "./types.js";
  */
 export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   avatarRenameMigration,
+  backfillInstallationIdMigration,
   seedDeviceIdMigration,
   extractCollectUsageDataMigration,
   addSendDiagnosticsMigration,
@@ -25,6 +26,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   voiceTimeoutAndMaxStepsMigration,
   backfillConversationDiskViewMigration,
   appDirRenameMigration,
-  backfillInstallationIdMigration,
   renameConversationDiskViewDirsMigration,
 ];


### PR DESCRIPTION
## Summary
- Renames `011-backfill-installation-id.ts` back to `002-backfill-installation-id.ts`
- Restores migration ID from `011-backfill-installation-id` to `002-backfill-installation-id`
- Moves `backfillInstallationIdMigration` back to index 1 in `WORKSPACE_MIGRATIONS` (between `avatarRenameMigration` and `seedDeviceIdMigration`), restoring the ordering dependency required by `003-seed-device-id`
- Updates test file import path and describe/assertion strings to match

Addresses review feedback from PR #19133.

## Test plan
- [x] All references to `011-backfill-installation-id` updated to `002-backfill-installation-id`
- [x] Migration array ordering restored: `002` runs before `003-seed-device-id`
- [x] Pre-commit hooks pass (lint, format, secrets scan)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
