### PR TITLE
feat: add storage-level conversation fork cloning

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -1,0 +1,413 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { eq, like } from "drizzle-orm";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "conversation-fork-crud-test-")),
+);
+const workspaceDir = join(testDir, ".vellum", "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  getAttachmentsForMessage,
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../memory/attachments-store.js";
+import {
+  getAttentionStateByConversationIds,
+  markConversationUnread,
+} from "../memory/conversation-attention-store.js";
+import {
+  addMessage,
+  createConversation,
+  forkConversation,
+  getMessages,
+} from "../memory/conversation-crud.js";
+import { getConversationDirPath } from "../memory/conversation-disk-view.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import {
+  channelInboundEvents,
+  conversationAssistantAttentionState,
+  conversations,
+  externalConversationBindings,
+  llmRequestLogs,
+  memoryJobs,
+  toolInvocations,
+} from "../memory/schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(channelInboundEvents).run();
+  db.delete(externalConversationBindings).run();
+  db.delete(conversationAssistantAttentionState).run();
+  db.delete(llmRequestLogs).run();
+  db.delete(toolInvocations).run();
+  db.delete(memoryJobs).run();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function parseMetadata(metadata: string | null): unknown {
+  return metadata == null ? null : JSON.parse(metadata);
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("forkConversation", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("forks a full transcript with copied history and lineage", async () => {
+    const source = createConversation("Planning thread");
+    await addMessage(
+      source.id,
+      "user",
+      "Can you draft a launch plan?",
+      { branch: 1, source: "user" },
+      { skipIndexing: true },
+    );
+    await addMessage(
+      source.id,
+      "assistant",
+      "Absolutely. Here is a first pass.",
+      { automated: true },
+      { skipIndexing: true },
+    );
+    const finalSourceMessage = await addMessage(
+      source.id,
+      "user",
+      "Fork from here",
+      { nested: { keep: true } },
+      { skipIndexing: true },
+    );
+
+    const sourceMessages = getMessages(source.id);
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = getMessages(fork.id);
+
+    expect(fork.id).not.toBe(source.id);
+    expect(fork.title).toBe("Planning thread (Fork)");
+    expect(fork.forkParentConversationId).toBe(source.id);
+    expect(fork.forkParentMessageId).toBe(finalSourceMessage.id);
+    expect(forkMessages).toHaveLength(sourceMessages.length);
+    expect(forkMessages.map((message) => message.role)).toEqual(
+      sourceMessages.map((message) => message.role),
+    );
+    expect(forkMessages.map((message) => message.content)).toEqual(
+      sourceMessages.map((message) => message.content),
+    );
+    expect(forkMessages.map((message) => message.createdAt)).toEqual(
+      sourceMessages.map((message) => message.createdAt),
+    );
+    expect(forkMessages.map((message) => parseMetadata(message.metadata))).toEqual(
+      sourceMessages.map((message) => parseMetadata(message.metadata)),
+    );
+    expect(
+      forkMessages.every(
+        (message, index) => message.id !== sourceMessages[index]?.id,
+      ),
+    ).toBe(true);
+  });
+
+  test("forks only through the requested branch point", async () => {
+    const source = createConversation("Branchable thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const branchPoint = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "user", "Message 3", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "Message 4", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: branchPoint.id,
+    });
+
+    expect(fork.forkParentConversationId).toBe(source.id);
+    expect(fork.forkParentMessageId).toBe(branchPoint.id);
+    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
+      "Message 1",
+      "Message 2",
+    ]);
+  });
+
+  test("relinks copied attachments into the fork and syncs disk view", async () => {
+    const source = createConversation("Attachment thread");
+    await addMessage(source.id, "user", "Please review this image", undefined, {
+      skipIndexing: true,
+    });
+    const sourceAssistant = await addMessage(
+      source.id,
+      "assistant",
+      "Attached the updated mock.",
+      undefined,
+      { skipIndexing: true },
+    );
+    const uploaded = uploadAttachment("wireframe.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(sourceAssistant.id, uploaded.id, 0);
+
+    const sourceAttachments = getAttachmentsForMessage(sourceAssistant.id);
+    const fork = forkConversation({ conversationId: source.id });
+    const forkAssistant = getMessages(fork.id).find(
+      (message) => message.role === "assistant",
+    );
+    const forkJsonl = readFileSync(
+      join(getConversationDirPath(fork.id, fork.createdAt), "messages.jsonl"),
+      "utf-8",
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(forkAssistant).toBeDefined();
+    const forkAttachments = getAttachmentsForMessage(forkAssistant!.id);
+    expect(sourceAttachments).toHaveLength(1);
+    expect(forkAttachments).toHaveLength(1);
+    expect(forkAttachments[0]?.id).not.toBe(sourceAttachments[0]?.id);
+    expect(
+      existsSync(
+        join(
+          getConversationDirPath(fork.id, fork.createdAt),
+          "attachments",
+          "wireframe.png",
+        ),
+      ),
+    ).toBe(true);
+    expect(forkJsonl[1]?.attachments).toEqual(["wireframe.png"]);
+    expect(getAttachmentsForMessage(sourceAssistant.id)[0]?.id).toBe(
+      sourceAttachments[0]?.id,
+    );
+  });
+
+  test("normalizes private source forks to standard conversations without external bindings", async () => {
+    const source = createConversation({
+      title: "Private notes",
+      conversationType: "private",
+    });
+    await addMessage(
+      source.id,
+      "assistant",
+      "This started as private context.",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const db = getDb();
+    const now = Date.now();
+    db.update(conversations)
+      .set({ originChannel: "telegram", originInterface: "cli" })
+      .where(eq(conversations.id, source.id))
+      .run();
+    db.insert(externalConversationBindings)
+      .values({
+        conversationId: source.id,
+        sourceChannel: "telegram",
+        externalChatId: "chat-1",
+        externalUserId: "user-1",
+        displayName: "Alex",
+        username: "alex",
+        createdAt: now,
+        updatedAt: now,
+        lastInboundAt: now,
+        lastOutboundAt: now,
+      })
+      .run();
+
+    const fork = forkConversation({ conversationId: source.id });
+    const binding = db
+      .select()
+      .from(externalConversationBindings)
+      .where(eq(externalConversationBindings.conversationId, fork.id))
+      .get();
+
+    expect(source.conversationType).toBe("private");
+    expect(fork.conversationType).toBe("standard");
+    expect(fork.memoryScopeId).toBe("default");
+    expect(fork.originChannel).toBeNull();
+    expect(fork.originInterface).toBeNull();
+    expect(binding).toBeUndefined();
+  });
+
+  test("marks copied assistant history as seen and excludes request logs, queued work, and inbound events", async () => {
+    const source = createConversation("Support thread");
+    const sourceUser = await addMessage(
+      source.id,
+      "user",
+      "The deploy is failing.",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(
+      source.id,
+      "assistant",
+      "I found the failing migration.",
+      undefined,
+      { skipIndexing: true },
+    );
+    markConversationUnread(source.id);
+
+    const db = getDb();
+    const now = Date.now();
+    db.insert(llmRequestLogs)
+      .values({
+        id: "llm-log-1",
+        conversationId: source.id,
+        messageId: sourceUser.id,
+        requestPayload: '{"prompt":"debug"}',
+        responsePayload: '{"result":"ok"}',
+        createdAt: now,
+      })
+      .run();
+    db.insert(toolInvocations)
+      .values({
+        id: "tool-invocation-1",
+        conversationId: source.id,
+        toolName: "bash",
+        input: '{"command":"bun test"}',
+        result: '{"ok":true}',
+        decision: "allow",
+        riskLevel: "medium",
+        durationMs: 42,
+        createdAt: now,
+      })
+      .run();
+    db.insert(memoryJobs)
+      .values({
+        id: "memory-job-1",
+        type: "delete_qdrant_vectors",
+        payload: JSON.stringify({ conversationId: source.id }),
+        status: "pending",
+        attempts: 0,
+        deferrals: 0,
+        runAfter: now,
+        lastError: null,
+        startedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(channelInboundEvents)
+      .values({
+        id: "inbound-event-1",
+        sourceChannel: "telegram",
+        externalChatId: "chat-1",
+        externalMessageId: "message-1",
+        sourceMessageId: "source-message-1",
+        conversationId: source.id,
+        messageId: sourceUser.id,
+        deliveryStatus: "pending",
+        processingStatus: "pending",
+        processingAttempts: 0,
+        lastProcessingError: null,
+        retryAfter: null,
+        rawPayload: "{}",
+        deliveredSegmentCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const sourceState = getAttentionStateByConversationIds([source.id]).get(
+      source.id,
+    );
+    const fork = forkConversation({ conversationId: source.id });
+    const forkAssistant = getMessages(fork.id).find(
+      (message) => message.role === "assistant",
+    );
+    const forkState = getAttentionStateByConversationIds([fork.id]).get(fork.id);
+    const forkRequestLogCount = db
+      .select()
+      .from(llmRequestLogs)
+      .where(eq(llmRequestLogs.conversationId, fork.id))
+      .all().length;
+    const forkToolInvocationCount = db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.conversationId, fork.id))
+      .all().length;
+    const forkInboundEventCount = db
+      .select()
+      .from(channelInboundEvents)
+      .where(eq(channelInboundEvents.conversationId, fork.id))
+      .all().length;
+    const forkQueuedWorkCount = db
+      .select()
+      .from(memoryJobs)
+      .where(like(memoryJobs.payload, `%${fork.id}%`))
+      .all().length;
+
+    expect(sourceState).toBeDefined();
+    expect(sourceState?.lastSeenAssistantMessageId).toBeNull();
+    expect(forkAssistant).toBeDefined();
+    expect(forkState).toBeDefined();
+    expect(forkState?.latestAssistantMessageId).toBe(forkAssistant?.id);
+    expect(forkState?.lastSeenAssistantMessageId).toBe(forkAssistant?.id);
+    expect(forkState?.lastSeenAssistantMessageAt).toBe(forkAssistant?.createdAt);
+    expect(forkRequestLogCount).toBe(0);
+    expect(forkToolInvocationCount).toBe(0);
+    expect(forkInboundEventCount).toBe(0);
+    expect(forkQueuedWorkCount).toBe(0);
+  });
+});

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -163,6 +163,76 @@ export function projectAssistantMessage(params: {
     .run();
 }
 
+/**
+ * Seed a forked conversation's assistant-attention projection so copied
+ * assistant history is treated as already seen from the outset.
+ */
+export function seedForkedConversationAttention(params: {
+  conversationId: string;
+  latestAssistantMessageId: string | null;
+  latestAssistantMessageAt: number | null;
+}): void {
+  const {
+    conversationId,
+    latestAssistantMessageId,
+    latestAssistantMessageAt,
+  } = params;
+
+  if (!latestAssistantMessageId || latestAssistantMessageAt == null) {
+    return;
+  }
+
+  const db = getDb();
+  const now = Date.now();
+  const existing = db
+    .select()
+    .from(conversationAssistantAttentionState)
+    .where(
+      eq(conversationAssistantAttentionState.conversationId, conversationId),
+    )
+    .get();
+
+  if (!existing) {
+    db.insert(conversationAssistantAttentionState)
+      .values({
+        conversationId,
+        latestAssistantMessageId,
+        latestAssistantMessageAt,
+        lastSeenAssistantMessageId: latestAssistantMessageId,
+        lastSeenAssistantMessageAt: latestAssistantMessageAt,
+        lastSeenEventAt: null,
+        lastSeenConfidence: null,
+        lastSeenSignalType: null,
+        lastSeenSourceChannel: null,
+        lastSeenSource: null,
+        lastSeenEvidenceText: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return;
+  }
+
+  db.update(conversationAssistantAttentionState)
+    .set({
+      latestAssistantMessageId,
+      latestAssistantMessageAt,
+      lastSeenAssistantMessageId: latestAssistantMessageId,
+      lastSeenAssistantMessageAt: latestAssistantMessageAt,
+      lastSeenEventAt: null,
+      lastSeenConfidence: null,
+      lastSeenSignalType: null,
+      lastSeenSourceChannel: null,
+      lastSeenSource: null,
+      lastSeenEvidenceText: null,
+      updatedAt: now,
+    })
+    .where(
+      eq(conversationAssistantAttentionState.conversationId, conversationId),
+    )
+    .run();
+}
+
 // ── recordConversationSeenSignal ─────────────────────────────────────
 
 /**

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -12,11 +12,19 @@ import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
-import { deleteOrphanAttachments } from "./attachments-store.js";
-import { projectAssistantMessage } from "./conversation-attention-store.js";
+import { UserError } from "../util/errors.js";
+import {
+  deleteOrphanAttachments,
+  linkAttachmentToMessage,
+} from "./attachments-store.js";
+import {
+  projectAssistantMessage,
+  seedForkedConversationAttention,
+} from "./conversation-attention-store.js";
 import {
   initConversationDir,
   removeConversationDir,
+  syncMessageToDisk,
   updateMetaFile,
 } from "./conversation-disk-view.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
@@ -272,6 +280,167 @@ export function getConversationType(
 export function getConversationMemoryScopeId(conversationId: string): string {
   const conv = getConversation(conversationId);
   return conv?.memoryScopeId ?? "default";
+}
+
+export function forkConversation(params: {
+  conversationId: string;
+  throughMessageId?: string;
+}): ConversationRow {
+  const { conversationId, throughMessageId } = params;
+  const db = getDb();
+  const sourceConversation = getConversation(conversationId);
+
+  if (!sourceConversation) {
+    throw new UserError(`Conversation ${conversationId} not found`);
+  }
+
+  const sourceMessages = db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(asc(messages.createdAt), asc(messages.id))
+    .all()
+    .map(parseMessage);
+
+  const copyBoundaryIndex =
+    throughMessageId == null
+      ? sourceMessages.length - 1
+      : sourceMessages.findIndex((message) => message.id === throughMessageId);
+
+  if (throughMessageId != null && copyBoundaryIndex === -1) {
+    throw new UserError(
+      `Message ${throughMessageId} does not belong to conversation ${conversationId}`,
+    );
+  }
+
+  const messagesToCopy =
+    copyBoundaryIndex >= 0
+      ? sourceMessages.slice(0, copyBoundaryIndex + 1)
+      : ([] as MessageRow[]);
+  const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
+  const forkTitle = `${sourceConversation.title ?? "Untitled"} (Fork)`;
+  const forkedConversation = createConversation({
+    title: forkTitle,
+    conversationType: "standard",
+  });
+
+  db.update(conversations)
+    .set({
+      forkParentConversationId: sourceConversation.id,
+      forkParentMessageId,
+    })
+    .where(eq(conversations.id, forkedConversation.id))
+    .run();
+
+  const forkedMessageIds = new Map<string, string>();
+  let latestForkedAssistant:
+    | { messageId: string; messageAt: number }
+    | null = null;
+
+  for (const message of messagesToCopy) {
+    const forkedMessageId = uuid();
+    db.insert(messages)
+      .values({
+        id: forkedMessageId,
+        conversationId: forkedConversation.id,
+        role: message.role,
+        content: message.content,
+        createdAt: message.createdAt,
+        metadata: message.metadata,
+      })
+      .run();
+    forkedMessageIds.set(message.id, forkedMessageId);
+
+    if (message.role === "assistant") {
+      latestForkedAssistant = {
+        messageId: forkedMessageId,
+        messageAt: message.createdAt,
+      };
+    }
+  }
+
+  const attachmentIdMap = new Map<string, string>();
+  for (const message of messagesToCopy) {
+    const forkedMessageId = forkedMessageIds.get(message.id);
+    if (!forkedMessageId) continue;
+
+    const attachmentLinks = db
+      .select({
+        attachmentId: messageAttachments.attachmentId,
+        position: messageAttachments.position,
+      })
+      .from(messageAttachments)
+      .where(eq(messageAttachments.messageId, message.id))
+      .orderBy(messageAttachments.position)
+      .all();
+    const uncachedAttachmentLinks = attachmentLinks.filter(
+      (link) => !attachmentIdMap.has(link.attachmentId),
+    );
+    const stagingMessageId =
+      uncachedAttachmentLinks.length > 0 ? uuid() : null;
+
+    if (stagingMessageId) {
+      db.insert(messages)
+        .values({
+          id: stagingMessageId,
+          conversationId: forkedConversation.id,
+          role: message.role,
+          content: "",
+          createdAt: message.createdAt,
+          metadata: null,
+        })
+        .run();
+    }
+
+    for (const link of attachmentLinks) {
+      const cachedAttachmentId = attachmentIdMap.get(link.attachmentId);
+      if (cachedAttachmentId) {
+        db.insert(messageAttachments)
+          .values({
+            id: uuid(),
+            messageId: forkedMessageId,
+            attachmentId: cachedAttachmentId,
+            position: link.position,
+            createdAt: Date.now(),
+          })
+          .run();
+        continue;
+      }
+
+      const scopedAttachmentId = linkAttachmentToMessage(
+        stagingMessageId ?? forkedMessageId,
+        link.attachmentId,
+        link.position,
+      );
+      attachmentIdMap.set(link.attachmentId, scopedAttachmentId);
+    }
+
+    if (stagingMessageId) {
+      relinkAttachments([stagingMessageId], forkedMessageId);
+      db.delete(messages).where(eq(messages.id, stagingMessageId)).run();
+    }
+
+    syncMessageToDisk(
+      forkedConversation.id,
+      forkedMessageId,
+      forkedConversation.createdAt,
+    );
+  }
+
+  seedForkedConversationAttention({
+    conversationId: forkedConversation.id,
+    latestAssistantMessageId: latestForkedAssistant?.messageId ?? null,
+    latestAssistantMessageAt: latestForkedAssistant?.messageAt ?? null,
+  });
+
+  const persistedFork = getConversation(forkedConversation.id);
+  if (!persistedFork) {
+    throw new Error(
+      `Failed to load forked conversation ${forkedConversation.id} after creation`,
+    );
+  }
+
+  return persistedFork;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add the storage-level conversation fork helper and copied-history attention seeding
- clone transcript messages and attachment links through an optional branch point
- add focused CRUD coverage for fork behavior and excluded copied state

Part of plan: conversation-forking.md (PR 5 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
