### PR TITLE
Fix response metadata fallback in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -19,10 +19,6 @@ struct MessageInspectorResponseTab: View {
                         responseSectionCard(for: section)
                     }
                 } else {
-                    if model.responseModeLabel != nil {
-                        responseMetadataCard
-                    }
-
                     fallbackCard
                 }
             }
@@ -41,6 +37,10 @@ struct MessageInspectorResponseTab: View {
                     .foregroundColor(VColor.contentDefault)
 
                 HStack(alignment: .top, spacing: VSpacing.xs) {
+                    if let stopReason = model.responseStopReason {
+                        metadataChip("Stop reason: \(stopReason)")
+                    }
+
                     if let responseModeLabel = model.responseModeLabel {
                         metadataChip(responseModeLabel)
                     }
@@ -209,6 +209,7 @@ struct MessageInspectorResponseTab: View {
 struct MessageInspectorResponseTabModel: Equatable {
     let sections: [MessageInspectorResponseSectionModel]
     let responseModeLabel: String?
+    let responseStopReason: String?
     let fallbackMessage: String?
 
     init(entry: LLMRequestLogEntry) {
@@ -217,7 +218,14 @@ struct MessageInspectorResponseTabModel: Equatable {
             MessageInspectorResponseSectionModel(index: index, section: section)
         }
 
-        responseModeLabel = Self.deriveResponseModeLabel(summary: entry.summary, sections: sections)
+        if sections.isEmpty {
+            responseModeLabel = nil
+            responseStopReason = nil
+        } else {
+            responseModeLabel = Self.deriveResponseModeLabel(summary: entry.summary, sections: sections)
+            responseStopReason = Self.deriveStopReasonLabel(summary: entry.summary)
+        }
+
         fallbackMessage = sections.isEmpty
             ? "This provider response has not been normalized yet. Open the Raw tab to inspect the full provider payload."
             : nil
@@ -248,6 +256,15 @@ struct MessageInspectorResponseTabModel: Equatable {
         }
 
         return sections.isEmpty ? nil : "Text-only response"
+    }
+
+    private static func deriveStopReasonLabel(summary: LLMCallSummary?) -> String? {
+        guard let stopReason = summary?.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !stopReason.isEmpty else {
+            return nil
+        }
+
+        return stopReason
     }
 }
 

--- a/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
@@ -69,6 +69,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         )
 
         XCTAssertTrue(model.hasNormalizedSections)
+        XCTAssertEqual(model.responseStopReason, "tool_calls")
         XCTAssertEqual(model.responseModeLabel, "Tool-calling response")
         XCTAssertEqual(model.sections.count, 3)
 
@@ -105,6 +106,32 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         XCTAssertEqual(model.sections[2].copyText, model.sections[2].bodyText)
     }
 
+    func testResponseTabModelDerivesTextOnlyMetadataForNormalizedSections() {
+        let model = MessageInspectorResponseTabModel(
+            entry: makeEntry(
+                responsePayload: AnyCodable([
+                    "text": "A normalized assistant response"
+                ]),
+                summary: LLMCallSummary(
+                    stopReason: "end_turn"
+                ),
+                responseSections: [
+                    LLMContextSection(
+                        kind: .assistant,
+                        label: "Assistant response",
+                        role: "assistant",
+                        text: "A normalized assistant response"
+                    )
+                ]
+            )
+        )
+
+        XCTAssertTrue(model.hasNormalizedSections)
+        XCTAssertEqual(model.responseStopReason, "end_turn")
+        XCTAssertEqual(model.responseModeLabel, "Text-only response")
+        XCTAssertEqual(model.sections.count, 1)
+    }
+
     func testResponseTabModelFallsBackWithoutNormalizedSections() {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(
@@ -118,7 +145,8 @@ final class MessageInspectorResponseTabTests: XCTestCase {
 
         XCTAssertFalse(model.hasNormalizedSections)
         XCTAssertTrue(model.sections.isEmpty)
-        XCTAssertEqual(model.responseModeLabel, "Text-only response")
+        XCTAssertNil(model.responseModeLabel)
+        XCTAssertNil(model.responseStopReason)
         XCTAssertEqual(model.fallbackMessage, "This provider response has not been normalized yet. Open the Raw tab to inspect the full provider payload.")
     }
 


### PR DESCRIPTION
## Summary
- surface stop reason alongside response mode when normalized response sections are available
- keep section-less responses on the raw fallback path instead of showing normalized metadata
- update response-tab tests to lock the intended metadata behavior

Part of plan: llm-context-inspector-redesign.md (remediation round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
