### PR TITLE
feat: add conversation fork transport types

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -178,6 +178,12 @@ export interface AssistantAttention {
   lastSeenSignalType?: string;
 }
 
+export interface ConversationForkParent {
+  conversationId: string;
+  messageId: string;
+  title: string;
+}
+
 export interface ConversationListResponse {
   type: "conversation_list_response";
   conversations: Array<{
@@ -194,6 +200,7 @@ export interface ConversationListResponse {
     assistantAttention?: AssistantAttention;
     displayOrder?: number;
     isPinned?: boolean;
+    forkParent?: ConversationForkParent;
   }>;
   /** Whether more conversations exist beyond the returned page. */
   hasMore?: boolean;

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -43,7 +43,8 @@ public struct ConversationListClient: ConversationListClientProtocol {
                     conversationOriginInterface: $0.conversationOriginInterface,
                     assistantAttention: $0.assistantAttention,
                     displayOrder: $0.displayOrder,
-                    isPinned: $0.isPinned
+                    isPinned: $0.isPinned,
+                    forkParent: $0.forkParent
                 )
             }
             return ConversationListResponse(
@@ -78,6 +79,7 @@ private struct HTTPConversationsListResponse: Decodable {
         let assistantAttention: AssistantAttention?
         let displayOrder: Double?
         let isPinned: Bool?
+        let forkParent: ConversationForkParent?
     }
     let conversations: [Conversation]
     let hasMore: Bool?

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3422,6 +3422,18 @@ public struct ConversationInfo: Codable, Sendable {
     }
 }
 
+public struct ConversationForkParent: Codable, Sendable {
+    public let conversationId: String
+    public let messageId: String
+    public let title: String
+
+    public init(conversationId: String, messageId: String, title: String) {
+        self.conversationId = conversationId
+        self.messageId = messageId
+        self.title = title
+    }
+}
+
 public struct ConversationListRequest: Codable, Sendable {
     public let type: String
     /// Number of conversations to skip (for pagination). Defaults to 0.
@@ -3465,8 +3477,9 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let assistantAttention: AssistantAttention?
     public let displayOrder: Double?
     public let isPinned: Bool?
+    public let forkParent: ConversationForkParent?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, forkParent: ConversationForkParent? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -3480,6 +3493,7 @@ public struct ConversationListResponseItem: Codable, Sendable {
         self.assistantAttention = assistantAttention
         self.displayOrder = displayOrder
         self.isPinned = isPinned
+        self.forkParent = forkParent
     }
 }
 

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -36,6 +36,7 @@ public struct ConversationsListResponse: Decodable {
         public let assistantAttention: AssistantAttention?
         public let displayOrder: Double?
         public let isPinned: Bool?
+        public let forkParent: ConversationForkParent?
     }
     public let conversations: [Conversation]
     public let hasMore: Bool?
@@ -43,6 +44,11 @@ public struct ConversationsListResponse: Decodable {
 
 /// Response shape from `GET /v1/conversations/:id`.
 public struct SingleConversationResponse: Decodable {
+    public let conversation: ConversationsListResponse.Conversation
+}
+
+/// Response shape from `POST /v1/conversations/:id/fork`.
+public struct ForkConversationResponse: Decodable {
     public let conversation: ConversationsListResponse.Conversation
 }
 

--- a/clients/shared/Tests/HTTPDaemonClientConversationForkDecodingTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientConversationForkDecodingTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class HTTPDaemonClientConversationForkDecodingTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    func testHTTPConversationsListResponseDecodesForkParent() throws {
+        let data = Data(
+            """
+            {
+              "conversations": [
+                {
+                  "id": "conv-child",
+                  "title": "Forked thread",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100,
+                  "forkParent": {
+                    "conversationId": "conv-parent",
+                    "messageId": "msg-parent",
+                    "title": "Original thread"
+                  }
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationsListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertEqual(conversation.forkParent?.conversationId, "conv-parent")
+        XCTAssertEqual(conversation.forkParent?.messageId, "msg-parent")
+        XCTAssertEqual(conversation.forkParent?.title, "Original thread")
+    }
+
+    func testConversationListTransportDecodesForkParent() throws {
+        let data = Data(
+            """
+            {
+              "type": "conversation_list_response",
+              "conversations": [
+                {
+                  "id": "conv-child",
+                  "title": "Forked thread",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100,
+                  "forkParent": {
+                    "conversationId": "conv-parent",
+                    "messageId": "msg-parent",
+                    "title": "Original thread"
+                  }
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertEqual(conversation.forkParent?.conversationId, "conv-parent")
+        XCTAssertEqual(conversation.forkParent?.messageId, "msg-parent")
+        XCTAssertEqual(conversation.forkParent?.title, "Original thread")
+    }
+
+    func testConversationListTransportDecodesWithoutForkParent() throws {
+        let data = Data(
+            """
+            {
+              "type": "conversation_list_response",
+              "conversations": [
+                {
+                  "id": "conv-standard",
+                  "title": "Standard thread",
+                  "createdAt": 1700000000,
+                  "updatedAt": 1700000100
+                }
+              ],
+              "hasMore": false
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ConversationListResponse.self, from: data)
+        let conversation = try XCTUnwrap(response.conversations.first)
+
+        XCTAssertNil(conversation.forkParent)
+    }
+
+    func testSingleConversationResponseDecodesForkParent() throws {
+        let data = Data(
+            """
+            {
+              "conversation": {
+                "id": "conv-child",
+                "title": "Forked thread",
+                "createdAt": 1700000000,
+                "updatedAt": 1700000100,
+                "forkParent": {
+                  "conversationId": "conv-parent",
+                  "messageId": "msg-parent",
+                  "title": "Original thread"
+                }
+              }
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(SingleConversationResponse.self, from: data)
+
+        XCTAssertEqual(response.conversation.forkParent?.conversationId, "conv-parent")
+        XCTAssertEqual(response.conversation.forkParent?.messageId, "msg-parent")
+        XCTAssertEqual(response.conversation.forkParent?.title, "Original thread")
+    }
+
+    func testForkConversationResponseDecodesForkRoutePayloadShape() throws {
+        let data = Data(
+            """
+            {
+              "conversation": {
+                "id": "conv-forked",
+                "title": "Fork result",
+                "createdAt": 1700000200,
+                "updatedAt": 1700000300,
+                "forkParent": {
+                  "conversationId": "conv-parent",
+                  "messageId": "msg-parent",
+                  "title": "Original thread"
+                }
+              }
+            }
+            """.utf8
+        )
+
+        let response = try decoder.decode(ForkConversationResponse.self, from: data)
+
+        XCTAssertEqual(response.conversation.id, "conv-forked")
+        XCTAssertEqual(response.conversation.forkParent?.conversationId, "conv-parent")
+        XCTAssertEqual(response.conversation.forkParent?.messageId, "msg-parent")
+        XCTAssertEqual(response.conversation.forkParent?.title, "Original thread")
+    }
+}


### PR DESCRIPTION
## Summary
- add shared fork parent transport types for conversation payloads
- extend Apple HTTP decoding and list mapping to preserve fork lineage
- add focused decoding coverage for list, single, and fork route payloads

Part of plan: conversation-forking.md (PR 2 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
