### PR TITLE
fix: use window.currentEvent for reliable click detection in ClickReportingTextView

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -442,24 +442,17 @@ private class ClickReportingTextView: NSTextView {
     var onContentClick: (() -> Void)?
 
     override func mouseDown(with event: NSEvent) {
-        let mouseDownLocation = event.locationInWindow
+        let downLocation = event.locationInWindow
         super.mouseDown(with: event)
-
-        // NSTextView handles click/drag tracking inside mouseDown and may not
-        // invoke our mouseUp override afterward, so detect the completed click
-        // here once AppKit returns control to us.
-        guard event.clickCount == 1 else { return }
-
-        // Only fire if the mouse didn't move significantly (i.e. not a drag
-        // for text selection). A 3-point threshold accounts for minor jitter.
-        let mouseUpLocation = window?.mouseLocationOutsideOfEventStream ?? mouseDownLocation
-        let dx = abs(mouseUpLocation.x - mouseDownLocation.x)
-        let dy = abs(mouseUpLocation.y - mouseDownLocation.y)
+        // super.mouseDown blocks until mouse-up (NSTextView runs a tracking
+        // loop for text selection). Detect click vs drag here, not in mouseUp
+        // which is never called through the normal responder chain.
+        guard let currentEvent = window?.currentEvent else { return }
+        let upLocation = currentEvent.locationInWindow
+        let dx = abs(upLocation.x - downLocation.x)
+        let dy = abs(upLocation.y - downLocation.y)
         if dx < 3 && dy < 3 {
-            let onContentClick = onContentClick
-            DispatchQueue.main.async {
-                onContentClick?()
-            }
+            onContentClick?()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `window?.mouseLocationOutsideOfEventStream` with `window?.currentEvent` in `ClickReportingTextView.mouseDown(with:)` for more reliable mouse-up location detection
- `currentEvent` captures the actual event that ended NSTextView's internal tracking loop, whereas `mouseLocationOutsideOfEventStream` returns the cursor position at query time (which could differ if the mouse moved after release)
- Remove unnecessary `event.clickCount == 1` guard and `DispatchQueue.main.async` wrapper (already on main thread when `super.mouseDown` returns)

Addresses review feedback on #19182.

## Test plan
- [ ] Click on code content in read-only mode -- verify it enters edit mode
- [ ] Click-drag to select text in read-only mode -- verify it does NOT trigger edit mode
- [ ] Verify search bar clicks do not trigger edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
