### PR TITLE
Fix macOS command list fallback rendering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1418,15 +1418,19 @@ private struct MessageCellView: View, Equatable {
         ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders, providerCatalog: providerCatalog)
     }
 
+    private func commandListFallbackMessage(for message: ChatMessage) -> ChatMessage {
+        var fallbackMessage = message
+        fallbackMessage.commandList = nil
+        return fallbackMessage
+    }
+
     @ViewBuilder
     private func commandListView(for message: ChatMessage, nextDecidedConfirmation: ToolConfirmationData? = nil) -> some View {
         if let commandEntries = CommandListBubble.parsedEntries(from: message.text) {
             CommandListBubble(commands: commandEntries)
         } else {
-            var fallbackMessage = message
-            fallbackMessage.commandList = nil
             ChatBubble(
-                message: fallbackMessage,
+                message: commandListFallbackMessage(for: message),
                 decidedConfirmation: nextDecidedConfirmation,
                 onSurfaceAction: onSurfaceAction,
                 onDismissDocumentWidget: { surfaceId in


### PR DESCRIPTION
## Summary
- move command list fallback message mutation out of the SwiftUI view builder
- keep the fallback ChatBubble path intact when command list parsing fails
- fix the macOS CI compiler error in MessageListView

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282788726/job/67699647109
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
