### PR TITLE
Close remaining slash command consistency gaps

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -330,10 +330,18 @@ struct ChatContentView: View {
         if let parsedEntries = CommandListBubble.parsedEntries(from: message.text) {
             CommandListBubble(commands: parsedEntries)
         } else {
-            var fallbackMessage = message
-            fallbackMessage.commandList = nil
-            regularMessageBubble(message: fallbackMessage, index: index, messages: messages)
+            regularMessageBubble(
+                message: commandListFallbackMessage(from: message),
+                index: index,
+                messages: messages
+            )
         }
+    }
+
+    private func commandListFallbackMessage(from message: ChatMessage) -> ChatMessage {
+        var fallbackMessage = message
+        fallbackMessage.commandList = nil
+        return fallbackMessage
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1423,10 +1423,8 @@ private struct MessageCellView: View, Equatable {
         if let commandEntries = CommandListBubble.parsedEntries(from: message.text) {
             CommandListBubble(commands: commandEntries)
         } else {
-            var fallbackMessage = message
-            fallbackMessage.commandList = nil
             ChatBubble(
-                message: fallbackMessage,
+                message: commandListFallbackMessage(from: message),
                 decidedConfirmation: nextDecidedConfirmation,
                 onSurfaceAction: onSurfaceAction,
                 onDismissDocumentWidget: { surfaceId in
@@ -1453,6 +1451,12 @@ private struct MessageCellView: View, Equatable {
                 activeSurfaceId: activeSurfaceId
             )
         }
+    }
+
+    private func commandListFallbackMessage(from message: ChatMessage) -> ChatMessage {
+        var fallbackMessage = message
+        fallbackMessage.commandList = nil
+        return fallbackMessage
     }
 
     @ViewBuilder

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1257,12 +1257,11 @@ public final class ChatViewModel: ObservableObject {
         let attachments = pendingAttachments
         pendingAttachments = []
 
-        let hasRecognizedSlashCommand = ChatSlashCommandCatalog.isRecognizedSlashCommand(
-            text,
-            platform: sendPathPlatform,
-            surface: .sendPath
+        let shouldBypassWorkspaceRefinement = ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: text,
+            platform: sendPathPlatform
         )
-        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !hasRecognizedSlashCommand
+        let isWorkspaceRefinement = activeSurfaceId != nil && !isChatDockedToSide && !shouldBypassWorkspaceRefinement
 
         let willBeQueued = isSending && conversationId != nil
         var queuedMessageId: UUID?
@@ -2884,39 +2883,6 @@ public final class ChatViewModel: ObservableObject {
             activeSubagents.append(info)
         }
 
-        // Tag assistant messages that follow "/models" user messages
-        // so the client renders the table UI instead of plain text.
-        var hasModelCommand = false
-        for i in chatMessages.indices {
-            guard chatMessages[i].role == .user,
-                  i + 1 < chatMessages.count && chatMessages[i + 1].role == .assistant else { continue }
-            let userText = chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if userText == "/models" {
-                chatMessages[i + 1].modelList = ModelListData()
-                hasModelCommand = true
-            } else if userText == "/commands" {
-                chatMessages[i + 1].commandList = CommandListData()
-            }
-        }
-        // Refresh model/provider state so the picker/table has correct data on restart
-        if hasModelCommand {
-            Task {
-                let info = await SettingsClient().fetchModelInfo()
-                if let model = info?.model {
-                    self.selectedModel = model
-                }
-                if let providers = info?.configuredProviders {
-                    self.configuredProviders = Set(providers)
-                }
-                if let allProviders = info?.allProviders, !allProviders.isEmpty {
-                    self.providerCatalog = allProviders
-                }
-                if let maskedKeys = info?.maskedKeys {
-                    self.providerMaskedKeys = maskedKeys
-                }
-            }
-        }
-
         // Update daemon pagination cursor from the response metadata.
         self.hasMoreHistory = hasMore
         self.historyCursor = oldestTimestamp
@@ -2928,7 +2894,9 @@ public final class ChatViewModel: ObservableObject {
             // Flush any buffered partial output before prepending — the prepend
             // shifts positional indices so stale buffer entries would corrupt.
             flushPartialOutputBuffer()
-            self.messages = chatMessages + self.messages
+            var mergedMessages = chatMessages + self.messages
+            let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
+            self.messages = mergedMessages
             // Expand the display window by the number of messages prepended so
             // the user sees them immediately. Use Int.max if no more pages exist.
             if hasMore {
@@ -2942,6 +2910,7 @@ public final class ChatViewModel: ObservableObject {
             self.loadMoreTimeoutTask = nil
             self.isLoadingMoreMessages = false
             trimOldMessagesIfNeeded()
+            refreshModelMetadataIfNeeded(hasModelCommand)
             return
         }
 
@@ -2987,9 +2956,12 @@ public final class ChatViewModel: ObservableObject {
                 }
                 if !isDuplicate { localOnly.append(local) }
             }
-            self.messages = chatMessages + localOnly
+            var mergedMessages = chatMessages + localOnly
+            let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
+            self.messages = mergedMessages
             self.reconnectLatchTimeoutTask?.cancel()
             self.isReconnectHistoryLoading = false
+            refreshModelMetadataIfNeeded(hasModelCommand)
         } else if messages.contains(where: { $0.role == .user }) {
             // History arrived after the user already sent messages.
             // The history payload includes ALL persisted messages — including
@@ -3004,9 +2976,15 @@ public final class ChatViewModel: ObservableObject {
             } else {
                 uniqueHistory = chatMessages
             }
-            self.messages = uniqueHistory + self.messages
+            var mergedMessages = uniqueHistory + self.messages
+            let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
+            self.messages = mergedMessages
+            refreshModelMetadataIfNeeded(hasModelCommand)
         } else {
-            self.messages = chatMessages
+            var taggedMessages = chatMessages
+            let hasModelCommand = applyHistoryResponseMarkers(to: &taggedMessages)
+            self.messages = taggedMessages
+            refreshModelMetadataIfNeeded(hasModelCommand)
         }
         self.isLoadingHistory = false
         self.isHistoryLoaded = true
@@ -3017,6 +2995,48 @@ public final class ChatViewModel: ObservableObject {
         trimOldMessagesIfNeeded()
         // Fetch pending guardian prompts when history loads (conversation open/restore)
         refreshGuardianPrompts()
+    }
+
+    private func applyHistoryResponseMarkers(to chatMessages: inout [ChatMessage]) -> Bool {
+        var hasModelCommand = false
+
+        for i in chatMessages.indices {
+            guard chatMessages[i].role == .user,
+                  i + 1 < chatMessages.count,
+                  chatMessages[i + 1].role == .assistant else {
+                continue
+            }
+
+            let userText = chatMessages[i].text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if userText == "/models" {
+                chatMessages[i + 1].modelList = ModelListData()
+                hasModelCommand = true
+            } else if userText == "/commands" {
+                chatMessages[i + 1].commandList = CommandListData()
+            }
+        }
+
+        return hasModelCommand
+    }
+
+    private func refreshModelMetadataIfNeeded(_ shouldRefresh: Bool) {
+        guard shouldRefresh else { return }
+
+        Task {
+            let info = await SettingsClient().fetchModelInfo()
+            if let model = info?.model {
+                self.selectedModel = model
+            }
+            if let providers = info?.configuredProviders {
+                self.configuredProviders = Set(providers)
+            }
+            if let allProviders = info?.allProviders, !allProviders.isEmpty {
+                self.providerCatalog = allProviders
+            }
+            if let maskedKeys = info?.maskedKeys {
+                self.providerMaskedKeys = maskedKeys
+            }
+        }
     }
 
     deinit {

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -19,9 +19,23 @@ public struct CommandListBubble: View {
     }
 
     public static func parsedEntries(from assistantText: String) -> [CommandEntry]? {
-        let commands = assistantText
-            .split(whereSeparator: \.isNewline)
-            .compactMap(parseEntry(from:))
+        var commands: [CommandEntry] = []
+
+        for rawLine in assistantText.split(
+            omittingEmptySubsequences: false,
+            whereSeparator: \.isNewline
+        ) {
+            let trimmed = String(rawLine).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if trimmed.caseInsensitiveCompare("COMMANDS") == .orderedSame {
+                continue
+            }
+            guard let entry = parseEntry(from: Substring(trimmed)) else {
+                return nil
+            }
+            commands.append(entry)
+        }
+
         return commands.isEmpty ? nil : commands
     }
 
@@ -69,14 +83,17 @@ public struct CommandListBubble: View {
         guard !trimmed.isEmpty else { return nil }
 
         let stripped = trimmed.trimmingLeadingListMarker()
-        guard stripped.hasPrefix("/") else { return nil }
+        let unwrapped = stripped.trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+        guard unwrapped.hasPrefix("/") else { return nil }
 
-        let commandEnd = stripped.firstIndex(where: { $0.isWhitespace || $0 == "-" || $0 == "–" || $0 == "—" || $0 == ":" }) ?? stripped.endIndex
-        let commandToken = String(stripped[..<commandEnd]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+        let commandEnd = unwrapped.firstIndex(where: {
+            $0.isWhitespace || $0 == "-" || $0 == "–" || $0 == "—" || $0 == ":" || $0 == "`"
+        }) ?? unwrapped.endIndex
+        let commandToken = String(unwrapped[..<commandEnd]).trimmingCharacters(in: CharacterSet(charactersIn: "`"))
         guard commandToken.count > 1 else { return nil }
 
-        let description = String(stripped[commandEnd...])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let description = String(unwrapped[commandEnd...])
+            .trimmingCharacters(in: CharacterSet(charactersIn: "`").union(.whitespacesAndNewlines))
             .trimmingLeadingListMarker()
         guard !description.isEmpty else { return nil }
 

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -79,6 +79,13 @@ public struct ChatSlashCommandDescriptor: Hashable {
 
 public enum ChatSlashCommandCatalog {
     private static let allPlatforms: Set<ChatSlashCommandPlatform> = [.macos, .ios]
+    private static let deprecatedModelShortcutCommands: Set<String> = [
+        "opus",
+        "sonnet",
+        "haiku",
+        "grok-beta",
+        "grok-multi",
+    ]
 
     public static let allCommands: [ChatSlashCommandDescriptor] = [
         ChatSlashCommandDescriptor(
@@ -217,6 +224,27 @@ public enum ChatSlashCommandCatalog {
         surface: ChatSlashCommandSurface? = nil
     ) -> Bool {
         descriptor(forRawInput: rawInput, platform: platform, surface: surface) != nil
+    }
+
+    static func shouldBypassWorkspaceRefinement(
+        forRawInput rawInput: String,
+        platform: ChatSlashCommandPlatform
+    ) -> Bool {
+        if isRecognizedSlashCommand(rawInput, platform: platform, surface: .sendPath) {
+            return true
+        }
+
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "/model" || (trimmed.hasPrefix("/model ") && trimmed != "/models") {
+            return true
+        }
+
+        guard trimmed.hasPrefix("/") else { return false }
+        guard let commandToken = trimmed.dropFirst().split(whereSeparator: \.isWhitespace).first else {
+            return false
+        }
+
+        return deprecatedModelShortcutCommands.contains(String(commandToken).lowercased())
     }
 
     public static func shouldRefreshModelMetadata(forRawInput rawInput: String) -> Bool {

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -157,12 +157,63 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
 
         XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
         XCTAssertEqual(viewModel.messages.count, 0)
+    }
 
-        viewModel.isWorkspaceRefinementInFlight = false
-        viewModel.inputText = "/model"
-        viewModel.sendMessage()
+    func testDeprecatedDaemonManagedSlashCommandsBypassWorkspaceRefinement() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
 
-        XCTAssertTrue(viewModel.isWorkspaceRefinementInFlight)
-        XCTAssertEqual(viewModel.messages.count, 0)
+        let deprecatedCommands = [
+            "/model",
+            "/opus write a summary",
+            "/OPUS write a summary",
+        ]
+
+        for command in deprecatedCommands {
+            viewModel.isWorkspaceRefinementInFlight = false
+            viewModel.inputText = command
+            viewModel.sendMessage()
+
+            XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
+        }
+
+        XCTAssertEqual(viewModel.messages.map(\.text), deprecatedCommands)
+    }
+
+    func testPopulateFromHistoryRetagsCommandListAcrossPaginationBoundary() {
+        let assistantReply = HistoryResponseMessage(
+            id: UUID().uuidString,
+            role: "assistant",
+            text: "/commands — List all available commands",
+            timestamp: 2_000
+        )
+
+        viewModel.populateFromHistory(
+            [assistantReply],
+            hasMore: true,
+            oldestTimestamp: 2_000
+        )
+
+        XCTAssertNil(viewModel.messages.first?.commandList)
+
+        let olderUserMessage = HistoryResponseMessage(
+            id: UUID().uuidString,
+            role: "user",
+            text: "/commands",
+            timestamp: 1_000
+        )
+
+        viewModel.populateFromHistory(
+            [olderUserMessage],
+            hasMore: false,
+            oldestTimestamp: 1_000,
+            isPaginationLoad: true
+        )
+
+        XCTAssertEqual(viewModel.messages.map(\.text), [
+            "/commands",
+            "/commands — List all available commands",
+        ])
+        XCTAssertNotNil(viewModel.messages[1].commandList)
     }
 }

--- a/clients/shared/Tests/CommandListBubbleTests.swift
+++ b/clients/shared/Tests/CommandListBubbleTests.swift
@@ -29,4 +29,30 @@ final class CommandListBubbleTests: XCTestCase {
 
         XCTAssertNil(CommandListBubble.parsedEntries(from: assistantText))
     }
+
+    func testParsedEntriesSupportMarkdownWrappedCommandTokens() {
+        let assistantText = """
+        COMMANDS
+        - `/commands` — List all available commands
+        - `/models` — List all available models
+        """
+
+        let parsed = CommandListBubble.parsedEntries(from: assistantText)
+
+        XCTAssertEqual(parsed?.map(\.id), ["/commands", "/models"])
+        XCTAssertEqual(parsed?.map(\.description), [
+            "List all available commands",
+            "List all available models",
+        ])
+    }
+
+    func testParsedEntriesReturnNilWhenAssistantTextMixesIntroProseWithCommandRows() {
+        let assistantText = """
+        Here are the commands you can use:
+        - /commands — List all available commands
+        - /models — List all available models
+        """
+
+        XCTAssertNil(CommandListBubble.parsedEntries(from: assistantText))
+    }
 }

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -169,6 +169,32 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
     }
 
+    func testDeprecatedDaemonManagedCommandsStillBypassWorkspaceRefinement() {
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: "/model",
+            platform: .macos
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: "/opus explain this",
+            platform: .macos
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: "/OPUS explain this",
+            platform: .macos
+        ))
+
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/model",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/OPUS explain this",
+            platform: .macos,
+            surface: .sendPath
+        ))
+    }
+
     func testModelMetadataRefreshOnlyForExactModelsCommand() {
         XCTAssertTrue(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
             forRawInput: "/models",


### PR DESCRIPTION
## Summary
- keep deprecated daemon-managed slash inputs on the send path instead of routing them into workspace refinement
- tighten  bubble parsing so it only renders clean persisted command lists and supports markdown-wrapped command tokens
- retag restored slash-command responses after history merges so  survives pagination boundaries

Part of plan: unify-desktop-slash-command-ux.md (remediation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
