### PR TITLE
fix: align macOS chat build with current signatures

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -742,6 +742,7 @@ struct ActiveChatViewWrapper: View {
                 viewModel?.inputText = starter.prompt
             },
             onFetchConversationStarters: { [weak viewModel] in viewModel?.fetchConversationStarters() },
+            isInteractionEnabled: inspectorMessageId == nil,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,
@@ -759,7 +760,6 @@ struct ActiveChatViewWrapper: View {
             loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() },
             isBootstrapping: isBootstrapping,
             isBootstrapTimedOut: isBootstrapTimedOut,
-            isInteractionEnabled: inspectorMessageId == nil,
             onBootstrapSendLogs: {
                 AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
             }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -354,13 +354,13 @@ extension ChatViewModel {
                 id: id,
                 filename: attachment.filename,
                 mimeType: attachment.mimeType,
-                sourceType: attachment.sourceType,
                 data: base64,
                 thumbnailData: thumbnailData,
                 dataLength: dataLength,
                 sizeBytes: sizeBytes,
                 thumbnailImage: thumbnailImage,
-                filePath: attachment.filePath
+                filePath: attachment.filePath,
+                sourceType: nil
             )
         }
     }
@@ -376,21 +376,6 @@ extension ChatViewModel {
             messages[index].attachments.append(contentsOf: chatAttachments)
         } else {
             let msg = ChatMessage(role: .assistant, text: "", attachments: chatAttachments)
-            currentAssistantMessageId = msg.id
-            messages.append(msg)
-        }
-    }
-
-    /// Ingest attachment warnings from a completion/handoff event into the
-    /// current or new assistant message.
-    func ingestAssistantAttachmentWarnings(_ warnings: [String]?) {
-        guard let warnings, !warnings.isEmpty else { return }
-
-        if let existingId = currentAssistantMessageId,
-           let index = messages.firstIndex(where: { $0.id == existingId }) {
-            messages[index].attachmentWarnings.append(contentsOf: warnings)
-        } else {
-            let msg = ChatMessage(role: .assistant, text: "", attachmentWarnings: warnings)
             currentAssistantMessageId = msg.id
             messages.append(msg)
         }
@@ -727,7 +712,6 @@ extension ChatViewModel {
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             if !wasRefinement {
                 ingestAssistantAttachments(complete.attachments)
-                ingestAssistantAttachmentWarnings(complete.attachmentWarnings)
             }
             if pendingVoiceMessage {
                 pendingVoiceMessage = false
@@ -1020,7 +1004,6 @@ extension ChatViewModel {
             flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
-            ingestAssistantAttachmentWarnings(handoff.attachmentWarnings)
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {


### PR DESCRIPTION
## Summary
- Align `ChatViewModel+MessageHandling` with the current generated attachment payloads by removing stale `sourceType` and `attachmentWarnings` references.
- Drop the dead attachment-warning ingestion path that no longer matches `message_complete` and `generation_handoff`, keeping assistant attachment handling compile-safe.
- Reorder the `ChatView` call in `PanelCoordinator` to match the current synthesized initializer so the macOS build completes.

Apple refs checked (2026-03-19): none needed; this is a compile-only alignment with existing Swift signatures, not a platform API behavior change.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23281789735/job/67696692615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
