### PR TITLE
feat: normalize llm context summaries in assistant route

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeLlmContextPayloads } from "../runtime/routes/llm-context-normalization.js";
+
+describe("normalizeLlmContextPayloads", () => {
+  test("normalizes OpenAI request and response payloads", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_000,
+      requestPayload: {
+        model: "gpt-4.1",
+        messages: [
+          { role: "system", content: "Be concise." },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "What's the weather in Boston?" },
+              { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+            ],
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              description: "Search the web",
+              parameters: { type: "object" },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Read forecast data",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "tool_calls",
+            message: {
+              role: "assistant",
+              content: "I'll check the forecast.",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "web_search",
+                    arguments: JSON.stringify({ query: "Boston weather" }),
+                  },
+                },
+                {
+                  id: "call_2",
+                  type: "function",
+                  function: {
+                    name: "get_weather",
+                    arguments: JSON.stringify({ city: "Boston" }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 321,
+          completion_tokens: 54,
+        },
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-2026-03-01",
+      inputTokens: 321,
+      outputTokens: 54,
+      stopReason: "tool_calls",
+      requestMessageCount: 2,
+      requestToolCount: 2,
+      responseMessageCount: 1,
+      responseToolCallCount: 2,
+      responsePreview: "I'll check the forecast.",
+      toolCallNames: ["web_search", "get_weather"],
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "Be concise.",
+      },
+      {
+        kind: "message",
+        label: "User message 2",
+        role: "user",
+        text: "What's the weather in Boston? [image]",
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        text: "web_search, get_weather",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "I'll check the forecast.",
+      },
+      {
+        kind: "function_call",
+        label: "Response tool call 1",
+        role: "assistant",
+        toolName: "web_search",
+        data: { query: "Boston weather" },
+        text: '{"query":"Boston weather"}',
+      },
+      {
+        kind: "function_call",
+        label: "Response tool call 2",
+        role: "assistant",
+        toolName: "get_weather",
+        data: { city: "Boston" },
+        text: '{"city":"Boston"}',
+      },
+    ]);
+  });
+
+  test("normalizes Anthropic request and response payloads", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_001,
+      requestPayload: {
+        model: "claude-sonnet",
+        system: [
+          {
+            type: "text",
+            text: "Use tools when they improve accuracy.",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Find the latest changelog." }],
+          },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Checking sources." },
+              {
+                type: "tool_use",
+                id: "toolu_req_1",
+                name: "web_search",
+                input: { query: "vellum changelog" },
+              },
+            ],
+          },
+        ],
+        tools: [
+          {
+            name: "web_search",
+            description: "Search the web",
+            input_schema: { type: "object" },
+          },
+        ],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        stop_reason: "tool_use",
+        usage: {
+          input_tokens: 410,
+          output_tokens: 73,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 80,
+        },
+        content: [
+          { type: "text", text: "I found the changelog." },
+          {
+            type: "tool_use",
+            id: "toolu_resp_1",
+            name: "fetch_page",
+            input: { url: "https://example.com/changelog" },
+          },
+        ],
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      inputTokens: 410,
+      outputTokens: 73,
+      cacheCreationInputTokens: 200,
+      cacheReadInputTokens: 80,
+      stopReason: "tool_use",
+      requestMessageCount: 2,
+      requestToolCount: 1,
+      responseMessageCount: 1,
+      responseToolCallCount: 1,
+      responsePreview: "I found the changelog.",
+      toolCallNames: ["fetch_page"],
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "Use tools when they improve accuracy.",
+      },
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "Find the latest changelog.",
+      },
+      {
+        kind: "message",
+        label: "Assistant message 2",
+        role: "assistant",
+        text: "Checking sources.",
+      },
+      {
+        kind: "tool_use",
+        label: "Assistant message 2 tool use",
+        role: "assistant",
+        toolName: "web_search",
+        data: { query: "vellum changelog" },
+        text: '{"query":"vellum changelog"}',
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        text: "web_search",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "I found the changelog.",
+      },
+      {
+        kind: "tool_use",
+        label: "Assistant response tool use",
+        role: "assistant",
+        toolName: "fetch_page",
+        data: { url: "https://example.com/changelog" },
+        text: '{"url":"https://example.com/changelog"}',
+      },
+    ]);
+  });
+
+  test("normalizes Gemini request and response payloads", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_002,
+      requestPayload: {
+        model: "gemini-3-flash",
+        contents: [
+          {
+            role: "user",
+            parts: [
+              { text: "Summarize this file." },
+              {
+                functionResponse: {
+                  id: "call_req_1",
+                  name: "read_file",
+                  response: { output: "Long file body" },
+                },
+              },
+            ],
+          },
+          {
+            role: "model",
+            parts: [
+              { text: "I can do that." },
+              {
+                functionCall: {
+                  id: "call_req_2",
+                  name: "search_notes",
+                  args: { query: "summary" },
+                },
+              },
+            ],
+          },
+        ],
+        config: {
+          systemInstruction: "Answer briefly.",
+          tools: [
+            {
+              functionDeclarations: [
+                { name: "read_file", description: "Read a file" },
+                { name: "search_notes", description: "Search notes" },
+              ],
+            },
+          ],
+        },
+      },
+      responsePayload: {
+        model: "gemini-3-flash-001",
+        text: "Here is the summary.",
+        functionCalls: [
+          {
+            id: "call_resp_1",
+            name: "save_note",
+            args: { title: "brief" },
+          },
+        ],
+        finishReason: "STOP",
+        usageMetadata: {
+          promptTokenCount: 200,
+          candidatesTokenCount: 31,
+        },
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "gemini",
+      model: "gemini-3-flash-001",
+      inputTokens: 200,
+      outputTokens: 31,
+      stopReason: "STOP",
+      requestMessageCount: 2,
+      requestToolCount: 2,
+      responseMessageCount: 1,
+      responseToolCallCount: 1,
+      responsePreview: "Here is the summary.",
+      toolCallNames: ["save_note"],
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System instruction",
+        role: "system",
+        text: "Answer briefly.",
+      },
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "Summarize this file.",
+      },
+      {
+        kind: "function_response",
+        label: "User message 1 function response",
+        role: "user",
+        toolName: "read_file",
+        data: { output: "Long file body" },
+        text: '{"output":"Long file body"}',
+      },
+      {
+        kind: "message",
+        label: "Model message 2",
+        role: "model",
+        text: "I can do that.",
+      },
+      {
+        kind: "function_call",
+        label: "Model message 2 function call",
+        role: "model",
+        toolName: "search_notes",
+        data: { query: "summary" },
+        text: '{"query":"summary"}',
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        text: "read_file, search_notes",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "model",
+        text: "Here is the summary.",
+      },
+      {
+        kind: "function_call",
+        label: "Response function call 1",
+        role: "model",
+        toolName: "save_note",
+        data: { title: "brief" },
+        text: '{"title":"brief"}',
+      },
+    ]);
+  });
+
+  test("omits normalized fields for malformed or unknown payloads", () => {
+    const malformed = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_003,
+      requestPayload: "not-json",
+      responsePayload: { foo: "bar" },
+    });
+
+    expect(malformed.summary).toBeUndefined();
+    expect(malformed.requestSections).toBeUndefined();
+    expect(malformed.responseSections).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -28,6 +28,7 @@ import { deleteQueuedMessage } from "../../daemon/handlers/conversations.js";
 import { getRequestLogsByMessageId } from "../../memory/llm-request-log-store.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+import { normalizeLlmContextPayloads } from "./llm-context-normalization.js";
 
 const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
 
