### PR TITLE
feat: add iOS fork parent navigation and current-tip UI

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -134,6 +134,12 @@ struct ConversationSelectionRequest: Equatable {
     let conversationLocalId: UUID
 }
 
+struct PendingConversationAnchorRequest: Equatable {
+    let id = UUID()
+    let conversationLocalId: UUID
+    let daemonMessageId: String
+}
+
 // MARK: - IOSConversationStore
 
 /// Manages a list of chat conversations for iOS.
@@ -153,12 +159,14 @@ class IOSConversationStore: ObservableObject {
     /// Used by the UI to show a loading indicator instead of a placeholder conversation.
     @Published var isLoadingInitialConversations: Bool = false
     @Published var selectionRequest: ConversationSelectionRequest?
+    @Published var pendingConversationAnchorRequest: PendingConversationAnchorRequest?
 
     /// ViewModels keyed by conversation ID, created lazily on first access.
     private var viewModels: [UUID: ChatViewModel] = [:]
     private var daemonClient: any DaemonClientProtocol
     private let conversationHistoryClient: any ConversationHistoryClientProtocol
     private let conversationListClient: any ConversationListClientProtocol
+    private let conversationDetailClient: any ConversationDetailClientProtocol
     private let conversationForkClient: any ConversationForkClientProtocol
     private let userDefaults: UserDefaults
     private static let persistenceKey = "ios_conversations_v1"
@@ -337,8 +345,19 @@ class IOSConversationStore: ObservableObject {
         return conversation
     }
 
-    private func publishSelectionRequest(for conversationLocalId: UUID) {
+    private func publishSelectionRequest(
+        for conversationLocalId: UUID,
+        anchorDaemonMessageId: String? = nil
+    ) {
         selectionRequest = ConversationSelectionRequest(conversationLocalId: conversationLocalId)
+        if let anchorDaemonMessageId {
+            pendingConversationAnchorRequest = PendingConversationAnchorRequest(
+                conversationLocalId: conversationLocalId,
+                daemonMessageId: anchorDaemonMessageId
+            )
+        } else {
+            pendingConversationAnchorRequest = nil
+        }
     }
 
     /// One-time migration: move data from legacy "threads" keys to new "conversations" keys.
@@ -359,12 +378,14 @@ class IOSConversationStore: ObservableObject {
         connectedModeOverride: Bool? = nil,
         conversationHistoryClient: any ConversationHistoryClientProtocol = ConversationHistoryClient(),
         conversationListClient: any ConversationListClientProtocol = ConversationListClient(),
+        conversationDetailClient: any ConversationDetailClientProtocol = ConversationDetailClient(),
         conversationForkClient: any ConversationForkClientProtocol = ConversationForkClient(),
         userDefaults: UserDefaults = .standard
     ) {
         self.daemonClient = daemonClient
         self.conversationHistoryClient = conversationHistoryClient
         self.conversationListClient = conversationListClient
+        self.conversationDetailClient = conversationDetailClient
         self.conversationForkClient = conversationForkClient
         self.userDefaults = userDefaults
         Self.migrateKeysIfNeeded(userDefaults: userDefaults)
@@ -529,6 +550,7 @@ class IOSConversationStore: ObservableObject {
         pendingHistoryByConversationId.removeAll()
         pendingAttentionOverrides.removeAll()
         selectionRequest = nil
+        pendingConversationAnchorRequest = nil
 
         if let daemon = newClient as? DaemonClient {
             // Connected mode — show cached conversations instantly or spinner on first launch.
@@ -653,6 +675,10 @@ class IOSConversationStore: ObservableObject {
 
                 var merged: [IOSConversation] = []
                 for var restored in restoredConversations {
+                    if let conversationId = restored.conversationId,
+                       let cachedConversation = conversations.first(where: { $0.conversationId == conversationId }) {
+                        restored.forkParent = restored.forkParent ?? cachedConversation.forkParent
+                    }
                     if let local = localOverrides[restored.conversationId ?? ""] {
                         let sid = restored.conversationId ?? ""
                         let useLocalPin = locallyEditedPinConversationIds.contains(sid)
@@ -1156,7 +1182,17 @@ class IOSConversationStore: ObservableObject {
         selectionRequest = nil
     }
 
-    private func upsertForkedConversation(_ item: ConversationListResponseItem) -> UUID {
+    func pendingAnchorRequest(for conversationLocalId: UUID) -> PendingConversationAnchorRequest? {
+        guard pendingConversationAnchorRequest?.conversationLocalId == conversationLocalId else { return nil }
+        return pendingConversationAnchorRequest
+    }
+
+    func consumePendingAnchorRequest(id: UUID) {
+        guard pendingConversationAnchorRequest?.id == id else { return }
+        pendingConversationAnchorRequest = nil
+    }
+
+    private func upsertConversationListItem(_ item: ConversationListResponseItem) -> UUID {
         if let existingIndex = existingConversationIndex(forConversationId: item.id) {
             var mergedConversation = conversations[existingIndex]
             mergedConversation.title = item.title
@@ -1184,6 +1220,34 @@ class IOSConversationStore: ObservableObject {
     }
 
     @discardableResult
+    func openForkParent(of conversationLocalId: UUID) async -> UUID? {
+        guard isConnectedMode,
+              let conversation = conversations.first(where: { $0.id == conversationLocalId }),
+              let forkParent = conversation.forkParent else {
+            return nil
+        }
+
+        let parentLocalId: UUID
+        if let existingIndex = existingConversationIndex(forConversationId: forkParent.conversationId) {
+            parentLocalId = conversations[existingIndex].id
+        } else {
+            guard let parentConversation = await conversationDetailClient.fetchConversation(
+                conversationId: forkParent.conversationId
+            ) else {
+                return nil
+            }
+            parentLocalId = upsertConversationListItem(parentConversation)
+            saveConnectedCache()
+        }
+
+        publishSelectionRequest(
+            for: parentLocalId,
+            anchorDaemonMessageId: forkParent.messageId
+        )
+        return parentLocalId
+    }
+
+    @discardableResult
     func forkConversation(conversationLocalId: UUID, throughDaemonMessageId: String?) async -> UUID? {
         guard isConnectedMode,
               let conversation = conversations.first(where: { $0.id == conversationLocalId }),
@@ -1195,7 +1259,7 @@ class IOSConversationStore: ObservableObject {
             return nil
         }
 
-        let forkedLocalId = upsertForkedConversation(forkedConversation)
+        let forkedLocalId = upsertConversationListItem(forkedConversation)
         saveConnectedCache()
         publishSelectionRequest(for: forkedLocalId)
         return forkedLocalId

--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -1,0 +1,224 @@
+#if canImport(UIKit)
+import SwiftUI
+import XCTest
+
+@testable import VellumAssistantShared
+@testable import vellum_assistant_ios
+
+@MainActor
+final class ConversationForkNavigationIOSTests: XCTestCase {
+    func testOpenForkParentFetchesMissingParentPublishesSelectionAndAnchor() async throws {
+        let (userDefaults, suiteName) = makeUserDefaults()
+        defer { clear(userDefaults, suiteName: suiteName) }
+
+        let daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        let detailClient = MockConversationDetailClient()
+        detailClient.response = ConversationListResponseItem(
+            id: "conv-parent",
+            title: "Parent thread",
+            createdAt: 1_700_000_000,
+            updatedAt: 1_700_000_100
+        )
+
+        let store = IOSConversationStore(
+            daemonClient: daemonClient,
+            connectedModeOverride: true,
+            conversationDetailClient: detailClient,
+            userDefaults: userDefaults
+        )
+        store.isLoadingInitialConversations = false
+        let child = IOSConversation(
+            title: "Forked child",
+            conversationId: "conv-child",
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: "msg-source",
+                title: "Parent thread"
+            )
+        )
+        store.conversations = [child]
+
+        let parentLocalId = try XCTUnwrap(await store.openForkParent(of: child.id))
+
+        XCTAssertEqual(detailClient.requests, ["conv-parent"])
+        XCTAssertEqual(store.selectionRequest?.conversationLocalId, parentLocalId)
+        XCTAssertEqual(
+            store.pendingAnchorRequest(for: parentLocalId)?.daemonMessageId,
+            "msg-source"
+        )
+
+        let parentConversation = try XCTUnwrap(
+            store.conversations.first(where: { $0.id == parentLocalId })
+        )
+        XCTAssertEqual(parentConversation.conversationId, "conv-parent")
+        XCTAssertEqual(parentConversation.title, "Parent thread")
+    }
+
+    func testResolvePendingChatAnchorFindsMessageAndSignalsWindowExpansion() {
+        let oldest = makeMessage(text: "Oldest", daemonMessageId: "msg-oldest")
+        let middle = makeMessage(text: "Middle", daemonMessageId: "msg-middle")
+        let newest = makeMessage(text: "Newest", daemonMessageId: "msg-newest")
+        let displayedMessages = [oldest, middle, newest]
+
+        let expandedResolution = resolvePendingChatAnchor(
+            daemonMessageId: "msg-oldest",
+            displayedMessages: displayedMessages,
+            displayedMessageCount: 2
+        )
+        XCTAssertEqual(
+            expandedResolution,
+            PendingChatAnchorResolution(
+                localMessageId: oldest.id,
+                requiresExpandedWindow: true
+            )
+        )
+
+        let visibleResolution = resolvePendingChatAnchor(
+            daemonMessageId: "msg-newest",
+            displayedMessages: displayedMessages,
+            displayedMessageCount: 2
+        )
+        XCTAssertEqual(
+            visibleResolution,
+            PendingChatAnchorResolution(
+                localMessageId: newest.id,
+                requiresExpandedWindow: false
+            )
+        )
+
+        XCTAssertNil(
+            resolvePendingChatAnchor(
+                daemonMessageId: "msg-missing",
+                displayedMessages: displayedMessages,
+                displayedMessageCount: 2
+            )
+        )
+    }
+
+    func testCurrentTipForkToolbarActionOnlyExistsForPersistedConversationAndForksCurrentTip() async throws {
+        let (userDefaults, suiteName) = makeUserDefaults()
+        defer { clear(userDefaults, suiteName: suiteName) }
+
+        let daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        let forkClient = MockConversationForkClient()
+        forkClient.response = makeForkedConversationItem(messageId: "msg-tip")
+
+        let store = IOSConversationStore(
+            daemonClient: daemonClient,
+            connectedModeOverride: true,
+            conversationForkClient: forkClient,
+            userDefaults: userDefaults
+        )
+        store.isLoadingInitialConversations = false
+
+        let persistedConversation = IOSConversation(
+            title: "Persisted",
+            conversationId: "conv-parent"
+        )
+        let localConversation = IOSConversation(title: "Draft")
+        store.conversations = [persistedConversation, localConversation]
+
+        XCTAssertNil(
+            makeCurrentTipForkToolbarAction(store: store, conversation: localConversation)
+        )
+
+        let viewModel = store.viewModel(for: persistedConversation.id)
+        viewModel.messages = [makeMessage(text: "Persisted assistant reply", daemonMessageId: "msg-tip")]
+
+        let action = try XCTUnwrap(
+            makeCurrentTipForkToolbarAction(store: store, conversation: persistedConversation)
+        )
+        action()
+
+        waitUntil(timeout: 1.0) { store.selectionRequest != nil }
+
+        XCTAssertEqual(forkClient.requests.count, 1)
+        XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
+        XCTAssertEqual(forkClient.requests.first?.throughMessageId, "msg-tip")
+    }
+
+    private func makeUserDefaults() -> (UserDefaults, String) {
+        let suiteName = "ConversationForkNavigationIOSTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private func clear(_ userDefaults: UserDefaults, suiteName: String) {
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeMessage(text: String, daemonMessageId: String) -> ChatMessage {
+        var message = ChatMessage(role: .assistant, text: text)
+        message.daemonMessageId = daemonMessageId
+        return message
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping () -> Bool
+    ) {
+        let expectation = expectation(description: "Condition met")
+        let deadline = Date().addingTimeInterval(timeout)
+
+        func poll() {
+            if condition() {
+                expectation.fulfill()
+            } else if Date() < deadline {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                    poll()
+                }
+            }
+        }
+
+        poll()
+        wait(for: [expectation], timeout: timeout + 0.2)
+        XCTAssertTrue(condition(), file: file, line: line)
+    }
+
+    private func makeForkedConversationItem(messageId: String) -> ConversationListResponseItem {
+        ConversationListResponseItem(
+            id: "conv-forked",
+            title: "Forked thread",
+            createdAt: 1_700_000_100,
+            updatedAt: 1_700_000_120,
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: messageId,
+                title: "Parent thread"
+            )
+        )
+    }
+}
+
+@MainActor
+private final class MockConversationDetailClient: ConversationDetailClientProtocol {
+    var response: ConversationListResponseItem?
+    private(set) var requests: [String] = []
+
+    func fetchConversation(conversationId: String) async -> ConversationListResponseItem? {
+        requests.append(conversationId)
+        return response
+    }
+}
+
+@MainActor
+private final class MockConversationForkClient: ConversationForkClientProtocol {
+    struct Request: Equatable {
+        let conversationId: String
+        let throughMessageId: String?
+    }
+
+    var response: ConversationListResponseItem?
+    private(set) var requests: [Request] = []
+
+    func forkConversation(conversationId: String, throughMessageId: String?) async -> ConversationListResponseItem? {
+        requests.append(Request(conversationId: conversationId, throughMessageId: throughMessageId))
+        return response
+    }
+}
+#endif

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -27,8 +27,36 @@ private struct ScrollViewportHeightKey: PreferenceKey {
     }
 }
 
+struct PendingChatAnchorResolution: Equatable {
+    let localMessageId: UUID
+    let requiresExpandedWindow: Bool
+}
+
+func resolvePendingChatAnchor(
+    daemonMessageId: String,
+    displayedMessages: [ChatMessage],
+    displayedMessageCount: Int
+) -> PendingChatAnchorResolution? {
+    guard let messageIndex = displayedMessages.firstIndex(where: { $0.daemonMessageId == daemonMessageId }) else {
+        return nil
+    }
+
+    let visibleCount = displayedMessageCount == Int.max
+        ? displayedMessages.count
+        : min(displayedMessageCount, displayedMessages.count)
+    let visibleStartIndex = max(0, displayedMessages.count - visibleCount)
+
+    return PendingChatAnchorResolution(
+        localMessageId: displayedMessages[messageIndex].id,
+        requiresExpandedWindow: displayedMessageCount != Int.max && messageIndex < visibleStartIndex
+    )
+}
+
 struct ChatContentView: View {
     @ObservedObject var viewModel: ChatViewModel
+    var pendingAnchorRequestId: UUID? = nil
+    var pendingAnchorDaemonMessageId: String? = nil
+    var onPendingAnchorHandled: ((UUID) -> Void)? = nil
     @FocusState private var isInputFocused: Bool
     @Environment(\.colorScheme) private var colorScheme
     @State private var emptyStateVisible = false
@@ -58,6 +86,10 @@ struct ChatContentView: View {
         // as new messages arrive, which would cause previously loaded history to vanish.
         guard viewModel.displayedMessageCount < all.count else { return all }
         return Array(all.suffix(viewModel.displayedMessageCount))
+    }
+
+    private var hasPendingAnchor: Bool {
+        pendingAnchorRequestId != nil && pendingAnchorDaemonMessageId != nil
     }
 
     var body: some View {
@@ -171,7 +203,7 @@ struct ChatContentView: View {
                 }
             }
             .onChange(of: viewModel.messages.count) { _, _ in
-                if isNearBottom && !viewModel.isLoadingMoreMessages {
+                if !hasPendingAnchor && isNearBottom && !viewModel.isLoadingMoreMessages {
                     scrollToBottom(proxy: proxy, animated: true)
                 }
             }
@@ -179,12 +211,12 @@ struct ChatContentView: View {
                 // Scroll without animation during streaming to avoid jank.
                 // Only scroll when actively streaming and the user hasn't
                 // scrolled away.
-                if viewModel.messages.last?.isStreaming == true && isNearBottom {
+                if !hasPendingAnchor && viewModel.messages.last?.isStreaming == true && isNearBottom {
                     scrollToBottom(proxy: proxy, animated: false)
                 }
             }
             .onChange(of: viewModel.isSending) { _, isSending in
-                if isSending {
+                if !hasPendingAnchor && isSending {
                     isNearBottom = true
                     withAnimation(.easeOut(duration: 0.3)) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -192,7 +224,7 @@ struct ChatContentView: View {
                 }
             }
             .onChange(of: viewModel.activeSubagents.count) { oldCount, newCount in
-                if newCount > oldCount && isNearBottom {
+                if !hasPendingAnchor && newCount > oldCount && isNearBottom {
                     scrollToBottom(proxy: proxy, animated: true)
                 }
             }
@@ -202,6 +234,7 @@ struct ChatContentView: View {
                 isNearBottom = true
                 isPaginationInFlight = false
                 scrollRestoreTask?.cancel()
+                guard !hasPendingAnchor else { return }
                 scrollRestoreTask = Task { @MainActor in
                     // Stage 0: immediate — covers the happy path where
                     // layout is already ready.
@@ -216,9 +249,17 @@ struct ChatContentView: View {
                     try? await Task.sleep(nanoseconds: 150_000_000)
                     guard !Task.isCancelled else { return }
                     scrollToBottom(proxy: proxy, animated: false)
-
-                    scrollRestoreTask = nil
                 }
+            }
+            .onAppear {
+                attemptPendingAnchorScrollIfNeeded(proxy: proxy)
+            }
+            .onChange(of: pendingAnchorRequestId) { _, _ in
+                attemptPendingAnchorScrollIfNeeded(proxy: proxy)
+            }
+            .onChange(of: viewModel.isHistoryLoaded) { _, isHistoryLoaded in
+                guard isHistoryLoaded else { return }
+                attemptPendingAnchorScrollIfNeeded(proxy: proxy)
             }
             .onDisappear {
                 scrollRestoreTask?.cancel()
@@ -639,6 +680,38 @@ struct ChatContentView: View {
             }
         } else {
             proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+        }
+    }
+
+    private func attemptPendingAnchorScrollIfNeeded(proxy: ScrollViewProxy) {
+        guard let pendingAnchorRequestId,
+              let pendingAnchorDaemonMessageId,
+              viewModel.isHistoryLoaded else {
+            return
+        }
+
+        scrollRestoreTask?.cancel()
+
+        guard let resolution = resolvePendingChatAnchor(
+            daemonMessageId: pendingAnchorDaemonMessageId,
+            displayedMessages: viewModel.displayedMessages,
+            displayedMessageCount: viewModel.displayedMessageCount
+        ) else {
+            onPendingAnchorHandled?(pendingAnchorRequestId)
+            return
+        }
+
+        scrollRestoreTask = Task { @MainActor in
+            if resolution.requiresExpandedWindow {
+                viewModel.displayedMessageCount = Int.max
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                guard !Task.isCancelled else { return }
+            }
+
+            withAnimation(.easeOut(duration: 0.3)) {
+                proxy.scrollTo(resolution.localMessageId, anchor: .center)
+            }
+            onPendingAnchorHandled?(pendingAnchorRequestId)
         }
     }
 }

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -42,6 +42,36 @@ func applyConversationSelectionRequest(
     }
 }
 
+func shouldShowCurrentTipForkAction(for conversation: IOSConversation) -> Bool {
+    conversation.conversationId != nil
+}
+
+@MainActor
+func makeCurrentTipForkToolbarAction(
+    store: IOSConversationStore,
+    conversation: IOSConversation
+) -> (() -> Void)? {
+    guard shouldShowCurrentTipForkAction(for: conversation) else { return nil }
+    return {
+        Task { @MainActor in
+            _ = await store.forkCurrentTip(conversationLocalId: conversation.id)
+        }
+    }
+}
+
+@MainActor
+func makeOpenForkParentAction(
+    store: IOSConversationStore,
+    conversation: IOSConversation
+) -> (() -> Void)? {
+    guard conversation.forkParent != nil else { return nil }
+    return {
+        Task { @MainActor in
+            _ = await store.openForkParent(of: conversation.id)
+        }
+    }
+}
+
 // MARK: - Tab Entry Point
 
 /// The tab-level Chats entry point. Switches between connected and disconnected
@@ -236,7 +266,8 @@ struct ConversationListView: View {
         if let conversation = store.conversations.first(where: { $0.id == conversationLocalId }) {
             ConversationChatView(
                 viewModel: store.viewModel(for: conversationLocalId),
-                conversationTitle: conversation.title
+                store: store,
+                conversation: conversation
             )
             .onAppear {
                 store.loadHistoryIfNeeded(for: conversationLocalId)
@@ -668,7 +699,8 @@ struct ConversationListView: View {
 /// Thin wrapper around ChatContentView for a conversation-owned ChatViewModel.
 struct ConversationChatView: View {
     @ObservedObject var viewModel: ChatViewModel
-    var conversationTitle: String?
+    @ObservedObject var store: IOSConversationStore
+    let conversation: IOSConversation
 
     @EnvironmentObject var clientProvider: ClientProvider
     @AppStorage(UserDefaultsKeys.developerModeEnabled) private var developerModeEnabled: Bool = false
@@ -678,7 +710,22 @@ struct ConversationChatView: View {
     @State private var showDebugPanel = false
 
     var body: some View {
-        ChatContentView(viewModel: viewModel)
+        let anchorRequest = store.pendingAnchorRequest(for: conversation.id)
+        VStack(spacing: 0) {
+            if let parentChromeAction = makeOpenForkParentAction(store: store, conversation: conversation),
+               let forkParent = conversation.forkParent {
+                forkParentChrome(forkParent: forkParent, action: parentChromeAction)
+            }
+
+            ChatContentView(
+                viewModel: viewModel,
+                pendingAnchorRequestId: anchorRequest?.id,
+                pendingAnchorDaemonMessageId: anchorRequest?.daemonMessageId,
+                onPendingAnchorHandled: { requestId in
+                    store.consumePendingAnchorRequest(id: requestId)
+                }
+            )
+        }
             .navigationTitle("Chat")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -689,6 +736,17 @@ struct ConversationChatView: View {
                         } label: {
                             VIconView(.bug, size: 20)
                                 .foregroundColor(VColor.contentTertiary)
+                        }
+                    }
+                }
+                if let forkAction = makeCurrentTipForkToolbarAction(store: store, conversation: conversation) {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button(action: forkAction) {
+                            Label {
+                                Text("Fork conversation")
+                            } icon: {
+                                VIconView(.gitBranch, size: 14)
+                            }
                         }
                     }
                 }
@@ -706,6 +764,45 @@ struct ConversationChatView: View {
                     onClose: { showDebugPanel = false }
                 )
             }
+    }
+
+    @ViewBuilder
+    private func forkParentChrome(
+        forkParent: ConversationForkParent,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.gitBranch, size: 14)
+                    .foregroundColor(VColor.primaryBase)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Forked from")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text(forkParent.title ?? "Parent conversation")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                VIconView(.chevronRight, size: 14)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(VColor.surfaceBase)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(VColor.borderBase)
+                    .frame(height: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Open parent conversation")
+        .accessibilityHint("Opens the conversation this chat forked from")
     }
 
     @ViewBuilder
@@ -753,7 +850,7 @@ struct ConversationChatView: View {
         )
         return ChatTranscriptFormatter.conversationMarkdown(
             messages: viewModel.messages,
-            conversationTitle: conversationTitle,
+            conversationTitle: conversation.title,
             participantNames: names
         )
     }


### PR DESCRIPTION
## Summary
- add iOS parent conversation loading, pending anchor state, and navigation flow
- surface current-tip fork and parent-link chrome in the chat header
- add focused iOS coverage for parent open, anchor handling, and toolbar forking

Part of plan: conversation-forking.md (PR 12 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
