### PR TITLE
fix: move PersistedConversation Codable init to extension to preserve memberwise init

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -79,37 +79,12 @@ private struct PersistedConversation: Codable {
         // Legacy key used before the session-to-conversation rename.
         case legacySessionId = "sessionId"
     }
+}
 
-    init(
-        id: UUID,
-        title: String,
-        createdAt: Date,
-        lastActivityAt: Date? = nil,
-        isArchived: Bool? = nil,
-        isPinned: Bool? = nil,
-        displayOrder: Int? = nil,
-        isPrivate: Bool? = nil,
-        conversationId: String? = nil,
-        scheduleJobId: String? = nil,
-        hasUnseenLatestAssistantMessage: Bool? = nil,
-        latestAssistantMessageAt: Date? = nil,
-        lastSeenAssistantMessageAt: Date? = nil
-    ) {
-        self.id = id
-        self.title = title
-        self.createdAt = createdAt
-        self.lastActivityAt = lastActivityAt
-        self.isArchived = isArchived
-        self.isPinned = isPinned
-        self.displayOrder = displayOrder
-        self.isPrivate = isPrivate
-        self.conversationId = conversationId
-        self.scheduleJobId = scheduleJobId
-        self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
-        self.latestAssistantMessageAt = latestAssistantMessageAt
-        self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
-    }
-
+// Custom Codable conformance lives in an extension so that Swift's
+// synthesized memberwise initializer is preserved for call sites like
+// saveConnectedCache() and save().
+extension PersistedConversation {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)


### PR DESCRIPTION
## Summary
- Move `init(from:)` and `encode(to:)` from the `PersistedConversation` struct body into an extension, so Swift's synthesized memberwise initializer is preserved
- Remove the manually-written memberwise initializer that was added as a workaround — it's no longer needed since Swift synthesizes one when custom inits are only in extensions
- Addresses review feedback from PR #19140

## Test plan
- [ ] Verify iOS builds compile successfully (memberwise init at `saveConnectedCache()` and `save()` should resolve to Swift's synthesized init)
- [ ] Verify cross-version UserDefaults decoding still works (both `sessionId` and `conversationId` keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
