### PR TITLE
refactor: extract shared conversation disk-view rebuild helper

### DIFF
--- a/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
@@ -1,0 +1,212 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must come before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "workspace-migration-009-test-"));
+const workspaceDir = join(testDir, "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import { getConversationDirPath } from "../memory/conversation-disk-view.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import {
+  attachments,
+  conversations,
+  messageAttachments,
+  messages,
+} from "../memory/schema.js";
+import { backfillConversationDiskViewMigration } from "../workspace/migrations/009-backfill-conversation-disk-view.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function resetConversationsDir() {
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+}
+
+function seedConversationRows(): {
+  conversationId: string;
+  conversationCreatedAt: number;
+  conversationUpdatedAt: number;
+} {
+  const db = getDb();
+  const conversationId = "conv-009-backfill";
+  const messageId = "msg-009-backfill";
+  const attachmentId = "att-009-backfill";
+  const conversationCreatedAt = Date.parse("2026-03-18T14:23:00.000Z");
+  const messageCreatedAt = Date.parse("2026-03-18T14:24:00.000Z");
+  const conversationUpdatedAt = Date.parse("2026-03-18T14:25:00.000Z");
+
+  db.insert(conversations)
+    .values({
+      id: conversationId,
+      title: "Backfill Test",
+      createdAt: conversationCreatedAt,
+      updatedAt: conversationUpdatedAt,
+      conversationType: "standard",
+      source: "user",
+      memoryScopeId: "default",
+      originChannel: "desktop",
+    })
+    .run();
+
+  db.insert(messages)
+    .values({
+      id: messageId,
+      conversationId,
+      role: "user",
+      content: "Hello from sqlite row",
+      createdAt: messageCreatedAt,
+      metadata: null,
+    })
+    .run();
+
+  db.insert(attachments)
+    .values({
+      id: attachmentId,
+      originalFilename: "note.txt",
+      mimeType: "text/plain",
+      sizeBytes: 11,
+      kind: "document",
+      dataBase64: Buffer.from("hello world").toString("base64"),
+      contentHash: null,
+      thumbnailBase64: null,
+      filePath: null,
+      createdAt: messageCreatedAt,
+    })
+    .run();
+
+  db.insert(messageAttachments)
+    .values({
+      id: "link-009-backfill",
+      messageId,
+      attachmentId,
+      position: 0,
+      createdAt: messageCreatedAt,
+    })
+    .run();
+
+  return { conversationId, conversationCreatedAt, conversationUpdatedAt };
+}
+
+describe("009-backfill-conversation-disk-view migration", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  test("materializes disk view from sqlite-only rows and stays idempotent on rerun", () => {
+    const { conversationId, conversationCreatedAt, conversationUpdatedAt } =
+      seedConversationRows();
+    const conversationDir = getConversationDirPath(
+      conversationId,
+      conversationCreatedAt,
+    );
+    const metaPath = join(conversationDir, "meta.json");
+    const messagesPath = join(conversationDir, "messages.jsonl");
+    const attachmentsDir = join(conversationDir, "attachments");
+
+    // Precondition: only SQLite rows exist, disk view has not been created yet.
+    expect(existsSync(conversationDir)).toBe(false);
+
+    backfillConversationDiskViewMigration.run(workspaceDir);
+
+    expect(existsSync(conversationDir)).toBe(true);
+    expect(existsSync(metaPath)).toBe(true);
+    expect(existsSync(messagesPath)).toBe(true);
+    expect(existsSync(join(attachmentsDir, "note.txt"))).toBe(true);
+
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.id).toBe(conversationId);
+    expect(meta.updatedAt).toBe(new Date(conversationUpdatedAt).toISOString());
+
+    const firstRunLines = readFileSync(messagesPath, "utf-8")
+      .trim()
+      .split("\n");
+    expect(firstRunLines).toHaveLength(1);
+    expect(JSON.parse(firstRunLines[0])).toEqual({
+      role: "user",
+      ts: "2026-03-18T14:24:00.000Z",
+      content: "Hello from sqlite row",
+      attachments: ["note.txt"],
+    });
+
+    backfillConversationDiskViewMigration.run(workspaceDir);
+
+    const secondRunLines = readFileSync(messagesPath, "utf-8")
+      .trim()
+      .split("\n");
+    expect(secondRunLines).toHaveLength(1);
+    expect(JSON.parse(secondRunLines[0])).toEqual(JSON.parse(firstRunLines[0]));
+
+    const attachmentFiles = readdirSync(attachmentsDir).sort();
+    expect(attachmentFiles).toEqual(["note.txt"]);
+    expect(readFileSync(join(attachmentsDir, "note.txt"), "utf-8")).toBe(
+      "hello world",
+    );
+  });
+});

--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -1,98 +1,10 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
-
-import { asc, eq } from "drizzle-orm";
-
-import {
-  getConversationDirPath,
-  initConversationDir,
-  syncMessageToDisk,
-  updateMetaFile,
-} from "../../memory/conversation-disk-view.js";
-import { getDb } from "../../memory/db.js";
-import { conversations, messages } from "../../memory/schema.js";
-import { getLogger } from "../../util/logger.js";
+import { rebuildConversationDiskViewFromDb } from "./rebuild-conversation-disk-view.js";
 import type { WorkspaceMigration } from "./types.js";
