### PR TITLE
fix: align slash command contract across client and daemon

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -77,3 +77,47 @@ describe("resolveSlash /commands interface-aware help", () => {
     ]);
   });
 });
+
+describe("resolveSlash command contract", () => {
+  test("keeps unsupported slash forms as passthrough", async () => {
+    const slashForms = [
+      "/commands foo",
+      "/models foo",
+      "/status foo",
+      "/pair foo",
+      "/btw",
+    ];
+
+    for (const input of slashForms) {
+      const result = await resolveSlash(
+        input,
+        makeSlashContext({ userMessageInterface: "macos" }),
+      );
+      expect(result).toEqual({ kind: "passthrough", content: input });
+    }
+  });
+
+  test("rejects /pair on iOS interfaces", async () => {
+    const result = await resolveSlash(
+      "/pair",
+      makeSlashContext({ userMessageInterface: "ios" }),
+    );
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") {
+      throw new Error("Expected /pair on iOS to resolve to kind=unknown");
+    }
+    expect(result.message).toContain("only available in the macOS desktop app");
+  });
+
+  test("keeps /pair handling enabled on macOS interfaces", async () => {
+    const result = await resolveSlash(
+      "/pair",
+      makeSlashContext({ userMessageInterface: "macos" }),
+    );
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") {
+      throw new Error("Expected /pair on macOS to resolve to kind=unknown");
+    }
+    expect(result.message).toContain("Pairing is not available");
+  });
+});

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -199,7 +199,7 @@ export async function resolveSlash(
   }
 
   // Handle /pair command
-  const pairResult = resolvePairCommand(content);
+  const pairResult = resolvePairCommand(content, context);
   if (pairResult) return pairResult;
 
   // Handle /status command
@@ -253,8 +253,19 @@ async function savePairingQRCodePng(
   writeFileSync(qrPngPath, pngBuffer);
 }
 
