### PR TITLE
feat: expose fork lineage in conversation list and detail reads

### DIFF
--- a/assistant/src/__tests__/http-conversation-lineage.test.ts
+++ b/assistant/src/__tests__/http-conversation-lineage.test.ts
@@ -1,0 +1,219 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "http-conversation-lineage-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(testDir, ".vellum", "workspace", "data"),
+  getWorkspaceDir: () => join(testDir, ".vellum", "workspace"),
+  getConversationsDir: () =>
+    join(testDir, ".vellum", "workspace", "conversations"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  createConversation,
+  updateConversationTitle,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, rawRun, resetDb } from "../memory/db.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+
+initializeDb();
+
+type ConversationSummary = {
+  id: string;
+  title: string;
+  forkParent?: {
+    conversationId: string;
+    messageId: string;
+    title: string;
+  };
+};
+
+describe("conversation lineage in HTTP reads", () => {
+  let server: RuntimeHttpServer | null = null;
+
+  beforeEach(async () => {
+    await server?.stop();
+    server = null;
+    clearTables();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("GET /v1/conversations returns forkParent for surviving parents", async () => {
+    const { child, parent } = seedForkedConversation();
+    await startServer();
+
+    const response = await fetch(url("/conversations"));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversations: ConversationSummary[];
+      hasMore: boolean;
+    };
+    const listedChild = body.conversations.find((item) => item.id === child.id);
+
+    expect(listedChild).toMatchObject({
+      id: child.id,
+      title: child.title ?? "Untitled",
+      forkParent: {
+        conversationId: parent.id,
+        messageId: "parent-msg-1",
+        title: parent.title ?? "Untitled",
+      },
+    });
+    expect(body.hasMore).toBe(false);
+  });
+
+  test("GET /v1/conversations/:id returns forkParent for surviving parents", async () => {
+    const { child, parent } = seedForkedConversation();
+    await startServer();
+
+    const response = await fetch(url(`/conversations/${child.id}`));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversation: ConversationSummary;
+    };
+
+    expect(body.conversation).toMatchObject({
+      id: child.id,
+      title: child.title ?? "Untitled",
+      forkParent: {
+        conversationId: parent.id,
+        messageId: "parent-msg-1",
+        title: parent.title ?? "Untitled",
+      },
+    });
+  });
+
+  test("GET /v1/conversations/:id resolves the parent's current title at read time", async () => {
+    const { child, parent } = seedForkedConversation({
+      parentTitle: "Original parent title",
+    });
+    updateConversationTitle(parent.id, "Renamed parent title", 0);
+    await startServer();
+
+    const response = await fetch(url(`/conversations/${child.id}`));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversation: ConversationSummary;
+    };
+
+    expect(body.conversation.forkParent).toEqual({
+      conversationId: parent.id,
+      messageId: "parent-msg-1",
+      title: "Renamed parent title",
+    });
+  });
+
+  test("deleted parents are omitted from list and detail responses", async () => {
+    const { child, parent } = seedForkedConversation();
+    rawRun("DELETE FROM conversations WHERE id = ?", parent.id);
+    await startServer();
+
+    const listResponse = await fetch(url("/conversations"));
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      conversations: ConversationSummary[];
+    };
+    const listedChild = listBody.conversations.find((item) => item.id === child.id);
+    expect(listedChild).toBeDefined();
+    expect(listedChild?.forkParent).toBeUndefined();
+
+    const detailResponse = await fetch(url(`/conversations/${child.id}`));
+    expect(detailResponse.status).toBe(200);
+    const detailBody = (await detailResponse.json()) as {
+      conversation: ConversationSummary;
+    };
+    expect(detailBody.conversation.forkParent).toBeUndefined();
+  });
+
+  function clearTables(): void {
+    const db = getDb();
+    db.run("DELETE FROM conversation_assistant_attention_state");
+    db.run("DELETE FROM external_conversation_bindings");
+    db.run("DELETE FROM conversation_keys");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  }
+
+  function seedForkedConversation(opts?: { parentTitle?: string }) {
+    const parent = createConversation(opts?.parentTitle ?? "Parent conversation");
+    const child = createConversation("Forked conversation");
+
+    rawRun(
+      `
+        UPDATE conversations
+        SET fork_parent_conversation_id = ?, fork_parent_message_id = ?
+        WHERE id = ?
+      `,
+      parent.id,
+      "parent-msg-1",
+      child.id,
+    );
+
+    return { parent, child };
+  }
+
+  async function startServer(): Promise<void> {
+    server = new RuntimeHttpServer({ port: 0, bearerToken: "test-bearer-token" });
+    await server.start();
+  }
+
+  function url(pathname: string): string {
+    if (!server) throw new Error("server not started");
+    return `http://127.0.0.1:${server.actualPort}/v1${pathname}`;
+  }
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -116,6 +116,8 @@ export interface ConversationRow {
   memoryScopeId: string;
   originChannel: string | null;
   originInterface: string | null;
+  forkParentConversationId: string | null;
+  forkParentMessageId: string | null;
   isAutoTitle: number;
   scheduleJobId: string | null;
 }
