### PR TITLE
feat: add shared conversation fork and detail clients

### DIFF
--- a/clients/shared/Network/ConversationDetailClient.swift
+++ b/clients/shared/Network/ConversationDetailClient.swift
@@ -1,0 +1,55 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationDetailClient")
+
+/// Focused client for fetching a single conversation summary through the gateway.
+@MainActor
+public protocol ConversationDetailClientProtocol {
+    func fetchConversation(conversationId: String) async -> ConversationListResponseItem?
+}
+
+/// Gateway-backed implementation of ``ConversationDetailClientProtocol``.
+@MainActor
+public struct ConversationDetailClient: ConversationDetailClientProtocol {
+    nonisolated public init() {}
+
+    public func fetchConversation(conversationId: String) async -> ConversationListResponseItem? {
+        do {
+            let encodedConversationId = conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/conversations/\(encodedConversationId)",
+                timeout: 15
+            )
+            guard response.isSuccess else {
+                log.error("fetchConversation failed (HTTP \(response.statusCode))")
+                return nil
+            }
+
+            let decoded = try JSONDecoder().decode(SingleConversationResponse.self, from: response.data)
+            return conversationSummary(from: decoded.conversation)
+        } catch {
+            log.error("fetchConversation error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func conversationSummary(from conversation: ConversationsListResponse.Conversation) -> ConversationListResponseItem {
+        ConversationListResponseItem(
+            id: conversation.id,
+            title: conversation.title,
+            createdAt: conversation.createdAt,
+            updatedAt: conversation.updatedAt,
+            conversationType: conversation.conversationType,
+            source: conversation.source,
+            scheduleJobId: conversation.scheduleJobId,
+            channelBinding: conversation.channelBinding,
+            conversationOriginChannel: conversation.conversationOriginChannel,
+            conversationOriginInterface: conversation.conversationOriginInterface,
+            assistantAttention: conversation.assistantAttention,
+            displayOrder: conversation.displayOrder,
+            isPinned: conversation.isPinned,
+            forkParent: conversation.forkParent
+        )
+    }
+}

--- a/clients/shared/Network/ConversationForkClient.swift
+++ b/clients/shared/Network/ConversationForkClient.swift
@@ -1,0 +1,60 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationForkClient")
+
+/// Focused client for creating conversation forks through the gateway.
+@MainActor
+public protocol ConversationForkClientProtocol {
+    func forkConversation(conversationId: String, throughMessageId: String?) async -> ConversationListResponseItem?
+}
+
+/// Gateway-backed implementation of ``ConversationForkClientProtocol``.
+@MainActor
+public struct ConversationForkClient: ConversationForkClientProtocol {
+    nonisolated public init() {}
+
+    public func forkConversation(conversationId: String, throughMessageId: String? = nil) async -> ConversationListResponseItem? {
+        do {
+            var body: [String: Any] = ["conversationId": conversationId]
+            if let throughMessageId {
+                body["throughMessageId"] = throughMessageId
+            }
+
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/conversations/fork",
+                json: body,
+                timeout: 15
+            )
+            guard response.isSuccess else {
+                log.error("forkConversation failed (HTTP \(response.statusCode))")
+                return nil
+            }
+
+            let decoded = try JSONDecoder().decode(ForkConversationResponse.self, from: response.data)
+            return conversationSummary(from: decoded.conversation)
+        } catch {
+            log.error("forkConversation error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func conversationSummary(from conversation: ConversationsListResponse.Conversation) -> ConversationListResponseItem {
+        ConversationListResponseItem(
+            id: conversation.id,
+            title: conversation.title,
+            createdAt: conversation.createdAt,
+            updatedAt: conversation.updatedAt,
+            conversationType: conversation.conversationType,
+            source: conversation.source,
+            scheduleJobId: conversation.scheduleJobId,
+            channelBinding: conversation.channelBinding,
+            conversationOriginChannel: conversation.conversationOriginChannel,
+            conversationOriginInterface: conversation.conversationOriginInterface,
+            assistantAttention: conversation.assistantAttention,
+            displayOrder: conversation.displayOrder,
+            isPinned: conversation.isPinned,
+            forkParent: conversation.forkParent
+        )
+    }
+}

--- a/clients/shared/Tests/ConversationDetailClientTests.swift
+++ b/clients/shared/Tests/ConversationDetailClientTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class MockConversationDetailURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class ConversationDetailClientTests: XCTestCase {
+    private let assistantId = "assistant-detail-test"
+    private let gatewayPort = 7832
+    private var originalConnectedAssistantId: Any?
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockConversationDetailURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockConversationDetailURLProtocol.self)
+
+        originalConnectedAssistantId = UserDefaults.standard.object(forKey: "connectedAssistantId")
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockConversationDetailURLProtocol.self)
+        MockConversationDetailURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        if let originalConnectedAssistantId {
+            UserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        }
+
+        try super.tearDownWithError()
+    }
+
+    func testFetchConversationBuildsExpectedPathAndDecodesResponse() async throws {
+        let requestExpectation = expectation(description: "conversation detail request")
+        var capturedRequest: URLRequest?
+
+        MockConversationDetailURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "conversation": {
+                    "id": "conv-parent",
+                    "title": "Original thread",
+                    "createdAt": 1700000000,
+                    "updatedAt": 1700000100,
+                    "forkParent": {
+                      "conversationId": "conv-root",
+                      "messageId": "msg-root",
+                      "title": "Root thread"
+                    }
+                  }
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let client = ConversationDetailClient()
+        let conversation = await client.fetchConversation(conversationId: "conv-parent")
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://127.0.0.1:7832/v1/assistants/assistant-detail-test/conversations/conv-parent/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+        XCTAssertEqual(conversation?.id, "conv-parent")
+        XCTAssertEqual(conversation?.title, "Original thread")
+        XCTAssertEqual(conversation?.forkParent?.conversationId, "conv-root")
+        XCTAssertEqual(conversation?.forkParent?.messageId, "msg-root")
+    }
+
+    func testFetchConversationReturnsNilForNonSuccessStatus() async {
+        MockConversationDetailURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"not found"}}"#.utf8))
+        }
+
+        let client = ConversationDetailClient()
+        let conversation = await client.fetchConversation(conversationId: "conv-missing")
+
+        XCTAssertNil(conversation)
+    }
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+        UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+    }
+}

