### PR TITLE
fix: use explicit sync flag to distinguish store-driven provider changes from user picks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -32,6 +32,10 @@ struct InferenceServiceCard: View {
     @State private var initialProvider: String = ""
     /// Guards against provider-change side-effects during initial load.
     @State private var didInitialSync = false
+    /// Set `true` right before an external store sync updates `draftProvider`,
+    /// so `onChange(of: draftProvider)` can distinguish daemon-driven updates
+    /// from user-initiated picks and skip the model/key reset.
+    @State private var isSyncingProviderFromStore = false
 
     // MARK: - Feature Flag
 
@@ -198,6 +202,9 @@ struct InferenceServiceCard: View {
             // Sync draft & baseline when the daemon reports a provider
             // update. Also refresh the model baseline so hasChanges does
             // not flag a stale diff against the old provider's model.
+            // Flag the update so onChange(of: draftProvider) skips the
+            // model/key reset that is only appropriate for user picks.
+            isSyncingProviderFromStore = true
             draftProvider = newValue
             initialProvider = newValue
             draftModel = store.selectedModel
@@ -212,10 +219,13 @@ struct InferenceServiceCard: View {
             // Only reset the model and API key text for user-initiated
             // provider changes. Skip during initial load (onAppear sets
             // draftProvider before didInitialSync is true) and during
-            // external store syncs (onChange of store.selectedInferenceProvider
-            // updates both draftProvider and initialProvider together, so
-            // they will match).
-            guard didInitialSync, newProvider != initialProvider else { return }
+            // external store syncs (which set isSyncingProviderFromStore
+            // before updating draftProvider).
+            if isSyncingProviderFromStore {
+                isSyncingProviderFromStore = false
+                return
+            }
+            guard didInitialSync else { return }
             if isCustomProviderEnabled {
                 let defaultModel = store.dynamicProviderDefaultModel(newProvider)
                 let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""


### PR DESCRIPTION
## Summary
- Replaces the `newProvider != initialProvider` guard in `onChange(of: draftProvider)` with a dedicated `isSyncingProviderFromStore` flag
- The old guard incorrectly skipped model/key reset when users switched providers in a round-trip (A -> B -> A) because the final provider matched `initialProvider`
- The new flag is set `true` in `onChange(of: store.selectedInferenceProvider)` before updating `draftProvider`, then checked and cleared in `onChange(of: draftProvider)`
- Addresses review feedback from PR #19233

## Test plan
- [ ] Switch provider A -> B -> A without saving: verify model resets to A's default on each switch
- [ ] Daemon provider sync: verify no spurious model/key reset
- [ ] Initial load with non-default provider: verify model is preserved

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
