### PR TITLE
fix: sort conversation key store test imports

### DIFF
--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
 import { eq } from "drizzle-orm";
 
 const testDir = realpathSync(
@@ -66,7 +67,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
-import { initializeDb, getDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { conversationKeys, conversations } from "../memory/schema.js";
 
 initializeDb();


### PR DESCRIPTION
## Summary
- sort imports in the conversation key store disk-view test to satisfy eslint import ordering
- keep the change scoped to the failing CI lint job only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
