### PR TITLE
feat: advertise /fork in Apple slash help

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -39,6 +39,7 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
+      "/fork — Fork the current conversation into a new branch",
       "/pair — Generate pairing info for connecting a mobile device",
     ]);
     expect(lines).not.toContain(
@@ -46,7 +47,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     );
   });
 
-  test("renders iOS command help without /pair", async () => {
+  test("renders iOS command help with /fork but without /pair", async () => {
     const lines = await resolveCommandsLines(
       makeSlashContext({ userMessageInterface: "ios" }),
     );
@@ -55,6 +56,7 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
+      "/fork — Fork the current conversation into a new branch",
     ]);
   });
 

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -144,6 +144,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
+      "/fork — Fork the current conversation into a new branch",
       "/pair — Generate pairing info for connecting a mobile device",
     ];
   }
@@ -154,6 +155,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
+      "/fork — Fork the current conversation into a new branch",
     ];
   }
 

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -120,6 +120,15 @@ public enum ChatSlashCommandCatalog {
             sendPathPlatforms: allPlatforms
         ),
         ChatSlashCommandDescriptor(
+            name: "fork",
+            description: "Fork the current conversation into a new branch",
+            icon: "arrow.triangle.branch",
+            selectionBehavior: .autoSend,
+            pickerPlatforms: [.macos],
+            helpBubblePlatforms: allPlatforms,
+            sendPathPlatforms: allPlatforms
+        ),
+        ChatSlashCommandDescriptor(
             name: "pair",
             description: "Generate pairing info for connecting a mobile device",
             icon: "qrcode",

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -8,7 +8,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .picker
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw", "/pair"])
+        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw", "/fork", "/pair"])
     }
 
     func testMacOSHelpOrderMatchesExpectedDesktopCommands() {
@@ -16,18 +16,18 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw", "/pair"])
+        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw", "/fork", "/pair"])
     }
 
-    func testIOSHelpOmitsPairingCommand() {
+    func testIOSHelpOmitsPairingCommandButShowsFork() {
         let commands = ChatSlashCommandCatalog.commands(
             for: .ios,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw"])
+        XCTAssertEqual(commands, ["/commands", "/models", "/status", "/btw", "/fork"])
     }
 
-    func testIOSPickerOmitsPairingCommand() {
+    func testIOSPickerOmitsForkAndPairingCommands() {
         let commands = ChatSlashCommandCatalog.commands(
             for: .ios,
             surface: .picker
@@ -90,6 +90,11 @@ final class SlashCommandCatalogTests: XCTestCase {
             surface: .sendPath
         ))
         XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/fork",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/btw follow up",
             platform: .macos,
             surface: .sendPath
@@ -112,6 +117,11 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/pair foo",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/fork foo",
             platform: .macos,
             surface: .sendPath
         ))
@@ -144,10 +154,24 @@ final class SlashCommandCatalogTests: XCTestCase {
             surface: .sendPath
         ))
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/FORK",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/BTW follow up",
             platform: .macos,
             surface: .sendPath
         ))
+    }
+
+    func testForkUsesAutoSendBehaviorWhereDiscoverable() {
+        let descriptor = ChatSlashCommandCatalog.descriptor(
+            forRawInput: "/fork",
+            platform: .macos,
+            surface: .picker
+        )
+        XCTAssertEqual(descriptor?.selectionBehavior, .autoSend)
     }
 
     func testPairIsAvailableOnIOSSendPathButHiddenFromDiscoverySurfaces() {
@@ -167,6 +191,30 @@ final class SlashCommandCatalogTests: XCTestCase {
             platform: .ios,
             surface: .helpBubble
         ))
+    }
+
+    func testForkIsAvailableOnIOSSendPathAndHelpButHiddenFromPicker() {
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/fork",
+            platform: .ios,
+            surface: .sendPath
+        ))
+
+        XCTAssertNil(ChatSlashCommandCatalog.descriptor(
+            forRawInput: "/fork",
+            platform: .ios,
+            surface: .picker
+        ))
+
+        let helpDescriptor = ChatSlashCommandCatalog.descriptor(
+            forRawInput: "/fork",
+            platform: .ios,
+            surface: .helpBubble
+        )
+        XCTAssertEqual(
+            helpDescriptor?.description,
+            "Fork the current conversation into a new branch"
+        )
     }
 
     func testModelMetadataRefreshOnlyForExactModelsCommand() {


### PR DESCRIPTION
## Summary
- add /fork to Apple slash command discovery surfaces and send-path helpers
- update daemon /commands output so Apple help stays aligned with the client catalog
- extend shared and daemon slash tests to lock the new /fork visibility

Part of plan: conversation-forking.md (PR 14 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
