### PR TITLE
Fix response metadata rendering in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift
@@ -16,7 +16,7 @@ struct MessageInspectorOverviewTab: View {
                 } else {
                     metadataCard(
                         title: "Normalized metadata",
-                        subtitle: "Provider, model, timestamps, stop reason, and usage counts.",
+                        subtitle: "Provider, model, timestamps, and usage counts.",
                         rows: content.identityRows
                     )
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -13,14 +13,14 @@ struct MessageInspectorResponseTab: View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 if model.hasNormalizedSections {
-                    responseMetadataCard(showResponseMode: true)
+                    responseMetadataCard
 
                     ForEach(model.sections) { section in
                         responseSectionCard(for: section)
                     }
                 } else {
-                    if model.stopReason != nil {
-                        responseMetadataCard(showResponseMode: false)
+                    if model.responseModeLabel != nil {
+                        responseMetadataCard
                     }
 
                     fallbackCard
@@ -33,7 +33,7 @@ struct MessageInspectorResponseTab: View {
         .background(VColor.surfaceBase)
     }
 
-    private func responseMetadataCard(showResponseMode: Bool) -> some View {
+    private var responseMetadataCard: some View {
         VCard {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Response metadata")
@@ -41,12 +41,8 @@ struct MessageInspectorResponseTab: View {
                     .foregroundColor(VColor.contentDefault)
 
                 HStack(alignment: .top, spacing: VSpacing.xs) {
-                    if showResponseMode {
-                        metadataChip(model.responseModeLabel)
-                    }
-
-                    if let stopReason = model.stopReason {
-                        metadataChip("Stop reason: \(stopReason)")
+                    if let responseModeLabel = model.responseModeLabel {
+                        metadataChip(responseModeLabel)
                     }
                 }
             }
@@ -212,8 +208,7 @@ struct MessageInspectorResponseTab: View {
 
 struct MessageInspectorResponseTabModel: Equatable {
     let sections: [MessageInspectorResponseSectionModel]
-    let responseModeLabel: String
-    let stopReason: String?
+    let responseModeLabel: String?
     let fallbackMessage: String?
 
     init(entry: LLMRequestLogEntry) {
@@ -222,10 +217,7 @@ struct MessageInspectorResponseTabModel: Equatable {
             MessageInspectorResponseSectionModel(index: index, section: section)
         }
 
-        stopReason = entry.summary?.stopReason
-        responseModeLabel = (entry.summary?.responseToolCallCount ?? 0) > 0 || sections.contains(where: { $0.isToolCallLike })
-            ? "Tool-calling response"
-            : "Text-only response"
+        responseModeLabel = Self.deriveResponseModeLabel(summary: entry.summary, sections: sections)
         fallbackMessage = sections.isEmpty
             ? "This provider response has not been normalized yet. Open the Raw tab to inspect the full provider payload."
             : nil
@@ -233,6 +225,29 @@ struct MessageInspectorResponseTabModel: Equatable {
 
     var hasNormalizedSections: Bool {
         !sections.isEmpty
+    }
+
+    private static func deriveResponseModeLabel(
+        summary: LLMCallSummary?,
+        sections: [MessageInspectorResponseSectionModel]
+    ) -> String? {
+        if let responseToolCallCount = summary?.responseToolCallCount {
+            return responseToolCallCount > 0 ? "Tool-calling response" : "Text-only response"
+        }
+
+        if let stopReason = summary?.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            if ["tool_calls", "tool_use", "function_call", "function_response"].contains(stopReason) {
+                return "Tool-calling response"
+            }
+
+            return "Text-only response"
+        }
+
+        if sections.contains(where: { $0.isToolCallLike }) {
+            return "Tool-calling response"
+        }
+
+        return sections.isEmpty ? nil : "Text-only response"
     }
 }
 
@@ -252,6 +267,10 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
     let presentationKind: PresentationKind
     let isToolCallLike: Bool
 
+    var showsRawPayloadHint: Bool {
+        presentationKind == .toolCall
+    }
+
     init(index: Int, section: LLMContextSection) {
         id = index
         toolName = section.toolName
@@ -265,7 +284,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
             presentationKind = .toolCall
             isToolCallLike = true
             kindLabel = "Tool call"
-            let preview = section.text ?? Self.previewText(for: section.data)
+            let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
             let copySource = preview ?? title
             copyText = copySource
@@ -273,7 +292,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
             presentationKind = .other
             isToolCallLike = true
             kindLabel = section.kind == .functionResponse ? "Function response" : "Tool result"
-            let preview = section.text ?? Self.previewText(for: section.data)
+            let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
             copyText = preview ?? title
         case .assistant, .message, .text, .output, .completion, .reasoning, .markdown, .code, .json:
@@ -290,10 +309,6 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
             bodyText = preview
             copyText = bodyText ?? title
         }
-    }
-
-    var showsRawPayloadHint: Bool {
-        presentationKind == .toolCall
     }
 
     private static func previewText(for data: AnyCodable?) -> String? {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -31,7 +31,6 @@ struct MessageInspectorOverviewContent: Equatable {
             .init(label: "Provider", value: MessageInspectorSummaryFormatters.displayProvider(summary.provider)),
             .init(label: "Model", value: MessageInspectorSummaryFormatters.displayText(summary.model)),
             .init(label: "Created", value: MessageInspectorSummaryFormatters.formattedCreatedAt(entry.createdAt)),
-            .init(label: "Stop reason", value: MessageInspectorSummaryFormatters.displayStopReason(summary.stopReason)),
         ]
 
         usageRows = [
@@ -78,7 +77,7 @@ enum MessageInspectorSummaryFormatters {
     }
 
     static func displayProvider(_ provider: String?) -> String {
-        guard let provider = displayText(provider).nilIfEmpty else {
+        guard let provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines), !provider.isEmpty else {
             return missingValue
         }
 
@@ -92,14 +91,6 @@ enum MessageInspectorSummaryFormatters {
         default:
             return provider
         }
-    }
-
-    static func displayStopReason(_ stopReason: String?) -> String {
-        guard let stopReason = displayText(stopReason).nilIfEmpty else {
-            return missingValue
-        }
-
-        return humanizedIdentifier(stopReason)
     }
 
     static func displayText(_ value: String?) -> String {
@@ -148,22 +139,9 @@ enum MessageInspectorSummaryFormatters {
             .formatted(date: .abbreviated, time: .shortened)
     }
 
-    static func humanizedIdentifier(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "_", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .capitalized
-    }
-
     private static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         return formatter
     }()
-}
-
-private extension String {
-    var nilIfEmpty: String? {
-        isEmpty ? nil : self
-    }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -38,11 +38,10 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
 
         let content = MessageInspectorOverviewContent(entry: entry)
 
-        XCTAssertEqual(content.identityRows.map(\.label), ["Provider", "Model", "Created", "Stop reason"])
+        XCTAssertEqual(content.identityRows.map(\.label), ["Provider", "Model", "Created"])
         XCTAssertEqual(content.identityRows.map(\.value)[0], "OpenAI")
         XCTAssertEqual(content.identityRows.map(\.value)[1], "gpt-4.1")
         XCTAssertTrue(content.identityRows.map(\.value)[2].contains("1970"))
-        XCTAssertEqual(content.identityRows.map(\.value)[3], "Tool Calls")
 
         XCTAssertEqual(content.usageRows.map(\.label), ["Input tokens", "Output tokens", "Cache tokens", "Request messages", "Tool count"])
         XCTAssertEqual(content.usageRows.map(\.value), ["321", "54", "Unavailable", "2", "2"])
@@ -84,7 +83,6 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         let content = MessageInspectorOverviewContent(entry: entry)
 
         XCTAssertEqual(content.identityRows.map(\.value)[0], "Anthropic")
-        XCTAssertEqual(content.identityRows.map(\.value)[3], "Tool Use")
         XCTAssertEqual(content.usageRows.map(\.value), ["410", "73", "Created 200, Read 80", "2", "1"])
         XCTAssertEqual(content.responsePreview, "I found the changelog.")
         XCTAssertEqual(content.toolCallNames, "fetch_page")
@@ -124,7 +122,6 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         let content = MessageInspectorOverviewContent(entry: entry)
 
         XCTAssertEqual(content.identityRows.map(\.value)[0], "Gemini")
-        XCTAssertEqual(content.identityRows.map(\.value)[3], "Stop")
         XCTAssertEqual(content.usageRows.map(\.value), ["120", "34", "Unavailable", "2", "1"])
         XCTAssertEqual(content.responsePreview, "Here is a concise summary.")
         XCTAssertEqual(content.toolCallNames, "save_note")

--- a/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
@@ -41,11 +41,27 @@ final class MessageInspectorResponseTabTests: XCTestCase {
                         kind: .functionCall,
                         label: "Response tool call 1",
                         role: "assistant",
-                        text: "{\"query\":\"docs\",\"limit\":3}",
+                        text: "truncated arguments preview",
                         toolName: "search_web",
                         data: AnyCodable([
                             "query": "docs",
-                            "limit": 3
+                            "limit": 3,
+                            "filters": [
+                                "lang": "en"
+                            ]
+                        ])
+                    ),
+                    LLMContextSection(
+                        kind: .functionResponse,
+                        label: "Response tool result 1",
+                        role: "assistant",
+                        text: "truncated result preview",
+                        toolName: "search_web",
+                        data: AnyCodable([
+                            "results": [
+                                "docs",
+                                "reference"
+                            ]
                         ])
                     )
                 ]
@@ -54,8 +70,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
 
         XCTAssertTrue(model.hasNormalizedSections)
         XCTAssertEqual(model.responseModeLabel, "Tool-calling response")
-        XCTAssertEqual(model.stopReason, "tool_calls")
-        XCTAssertEqual(model.sections.count, 2)
+        XCTAssertEqual(model.sections.count, 3)
 
         XCTAssertEqual(model.sections[0].presentationKind, .assistantText)
         XCTAssertEqual(model.sections[0].title, "Assistant response")
@@ -65,10 +80,29 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         XCTAssertEqual(model.sections[1].presentationKind, .toolCall)
         XCTAssertEqual(model.sections[1].toolName, "search_web")
         XCTAssertEqual(model.sections[1].kindLabel, "Tool call")
-        XCTAssertTrue(model.sections[1].bodyText?.contains("\"query\"") ?? false)
-        XCTAssertTrue(model.sections[1].bodyText?.contains("\"docs\"") ?? false)
+        XCTAssertEqual(model.sections[1].bodyText, """
+        {
+          "filters" : {
+            "lang" : "en"
+          },
+          "limit" : 3,
+          "query" : "docs"
+        }
+        """)
         XCTAssertEqual(model.sections[1].copyText, model.sections[1].bodyText)
         XCTAssertTrue(model.sections[1].showsRawPayloadHint)
+
+        XCTAssertEqual(model.sections[2].presentationKind, .other)
+        XCTAssertEqual(model.sections[2].kindLabel, "Function response")
+        XCTAssertEqual(model.sections[2].bodyText, """
+        {
+          "results" : [
+            "docs",
+            "reference"
+          ]
+        }
+        """)
+        XCTAssertEqual(model.sections[2].copyText, model.sections[2].bodyText)
     }
 
     func testResponseTabModelFallsBackWithoutNormalizedSections() {
@@ -84,7 +118,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
 
         XCTAssertFalse(model.hasNormalizedSections)
         XCTAssertTrue(model.sections.isEmpty)
-        XCTAssertEqual(model.stopReason, "end_turn")
+        XCTAssertEqual(model.responseModeLabel, "Text-only response")
         XCTAssertEqual(model.fallbackMessage, "This provider response has not been normalized yet. Open the Raw tab to inspect the full provider payload.")
     }
 


### PR DESCRIPTION
## Summary
- prefer full structured response payloads over truncated previews in the response tab
- move response-specific finish metadata out of overview and keep response mode visible in fallback states
- preserve text-first rendering for plain assistant response sections

Part of plan: llm-context-inspector-redesign.md (remediation round 2)