### PR TITLE
feat: add structured raw payload viewer for message inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+import VellumAssistantShared
+
+enum MessageInspectorPayloadViewMode: String, Hashable {
+    case tree
+    case source
+
+    var label: String {
+        switch self {
+        case .tree:
+            return "Tree"
+        case .source:
+            return "Source"
+        }
+    }
+}
+
+struct MessageInspectorPayloadModel: Equatable {
+    let source: String
+    let isTreeAvailable: Bool
+    var viewMode: MessageInspectorPayloadViewMode {
+        didSet {
+            if !isTreeAvailable, viewMode != .source {
+                viewMode = .source
+            }
+        }
+    }
+
+    init(payload: AnyCodable, preferredViewMode: MessageInspectorPayloadViewMode = .tree) {
+        self.init(
+            source: Self.renderSource(from: payload),
+            preferredViewMode: preferredViewMode
+        )
+    }
+
+    init(source: String, preferredViewMode: MessageInspectorPayloadViewMode = .tree) {
+        self.source = source
+        isTreeAvailable = Self.canRenderTree(source: source)
+        viewMode = isTreeAvailable ? preferredViewMode : .source
+    }
+
+    var availableViewModes: [MessageInspectorPayloadViewMode] {
+        isTreeAvailable ? [.tree, .source] : [.source]
+    }
+
+    var showsViewModePicker: Bool {
+        availableViewModes.count > 1
+    }
+
+    var showsExpandCollapseActions: Bool {
+        isTreeAvailable && viewMode == .tree
+    }
+
+    static func canRenderTree(source: String) -> Bool {
+        let trimmedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSource.isEmpty, let data = trimmedSource.data(using: .utf8) else {
+            return false
+        }
+
+        do {
+            _ = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func renderSource(from payload: AnyCodable) -> String {
+        guard let value = payload.value else {
+            return "null"
+        }
+
+        if let object = wrapJSONObject(value) {
+            do {
+                let data = try JSONSerialization.data(
+                    withJSONObject: object,
+                    options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+                )
+                return String(data: data, encoding: .utf8) ?? String(describing: value)
+            } catch {
+                return String(describing: value)
+            }
+        }
+
+        if isJSONFragment(value) {
+            do {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+                let data = try encoder.encode(payload)
+                return String(data: data, encoding: .utf8) ?? String(describing: value)
+            } catch {
+                return String(describing: value)
+            }
+        }
+
+        return String(describing: value)
+    }
+
+    private static func wrapJSONObject(_ value: Any) -> Any? {
+        if let dict = value as? [String: Any?] {
+            return dict.reduce(into: [String: Any]()) { result, pair in
+                result[pair.key] = pair.value.flatMap { wrapJSONObjectValue($0) } ?? NSNull()
+            }
+        }
+
+        if let array = value as? [Any?] {
+            return array.map { $0.flatMap { wrapJSONObjectValue($0) } ?? NSNull() }
+        }
+
+        return nil
+    }
+
+    private static func wrapJSONObjectValue(_ value: Any) -> Any? {
+        if let wrappedObject = wrapJSONObject(value) {
+            return wrappedObject
+        }
+        return isJSONFragment(value) ? value : nil
+    }
+
+    private static func isJSONFragment(_ value: Any) -> Bool {
+        switch value {
+        case is String, is Int, is Double, is Bool, is NSNull:
+            return true
+        case is NSNumber:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MessageInspectorPayloadView: View {
+    let title: String
+    @Binding var model: MessageInspectorPayloadModel
+    let viewportHeight: CGFloat
+
+    @State private var isActivelyEditing = false
+    @State private var expandAllTrigger = 0
+    @State private var collapseAllTrigger = 0
+    @State private var isTreeExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            header
+            content
+        }
+        .onChange(of: model.viewMode) { _, newMode in
+            if newMode != .tree {
+                isTreeExpanded = false
+            }
+        }
+        .onChange(of: model.source) { _, _ in
+            isTreeExpanded = false
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: VSpacing.sm) {
+            Text(title)
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.contentDefault)
+
+            Spacer(minLength: VSpacing.md)
+
+            if model.showsViewModePicker {
+                VSegmentedControl(
+                    items: model.availableViewModes.map { (label: $0.label, tag: $0) },
+                    selection: viewModeBinding,
+                    style: .pill,
+                    size: .compact
+                )
+                .fixedSize()
+            }
+
+            if model.showsExpandCollapseActions {
+                VButton(
+                    label: isTreeExpanded ? "Collapse All" : "Expand All",
+                    iconOnly: (isTreeExpanded ? VIcon.minimize : VIcon.maximize).rawValue,
+                    style: .ghost,
+                    size: .compact,
+                    tooltip: isTreeExpanded ? "Collapse All" : "Expand All"
+                ) {
+                    if isTreeExpanded {
+                        collapseAllTrigger += 1
+                    } else {
+                        expandAllTrigger += 1
+                    }
+                    isTreeExpanded.toggle()
+                }
+            }
+
+            VCopyButton(
+                text: model.source,
+                size: .compact,
+                accessibilityHint: "Copy \(title)"
+            )
+        }
+    }
+
+    private var content: some View {
+        Group {
+            switch model.viewMode {
+            case .tree:
+                JSONTreeView(
+                    content: model.source,
+                    expandAllTrigger: expandAllTrigger,
+                    collapseAllTrigger: collapseAllTrigger
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            case .source:
+                HighlightedTextView(
+                    text: .constant(model.source),
+                    language: model.isTreeAvailable ? .json : .plain,
+                    isEditable: false,
+                    isActivelyEditing: $isActivelyEditing
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: viewportHeight)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+    }
+
+    private var viewModeBinding: Binding<MessageInspectorPayloadViewMode> {
+        Binding(
+            get: { model.viewMode },
+            set: { model.viewMode = $0 }
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -17,8 +17,7 @@ struct MessageInspectorView: View {
     @State private var response: LLMContextResponse?
     @State private var isLoading = true
     @State private var expandedLogIds: Set<String> = []
-    /// Pre-formatted JSON strings keyed by "\(entryId)-request" / "\(entryId)-response".
-    @State private var formattedJSON: [String: String] = [:]
+    @State private var payloadModels: [String: MessageInspectorPayloadModel] = [:]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -31,19 +30,23 @@ struct MessageInspectorView: View {
         .task(id: messageId) {
             isLoading = true
             response = nil
-            formattedJSON = [:]
+            payloadModels = [:]
             expandedLogIds = []
 
             let result = await llmContextClient.fetchContext(messageId: messageId)
             response = result
-            // Pre-format JSON strings outside the render path
+            // Prepare payload view state outside the render path.
             if let logs = result?.logs {
-                var formatted: [String: String] = [:]
+                var nextPayloadModels: [String: MessageInspectorPayloadModel] = [:]
                 for entry in logs {
-                    formatted["\(entry.id)-request"] = prettyPrintJSON(entry.requestPayload)
-                    formatted["\(entry.id)-response"] = prettyPrintJSON(entry.responsePayload)
+                    nextPayloadModels["\(entry.id)-request"] = MessageInspectorPayloadModel(
+                        payload: entry.requestPayload
+                    )
+                    nextPayloadModels["\(entry.id)-response"] = MessageInspectorPayloadModel(
+                        payload: entry.responsePayload
+                    )
                 }
-                formattedJSON = formatted
+                payloadModels = nextPayloadModels
                 // Auto-expand all entries on load
                 expandedLogIds = Set(logs.map(\.id))
             }
@@ -222,14 +225,14 @@ struct MessageInspectorView: View {
 
             if isExpanded {
                 HStack(alignment: .top, spacing: VSpacing.lg) {
-                    jsonSection(
+                    payloadSection(
                         title: "Request",
-                        formattedText: formattedJSON["\(entry.id)-request"] ?? ""
+                        key: "\(entry.id)-request"
                     )
 
-                    jsonSection(
+                    payloadSection(
                         title: "Response",
-                        formattedText: formattedJSON["\(entry.id)-response"] ?? ""
+                        key: "\(entry.id)-response"
                     )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -251,59 +254,29 @@ struct MessageInspectorView: View {
         }
     }
 
-    // MARK: - JSON Section
+    // MARK: - Payload Section
 
-    private func jsonSection(title: String, formattedText: String) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack {
-                Text(title)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.contentDefault)
-
-                Spacer()
-
-                Button(action: {
-                    copyToClipboard(formattedText)
-                }) {
-                    HStack(spacing: VSpacing.xxs) {
-                        VIconView(.copy, size: 10)
-                        Text("Copy \(title)")
-                            .font(VFont.small)
-                    }
-                    .foregroundColor(VColor.contentSecondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Copy \(title)")
-            }
-
-            GeometryReader { proxy in
-                ScrollView([.vertical, .horizontal]) {
-                    Text(verbatim: formattedText)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.contentDefault)
-                        .textSelection(.enabled)
-                        .padding(VSpacing.sm)
-                        .fixedSize(horizontal: true, vertical: true)
-                        .frame(
-                            minWidth: proxy.size.width,
-                            minHeight: proxy.size.height,
-                            alignment: .topLeading
-                        )
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: payloadViewportHeight)
-            .background(VColor.surfaceBase)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.sm)
-                    .stroke(VColor.borderBase, lineWidth: 1)
-            )
-        }
+    private func payloadSection(title: String, key: String) -> some View {
+        MessageInspectorPayloadView(
+            title: title,
+            model: payloadBinding(for: key),
+            viewportHeight: payloadViewportHeight
+        )
         .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     // MARK: - Helpers
+
+    private func payloadBinding(for key: String) -> Binding<MessageInspectorPayloadModel> {
+        Binding(
+            get: {
+                payloadModels[key] ?? MessageInspectorPayloadModel(source: "")
+            },
+            set: { newValue in
+                payloadModels[key] = newValue
+            }
+        )
+    }
 
     private var skeletonColumn: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -329,47 +302,11 @@ struct MessageInspectorView: View {
         .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
-    private func prettyPrintJSON(_ value: AnyCodable) -> String {
-        guard let rawValue = value.value else { return "null" }
-        guard JSONSerialization.isValidJSONObject(wrapForSerialization(rawValue)) else {
-            return String(describing: rawValue)
-        }
-        do {
-            let data = try JSONSerialization.data(
-                withJSONObject: wrapForSerialization(rawValue),
-                options: [.prettyPrinted, .sortedKeys]
-            )
-            return String(data: data, encoding: .utf8) ?? String(describing: rawValue)
-        } catch {
-            return String(describing: rawValue)
-        }
-    }
-
-    /// Wraps AnyCodable-decoded values so JSONSerialization accepts them.
-    /// AnyCodable decodes arrays as `[Any?]` and dicts as `[String: Any?]`;
-    /// JSONSerialization requires non-optional element types.
-    private func wrapForSerialization(_ value: Any) -> Any {
-        if let dict = value as? [String: Any?] {
-            return dict.reduce(into: [String: Any]()) { result, pair in
-                result[pair.key] = pair.value.map { wrapForSerialization($0) } ?? NSNull()
-            }
-        }
-        if let array = value as? [Any?] {
-            return array.map { $0.map { wrapForSerialization($0) } ?? NSNull() }
-        }
-        return value
-    }
-
     private func formattedTimestamp(_ epochMs: Int) -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .medium
         return formatter.string(from: date)
-    }
-
-    private func copyToClipboard(_ text: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorPayloadModelTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPayloadModelTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class MessageInspectorPayloadModelTests: XCTestCase {
+    func testPayloadDefaultsToTreeWhenSourceIsValidJSON() {
+        let model = MessageInspectorPayloadModel(
+            payload: AnyCodable(["beta": 2, "alpha": 1])
+        )
+
+        XCTAssertEqual(model.availableViewModes, [.tree, .source])
+        XCTAssertEqual(model.viewMode, .tree)
+        XCTAssertTrue(model.showsViewModePicker)
+        XCTAssertTrue(model.showsExpandCollapseActions)
+        XCTAssertEqual(
+            model.source,
+            """
+            {
+              "alpha" : 1,
+              "beta" : 2
+            }
+            """
+        )
+    }
+
+    func testPreferredSourceModeKeepsTreeAvailableButHidesTreeActions() {
+        let model = MessageInspectorPayloadModel(
+            payload: AnyCodable(["ok": true]),
+            preferredViewMode: .source
+        )
+
+        XCTAssertEqual(model.availableViewModes, [.tree, .source])
+        XCTAssertEqual(model.viewMode, .source)
+        XCTAssertFalse(model.showsExpandCollapseActions)
+    }
+
+    func testInvalidSourceFallsBackToSourceMode() {
+        let model = MessageInspectorPayloadModel(
+            source: "not valid json",
+            preferredViewMode: .tree
+        )
+
+        XCTAssertEqual(model.availableViewModes, [.source])
+        XCTAssertEqual(model.viewMode, .source)
+        XCTAssertFalse(model.showsViewModePicker)
+        XCTAssertFalse(model.showsExpandCollapseActions)
+        XCTAssertFalse(model.isTreeAvailable)
+    }
+
+    func testTopLevelJSONFragmentStillSupportsTreeMode() {
+        let model = MessageInspectorPayloadModel(payload: AnyCodable("hello"))
+
+        XCTAssertEqual(model.availableViewModes, [.tree, .source])
+        XCTAssertEqual(model.viewMode, .tree)
+        XCTAssertEqual(model.source, "\"hello\"")
+    }
+}


### PR DESCRIPTION
## Summary
- extract reusable raw payload viewer state and UI for the message inspector
- replace raw verbatim text panes with tree/source rendering built on existing project components
- add focused tests for payload mode and fallback behavior

Part of plan: llm-context-inspector-redesign.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
