### PR TITLE
fix: make checkpoint key rename collision-safe in migration 181

### DIFF
--- a/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
+++ b/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
@@ -13,6 +13,11 @@ import { withCrashRecovery } from "./validate-migration-state.js";
  * would skip the entire body for users who had already run it. Moving
  * the checkpoint-key rewrite into its own migration with an independent
  * checkpoint key ensures it runs for all users.
+ *
+ * The rename is collision-safe: if a database already has both old
+ * `thread_starters:*` keys and new `conversation_starters:*` keys
+ * (written by updated code after the table rename), we drop the stale
+ * old rows first to avoid UNIQUE constraint violations on the primary key.
  */
 export function migrateRenameThreadStartersCheckpoints(
   database: DrizzleDb,
@@ -23,6 +28,16 @@ export function migrateRenameThreadStartersCheckpoints(
     () => {
       const raw = getSqliteFrom(database);
 
+      // 1. Delete old thread_starters: keys where a corresponding
+      //    conversation_starters: key already exists (the newer key
+      //    written by updated code takes precedence).
+      raw.exec(/*sql*/ `DELETE FROM memory_checkpoints
+         WHERE key LIKE 'thread_starters:%'
+           AND replace(key, 'thread_starters:', 'conversation_starters:') IN (
+             SELECT key FROM memory_checkpoints WHERE key LIKE 'conversation_starters:%'
+           )`);
+
+      // 2. Rename remaining old keys that have no collision.
       raw.exec(
         /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
       );


### PR DESCRIPTION
## Summary
- Made migration 181's checkpoint key rename collision-safe to prevent `UNIQUE constraint failed` errors
- If a database has both old `thread_starters:*` and new `conversation_starters:*` keys, the old rows are deleted first (the newer keys written by updated code take precedence)
- Remaining non-colliding old keys are then renamed as before

## Test plan
- [x] Verify the DELETE correctly targets only old keys that would collide
- [x] Verify the UPDATE still renames non-colliding old keys
- [x] Both operations are idempotent (safe to re-run)

Addresses review feedback on #19184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
