### PR TITLE
feat: render normalized prompt sections in llm inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -1,32 +1,28 @@
+import Foundation
 import SwiftUI
 import VellumAssistantShared
 
 struct MessageInspectorPromptTab: View {
     let entry: LLMRequestLogEntry
 
+    private var model: MessageInspectorPromptTabModel {
+        MessageInspectorPromptTabModel(entry: entry)
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Prompt sections")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
+                headerCard
 
-                    Text(promptAvailabilityText)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
+                if model.sections.isEmpty {
+                    emptyState
+                } else {
+                    LazyVStack(alignment: .leading, spacing: VSpacing.md) {
+                        ForEach(model.sections) { section in
+                            sectionCard(section)
+                        }
+                    }
                 }
-                .padding(VSpacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(VColor.surfaceOverlay)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-
-                VEmptyState(
-                    title: "Prompt data unavailable yet",
-                    subtitle: "A dedicated prompt renderer will arrive in a follow-up PR.",
-                    icon: VIcon.scrollText.rawValue
-                )
-                .frame(minHeight: 280)
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -35,13 +31,179 @@ struct MessageInspectorPromptTab: View {
         .background(VColor.surfaceBase)
     }
 
-    private var promptAvailabilityText: String {
-        let sectionCount = entry.requestSections?.count ?? 0
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Prompt sections")
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.contentDefault)
 
-        if sectionCount == 0 {
-            return "This call does not expose normalized prompt sections yet."
+            Text(model.bannerText)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+    }
+
+    private var emptyState: some View {
+        VEmptyState(
+            title: "No normalized prompt sections",
+            subtitle: model.fallbackMessage,
+            icon: VIcon.scrollText.rawValue
+        )
+        .frame(minHeight: 280)
+    }
+
+    private func sectionCard(_ section: MessageInspectorPromptSectionModel) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(section.title)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(2)
+
+                    Text(section.kindLabel)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+
+                Spacer(minLength: VSpacing.md)
+
+                VCopyButton(
+                    text: section.copyText,
+                    size: .compact,
+                    accessibilityHint: "Copy \(section.title)"
+                )
+            }
+
+            sectionContent(section)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+    }
+
+    @ViewBuilder
+    private func sectionContent(_ section: MessageInspectorPromptSectionModel) -> some View {
+        switch section.presentationStyle {
+        case .text:
+            Text(section.displayText)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.md)
+                .background(VColor.surfaceBase)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        case .structured:
+            HighlightedTextView(
+                text: .constant(section.displayText),
+                language: section.syntaxLanguage,
+                isEditable: false,
+                isActivelyEditing: .constant(false)
+            )
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: 120, maxHeight: 260)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+    }
+}
+
+struct MessageInspectorPromptTabModel {
+    let sections: [MessageInspectorPromptSectionModel]
+    let bannerText: String
+    let fallbackMessage: String
+
+    init(entry: LLMRequestLogEntry) {
+        let requestSections = entry.requestSections ?? []
+        sections = requestSections.enumerated().map { index, section in
+            MessageInspectorPromptSectionModel(index: index, section: section)
         }
 
-        return "\(sectionCount) normalized prompt section(s) are present, but this placeholder tab is intentionally lightweight in this PR."
+        fallbackMessage = "This call has no normalized prompt sections. Use the Raw tab to inspect the full request payload."
+
+        if sections.isEmpty {
+            bannerText = "This call has no normalized prompt sections yet."
+        } else {
+            bannerText = "\(sections.count) normalized request section(s) are shown in the same order returned by the assistant route."
+        }
+    }
+}
+
+struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
+    enum PresentationStyle: Equatable {
+        case text
+        case structured
+    }
+
+    let id: String
+    let title: String
+    let kindLabel: String
+    let displayText: String
+    let copyText: String
+    let syntaxLanguage: SyntaxLanguage
+    let presentationStyle: PresentationStyle
+
+    init(index: Int, section: LLMContextSection) {
+        id = "\(index)"
+        title = Self.displayTitle(for: section, index: index)
+        kindLabel = Self.displayKindLabel(for: section.kind)
+
+        let renderedContent = Self.renderedContent(for: section.content)
+        displayText = renderedContent.text
+        copyText = renderedContent.text
+        syntaxLanguage = renderedContent.syntaxLanguage
+        presentationStyle = renderedContent.isStructured ? .structured : .text
+    }
+
+    private static func displayTitle(for section: LLMContextSection, index: Int) -> String {
+        if let title = section.title, !title.isEmpty {
+            return title
+        }
+
+        return "\(displayKindLabel(for: section.kind)) \(index + 1)"
+    }
+
+    private static func displayKindLabel(for kind: LLMContextSectionKind) -> String {
+        kind.rawValue
+            .replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.capitalized }
+            .joined(separator: " ")
+    }
+
+    private static func renderedContent(for content: AnyCodable?) -> (text: String, syntaxLanguage: SyntaxLanguage, isStructured: Bool) {
+        guard let value = content?.value else {
+            return ("No content available.", .plain, false)
+        }
+
+        if let string = value as? String {
+            return (string, .plain, false)
+        }
+
+        if let json = prettyPrintedJSONString(for: value) {
+            return (json, .json, true)
+        }
+
+        return (String(describing: value), .plain, true)
+    }
+
+    private static func prettyPrintedJSONString(for value: Any) -> String? {
+        guard JSONSerialization.isValidJSONObject(value) else {
+            return nil
+        }
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: value,
+            options: [.prettyPrinted, .withoutEscapingSlashes]
+        ) else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class MessageInspectorPromptTabTests: XCTestCase {
+    func testPromptTabModelPreservesSectionOrderAndFormatsCopyText() {
+        let entry = makeEntry(
+            requestPayload: AnyCodable([
+                "messages": [
+                    ["role": "system", "content": "You are helpful"],
+                    ["role": "user", "content": "Write a summary"]
+                ]
+            ]),
+            requestSections: [
+                LLMContextSection(
+                    kind: .unknown("message"),
+                    title: "System prompt",
+                    content: AnyCodable("You are helpful")
+                ),
+                LLMContextSection(
+                    kind: .unknown("tool_definitions"),
+                    title: "Available tools",
+                    content: AnyCodable([
+                        "tools": [
+                            [
+                                "name": "web_search",
+                                "description": "Search the web"
+                            ]
+                        ],
+                        "max_output_tokens": 256
+                    ])
+                ),
+                LLMContextSection(
+                    kind: .unknown("message"),
+                    title: "User message 1",
+                    content: AnyCodable("Write a summary")
+                )
+            ]
+        )
+
+        let model = MessageInspectorPromptTabModel(entry: entry)
+
+        XCTAssertEqual(model.sections.map(\.title), [
+            "System prompt",
+            "Available tools",
+            "User message 1"
+        ])
+        XCTAssertEqual(model.sections.map(\.presentationStyle), [
+            .text,
+            .structured,
+            .text
+        ])
+        XCTAssertEqual(model.sections[0].copyText, "You are helpful")
+        XCTAssertTrue(model.sections[1].copyText.contains("\"web_search\""))
+        XCTAssertTrue(model.sections[1].copyText.contains("\"max_output_tokens\""))
+        XCTAssertEqual(model.sections[2].copyText, "Write a summary")
+        XCTAssertTrue(model.bannerText.contains("same order"))
+    }
+
+    func testPromptTabModelUsesOnlyNormalizedSectionsAndShowsRawFallback() {
+        let entry = makeEntry(
+            requestPayload: AnyCodable([
+                "messages": [
+                    ["role": "user", "content": "Hello from the raw payload"]
+                ],
+                "tools": [
+                    [
+                        "function": [
+                            "name": "search"
+                        ]
+                    ]
+                ]
+            ]),
+            requestSections: nil
+        )
+
+        let model = MessageInspectorPromptTabModel(entry: entry)
+
+        XCTAssertTrue(model.sections.isEmpty)
+        XCTAssertTrue(model.bannerText.contains("normalized prompt sections"))
+        XCTAssertTrue(model.fallbackMessage.contains("Raw tab"))
+    }
+
+    private func makeEntry(
+        requestPayload: AnyCodable,
+        requestSections: [LLMContextSection]?
+    ) -> LLMRequestLogEntry {
+        LLMRequestLogEntry(
+            id: UUID().uuidString,
+            requestPayload: requestPayload,
+            responsePayload: AnyCodable([:]),
+            createdAt: 1_000,
+            summary: nil,
+            requestSections: requestSections,
+            responseSections: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder prompt tab with ordered normalized request-section rendering
- add per-section copy affordances and structured rendering for text and json-style sections
- add focused prompt-tab tests covering populated and fallback states

Part of plan: llm-context-inspector-redesign.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)