### PR TITLE
fix: add openrouter to allSyncableProviders for daemon key sync

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -45,6 +45,7 @@ enum APIKeyManager {
         "fireworks",
         "gemini",
         "openai",
+        "openrouter",
         "perplexity",
     ]
 


### PR DESCRIPTION
## Summary
- Add "openrouter" to `APIKeyManager.allSyncableProviders` so that OpenRouter API keys are synced to the daemon on reconnection and restart
- Without this fix, OpenRouter keys saved during onboarding were only forwarded as env vars during the initial hatch, but not re-synced via the gateway after daemon restarts

Addresses review feedback from #19251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
