### PR TITLE
Fix runtime HTTP server import sorting

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -36,8 +36,8 @@ import {
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
-  type Confidence,
   type AttentionState,
+  type Confidence,
   getAttentionStateByConversationIds,
   markConversationUnread,
   recordConversationSeenSignal,
@@ -53,8 +53,8 @@ import {
   countConversations,
   listConversations,
 } from "../memory/conversation-queries.js";
-import * as externalConversationStore from "../memory/external-conversation-store.js";
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
+import * as externalConversationStore from "../memory/external-conversation-store.js";
 import {
   consumeCallback,
   consumeCallbackError,


### PR DESCRIPTION
## Summary
- Fix import sorting in `assistant/src/runtime/http-server.ts` so the lint job passes.
- Keep the change non-functional and scoped to the single failing CI file.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282597581/job/67699066068