### PR TITLE
fix: repair macOS slash command picker tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
@@ -15,19 +15,19 @@ final class ComposerSlashCommandPickerTests: XCTestCase {
         XCTAssertFalse(SlashCommand.all.contains(where: { $0.name == "model" }))
     }
 
-    func testBtwSelectionInsertsTrailingSpaceWithoutAutoSend() {
+    func testBtwSelectionInsertsTrailingSpaceWithoutAutoSend() throws {
         let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "btw" }))
         XCTAssertEqual(command.selectedInputText, "/btw ")
         XCTAssertFalse(command.shouldAutoSendOnSelect)
     }
 
-    func testPairSelectionAutoSendsWithoutTrailingSpace() {
+    func testPairSelectionAutoSendsWithoutTrailingSpace() throws {
         let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "pair" }))
         XCTAssertEqual(command.selectedInputText, "/pair")
         XCTAssertTrue(command.shouldAutoSendOnSelect)
     }
 
-    func testBtwTabCompletionUsesSelectionInsertionText() {
+    func testBtwTabCompletionUsesSelectionInsertionText() throws {
         let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "btw" }))
         XCTAssertEqual(ComposerView.slashCommandInputTextForSelection(command), "/btw ")
     }


### PR DESCRIPTION
## Summary
- mark the slash command picker tests as `throws` so `try XCTUnwrap(...)` compiles in macOS CI
- keep the change scoped to the single failing test file from the reported GitHub Actions job

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23282998271/job/67700293625