### PR TITLE
fix: remove stale /model footer guidance

### DIFF
--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -89,7 +89,7 @@ public struct ModelListBubble: View {
             }
 
             // Footer
-            Text("Switch with /model <id> or `keys set <provider> <key>` to add a provider.")
+            Text("Use Settings -> Models & Services to switch models, or `keys set <provider> <key>` to add a provider.")
                 .font(VFont.small)
                 .foregroundColor(VColor.contentTertiary)
                 .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-desktop-slash-command-ux.md.

**Gap:** Stale /model discovery still exists in the client UI
**What was expected:** Model guidance should match the supported slash command UX.
**What was found:** The model list bubble still advertises deprecated /model usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
