### PR TITLE
Render command help from assistant output

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -309,51 +309,67 @@ struct ChatContentView: View {
                 removal: .opacity
             ))
         } else if message.commandList != nil {
-            CommandListBubble(platform: .ios)
+            commandListBubble(message: message, index: index, messages: messages)
                 .id(message.id)
                 .transition(.asymmetric(
                     insertion: .move(edge: .bottom).combined(with: .opacity),
                     removal: .opacity
                 ))
         } else {
-            let isLastAssistant = message.role == .assistant
-                && !message.isStreaming
-                && (index == messages.count - 1
-                    || (index == messages.count - 2
-                        && messages[messages.count - 1].confirmation != nil
-                        && messages[messages.count - 1].confirmation?.state != .pending))
-                && !viewModel.isSending
-                && !viewModel.isThinking
-            MessageBubbleView(
-                message: message,
-                onConfirmationResponse: { requestId, decision in
-                    viewModel.respondToConfirmation(requestId: requestId, decision: decision)
-                },
-                onSurfaceAction: { surfaceId, actionId, data in
-                    viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
-                },
-                onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
-                onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in
-                    viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision)
-                },
-                onGuardianAction: { requestId, action in
-                    viewModel.submitGuardianDecision(requestId: requestId, action: action)
-                },
-                onSurfaceRefetch: { surfaceId, conversationId in
-                    viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
-                },
-                onRetryConversationError: message.isError && index == messages.count - 1 ? { viewModel.retryAfterConversationError() } : nil
-            )
-            .id(message.id)
-            .transition(.asymmetric(
-                insertion: .move(edge: .bottom).combined(with: .opacity),
-                removal: .opacity
-            ))
+            regularMessageBubble(message: message, index: index, messages: messages)
+                .id(message.id)
+                .transition(.asymmetric(
+                    insertion: .move(edge: .bottom).combined(with: .opacity),
+                    removal: .opacity
+                ))
+        }
+    }
 
