### PR TITLE
fix: recreate missing conversation disk-view directories during sync

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -69,7 +69,7 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, rawRun, resetDb } from "../memory/db.js";
 
 initializeDb();
 
@@ -240,6 +240,40 @@ describe("updateMetaFile", () => {
     );
 
     rmSync(legacyDirPath, { recursive: true, force: true });
+  });
+
+  test("recreates a missing directory before rewriting meta.json", () => {
+    const created = Date.now();
+    const updated = created + 2500;
+    initConversationDir({
+      id: "conv-update-recreate",
+      title: "Original",
+      createdAt: created,
+      conversationType: "standard",
+      originChannel: null,
+    });
+
+    const dirPath = getConversationDirPath("conv-update-recreate", created);
+    rmSync(dirPath, { recursive: true, force: true });
+
+    updateMetaFile({
+      id: "conv-update-recreate",
+      title: "Recreated",
+      createdAt: created,
+      updatedAt: updated,
+      conversationType: "standard",
+      originChannel: "desktop",
+    });
+
+    expect(existsSync(dirPath)).toBe(true);
+    expect(existsSync(join(dirPath, "meta.json"))).toBe(true);
+
+    const meta = JSON.parse(readFileSync(join(dirPath, "meta.json"), "utf-8"));
+    expect(meta.title).toBe("Recreated");
+    expect(meta.channel).toBe("desktop");
+    expect(meta.updatedAt).toBe(new Date(updated).toISOString());
+
+    rmSync(dirPath, { recursive: true, force: true });
   });
 });
 
@@ -523,6 +557,58 @@ describe("syncMessageToDisk", () => {
     );
 
     rmSync(legacyDirPath, { recursive: true, force: true });
+  });
+
+  test("recreates a missing directory before appending messages and attachments", async () => {
+    const conv = createConversation("Recreate Sync");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const msg = await addMessage(conv.id, "user", "Disk repair", undefined, {
+      skipIndexing: true,
+    });
+    const att = uploadAttachment("repair.png", "image/png", "iVBORw0K");
+    rawRun(
+      `INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      `manual-link-${msg.id}`,
+      msg.id,
+      att.id,
+      0,
+      Date.now(),
+    );
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const legacyDirPath = join(
+      conversationsDir,
+      getLegacyConversationDirName(conv.id, conv.createdAt),
+    );
+    rmSync(dirPath, { recursive: true, force: true });
+    rmSync(legacyDirPath, { recursive: true, force: true });
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    expect(existsSync(dirPath)).toBe(true);
+    expect(existsSync(join(dirPath, "messages.jsonl"))).toBe(true);
+    expect(existsSync(join(dirPath, "attachments", "repair.png"))).toBe(true);
+
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0]);
+    expect(record.content).toBe("Disk repair");
+    expect(record.attachments).toHaveLength(1);
+    expect(existsSync(join(dirPath, "attachments", record.attachments[0]))).toBe(
+      true,
+    );
+
+    rmSync(dirPath, { recursive: true, force: true });
   });
 });
 

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -87,6 +87,15 @@ function resolveConversationDirPath(id: string, createdAtMs: number): string {
   return dirPath;
 }
 
+function ensureConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  const dirPath = resolveConversationDirPath(id, createdAtMs);
+  mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
 // ---------------------------------------------------------------------------
 // Write operations
 // ---------------------------------------------------------------------------
@@ -102,8 +111,7 @@ export function initConversationDir(conv: {
   originChannel: string | null;
 }): void {
   try {
-    const dirPath = resolveConversationDirPath(conv.id, conv.createdAt);
-    mkdirSync(dirPath, { recursive: true });
+    const dirPath = ensureConversationDirPath(conv.id, conv.createdAt);
 
     const meta = {
       id: conv.id,
@@ -138,7 +146,7 @@ export function updateMetaFile(conv: {
   originChannel: string | null;
 }): void {
   try {
-    const dirPath = resolveConversationDirPath(conv.id, conv.createdAt);
+    const dirPath = ensureConversationDirPath(conv.id, conv.createdAt);
 
     const meta = {
       id: conv.id,
@@ -313,7 +321,7 @@ export function syncMessageToDisk(
       return;
     }
 
-    const dirPath = resolveConversationDirPath(conversationId, createdAtMs);
+    const dirPath = ensureConversationDirPath(conversationId, createdAtMs);
     const { content, toolCalls, toolResults } = flattenContentBlocks(
       message.content,
     );


### PR DESCRIPTION
## Summary
- recreate missing conversation disk-view directories before meta and message writes
- preserve existing legacy-directory resolution behavior during repair writes
- add regression coverage for missing-directory repair paths

Part of plan: repair-conversation-disk-view.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
