### PR TITLE
fix: dispatch voice override ID to @MainActor in settings callback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -298,7 +298,9 @@ extension AppDelegate {
         // override properties; write all other keys to UserDefaults as before.
         daemonClient.onClientSettingsUpdate = { msg in
             if msg.key == "ttsVoiceId" {
-                OpenAIVoiceService.overrideVoiceId = msg.value
+                Task { @MainActor in
+                    OpenAIVoiceService.overrideVoiceId = msg.value
+                }
                 UserDefaults.standard.set(msg.value, forKey: msg.key)
             } else if msg.key == "voiceConversationTimeoutSeconds" {
                 let parsed = Int(msg.value)


### PR DESCRIPTION
## Summary
- Wrap `OpenAIVoiceService.overrideVoiceId` assignment in `Task { @MainActor in }` inside `onClientSettingsUpdate`
- `OpenAIVoiceService` is `@MainActor`-isolated, so accessing its static var from a non-main-actor context is a concurrency violation
- Addresses review feedback from PR #19220 which fixed the same issue for `VoiceModeManager.conversationTimeoutOverride` but missed this case

## Test plan
- Verify voice ID setting changes from daemon still apply correctly
- Confirm no strict concurrency warnings related to this code path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
