### PR TITLE
fix: make iOS conversation fork test compile on newer Xcode

### DIFF
--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class ConversationForkIOSTests: XCTestCase {
     private let connectedCacheKey = "ios_connected_conversations_cache_v1"
 
-    func testForkConversationPublishesSelectionAndPersistsLineageInConnectedCache() async {
+    func testForkConversationPublishesSelectionAndPersistsLineageInConnectedCache() async throws {
         let (userDefaults, suiteName) = makeUserDefaults()
         defer { clear(userDefaults, suiteName: suiteName) }
 
@@ -32,21 +32,22 @@ final class ConversationForkIOSTests: XCTestCase {
         )
         store.conversations = [parent]
 
-        let forkedLocalId = try XCTUnwrap(await store.forkConversation(
+        let forkedLocalId = await store.forkConversation(
             conversationLocalId: parent.id,
             throughDaemonMessageId: "msg-root"
-        ))
+        )
+        let unwrappedForkedLocalId = try XCTUnwrap(forkedLocalId)
 
         XCTAssertEqual(forkClient.requests.count, 1)
         XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
         XCTAssertEqual(forkClient.requests.first?.throughMessageId, "msg-root")
-        XCTAssertEqual(store.selectionRequest?.conversationLocalId, forkedLocalId)
+        XCTAssertEqual(store.selectionRequest?.conversationLocalId, unwrappedForkedLocalId)
 
-        let forkedConversation = try XCTUnwrap(store.conversations.first(where: { $0.id == forkedLocalId }))
+        let forkedConversation = try XCTUnwrap(store.conversations.first(where: { $0.id == unwrappedForkedLocalId }))
         XCTAssertEqual(forkedConversation.conversationId, "conv-forked")
         XCTAssertEqual(forkedConversation.forkParent?.conversationId, "conv-parent")
         XCTAssertEqual(forkedConversation.forkParent?.messageId, "msg-root")
-        XCTAssertEqual(store.conversations.first?.id, forkedLocalId)
+        XCTAssertEqual(store.conversations.first?.id, unwrappedForkedLocalId)
 
         let restoredStore = IOSConversationStore(
             daemonClient: daemonClient,


### PR DESCRIPTION
## Summary
- update the iOS conversation fork test to avoid using an async expression inside `XCTUnwrap`
- mark the test as `async throws` so the unwrap-based assertions compile under the current Swift/XCTest toolchain

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23283142477/job/67700705945
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