--- a/clients/shared/Tests/ConversationForkClientTests.swift
+++ b/clients/shared/Tests/ConversationForkClientTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class MockConversationForkURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class ConversationForkClientTests: XCTestCase {
+    private let assistantId = "assistant-fork-test"
+    private let gatewayPort = 7831
+    private var originalConnectedAssistantId: Any?
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockConversationForkURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockConversationForkURLProtocol.self)
+
+        originalConnectedAssistantId = UserDefaults.standard.object(forKey: "connectedAssistantId")
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installLockfileFixture()
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(MockConversationForkURLProtocol.self)
+        MockConversationForkURLProtocol.requestHandler = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        if let originalConnectedAssistantId {
+            UserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        }
+
+        try super.tearDownWithError()
+    }
+
+    func testForkConversationPostsExpectedPathAndBodyAndDecodesResponse() async throws {
+        let requestExpectation = expectation(description: "fork conversation request")
+        var capturedRequest: URLRequest?
+
+        MockConversationForkURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "conversation": {
+                    "id": "conv-forked",
+                    "title": "Forked thread",
+                    "createdAt": 1700000200,
+                    "updatedAt": 1700000300,
+                    "forkParent": {
+                      "conversationId": "conv-parent",
+                      "messageId": "msg-parent",
+                      "title": "Original thread"
+                    }
+                  }
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let client = ConversationForkClient()
+        let conversation = await client.forkConversation(
+            conversationId: "conv-parent",
+            throughMessageId: "msg-parent"
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://127.0.0.1:7831/v1/assistants/assistant-fork-test/conversations/fork/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+
+        let body = try requestJSONBody(from: try XCTUnwrap(capturedRequest))
+        XCTAssertEqual(body["conversationId"] as? String, "conv-parent")
+        XCTAssertEqual(body["throughMessageId"] as? String, "msg-parent")
+
+        XCTAssertEqual(conversation?.id, "conv-forked")
+        XCTAssertEqual(conversation?.title, "Forked thread")
+        XCTAssertEqual(conversation?.forkParent?.conversationId, "conv-parent")
+        XCTAssertEqual(conversation?.forkParent?.messageId, "msg-parent")
+    }
+
+    func testForkConversationOmitsThroughMessageIdWhenNil() async throws {
+        let requestExpectation = expectation(description: "fork conversation request without throughMessageId")
+        var capturedRequest: URLRequest?
+
+        MockConversationForkURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"conversation":{"id":"conv-forked","title":"Forked thread","updatedAt":1700000300}}"#.utf8))
+        }
+
+        let client = ConversationForkClient()
+        _ = await client.forkConversation(conversationId: "conv-parent", throughMessageId: nil)
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let body = try requestJSONBody(from: try XCTUnwrap(capturedRequest))
+        XCTAssertEqual(body["conversationId"] as? String, "conv-parent")
+        XCTAssertNil(body["throughMessageId"])
+    }
+
+    func testForkConversationReturnsNilForNonSuccessStatus() async {
+        MockConversationForkURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"error":{"message":"boom"}}"#.utf8))
+        }
+
+        let client = ConversationForkClient()
+        let conversation = await client.forkConversation(
+            conversationId: "conv-parent",
+            throughMessageId: "msg-parent"
+        )
+
+        XCTAssertNil(conversation)
+    }
+
+    private func installLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "cloud": "local",
+                    "hatchedAt": "2026-03-19T12:00:00Z",
+                    "resources": [
+                        "gatewayPort": gatewayPort,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+        UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+    }
+
+    private func requestJSONBody(from request: URLRequest) throws -> [String: Any] {
+        let body: Data
+        if let httpBody = request.httpBody {
+            body = httpBody
+        } else {
+            let stream = try XCTUnwrap(request.httpBodyStream)
+            stream.open()
+            defer { stream.close() }
+
+            var data = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while stream.hasBytesAvailable {
+                let bytesRead = stream.read(&buffer, maxLength: buffer.count)
+                if bytesRead < 0 {
+                    throw try XCTUnwrap(stream.streamError)
+                }
+                if bytesRead == 0 {
+                    break
+                }
+                data.append(buffer, count: bytesRead)
+            }
+            body = data
+        }
+
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+}


### PR DESCRIPTION
## Summary
- add gateway-backed shared clients for conversation forking and single-conversation lookup
- keep the new clients focused on transport concerns without expanding HTTPTransport
- add targeted request and decoding coverage for both clients

Part of plan: conversation-forking.md (PR 3 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
