### PR TITLE
feat: add shared fork intent hooks for Apple chat clients

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -580,6 +580,9 @@ public final class ChatViewModel: ObservableObject {
     /// Called every time a user message is sent. Used by ConversationManager to
     /// bump the conversation's lastInteractedAt so it rises to the top of the list.
     public var onUserMessageSent: (() -> Void)?
+    /// Called when the exact `/fork` composer command should be handled locally
+    /// by the client instead of being sent to the assistant.
+    public var onFork: (() -> Void)?
 
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
@@ -1128,6 +1131,21 @@ public final class ChatViewModel: ObservableObject {
         let hasAttachments = !pendingAttachments.isEmpty
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
+
+        // Intercept the exact `/fork` command only when the platform has
+        // registered a local fork handler and there is no extra payload.
+        if text == "/fork",
+           !hasAttachments,
+           !hasSkillInvocation,
+           let onFork
+        {
+            inputText = ""
+            suggestion = nil
+            pendingSuggestionRequestId = nil
+            flushCoalescedPublish()
+            onFork()
+            return
+        }
 
         // Intercept /btw side-chain messages before the normal send path.
         if text.hasPrefix("/btw ") {

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -22,6 +22,8 @@ public struct MessageBubbleView: View {
     public let onRetryFailedMessage: ((UUID) -> Void)?
     /// Called when the user taps "Retry" on an inline conversation error.
     public let onRetryConversationError: (() -> Void)?
+    /// Called when the user wants to fork the conversation from this persisted message.
+    public let onForkFromMessage: ((String) -> Void)?
 
     public init(
         message: ChatMessage,
@@ -32,7 +34,8 @@ public struct MessageBubbleView: View {
         onGuardianAction: ((String, String) -> Void)? = nil,
         onSurfaceRefetch: ((String, String) -> Void)? = nil,
         onRetryFailedMessage: ((UUID) -> Void)? = nil,
-        onRetryConversationError: (() -> Void)? = nil
+        onRetryConversationError: (() -> Void)? = nil,
+        onForkFromMessage: ((String) -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
@@ -43,6 +46,7 @@ public struct MessageBubbleView: View {
         self.onSurfaceRefetch = onSurfaceRefetch
         self.onRetryFailedMessage = onRetryFailedMessage
         self.onRetryConversationError = onRetryConversationError
+        self.onForkFromMessage = onForkFromMessage
     }
 
     public var body: some View {
@@ -192,6 +196,10 @@ public struct MessageBubbleView: View {
         return false
     }
 
+    var canForkFromMessage: Bool {
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+    }
+
     private enum ContentGroup {
         case text(Int)
         case toolCalls([Int])
@@ -263,6 +271,9 @@ public struct MessageBubbleView: View {
                 .background(VColor.surfaceActive)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .textSelection(.enabled)
+                .contextMenu {
+                    sharedContextMenu()
+                }
         } else if message.isError {
             InlineChatErrorAlert(
                 message: text,
@@ -270,13 +281,7 @@ public struct MessageBubbleView: View {
                 onRetry: onRetryConversationError
             )
             .contextMenu {
-                if let onRegenerate {
-                    Button {
-                        onRegenerate()
-                    } label: {
-                        Label { Text("Regenerate") } icon: { VIconView(.rotateCcw, size: 14) }
-                    }
-                }
+                sharedContextMenu()
             }
         } else {
             MarkdownRenderer(text: text)
@@ -284,14 +289,27 @@ public struct MessageBubbleView: View {
                 .background(VColor.surfaceBase)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                 .contextMenu {
-                    if let onRegenerate {
-                        Button {
-                            onRegenerate()
-                        } label: {
-                            Label { Text("Regenerate") } icon: { VIconView(.rotateCcw, size: 14) }
-                        }
-                    }
+                    sharedContextMenu()
                 }
+        }
+    }
+
+    @ViewBuilder
+    private func sharedContextMenu() -> some View {
+        if let onRegenerate {
+            Button {
+                onRegenerate()
+            } label: {
+                Label { Text("Regenerate") } icon: { VIconView(.rotateCcw, size: 14) }
+            }
+        }
+
+        if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
+            Button {
+                onForkFromMessage(daemonMessageId)
+            } label: {
+                Label { Text("Fork from here") } icon: { VIconView(.gitBranch, size: 14) }
+            }
         }
     }
 
@@ -312,5 +330,4 @@ public struct MessageBubbleView: View {
         return 1.0 + 0.4 * sin(normalized * 2 * .pi)
     }
 }
-
 

--- a/clients/shared/Tests/ChatViewModelForkCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelForkCommandTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatViewModelForkCommandTests: XCTestCase {
+
+    private var daemonClient: MockDaemonClient!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        viewModel = ChatViewModel(daemonClient: daemonClient)
+        viewModel.conversationId = "sess-1"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    func testExactForkUsesLocalHandlerWithoutTranscriptArtifact() {
+        var forkCount = 0
+        var sentCount = 0
+        viewModel.onFork = { forkCount += 1 }
+        viewModel.onUserMessageSent = { sentCount += 1 }
+        viewModel.inputText = "/fork"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(forkCount, 1)
+        XCTAssertEqual(sentCount, 0)
+        XCTAssertEqual(viewModel.inputText, "")
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertTrue(daemonClient.sentMessages.isEmpty)
+    }
+
+    func testForkWithArgumentsStaysOnNormalSendPath() {
+        var forkCount = 0
+        viewModel.onFork = { forkCount += 1 }
+        viewModel.inputText = "/fork this branch"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(forkCount, 0)
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/fork this branch")
+        XCTAssertEqual(daemonClient.sentMessages.count, 1)
+    }
+
+    func testForkWithAttachmentStaysOnNormalSendPath() {
+        var forkCount = 0
+        viewModel.onFork = { forkCount += 1 }
+        viewModel.pendingAttachments = [makeAttachment()]
+        viewModel.inputText = "/fork"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(forkCount, 0)
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/fork")
+        XCTAssertEqual(viewModel.messages[0].attachments.count, 1)
+        XCTAssertEqual(daemonClient.sentMessages.count, 1)
+    }
+
+    func testForkWithPendingSkillInvocationStaysOnNormalSendPath() {
+        var forkCount = 0
+        viewModel.onFork = { forkCount += 1 }
+        viewModel.pendingSkillInvocation = SkillInvocationData(
+            name: "planner",
+            emoji: nil,
+            description: "Plan the next step"
+        )
+        viewModel.inputText = "/fork"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(forkCount, 0)
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/fork")
+        XCTAssertEqual(viewModel.messages[0].skillInvocation?.name, "planner")
+        XCTAssertEqual(daemonClient.sentMessages.count, 1)
+    }
+
+    func testBtwStillUsesExistingLocalSidechainPath() {
+        viewModel.onFork = {}
+        viewModel.inputText = "/btw what changed?"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.inputText, "")
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertTrue(viewModel.btwLoading)
+        XCTAssertEqual(viewModel.btwResponse, "")
+        XCTAssertTrue(daemonClient.sentMessages.isEmpty)
+    }
+
+    func testGenericSlashCommandStillSendsNormallyWithForkHandler() {
+        viewModel.onFork = {}
+        viewModel.inputText = "/foo"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "/foo")
+        XCTAssertEqual(daemonClient.sentMessages.count, 1)
+    }
+
+    func testMessageBubbleForkActionRequiresPersistedNonStreamingMessage() {
+        let persistedMessage = makeMessage(daemonMessageId: "msg-1", isStreaming: false)
+        let localOnlyMessage = makeMessage(daemonMessageId: nil, isStreaming: false)
+        let streamingMessage = makeMessage(daemonMessageId: "msg-2", isStreaming: true)
+
+        let persistedView = MessageBubbleView(
+            message: persistedMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+        let localOnlyView = MessageBubbleView(
+            message: localOnlyMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+        let streamingView = MessageBubbleView(
+            message: streamingMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+        let missingCallbackView = MessageBubbleView(
+            message: persistedMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil
+        )
+
+        XCTAssertTrue(persistedView.canForkFromMessage)
+        XCTAssertFalse(localOnlyView.canForkFromMessage)
+        XCTAssertFalse(streamingView.canForkFromMessage)
+        XCTAssertFalse(missingCallbackView.canForkFromMessage)
+    }
+
+    private func makeMessage(daemonMessageId: String?, isStreaming: Bool) -> ChatMessage {
+        var message = ChatMessage(role: .assistant, text: "Persisted reply", isStreaming: isStreaming)
+        message.daemonMessageId = daemonMessageId
+        return message
+    }
+
+    private func makeAttachment() -> ChatAttachment {
+        #if os(macOS)
+        ChatAttachment(
+            id: "attachment-1",
+            filename: "note.txt",
+            mimeType: "text/plain",
+            data: "ZGF0YQ==",
+            thumbnailData: nil,
+            dataLength: 8,
+            thumbnailImage: nil
+        )
+        #elseif os(iOS)
+        ChatAttachment(
+            id: "attachment-1",
+            filename: "note.txt",
+            mimeType: "text/plain",
+            data: "ZGF0YQ==",
+            thumbnailData: nil,
+            dataLength: 8,
+            thumbnailImage: nil
+        )
+        #else
+        fatalError("Unsupported platform")
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- intercept exact /fork locally in the shared chat send path
- add shared message-level fork callback plumbing for persisted messages
- add focused shared tests for /fork behavior and message action visibility

Part of plan: conversation-forking.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)