### PR TITLE
feat: add macOS fork header action and parent link

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -11,6 +11,14 @@ struct ConversationHeaderPresentation {
     let isPrivateConversation: Bool
     let canCopy: Bool
     let isPinned: Bool
+    let showsForkConversationAction: Bool
+    let forkParentTitle: String?
+    let forkParentConversationId: String?
+    let forkParentMessageId: String?
+
+    var showsForkParentLink: Bool {
+        forkParentConversationId != nil
+    }
 
     init(activeConversation: ConversationModel?, activeViewModel: ChatViewModel?, isConversationVisible: Bool) {
         guard isConversationVisible, let conversation = activeConversation else {
@@ -20,6 +28,10 @@ struct ConversationHeaderPresentation {
             self.isPrivateConversation = false
             self.canCopy = false
             self.isPinned = false
+            self.showsForkConversationAction = false
+            self.forkParentTitle = nil
+            self.forkParentConversationId = nil
+            self.forkParentMessageId = nil
             return
         }
 
@@ -38,5 +50,9 @@ struct ConversationHeaderPresentation {
 
         // Can copy when there's non-empty content
         self.canCopy = hasUserMessage
+        self.showsForkConversationAction = conversation.conversationId != nil && !isPrivateConversation
+        self.forkParentTitle = conversation.forkParent?.title
+        self.forkParentConversationId = conversation.forkParent?.conversationId
+        self.forkParentMessageId = conversation.forkParent?.messageId
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -13,24 +13,16 @@ private let archivedConversationsNewKey = "archivedConversationIds"
 
 // MARK: - Conversation Client Protocol
 
-/// Abstraction for fetching individual conversations, decoupled from DaemonClient.
+/// Abstraction for direct conversation mutations, decoupled from DaemonClient.
 @MainActor
 protocol ConversationClientProtocol {
-    func fetchConversationById(_ conversationId: String) async -> ConversationsListResponse.Conversation?
     func deleteConversation(_ conversationId: String) async
 }
 
-/// Fetches conversation data via GatewayHTTPClient.
+/// Gateway-backed conversation mutation client.
 @MainActor
 struct ConversationClient: ConversationClientProtocol {
     nonisolated init() {}
-
-    func fetchConversationById(_ conversationId: String) async -> ConversationsListResponse.Conversation? {
-        let result: (SingleConversationResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/conversations/\(conversationId)", timeout: 10
-        )
-        return result?.0?.conversation
-    }
 
     func deleteConversation(_ conversationId: String) async {
         let response = try? await GatewayHTTPClient.delete(
@@ -843,6 +835,52 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         return true
     }
 
+    @discardableResult
+    func openForkParentConversation(conversationId: String, sourceMessageId: String?) async -> Bool {
+        if selectConversationByConversationId(conversationId) {
+            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
+                unarchiveConversation(id: match.id)
+            }
+            applyPendingAnchorMessageIfPossible(
+                localConversationId: activeConversationId,
+                daemonMessageId: sourceMessageId
+            )
+            return true
+        }
+
+        guard let conversation = await conversationDetailClient.fetchConversation(conversationId: conversationId) else {
+            return false
+        }
+
+        if selectConversationByConversationId(conversationId) {
+            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
+                unarchiveConversation(id: match.id)
+            }
+            applyPendingAnchorMessageIfPossible(
+                localConversationId: activeConversationId,
+                daemonMessageId: sourceMessageId
+            )
+            return true
+        }
+
+        if isConversationArchived(conversation.id) {
+            var archived = archivedConversationIds
+            archived.remove(conversation.id)
+            archivedConversationIds = archived
+        }
+
+        guard let localConversationId = upsertConversation(from: conversation, isArchived: false) else {
+            return false
+        }
+
+        selectConversation(id: localConversationId)
+        applyPendingAnchorMessageIfPossible(
+            localConversationId: localConversationId,
+            daemonMessageId: sourceMessageId
+        )
+        return true
+    }
+
     /// Select a conversation by conversation ID, fetching it on-demand from the server if not locally available.
     /// Returns `true` if the conversation was found (or fetched) and selected, `false` on failure.
     /// If the conversation is archived, it is automatically unarchived since the caller
@@ -859,7 +897,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         // Slow path: fetch the conversation via the gateway and insert it locally
-        guard let conversation = await conversationClient.fetchConversationById(conversationId) else {
+        guard let conversation = await conversationDetailClient.fetchConversation(conversationId: conversationId) else {
             return false
         }
 
@@ -887,7 +925,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         guard let localConversationId = upsertConversation(
-            from: conversationListItem(from: conversation),
+            from: conversation,
             isArchived: false
         ) else {
             return false
@@ -940,7 +978,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                 localId: existingConversation.id,
                 createdAt: existingConversation.createdAt,
                 isArchived: isArchived,
-                fallbackPinnedOrder: existingConversation.pinnedOrder
+                fallbackPinnedOrder: existingConversation.pinnedOrder,
+                fallbackForkParent: existingConversation.forkParent
             )
             mergeAssistantAttention(from: item, intoConversationAt: existingIdx)
             if let viewModel = chatViewModels[existingConversation.id] {
@@ -966,31 +1005,13 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         return conversationModel.id
     }
 
-    private func conversationListItem(from conversation: ConversationsListResponse.Conversation) -> ConversationListResponseItem {
-        ConversationListResponseItem(
-            id: conversation.id,
-            title: conversation.title,
-            createdAt: conversation.createdAt,
-            updatedAt: conversation.updatedAt,
-            conversationType: conversation.conversationType,
-            source: conversation.source,
-            scheduleJobId: conversation.scheduleJobId,
-            channelBinding: conversation.channelBinding,
-            conversationOriginChannel: conversation.conversationOriginChannel,
-            conversationOriginInterface: conversation.conversationOriginInterface,
-            assistantAttention: conversation.assistantAttention,
-            displayOrder: conversation.displayOrder,
-            isPinned: conversation.isPinned,
-            forkParent: conversation.forkParent
-        )
-    }
-
     private func conversationModel(
         from item: ConversationListResponseItem,
         localId: UUID = UUID(),
         createdAt: Date? = nil,
         isArchived: Bool,
-        fallbackPinnedOrder: Int? = nil
+        fallbackPinnedOrder: Int? = nil,
+        fallbackForkParent: ConversationForkParent? = nil
     ) -> ConversationModel {
         let effectiveCreatedAtMillis = item.createdAt ?? item.updatedAt
         let isPinned = item.isPinned ?? false
@@ -1014,8 +1035,15 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             lastSeenAssistantMessageAt: item.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             },
-            forkParent: item.forkParent
+            forkParent: item.forkParent ?? fallbackForkParent
         )
+    }
+
+    private func applyPendingAnchorMessageIfPossible(localConversationId: UUID?, daemonMessageId: String?) {
+        guard let localConversationId,
+              let daemonMessageId,
+              let messageId = UUID(uuidString: daemonMessageId) else { return }
+        setPendingAnchorMessage(conversationId: localConversationId, messageId: messageId)
     }
 
     // MARK: - Render Cache Management

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -209,6 +209,8 @@ final class ConversationRestorer {
                 delegate.conversations[existingIdx].isPinned = isPinned
                 delegate.conversations[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
                 delegate.conversations[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
+                delegate.conversations[existingIdx].forkParent =
+                    session.forkParent ?? delegate.conversations[existingIdx].forkParent
                 delegate.mergeAssistantAttention(from: session, intoConversationAt: existingIdx)
                 if isPinned && session.displayOrder == nil { pinnedCount += 1 }
                 continue
@@ -244,7 +246,8 @@ final class ConversationRestorer {
                 },
                 lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
                     Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
-                }
+                },
+                forkParent: session.forkParent
             )
             if isPinned && session.displayOrder == nil { pinnedCount += 1 }
             // VM creation is lazy — only the active conversation will get a VM via

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -6,22 +6,42 @@ import VellumAssistantShared
 struct ConversationTitleActionsControl: View {
     let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
+    let onForkConversation: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
+    let onOpenForkParent: () -> Void
     @Binding var showDrawer: Bool
 
     var body: some View {
-        VButton(
-            label: presentation.displayTitle,
-            rightIcon: presentation.showsActionsMenu ? VIcon.chevronDown.rawValue : nil,
-            style: .ghost
-        ) {
-            if presentation.showsActionsMenu {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                    showDrawer.toggle()
+        VStack(alignment: .leading, spacing: 2) {
+            VButton(
+                label: presentation.displayTitle,
+                rightIcon: presentation.showsActionsMenu ? VIcon.chevronDown.rawValue : nil,
+                style: .ghost
+            ) {
+                if presentation.showsActionsMenu {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        showDrawer.toggle()
+                    }
                 }
+            }
+
+            if let parentTitle = presentation.forkParentTitle, presentation.showsForkParentLink {
+                Button(action: onOpenForkParent) {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.gitBranch, size: 11)
+                        Text("Forked from \(parentTitle)")
+                            .font(VFont.small)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .foregroundStyle(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .accessibilityLabel("Open parent conversation")
             }
         }
     }
@@ -31,6 +51,7 @@ struct ConversationTitleActionsControl: View {
 struct ConversationActionsDrawer: View {
     let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
+    let onForkConversation: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
     let onArchive: () -> Void
@@ -40,6 +61,10 @@ struct ConversationActionsDrawer: View {
         VStack(alignment: .leading, spacing: 0) {
             if presentation.canCopy {
                 SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
+            }
+
+            if presentation.showsForkConversationAction {
+                SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
             SidebarPrimaryRow(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -224,6 +224,17 @@ struct MainWindowView: View {
         sidebar.renameText = conversation.title
     }
 
+    func openForkParentConversation() {
+        guard let parentConversationId = conversationHeaderPresentation.forkParentConversationId else { return }
+        let sourceMessageId = conversationHeaderPresentation.forkParentMessageId
+        Task {
+            _ = await conversationManager.openForkParentConversation(
+                conversationId: parentConversationId,
+                sourceMessageId: sourceMessageId
+            )
+        }
+    }
+
     var body: some View {
         coreLayoutView
             .opacity(showComingAlive ? 0 : 1)
@@ -419,6 +430,14 @@ struct MainWindowView: View {
                 ConversationTitleActionsControl(
                     presentation: conversationHeaderPresentation,
                     onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
+                    onForkConversation: {
+                        Task {
+                            await conversationManager.forkActiveConversation()
+                            await MainActor.run {
+                                dismissConversationDrawer()
+                            }
+                        }
+                    },
                     onPin: {
                         guard let id = conversationManager.activeConversationId else { return }
                         conversationManager.pinConversation(id: id)
@@ -435,6 +454,7 @@ struct MainWindowView: View {
                         dismissConversationDrawer()
                     },
                     onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
+                    onOpenForkParent: { openForkParentConversation() },
                     showDrawer: $showConversationActionsDrawer
                 )
                 .background(GeometryReader { proxy in
@@ -922,6 +942,14 @@ struct MainWindowView: View {
             ConversationActionsDrawer(
                 presentation: conversationHeaderPresentation,
                 onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
+                onForkConversation: {
+                    Task {
+                        await conversationManager.forkActiveConversation()
+                        await MainActor.run {
+                            dismissConversationDrawer()
+                        }
+                    }
+                },
                 onPin: {
                     guard let id = conversationManager.activeConversationId else { return }
                     conversationManager.pinConversation(id: id)

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -17,6 +17,8 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertFalse(p.isStarted)
         XCTAssertFalse(p.showsActionsMenu)
         XCTAssertFalse(p.canCopy)
+        XCTAssertFalse(p.showsForkConversationAction)
+        XCTAssertFalse(p.showsForkParentLink)
     }
 
     func testConversationNotVisibleShowsNewConversation() {
@@ -28,6 +30,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         )
         XCTAssertEqual(p.displayTitle, "New conversation")
         XCTAssertFalse(p.showsActionsMenu)
+        XCTAssertFalse(p.showsForkParentLink)
     }
 
     // MARK: - Started standard conversation
@@ -43,6 +46,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertEqual(p.displayTitle, "Test Conversation")
         XCTAssertTrue(p.isStarted)
         XCTAssertTrue(p.showsActionsMenu)
+        XCTAssertTrue(p.showsForkConversationAction)
     }
 
     // MARK: - Private conversation
@@ -57,6 +61,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertTrue(p.isStarted)
         XCTAssertTrue(p.isPrivateConversation)
         XCTAssertFalse(p.showsActionsMenu)
+        XCTAssertFalse(p.showsForkConversationAction)
     }
 
     // MARK: - Not started (no conversationId, no messages)
@@ -72,6 +77,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertFalse(p.isStarted)
         XCTAssertFalse(p.showsActionsMenu)
         XCTAssertFalse(p.canCopy)
+        XCTAssertFalse(p.showsForkConversationAction)
     }
 
     // MARK: - Pin state
@@ -84,5 +90,27 @@ final class ConversationHeaderPresentationTests: XCTestCase {
             isConversationVisible: true
         )
         XCTAssertTrue(p.isPinned)
+    }
+
+    func testForkedConversationShowsParentLinkMetadata() {
+        let conversation = ConversationModel(
+            title: "Forked",
+            conversationId: "session-fork",
+            forkParent: ConversationForkParent(
+                conversationId: "session-parent",
+                messageId: "msg-parent",
+                title: "Original"
+            )
+        )
+        let p = ConversationHeaderPresentation(
+            activeConversation: conversation,
+            activeViewModel: nil,
+            isConversationVisible: true
+        )
+
+        XCTAssertTrue(p.showsForkParentLink)
+        XCTAssertEqual(p.forkParentTitle, "Original")
+        XCTAssertEqual(p.forkParentConversationId, "session-parent")
+        XCTAssertEqual(p.forkParentMessageId, "msg-parent")
     }
 }


### PR DESCRIPTION
## Summary
- preserve fork lineage during macOS restore and on-demand parent loading
- add current-tip fork entry points and parent-link navigation in the header UI
- extend focused header presentation coverage for forked conversations

Part of plan: conversation-forking.md (PR 9 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
