### PR TITLE
fix: unblock iOS command list fallback build

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -330,8 +330,9 @@ struct ChatContentView: View {
         if let parsedEntries = CommandListBubble.parsedEntries(from: message.text) {
             CommandListBubble(commands: parsedEntries)
         } else {
+            let fallbackMessage = commandListFallbackMessage(from: message)
             regularMessageBubble(
-                message: commandListFallbackMessage(from: message),
+                message: fallbackMessage,
                 index: index,
                 messages: messages
             )


### PR DESCRIPTION
## Summary
- fix the command list fallback path in ChatContentView so SwiftUI does not evaluate a mutation expression inside a ViewBuilder branch
- keep command-list messages falling back to the regular message bubble when parsing fails, matching the intended behavior
- local verification was limited because this machine is missing the iOS 26.2 simulator/platform used by CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282998283/job/67700280064
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