@@ -139,6 +141,8 @@ export const parseConversation = createRowMapper<
   memoryScopeId: "memoryScopeId",
   originChannel: "originChannel",
   originInterface: "originInterface",
+  forkParentConversationId: "forkParentConversationId",
+  forkParentMessageId: "forkParentMessageId",
   isAutoTitle: "isAutoTitle",
   scheduleJobId: "scheduleJobId",
 });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -37,12 +37,14 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
   type Confidence,
+  type AttentionState,
   getAttentionStateByConversationIds,
   markConversationUnread,
   recordConversationSeenSignal,
   type SignalType,
 } from "../memory/conversation-attention-store.js";
 import {
+  type ConversationRow,
   getConversation,
   getDisplayMetaForConversations,
 } from "../memory/conversation-crud.js";
@@ -52,6 +54,7 @@ import {
   listConversations,
 } from "../memory/conversation-queries.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
+import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
 import {
   consumeCallback,
   consumeCallbackError,
@@ -714,6 +717,119 @@ export class RuntimeHttpServer {
     });
   }
 
+  private buildAssistantAttention(
+    attentionState: AttentionState | undefined,
+  ):
+    | {
+        hasUnseenLatestAssistantMessage: boolean;
+        latestAssistantMessageAt?: number;
+        lastSeenAssistantMessageAt?: number;
+        lastSeenConfidence?: Confidence;
+        lastSeenSignalType?: SignalType;
+      }
+    | undefined {
+    if (!attentionState) return undefined;
+
+    return {
+      hasUnseenLatestAssistantMessage:
+        attentionState.latestAssistantMessageAt != null &&
+        (attentionState.lastSeenAssistantMessageAt == null ||
+          attentionState.lastSeenAssistantMessageAt <
+            attentionState.latestAssistantMessageAt),
+      ...(attentionState.latestAssistantMessageAt != null
+        ? {
+            latestAssistantMessageAt: attentionState.latestAssistantMessageAt,
+          }
+        : {}),
+      ...(attentionState.lastSeenAssistantMessageAt != null
+        ? {
+            lastSeenAssistantMessageAt:
+              attentionState.lastSeenAssistantMessageAt,
+          }
+        : {}),
+      ...(attentionState.lastSeenConfidence != null
+        ? { lastSeenConfidence: attentionState.lastSeenConfidence }
+        : {}),
+      ...(attentionState.lastSeenSignalType != null
+        ? { lastSeenSignalType: attentionState.lastSeenSignalType }
+        : {}),
+    };
+  }
+
+  private buildForkParent(
+    conversation: ConversationRow,
+    parentCache: Map<string, ConversationRow | null>,
+  ): { conversationId: string; messageId: string; title: string } | undefined {
+    const parentConversationId = conversation.forkParentConversationId;
+    const parentMessageId = conversation.forkParentMessageId;
+    if (!parentConversationId || !parentMessageId) return undefined;
+
+    let parentConversation: ConversationRow | null | undefined =
+      parentCache.get(parentConversationId);
+    if (parentConversation === undefined) {
+      parentConversation = getConversation(parentConversationId);
+      parentCache.set(parentConversationId, parentConversation);
+    }
+    if (!parentConversation) return undefined;
+
+    return {
+      conversationId: parentConversationId,
+      messageId: parentMessageId,
+      title: parentConversation.title ?? "Untitled",
+    };
+  }
+
+  private serializeConversationSummary(params: {
+    conversation: ConversationRow;
+    binding?: ExternalConversationBinding | null;
+    attentionState?: AttentionState;
+    displayMeta?: { displayOrder: number | null; isPinned: boolean };
+    parentCache: Map<string, ConversationRow | null>;
+  }) {
+    const { conversation, binding, attentionState, displayMeta, parentCache } =
+      params;
+    const originChannel = parseChannelId(conversation.originChannel);
+    const assistantAttention = this.buildAssistantAttention(attentionState);
+    const forkParent = this.buildForkParent(conversation, parentCache);
+
+    return {
+      id: conversation.id,
+      title: conversation.title ?? "Untitled",
+      createdAt: conversation.createdAt,
+      updatedAt: conversation.updatedAt,
+      conversationType:
+        conversation.conversationType === "private" ? "private" : "standard",
+      source: conversation.source ?? "user",
+      ...(conversation.scheduleJobId
+        ? { scheduleJobId: conversation.scheduleJobId }
+        : {}),
+      ...(binding
+        ? {
+            channelBinding: {
+              sourceChannel: binding.sourceChannel,
+              externalChatId: binding.externalChatId,
+              externalUserId: binding.externalUserId,
+              displayName: binding.displayName,
+              username: binding.username,
+            },
+          }
+        : {}),
+      ...(originChannel ? { conversationOriginChannel: originChannel } : {}),
+      ...(assistantAttention ? { assistantAttention } : {}),
+      ...(displayMeta?.isPinned
+        ? {
+            isPinned: true as const,
+            displayOrder: displayMeta.displayOrder,
+          }
+        : displayMeta?.displayOrder != null
+          ? {
+              displayOrder: displayMeta.displayOrder,
+            }
+          : {}),
+      ...(forkParent ? { forkParent } : {}),
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Declarative route table
   // ---------------------------------------------------------------------------
@@ -824,74 +940,17 @@ export class RuntimeHttpServer {
             );
           const attentionStates =
             getAttentionStateByConversationIds(conversationIds);
+          const parentCache = new Map<string, ConversationRow | null>();
           return Response.json({
-            conversations: conversations.map((c) => {
-              const binding = bindings.get(c.id);
-              const originChannel = parseChannelId(c.originChannel);
-              const attn = attentionStates.get(c.id);
-              const assistantAttention = attn
-                ? {
-                    hasUnseenLatestAssistantMessage:
-                      attn.latestAssistantMessageAt != null &&
-                      (attn.lastSeenAssistantMessageAt == null ||
-                        attn.lastSeenAssistantMessageAt <
-                          attn.latestAssistantMessageAt),
-                    ...(attn.latestAssistantMessageAt != null
-                      ? {
-                          latestAssistantMessageAt:
-                            attn.latestAssistantMessageAt,
-                        }
-                      : {}),
-                    ...(attn.lastSeenAssistantMessageAt != null
-                      ? {
-                          lastSeenAssistantMessageAt:
-                            attn.lastSeenAssistantMessageAt,
-                        }
-                      : {}),
-                    ...(attn.lastSeenConfidence != null
-                      ? { lastSeenConfidence: attn.lastSeenConfidence }
-                      : {}),
-                    ...(attn.lastSeenSignalType != null
-                      ? { lastSeenSignalType: attn.lastSeenSignalType }
-                      : {}),
-                  }
-                : undefined;
-              return {
-                id: c.id,
-                title: c.title ?? "Untitled",
-                createdAt: c.createdAt,
-                updatedAt: c.updatedAt,
-                conversationType:
-                  c.conversationType === "private" ? "private" : "standard",
-                source: c.source ?? "user",
-                ...(c.scheduleJobId ? { scheduleJobId: c.scheduleJobId } : {}),
-                ...(binding
-                  ? {
-                      channelBinding: {
-                        sourceChannel: binding.sourceChannel,
-                        externalChatId: binding.externalChatId,
-                        externalUserId: binding.externalUserId,
-                        displayName: binding.displayName,
-                        username: binding.username,
-                      },
-                    }
-                  : {}),
-                ...(originChannel
-                  ? { conversationOriginChannel: originChannel }
-                  : {}),
-                ...(assistantAttention ? { assistantAttention } : {}),
-                ...(displayMeta.get(c.id)?.isPinned
-                  ? {
-                      isPinned: true,
-                      displayOrder: displayMeta.get(c.id)!.displayOrder,
-                    }
-                  : displayMeta.get(c.id)?.displayOrder != null
-                    ? {
-                        displayOrder: displayMeta.get(c.id)!.displayOrder,
-                      }
-                    : {}),
-              };
-            }),
+            conversations: conversations.map((conversation) =>
+              this.serializeConversationSummary({
+                conversation,
+                binding: bindings.get(conversation.id),
+                attentionState: attentionStates.get(conversation.id),
+                displayMeta: displayMeta.get(conversation.id),
+                parentCache,
+              }),
+            ),
             hasMore: offset + conversations.length < totalCount,
           });
         },
@@ -1006,65 +1065,14 @@ export class RuntimeHttpServer {
           const attentionStates = getAttentionStateByConversationIds([
             conversation.id,
           ]);
-          const binding = bindings.get(conversation.id);
-          const originChannel = parseChannelId(conversation.originChannel);
-          const attn = attentionStates.get(conversation.id);
-          const assistantAttention = attn
-            ? {
-                hasUnseenLatestAssistantMessage:
-                  attn.latestAssistantMessageAt != null &&
-                  (attn.lastSeenAssistantMessageAt == null ||
-                    attn.lastSeenAssistantMessageAt <
-                      attn.latestAssistantMessageAt),
-                ...(attn.latestAssistantMessageAt != null
-                  ? {
-                      latestAssistantMessageAt: attn.latestAssistantMessageAt,
-                    }
-                  : {}),
-                ...(attn.lastSeenAssistantMessageAt != null
-                  ? {
-                      lastSeenAssistantMessageAt:
-                        attn.lastSeenAssistantMessageAt,
-                    }
-                  : {}),
-                ...(attn.lastSeenConfidence != null
-                  ? { lastSeenConfidence: attn.lastSeenConfidence }
-                  : {}),
-                ...(attn.lastSeenSignalType != null
-                  ? { lastSeenSignalType: attn.lastSeenSignalType }
-                  : {}),
-              }
-            : undefined;
+          const parentCache = new Map<string, ConversationRow | null>();
           return Response.json({
-            conversation: {
-              id: conversation.id,
-              title: conversation.title ?? "Untitled",
-              createdAt: conversation.createdAt,
-              updatedAt: conversation.updatedAt,
-              conversationType:
-                conversation.conversationType === "private"
-                  ? "private"
-                  : "standard",
-              source: conversation.source ?? "user",
-              ...(conversation.scheduleJobId
-                ? { scheduleJobId: conversation.scheduleJobId }
-                : {}),
-              ...(binding
-                ? {
-                    channelBinding: {
-                      sourceChannel: binding.sourceChannel,
-                      externalChatId: binding.externalChatId,
-                      externalUserId: binding.externalUserId,
-                      displayName: binding.displayName,
-                      username: binding.username,
-                    },
-                  }
-                : {}),
-              ...(originChannel
-                ? { conversationOriginChannel: originChannel }
-                : {}),
-              ...(assistantAttention ? { assistantAttention } : {}),
-            },
+            conversation: this.serializeConversationSummary({
+              conversation,
+              binding: bindings.get(conversation.id),
+              attentionState: attentionStates.get(conversation.id),
+              parentCache,
+            }),
           });
         },
       },


### PR DESCRIPTION
## Summary
- project fork lineage through conversation row parsing and HTTP summaries
- share conversation summary serialization across list and single-conversation reads
- add route coverage for parent title resolution and deleted-parent omission

Part of plan: conversation-forking.md (PR 4 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