-function resolvePairCommand(content: string): SlashResolution | null {
+function resolvePairCommand(
+  content: string,
+  context?: SlashContext,
+): SlashResolution | null {
   if (content.trim() !== "/pair") return null;
+
+  if (context?.userMessageInterface && context.userMessageInterface !== "macos") {
+    return {
+      kind: "unknown",
+      message:
+        "The `/pair` command is only available in the macOS desktop app.",
+    };
+  }
 
   if (!pairingStoreRef) {
     return {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1122,6 +1122,16 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - Sending
 
+    private var sendPathPlatform: ChatSlashCommandPlatform {
+        #if os(macOS)
+        return .macos
+        #elseif os(iOS)
+        return .ios
+        #else
+        #error("Unsupported platform")
+        #endif
+    }
+
     public func sendMessage(hidden: Bool = false) {
         let rawText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let text = rawText
@@ -1146,7 +1156,10 @@ public final class ChatViewModel: ObservableObject {
 
         // Refresh model state only for slash commands that explicitly opt in.
         let shouldRefreshModelMetadata = !hasSkillInvocation
-            && ChatSlashCommandCatalog.shouldRefreshModelMetadata(forRawInput: text)
+            && ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+                forRawInput: text,
+                platform: sendPathPlatform
+            )
         if shouldRefreshModelMetadata {
             Task {
                 let info = await self.settingsClient.fetchModelInfo()
@@ -1228,6 +1241,7 @@ public final class ChatViewModel: ObservableObject {
 
         let hasRecognizedSlashCommand = ChatSlashCommandCatalog.isRecognizedSlashCommand(
             text,
+            platform: sendPathPlatform,
             surface: .sendPath
         )
         let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !hasRecognizedSlashCommand

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -16,11 +16,17 @@ public enum ChatSlashCommandSelectionBehavior: Hashable {
     case insertTrailingSpace
 }
 
+public enum ChatSlashCommandSendPathMatchRule: Hashable {
+    case exact
+    case commandWithArgument
+}
+
 public struct ChatSlashCommandDescriptor: Hashable {
     public let name: String
     public let description: String
     public let icon: String
     public let selectionBehavior: ChatSlashCommandSelectionBehavior
+    public let sendPathMatchRule: ChatSlashCommandSendPathMatchRule
     public let pickerPlatforms: Set<ChatSlashCommandPlatform>
     public let helpBubblePlatforms: Set<ChatSlashCommandPlatform>
     public let sendPathPlatforms: Set<ChatSlashCommandPlatform>
@@ -31,6 +37,7 @@ public struct ChatSlashCommandDescriptor: Hashable {
         description: String,
         icon: String,
         selectionBehavior: ChatSlashCommandSelectionBehavior,
+        sendPathMatchRule: ChatSlashCommandSendPathMatchRule = .exact,
         pickerPlatforms: Set<ChatSlashCommandPlatform>,
         helpBubblePlatforms: Set<ChatSlashCommandPlatform>,
         sendPathPlatforms: Set<ChatSlashCommandPlatform>,
@@ -40,6 +47,7 @@ public struct ChatSlashCommandDescriptor: Hashable {
         self.description = description
         self.icon = icon
         self.selectionBehavior = selectionBehavior
+        self.sendPathMatchRule = sendPathMatchRule
         self.pickerPlatforms = pickerPlatforms
         self.helpBubblePlatforms = helpBubblePlatforms
         self.sendPathPlatforms = sendPathPlatforms
@@ -94,7 +102,7 @@ public enum ChatSlashCommandCatalog {
         ),
         ChatSlashCommandDescriptor(
             name: "status",
-            description: "Show session status and context usage",
+            description: "Show conversation status and context usage",
             icon: "info.circle",
             selectionBehavior: .autoSend,
             pickerPlatforms: allPlatforms,
@@ -106,6 +114,7 @@ public enum ChatSlashCommandCatalog {
             description: "Ask a side question while the assistant is working",
             icon: "bubble.left.and.text.bubble.right",
             selectionBehavior: .insertTrailingSpace,
+            sendPathMatchRule: .commandWithArgument,
             pickerPlatforms: allPlatforms,
             helpBubblePlatforms: allPlatforms,
             sendPathPlatforms: allPlatforms
@@ -117,7 +126,7 @@ public enum ChatSlashCommandCatalog {
             selectionBehavior: .autoSend,
             pickerPlatforms: [.macos],
             helpBubblePlatforms: [.macos],
-            sendPathPlatforms: allPlatforms
+            sendPathPlatforms: [.macos]
         ),
     ]
 
@@ -144,6 +153,13 @@ public enum ChatSlashCommandCatalog {
         platform: ChatSlashCommandPlatform? = nil,
         surface: ChatSlashCommandSurface? = nil
     ) -> ChatSlashCommandDescriptor? {
+        if surface == .sendPath {
+            return descriptorForSendPath(
+                forRawInput: rawInput,
+                platform: platform
+            )
+        }
+
         guard let commandName = normalizedCommandName(from: rawInput) else {
             return nil
         }
@@ -167,6 +183,34 @@ public enum ChatSlashCommandCatalog {
         return descriptor
     }
 
+    private static func descriptorForSendPath(
+        forRawInput rawInput: String,
+        platform: ChatSlashCommandPlatform?
+    ) -> ChatSlashCommandDescriptor? {
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard trimmed.hasPrefix("/") else {
+            return nil
+        }
+
+        return allCommands.first { descriptor in
+            if let platform, !descriptor.isVisible(on: platform, surface: .sendPath) {
+                return false
+            }
+            let slashName = descriptor.slashName.lowercased()
+            switch descriptor.sendPathMatchRule {
+            case .exact:
+                return trimmed == slashName
+            case .commandWithArgument:
+                guard trimmed.hasPrefix("\(slashName) ") else {
+                    return false
+                }
+                let argument = String(trimmed.dropFirst(slashName.count + 1))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return !argument.isEmpty
+            }
+        }
+    }
+
     public static func isRecognizedSlashCommand(
         _ rawInput: String,
         platform: ChatSlashCommandPlatform? = nil,
@@ -176,6 +220,17 @@ public enum ChatSlashCommandCatalog {
     }
 
     public static func shouldRefreshModelMetadata(forRawInput rawInput: String) -> Bool {
-        descriptor(forRawInput: rawInput, surface: .sendPath)?.refreshesModelMetadata == true
+        shouldRefreshModelMetadata(forRawInput: rawInput, platform: nil)
+    }
+
+    public static func shouldRefreshModelMetadata(
+        forRawInput rawInput: String,
+        platform: ChatSlashCommandPlatform?
+    ) -> Bool {
+        descriptor(
+            forRawInput: rawInput,
+            platform: platform,
+            surface: .sendPath
+        )?.refreshesModelMetadata == true
     }
 }

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -74,7 +74,7 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[1].text, "/status")
     }
 
-    func testModelsRefreshesMetadataButDeprecatedModelDoesNot() async {
+    func testModelsRefreshesMetadataButUnsupportedFormsDoNot() async {
         settingsClient.modelInfoResponse = ModelInfoMessage(
             type: "model_info",
             model: "test-model",
@@ -89,12 +89,41 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         await Task.yield()
         XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
 
+        viewModel.inputText = "/models foo"
+        viewModel.sendMessage()
+
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
+
         viewModel.inputText = "/model"
         viewModel.sendMessage()
 
         await Task.yield()
         await Task.yield()
         XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
+    }
+
+    func testUnsupportedSlashFormsUseWorkspaceRefinementWhenSurfaceIsActive() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
+
+        let unsupportedForms = [
+            "/commands foo",
+            "/models foo",
+            "/status foo",
+            "/pair foo",
+            "/btw",
+        ]
+
+        for command in unsupportedForms {
+            viewModel.isWorkspaceRefinementInFlight = false
+            viewModel.inputText = command
+            viewModel.sendMessage()
+
+            XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
+            XCTAssertEqual(viewModel.messages.count, 0)
+        }
     }
 
     func testUnknownSlashCommandsUseWorkspaceRefinementWhenSurfaceIsActive() {

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -27,6 +27,14 @@ final class SlashCommandCatalogTests: XCTestCase {
         XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw"])
     }
 
+    func testStatusDescriptionMatchesConversationCopy() {
+        let status = ChatSlashCommandCatalog.commands(
+            for: .macos,
+            surface: .helpBubble
+        ).first(where: { $0.name == "status" })
+        XCTAssertEqual(status?.description, "Show conversation status and context usage")
+    }
+
     func testBtwSelectionBehaviorUsesTrailingSpaceInsertion() {
         let descriptor = ChatSlashCommandCatalog.descriptor(
             forRawInput: "/btw tell me more",
@@ -50,5 +58,87 @@ final class SlashCommandCatalogTests: XCTestCase {
             surface: .helpBubble
         )
         XCTAssertNil(helpDescriptor)
+    }
+
+    func testSendPathRecognitionRequiresSupportedForms() {
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/commands",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/models",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/status",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/pair",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/btw follow up",
+            platform: .macos,
+            surface: .sendPath
+        ))
+
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/commands foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/models foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/status foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/pair foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/btw",
+            platform: .macos,
+            surface: .sendPath
+        ))
+    }
+
+    func testPairIsMacOSOnlyOnSendPath() {
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/pair",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/pair",
+            platform: .ios,
+            surface: .sendPath
+        ))
+    }
+
+    func testModelMetadataRefreshOnlyForExactModelsCommand() {
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+            forRawInput: "/models",
+            platform: .macos
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+            forRawInput: "/models foo",
+            platform: .macos
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+            forRawInput: "/commands",
+            platform: .macos
+        ))
     }
 }


### PR DESCRIPTION
## Summary
Fixes remaining slash-command contract gaps from re-review for unify-desktop-slash-command-ux.md.

**Gaps:** over-broad send-path command matching, stale /status copy, and inconsistent /pair availability on iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
