### PR TITLE
Align slash command routing with the desktop contract

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -58,6 +58,18 @@ describe("resolveSlash /commands interface-aware help", () => {
     ]);
   });
 
+  test("renders explicit cli command help without /pair", async () => {
+    const lines = await resolveCommandsLines(
+      makeSlashContext({ userMessageInterface: "cli" }),
+    );
+    expect(lines).toEqual([
+      "/commands — List all available commands",
+      "/models — List all available models",
+      "/status — Show conversation status and context usage",
+      "/btw — Ask a side question while the assistant is working",
+    ]);
+  });
+
   test("keeps legacy fallback help when no interface is provided", async () => {
     const lines = await resolveCommandsLines(makeSlashContext());
     expect(lines).toEqual([
@@ -105,6 +117,18 @@ describe("resolveSlash command contract", () => {
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") {
       throw new Error("Expected /pair on iOS to resolve to kind=unknown");
+    }
+    expect(result.message).toContain("only available in the macOS desktop app");
+  });
+
+  test("keeps /pair rejected for explicit non-macOS interfaces", async () => {
+    const result = await resolveSlash(
+      "/pair",
+      makeSlashContext({ userMessageInterface: "cli" }),
+    );
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") {
+      throw new Error("Expected /pair on cli to resolve to kind=unknown");
     }
     expect(result.message).toContain("only available in the macOS desktop app");
   });

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -136,7 +136,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
     fallbackLines.push("/status — Show conversation status and context usage");
   }
 
-  if (!context) return fallbackLines;
+  if (!context?.userMessageInterface) return fallbackLines;
 
   if (context.userMessageInterface === "macos") {
     return [
@@ -157,7 +157,12 @@ function resolveCommandsList(context?: SlashContext): string[] {
     ];
   }
 
-  return fallbackLines;
+  return [
+    "/commands — List all available commands",
+    "/models — List all available models",
+    "/status — Show conversation status and context usage",
+    "/btw — Ask a side question while the assistant is working",
+  ];
 }
 
 /**

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -126,7 +126,7 @@ public enum ChatSlashCommandCatalog {
             selectionBehavior: .autoSend,
             pickerPlatforms: [.macos],
             helpBubblePlatforms: [.macos],
-            sendPathPlatforms: [.macos]
+            sendPathPlatforms: allPlatforms
         ),
     ]
 
@@ -187,7 +187,7 @@ public enum ChatSlashCommandCatalog {
         forRawInput rawInput: String,
         platform: ChatSlashCommandPlatform?
     ) -> ChatSlashCommandDescriptor? {
-        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.hasPrefix("/") else {
             return nil
         }
@@ -196,7 +196,7 @@ public enum ChatSlashCommandCatalog {
             if let platform, !descriptor.isVisible(on: platform, surface: .sendPath) {
                 return false
             }
-            let slashName = descriptor.slashName.lowercased()
+            let slashName = descriptor.slashName
             switch descriptor.sendPathMatchRule {
             case .exact:
                 return trimmed == slashName

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -126,6 +126,28 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         }
     }
 
+    func testSendPathMatchingRequiresExactLowercaseCommands() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
+
+        let mixedCaseForms = [
+            "/COMMANDS",
+            "/MODELS",
+            "/STATUS",
+            "/PAIR",
+            "/BTW follow up",
+        ]
+
+        for command in mixedCaseForms {
+            viewModel.isWorkspaceRefinementInFlight = false
+            viewModel.inputText = command
+            viewModel.sendMessage()
+
+            XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
+            XCTAssertEqual(viewModel.messages.count, 0)
+        }
+    }
+
     func testUnknownSlashCommandsUseWorkspaceRefinementWhenSurfaceIsActive() {
         viewModel.activeSurfaceId = "surface-1"
         viewModel.isChatDockedToSide = false

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -27,6 +27,14 @@ final class SlashCommandCatalogTests: XCTestCase {
         XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw"])
     }
 
+    func testIOSPickerOmitsPairingCommand() {
+        let commands = ChatSlashCommandCatalog.commands(
+            for: .ios,
+            surface: .picker
+        ).map(\.slashName)
+        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw"])
+    }
+
     func testStatusDescriptionMatchesConversationCopy() {
         let status = ChatSlashCommandCatalog.commands(
             for: .macos,
@@ -114,16 +122,50 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
     }
 
-    func testPairIsMacOSOnlyOnSendPath() {
-        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
-            "/pair",
+    func testSendPathRecognitionIsCaseSensitiveAndLowercaseOnly() {
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/COMMANDS",
             platform: .macos,
             surface: .sendPath
         ))
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/MODELS",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/STATUS",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/PAIR",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/BTW follow up",
+            platform: .macos,
+            surface: .sendPath
+        ))
+    }
+
+    func testPairIsAvailableOnIOSSendPathButHiddenFromDiscoverySurfaces() {
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/pair",
             platform: .ios,
             surface: .sendPath
+        ))
+
+        XCTAssertNil(ChatSlashCommandCatalog.descriptor(
+            forRawInput: "/pair",
+            platform: .ios,
+            surface: .picker
+        ))
+        XCTAssertNil(ChatSlashCommandCatalog.descriptor(
+            forRawInput: "/pair",
+            platform: .ios,
+            surface: .helpBubble
         ))
     }
 


### PR DESCRIPTION
## Summary
- tighten shared slash-command send-path matching to the supported exact forms
- keep manual /pair routed to the daemon while hiding it from non-macOS discovery surfaces
- stop interface-aware /commands help from advertising /pair off macOS

Part of plan: unify-desktop-slash-command-ux.md (remediation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