@@ -216,11 +217,17 @@ export function conversationQueryRouteDefinitions(
             } catch {
               responsePayload = log.responsePayload;
             }
+            const normalized = normalizeLlmContextPayloads({
+              requestPayload,
+              responsePayload,
+              createdAt: log.createdAt,
+            });
             return {
               id: log.id,
               requestPayload,
               responsePayload,
               createdAt: log.createdAt,
+              ...normalized,
             };
           }),
         });

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -1,0 +1,703 @@
+export interface LlmContextNormalizationInput {
+  requestPayload: unknown;
+  responsePayload: unknown;
+  createdAt: number;
+}
+
+export interface LlmContextSummary {
+  provider: "openai" | "anthropic" | "gemini";
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  stopReason?: string;
+  requestMessageCount?: number;
+  requestToolCount?: number;
+  responseMessageCount?: number;
+  responseToolCallCount?: number;
+  responsePreview?: string;
+  toolCallNames?: string[];
+}
+
+export interface LlmContextSection {
+  kind:
+    | "system"
+    | "message"
+    | "tool_definitions"
+    | "tool_use"
+    | "tool_result"
+    | "function_call"
+    | "function_response";
+  label: string;
+  role?: string;
+  text?: string;
+  toolName?: string;
+  data?: unknown;
+}
+
+export interface LlmContextNormalizationResult {
+  summary?: LlmContextSummary;
+  requestSections?: LlmContextSection[];
+  responseSections?: LlmContextSection[];
+}
+
+export function normalizeLlmContextPayloads(
+  input: LlmContextNormalizationInput,
+): LlmContextNormalizationResult {
+  const openAi = normalizeOpenAiPayloads(
+    input.requestPayload,
+    input.responsePayload,
+  );
+  if (openAi) {
+    return openAi;
+  }
+
+  const anthropic = normalizeAnthropicPayloads(
+    input.requestPayload,
+    input.responsePayload,
+  );
+  if (anthropic) {
+    return anthropic;
+  }
+
+  const gemini = normalizeGeminiPayloads(
+    input.requestPayload,
+    input.responsePayload,
+  );
+  if (gemini) {
+    return gemini;
+  }
+
+  return {};
+}
+
+function normalizeOpenAiPayloads(
+  requestPayload: unknown,
+  responsePayload: unknown,
+): LlmContextNormalizationResult | null {
+  const request = asRecord(requestPayload);
+  const response = asRecord(responsePayload);
+  if (!request || !response) {
+    return null;
+  }
+
+  const messages = asRecordArray(request.messages);
+  const choices = asRecordArray(response.choices);
+  if (!messages || !choices) {
+    return null;
+  }
+
+  const requestSections: LlmContextSection[] = [];
+  for (const [index, message] of messages.entries()) {
+    const role = asString(message.role) ?? "unknown";
+    const messageText = extractOpenAiContentText(message.content);
+    if (messageText) {
+      requestSections.push({
+        kind: role === "system" ? "system" : role === "tool" ? "tool_result" : "message",
+        label: buildMessageLabel(role, index + 1),
+        role,
+        text: messageText,
+      });
+    }
+
+    for (const toolCallSection of openAiToolCallSections(
+      message.tool_calls,
+      "Request tool call",
+    )) {
+      requestSections.push(toolCallSection);
+    }
+  }
+
+  const requestToolNames = extractOpenAiRequestToolNames(request.tools);
+  if (requestToolNames.length > 0) {
+    requestSections.push({
+      kind: "tool_definitions",
+      label: "Available tools",
+      text: requestToolNames.join(", "),
+    });
+  }
+
+  const firstChoice = choices[0];
+  const responseMessage = asRecord(firstChoice?.message);
+  const responseText = extractOpenAiContentText(responseMessage?.content);
+  const responseSections: LlmContextSection[] = [];
+  if (responseText) {
+    responseSections.push({
+      kind: "message",
+      label: "Assistant response",
+      role: asString(responseMessage?.role) ?? "assistant",
+      text: responseText,
+    });
+  }
+  const responseToolSections = openAiToolCallSections(
+    responseMessage?.tool_calls,
+    "Response tool call",
+  );
+  responseSections.push(...responseToolSections);
+
+  const usage = asRecord(response.usage);
+  const toolCallNames = responseToolSections
+    .map((section) => section.toolName)
+    .filter((name): name is string => typeof name === "string");
+
+  return {
+    summary: {
+      provider: "openai",
+      model: asString(response.model) ?? asString(request.model),
+      inputTokens: asNumber(usage?.prompt_tokens),
+      outputTokens: asNumber(usage?.completion_tokens),
+      stopReason: asString(firstChoice?.finish_reason),
+      requestMessageCount: messages.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount:
+        responseText || responseToolSections.length > 0 ? 1 : undefined,
+      responseToolCallCount:
+        responseToolSections.length > 0 ? responseToolSections.length : undefined,
+      responsePreview: responseText ? truncateText(responseText) : undefined,
+      toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+    responseSections: responseSections.length > 0 ? responseSections : undefined,
+  };
+}
+
+function normalizeAnthropicPayloads(
+  requestPayload: unknown,
+  responsePayload: unknown,
+): LlmContextNormalizationResult | null {
+  const request = asRecord(requestPayload);
+  const response = asRecord(responsePayload);
+  if (!request || !response) {
+    return null;
+  }
+
+  const messages = asRecordArray(request.messages);
+  const content = asRecordArray(response.content);
+  if (!messages || !content) {
+    return null;
+  }
+
+  const requestSections: LlmContextSection[] = [];
+  const systemSections = anthropicSystemSections(request.system);
+  requestSections.push(...systemSections);
+
+  for (const [index, message] of messages.entries()) {
+    requestSections.push(
+      ...anthropicMessageSections(
+        message,
+        buildMessageLabel(asString(message.role) ?? "unknown", index + 1),
+      ),
+    );
+  }
+
+  const requestToolNames = extractAnthropicToolNames(request.tools);
+  if (requestToolNames.length > 0) {
+    requestSections.push({
+      kind: "tool_definitions",
+      label: "Available tools",
+      text: requestToolNames.join(", "),
+    });
+  }
+
+  const responseSections = anthropicContentSections(content, "Assistant response");
+  const responseText = collectAnthropicText(content);
+  const responseToolNames = content
+    .map((block) => (asString(block.type) === "tool_use" ? asString(block.name) : undefined))
+    .filter((name): name is string => typeof name === "string");
+
+  const usage = asRecord(response.usage);
+  return {
+    summary: {
+      provider: "anthropic",
+      model: asString(response.model) ?? asString(request.model),
+      inputTokens: asNumber(usage?.input_tokens),
+      outputTokens: asNumber(usage?.output_tokens),
+      cacheCreationInputTokens: asNumber(usage?.cache_creation_input_tokens),
+      cacheReadInputTokens: asNumber(usage?.cache_read_input_tokens),
+      stopReason: asString(response.stop_reason),
+      requestMessageCount: messages.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount:
+        responseText || responseToolNames.length > 0 ? 1 : undefined,
+      responseToolCallCount:
+        responseToolNames.length > 0 ? responseToolNames.length : undefined,
+      responsePreview: responseText ? truncateText(responseText) : undefined,
+      toolCallNames: responseToolNames.length > 0 ? responseToolNames : undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+    responseSections: responseSections.length > 0 ? responseSections : undefined,
+  };
+}
+
+function normalizeGeminiPayloads(
+  requestPayload: unknown,
+  responsePayload: unknown,
+): LlmContextNormalizationResult | null {
+  const request = asRecord(requestPayload);
+  const response = asRecord(responsePayload);
+  if (!request || !response) {
+    return null;
+  }
+
+  const contents = asRecordArray(request.contents);
+  if (!contents) {
+    return null;
+  }
+
+  const requestSections: LlmContextSection[] = [];
+  const config = asRecord(request.config);
+  const systemText = extractGeminiSystemInstructionText(config?.systemInstruction);
+  if (systemText) {
+    requestSections.push({
+      kind: "system",
+      label: "System instruction",
+      role: "system",
+      text: systemText,
+    });
+  }
+
+  for (const [index, content] of contents.entries()) {
+    requestSections.push(...geminiContentSections(content, index + 1));
+  }
+
+  const requestToolNames = extractGeminiToolNames(config?.tools);
+  if (requestToolNames.length > 0) {
+    requestSections.push({
+      kind: "tool_definitions",
+      label: "Available tools",
+      text: requestToolNames.join(", "),
+    });
+  }
+
+  const responseSections: LlmContextSection[] = [];
+  const responseText = asString(response.text);
+  if (responseText) {
+    responseSections.push({
+      kind: "message",
+      label: "Assistant response",
+      role: "model",
+      text: responseText,
+    });
+  }
+  const responseFunctionSections = geminiFunctionCallSections(
+    response.functionCalls,
+    "Response function call",
+  );
+  responseSections.push(...responseFunctionSections);
+
+  const usage = asRecord(response.usageMetadata);
+  const toolCallNames = responseFunctionSections
+    .map((section) => section.toolName)
+    .filter((name): name is string => typeof name === "string");
+
+  return {
+    summary: {
+      provider: "gemini",
+      model: asString(response.model) ?? asString(request.model),
+      inputTokens: asNumber(usage?.promptTokenCount),
+      outputTokens: asNumber(usage?.candidatesTokenCount),
+      stopReason: asString(response.finishReason),
+      requestMessageCount: contents.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount:
+        responseText || responseFunctionSections.length > 0 ? 1 : undefined,
+      responseToolCallCount:
+        responseFunctionSections.length > 0
+          ? responseFunctionSections.length
+          : undefined,
+      responsePreview: responseText ? truncateText(responseText) : undefined,
+      toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+    responseSections: responseSections.length > 0 ? responseSections : undefined,
+  };
+}
+
+function anthropicSystemSections(system: unknown): LlmContextSection[] {
+  const text = extractAnthropicSystemText(system);
+  if (!text) {
+    return [];
+  }
+  return [
+    {
+      kind: "system",
+      label: "System prompt",
+      role: "system",
+      text,
+    },
+  ];
+}
+
+function anthropicMessageSections(
+  message: Record<string, unknown>,
+  label: string,
+): LlmContextSection[] {
+  const role = asString(message.role) ?? "unknown";
+  const content = message.content;
+  const sections: LlmContextSection[] = [];
+  const text = collectAnthropicText(content);
+  if (text) {
+    sections.push({
+      kind: "message",
+      label,
+      role,
+      text,
+    });
+  }
+
+  for (const block of asRecordArray(content) ?? []) {
+    const type = asString(block.type);
+    if (type === "tool_use") {
+      sections.push({
+        kind: "tool_use",
+        label: `${label} tool use`,
+        role,
+        toolName: asString(block.name),
+        data: asRecord(block.input) ?? block.input,
+        text: previewStructuredValue(block.input),
+      });
+      continue;
+    }
+
+    if (type === "tool_result") {
+      sections.push({
+        kind: "tool_result",
+        label: `${label} tool result`,
+        role,
+        toolName: asString(block.name) ?? asString(block.tool_use_id),
+        text: collectAnthropicText(block.content),
+      });
+    }
+  }
+
+  return sections;
+}
+
+function anthropicContentSections(
+  content: Record<string, unknown>[],
+  label: string,
+): LlmContextSection[] {
+  return anthropicMessageSections(
+    {
+      role: "assistant",
+      content,
+    },
+    label,
+  );
+}
+
+function geminiContentSections(
+  content: Record<string, unknown>,
+  index: number,
+): LlmContextSection[] {
+  const role = asString(content.role) ?? "unknown";
+  const parts = asRecordArray(content.parts) ?? [];
+  const sections: LlmContextSection[] = [];
+  const textParts: string[] = [];
+
+  for (const part of parts) {
+    const text = asString(part.text);
+    if (text) {
+      textParts.push(text);
+      continue;
+    }
+
+    const inlineData = asRecord(part.inlineData);
+    if (inlineData) {
+      const mimeType = asString(inlineData.mimeType) ?? "application/octet-stream";
+      textParts.push(`[inline data: ${mimeType}]`);
+      continue;
+    }
+
+    const functionCall = asRecord(part.functionCall);
+    if (functionCall) {
+      sections.push({
+        kind: "function_call",
+        label: `${buildMessageLabel(role, index)} function call`,
+        role,
+        toolName: asString(functionCall.name),
+        data: asRecord(functionCall.args) ?? functionCall.args,
+        text: previewStructuredValue(functionCall.args),
+      });
+      continue;
+    }
+
+    const functionResponse = asRecord(part.functionResponse);
+    if (functionResponse) {
+      sections.push({
+        kind: "function_response",
+        label: `${buildMessageLabel(role, index)} function response`,
+        role,
+        toolName: asString(functionResponse.name),
+        data: asRecord(functionResponse.response) ?? functionResponse.response,
+        text: previewStructuredValue(functionResponse.response),
+      });
+    }
+  }
+
+  const text = joinTextParts(textParts);
+  if (text) {
+    sections.unshift({
+      kind: "message",
+      label: buildMessageLabel(role, index),
+      role,
+      text,
+    });
+  }
+
+  return sections;
+}
+
+function openAiToolCallSections(
+  toolCalls: unknown,
+  labelPrefix: string,
+): LlmContextSection[] {
+  return (asRecordArray(toolCalls) ?? []).map((toolCall, index) => {
+    const fn = asRecord(toolCall.function);
+    return {
+      kind: "function_call",
+      label: `${labelPrefix} ${index + 1}`,
+      role: "assistant",
+      toolName: asString(fn?.name),
+      data: parseJsonValue(asString(fn?.arguments)),
+      text: previewStructuredValue(parseJsonValue(asString(fn?.arguments))),
+    };
+  });
+}
+
+function geminiFunctionCallSections(
+  functionCalls: unknown,
+  labelPrefix: string,
+): LlmContextSection[] {
+  return (asRecordArray(functionCalls) ?? []).map((call, index) => ({
+    kind: "function_call",
+    label: `${labelPrefix} ${index + 1}`,
+    role: "model",
+    toolName: asString(call.name),
+    data: asRecord(call.args) ?? call.args,
+    text: previewStructuredValue(call.args),
+  }));
+}
+
+function extractOpenAiRequestToolNames(tools: unknown): string[] {
+  return (asRecordArray(tools) ?? [])
+    .map((tool) => asString(asRecord(tool.function)?.name))
+    .filter((name): name is string => typeof name === "string");
+}
+
+function extractAnthropicToolNames(tools: unknown): string[] {
+  return (asRecordArray(tools) ?? [])
+    .map((tool) => asString(tool.name))
+    .filter((name): name is string => typeof name === "string");
+}
+
+function extractGeminiToolNames(tools: unknown): string[] {
+  const toolGroups = asRecordArray(tools) ?? [];
+  const names: string[] = [];
+  for (const toolGroup of toolGroups) {
+    for (const declaration of asRecordArray(toolGroup.functionDeclarations) ?? []) {
+      const name = asString(declaration.name);
+      if (name) {
+        names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
+function extractOpenAiContentText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return normalizeText(content);
+  }
+
+  const parts = asRecordArray(content);
+  if (!parts) {
+    return undefined;
+  }
+
+  const textParts: string[] = [];
+  for (const part of parts) {
+    const type = asString(part.type);
+    if (type === "text" || type === "input_text" || type === "output_text") {
+      const text = asString(part.text);
+      if (text) {
+        textParts.push(text);
+      }
+      continue;
+    }
+
+    if (type === "image_url" || type === "input_image") {
+      textParts.push("[image]");
+      continue;
+    }
+
+    if (type === "file") {
+      textParts.push("[file]");
+    }
+  }
+
+  return joinTextParts(textParts);
+}
+
+function extractAnthropicSystemText(system: unknown): string | undefined {
+  if (typeof system === "string") {
+    return normalizeText(system);
+  }
+
+  const parts = asRecordArray(system);
+  if (!parts) {
+    return undefined;
+  }
+
+  const textParts = parts
+    .map((part) => asString(part.text))
+    .filter((text): text is string => typeof text === "string");
+  return joinTextParts(textParts);
+}
+
+function extractGeminiSystemInstructionText(systemInstruction: unknown): string | undefined {
+  if (typeof systemInstruction === "string") {
+    return normalizeText(systemInstruction);
+  }
+
+  const record = asRecord(systemInstruction);
+  if (!record) {
+    return undefined;
+  }
+
+  const parts = asRecordArray(record.parts) ?? [];
+  const textParts = parts
+    .map((part) => asString(part.text))
+    .filter((text): text is string => typeof text === "string");
+  return joinTextParts(textParts);
+}
+
+function collectAnthropicText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return normalizeText(content);
+  }
+
+  const blocks = asRecordArray(content);
+  if (!blocks) {
+    return undefined;
+  }
+
+  const textParts: string[] = [];
+  for (const block of blocks) {
+    const type = asString(block.type);
+    if (type === "text") {
+      const text = asString(block.text);
+      if (text) {
+        textParts.push(text);
+      }
+      continue;
+    }
+
+    if (type === "thinking") {
+      const thinking = asString(block.thinking);
+      if (thinking) {
+        textParts.push(thinking);
+      }
+      continue;
+    }
+
+    if (type === "redacted_thinking") {
+      textParts.push("[redacted thinking]");
+      continue;
+    }
+
+    if (type === "image") {
+      textParts.push("[image]");
+      continue;
+    }
+
+    if (type === "tool_result") {
+      const resultText = collectAnthropicText(block.content);
+      if (resultText) {
+        textParts.push(resultText);
+      }
+    }
+  }
+
+  return joinTextParts(textParts);
+}
+
+function buildMessageLabel(role: string, index: number): string {
+  const capitalizedRole =
+    role.length > 0 ? role[0]!.toUpperCase() + role.slice(1) : "Message";
+  if (role === "system") {
+    return "System prompt";
+  }
+  return `${capitalizedRole} message ${index}`;
+}
+
+function previewStructuredValue(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return truncateText(value);
+  }
+  try {
+    return truncateText(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonValue(value: string | undefined): unknown {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function joinTextParts(parts: string[]): string | undefined {
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return normalizeText(parts.join("\n\n"));
+}
+
+function truncateText(text: string, maxLength = 280): string {
+  const normalized = normalizeText(text);
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function normalizeText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : "";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  return value.filter(
+    (entry): entry is Record<string, unknown> =>
+      typeof entry === "object" && entry !== null && !Array.isArray(entry),
+  );
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- normalize provider-specific LLM request/response payloads into summary and section metadata for the llm-context route
- keep raw payloads unchanged while returning additive normalized fields for Apple clients
- add focused route normalization tests for OpenAI, Anthropic, Gemini, and malformed payloads

Part of plan: llm-context-inspector-redesign.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
