### PR TITLE
Fix assistant import ordering for lint

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
 import { eq, like } from "drizzle-orm";
 
 const testDir = realpathSync(

--- a/assistant/src/__tests__/conversation-fork-route.test.ts
+++ b/assistant/src/__tests__/conversation-fork-route.test.ts
@@ -68,8 +68,8 @@ mock.module("../config/loader.js", () => ({
 
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { mintToken } from "../runtime/auth/token-service.js";
 import { getPolicy } from "../runtime/auth/route-policy.js";
+import { mintToken } from "../runtime/auth/token-service.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 
 initializeDb();

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -9,10 +9,10 @@ import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
-import { UserError } from "../util/errors.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -127,8 +127,8 @@ import {
 } from "./routes/contact-routes.js";
 import { conversationAttentionRouteDefinitions } from "./routes/conversation-attention-routes.js";
 import {
-  conversationManagementRouteDefinitions,
   type ConversationManagementDeps,
+  conversationManagementRouteDefinitions,
 } from "./routes/conversation-management-routes.js";
 import { conversationQueryRouteDefinitions } from "./routes/conversation-query-routes.js";
 import { conversationRouteDefinitions } from "./routes/conversation-routes.js";


### PR DESCRIPTION
## Summary
- fix simple-import-sort ordering in the assistant files flagged by the failing lint job
- keep the change scoped to the single CI issue reported in the provided GitHub Actions job

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282788717/job/67699635758
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
