### PR TITLE
fix: repair resolved conversation disk-view rebuilds

### DIFF
--- a/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -153,6 +154,10 @@ function seedConversationRows(): {
   return { conversationId, conversationCreatedAt, conversationUpdatedAt };
 }
 
+function toConversationTimestamp(createdAtMs: number): string {
+  return new Date(createdAtMs).toISOString().replace(/:/g, "-");
+}
+
 describe("009-backfill-conversation-disk-view migration", () => {
   beforeEach(() => {
     resetTables();
@@ -208,5 +213,66 @@ describe("009-backfill-conversation-disk-view migration", () => {
     expect(readFileSync(join(attachmentsDir, "note.txt"), "utf-8")).toBe(
       "hello world",
     );
+  });
+
+  test("rebuilds stale legacy-named disk views in-place and stays idempotent", () => {
+    const { conversationId, conversationCreatedAt, conversationUpdatedAt } =
+      seedConversationRows();
+    const timestamp = toConversationTimestamp(conversationCreatedAt);
+    const expectedNewDirName = `${timestamp}_${conversationId}`;
+    const expectedNewDirPath = join(conversationsDir, expectedNewDirName);
+    const legacyDirPath = join(
+      conversationsDir,
+      `${conversationId}_${timestamp}`,
+    );
+    const metaPath = join(legacyDirPath, "meta.json");
+    const messagesPath = join(legacyDirPath, "messages.jsonl");
+    const attachmentsDir = join(legacyDirPath, "attachments");
+
+    mkdirSync(attachmentsDir, { recursive: true });
+    writeFileSync(
+      metaPath,
+      JSON.stringify(
+        {
+          id: conversationId,
+          title: "Backfill Test",
+          type: "standard",
+          channel: "desktop",
+          createdAt: new Date(conversationCreatedAt).toISOString(),
+          updatedAt: new Date(conversationUpdatedAt - 1000).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    writeFileSync(messagesPath, '{"role":"user","content":"stale line"}\n');
+    writeFileSync(join(attachmentsDir, "stale.txt"), "stale");
+
+    backfillConversationDiskViewMigration.run(workspaceDir);
+
+    expect(existsSync(expectedNewDirPath)).toBe(false);
+    expect(existsSync(legacyDirPath)).toBe(true);
+    expect(
+      JSON.parse(readFileSync(metaPath, "utf-8")).updatedAt,
+    ).toBe(new Date(conversationUpdatedAt).toISOString());
+    expect(readFileSync(messagesPath, "utf-8").trim().split("\n")).toHaveLength(
+      1,
+    );
+    expect(JSON.parse(readFileSync(messagesPath, "utf-8").trim())).toEqual({
+      role: "user",
+      ts: "2026-03-18T14:24:00.000Z",
+      content: "Hello from sqlite row",
+      attachments: ["note.txt"],
+    });
+    expect(readdirSync(attachmentsDir).sort()).toEqual(["note.txt"]);
+    expect(readFileSync(join(attachmentsDir, "note.txt"), "utf-8")).toBe(
+      "hello world",
+    );
+
+    const firstRunMessages = readFileSync(messagesPath, "utf-8");
+    backfillConversationDiskViewMigration.run(workspaceDir);
+
+    expect(readFileSync(messagesPath, "utf-8")).toBe(firstRunMessages);
+    expect(readdirSync(attachmentsDir).sort()).toEqual(["note.txt"]);
   });
 });

--- a/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -54,6 +55,7 @@ mock.module("../config/loader.js", () => ({
 // Imports — after mocks
 // ---------------------------------------------------------------------------
 
+import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
   attachments,
@@ -211,5 +213,61 @@ describe("013-repair-conversation-disk-view migration", () => {
     expect(readFileSync(join(attachmentsDir, "transcript.txt"), "utf-8")).toBe(
       "hello world",
     );
+  });
+
+  test("rebuilds when meta.json matches updatedAt but messages and attachments are missing", () => {
+    const { conversationId, conversationCreatedAt, conversationUpdatedAt } =
+      seedConversationRows();
+    const conversationDir = getConversationDirPath(
+      conversationId,
+      conversationCreatedAt,
+    );
+    const metaPath = join(conversationDir, "meta.json");
+    const messagesPath = join(conversationDir, "messages.jsonl");
+    const attachmentsDir = join(conversationDir, "attachments");
+
+    mkdirSync(conversationDir, { recursive: true });
+    writeFileSync(
+      metaPath,
+      JSON.stringify(
+        {
+          id: conversationId,
+          title: "Repair Test",
+          type: "standard",
+          channel: "desktop",
+          createdAt: new Date(conversationCreatedAt).toISOString(),
+          updatedAt: new Date(conversationUpdatedAt).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    expect(existsSync(metaPath)).toBe(true);
+    expect(existsSync(messagesPath)).toBe(false);
+    expect(existsSync(attachmentsDir)).toBe(false);
+
+    repairConversationDiskViewMigration.run(workspaceDir);
+
+    expect(existsSync(messagesPath)).toBe(true);
+    expect(existsSync(attachmentsDir)).toBe(true);
+    expect(readFileSync(messagesPath, "utf-8").trim().split("\n")).toHaveLength(
+      1,
+    );
+    expect(JSON.parse(readFileSync(messagesPath, "utf-8").trim())).toEqual({
+      role: "user",
+      ts: "2026-03-18T16:01:00.000Z",
+      content: "Repair missing disk view",
+      attachments: ["transcript.txt"],
+    });
+    expect(readdirSync(attachmentsDir).sort()).toEqual(["transcript.txt"]);
+    expect(readFileSync(join(attachmentsDir, "transcript.txt"), "utf-8")).toBe(
+      "hello world",
+    );
+
+    const firstRunMessages = readFileSync(messagesPath, "utf-8");
+    repairConversationDiskViewMigration.run(workspaceDir);
+    expect(readFileSync(messagesPath, "utf-8")).toBe(firstRunMessages);
+    expect(readdirSync(attachmentsDir).sort()).toEqual(["transcript.txt"]);
   });
 });

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -77,7 +77,10 @@ function getLegacyConversationDirPath(
   );
 }
 
-function resolveConversationDirPath(id: string, createdAtMs: number): string {
+export function getResolvedConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
   const dirPath = getConversationDirPath(id, createdAtMs);
   if (existsSync(dirPath)) return dirPath;
 
@@ -91,7 +94,7 @@ function ensureConversationDirPath(
   id: string,
   createdAtMs: number,
 ): string {
-  const dirPath = resolveConversationDirPath(id, createdAtMs);
+  const dirPath = getResolvedConversationDirPath(id, createdAtMs);
   mkdirSync(dirPath, { recursive: true });
   return dirPath;
 }

--- a/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
@@ -1,10 +1,10 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { asc, eq } from "drizzle-orm";
 
 import {
-  getConversationDirPath,
+  getResolvedConversationDirPath,
   initConversationDir,
   syncMessageToDisk,
   updateMetaFile,
@@ -34,15 +34,19 @@ export function rebuildConversationDiskViewFromDb(): void {
   let processed = 0;
 
   for (const conv of allConversations) {
-    // Check if already migrated (idempotent)
-    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const dirPath = getResolvedConversationDirPath(conv.id, conv.createdAt);
     const metaPath = join(dirPath, "meta.json");
+    const messagesPath = join(dirPath, "messages.jsonl");
+    const attachDir = join(dirPath, "attachments");
 
+    // Check if already migrated (idempotent)
     if (existsSync(metaPath)) {
       try {
         const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
         const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
-        if (existing.updatedAt === expectedUpdatedAt) {
+        const hasRequiredArtifacts =
+          existsSync(messagesPath) && existsSync(attachDir);
+        if (existing.updatedAt === expectedUpdatedAt && hasRequiredArtifacts) {
           processed++;
           if (processed % 50 === 0) {
             log.info(`Backfilled ${processed}/${total} conversations to disk`);
@@ -57,16 +61,16 @@ export function rebuildConversationDiskViewFromDb(): void {
     // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
     initConversationDir(conv);
 
-    // Clear stale data from any previous interrupted run so the append-only
+    // Clear stale data from any previous interrupted run so append-only
     // syncMessageToDisk calls below don't produce duplicates.
-    const messagesPath = join(dirPath, "messages.jsonl");
     if (existsSync(messagesPath)) {
       rmSync(messagesPath, { force: true });
     }
-    const attachDir = join(dirPath, "attachments");
     if (existsSync(attachDir)) {
       rmSync(attachDir, { recursive: true, force: true });
     }
+    writeFileSync(messagesPath, "");
+    mkdirSync(attachDir, { recursive: true });
 
     // Query all messages for this conversation and sync each to disk
     const convMessages = db


### PR DESCRIPTION
## Summary
- rebuild the resolved active conversation disk-view directory instead of only the new-format path
- stop skipping partially broken disk views when message or attachment artifacts are missing
- add regression coverage for partial repair recovery and legacy-directory idempotency

Fixes gap identified during plan review for repair-conversation-disk-view.md.

**Gap:** Repair helper must rebuild the resolved active disk-view directory, not just meta.json
**What was expected:** The shared rebuild helper and migration 013 should fully repair broken disk views and remain idempotent across partial and legacy-directory states.
**What was found:** The helper could skip partially broken disk views and clear the wrong directory when the active folder was legacy-named.