### PR TITLE
Fix raw payload string rendering in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
@@ -27,6 +27,13 @@ struct MessageInspectorPayloadModel: Equatable {
     }
 
     init(payload: AnyCodable, preferredViewMode: MessageInspectorPayloadViewMode = .tree) {
+        if let string = payload.value as? String {
+            source = string
+            isTreeAvailable = false
+            viewMode = .source
+            return
+        }
+
         self.init(
             source: Self.renderSource(from: payload),
             preferredViewMode: preferredViewMode

--- a/clients/macos/vellum-assistantTests/MessageInspectorPayloadModelTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPayloadModelTests.swift
@@ -47,11 +47,26 @@ final class MessageInspectorPayloadModelTests: XCTestCase {
         XCTAssertFalse(model.isTreeAvailable)
     }
 
-    func testTopLevelJSONFragmentStillSupportsTreeMode() {
-        let model = MessageInspectorPayloadModel(payload: AnyCodable("hello"))
+    func testTopLevelStringPayloadPreservesRawSourceVerbatim() {
+        let rawSource = "{\"answer\": \"hello \\\"world\\\"\"}"
+        let model = MessageInspectorPayloadModel(payload: AnyCodable(rawSource))
 
-        XCTAssertEqual(model.availableViewModes, [.tree, .source])
-        XCTAssertEqual(model.viewMode, .tree)
-        XCTAssertEqual(model.source, "\"hello\"")
+        XCTAssertEqual(model.availableViewModes, [.source])
+        XCTAssertEqual(model.viewMode, .source)
+        XCTAssertEqual(model.source, rawSource)
+        XCTAssertFalse(model.showsViewModePicker)
+        XCTAssertFalse(model.showsExpandCollapseActions)
+        XCTAssertFalse(model.isTreeAvailable)
+    }
+
+    func testTopLevelStringPayloadIgnoresPreferredTreeMode() {
+        let model = MessageInspectorPayloadModel(
+            payload: AnyCodable("hello"),
+            preferredViewMode: .tree
+        )
+
+        XCTAssertEqual(model.availableViewModes, [.source])
+        XCTAssertEqual(model.viewMode, .source)
+        XCTAssertEqual(model.source, "hello")
     }
 }


### PR DESCRIPTION
## Summary
- preserve top-level raw string payloads verbatim in the payload viewer
- stop offering tree mode for non-JSON raw strings
- lock the raw-string behavior with payload model tests

Part of plan: llm-context-inspector-redesign.md (remediation round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
