### PR TITLE
feat: add normalized llm context models for Apple clients

### DIFF
--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -3,12 +3,313 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LLMContextClient")
 
+// MARK: - Normalized LLM Context Models
+
+/// Normalized summary metadata for a single LLM call.
+public struct LLMCallSummary: Codable, Sendable, Equatable {
+    public let title: String?
+    public let subtitle: String?
+    public let summary: AnyCodable?
+    public let model: String?
+    public let provider: String?
+    public let status: String?
+    public let inputTokens: Int?
+    public let outputTokens: Int?
+    public let durationMs: Int?
+
+    public init(
+        title: String? = nil,
+        subtitle: String? = nil,
+        summary: AnyCodable? = nil,
+        model: String? = nil,
+        provider: String? = nil,
+        status: String? = nil,
+        inputTokens: Int? = nil,
+        outputTokens: Int? = nil,
+        durationMs: Int? = nil
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.summary = summary
+        self.model = model
+        self.provider = provider
+        self.status = status
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.durationMs = durationMs
+    }
+
+    /// String form of the normalized summary when the payload uses text.
+    public var summaryText: String? {
+        summary?.value as? String
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: LLMContextCodingKey.self)
+        title = container.decodeString(for: ["title", "label", "name", "heading"])
+        subtitle = container.decodeString(for: ["subtitle", "secondaryTitle"])
+        summary = container.decodeAnyCodable(for: ["summary", "description", "details", "text", "body", "content", "value"])
+        model = container.decodeString(for: ["model"])
+        provider = container.decodeString(for: ["provider"])
+        status = container.decodeString(for: ["status", "outcome"])
+        inputTokens = container.decodeInt(for: ["inputTokens", "input_token_count", "promptTokens"])
+        outputTokens = container.decodeInt(for: ["outputTokens", "output_token_count", "completionTokens"])
+        durationMs = container.decodeInt(for: ["durationMs", "duration_ms", "elapsedMs"])
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: LLMContextCodingKey.self)
+        try container.encodeIfPresent(title, forKey: "title")
+        try container.encodeIfPresent(subtitle, forKey: "subtitle")
+        try container.encodeIfPresent(summary, forKey: "summary")
+        try container.encodeIfPresent(model, forKey: "model")
+        try container.encodeIfPresent(provider, forKey: "provider")
+        try container.encodeIfPresent(status, forKey: "status")
+        try container.encodeIfPresent(inputTokens, forKey: "inputTokens")
+        try container.encodeIfPresent(outputTokens, forKey: "outputTokens")
+        try container.encodeIfPresent(durationMs, forKey: "durationMs")
+    }
+}
+
+/// A normalized section inside the request or response payload.
+public struct LLMContextSection: Codable, Sendable, Equatable {
+    public let kind: LLMContextSectionKind
+    public let title: String?
+    public let content: AnyCodable?
+    public let language: String?
+    public let collapsedByDefault: Bool?
+
+    public init(
+        kind: LLMContextSectionKind,
+        title: String? = nil,
+        content: AnyCodable? = nil,
+        language: String? = nil,
+        collapsedByDefault: Bool? = nil
+    ) {
+        self.kind = kind
+        self.title = title
+        self.content = content
+        self.language = language
+        self.collapsedByDefault = collapsedByDefault
+    }
+
+    /// String form of the section content when the payload uses text.
+    public var stringContent: String? {
+        content?.value as? String
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: LLMContextCodingKey.self)
+        let kindRaw = container.decodeString(for: ["kind", "type", "role"]) ?? "unknown"
+        kind = LLMContextSectionKind(rawValue: kindRaw)
+        title = container.decodeString(for: ["title", "label", "name", "heading"])
+        content = container.decodeAnyCodable(for: ["content", "text", "value", "body", "payload", "data"])
+        language = container.decodeString(for: ["language", "syntax", "format"])
+        collapsedByDefault = container.decodeBool(for: ["collapsedByDefault", "collapsed"])
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: LLMContextCodingKey.self)
+        try container.encode(kind, forKey: LLMContextCodingKey.key("kind"))
+        try container.encodeIfPresent(title, forKey: "title")
+        try container.encodeIfPresent(content, forKey: "content")
+        try container.encodeIfPresent(language, forKey: "language")
+        try container.encodeIfPresent(collapsedByDefault, forKey: "collapsedByDefault")
+    }
+}
+
+/// Section kind values returned by the normalized LLM context response.
+public enum LLMContextSectionKind: Sendable, Codable, Equatable, CustomStringConvertible {
+    case system
+    case user
+    case assistant
+    case tool
+    case reasoning
+    case input
+    case output
+    case prompt
+    case completion
+    case text
+    case json
+    case code
+    case markdown
+    case list
+    case table
+    case metadata
+    case other
+    case unknown(String)
+
+    public var rawValue: String {
+        switch self {
+        case .system: return "system"
+        case .user: return "user"
+        case .assistant: return "assistant"
+        case .tool: return "tool"
+        case .reasoning: return "reasoning"
+        case .input: return "input"
+        case .output: return "output"
+        case .prompt: return "prompt"
+        case .completion: return "completion"
+        case .text: return "text"
+        case .json: return "json"
+        case .code: return "code"
+        case .markdown: return "markdown"
+        case .list: return "list"
+        case .table: return "table"
+        case .metadata: return "metadata"
+        case .other: return "other"
+        case .unknown(let rawValue): return rawValue
+        }
+    }
+
+    public var description: String {
+        rawValue
+    }
+
+    public init(rawValue: String) {
+        switch rawValue.lowercased() {
+        case "system":
+            self = .system
+        case "user":
+            self = .user
+        case "assistant":
+            self = .assistant
+        case "tool":
+            self = .tool
+        case "reasoning":
+            self = .reasoning
+        case "input":
+            self = .input
+        case "output":
+            self = .output
+        case "prompt":
+            self = .prompt
+        case "completion":
+            self = .completion
+        case "text":
+            self = .text
+        case "json":
+            self = .json
+        case "code":
+            self = .code
+        case "markdown":
+            self = .markdown
+        case "list":
+            self = .list
+        case "table":
+            self = .table
+        case "metadata":
+            self = .metadata
+        case "other":
+            self = .other
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self = Self(rawValue: try container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+private struct LLMContextCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+        self.intValue = intValue
+    }
+
+    static func key(_ string: String) -> LLMContextCodingKey {
+        LLMContextCodingKey(stringValue: string)!
+    }
+}
+
+private extension KeyedDecodingContainer where Key == LLMContextCodingKey {
+    func decodeString(for keys: [String]) -> String? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent(String.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func decodeInt(for keys: [String]) -> Int? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent(Int.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func decodeBool(for keys: [String]) -> Bool? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent(Bool.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    func decodeAnyCodable(for keys: [String]) -> AnyCodable? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent(AnyCodable.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+}
+
+private extension KeyedEncodingContainer where Key == LLMContextCodingKey {
+    mutating func encodeIfPresent(_ value: String?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+
+    mutating func encodeIfPresent(_ value: Int?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+
+    mutating func encodeIfPresent(_ value: Bool?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+
+    mutating func encodeIfPresent(_ value: AnyCodable?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+}
+
 /// A single LLM request/response log entry returned by the context endpoint.
 public struct LLMRequestLogEntry: Codable, Identifiable, Sendable {
     public let id: String
     public let requestPayload: AnyCodable
     public let responsePayload: AnyCodable
     public let createdAt: Int
+    public let summary: LLMCallSummary?
+    public let requestSections: [LLMContextSection]?
+    public let responseSections: [LLMContextSection]?
 }
 
 /// Response wrapper for the LLM context endpoint.

--- a/clients/shared/Tests/LLMContextClientDecodingTests.swift
+++ b/clients/shared/Tests/LLMContextClientDecodingTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class LLMContextClientDecodingTests: XCTestCase {
+    func testLegacyPayloadDecodesWithoutNormalizedFields() throws {
+        let response = try decodeResponse(
+            #"""
+            {
+              "messageId": "msg-legacy",
+              "logs": [
+                {
+                  "id": "log-1",
+                  "requestPayload": {
+                    "type": "request",
+                    "messages": []
+                  },
+                  "responsePayload": {
+                    "type": "response",
+                    "text": "ok"
+                  },
+                  "createdAt": 1234567890
+                }
+              ]
+            }
+            """#
+        )
+
+        XCTAssertEqual(response.messageId, "msg-legacy")
+        XCTAssertEqual(response.logs.count, 1)
+
+        let entry = response.logs[0]
+        XCTAssertEqual(entry.id, "log-1")
+        XCTAssertEqual(entry.createdAt, 1234567890)
+        XCTAssertNil(entry.summary)
+        XCTAssertNil(entry.requestSections)
+        XCTAssertNil(entry.responseSections)
+    }
+
+    func testEnrichedPayloadDecodesAllNormalizedFields() throws {
+        let response = try decodeResponse(
+            #"""
+            {
+              "messageId": "msg-enriched",
+              "logs": [
+                {
+                  "id": "log-2",
+                  "requestPayload": {
+                    "type": "request",
+                    "messages": [
+                      { "role": "user", "content": "Hello" }
+                    ]
+                  },
+                  "responsePayload": {
+                    "type": "response",
+                    "text": "Hi there"
+                  },
+                  "createdAt": 2233445566,
+                  "summary": {
+                    "title": "Chat completion",
+                    "subtitle": "gpt-4.1",
+                    "summary": "Answered the user",
+                    "model": "gpt-4.1",
+                    "provider": "openai",
+                    "status": "success",
+                    "inputTokens": 42,
+                    "outputTokens": 17,
+                    "durationMs": 250,
+                    "ignoredSummaryKey": true
+                  },
+                  "requestSections": [
+                    {
+                      "kind": "system",
+                      "title": "System",
+                      "content": "You are helpful",
+                      "language": "markdown",
+                      "collapsedByDefault": true,
+                      "ignoredSectionKey": "ignored"
+                    },
+                    {
+                      "kind": "prompt",
+                      "title": "Prompt",
+                      "content": "Write a reply"
+                    }
+                  ],
+                  "responseSections": [
+                    {
+                      "kind": "assistant",
+                      "title": "Assistant",
+                      "content": "Hi there",
+                      "language": "text"
+                    }
+                  ]
+                }
+              ]
+            }
+            """#
+        )
+
+        let entry = try XCTUnwrap(response.logs.first)
+        let summary = try XCTUnwrap(entry.summary)
+        XCTAssertEqual(summary.title, "Chat completion")
+        XCTAssertEqual(summary.subtitle, "gpt-4.1")
+        XCTAssertEqual(summary.summaryText, "Answered the user")
+        XCTAssertEqual(summary.model, "gpt-4.1")
+        XCTAssertEqual(summary.provider, "openai")
+        XCTAssertEqual(summary.status, "success")
+        XCTAssertEqual(summary.inputTokens, 42)
+        XCTAssertEqual(summary.outputTokens, 17)
+        XCTAssertEqual(summary.durationMs, 250)
+
+        let requestSections = try XCTUnwrap(entry.requestSections)
+        XCTAssertEqual(requestSections.count, 2)
+        XCTAssertEqual(requestSections[0].kind, .system)
+        XCTAssertEqual(requestSections[0].title, "System")
+        XCTAssertEqual(requestSections[0].stringContent, "You are helpful")
+        XCTAssertEqual(requestSections[0].language, "markdown")
+        XCTAssertEqual(requestSections[0].collapsedByDefault, true)
+        XCTAssertEqual(requestSections[1].kind, .prompt)
+        XCTAssertEqual(requestSections[1].title, "Prompt")
+        XCTAssertEqual(requestSections[1].stringContent, "Write a reply")
+
+        let responseSections = try XCTUnwrap(entry.responseSections)
+        XCTAssertEqual(responseSections.count, 1)
+        XCTAssertEqual(responseSections[0].kind, .assistant)
+        XCTAssertEqual(responseSections[0].title, "Assistant")
+        XCTAssertEqual(responseSections[0].stringContent, "Hi there")
+        XCTAssertEqual(responseSections[0].language, "text")
+    }
+
+    func testUnknownSectionKindsAndExtraKeysDecodeWithoutFailure() throws {
+        let response = try decodeResponse(
+            #"""
+            {
+              "messageId": "msg-forward-compatible",
+              "logs": [
+                {
+                  "id": "log-3",
+                  "requestPayload": { "type": "request" },
+                  "responsePayload": { "type": "response" },
+                  "createdAt": 99887766,
+                  "summary": {
+                    "details": "Forward-compatible summary",
+                    "extraSummaryField": "ignored"
+                  },
+                  "requestSections": [
+                    {
+                      "kind": "future_kind",
+                      "title": "Future request",
+                      "content": "Raw future content",
+                      "unexpectedNestedValue": { "ignored": true }
+                    }
+                  ],
+                  "responseSections": [
+                    {
+                      "kind": "future_response_kind",
+                      "title": "Future response",
+                      "content": "Result",
+                      "unexpectedArray": [1, 2, 3]
+                    }
+                  ],
+                  "extraTopLevelField": "ignored"
+                }
+              ]
+            }
+            """#
+        )
+
+        let entry = try XCTUnwrap(response.logs.first)
+        let summary = try XCTUnwrap(entry.summary)
+        XCTAssertEqual(summary.summaryText, "Forward-compatible summary")
+
+        let requestSection = try XCTUnwrap(entry.requestSections?.first)
+        XCTAssertEqual(requestSection.kind, .unknown("future_kind"))
+        XCTAssertEqual(requestSection.title, "Future request")
+        XCTAssertEqual(requestSection.stringContent, "Raw future content")
+
+        let responseSection = try XCTUnwrap(entry.responseSections?.first)
+        XCTAssertEqual(responseSection.kind, .unknown("future_response_kind"))
+        XCTAssertEqual(responseSection.title, "Future response")
+        XCTAssertEqual(responseSection.stringContent, "Result")
+    }
+
+    private func decodeResponse(_ json: String) throws -> LLMContextResponse {
+        try JSONDecoder().decode(LLMContextResponse.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary
- add shared Codable models for normalized llm context summaries and sections
- extend LLMRequestLogEntry with additive optional normalized fields while preserving the raw payload contract
- add decoding tests for legacy, enriched, and forward-compatible payloads
- Apple refs checked (2026-03-19): not needed; this PR only adds Codable models and decoding tests

Part of plan: llm-context-inspector-redesign.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
