### PR TITLE
fix: remove dead serviceKeys property after force-init refactor

### DIFF
--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -124,9 +124,6 @@ public enum WorkspaceConfigIO {
     /// Google OAuth mode is user-selected and must survive app restarts.
     static let initOnlyServiceKeys = ["google-oauth"]
 
-    /// All known service keys (union of forcible + init-only).
-    static let serviceKeys: [String] = forcibleServiceKeys + initOnlyServiceKeys
-
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").
     /// Existing user-chosen modes are preserved so that app restarts don't reset preferences.


### PR DESCRIPTION
## Summary
- Removes the dead `serviceKeys` property from `WorkspaceConfigIO.swift` that was left behind by PR #19209
- After #19209 split the single loop into separate `forcibleServiceKeys` and `initOnlyServiceKeys` loops, the combined `serviceKeys` property had zero references anywhere in the codebase
- Follows AGENTS.md dead code removal rule: "Remove code your change makes unused"

## Test plan
- [ ] Build the macOS app to verify no compilation errors
- [ ] Confirm no references to `serviceKeys` exist in the codebase

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