-
-const log = getLogger("workspace-migrations");
 
 export const backfillConversationDiskViewMigration: WorkspaceMigration = {
   id: "009-backfill-conversation-disk-view",
   description: "Rebuild conversation disk view for existing conversations",
   run(_workspaceDir: string): void {
-    const db = getDb();
-
-    const allConversations = db
-      .select()
-      .from(conversations)
-      .orderBy(asc(conversations.createdAt))
-      .all();
-
-    const total = allConversations.length;
-    let processed = 0;
-
-    for (const conv of allConversations) {
-      // Check if already migrated (idempotent)
-      const dirPath = getConversationDirPath(conv.id, conv.createdAt);
-      const metaPath = join(dirPath, "meta.json");
-
-      if (existsSync(metaPath)) {
-        try {
-          const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
-          const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
-          if (existing.updatedAt === expectedUpdatedAt) {
-            processed++;
-            if (processed % 50 === 0) {
-              log.info(
-                `Backfilled ${processed}/${total} conversations to disk`,
-              );
-            }
-            continue;
-          }
-        } catch {
-          // meta.json exists but is unreadable/malformed — re-create it
-        }
-      }
-
-      // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
-      initConversationDir(conv);
-
-      // Clear stale data from any previous interrupted run so the append-only
-      // syncMessageToDisk calls below don't produce duplicates.
-      const messagesPath = join(dirPath, "messages.jsonl");
-      if (existsSync(messagesPath)) {
-        rmSync(messagesPath, { force: true });
-      }
-      const attachDir = join(dirPath, "attachments");
-      if (existsSync(attachDir)) {
-        rmSync(attachDir, { recursive: true, force: true });
-      }
-
-      // Query all messages for this conversation and sync each to disk
-      const convMessages = db
-        .select()
-        .from(messages)
-        .where(eq(messages.conversationId, conv.id))
-        .orderBy(asc(messages.createdAt))
-        .all();
-
-      for (const msg of convMessages) {
-        syncMessageToDisk(conv.id, msg.id, conv.createdAt);
-      }
-
-      // Write the real updatedAt only AFTER all messages are synced so the
-      // idempotency check won't skip a conversation with incomplete messages
-      // if the migration is interrupted mid-loop.
-      updateMetaFile(conv);
-
-      processed++;
-      if (processed % 50 === 0) {
-        log.info(`Backfilled ${processed}/${total} conversations to disk`);
-      }
-    }
-
-    if (total > 0) {
-      log.info(`Backfilled ${processed}/${total} conversations to disk`);
-    }
+    rebuildConversationDiskViewFromDb();
   },
 };

--- a/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { asc, eq } from "drizzle-orm";
+
+import {
+  getConversationDirPath,
+  initConversationDir,
+  syncMessageToDisk,
+  updateMetaFile,
+} from "../../memory/conversation-disk-view.js";
+import { getDb } from "../../memory/db.js";
+import { conversations, messages } from "../../memory/schema.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("workspace-migrations");
+
+/**
+ * Rebuild the conversation disk view for all persisted conversations.
+ *
+ * Conversations are processed by ascending createdAt so replay ordering is
+ * stable and deterministic across runs.
+ */
+export function rebuildConversationDiskViewFromDb(): void {
+  const db = getDb();
+
+  const allConversations = db
+    .select()
+    .from(conversations)
+    .orderBy(asc(conversations.createdAt))
+    .all();
+
+  const total = allConversations.length;
+  let processed = 0;
+
+  for (const conv of allConversations) {
+    // Check if already migrated (idempotent)
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const metaPath = join(dirPath, "meta.json");
+
+    if (existsSync(metaPath)) {
+      try {
+        const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
+        const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
+        if (existing.updatedAt === expectedUpdatedAt) {
+          processed++;
+          if (processed % 50 === 0) {
+            log.info(`Backfilled ${processed}/${total} conversations to disk`);
+          }
+          continue;
+        }
+      } catch {
+        // meta.json exists but is unreadable/malformed — re-create it
+      }
+    }
+
+    // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
+    initConversationDir(conv);
+
+    // Clear stale data from any previous interrupted run so the append-only
+    // syncMessageToDisk calls below don't produce duplicates.
+    const messagesPath = join(dirPath, "messages.jsonl");
+    if (existsSync(messagesPath)) {
+      rmSync(messagesPath, { force: true });
+    }
+    const attachDir = join(dirPath, "attachments");
+    if (existsSync(attachDir)) {
+      rmSync(attachDir, { recursive: true, force: true });
+    }
+
+    // Query all messages for this conversation and sync each to disk
+    const convMessages = db
+      .select()
+      .from(messages)
+      .where(eq(messages.conversationId, conv.id))
+      .orderBy(asc(messages.createdAt))
+      .all();
+
+    for (const msg of convMessages) {
+      syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+    }
+
+    // Write the real updatedAt only AFTER all messages are synced so the
+    // idempotency check won't skip a conversation with incomplete messages
+    // if the migration is interrupted mid-loop.
+    updateMetaFile(conv);
+
+    processed++;
+    if (processed % 50 === 0) {
+      log.info(`Backfilled ${processed}/${total} conversations to disk`);
+    }
+  }
+
+  if (total > 0) {
+    log.info(`Backfilled ${processed}/${total} conversations to disk`);
+  }
+}


### PR DESCRIPTION
## Summary
- extract the conversation disk-view rebuild loop into a shared migration helper
- keep migration 009 as a thin wrapper around the shared rebuild implementation
- add focused migration tests for rebuild correctness and idempotency

Part of plan: repair-conversation-disk-view.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
