### PR TITLE
Fix macOS message inspector CI build errors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -259,8 +259,8 @@ struct MessageInspectorResponseTabModel: Equatable {
         guard let records = jsonRecords(from: root) else { return [] }
 
         if let openAiChoices = records["choices"] as? [Any] {
-            return openAiChoices.compactMap { choice in
-                guard let choiceRecord = choice as? [String: Any] else { return nil }
+            return openAiChoices.flatMap { choice -> [String] in
+                guard let choiceRecord = choice as? [String: Any] else { return [] }
                 let message = choiceRecord["message"] as? [String: Any]
                 let toolCalls = message?["tool_calls"] as? [Any]
                 return toolCalls?.compactMap { toolCall in
@@ -275,7 +275,6 @@ struct MessageInspectorResponseTabModel: Equatable {
                     return toolName
                 } ?? []
             }
-            .flatMap { $0 }
         }
 
         if let content = records["content"] as? [Any] {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -112,7 +112,8 @@ struct MessageInspectorView: View {
                 Spacer()
             }
             .padding(VSpacing.lg)
-            .frame(width: callRailWidth, maxHeight: .infinity, alignment: .topLeading)
+            .frame(width: callRailWidth, alignment: .topLeading)
+            .frame(maxHeight: .infinity, alignment: .topLeading)
 
             Divider()
 
@@ -188,7 +189,8 @@ struct MessageInspectorView: View {
             }
             .padding(VSpacing.md)
         }
-        .frame(width: callRailWidth, maxHeight: .infinity, alignment: .topLeading)
+        .frame(width: callRailWidth, alignment: .topLeading)
+        .frame(maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceBase)
     }
 


### PR DESCRIPTION
## Summary
- Fix the macOS message inspector rail layout by using supported SwiftUI frame overloads instead of mixing width and maxHeight in a single call.
- Collect OpenAI tool-call names with flatMap so malformed choice entries fall back to an empty list without breaking type inference.
- Apple refs checked (2026-03-19): SwiftUI frame modifier documentation on developer.apple.com.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282546973/job/67698928969
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
