### PR TITLE
fix: initialize disk-view folders for conversation-key conversations

### DIFF
--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -1,0 +1,129 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "conversation-key-store-disk-view-")),
+);
+const workspaceDir = join(testDir, "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => join(testDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+}));
+
+import { getOrCreateConversation } from "../memory/conversation-key-store.js";
+import { initializeDb, getDb, resetDb } from "../memory/db.js";
+import { conversationKeys, conversations } from "../memory/schema.js";
+
+initializeDb();
+
+beforeEach(() => {
+  const db = getDb();
+  db.delete(conversationKeys).run();
+  db.delete(conversations).run();
+
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+});
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("conversation-key-store disk view", () => {
+  test("creates disk-view directory on first key use and reuses it on second call", () => {
+    const first = getOrCreateConversation("client-key");
+    expect(first.created).toBe(true);
+
+    const db = getDb();
+    const conversation = db
+      .select({ id: conversations.id, createdAt: conversations.createdAt })
+      .from(conversations)
+      .where(eq(conversations.id, first.conversationId))
+      .get();
+    expect(conversation).not.toBeUndefined();
+
+    const expectedDirName = `${new Date(conversation!.createdAt).toISOString().replace(/:/g, "-")}_${first.conversationId}`;
+    const metaPath = join(conversationsDir, expectedDirName, "meta.json");
+    expect(existsSync(metaPath)).toBe(true);
+
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.id).toBe(first.conversationId);
+    expect(meta.title).toBe("Generating title...");
+    expect(meta.type).toBe("standard");
+    expect(meta.channel).toBeNull();
+    expect(readdirSync(conversationsDir)).toEqual([expectedDirName]);
+
+    const second = getOrCreateConversation("client-key");
+    expect(second.created).toBe(false);
+    expect(second.conversationId).toBe(first.conversationId);
+
+    const conversationRows = db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .all();
+    const keyRows = db.select({ id: conversationKeys.id }).from(conversationKeys).all();
+    expect(conversationRows).toHaveLength(1);
+    expect(keyRows).toHaveLength(1);
+    expect(readdirSync(conversationsDir)).toEqual([expectedDirName]);
+  });
+});

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -10,6 +10,7 @@
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db.js";
 import { conversationKeys, conversations } from "./schema.js";
@@ -138,7 +139,7 @@ export function getOrCreateConversation(
   const db = getDb();
   const conversationType = opts?.conversationType ?? "standard";
 
-  return db.transaction((tx) => {
+  const result = db.transaction((tx) => {
     const existing = tx
       .select()
       .from(conversationKeys)
@@ -146,7 +147,7 @@ export function getOrCreateConversation(
       .get();
 
     if (existing) {
-      return { conversationId: existing.conversationId, created: false };
+      return { conversationId: existing.conversationId, created: false as const };
     }
 
     // Check if the conversationKey itself is an existing conversation ID.
@@ -167,18 +168,19 @@ export function getOrCreateConversation(
           createdAt: Date.now(),
         })
         .run();
-      return { conversationId: existingConversation.id, created: false };
+      return { conversationId: existingConversation.id, created: false as const };
     }
 
     const now = Date.now();
     const conversationId = uuid();
+    const title = GENERATING_TITLE;
     const memoryScopeId =
       conversationType === "private" ? `private:${conversationId}` : "default";
 
     tx.insert(conversations)
       .values({
         id: conversationId,
-        title: GENERATING_TITLE,
+        title,
         createdAt: now,
         updatedAt: now,
         totalInputTokens: 0,
@@ -201,6 +203,16 @@ export function getOrCreateConversation(
       })
       .run();
 
-    return { conversationId, created: true };
+    return {
+      conversationId,
+      created: true as const,
+      conversation: { id: conversationId, title, createdAt: now, conversationType },
+    };
   });
+
+  if (result.created) {
+    initConversationDir({ ...result.conversation, originChannel: null });
+  }
+
+  return { conversationId: result.conversationId, created: result.created };
 }


### PR DESCRIPTION
## Summary
- initialize conversation disk-view folders when getOrCreateConversation creates a new row
- keep existing key and direct-conversation fast paths unchanged
- add regression coverage for conversation-key disk-view initialization

Part of plan: repair-conversation-disk-view.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
