### PR TITLE
fix: add structured prompt sections to llm inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -8,6 +8,8 @@ describe("normalizeLlmContextPayloads", () => {
       createdAt: 1_742_400_000_000,
       requestPayload: {
         model: "gpt-4.1",
+        temperature: 0.2,
+        tool_choice: "auto",
         messages: [
           { role: "system", content: "Be concise." },
           {
@@ -102,7 +104,37 @@ describe("normalizeLlmContextPayloads", () => {
       {
         kind: "tool_definitions",
         label: "Available tools",
-        text: "web_search, get_weather",
+        data: {
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "web_search",
+                description: "Search the web",
+                parameters: { type: "object" },
+              },
+            },
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Read forecast data",
+                parameters: { type: "object" },
+              },
+            },
+          ],
+        },
+        language: "json",
+      },
+      {
+        kind: "settings",
+        label: "Request settings",
+        data: {
+          model: "gpt-4.1",
+          temperature: 0.2,
+          tool_choice: "auto",
+        },
+        language: "json",
       },
     ]);
     expect(normalized.responseSections).toEqual([
@@ -136,6 +168,9 @@ describe("normalizeLlmContextPayloads", () => {
       createdAt: 1_742_400_000_001,
       requestPayload: {
         model: "claude-sonnet",
+        max_tokens: 1_024,
+        temperature: 0.1,
+        tool_choice: { type: "auto" },
         system: [
           {
             type: "text",
@@ -235,7 +270,27 @@ describe("normalizeLlmContextPayloads", () => {
       {
         kind: "tool_definitions",
         label: "Available tools",
-        text: "web_search",
+        data: {
+          tools: [
+            {
+              name: "web_search",
+              description: "Search the web",
+              input_schema: { type: "object" },
+            },
+          ],
+        },
+        language: "json",
+      },
+      {
+        kind: "settings",
+        label: "Request settings",
+        data: {
+          model: "claude-sonnet",
+          max_tokens: 1_024,
+          temperature: 0.1,
+          tool_choice: { type: "auto" },
+        },
+        language: "json",
       },
     ]);
     expect(normalized.responseSections).toEqual([
@@ -387,6 +442,8 @@ describe("normalizeLlmContextPayloads", () => {
         ],
         config: {
           systemInstruction: "Answer briefly.",
+          temperature: 0.4,
+          responseMimeType: "application/json",
           tools: [
             {
               functionDeclarations: [
@@ -466,7 +523,29 @@ describe("normalizeLlmContextPayloads", () => {
       {
         kind: "tool_definitions",
         label: "Available tools",
-        text: "read_file, search_notes",
+        data: {
+          tools: [
+            {
+              functionDeclarations: [
+                { name: "read_file", description: "Read a file" },
+                { name: "search_notes", description: "Search notes" },
+              ],
+            },
+          ],
+        },
+        language: "json",
+      },
+      {
+        kind: "settings",
+        label: "Generation config",
+        data: {
+          model: "gemini-3-flash",
+          config: {
+            temperature: 0.4,
+            responseMimeType: "application/json",
+          },
+        },
+        language: "json",
       },
     ]);
     expect(normalized.responseSections).toEqual([

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -24,6 +24,7 @@ export interface LlmContextSection {
   kind:
     | "system"
     | "message"
+    | "settings"
     | "tool_definitions"
     | "tool_use"
     | "tool_result"
@@ -34,6 +35,7 @@ export interface LlmContextSection {
   text?: string;
   toolName?: string;
   data?: unknown;
+  language?: string;
 }
 
 export interface LlmContextNormalizationResult {
@@ -114,8 +116,16 @@ function normalizeOpenAiPayloads(
     requestSections.push({
       kind: "tool_definitions",
       label: "Available tools",
-      text: requestToolNames.join(", "),
+      data: {
+        tools: asRecordArray(request.tools) ?? request.tools,
+      },
+      language: "json",
     });
+  }
+
+  const requestSettings = omitRecordKeys(request, ["messages", "tools"]);
+  if (hasMeaningfulRequestSettings(requestSettings)) {
+    requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
   }
 
   const firstChoice = choices[0];
@@ -196,8 +206,16 @@ function normalizeAnthropicPayloads(
     requestSections.push({
       kind: "tool_definitions",
       label: "Available tools",
-      text: requestToolNames.join(", "),
+      data: {
+        tools: asRecordArray(request.tools) ?? request.tools,
+      },
+      language: "json",
     });
+  }
+
+  const requestSettings = omitRecordKeys(request, ["system", "messages", "tools"]);
+  if (hasMeaningfulRequestSettings(requestSettings)) {
+    requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
   }
 
   const responseSections = anthropicContentSections(content, "Assistant response");
@@ -266,8 +284,18 @@ function normalizeGeminiPayloads(
     requestSections.push({
       kind: "tool_definitions",
       label: "Available tools",
-      text: requestToolNames.join(", "),
+      data: {
+        tools: asRecordArray(config?.tools) ?? config?.tools,
+      },
+      language: "json",
     });
+  }
+
+  const requestSettings = buildGeminiRequestSettings(request, config);
+  if (hasMeaningfulRequestSettings(requestSettings)) {
+    requestSections.push(
+      structuredJsonSection("settings", "Generation config", requestSettings),
+    );
   }
 
   const responseSections: LlmContextSection[] = [];
@@ -643,6 +671,65 @@ function buildMessageLabel(role: string, index: number): string {
     return "System prompt";
   }
   return `${capitalizedRole} message ${index}`;
+}
+
+function buildGeminiRequestSettings(
+  request: Record<string, unknown>,
+  config: Record<string, unknown> | null,
+): Record<string, unknown> | undefined {
+  const topLevelSettings = omitRecordKeys(request, ["contents", "config"]);
+  const configSettings = omitRecordKeys(config, ["systemInstruction", "tools"]);
+
+  if (!topLevelSettings && !configSettings) {
+    return undefined;
+  }
+
+  return {
+    ...(topLevelSettings ?? {}),
+    ...(configSettings ? { config: configSettings } : {}),
+  };
+}
+
+function structuredJsonSection(
+  kind: LlmContextSection["kind"],
+  label: string,
+  data: unknown,
+): LlmContextSection {
+  return {
+    kind,
+    label,
+    data,
+    language: "json",
+  };
+}
+
+function hasMeaningfulRequestSettings(
+  settings: Record<string, unknown> | undefined,
+): settings is Record<string, unknown> {
+  if (!settings) {
+    return false;
+  }
+
+  const keys = Object.keys(settings);
+  return !(keys.length === 1 && keys[0] === "model");
+}
+
+function omitRecordKeys(
+  record: Record<string, unknown> | null,
+  omittedKeys: string[],
+): Record<string, unknown> | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const filteredEntries = Object.entries(record).filter(
+    ([key, value]) => !omittedKeys.includes(key) && value !== undefined,
+  );
+  if (filteredEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(filteredEntries);
 }
 
 function previewStructuredValue(value: unknown): string | undefined {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -65,9 +65,17 @@ struct MessageInspectorPromptTab: View {
                         .foregroundColor(VColor.contentDefault)
                         .lineLimit(2)
 
-                    Text(section.kindLabel)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                    HStack(spacing: VSpacing.xs) {
+                        Text(section.kindLabel)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+
+                        if let formatLabel = section.formatLabel {
+                            Text(formatLabel)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentSecondary)
+                        }
+                    }
                 }
 
                 Spacer(minLength: VSpacing.md)
@@ -147,17 +155,19 @@ struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
     let copyText: String
     let syntaxLanguage: SyntaxLanguage
     let presentationStyle: PresentationStyle
+    let formatLabel: String?
 
     init(index: Int, section: LLMContextSection) {
         id = "\(index)"
         title = Self.displayTitle(for: section, index: index)
         kindLabel = Self.displayKindLabel(for: section.kind)
 
-        let renderedContent = Self.renderedContent(for: section.content)
+        let renderedContent = Self.renderedContent(for: section)
         displayText = renderedContent.text
         copyText = renderedContent.text
         syntaxLanguage = renderedContent.syntaxLanguage
         presentationStyle = renderedContent.isStructured ? .structured : .text
+        formatLabel = renderedContent.formatLabel
     }
 
     private static func displayTitle(for section: LLMContextSection, index: Int) -> String {
@@ -176,20 +186,48 @@ struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
             .joined(separator: " ")
     }
 
-    private static func renderedContent(for content: AnyCodable?) -> (text: String, syntaxLanguage: SyntaxLanguage, isStructured: Bool) {
-        guard let value = content?.value else {
-            return ("No content available.", .plain, false)
+    private static func renderedContent(for section: LLMContextSection) -> (text: String, syntaxLanguage: SyntaxLanguage, isStructured: Bool, formatLabel: String?) {
+        let preferredLanguage = syntaxLanguage(for: section.language)
+
+        guard let value = section.content?.value else {
+            return ("No content available.", preferredLanguage ?? .plain, false, nil)
         }
 
         if let string = value as? String {
-            return (string, .plain, false)
+            if preferredLanguage == .json, let parsedJSON = parseJSONString(string) {
+                return (
+                    prettyPrintedJSONString(for: parsedJSON) ?? string,
+                    .json,
+                    true,
+                    "JSON"
+                )
+            }
+
+            return (
+                string,
+                preferredLanguage ?? .plain,
+                false,
+                preferredLanguage.flatMap { formatLabel(for: $0) }
+            )
         }
 
         if let json = prettyPrintedJSONString(for: value) {
-            return (json, .json, true)
+            let syntaxLanguage = preferredLanguage ?? .json
+            return (
+                json,
+                syntaxLanguage,
+                true,
+                formatLabel(for: syntaxLanguage)
+            )
         }
 
-        return (String(describing: value), .plain, true)
+        let syntaxLanguage = preferredLanguage ?? .plain
+        return (
+            String(describing: value),
+            syntaxLanguage,
+            true,
+            preferredLanguage.flatMap { formatLabel(for: $0) }
+        )
     }
 
     private static func prettyPrintedJSONString(for value: Any) -> String? {
@@ -205,5 +243,45 @@ struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
         }
 
         return String(data: data, encoding: .utf8)
+    }
+
+    private static func parseJSONString(_ string: String) -> Any? {
+        guard let data = string.data(using: .utf8) else {
+            return nil
+        }
+
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+
+    private static func syntaxLanguage(for language: String?) -> SyntaxLanguage? {
+        guard let language else { return nil }
+
+        switch language.lowercased() {
+        case "json", "application/json":
+            return .json
+        case "markdown", "md", "text/markdown":
+            return .markdown
+        case "javascript", "application/javascript", "text/javascript":
+            return .javascript
+        case "typescript", "application/typescript", "text/typescript":
+            return .typescript
+        default:
+            return .plain
+        }
+    }
+
+    private static func formatLabel(for syntaxLanguage: SyntaxLanguage) -> String? {
+        switch syntaxLanguage {
+        case .json:
+            return "JSON"
+        case .markdown:
+            return "Markdown"
+        case .javascript:
+            return "JavaScript"
+        case .typescript:
+            return "TypeScript"
+        case .plain:
+            return nil
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import VellumAssistantShared
 
 final class MessageInspectorPromptTabTests: XCTestCase {
-    func testPromptTabModelPreservesSectionOrderAndFormatsCopyText() {
+    func testPromptTabModelPreservesSectionOrderAndFormatsStructuredPromptSections() {
         let entry = makeEntry(
             requestPayload: AnyCodable([
                 "messages": [
@@ -14,7 +14,7 @@ final class MessageInspectorPromptTabTests: XCTestCase {
             ]),
             requestSections: [
                 LLMContextSection(
-                    kind: .unknown("message"),
+                    kind: .system,
                     title: "System prompt",
                     content: AnyCodable("You are helpful")
                 ),
@@ -29,10 +29,20 @@ final class MessageInspectorPromptTabTests: XCTestCase {
                             ]
                         ],
                         "max_output_tokens": 256
-                    ])
+                    ]),
+                    language: "json"
                 ),
                 LLMContextSection(
-                    kind: .unknown("message"),
+                    kind: .unknown("settings"),
+                    title: "Request settings",
+                    content: AnyCodable([
+                        "model": "gpt-5",
+                        "temperature": 0.2
+                    ]),
+                    language: "json"
+                ),
+                LLMContextSection(
+                    kind: .user,
                     title: "User message 1",
                     content: AnyCodable("Write a summary")
                 )
@@ -44,18 +54,44 @@ final class MessageInspectorPromptTabTests: XCTestCase {
         XCTAssertEqual(model.sections.map(\.title), [
             "System prompt",
             "Available tools",
+            "Request settings",
             "User message 1"
         ])
         XCTAssertEqual(model.sections.map(\.presentationStyle), [
             .text,
+            .structured,
             .structured,
             .text
         ])
         XCTAssertEqual(model.sections[0].copyText, "You are helpful")
         XCTAssertTrue(model.sections[1].copyText.contains("\"web_search\""))
         XCTAssertTrue(model.sections[1].copyText.contains("\"max_output_tokens\""))
-        XCTAssertEqual(model.sections[2].copyText, "Write a summary")
+        XCTAssertEqual(model.sections[1].formatLabel, "JSON")
+        XCTAssertTrue(model.sections[2].copyText.contains("\"temperature\""))
+        XCTAssertEqual(model.sections[2].formatLabel, "JSON")
+        XCTAssertEqual(model.sections[3].copyText, "Write a summary")
         XCTAssertTrue(model.bannerText.contains("same order"))
+    }
+
+    func testPromptTabModelUsesLanguageHintForJSONStringSections() {
+        let entry = makeEntry(
+            requestPayload: AnyCodable([:]),
+            requestSections: [
+                LLMContextSection(
+                    kind: .unknown("settings"),
+                    title: "Request settings",
+                    content: AnyCodable("{\"temperature\":0.4,\"top_p\":0.9}"),
+                    language: "json"
+                )
+            ]
+        )
+
+        let model = MessageInspectorPromptTabModel(entry: entry)
+
+        XCTAssertEqual(model.sections[0].presentationStyle, .structured)
+        XCTAssertEqual(model.sections[0].syntaxLanguage, .json)
+        XCTAssertTrue(model.sections[0].displayText.contains("\"temperature\""))
+        XCTAssertEqual(model.sections[0].formatLabel, "JSON")
     }
 
     func testPromptTabModelUsesOnlyNormalizedSectionsAndShowsRawFallback() {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for llm-context-inspector-redesign.md.

**Gap:** Expose structured tool and settings sections in the prompt flow
**What was expected:** Prompt normalization should include structured tool definitions and request settings sections for the prompt tab.
**What was found:** The assistant emits only text-only tool summaries and no structured request settings/config sections, so the prompt tab cannot render them.

🤖 Generated by an AI coding agent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
