### PR TITLE
Fix iOS private conversation chat view initializer

### DIFF
--- a/clients/ios/Views/Settings/PrivateConversationsSection.swift
+++ b/clients/ios/Views/Settings/PrivateConversationsSection.swift
@@ -126,7 +126,8 @@ struct PrivateConversationsSection: View {
     private func privateConversationChatView(for conversation: IOSConversation) -> some View {
         ConversationChatView(
             viewModel: store.viewModel(for: conversation.id),
-            conversationTitle: conversation.title
+            store: store,
+            conversation: conversation
         )
         .onAppear {
             store.loadHistoryIfNeeded(for: conversation.id)


### PR DESCRIPTION
## Summary
- update the iOS private conversations settings screen to use the current `ConversationChatView` initializer
- pass the shared conversation store and full `IOSConversation` model so the private conversation detail view builds again
- fix the specific iOS CI compile failure without broadening scope
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
