### PR TITLE
fix: narrow slash command send-path classification

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1226,8 +1226,11 @@ public final class ChatViewModel: ObservableObject {
         let attachments = pendingAttachments
         pendingAttachments = []
 
-        let hasSlashCommandToken = ChatSlashCommandCatalog.normalizedCommandName(from: text) != nil
-        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !hasSlashCommandToken
+        let hasRecognizedSlashCommand = ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            text,
+            surface: .sendPath
+        )
+        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !hasRecognizedSlashCommand
 
         let willBeQueued = isSending && conversationId != nil
         var queuedMessageId: UUID?

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -97,15 +97,21 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
     }
 
-    func testDeprecatedModelStillBypassesWorkspaceRefinementAndSends() {
+    func testUnknownSlashCommandsUseWorkspaceRefinementWhenSurfaceIsActive() {
         viewModel.activeSurfaceId = "surface-1"
         viewModel.isChatDockedToSide = false
 
+        viewModel.inputText = "/foo"
+        viewModel.sendMessage()
+
+        XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
+        XCTAssertEqual(viewModel.messages.count, 0)
+
+        viewModel.isWorkspaceRefinementInFlight = false
         viewModel.inputText = "/model"
         viewModel.sendMessage()
 
-        XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
-        XCTAssertEqual(viewModel.messages.count, 1)
-        XCTAssertEqual(viewModel.messages[0].text, "/model")
+        XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
+        XCTAssertEqual(viewModel.messages.count, 0)
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-desktop-slash-command-ux.md.

**Gap:** Send-path classification is broader than the shared catalog
**What was expected:** Shared send-path routing should only treat recognized slash commands as special.
**What was found:** Unknown slash tokens also bypass workspace refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
