### PR TITLE
feat: add summary-first overview tab for llm inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift
@@ -4,40 +4,38 @@ import VellumAssistantShared
 struct MessageInspectorOverviewTab: View {
     let entry: LLMRequestLogEntry
 
+    private var content: MessageInspectorOverviewContent {
+        MessageInspectorOverviewContent(entry: entry)
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                if let summary = entry.summary {
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Available summary data")
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.contentDefault)
+                if let fallbackMessage = content.fallbackMessage {
+                    fallbackCard(message: fallbackMessage)
+                } else {
+                    metadataCard(
+                        title: "Normalized metadata",
+                        subtitle: "Provider, model, timestamps, stop reason, and usage counts.",
+                        rows: content.identityRows
+                    )
 
-                        if let title = summary.title, !title.isEmpty {
-                            summaryRow(label: "Title", value: title)
-                        }
-                        if let provider = summary.provider, !provider.isEmpty {
-                            summaryRow(label: "Provider", value: provider)
-                        }
-                        if let model = summary.model, !model.isEmpty {
-                            summaryRow(label: "Model", value: model)
-                        }
-                        if let status = summary.status, !status.isEmpty {
-                            summaryRow(label: "Status", value: status)
-                        }
-                    }
-                    .padding(VSpacing.lg)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(VColor.surfaceOverlay)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    metadataCard(
+                        title: "Usage",
+                        subtitle: "Token and call counts normalized by the assistant route.",
+                        rows: content.usageRows
+                    )
+
+                    secondaryCard(
+                        title: "Response preview",
+                        body: content.responsePreview ?? MessageInspectorSummaryFormatters.missingValue
+                    )
+
+                    secondaryCard(
+                        title: "Tool calls",
+                        body: content.toolCallNames ?? MessageInspectorSummaryFormatters.missingValue
+                    )
                 }
-
-                VEmptyState(
-                    title: "Overview data unavailable yet",
-                    subtitle: "This tab is wired up, but richer per-call overview content lands in a follow-up PR.",
-                    icon: VIcon.layoutGrid.rawValue
-                )
-                .frame(minHeight: 280)
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -46,15 +44,78 @@ struct MessageInspectorOverviewTab: View {
         .background(VColor.surfaceBase)
     }
 
-    private func summaryRow(label: String, value: String) -> some View {
+    private func metadataCard(title: String, subtitle: String, rows: [MessageInspectorOverviewContent.Row]) -> some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(title: title, subtitle: subtitle)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(rows) { row in
+                        metadataRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    private func secondaryCard(title: String, body: String) -> some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                cardHeader(title: title, subtitle: nil)
+
+                Text(body)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func fallbackCard(message: String) -> some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                cardHeader(
+                    title: "Normalized summary unavailable",
+                    subtitle: "This call still has raw request and response payloads."
+                )
+
+                Text(message)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func cardHeader(title: String, subtitle: String?) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            Text(label)
+            Text(title)
+                .font(VFont.bodyMedium)
+                .foregroundColor(VColor.contentDefault)
+
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        }
+    }
+
+    private func metadataRow(_ row: MessageInspectorOverviewContent.Row) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: VSpacing.md) {
+            Text(row.label)
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentSecondary)
 
