### PR TITLE
fix: normalize web search tool results in llm context

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -256,6 +256,102 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
+  test("normalizes Anthropic web_search_tool_result blocks", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_004,
+      requestPayload: {
+        model: "claude-sonnet",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "web_search_tool_result",
+                tool_use_id: "stu_req_1",
+                content: [
+                  {
+                    type: "web_search_result",
+                    url: "https://example.com",
+                    title: "Example result",
+                    encrypted_content: "enc_123",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 12,
+          output_tokens: 8,
+        },
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_resp_1",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.org",
+                title: "Another result",
+                encrypted_content: "enc_456",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      inputTokens: 12,
+      outputTokens: 8,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: "end_turn",
+      requestMessageCount: 1,
+      requestToolCount: 0,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "[Web search results]",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "[Web search results]",
+      },
+      {
+        kind: "tool_result",
+        label: "User message 1 tool result",
+        role: "user",
+        toolName: "stu_req_1",
+        text: "[Web search results]",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "[Web search results]",
+      },
+      {
+        kind: "tool_result",
+        label: "Assistant response tool result",
+        role: "assistant",
+        toolName: "stu_resp_1",
+        text: "[Web search results]",
+      },
+    ]);
+  });
+
   test("normalizes Gemini request and response payloads", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_002,

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -360,13 +360,13 @@ function anthropicMessageSections(
       continue;
     }
 
-    if (type === "tool_result") {
+    if (isAnthropicToolResultType(type)) {
       sections.push({
         kind: "tool_result",
         label: `${label} tool result`,
         role,
         toolName: asString(block.name) ?? asString(block.tool_use_id),
-        text: collectAnthropicText(block.content),
+        text: collectAnthropicToolResultText(block),
       });
     }
   }
@@ -612,8 +612,8 @@ function collectAnthropicText(content: unknown): string | undefined {
       continue;
     }
 
-    if (type === "tool_result") {
-      const resultText = collectAnthropicText(block.content);
+    if (isAnthropicToolResultType(type)) {
+      const resultText = collectAnthropicToolResultText(block);
       if (resultText) {
         textParts.push(resultText);
       }
@@ -621,6 +621,19 @@ function collectAnthropicText(content: unknown): string | undefined {
   }
 
   return joinTextParts(textParts);
+}
+
+function isAnthropicToolResultType(type: string | undefined): boolean {
+  return type === "tool_result" || type === "web_search_tool_result";
+}
+
+function collectAnthropicToolResultText(
+  block: Record<string, unknown>,
+): string | undefined {
+  if (asString(block.type) === "web_search_tool_result") {
+    return "[Web search results]";
+  }
+  return collectAnthropicText(block.content);
 }
 
 function buildMessageLabel(role: string, index: number): string {


### PR DESCRIPTION
## Summary
- treat Anthropic `web_search_tool_result` blocks like tool results when normalizing LLM context
- use a stable `[Web search results]` placeholder so diagnostics previews do not drop provider-native search results
- add a regression test covering Anthropic request and response payloads with web search results

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282158715/job/67697766795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
