### PR TITLE
Fix inspector load-state handling for LLM context

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -386,17 +386,27 @@ struct MessageInspectorView: View {
         )
     }
 
+    @MainActor
     private func reloadContext(resetSelection: Bool) async {
-        viewState.beginLoading(resetSelection: resetSelection)
+        let requestToken = viewState.beginLoading(resetSelection: resetSelection)
         payloadModels = [:]
 
-        let result = await llmContextClient.fetchContext(messageId: messageId)
+        do {
+            let result = try await llmContextClient.fetchContextResult(messageId: messageId)
+            try Task.checkCancellation()
+            guard viewState.isActiveLoad(requestToken) else { return }
 
-        if let result {
-            payloadModels = payloadModelsByKey(for: result.logs)
+            if case let .loaded(response) = result {
+                payloadModels = payloadModelsByKey(for: response.logs)
+            }
+
+            viewState.finishLoading(with: result, requestToken: requestToken)
+        } catch is CancellationError {
+            guard viewState.isActiveLoad(requestToken) else { return }
+        } catch {
+            guard viewState.isActiveLoad(requestToken) else { return }
+            viewState.finishLoading(with: .failed, requestToken: requestToken)
         }
-
-        viewState.finishLoading(with: result)
     }
 
     private func payloadModelsByKey(for logs: [LLMRequestLogEntry]) -> [String: MessageInspectorPayloadModel] {
@@ -566,13 +576,16 @@ struct MessageInspectorViewState {
     private(set) var logs: [LLMRequestLogEntry] = []
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
+    private(set) var activeLoadToken: UUID?
 
     var selectedLog: LLMRequestLogEntry? {
         guard let selectedLogID else { return nil }
         return logs.first(where: { $0.id == selectedLogID })
     }
 
-    mutating func beginLoading(resetSelection: Bool) {
+    mutating func beginLoading(resetSelection: Bool) -> UUID {
+        let requestToken = UUID()
+        activeLoadToken = requestToken
         loadState = .loading
         logs = []
 
@@ -580,33 +593,46 @@ struct MessageInspectorViewState {
             selectedLogID = nil
             selectedDetailTab = .overview
         }
+
+        return requestToken
     }
 
-    mutating func finishLoading(with response: LLMContextResponse?) {
-        guard let response else {
-            loadState = .failed
+    func isActiveLoad(_ requestToken: UUID) -> Bool {
+        activeLoadToken == requestToken
+    }
+
+    mutating func finishLoading(with result: LLMContextFetchResult, requestToken: UUID) {
+        guard activeLoadToken == requestToken else { return }
+        activeLoadToken = nil
+
+        switch result {
+        case .loaded(let response):
+            let orderedLogs = Self.ordered(response.logs)
+            logs = orderedLogs
+
+            guard !orderedLogs.isEmpty else {
+                loadState = .empty
+                selectedLogID = nil
+                return
+            }
+
+            loadState = .loaded
+
+            if let selectedLogID,
+               orderedLogs.contains(where: { $0.id == selectedLogID }) {
+                return
+            }
+
+            selectedLogID = orderedLogs.first?.id
+        case .empty:
             logs = []
-            selectedLogID = nil
-            return
-        }
-
-        let orderedLogs = Self.ordered(response.logs)
-        logs = orderedLogs
-
-        guard !orderedLogs.isEmpty else {
             loadState = .empty
             selectedLogID = nil
-            return
+        case .failed:
+            logs = []
+            loadState = .failed
+            selectedLogID = nil
         }
-
-        loadState = .loaded
-
-        if let selectedLogID,
-           orderedLogs.contains(where: { $0.id == selectedLogID }) {
-            return
-        }
-
-        selectedLogID = orderedLogs.first?.id
     }
 
     mutating func selectLog(id: String) {

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -480,11 +480,19 @@ public struct LLMContextResponse: Codable, Sendable {
     public let logs: [LLMRequestLogEntry]
 }
 
+/// Explicit outcome for an LLM context fetch.
+public enum LLMContextFetchResult: Sendable {
+    case loaded(LLMContextResponse)
+    case empty
+    case failed
+}
+
 /// Focused client for fetching LLM request/response context for a given message,
 /// routed through the gateway.
 @MainActor
 public protocol LLMContextClientProtocol {
     func fetchContext(messageId: String) async -> LLMContextResponse?
+    func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult
 }
 
 /// Gateway-backed implementation of ``LLMContextClientProtocol``.
@@ -494,18 +502,53 @@ public struct LLMContextClient: LLMContextClientProtocol {
 
     public func fetchContext(messageId: String) async -> LLMContextResponse? {
         do {
-            let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/messages/\(messageId)/llm-context",
-                timeout: 15
-            )
-            guard response.isSuccess else {
-                log.error("fetchContext failed (HTTP \(response.statusCode))")
+            switch try await fetchContextResult(messageId: messageId) {
+            case .loaded(let response):
+                return response
+            case .empty, .failed:
                 return nil
             }
-            return try JSONDecoder().decode(LLMContextResponse.self, from: response.data)
+        } catch is CancellationError {
+            return nil
         } catch {
             log.error("fetchContext error: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    public func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult {
+        do {
+            try Task.checkCancellation()
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/messages/\(messageId)/llm-context",
+                timeout: 15
+            )
+            try Task.checkCancellation()
+            guard response.isSuccess else {
+                log.error("fetchContext failed (HTTP \(response.statusCode))")
+                return .failed
+            }
+            let decoded = try JSONDecoder().decode(LLMContextResponse.self, from: response.data)
+            try Task.checkCancellation()
+            return decoded.logs.isEmpty ? .empty : .loaded(decoded)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
+            log.error("fetchContext error: \(error.localizedDescription)")
+            return .failed
+        }
+    }
+}
+
+public extension LLMContextClientProtocol {
+    func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult {
+        guard let response = await fetchContext(messageId: messageId) else {
+            return .failed
+        }
+
+        return response.logs.isEmpty ? .empty : .loaded(response)
     }
 }


### PR DESCRIPTION
## Summary
- add an explicit LLM context fetch result for the inspector flow
- keep cancellation from surfacing as a stale failed state when switching messages
- preserve the inspector's loading, empty, failed, and loaded states with the richer contract

Part of plan: llm-context-inspector-redesign.md (remediation round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
