### PR TITLE
fix: honor slash command behavior on tab completion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -49,6 +49,10 @@ enum SlashNavigation {
 // MARK: - Slash Command Logic (ComposerView extension)
 
 extension ComposerView {
+    static func slashCommandInputTextForSelection(_ command: SlashCommand) -> String {
+        command.selectedInputText
+    }
+
     /// Range of a slash command token (e.g. `/model`) at the start of input.
     var slashCommandRange: Range<String.Index>? {
         guard !inputText.isEmpty else { return nil }
@@ -104,7 +108,7 @@ extension ComposerView {
     func selectSlashCommand(_ command: SlashCommand) {
         withAnimation(VAnimation.fast) { showSlashMenu = false }
         slashSelectedIndex = 0
-        inputText = command.selectedInputText
+        inputText = Self.slashCommandInputTextForSelection(command)
         if command.shouldAutoSendOnSelect {
             onSend()
         }
@@ -123,7 +127,7 @@ extension ComposerView {
                 selectSlashCommand(filtered[slashSelectedIndex])
             case .tab:
                 let command = filtered[slashSelectedIndex]
-                let newText = "/\(command.name)"
+                let newText = Self.slashCommandInputTextForSelection(command)
                 if inputText != newText {
                     suppressSlashReopen = true
                 }

--- a/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
@@ -26,5 +26,10 @@ final class ComposerSlashCommandPickerTests: XCTestCase {
         XCTAssertEqual(command.selectedInputText, "/pair")
         XCTAssertTrue(command.shouldAutoSendOnSelect)
     }
+
+    func testBtwTabCompletionUsesSelectionInsertionText() {
+        let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "btw" }))
+        XCTAssertEqual(ComposerView.slashCommandInputTextForSelection(command), "/btw ")
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
Fixes remaining slash-command picker gap from re-review for unify-desktop-slash-command-ux.md.

**Gap:** Tab-completing /btw ignored selection behavior and dropped the required trailing space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)