### PR TITLE
fix: preserve normalized llm context structured fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -218,19 +218,12 @@ struct MessageInspectorResponseTabModel: Equatable {
 
     init(entry: LLMRequestLogEntry) {
         let responseSections = entry.responseSections ?? []
-        let toolNames = Self.extractResponseToolNames(from: entry.responsePayload)
-        let stopReason = Self.extractStopReason(from: entry.responsePayload)
-
         sections = responseSections.enumerated().map { index, section in
-            MessageInspectorResponseSectionModel(
-                index: index,
-                section: section,
-                toolName: toolNames[safe: index]
-            )
+            MessageInspectorResponseSectionModel(index: index, section: section)
         }
 
-        self.stopReason = stopReason
-        responseModeLabel = sections.contains(where: { $0.isToolCallLike })
+        stopReason = entry.summary?.stopReason
+        responseModeLabel = (entry.summary?.responseToolCallCount ?? 0) > 0 || sections.contains(where: { $0.isToolCallLike })
             ? "Tool-calling response"
             : "Text-only response"
         fallbackMessage = sections.isEmpty
@@ -240,130 +233,6 @@ struct MessageInspectorResponseTabModel: Equatable {
 
     var hasNormalizedSections: Bool {
         !sections.isEmpty
-    }
-
-    private static func extractStopReason(from payload: AnyCodable) -> String? {
-        guard let root = payload.value else { return nil }
-
-        if let records = jsonRecords(from: root) {
-            if let reason = stopReason(in: records) {
-                return reason
-            }
-        }
-
-        return nil
-    }
-
-    private static func extractResponseToolNames(from payload: AnyCodable) -> [String] {
-        guard let root = payload.value else { return [] }
-        guard let records = jsonRecords(from: root) else { return [] }
-
-        if let openAiChoices = records["choices"] as? [Any] {
-            return openAiChoices.flatMap { choice -> [String] in
-                guard let choiceRecord = choice as? [String: Any] else { return [] }
-                let message = choiceRecord["message"] as? [String: Any]
-                let toolCalls = message?["tool_calls"] as? [Any]
-                return toolCalls?.compactMap { toolCall in
-                    guard
-                        let toolCallRecord = toolCall as? [String: Any],
-                        let function = toolCallRecord["function"] as? [String: Any],
-                        let toolName = function["name"] as? String,
-                        !toolName.isEmpty
-                    else {
-                        return nil
-                    }
-                    return toolName
-                } ?? []
-            }
-        }
-
-        if let content = records["content"] as? [Any] {
-            return content.compactMap { block in
-                guard
-                    let blockRecord = block as? [String: Any],
-                    let type = blockRecord["type"] as? String,
-                    type == "tool_use",
-                    let toolName = blockRecord["name"] as? String,
-                    !toolName.isEmpty
-                else {
-                    return nil
-                }
-                return toolName
-            }
-        }
-
-        if let functionCalls = records["functionCalls"] as? [Any] {
-            return functionCalls.compactMap { call in
-                guard
-                    let callRecord = call as? [String: Any],
-                    let toolName = callRecord["name"] as? String,
-                    !toolName.isEmpty
-                else {
-                    return nil
-                }
-                return toolName
-            }
-        }
-
-        if let candidates = records["candidates"] as? [Any] {
-            return candidates.compactMap { candidate in
-                guard let candidateRecord = candidate as? [String: Any] else { return nil }
-                if let functionCalls = candidateRecord["functionCalls"] as? [Any] {
-                    return functionCalls.compactMap { call in
-                        guard
-                            let callRecord = call as? [String: Any],
-                            let toolName = callRecord["name"] as? String,
-                            !toolName.isEmpty
-                        else {
-                            return nil
-                        }
-                        return toolName
-                    }
-                    .first
-                }
-                return nil
-            }
-            .compactMap { $0 }
-        }
-
-        return []
-    }
-
-    private static func stopReason(in record: [String: Any]) -> String? {
-        if let finishReason = record["finishReason"] as? String, !finishReason.isEmpty {
-            return finishReason
-        }
-
-        if let stopReason = record["stop_reason"] as? String, !stopReason.isEmpty {
-            return stopReason
-        }
-
-        if let choices = record["choices"] as? [Any] {
-            for choice in choices {
-                guard let choiceRecord = choice as? [String: Any] else { continue }
-                if let finishReason = choiceRecord["finish_reason"] as? String, !finishReason.isEmpty {
-                    return finishReason
-                }
-                if let finishReason = choiceRecord["finishReason"] as? String, !finishReason.isEmpty {
-                    return finishReason
-                }
-            }
-        }
-
-        if let candidates = record["candidates"] as? [Any] {
-            for candidate in candidates {
-                guard let candidateRecord = candidate as? [String: Any] else { continue }
-                if let finishReason = candidateRecord["finishReason"] as? String, !finishReason.isEmpty {
-                    return finishReason
-                }
-            }
-        }
-
-        return nil
-    }
-
-    private static func jsonRecords(from root: Any) -> [String: Any]? {
-        root as? [String: Any]
     }
 }
 
@@ -383,42 +252,42 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
     let presentationKind: PresentationKind
     let isToolCallLike: Bool
 
-    init(index: Int, section: LLMContextSection, toolName: String?) {
+    init(index: Int, section: LLMContextSection) {
         id = index
-        self.toolName = toolName
+        toolName = section.toolName
 
-        let rawKind = section.kind.rawValue.lowercased()
-        let displayTitle = section.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayTitle = section.label.trimmingCharacters(in: .whitespacesAndNewlines)
         let fallbackTitle = "Section \(index + 1)"
-        title = displayTitle?.isEmpty == false ? displayTitle! : fallbackTitle
+        title = displayTitle.isEmpty ? fallbackTitle : displayTitle
 
-        switch rawKind {
-        case "tool", "tool_use", "function_call":
+        switch section.kind {
+        case .tool, .toolUse, .functionCall:
             presentationKind = .toolCall
             isToolCallLike = true
             kindLabel = "Tool call"
-            let preview = Self.previewText(for: section.content)
+            let preview = section.text ?? Self.previewText(for: section.data)
             bodyText = preview
-            let copySource = preview ?? section.stringContent ?? title
+            let copySource = preview ?? title
             copyText = copySource
-        case "tool_result":
+        case .toolResult, .functionResponse:
             presentationKind = .other
             isToolCallLike = true
-            kindLabel = "Tool result"
-            let preview = Self.previewText(for: section.content)
+            kindLabel = section.kind == .functionResponse ? "Function response" : "Tool result"
+            let preview = section.text ?? Self.previewText(for: section.data)
             bodyText = preview
-            copyText = preview ?? section.stringContent ?? title
-        case "assistant", "message", "text", "output", "completion", "reasoning", "markdown", "code", "json":
+            copyText = preview ?? title
+        case .assistant, .message, .text, .output, .completion, .reasoning, .markdown, .code, .json:
             presentationKind = .assistantText
             isToolCallLike = false
             kindLabel = "Assistant text"
-            bodyText = section.stringContent ?? Self.previewText(for: section.content)
+            bodyText = section.text ?? Self.previewText(for: section.data)
             copyText = bodyText ?? title
         default:
-            presentationKind = section.stringContent == nil ? .other : .assistantText
+            let preview = section.text ?? Self.previewText(for: section.data)
+            presentationKind = preview == nil ? .other : .assistantText
             isToolCallLike = false
             kindLabel = section.kind.rawValue
-            bodyText = section.stringContent ?? Self.previewText(for: section.content)
+            bodyText = preview
             copyText = bodyText ?? title
         }
     }
@@ -427,8 +296,8 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         presentationKind == .toolCall
     }
 
-    private static func previewText(for content: AnyCodable?) -> String? {
-        guard let value = content?.value else { return nil }
+    private static func previewText(for data: AnyCodable?) -> String? {
+        guard let value = data?.value else { return nil }
 
         if let string = value as? String {
             return string
@@ -460,11 +329,5 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         }
 
         return nil
-    }
-}
-
-private extension Collection {
-    subscript(safe index: Index) -> Element? {
-        indices.contains(index) ? self[index] : nil
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
@@ -19,7 +19,7 @@ final class MessageInspectorPromptTabTests: XCTestCase {
                     content: AnyCodable("You are helpful")
                 ),
                 LLMContextSection(
-                    kind: .unknown("tool_definitions"),
+                    kind: .toolDefinitions,
                     title: "Available tools",
                     content: AnyCodable([
                         "tools": [

--- a/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
@@ -4,21 +4,21 @@ import XCTest
 @testable import VellumAssistantShared
 
 final class MessageInspectorResponseTabTests: XCTestCase {
-    func testResponseTabModelSeparatesAssistantTextAndToolCalls() {
+    func testResponseTabModelUsesNormalizedResponseSectionsAndSummaryFields() {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(
                 responsePayload: AnyCodable([
                     "choices": [
                         [
-                            "finish_reason": "tool_calls",
+                            "finish_reason": "stop",
                             "message": [
                                 "role": "assistant",
-                                "content": "Hello there!",
+                                "content": "Raw payload should not win",
                                 "tool_calls": [
                                     [
                                         "function": [
-                                            "name": "search_web",
-                                            "arguments": "{\"query\":\"docs\",\"limit\":3}"
+                                            "name": "wrong_tool_name",
+                                            "arguments": "{\"query\":\"wrong\"}"
                                         ]
                                     ]
                                 ]
@@ -26,21 +26,27 @@ final class MessageInspectorResponseTabTests: XCTestCase {
                         ]
                     ]
                 ]),
+                summary: LLMCallSummary(
+                    stopReason: "tool_calls",
+                    responseToolCallCount: 1
+                ),
                 responseSections: [
                     LLMContextSection(
-                        kind: .unknown("message"),
-                        title: "Assistant response",
-                        content: AnyCodable("Hello there!"),
-                        language: "text"
+                        kind: .message,
+                        label: "Assistant response",
+                        role: "assistant",
+                        text: "Hello there!"
                     ),
                     LLMContextSection(
-                        kind: .unknown("function_call"),
-                        title: "Response tool call 1",
-                        content: AnyCodable([
+                        kind: .functionCall,
+                        label: "Response tool call 1",
+                        role: "assistant",
+                        text: "{\"query\":\"docs\",\"limit\":3}",
+                        toolName: "search_web",
+                        data: AnyCodable([
                             "query": "docs",
                             "limit": 3
-                        ]),
-                        language: "json"
+                        ])
                     )
                 ]
             )
@@ -69,8 +75,9 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(
                 responsePayload: AnyCodable([
-                    "stop_reason": "end_turn"
+                    "stop_reason": "tool_use"
                 ]),
+                summary: LLMCallSummary(stopReason: "end_turn"),
                 responseSections: nil
             )
         )
@@ -83,6 +90,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
 
     private func makeEntry(
         responsePayload: AnyCodable,
+        summary: LLMCallSummary? = nil,
         responseSections: [LLMContextSection]?
     ) -> LLMRequestLogEntry {
         LLMRequestLogEntry(
@@ -90,7 +98,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
             requestPayload: AnyCodable(["type": "request"]),
             responsePayload: responsePayload,
             createdAt: 1_000,
-            summary: nil,
+            summary: summary,
             requestSections: nil,
             responseSections: responseSections
         )

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -119,11 +119,36 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
 /// A normalized section inside the request or response payload.
 public struct LLMContextSection: Codable, Sendable, Equatable {
     public let kind: LLMContextSectionKind
-    public let title: String?
-    public let content: AnyCodable?
+    public let label: String
+    public let role: String?
+    public let text: String?
+    public let toolName: String?
+    public let data: AnyCodable?
     public let language: String?
     public let collapsedByDefault: Bool?
 
+    public init(
+        kind: LLMContextSectionKind,
+        label: String,
+        role: String? = nil,
+        text: String? = nil,
+        toolName: String? = nil,
+        data: AnyCodable? = nil,
+        language: String? = nil,
+        collapsedByDefault: Bool? = nil
+    ) {
+        self.kind = kind
+        self.label = label
+        self.role = role
+        self.text = text
+        self.toolName = toolName
+        self.data = data
+        self.language = language
+        self.collapsedByDefault = collapsedByDefault
+    }
+
+    /// Compatibility initializer for existing Apple-client call sites that still construct sections
+    /// with the older title/content shape.
     public init(
         kind: LLMContextSectionKind,
         title: String? = nil,
@@ -131,41 +156,100 @@ public struct LLMContextSection: Codable, Sendable, Equatable {
         language: String? = nil,
         collapsedByDefault: Bool? = nil
     ) {
-        self.kind = kind
-        self.title = title
-        self.content = content
-        self.language = language
-        self.collapsedByDefault = collapsedByDefault
+        self.init(
+            kind: kind,
+            label: title ?? Self.defaultLabel(for: kind),
+            role: nil,
+            text: content?.value as? String,
+            toolName: nil,
+            data: (content?.value as? String) == nil ? content : nil,
+            language: language,
+            collapsedByDefault: collapsedByDefault
+        )
     }
 
-    /// String form of the section content when the payload uses text.
+    /// Compatibility alias for older call sites while the Apple clients finish migrating.
+    public var title: String? {
+        label
+    }
+
+    /// Compatibility alias that prefers structured data when available.
+    public var content: AnyCodable? {
+        data ?? text.map(AnyCodable.init)
+    }
+
+    /// String form of the normalized text field, with a fallback for string-backed data.
     public var stringContent: String? {
-        content?.value as? String
+        text ?? (data?.value as? String)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: LLMContextCodingKey.self)
         let kindRaw = container.decodeString(for: ["kind", "type", "role"]) ?? "unknown"
         kind = LLMContextSectionKind(rawValue: kindRaw)
-        title = container.decodeString(for: ["title", "label", "name", "heading"])
-        content = container.decodeAnyCodable(for: ["content", "text", "value", "body", "payload", "data"])
+        label = container.decodeString(for: ["label", "title", "name", "heading"])
+            ?? Self.defaultLabel(for: kind)
+        role = container.decodeString(for: ["role"])
+        toolName = container.decodeString(for: ["toolName", "tool_name"])
         language = container.decodeString(for: ["language", "syntax", "format"])
         collapsedByDefault = container.decodeBool(for: ["collapsedByDefault", "collapsed"])
+
+        let legacyContent = container.decodeAnyCodable(for: ["content", "body", "value", "payload"])
+        if let explicitText = container.decodeString(for: ["text"]) {
+            text = explicitText
+        } else if let legacyString = legacyContent?.value as? String {
+            text = legacyString
+        } else {
+            text = nil
+        }
+
+        data = container.decodeAnyCodable(for: ["data"])
+            ?? ((legacyContent?.value as? String) == nil ? legacyContent : nil)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: LLMContextCodingKey.self)
         try container.encode(kind, forKey: LLMContextCodingKey.key("kind"))
-        try container.encodeIfPresent(title, forKey: "title")
-        try container.encodeIfPresent(content, forKey: "content")
+        try container.encode(label, forKey: LLMContextCodingKey.key("label"))
+        try container.encodeIfPresent(role, forKey: "role")
+        try container.encodeIfPresent(text, forKey: "text")
+        try container.encodeIfPresent(toolName, forKey: "toolName")
+        try container.encodeIfPresent(data, forKey: "data")
         try container.encodeIfPresent(language, forKey: "language")
         try container.encodeIfPresent(collapsedByDefault, forKey: "collapsedByDefault")
+    }
+
+    private static func defaultLabel(for kind: LLMContextSectionKind) -> String {
+        switch kind {
+        case .system:
+            return "System prompt"
+        case .message:
+            return "Message"
+        case .toolDefinitions:
+            return "Available tools"
+        case .toolUse:
+            return "Tool use"
+        case .toolResult:
+            return "Tool result"
+        case .functionCall:
+            return "Function call"
+        case .functionResponse:
+            return "Function response"
+        default:
+            return "Section"
+        }
     }
 }
 
 /// Section kind values returned by the normalized LLM context response.
 public enum LLMContextSectionKind: Sendable, Codable, Equatable, CustomStringConvertible {
     case system
+    case message
+    case toolDefinitions
+    case toolUse
+    case toolResult
+    case functionCall
+    case functionResponse
     case user
     case assistant
     case tool
@@ -187,6 +271,12 @@ public enum LLMContextSectionKind: Sendable, Codable, Equatable, CustomStringCon
     public var rawValue: String {
         switch self {
         case .system: return "system"
+        case .message: return "message"
+        case .toolDefinitions: return "tool_definitions"
+        case .toolUse: return "tool_use"
+        case .toolResult: return "tool_result"
+        case .functionCall: return "function_call"
+        case .functionResponse: return "function_response"
         case .user: return "user"
         case .assistant: return "assistant"
         case .tool: return "tool"
@@ -215,6 +305,18 @@ public enum LLMContextSectionKind: Sendable, Codable, Equatable, CustomStringCon
         switch rawValue.lowercased() {
         case "system":
             self = .system
+        case "message":
+            self = .message
+        case "tool_definitions":
+            self = .toolDefinitions
+        case "tool_use":
+            self = .toolUse
+        case "tool_result":
+            self = .toolResult
+        case "function_call":
+            self = .functionCall
+        case "function_response":
+            self = .functionResponse
         case "user":
             self = .user
         case "assistant":

--- a/clients/shared/Tests/LLMContextClientDecodingTests.swift
+++ b/clients/shared/Tests/LLMContextClientDecodingTests.swift
@@ -38,58 +38,65 @@ final class LLMContextClientDecodingTests: XCTestCase {
         XCTAssertNil(entry.responseSections)
     }
 
-    func testEnrichedPayloadDecodesAllNormalizedFields() throws {
+    func testAssistantEmittedOpenAiSectionsDecodeWithStructuredFieldsIntact() throws {
         let response = try decodeResponse(
             #"""
             {
-              "messageId": "msg-enriched",
+              "messageId": "msg-openai",
               "logs": [
                 {
-                  "id": "log-2",
+                  "id": "log-openai",
                   "requestPayload": {
-                    "type": "request",
-                    "messages": [
-                      { "role": "user", "content": "Hello" }
-                    ]
+                    "model": "gpt-4.1",
+                    "messages": [{ "role": "user", "content": "Hello" }]
                   },
                   "responsePayload": {
-                    "type": "response",
-                    "text": "Hi there"
+                    "model": "gpt-4.1-2026-03-01",
+                    "choices": [{ "finish_reason": "tool_calls" }]
                   },
                   "createdAt": 2233445566,
                   "summary": {
-                    "title": "Chat completion",
-                    "subtitle": "gpt-4.1",
-                    "summary": "Answered the user",
-                    "model": "gpt-4.1",
                     "provider": "openai",
-                    "status": "success",
+                    "model": "gpt-4.1-2026-03-01",
                     "inputTokens": 42,
                     "outputTokens": 17,
-                    "durationMs": 250,
-                    "ignoredSummaryKey": true
+                    "stopReason": "tool_calls",
+                    "requestMessageCount": 1,
+                    "requestToolCount": 2,
+                    "responseMessageCount": 1,
+                    "responseToolCallCount": 1,
+                    "responsePreview": "Hi there",
+                    "toolCallNames": ["search_web"]
                   },
                   "requestSections": [
                     {
                       "kind": "system",
-                      "title": "System",
-                      "content": "You are helpful",
-                      "language": "markdown",
-                      "collapsedByDefault": true,
-                      "ignoredSectionKey": "ignored"
+                      "label": "System prompt",
+                      "role": "system",
+                      "text": "You are helpful"
                     },
                     {
-                      "kind": "prompt",
-                      "title": "Prompt",
-                      "content": "Write a reply"
+                      "kind": "tool_definitions",
+                      "label": "Available tools",
+                      "text": "search_web, lookup_docs"
                     }
                   ],
                   "responseSections": [
                     {
-                      "kind": "assistant",
-                      "title": "Assistant",
-                      "content": "Hi there",
-                      "language": "text"
+                      "kind": "message",
+                      "label": "Assistant response",
+                      "role": "assistant",
+                      "text": "Hi there"
+                    },
+                    {
+                      "kind": "function_call",
+                      "label": "Response tool call 1",
+                      "role": "assistant",
+                      "toolName": "search_web",
+                      "text": "{\"query\":\"docs\"}",
+                      "data": {
+                        "query": "docs"
+                      }
                     }
                   ]
                 }
@@ -100,33 +107,141 @@ final class LLMContextClientDecodingTests: XCTestCase {
 
         let entry = try XCTUnwrap(response.logs.first)
         let summary = try XCTUnwrap(entry.summary)
-        XCTAssertEqual(summary.title, "Chat completion")
-        XCTAssertEqual(summary.subtitle, "gpt-4.1")
-        XCTAssertEqual(summary.summaryText, "Answered the user")
-        XCTAssertEqual(summary.model, "gpt-4.1")
         XCTAssertEqual(summary.provider, "openai")
-        XCTAssertEqual(summary.status, "success")
+        XCTAssertEqual(summary.model, "gpt-4.1-2026-03-01")
         XCTAssertEqual(summary.inputTokens, 42)
         XCTAssertEqual(summary.outputTokens, 17)
-        XCTAssertEqual(summary.durationMs, 250)
+        XCTAssertEqual(summary.stopReason, "tool_calls")
+        XCTAssertEqual(summary.toolCallNames, ["search_web"])
 
         let requestSections = try XCTUnwrap(entry.requestSections)
         XCTAssertEqual(requestSections.count, 2)
         XCTAssertEqual(requestSections[0].kind, .system)
-        XCTAssertEqual(requestSections[0].title, "System")
-        XCTAssertEqual(requestSections[0].stringContent, "You are helpful")
-        XCTAssertEqual(requestSections[0].language, "markdown")
-        XCTAssertEqual(requestSections[0].collapsedByDefault, true)
-        XCTAssertEqual(requestSections[1].kind, .prompt)
-        XCTAssertEqual(requestSections[1].title, "Prompt")
-        XCTAssertEqual(requestSections[1].stringContent, "Write a reply")
+        XCTAssertEqual(requestSections[0].label, "System prompt")
+        XCTAssertEqual(requestSections[0].role, "system")
+        XCTAssertEqual(requestSections[0].text, "You are helpful")
+        XCTAssertNil(requestSections[0].toolName)
+        XCTAssertNil(requestSections[0].data)
+
+        XCTAssertEqual(requestSections[1].kind, .toolDefinitions)
+        XCTAssertEqual(requestSections[1].label, "Available tools")
+        XCTAssertEqual(requestSections[1].text, "search_web, lookup_docs")
 
         let responseSections = try XCTUnwrap(entry.responseSections)
-        XCTAssertEqual(responseSections.count, 1)
-        XCTAssertEqual(responseSections[0].kind, .assistant)
-        XCTAssertEqual(responseSections[0].title, "Assistant")
-        XCTAssertEqual(responseSections[0].stringContent, "Hi there")
-        XCTAssertEqual(responseSections[0].language, "text")
+        XCTAssertEqual(responseSections.count, 2)
+        XCTAssertEqual(responseSections[0].kind, .message)
+        XCTAssertEqual(responseSections[0].label, "Assistant response")
+        XCTAssertEqual(responseSections[0].role, "assistant")
+        XCTAssertEqual(responseSections[0].text, "Hi there")
+
+        XCTAssertEqual(responseSections[1].kind, .functionCall)
+        XCTAssertEqual(responseSections[1].label, "Response tool call 1")
+        XCTAssertEqual(responseSections[1].role, "assistant")
+        XCTAssertEqual(responseSections[1].text, "{\"query\":\"docs\"}")
+        XCTAssertEqual(responseSections[1].toolName, "search_web")
+        XCTAssertEqual(responseSections[1].data, AnyCodable(["query": "docs"]))
+    }
+
+    func testAssistantEmittedAnthropicAndGeminiKindsDecodeWithoutCollapsingFields() throws {
+        let response = try decodeResponse(
+            #"""
+            {
+              "messageId": "msg-mixed",
+              "logs": [
+                {
+                  "id": "log-anthropic",
+                  "requestPayload": { "messages": [] },
+                  "responsePayload": { "content": [] },
+                  "createdAt": 99887766,
+                  "summary": {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "cacheCreationInputTokens": 200,
+                    "cacheReadInputTokens": 80,
+                    "stopReason": "tool_use"
+                  },
+                  "requestSections": [
+                    {
+                      "kind": "tool_use",
+                      "label": "Assistant message 2 tool use",
+                      "role": "assistant",
+                      "toolName": "web_search",
+                      "text": "{\"query\":\"vellum changelog\"}",
+                      "data": {
+                        "query": "vellum changelog"
+                      }
+                    }
+                  ],
+                  "responseSections": [
+                    {
+                      "kind": "tool_result",
+                      "label": "Assistant response tool result",
+                      "role": "assistant",
+                      "toolName": "fetch_page",
+                      "text": "[Web search results]"
+                    }
+                  ]
+                },
+                {
+                  "id": "log-gemini",
+                  "requestPayload": { "contents": [] },
+                  "responsePayload": { "text": "done" },
+                  "createdAt": 99887767,
+                  "summary": {
+                    "provider": "gemini",
+                    "model": "gemini-3-flash-001",
+                    "stopReason": "STOP"
+                  },
+                  "requestSections": [
+                    {
+                      "kind": "function_response",
+                      "label": "User message 1 function response",
+                      "role": "user",
+                      "toolName": "read_file",
+                      "text": "{\"output\":\"Long file body\"}",
+                      "data": {
+                        "output": "Long file body"
+                      }
+                    }
+                  ],
+                  "responseSections": [
+                    {
+                      "kind": "function_call",
+                      "label": "Response function call 1",
+                      "role": "model",
+                      "toolName": "save_note",
+                      "text": "{\"title\":\"brief\"}",
+                      "data": {
+                        "title": "brief"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """#
+        )
+
+        let anthropic = response.logs[0]
+        XCTAssertEqual(anthropic.summary?.provider, "anthropic")
+        XCTAssertEqual(anthropic.summary?.cacheCreationInputTokens, 200)
+        XCTAssertEqual(anthropic.summary?.cacheReadInputTokens, 80)
+        XCTAssertEqual(anthropic.requestSections?.first?.kind, .toolUse)
+        XCTAssertEqual(anthropic.requestSections?.first?.toolName, "web_search")
+        XCTAssertEqual(anthropic.requestSections?.first?.data, AnyCodable(["query": "vellum changelog"]))
+        XCTAssertEqual(anthropic.responseSections?.first?.kind, .toolResult)
+        XCTAssertEqual(anthropic.responseSections?.first?.text, "[Web search results]")
+
+        let gemini = response.logs[1]
+        XCTAssertEqual(gemini.summary?.provider, "gemini")
+        XCTAssertEqual(gemini.requestSections?.first?.kind, .functionResponse)
+        XCTAssertEqual(gemini.requestSections?.first?.role, "user")
+        XCTAssertEqual(gemini.requestSections?.first?.toolName, "read_file")
+        XCTAssertEqual(gemini.requestSections?.first?.data, AnyCodable(["output": "Long file body"]))
+        XCTAssertEqual(gemini.responseSections?.first?.kind, .functionCall)
+        XCTAssertEqual(gemini.responseSections?.first?.role, "model")
+        XCTAssertEqual(gemini.responseSections?.first?.toolName, "save_note")
+        XCTAssertEqual(gemini.responseSections?.first?.data, AnyCodable(["title": "brief"]))
     }
 
     func testUnknownSectionKindsAndExtraKeysDecodeWithoutFailure() throws {
@@ -147,17 +262,21 @@ final class LLMContextClientDecodingTests: XCTestCase {
                   "requestSections": [
                     {
                       "kind": "future_kind",
-                      "title": "Future request",
-                      "content": "Raw future content",
-                      "unexpectedNestedValue": { "ignored": true }
+                      "label": "Future request",
+                      "role": "planner",
+                      "text": "Raw future content",
+                      "data": {
+                        "nested": true
+                      }
                     }
                   ],
                   "responseSections": [
                     {
                       "kind": "future_response_kind",
-                      "title": "Future response",
-                      "content": "Result",
-                      "unexpectedArray": [1, 2, 3]
+                      "label": "Future response",
+                      "toolName": "future_tool",
+                      "data": [1, 2, 3],
+                      "unexpectedArray": [4, 5, 6]
                     }
                   ],
                   "extraTopLevelField": "ignored"
@@ -173,13 +292,16 @@ final class LLMContextClientDecodingTests: XCTestCase {
 
         let requestSection = try XCTUnwrap(entry.requestSections?.first)
         XCTAssertEqual(requestSection.kind, .unknown("future_kind"))
-        XCTAssertEqual(requestSection.title, "Future request")
-        XCTAssertEqual(requestSection.stringContent, "Raw future content")
+        XCTAssertEqual(requestSection.label, "Future request")
+        XCTAssertEqual(requestSection.role, "planner")
+        XCTAssertEqual(requestSection.text, "Raw future content")
+        XCTAssertEqual(requestSection.data, AnyCodable(["nested": true]))
 
         let responseSection = try XCTUnwrap(entry.responseSections?.first)
         XCTAssertEqual(responseSection.kind, .unknown("future_response_kind"))
-        XCTAssertEqual(responseSection.title, "Future response")
-        XCTAssertEqual(responseSection.stringContent, "Result")
+        XCTAssertEqual(responseSection.label, "Future response")
+        XCTAssertEqual(responseSection.toolName, "future_tool")
+        XCTAssertEqual(responseSection.data, AnyCodable([1, 2, 3]))
     }
 
     private func decodeResponse(_ json: String) throws -> LLMContextResponse {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for llm-context-inspector-redesign.md.

**Gap:** Preserve normalized LLM context structured fields end-to-end
**What was expected:** Shared models preserve normalized section fields and the response tab consumes them directly.
**What was found:** Shared decoding drops structured section fields and the response tab reparses raw payloads, causing incorrect tool-name mapping.

🤖 Generated by an AI coding agent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