-            Text(value)
+            Spacer(minLength: VSpacing.sm)
+
+            Text(row.value)
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -1,0 +1,169 @@
+import Foundation
+import VellumAssistantShared
+
+struct MessageInspectorOverviewContent: Equatable {
+    struct Row: Identifiable, Equatable {
+        let label: String
+        let value: String
+
+        var id: String { label }
+    }
+
+    let identityRows: [Row]
+    let usageRows: [Row]
+    let responsePreview: String?
+    let toolCallNames: String?
+    let fallbackMessage: String?
+
+    init(entry: LLMRequestLogEntry) {
+        guard let summary = entry.summary else {
+            identityRows = []
+            usageRows = []
+            responsePreview = nil
+            toolCallNames = nil
+            fallbackMessage = MessageInspectorSummaryFormatters.summaryFallbackMessage(
+                recordedAt: MessageInspectorSummaryFormatters.formattedCreatedAt(entry.createdAt)
+            )
+            return
+        }
+
+        identityRows = [
+            .init(label: "Provider", value: MessageInspectorSummaryFormatters.displayProvider(summary.provider)),
+            .init(label: "Model", value: MessageInspectorSummaryFormatters.displayText(summary.model)),
+            .init(label: "Created", value: MessageInspectorSummaryFormatters.formattedCreatedAt(entry.createdAt)),
+            .init(label: "Stop reason", value: MessageInspectorSummaryFormatters.displayStopReason(summary.stopReason)),
+        ]
+
+        usageRows = [
+            .init(label: "Input tokens", value: MessageInspectorSummaryFormatters.formatCount(summary.inputTokens)),
+            .init(label: "Output tokens", value: MessageInspectorSummaryFormatters.formatCount(summary.outputTokens)),
+            .init(label: "Cache tokens", value: MessageInspectorSummaryFormatters.formatCacheTokens(
+                created: summary.cacheCreationInputTokens,
+                read: summary.cacheReadInputTokens
+            )),
+            .init(label: "Request messages", value: MessageInspectorSummaryFormatters.formatCount(summary.requestMessageCount)),
+            .init(label: "Tool count", value: MessageInspectorSummaryFormatters.formatCount(summary.requestToolCount)),
+        ]
+
+        responsePreview = MessageInspectorSummaryFormatters.truncatedResponsePreview(summary.responsePreview)
+        toolCallNames = MessageInspectorSummaryFormatters.compactToolNames(summary.toolCallNames)
+        fallbackMessage = nil
+    }
+}
+
+enum MessageInspectorSummaryFormatters {
+    static let missingValue = "Unavailable"
+
+    static func formatCount(_ value: Int?) -> String {
+        guard let value else { return missingValue }
+        return Self.numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    static func formatCacheTokens(created: Int?, read: Int?) -> String {
+        var parts: [String] = []
+
+        if let created {
+            parts.append("Created \(formatCount(created))")
+        }
+
+        if let read {
+            parts.append("Read \(formatCount(read))")
+        }
+
+        guard !parts.isEmpty else {
+            return missingValue
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    static func displayProvider(_ provider: String?) -> String {
+        guard let provider = displayText(provider).nilIfEmpty else {
+            return missingValue
+        }
+
+        switch provider.lowercased() {
+        case "openai":
+            return "OpenAI"
+        case "anthropic":
+            return "Anthropic"
+        case "gemini":
+            return "Gemini"
+        default:
+            return provider
+        }
+    }
+
+    static func displayStopReason(_ stopReason: String?) -> String {
+        guard let stopReason = displayText(stopReason).nilIfEmpty else {
+            return missingValue
+        }
+
+        return humanizedIdentifier(stopReason)
+    }
+
+    static func displayText(_ value: String?) -> String {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return missingValue
+        }
+        return value
+    }
+
+    static func summaryFallbackMessage(recordedAt: String) -> String {
+        "Normalized summary unavailable. Recorded at \(recordedAt). Raw request and response payloads are still available in the Raw tab."
+    }
+
+    static func truncatedResponsePreview(_ text: String?, limit: Int = 160) -> String? {
+        guard let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            return nil
+        }
+
+        guard text.count > limit else {
+            return text
+        }
+
+        let truncated = String(text.prefix(limit)).trimmingCharacters(in: .whitespacesAndNewlines)
+        return truncated.isEmpty ? nil : "\(truncated)…"
+    }
+
+    static func compactToolNames(_ names: [String]?, maxVisible: Int = 3) -> String? {
+        let cleanedNames = names?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+
+        guard !cleanedNames.isEmpty else {
+            return nil
+        }
+
+        guard cleanedNames.count > maxVisible else {
+            return cleanedNames.joined(separator: ", ")
+        }
+
+        let visible = cleanedNames.prefix(maxVisible).joined(separator: ", ")
+        return "\(visible) +\(cleanedNames.count - maxVisible) more"
+    }
+
+    static func formattedCreatedAt(_ epochMs: Int) -> String {
+        Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
+            .formatted(date: .abbreviated, time: .shortened)
+    }
+
+    static func humanizedIdentifier(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "_", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .capitalized
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class MessageInspectorOverviewTabTests: XCTestCase {
+    func testOpenAiFixtureProducesSummaryFirstMetadata() throws {
+        let entry = try decodeEntry(
+            #"""
+            {
+              "id": "openai-1",
+              "requestPayload": { "messages": [{ "role": "user", "content": "How's the weather?" }] },
+              "responsePayload": {
+                "choices": [{
+                  "finish_reason": "tool_calls",
+                  "message": {
+                    "role": "assistant",
+                    "content": "I'll check the forecast."
+                  }
+                }]
+              },
+              "createdAt": 0,
+              "summary": {
+                "provider": "openai",
+                "model": "gpt-4.1",
+                "inputTokens": 321,
+                "outputTokens": 54,
+                "stopReason": "tool_calls",
+                "requestMessageCount": 2,
+                "requestToolCount": 2,
+                "responseMessageCount": 1,
+                "responseToolCallCount": 2,
+                "responsePreview": "I'll check the forecast.",
+                "toolCallNames": ["web_search", "get_weather"]
+              }
+            }
+            """#
+        )
+
+        let content = MessageInspectorOverviewContent(entry: entry)
+
+        XCTAssertEqual(content.identityRows.map(\.label), ["Provider", "Model", "Created", "Stop reason"])
+        XCTAssertEqual(content.identityRows.map(\.value)[0], "OpenAI")
+        XCTAssertEqual(content.identityRows.map(\.value)[1], "gpt-4.1")
+        XCTAssertTrue(content.identityRows.map(\.value)[2].contains("1970"))
+        XCTAssertEqual(content.identityRows.map(\.value)[3], "Tool Calls")
+
+        XCTAssertEqual(content.usageRows.map(\.label), ["Input tokens", "Output tokens", "Cache tokens", "Request messages", "Tool count"])
+        XCTAssertEqual(content.usageRows.map(\.value), ["321", "54", "Unavailable", "2", "2"])
+        XCTAssertEqual(content.responsePreview, "I'll check the forecast.")
+        XCTAssertEqual(content.toolCallNames, "web_search, get_weather")
+        XCTAssertNil(content.fallbackMessage)
+
+        XCTAssertEqual(entry.summary?.responseMessageCount, 1)
+        XCTAssertEqual(entry.summary?.responseToolCallCount, 2)
+    }
+
+    func testAnthropicFixtureSurfacesCacheTokensAndToolNames() throws {
+        let entry = try decodeEntry(
+            #"""
+            {
+              "id": "anthropic-1",
+              "requestPayload": { "messages": [{ "role": "user", "content": "Find the latest changelog." }] },
+              "responsePayload": { "content": [{ "type": "text", "text": "I found the changelog." }] },
+              "createdAt": 0,
+              "summary": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "inputTokens": 410,
+                "outputTokens": 73,
+                "cacheCreationInputTokens": 200,
+                "cacheReadInputTokens": 80,
+                "stopReason": "tool_use",
+                "requestMessageCount": 2,
+                "requestToolCount": 1,
+                "responseMessageCount": 1,
+                "responseToolCallCount": 1,
+                "responsePreview": "I found the changelog.",
+                "toolCallNames": ["fetch_page"]
+              }
+            }
+            """#
+        )
+
+        let content = MessageInspectorOverviewContent(entry: entry)
+
+        XCTAssertEqual(content.identityRows.map(\.value)[0], "Anthropic")
+        XCTAssertEqual(content.identityRows.map(\.value)[3], "Tool Use")
+        XCTAssertEqual(content.usageRows.map(\.value), ["410", "73", "Created 200, Read 80", "2", "1"])
+        XCTAssertEqual(content.responsePreview, "I found the changelog.")
+        XCTAssertEqual(content.toolCallNames, "fetch_page")
+        XCTAssertNil(content.fallbackMessage)
+
+        XCTAssertEqual(entry.summary?.cacheCreationInputTokens, 200)
+        XCTAssertEqual(entry.summary?.cacheReadInputTokens, 80)
+    }
+
+    func testGeminiFixtureKeepsOverviewUsefulWithoutCacheTokens() throws {
+        let entry = try decodeEntry(
+            #"""
+            {
+              "id": "gemini-1",
+              "requestPayload": { "contents": [{ "role": "user", "parts": [{ "text": "Summarize the note." }] }] },
+              "responsePayload": {
+                "text": "Here is a concise summary."
+              },
+              "createdAt": 0,
+              "summary": {
+                "provider": "gemini",
+                "model": "gemini-2.0-flash",
+                "inputTokens": 120,
+                "outputTokens": 34,
+                "stopReason": "STOP",
+                "requestMessageCount": 2,
+                "requestToolCount": 1,
+                "responseMessageCount": 1,
+                "responseToolCallCount": 1,
+                "responsePreview": "Here is a concise summary.",
+                "toolCallNames": ["save_note"]
+              }
+            }
+            """#
+        )
+
+        let content = MessageInspectorOverviewContent(entry: entry)
+
+        XCTAssertEqual(content.identityRows.map(\.value)[0], "Gemini")
+        XCTAssertEqual(content.identityRows.map(\.value)[3], "Stop")
+        XCTAssertEqual(content.usageRows.map(\.value), ["120", "34", "Unavailable", "2", "1"])
+        XCTAssertEqual(content.responsePreview, "Here is a concise summary.")
+        XCTAssertEqual(content.toolCallNames, "save_note")
+        XCTAssertNil(content.fallbackMessage)
+    }
+
+    func testMissingSummaryFallsBackToRawPayloadHint() throws {
+        let entry = try decodeEntry(
+            #"""
+            {
+              "id": "legacy-1",
+              "requestPayload": { "type": "request", "messages": [] },
+              "responsePayload": { "type": "response", "text": "ok" },
+              "createdAt": 0
+            }
+            """#
+        )
+
+        let content = MessageInspectorOverviewContent(entry: entry)
+
+        XCTAssertTrue(content.identityRows.isEmpty)
+        XCTAssertTrue(content.usageRows.isEmpty)
+        XCTAssertNil(content.responsePreview)
+        XCTAssertNil(content.toolCallNames)
+        XCTAssertNotNil(content.fallbackMessage)
+        XCTAssertTrue(content.fallbackMessage?.contains("Raw tab") == true)
+        XCTAssertTrue(content.fallbackMessage?.contains("1970") == true)
+    }
+
+    func testFormatterHelpersTruncateAndCompactValues() {
+        let preview = String(repeating: "a", count: 200)
+        let truncated = MessageInspectorSummaryFormatters.truncatedResponsePreview(preview, limit: 40)
+
+        XCTAssertEqual(truncated, String(repeating: "a", count: 40) + "…")
+        XCTAssertNil(MessageInspectorSummaryFormatters.truncatedResponsePreview("   "))
+        XCTAssertEqual(
+            MessageInspectorSummaryFormatters.compactToolNames(["alpha", "beta", "gamma", "delta"], maxVisible: 3),
+            "alpha, beta, gamma +1 more"
+        )
+        XCTAssertNil(MessageInspectorSummaryFormatters.compactToolNames([], maxVisible: 3))
+        XCTAssertEqual(MessageInspectorSummaryFormatters.formatCacheTokens(created: nil, read: nil), "Unavailable")
+    }
+
+    private func decodeEntry(_ json: String) throws -> LLMRequestLogEntry {
+        try JSONDecoder().decode(LLMContextResponse.self, from: Data(json.utf8)).logs[0]
+    }
+}

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -15,6 +15,15 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
     public let status: String?
     public let inputTokens: Int?
     public let outputTokens: Int?
+    public let cacheCreationInputTokens: Int?
+    public let cacheReadInputTokens: Int?
+    public let stopReason: String?
+    public let requestMessageCount: Int?
+    public let requestToolCount: Int?
+    public let responseMessageCount: Int?
+    public let responseToolCallCount: Int?
+    public let responsePreview: String?
+    public let toolCallNames: [String]?
     public let durationMs: Int?
 
     public init(
@@ -26,6 +35,15 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         status: String? = nil,
         inputTokens: Int? = nil,
         outputTokens: Int? = nil,
+        cacheCreationInputTokens: Int? = nil,
+        cacheReadInputTokens: Int? = nil,
+        stopReason: String? = nil,
+        requestMessageCount: Int? = nil,
+        requestToolCount: Int? = nil,
+        responseMessageCount: Int? = nil,
+        responseToolCallCount: Int? = nil,
+        responsePreview: String? = nil,
+        toolCallNames: [String]? = nil,
         durationMs: Int? = nil
     ) {
         self.title = title
@@ -36,6 +54,15 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         self.status = status
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
+        self.cacheCreationInputTokens = cacheCreationInputTokens
+        self.cacheReadInputTokens = cacheReadInputTokens
+        self.stopReason = stopReason
+        self.requestMessageCount = requestMessageCount
+        self.requestToolCount = requestToolCount
+        self.responseMessageCount = responseMessageCount
+        self.responseToolCallCount = responseToolCallCount
+        self.responsePreview = responsePreview
+        self.toolCallNames = toolCallNames
         self.durationMs = durationMs
     }
 
@@ -54,6 +81,15 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         status = container.decodeString(for: ["status", "outcome"])
         inputTokens = container.decodeInt(for: ["inputTokens", "input_token_count", "promptTokens"])
         outputTokens = container.decodeInt(for: ["outputTokens", "output_token_count", "completionTokens"])
+        cacheCreationInputTokens = container.decodeInt(for: ["cacheCreationInputTokens", "cache_creation_input_tokens"])
+        cacheReadInputTokens = container.decodeInt(for: ["cacheReadInputTokens", "cache_read_input_tokens"])
+        stopReason = container.decodeString(for: ["stopReason", "stop_reason"])
+        requestMessageCount = container.decodeInt(for: ["requestMessageCount", "request_message_count"])
+        requestToolCount = container.decodeInt(for: ["requestToolCount", "request_tool_count"])
+        responseMessageCount = container.decodeInt(for: ["responseMessageCount", "response_message_count"])
+        responseToolCallCount = container.decodeInt(for: ["responseToolCallCount", "response_tool_call_count"])
+        responsePreview = container.decodeString(for: ["responsePreview", "responseTextPreview", "response_preview"])
+        toolCallNames = container.decodeStringArray(for: ["toolCallNames", "tool_call_names"])
         durationMs = container.decodeInt(for: ["durationMs", "duration_ms", "elapsedMs"])
     }
 
@@ -67,6 +103,15 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         try container.encodeIfPresent(status, forKey: "status")
         try container.encodeIfPresent(inputTokens, forKey: "inputTokens")
         try container.encodeIfPresent(outputTokens, forKey: "outputTokens")
+        try container.encodeIfPresent(cacheCreationInputTokens, forKey: "cacheCreationInputTokens")
+        try container.encodeIfPresent(cacheReadInputTokens, forKey: "cacheReadInputTokens")
+        try container.encodeIfPresent(stopReason, forKey: "stopReason")
+        try container.encodeIfPresent(requestMessageCount, forKey: "requestMessageCount")
+        try container.encodeIfPresent(requestToolCount, forKey: "requestToolCount")
+        try container.encodeIfPresent(responseMessageCount, forKey: "responseMessageCount")
+        try container.encodeIfPresent(responseToolCallCount, forKey: "responseToolCallCount")
+        try container.encodeIfPresent(responsePreview, forKey: "responsePreview")
+        try container.encodeIfPresent(toolCallNames, forKey: "toolCallNames")
         try container.encodeIfPresent(durationMs, forKey: "durationMs")
     }
 }
@@ -277,6 +322,16 @@ private extension KeyedDecodingContainer where Key == LLMContextCodingKey {
         }
         return nil
     }
+
+    func decodeStringArray(for keys: [String]) -> [String]? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent([String].self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
 }
 
 private extension KeyedEncodingContainer where Key == LLMContextCodingKey {
@@ -296,6 +351,11 @@ private extension KeyedEncodingContainer where Key == LLMContextCodingKey {
     }
 
     mutating func encodeIfPresent(_ value: AnyCodable?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+
+    mutating func encodeIfPresent(_ value: [String]?, forKey key: String) throws {
         guard let value, let codingKey = Key(stringValue: key) else { return }
         try encode(value, forKey: codingKey)
     }


### PR DESCRIPTION
## Summary
- replace the placeholder overview tab with summary-first metadata cards driven by normalized llm context data
- add dedicated formatters for token counts, fallbacks, previews, and tool name display
- add focused overview-tab tests for normalized and fallback rendering

Part of plan: llm-context-inspector-redesign.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