-            // Inline media embeds (images, videos)
-            if !message.text.isEmpty && !message.isStreaming {
-                MessageMediaEmbedsView(message: message)
-            }
+    @ViewBuilder
+    private func commandListBubble(message: ChatMessage, index: Int, messages: [ChatMessage]) -> some View {
+        if let parsedEntries = CommandListBubble.parsedEntries(from: message.text) {
+            CommandListBubble(commands: parsedEntries)
+        } else {
+            var fallbackMessage = message
+            fallbackMessage.commandList = nil
+            regularMessageBubble(message: fallbackMessage, index: index, messages: messages)
+        }
+    }
+
+    @ViewBuilder
+    private func regularMessageBubble(message: ChatMessage, index: Int, messages: [ChatMessage]) -> some View {
+        let isLastAssistant = message.role == .assistant
+            && !message.isStreaming
+            && (index == messages.count - 1
+                || (index == messages.count - 2
+                    && messages[messages.count - 1].confirmation != nil
+                    && messages[messages.count - 1].confirmation?.state != .pending))
+            && !viewModel.isSending
+            && !viewModel.isThinking
+        MessageBubbleView(
+            message: message,
+            onConfirmationResponse: { requestId, decision in
+                viewModel.respondToConfirmation(requestId: requestId, decision: decision)
+            },
+            onSurfaceAction: { surfaceId, actionId, data in
+                viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data)
+            },
+            onRegenerate: isLastAssistant ? { viewModel.regenerateLastMessage() } : nil,
+            onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in
+                viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision)
+            },
+            onGuardianAction: { requestId, action in
+                viewModel.submitGuardianDecision(requestId: requestId, action: action)
+            },
+            onSurfaceRefetch: { surfaceId, conversationId in
+                viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
+            },
+            onRetryConversationError: message.isError && index == messages.count - 1 ? { viewModel.retryAfterConversationError() } : nil
+        )
+
+        // Inline media embeds (images, videos)
+        if !message.text.isEmpty && !message.isStreaming {
+            MessageMediaEmbedsView(message: message)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1419,6 +1419,43 @@ private struct MessageCellView: View, Equatable {
     }
 
     @ViewBuilder
+    private func commandListView(for message: ChatMessage, nextDecidedConfirmation: ToolConfirmationData? = nil) -> some View {
+        if let commandEntries = CommandListBubble.parsedEntries(from: message.text) {
+            CommandListBubble(commands: commandEntries)
+        } else {
+            var fallbackMessage = message
+            fallbackMessage.commandList = nil
+            ChatBubble(
+                message: fallbackMessage,
+                decidedConfirmation: nextDecidedConfirmation,
+                onSurfaceAction: onSurfaceAction,
+                onDismissDocumentWidget: { surfaceId in
+                    onDismissDocumentWidget?(surfaceId)
+                },
+                dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
+                onReportMessage: onReportMessage,
+                showInspectButton: showInspectButton,
+                onInspectMessage: onInspectMessage,
+                onSurfaceRefetch: onSurfaceRefetch,
+                onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
+                mediaEmbedSettings: mediaEmbedSettings,
+                resolveHttpPort: resolveHttpPort,
+                onConfirmationAllow: onConfirmationAllow,
+                onConfirmationDeny: onConfirmationDeny,
+                onAlwaysAllow: onAlwaysAllow,
+                onTemporaryAllow: onTemporaryAllow,
+                activeConfirmationRequestId: activePendingRequestId,
+                onRetryFailedMessage: onRetryFailedMessage,
+                onRetryConversationError: message.isError ? { onRetryConversationError?(message.id) } : nil,
+                isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
+                isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
+                processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
+                activeSurfaceId: activeSurfaceId
+            )
+        }
+    }
+
+    @ViewBuilder
     private func thinkingIndicatorRow() -> some View {
         RunningIndicator(
             label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
@@ -1503,7 +1540,7 @@ private struct MessageCellView: View, Equatable {
             modelListView(for: message)
                 .id(message.id)
         } else if message.commandList != nil {
-            CommandListBubble(platform: .macos)
+            commandListView(for: message, nextDecidedConfirmation: nil)
                 .id(message.id)
         } else if let guardianDecision = message.guardianDecision {
             GuardianDecisionBubble(
@@ -1520,7 +1557,6 @@ private struct MessageCellView: View, Equatable {
                       conf.state != .pending else { return nil }
                 return conf
             }()
-
 
             ChatBubble(
                 message: message,

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -1,21 +1,28 @@
+import Foundation
 import SwiftUI
 
 public struct CommandListBubble: View {
-    struct CommandEntry: Identifiable {
-        let id: String // slash command
-        let description: String
-    }
+    public struct CommandEntry: Identifiable, Equatable {
+        public let id: String
+        public let description: String
 
-    private let platform: ChatSlashCommandPlatform
-
-    private var commands: [CommandEntry] {
-        ChatSlashCommandCatalog.commands(for: platform, surface: .helpBubble).map {
-            CommandEntry(id: $0.slashName, description: $0.description)
+        public init(id: String, description: String) {
+            self.id = id
+            self.description = description
         }
     }
 
-    public init(platform: ChatSlashCommandPlatform) {
-        self.platform = platform
+    private let commands: [CommandEntry]
+
+    public init(commands: [CommandEntry]) {
+        self.commands = commands
+    }
+
+    public static func parsedEntries(from assistantText: String) -> [CommandEntry]? {
+        let commands = assistantText
+            .split(whereSeparator: \.isNewline)
+            .compactMap(parseEntry(from:))
+        return commands.isEmpty ? nil : commands
     }
 
     public var body: some View {
@@ -55,5 +62,39 @@ public struct CommandListBubble: View {
                 .stroke(VColor.borderBase, lineWidth: 1)
         )
         .frame(maxWidth: 400)
+    }
+
+    private static func parseEntry(from rawLine: Substring) -> CommandEntry? {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let stripped = trimmed.trimmingLeadingListMarker()
+        guard stripped.hasPrefix("/") else { return nil }
+
+        let commandEnd = stripped.firstIndex(where: { $0.isWhitespace || $0 == "-" || $0 == "–" || $0 == "—" || $0 == ":" }) ?? stripped.endIndex
+        let commandToken = String(stripped[..<commandEnd]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+        guard commandToken.count > 1 else { return nil }
+
+        let description = String(stripped[commandEnd...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingLeadingListMarker()
+        guard !description.isEmpty else { return nil }
+
+        return CommandEntry(id: commandToken, description: description)
+    }
+}
+
+private extension String {
+    func trimmingLeadingListMarker() -> String {
+        var index = startIndex
+        while index < endIndex {
+            let character = self[index]
+            if character.isWhitespace || character == "-" || character == "*" || character == "•" || character == "·" || character == "–" || character == "—" {
+                index = self.index(after: index)
+                continue
+            }
+            break
+        }
+        return String(self[index...]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/clients/shared/Tests/CommandListBubbleTests.swift
+++ b/clients/shared/Tests/CommandListBubbleTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class CommandListBubbleTests: XCTestCase {
+    func testParsedEntriesPreserveAssistantCommandRowsWithoutSynthesizingPlatformCommands() {
+        let assistantText = """
+        COMMANDS
+        - /commands — List all available commands
+        - /models — List all available models
+        - /status — Show conversation status and context usage
+        - /btw — Ask a side question while the assistant is working
+        """
+
+        let parsed = CommandListBubble.parsedEntries(from: assistantText)
+
+        XCTAssertEqual(parsed?.map(\.id), ["/commands", "/models", "/status", "/btw"])
+        XCTAssertEqual(parsed?.map(\.description), [
+            "List all available commands",
+            "List all available models",
+            "Show conversation status and context usage",
+            "Ask a side question while the assistant is working",
+        ])
+    }
+
+    func testParsedEntriesReturnNilForNonCommandListText() {
+        let assistantText = """
+        I can help with commands, but this message is just prose.
+        """
+
+        XCTAssertNil(CommandListBubble.parsedEntries(from: assistantText))
+    }
+}


### PR DESCRIPTION
## Summary
- render the command help bubble from the assistant message content instead of the viewing platform
- preserve existing command-card styling while avoiding cross-platform drift in restored history
- add focused coverage where practical for the parsing/fallback behavior

Part of plan: unify-desktop-slash-command-ux.md (remediation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)