### PR TITLE
feat: add macOS message-level fork action

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -12,6 +12,7 @@ struct ChatBubble: View {
     let onDismissDocumentWidget: (String) -> Void
     let dismissedDocumentSurfaceIds: Set<String>
     var onReportMessage: ((String?) -> Void)?
+    var onForkFromMessage: ((String) -> Void)?
     var showInspectButton: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
@@ -63,8 +64,11 @@ struct ChatBubble: View {
     private var canInspectMessage: Bool {
         showInspectButton && !isUser && message.daemonMessageId != nil
     }
+    var canForkFromMessage: Bool {
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
+    }
     private var hasOverflowActions: Bool {
-        hasCopyableText || canReportMessage || canInspectMessage
+        hasCopyableText || canReportMessage || canInspectMessage || canForkFromMessage
     }
     private var showOverflowMenu: Bool {
         hasOverflowActions && !message.isStreaming && (isHovered || showCopyConfirmation)
@@ -335,6 +339,24 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Report message")
+            }
+            if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
+                Button {
+                    onForkFromMessage(daemonMessageId)
+                } label: {
+                    Label {
+                        Text("Fork from here")
+                            .font(VFont.caption)
+                    } icon: {
+                        VIconView(.gitBranch, size: 11)
+                    }
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(height: 24)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .accessibilityLabel("Fork from here")
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
                 Button {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -107,6 +107,7 @@ struct MessageListView: View {
     var onGuardianAction: ((String, String) -> Void)?
     let onDismissDocumentWidget: ((String) -> Void)?
     let onReportMessage: ((String?) -> Void)?
+    var onForkFromMessage: ((String) -> Void)? = nil
     var showInspectButton: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -320,6 +321,33 @@ struct MessageListView: View {
             shouldShowThinkingIndicator: shouldShowThinkingIndicator,
             effectiveStatusText: effectiveStatusText
         )
+    }
+
+    var hasForkActionHandler: Bool {
+        onForkFromMessage != nil || AppDelegate.shared?.mainWindow?.conversationManager != nil
+    }
+
+    func canFork(from message: ChatMessage) -> Bool {
+        hasForkActionHandler && message.daemonMessageId != nil && !message.isStreaming
+    }
+
+    func forkFromMessage(_ daemonMessageId: String) {
+        if let onForkFromMessage {
+            onForkFromMessage(daemonMessageId)
+            return
+        }
+
+        Task { @MainActor in
+            await AppDelegate.shared?.mainWindow?.conversationManager
+                .forkConversation(throughDaemonMessageId: daemonMessageId)
+        }
+    }
+
+    var forkFromMessageAction: ((String) -> Void)? {
+        guard hasForkActionHandler else { return nil }
+        return { daemonMessageId in
+            forkFromMessage(daemonMessageId)
+        }
     }
 
     /// Pre-compute which message indices should show a timestamp divider.
@@ -733,6 +761,7 @@ struct MessageListView: View {
                             onSurfaceAction: onSurfaceAction,
                             onDismissDocumentWidget: onDismissDocumentWidget,
                             onReportMessage: onReportMessage,
+                            onForkFromMessage: forkFromMessageAction,
                             showInspectButton: showInspectButton,
                             onInspectMessage: onInspectMessage,
                             onRehydrateMessage: onRehydrateMessage,
@@ -1395,6 +1424,7 @@ private struct MessageCellView: View, Equatable {
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
     let onDismissDocumentWidget: ((String) -> Void)?
     let onReportMessage: ((String?) -> Void)?
+    var onForkFromMessage: ((String) -> Void)?
     var showInspectButton: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     var onRehydrateMessage: ((UUID) -> Void)?
@@ -1438,6 +1468,7 @@ private struct MessageCellView: View, Equatable {
                 },
                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                 onReportMessage: onReportMessage,
+                onForkFromMessage: onForkFromMessage,
                 showInspectButton: showInspectButton,
                 onInspectMessage: onInspectMessage,
                 onSurfaceRefetch: onSurfaceRefetch,
@@ -1571,6 +1602,7 @@ private struct MessageCellView: View, Equatable {
                 },
                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                 onReportMessage: onReportMessage,
+                onForkFromMessage: onForkFromMessage,
                 showInspectButton: showInspectButton,
                 onInspectMessage: onInspectMessage,
                 onSurfaceRefetch: onSurfaceRefetch,

--- a/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class MessageListForkActionTests: XCTestCase {
+    func testForkActionIsHiddenForStreamingAndLocalOnlyMessages() {
+        let view = makeView(onForkFromMessage: { _ in })
+        let localOnlyMessage = makeMessage(daemonMessageId: nil, isStreaming: false)
+        let streamingMessage = makeMessage(daemonMessageId: "msg-stream", isStreaming: true)
+
+        XCTAssertFalse(view.canFork(from: localOnlyMessage))
+        XCTAssertFalse(view.canFork(from: streamingMessage))
+    }
+
+    func testForkActionIsVisibleForPersistedMessagesWhenHandlerExists() {
+        let view = makeView(onForkFromMessage: { _ in })
+        let persistedMessage = makeMessage(daemonMessageId: "msg-persisted", isStreaming: false)
+
+        XCTAssertTrue(view.canFork(from: persistedMessage))
+    }
+
+    func testForkActionRoutesThroughInjectedHandler() {
+        var capturedMessageId: String?
+        let view = makeView(onForkFromMessage: { daemonMessageId in
+            capturedMessageId = daemonMessageId
+        })
+
+        view.forkFromMessage("msg-persisted")
+
+        XCTAssertEqual(capturedMessageId, "msg-persisted")
+    }
+
+    private func makeView(
+        messages: [ChatMessage] = [],
+        onForkFromMessage: ((String) -> Void)? = nil
+    ) -> MessageListView {
+        MessageListView(
+            messages: messages,
+            isSending: false,
+            isThinking: false,
+            isCompacting: false,
+            assistantActivityPhase: "idle",
+            assistantActivityAnchor: "composer",
+            assistantActivityReason: nil,
+            assistantStatusText: nil,
+            selectedModel: "",
+            configuredProviders: [],
+            providerCatalog: [],
+            activeSubagents: [],
+            dismissedDocumentSurfaceIds: [],
+            onConfirmationAllow: { _ in },
+            onConfirmationDeny: { _ in },
+            onAlwaysAllow: { _, _, _, _ in },
+            onTemporaryAllow: nil,
+            onSurfaceAction: { _, _, _ in },
+            onGuardianAction: nil,
+            onDismissDocumentWidget: nil,
+            onReportMessage: nil,
+            onForkFromMessage: onForkFromMessage,
+            showInspectButton: false,
+            onInspectMessage: nil,
+            mediaEmbedSettings: nil,
+            resolveHttpPort: { nil },
+            onAbortSubagent: nil,
+            onSubagentTap: nil,
+            onRehydrateMessage: nil,
+            onSurfaceRefetch: nil,
+            onRetryFailedMessage: nil,
+            onRetryConversationError: nil,
+            subagentDetailStore: SubagentDetailStore(),
+            creditsExhaustedError: nil,
+            onAddFunds: nil,
+            onDismissCreditsExhausted: nil,
+            displayedMessageCount: .max,
+            hasMoreMessages: false,
+            isLoadingMoreMessages: false,
+            loadPreviousMessagePage: nil,
+            conversationId: nil,
+            anchorMessageId: .constant(nil),
+            highlightedMessageId: .constant(nil),
+            isNearBottom: .constant(true),
+            containerWidth: 0
+        )
+    }
+
+    private func makeMessage(daemonMessageId: String?, isStreaming: Bool) -> ChatMessage {
+        var message = ChatMessage(role: .assistant, text: "Forkable reply", isStreaming: isStreaming)
+        message.daemonMessageId = daemonMessageId
+        return message
+    }
+}


### PR DESCRIPTION
## Summary
- add macOS message-level fork affordances for persisted, non-streaming messages
- route branch-point actions from MessageListView through ConversationManager
- add focused visibility and callback coverage for the new message action

Part of plan: conversation-forking.md (PR 10 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)