### PR TITLE
fix: avoid feature-flag gating in showSettingsTab deep-link resolution

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -691,8 +691,14 @@ extension AppDelegate {
     public func showSettingsTab(_ tab: String) {
         // Don't gate on feature flags here — let SettingsPanel decide visibility
         // based on its own flag state when it processes pendingSettingsTab.
-        // Use fromRawValue to resolve legacy tab names (e.g. "Archived Threads").
-        if let settingsTab = SettingsTab.fromRawValue(tab) {
+        // Use a switch to resolve legacy tab names (e.g. "Archived Threads")
+        // without gating on feature flags.
+        let settingsTab: SettingsTab?
+        switch tab {
+        case "Archived Threads": settingsTab = .archivedConversations
+        default: settingsTab = SettingsTab(rawValue: tab)
+        }
+        if let settingsTab {
             services.settingsStore.pendingSettingsTab = settingsTab
         }
         showSettingsWindow(nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -23,21 +23,6 @@ enum SettingsTab: String {
         tabs.append(.archivedConversations)
         return tabs
     }
-
-    /// Resolves a tab name string to a SettingsTab, with backward compatibility for old names.
-    static func fromRawValue(_ value: String, billingEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
-        // Support old raw values for backward compatibility
-        let tab: SettingsTab?
-        switch value {
-        case "Archived Threads": tab = .archivedConversations
-        default: tab = SettingsTab(rawValue: value)
-        }
-        guard let tab else { return nil }
-        // Block feature-flagged tabs when disabled
-        if tab == .billing && !billingEnabled { return nil }
-        if tab == .developer && !developerEnabled { return nil }
-        return tab
-    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Replaces `SettingsTab.fromRawValue(tab)` call in `showSettingsTab` with an inline switch that resolves legacy tab names without feature-flag gating
- Removes the now-unused `fromRawValue` method which conflated name resolution and feature-flag gating
- Fixes a bug where deep-linking to Billing and Developer tabs was silently blocked because `fromRawValue` defaulted both flag params to `false`

Addresses review feedback on #19187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
