### PR TITLE
feat: add POST conversation fork route

### DIFF
--- a/assistant/src/__tests__/conversation-fork-route.test.ts
+++ b/assistant/src/__tests__/conversation-fork-route.test.ts
@@ -1,0 +1,307 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "conversation-fork-route-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(testDir, ".vellum", "workspace", "data"),
+  getWorkspaceDir: () => join(testDir, ".vellum", "workspace"),
+  getConversationsDir: () =>
+    join(testDir, ".vellum", "workspace", "conversations"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => false,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+}));
+
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { mintToken } from "../runtime/auth/token-service.js";
+import { getPolicy } from "../runtime/auth/route-policy.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+
+initializeDb();
+
+const CHAT_WRITE_JWT = mintToken({
+  aud: "vellum-daemon",
+  sub: "actor:self:fork-route-test",
+  scope_profile: "actor_client_v1",
+  policy_epoch: 1,
+  ttlSeconds: 3600,
+});
+
+const READ_ONLY_JWT = mintToken({
+  aud: "vellum-daemon",
+  sub: "actor:self:fork-route-read-only",
+  scope_profile: "ui_page_v1",
+  policy_epoch: 1,
+  ttlSeconds: 3600,
+});
+
+const AUTH_HEADERS = { Authorization: `Bearer ${CHAT_WRITE_JWT}` };
+const READ_ONLY_HEADERS = { Authorization: `Bearer ${READ_ONLY_JWT}` };
+
+type ConversationSummary = {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  conversationType: string;
+  source: string;
+  forkParent?: {
+    conversationId: string;
+    messageId: string;
+    title: string;
+  };
+};
+
+describe("POST /v1/conversations/fork", () => {
+  let server: RuntimeHttpServer | null = null;
+
+  beforeEach(async () => {
+    await server?.stop();
+    server = null;
+    clearTables();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("returns the same conversation summary shape as GET /v1/conversations/:id", async () => {
+    const source = createConversation("Roadmap draft");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const branchPoint = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "user", "Message 3", undefined, {
+      skipIndexing: true,
+    });
+
+    await startServer();
+
+    const forkResponse = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationId: source.id,
+        throughMessageId: branchPoint.id,
+      }),
+    });
+
+    expect(forkResponse.status).toBe(200);
+    const forkBody = (await forkResponse.json()) as {
+      conversation: ConversationSummary;
+    };
+
+    expect(forkBody.conversation).toMatchObject({
+      title: "Roadmap draft (Fork)",
+      conversationType: "standard",
+      source: "user",
+      forkParent: {
+        conversationId: source.id,
+        messageId: branchPoint.id,
+        title: "Roadmap draft",
+      },
+    });
+
+    const detailResponse = await fetch(
+      url(`/conversations/${forkBody.conversation.id}`),
+      { headers: AUTH_HEADERS },
+    );
+    expect(detailResponse.status).toBe(200);
+    const detailBody = (await detailResponse.json()) as {
+      conversation: ConversationSummary;
+    };
+
+    expect(forkBody).toEqual(detailBody);
+  });
+
+  test("returns NOT_FOUND when the source conversation does not exist", async () => {
+    await startServer();
+
+    const response = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationId: "missing-conversation" }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "NOT_FOUND",
+        message: "Conversation missing-conversation not found",
+      },
+    });
+  });
+
+  test("rejects nonexistent and cross-conversation branch point message IDs", async () => {
+    const source = createConversation("Source");
+    await addMessage(source.id, "user", "Source message", undefined, {
+      skipIndexing: true,
+    });
+    const otherConversation = createConversation("Other");
+    const otherMessage = await addMessage(
+      otherConversation.id,
+      "assistant",
+      "Other message",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    await startServer();
+
+    const missingMessageResponse = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationId: source.id,
+        throughMessageId: "missing-message-id",
+      }),
+    });
+
+    expect(missingMessageResponse.status).toBe(404);
+    expect(await missingMessageResponse.json()).toEqual({
+      error: {
+        code: "NOT_FOUND",
+        message: `Message missing-message-id does not belong to conversation ${source.id}`,
+      },
+    });
+
+    const crossConversationResponse = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationId: source.id,
+        throughMessageId: otherMessage.id,
+      }),
+    });
+
+    expect(crossConversationResponse.status).toBe(404);
+    expect(await crossConversationResponse.json()).toEqual({
+      error: {
+        code: "NOT_FOUND",
+        message: `Message ${otherMessage.id} does not belong to conversation ${source.id}`,
+      },
+    });
+  });
+
+  test("requires chat.write scope", async () => {
+    const source = createConversation("Auth gated");
+
+    await startServer();
+
+    const response = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...READ_ONLY_HEADERS },
+      body: JSON.stringify({ conversationId: source.id }),
+    });
+
+    expect(getPolicy("conversations/fork")).toEqual({
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
+    });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "FORBIDDEN",
+        message: "Missing required scope: chat.write",
+      },
+    });
+  });
+
+  async function startServer(): Promise<void> {
+    server = new RuntimeHttpServer({
+      port: 0,
+      bearerToken: "test-bearer-token",
+      conversationManagementDeps: {
+        switchConversation: async () => null,
+        renameConversation: () => false,
+        clearAllConversations: () => 0,
+        cancelGeneration: () => false,
+        destroyConversation: () => {},
+        undoLastMessage: async () => null,
+        regenerateResponse: async () => null,
+      },
+    });
+    await server.start();
+  }
+
+  function clearTables(): void {
+    const db = getDb();
+    db.run("DELETE FROM conversation_assistant_attention_state");
+    db.run("DELETE FROM external_conversation_bindings");
+    db.run("DELETE FROM conversation_keys");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  }
+
+  function url(pathname: string): string {
+    if (!server) throw new Error("server not started");
+    return `http://127.0.0.1:${server.actualPort}/v1${pathname}`;
+  }
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -129,6 +129,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "btw", scopes: ["chat.write"] },
   { endpoint: "conversations", scopes: ["chat.read"] },
   { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
+  { endpoint: "conversations/fork", scopes: ["chat.write"] },
   { endpoint: "conversations/switch", scopes: ["chat.write"] },
   { endpoint: "conversations/name", scopes: ["chat.write"] },
   { endpoint: "conversations/cancel", scopes: ["chat.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -45,6 +45,7 @@ import {
 } from "../memory/conversation-attention-store.js";
 import {
   type ConversationRow,
+  forkConversation as forkConversationInStore,
   getConversation,
   getDisplayMetaForConversations,
 } from "../memory/conversation-crud.js";
@@ -125,7 +126,10 @@ import {
   contactRouteDefinitions,
 } from "./routes/contact-routes.js";
 import { conversationAttentionRouteDefinitions } from "./routes/conversation-attention-routes.js";
-import { conversationManagementRouteDefinitions } from "./routes/conversation-management-routes.js";
+import {
+  conversationManagementRouteDefinitions,
+  type ConversationManagementDeps,
+} from "./routes/conversation-management-routes.js";
 import { conversationQueryRouteDefinitions } from "./routes/conversation-query-routes.js";
 import { conversationRouteDefinitions } from "./routes/conversation-routes.js";
 import { conversationStarterRouteDefinitions } from "./routes/conversation-starter-routes.js";
@@ -830,6 +834,57 @@ export class RuntimeHttpServer {
     };
   }
 
+  private buildConversationDetailResponse(conversationId: string) {
+    const conversation = getConversation(conversationId);
+    if (!conversation) {
+      return null;
+    }
+
+    const bindings = externalConversationStore.getBindingsForConversations([
+      conversation.id,
+    ]);
+    const attentionStates = getAttentionStateByConversationIds([conversation.id]);
+    const parentCache = new Map<string, ConversationRow | null>();
+
+    return {
+      conversation: this.serializeConversationSummary({
+        conversation,
+        binding: bindings.get(conversation.id),
+        attentionState: attentionStates.get(conversation.id),
+        parentCache,
+      }),
+    };
+  }
+
+  private getConversationManagementRouteDeps():
+    | ConversationManagementDeps
+    | null {
+    if (!this.conversationManagementDeps) {
+      return null;
+    }
+
+    return {
+      ...this.conversationManagementDeps,
+      forkConversation:
+        this.conversationManagementDeps.forkConversation ??
+        (async ({ conversationId, throughMessageId }) => {
+          const forkedConversation = forkConversationInStore({
+            conversationId,
+            throughMessageId,
+          });
+          const detail = this.buildConversationDetailResponse(
+            forkedConversation.id,
+          );
+          if (!detail) {
+            throw new Error(
+              `Forked conversation ${forkedConversation.id} could not be loaded`,
+            );
+          }
+          return detail.conversation;
+        }),
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Declarative route table
   // ---------------------------------------------------------------------------
@@ -845,6 +900,8 @@ export class RuntimeHttpServer {
    */
   private buildRouteTable(): RouteDefinition[] {
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+    const conversationManagementDeps =
+      this.getConversationManagementRouteDeps();
 
     return [
       ...pairingRouteDefinitions({
@@ -957,10 +1014,8 @@ export class RuntimeHttpServer {
       },
       ...conversationAttentionRouteDefinitions(),
 
-      ...(this.conversationManagementDeps
-        ? conversationManagementRouteDefinitions(
-            this.conversationManagementDeps,
-          )
+      ...(conversationManagementDeps
+        ? conversationManagementRouteDefinitions(conversationManagementDeps)
         : []),
 
       {
@@ -1050,30 +1105,15 @@ export class RuntimeHttpServer {
         endpoint: "conversations/:id",
         method: "GET",
         handler: ({ params }) => {
-          const conversation = getConversation(params.id);
-          if (!conversation) {
+          const detail = this.buildConversationDetailResponse(params.id);
+          if (!detail) {
             return httpError(
               "NOT_FOUND",
               `Conversation ${params.id} not found`,
               404,
             );
           }
-          const bindings =
-            externalConversationStore.getBindingsForConversations([
-              conversation.id,
-            ]);
-          const attentionStates = getAttentionStateByConversationIds([
-            conversation.id,
-          ]);
-          const parentCache = new Map<string, ConversationRow | null>();
-          return Response.json({
-            conversation: this.serializeConversationSummary({
-              conversation,
-              binding: bindings.get(conversation.id),
-              attentionState: attentionStates.get(conversation.id),
-              parentCache,
-            }),
-          });
+          return Response.json(detail);
         },
       },
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -2,6 +2,7 @@
  * Route handlers for conversation management operations.
  *
  * POST   /v1/conversations/switch         — switch to an existing conversation
+ * POST   /v1/conversations/fork           — fork an existing conversation
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
  * POST   /v1/conversations/:id/wipe       — wipe conversation and revert memory
@@ -22,6 +23,7 @@ import {
   setConversationKeyIfAbsent,
 } from "../../memory/conversation-key-store.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
+import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -33,6 +35,10 @@ const log = getLogger("conversation-management-routes");
 // ---------------------------------------------------------------------------
 
 export interface ConversationManagementDeps {
+  forkConversation?: (params: {
+    conversationId: string;
+    throughMessageId?: string;
+  }) => Promise<Record<string, unknown>> | Record<string, unknown>;
   switchConversation: (conversationId: string) => Promise<{
     conversationId: string;
     title: string;
@@ -59,6 +65,64 @@ export function conversationManagementRouteDefinitions(
   deps: ConversationManagementDeps,
 ): RouteDefinition[] {
   return [
+    {
+      endpoint: "conversations/fork",
+      method: "POST",
+      policyKey: "conversations/fork",
+      handler: async ({ req }) => {
+        if (!deps.forkConversation) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Conversation forking not available",
+            500,
+          );
+        }
+
+        const rawBody = (await req.json()) as unknown;
+        if (
+          rawBody == null ||
+          typeof rawBody !== "object" ||
+          Array.isArray(rawBody)
+        ) {
+          return httpError("BAD_REQUEST", "Invalid request body", 400);
+        }
+
+        const body = rawBody as {
+          conversationId?: string;
+          throughMessageId?: string;
+        };
+        const conversationId = body.conversationId;
+        if (!conversationId || typeof conversationId !== "string") {
+          return httpError("BAD_REQUEST", "Missing conversationId", 400);
+        }
+        if (
+          body.throughMessageId !== undefined &&
+          typeof body.throughMessageId !== "string"
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "throughMessageId must be a string",
+            400,
+          );
+        }
+
+        const resolvedConversationId =
+          resolveConversationId(conversationId) ?? conversationId;
+
+        try {
+          const conversation = await deps.forkConversation({
+            conversationId: resolvedConversationId,
+            throughMessageId: body.throughMessageId,
+          });
+          return Response.json({ conversation });
+        } catch (err) {
+          if (err instanceof UserError) {
+            return httpError("NOT_FOUND", err.message, 404);
+          }
+          throw err;
+        }
+      },
+    },
     {
       endpoint: "conversations/switch",
       method: "POST",


### PR DESCRIPTION
## Summary
- add the authenticated POST conversation fork route and dependency wiring
- return the shared conversation summary shape so clients can insert forks immediately
- add focused route coverage for validation, auth policy, and successful forking

Part of plan: conversation-forking.md (PR 6 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
