### PR TITLE
feat: add iOS message-level fork action

### DIFF
--- a/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
@@ -1,0 +1,177 @@
+#if canImport(UIKit)
+import SwiftUI
+import XCTest
+
+@testable import VellumAssistantShared
+@testable import vellum_assistant_ios
+
+@MainActor
+final class ConversationForkMessageActionIOSTests: XCTestCase {
+    func testPersistedMessagesExposeForkActionWhenHandlerExists() {
+        let message = makeMessage(daemonMessageId: "msg-persisted", isStreaming: false)
+        let view = MessageBubbleView(
+            message: message,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+
+        XCTAssertTrue(view.canForkFromMessage)
+    }
+
+    func testStreamingAndLocalOnlyMessagesDoNotExposeForkAction() {
+        let localOnlyMessage = makeMessage(daemonMessageId: nil, isStreaming: false)
+        let streamingMessage = makeMessage(daemonMessageId: "msg-stream", isStreaming: true)
+
+        let localOnlyView = MessageBubbleView(
+            message: localOnlyMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+        let streamingView = MessageBubbleView(
+            message: streamingMessage,
+            onConfirmationResponse: nil,
+            onSurfaceAction: nil,
+            onRegenerate: nil,
+            onForkFromMessage: { _ in }
+        )
+
+        XCTAssertFalse(localOnlyView.canForkFromMessage)
+        XCTAssertFalse(streamingView.canForkFromMessage)
+    }
+
+    func testMessageForkActionUsesStoreHelperAndPublishesSelectionForNewFork() async throws {
+        let (userDefaults, suiteName) = makeUserDefaults()
+        defer { clear(userDefaults, suiteName: suiteName) }
+
+        let daemonClient = MockDaemonClient()
+        daemonClient.isConnected = true
+        let forkClient = MockConversationForkClient()
+        forkClient.response = makeForkedConversationItem(messageId: "msg-branch")
+
+        let store = IOSConversationStore(
+            daemonClient: daemonClient,
+            connectedModeOverride: true,
+            conversationForkClient: forkClient,
+            userDefaults: userDefaults
+        )
+        store.isLoadingInitialConversations = false
+
+        let parent = IOSConversation(
+            title: "Parent thread",
+            conversationId: "conv-parent"
+        )
+        store.conversations = [parent]
+
+        let action = try XCTUnwrap(
+            makeOnForkFromMessageAction(
+                conversationLocalId: parent.id,
+                forkConversationFromMessage: { conversationLocalId, daemonMessageId in
+                    await store.forkConversation(
+                        conversationLocalId: conversationLocalId,
+                        throughDaemonMessageId: daemonMessageId
+                    )
+                }
+            )
+        )
+
+        action("msg-branch")
+
+        waitUntil(timeout: 1.0) { store.selectionRequest != nil }
+
+        XCTAssertEqual(forkClient.requests.count, 1)
+        XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
+        XCTAssertEqual(forkClient.requests.first?.throughMessageId, "msg-branch")
+
+        let forkedLocalId = try XCTUnwrap(store.selectionRequest?.conversationLocalId)
+        XCTAssertEqual(store.conversations.first?.id, forkedLocalId)
+        XCTAssertEqual(store.conversations.first?.conversationId, "conv-forked")
+
+        let request = try XCTUnwrap(store.selectionRequest)
+        var compactPath: [UUID] = []
+        var compactSelection: UUID?
+        applyConversationSelectionRequest(
+            request,
+            horizontalSizeClass: .compact,
+            navigationPath: &compactPath,
+            selectedConversationId: &compactSelection
+        )
+        XCTAssertEqual(compactPath, [forkedLocalId])
+        XCTAssertNil(compactSelection)
+    }
+
+    private func makeUserDefaults() -> (UserDefaults, String) {
+        let suiteName = "ConversationForkMessageActionIOSTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private func clear(_ userDefaults: UserDefaults, suiteName: String) {
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeMessage(daemonMessageId: String?, isStreaming: Bool) -> ChatMessage {
+        var message = ChatMessage(role: .assistant, text: "Persisted reply", isStreaming: isStreaming)
+        message.daemonMessageId = daemonMessageId
+        return message
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping () -> Bool
+    ) {
+        let expectation = expectation(description: "Condition met")
+        let deadline = Date().addingTimeInterval(timeout)
+
+        func poll() {
+            if condition() {
+                expectation.fulfill()
+            } else if Date() < deadline {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                    poll()
+                }
+            }
+        }
+
+        poll()
+        wait(for: [expectation], timeout: timeout + 0.2)
+        XCTAssertTrue(condition(), file: file, line: line)
+    }
+
+    private func makeForkedConversationItem(messageId: String) -> ConversationListResponseItem {
+        ConversationListResponseItem(
+            id: "conv-forked",
+            title: "Forked thread",
+            createdAt: 1_700_000_100,
+            updatedAt: 1_700_000_120,
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: messageId,
+                title: "Parent thread"
+            )
+        )
+    }
+}
+
+@MainActor
+private final class MockConversationForkClient: ConversationForkClientProtocol {
+    struct Request: Equatable {
+        let conversationId: String
+        let throughMessageId: String?
+    }
+
+    var response: ConversationListResponseItem?
+    private(set) var requests: [Request] = []
+
+    func forkConversation(conversationId: String, throughMessageId: String?) async -> ConversationListResponseItem? {
+        requests.append(Request(conversationId: conversationId, throughMessageId: throughMessageId))
+        return response
+    }
+}
+#endif

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -32,6 +32,21 @@ struct PendingChatAnchorResolution: Equatable {
     let requiresExpandedWindow: Bool
 }
 
+func makeOnForkFromMessageAction(
+    conversationLocalId: UUID?,
+    forkConversationFromMessage: ((UUID, String) async -> UUID?)?
+) -> ((String) -> Void)? {
+    guard let conversationLocalId, let forkConversationFromMessage else {
+        return nil
+    }
+
+    return { daemonMessageId in
+        Task {
+            _ = await forkConversationFromMessage(conversationLocalId, daemonMessageId)
+        }
+    }
+}
+
 func resolvePendingChatAnchor(
     daemonMessageId: String,
     displayedMessages: [ChatMessage],
@@ -57,6 +72,7 @@ struct ChatContentView: View {
     var pendingAnchorRequestId: UUID? = nil
     var pendingAnchorDaemonMessageId: String? = nil
     var onPendingAnchorHandled: ((UUID) -> Void)? = nil
+    var onForkFromMessage: ((String) -> Void)? = nil
     @FocusState private var isInputFocused: Bool
     @Environment(\.colorScheme) private var colorScheme
     @State private var emptyStateVisible = false
@@ -414,7 +430,8 @@ struct ChatContentView: View {
             onSurfaceRefetch: { surfaceId, conversationId in
                 viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
             },
-            onRetryConversationError: message.isError && index == messages.count - 1 ? { viewModel.retryAfterConversationError() } : nil
+            onRetryConversationError: message.isError && index == messages.count - 1 ? { viewModel.retryAfterConversationError() } : nil,
+            onForkFromMessage: onForkFromMessage
         )
 
         // Inline media embeds (images, videos)

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -723,7 +723,16 @@ struct ConversationChatView: View {
                 pendingAnchorDaemonMessageId: anchorRequest?.daemonMessageId,
                 onPendingAnchorHandled: { requestId in
                     store.consumePendingAnchorRequest(id: requestId)
-                }
+                },
+                onForkFromMessage: conversation.conversationId == nil ? nil : makeOnForkFromMessageAction(
+                    conversationLocalId: conversation.id,
+                    forkConversationFromMessage: { conversationLocalId, daemonMessageId in
+                        await store.forkConversation(
+                            conversationLocalId: conversationLocalId,
+                            throughDaemonMessageId: daemonMessageId
+                        )
+                    }
+                )
             )
         }
             .navigationTitle("Chat")


### PR DESCRIPTION
## Summary
- add iOS message-level fork wiring from the conversation wrapper through ChatContentView into the shared message bubble callback
- keep the message action limited to persisted conversation messages so local-only and streaming bubbles do not expose a fork branch point
- add focused iOS coverage for message-triggered forking, store selection publication, and compact navigation routing

Apple refs checked (2026-03-19): SwiftUI  documentation.

Part of plan: conversation-forking.md (PR 13 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)