### PR TITLE
Fix partial normalization fidelity for LLM context inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -99,7 +99,7 @@ describe("normalizeLlmContextPayloads", () => {
         kind: "message",
         label: "User message 2",
         role: "user",
-        text: "What's the weather in Boston? [image]",
+        text: "What's the weather in Boston?\n\n[image]",
       },
       {
         kind: "tool_definitions",
@@ -564,6 +564,173 @@ describe("normalizeLlmContextPayloads", () => {
         text: '{"title":"brief"}',
       },
     ]);
+  });
+
+  test("normalizes an OpenAI request even when the response payload is malformed", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_005,
+      requestPayload: {
+        model: "gpt-4.1",
+        tool_choice: "auto",
+        messages: [
+          {
+            role: "system",
+            content: "Line 1\n  Line 2",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "First paragraph" },
+              { type: "text", text: "  Second line\n    third line" },
+            ],
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Lookup a record",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+      },
+      responsePayload: "not-json",
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-4.1",
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: 2,
+      requestToolCount: 1,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "Line 1\n  Line 2",
+      },
+      {
+        kind: "message",
+        label: "User message 2",
+        role: "user",
+        text: "First paragraph\n\n  Second line\n    third line",
+      },
+      {
+        kind: "tool_definitions",
+        label: "Available tools",
+        data: {
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "lookup",
+                description: "Lookup a record",
+                parameters: { type: "object" },
+              },
+            },
+          ],
+        },
+        language: "json",
+      },
+      {
+        kind: "settings",
+        label: "Request settings",
+        data: {
+          model: "gpt-4.1",
+          tool_choice: "auto",
+        },
+        language: "json",
+      },
+    ]);
+    expect(normalized.responseSections).toBeUndefined();
+  });
+
+  test("normalizes an OpenAI response even when the request payload is malformed", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_006,
+      requestPayload: "not-json",
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "First line\n  Second line\n\n    Third line",
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 18,
+          completion_tokens: 9,
+        },
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-2026-03-01",
+      inputTokens: 18,
+      outputTokens: 9,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: "stop",
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "First line Second line Third line",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toBeUndefined();
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "First line\n  Second line\n\n    Third line",
+      },
+    ]);
+  });
+
+  test("does not mix request and response from different providers", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_007,
+      requestPayload: {
+        model: "gpt-4.1",
+        tool_choice: "auto",
+        messages: [{ role: "user", content: "Hello" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              description: "Lookup a record",
+              parameters: { type: "object" },
+            },
+          },
+        ],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Hello back." }],
+        stop_reason: "end_turn",
+      },
+    });
+
+    expect(normalized).toEqual({});
   });
 
   test("omits normalized fields for malformed or unknown payloads", () => {

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -44,49 +44,99 @@ export interface LlmContextNormalizationResult {
   responseSections?: LlmContextSection[];
 }
 
+interface NormalizedPayloadCandidate {
+  provider: LlmContextSummary["provider"];
+  summary: LlmContextSummary;
+  requestSections?: LlmContextSection[];
+  responseSections?: LlmContextSection[];
+}
+
 export function normalizeLlmContextPayloads(
   input: LlmContextNormalizationInput,
 ): LlmContextNormalizationResult {
-  const openAi = normalizeOpenAiPayloads(
-    input.requestPayload,
-    input.responsePayload,
+  const requestCandidates = [
+    normalizeOpenAiRequestPayload(input.requestPayload),
+    normalizeAnthropicRequestPayload(input.requestPayload),
+    normalizeGeminiRequestPayload(input.requestPayload),
+  ].filter((candidate): candidate is NormalizedPayloadCandidate => candidate !== null);
+  const responseCandidates = [
+    normalizeOpenAiResponsePayload(input.responsePayload),
+    normalizeAnthropicResponsePayload(input.responsePayload),
+    normalizeGeminiResponsePayload(input.responsePayload),
+  ].filter((candidate): candidate is NormalizedPayloadCandidate => candidate !== null);
+
+  const requestProviders = new Set(requestCandidates.map((candidate) => candidate.provider));
+  const responseProviders = new Set(
+    responseCandidates.map((candidate) => candidate.provider),
   );
-  if (openAi) {
-    return openAi;
+  const sharedProviders = [...requestProviders].filter((provider) =>
+    responseProviders.has(provider),
+  );
+
+  if (sharedProviders.length > 1) {
+    return {};
   }
 
-  const anthropic = normalizeAnthropicPayloads(
-    input.requestPayload,
-    input.responsePayload,
-  );
-  if (anthropic) {
-    return anthropic;
+  if (sharedProviders.length === 1) {
+    const provider = sharedProviders[0] as LlmContextSummary["provider"];
+    const requestCandidate = requestCandidates.find(
+      (candidate) => candidate.provider === provider,
+    );
+    const responseCandidate = responseCandidates.find(
+      (candidate) => candidate.provider === provider,
+    );
+
+    const requestSections = [
+      ...(requestCandidate?.requestSections ?? []),
+      ...(responseCandidate?.requestSections ?? []),
+    ];
+    const responseSections = [
+      ...(requestCandidate?.responseSections ?? []),
+      ...(responseCandidate?.responseSections ?? []),
+    ];
+
+    return {
+      summary: mergeSummaryFragments(
+        requestCandidate?.summary,
+        responseCandidate?.summary,
+      ),
+      requestSections: requestSections.length > 0 ? requestSections : undefined,
+      responseSections: responseSections.length > 0 ? responseSections : undefined,
+    };
   }
 
-  const gemini = normalizeGeminiPayloads(
-    input.requestPayload,
-    input.responsePayload,
-  );
-  if (gemini) {
-    return gemini;
+  if (requestCandidates.length === 1 && responseCandidates.length === 0) {
+    return requestCandidates[0] as LlmContextNormalizationResult;
+  }
+
+  if (responseCandidates.length === 1 && requestCandidates.length === 0) {
+    return responseCandidates[0] as LlmContextNormalizationResult;
   }
 
   return {};
 }
 
-function normalizeOpenAiPayloads(
+function normalizeOpenAiRequestPayload(
   requestPayload: unknown,
-  responsePayload: unknown,
-): LlmContextNormalizationResult | null {
+): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
-  const response = asRecord(responsePayload);
-  if (!request || !response) {
+  if (!request) {
     return null;
   }
 
   const messages = asRecordArray(request.messages);
-  const choices = asRecordArray(response.choices);
-  if (!messages || !choices) {
+  if (!messages) {
+    return null;
+  }
+
+  const requestToolNames = extractOpenAiRequestToolNames(request.tools);
+  const hasOpenAiSignal =
+    requestToolNames.length > 0 ||
+    asString(request.tool_choice) !== undefined ||
+    (request.parallel_tool_calls !== undefined &&
+      typeof request.parallel_tool_calls === "boolean") ||
+    messages.some((message) => asRecordArray(message.tool_calls) !== null);
+  if (!hasOpenAiSignal) {
     return null;
   }
 
@@ -94,7 +144,7 @@ function normalizeOpenAiPayloads(
   for (const [index, message] of messages.entries()) {
     const role = asString(message.role) ?? "unknown";
     const messageText = extractOpenAiContentText(message.content);
-    if (messageText) {
+    if (messageText !== undefined) {
       requestSections.push({
         kind: role === "system" ? "system" : role === "tool" ? "tool_result" : "message",
         label: buildMessageLabel(role, index + 1),
@@ -111,7 +161,6 @@ function normalizeOpenAiPayloads(
     }
   }
 
-  const requestToolNames = extractOpenAiRequestToolNames(request.tools);
   if (requestToolNames.length > 0) {
     requestSections.push({
       kind: "tool_definitions",
@@ -128,11 +177,45 @@ function normalizeOpenAiPayloads(
     requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
   }
 
+  return {
+    provider: "openai",
+    summary: {
+      provider: "openai",
+      model: asString(request.model),
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: messages.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+  };
+}
+
+function normalizeOpenAiResponsePayload(
+  responsePayload: unknown,
+): NormalizedPayloadCandidate | null {
+  const response = asRecord(responsePayload);
+  if (!response) {
+    return null;
+  }
+
+  const choices = asRecordArray(response.choices);
+  if (!choices) {
+    return null;
+  }
+
   const firstChoice = choices[0];
   const responseMessage = asRecord(firstChoice?.message);
   const responseText = extractOpenAiContentText(responseMessage?.content);
   const responseSections: LlmContextSection[] = [];
-  if (responseText) {
+  if (responseText !== undefined) {
     responseSections.push({
       kind: "message",
       label: "Assistant response",
@@ -152,39 +235,60 @@ function normalizeOpenAiPayloads(
     .filter((name): name is string => typeof name === "string");
 
   return {
+    provider: "openai",
     summary: {
       provider: "openai",
-      model: asString(response.model) ?? asString(request.model),
+      model: asString(response.model),
       inputTokens: asNumber(usage?.prompt_tokens),
       outputTokens: asNumber(usage?.completion_tokens),
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
       stopReason: asString(firstChoice?.finish_reason),
-      requestMessageCount: messages.length,
-      requestToolCount: requestToolNames.length,
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
       responseMessageCount:
-        responseText || responseToolSections.length > 0 ? 1 : undefined,
+        responseText !== undefined || responseToolSections.length > 0 ? 1 : undefined,
       responseToolCallCount:
         responseToolSections.length > 0 ? responseToolSections.length : undefined,
       responsePreview: responseText ? truncateText(responseText) : undefined,
       toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
     },
-    requestSections: requestSections.length > 0 ? requestSections : undefined,
     responseSections: responseSections.length > 0 ? responseSections : undefined,
   };
 }
 
-function normalizeAnthropicPayloads(
+function normalizeAnthropicRequestPayload(
   requestPayload: unknown,
-  responsePayload: unknown,
-): LlmContextNormalizationResult | null {
+): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
-  const response = asRecord(responsePayload);
-  if (!request || !response) {
+  if (!request) {
     return null;
   }
 
   const messages = asRecordArray(request.messages);
-  const content = asRecordArray(response.content);
-  if (!messages || !content) {
+  if (!messages) {
+    return null;
+  }
+
+  const requestToolNames = extractAnthropicToolNames(request.tools);
+  const hasAnthropicContentSignal = messages.some((message) =>
+    (asRecordArray(message.content) ?? []).some((block) => {
+      const type = asString(block.type);
+      return (
+        type === "tool_use" ||
+        type === "tool_result" ||
+        type === "web_search_tool_result" ||
+        type === "thinking" ||
+        type === "redacted_thinking"
+      );
+    }),
+  );
+  const hasAnthropicSignal =
+    request.system !== undefined ||
+    requestToolNames.length > 0 ||
+    asRecord(request.tool_choice) !== null ||
+    hasAnthropicContentSignal;
+  if (!hasAnthropicSignal) {
     return null;
   }
 
@@ -201,7 +305,6 @@ function normalizeAnthropicPayloads(
     );
   }
 
-  const requestToolNames = extractAnthropicToolNames(request.tools);
   if (requestToolNames.length > 0) {
     requestSections.push({
       kind: "tool_definitions",
@@ -218,6 +321,40 @@ function normalizeAnthropicPayloads(
     requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
   }
 
+  return {
+    provider: "anthropic",
+    summary: {
+      provider: "anthropic",
+      model: asString(request.model),
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: messages.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+  };
+}
+
+function normalizeAnthropicResponsePayload(
+  responsePayload: unknown,
+): NormalizedPayloadCandidate | null {
+  const response = asRecord(responsePayload);
+  if (!response) {
+    return null;
+  }
+
+  const content = asRecordArray(response.content);
+  if (!content) {
+    return null;
+  }
+
   const responseSections = anthropicContentSections(content, "Assistant response");
   const responseText = collectAnthropicText(content);
   const responseToolNames = content
@@ -226,35 +363,33 @@ function normalizeAnthropicPayloads(
 
   const usage = asRecord(response.usage);
   return {
+    provider: "anthropic",
     summary: {
       provider: "anthropic",
-      model: asString(response.model) ?? asString(request.model),
+      model: asString(response.model),
       inputTokens: asNumber(usage?.input_tokens),
       outputTokens: asNumber(usage?.output_tokens),
       cacheCreationInputTokens: asNumber(usage?.cache_creation_input_tokens),
       cacheReadInputTokens: asNumber(usage?.cache_read_input_tokens),
       stopReason: asString(response.stop_reason),
-      requestMessageCount: messages.length,
-      requestToolCount: requestToolNames.length,
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
       responseMessageCount:
-        responseText || responseToolNames.length > 0 ? 1 : undefined,
+        responseText !== undefined || responseToolNames.length > 0 ? 1 : undefined,
       responseToolCallCount:
         responseToolNames.length > 0 ? responseToolNames.length : undefined,
       responsePreview: responseText ? truncateText(responseText) : undefined,
       toolCallNames: responseToolNames.length > 0 ? responseToolNames : undefined,
     },
-    requestSections: requestSections.length > 0 ? requestSections : undefined,
     responseSections: responseSections.length > 0 ? responseSections : undefined,
   };
 }
 
-function normalizeGeminiPayloads(
+function normalizeGeminiRequestPayload(
   requestPayload: unknown,
-  responsePayload: unknown,
-): LlmContextNormalizationResult | null {
+): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
-  const response = asRecord(responsePayload);
-  if (!request || !response) {
+  if (!request) {
     return null;
   }
 
@@ -266,7 +401,7 @@ function normalizeGeminiPayloads(
   const requestSections: LlmContextSection[] = [];
   const config = asRecord(request.config);
   const systemText = extractGeminiSystemInstructionText(config?.systemInstruction);
-  if (systemText) {
+  if (systemText !== undefined) {
     requestSections.push({
       kind: "system",
       label: "System instruction",
@@ -298,9 +433,47 @@ function normalizeGeminiPayloads(
     );
   }
 
-  const responseSections: LlmContextSection[] = [];
+  return {
+    provider: "gemini",
+    summary: {
+      provider: "gemini",
+      model: asString(request.model),
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: contents.length,
+      requestToolCount: requestToolNames.length,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    },
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+  };
+}
+
+function normalizeGeminiResponsePayload(
+  responsePayload: unknown,
+): NormalizedPayloadCandidate | null {
+  const response = asRecord(responsePayload);
+  if (!response) {
+    return null;
+  }
+
   const responseText = asString(response.text);
-  if (responseText) {
+  const responseFunctionSections = geminiFunctionCallSections(
+    response.functionCalls,
+    "Response function call",
+  );
+  const usage = asRecord(response.usageMetadata);
+  if (responseText === undefined && responseFunctionSections.length === 0) {
+    return null;
+  }
+
+  const responseSections: LlmContextSection[] = [];
+  if (responseText !== undefined) {
     responseSections.push({
       kind: "message",
       label: "Assistant response",
@@ -308,28 +481,28 @@ function normalizeGeminiPayloads(
       text: responseText,
     });
   }
-  const responseFunctionSections = geminiFunctionCallSections(
-    response.functionCalls,
-    "Response function call",
-  );
   responseSections.push(...responseFunctionSections);
 
-  const usage = asRecord(response.usageMetadata);
   const toolCallNames = responseFunctionSections
     .map((section) => section.toolName)
     .filter((name): name is string => typeof name === "string");
 
   return {
+    provider: "gemini",
     summary: {
       provider: "gemini",
-      model: asString(response.model) ?? asString(request.model),
+      model: asString(response.model),
       inputTokens: asNumber(usage?.promptTokenCount),
       outputTokens: asNumber(usage?.candidatesTokenCount),
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
       stopReason: asString(response.finishReason),
-      requestMessageCount: contents.length,
-      requestToolCount: requestToolNames.length,
+      requestMessageCount: undefined,
+      requestToolCount: undefined,
       responseMessageCount:
-        responseText || responseFunctionSections.length > 0 ? 1 : undefined,
+        responseText !== undefined || responseFunctionSections.length > 0
+          ? 1
+          : undefined,
       responseToolCallCount:
         responseFunctionSections.length > 0
           ? responseFunctionSections.length
@@ -337,7 +510,6 @@ function normalizeGeminiPayloads(
       responsePreview: responseText ? truncateText(responseText) : undefined,
       toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
     },
-    requestSections: requestSections.length > 0 ? requestSections : undefined,
     responseSections: responseSections.length > 0 ? responseSections : undefined,
   };
 }
@@ -536,7 +708,7 @@ function extractGeminiToolNames(tools: unknown): string[] {
 
 function extractOpenAiContentText(content: unknown): string | undefined {
   if (typeof content === "string") {
-    return normalizeText(content);
+    return hasMeaningfulText(content) ? content : undefined;
   }
 
   const parts = asRecordArray(content);
@@ -570,7 +742,7 @@ function extractOpenAiContentText(content: unknown): string | undefined {
 
 function extractAnthropicSystemText(system: unknown): string | undefined {
   if (typeof system === "string") {
-    return normalizeText(system);
+    return hasMeaningfulText(system) ? system : undefined;
   }
 
   const parts = asRecordArray(system);
@@ -586,7 +758,7 @@ function extractAnthropicSystemText(system: unknown): string | undefined {
 
 function extractGeminiSystemInstructionText(systemInstruction: unknown): string | undefined {
   if (typeof systemInstruction === "string") {
-    return normalizeText(systemInstruction);
+    return hasMeaningfulText(systemInstruction) ? systemInstruction : undefined;
   }
 
   const record = asRecord(systemInstruction);
@@ -603,7 +775,7 @@ function extractGeminiSystemInstructionText(systemInstruction: unknown): string 
 
 function collectAnthropicText(content: unknown): string | undefined {
   if (typeof content === "string") {
-    return normalizeText(content);
+    return hasMeaningfulText(content) ? content : undefined;
   }
 
   const blocks = asRecordArray(content);
@@ -761,7 +933,8 @@ function joinTextParts(parts: string[]): string | undefined {
   if (parts.length === 0) {
     return undefined;
   }
-  return normalizeText(parts.join("\n\n"));
+  const text = parts.join("\n\n");
+  return hasMeaningfulText(text) ? text : undefined;
 }
 
 function truncateText(text: string, maxLength = 280): string {
@@ -775,6 +948,38 @@ function truncateText(text: string, maxLength = 280): string {
 function normalizeText(text: string): string {
   const normalized = text.replace(/\s+/g, " ").trim();
   return normalized.length > 0 ? normalized : "";
+}
+
+function hasMeaningfulText(text: string): boolean {
+  return text.trim().length > 0;
+}
+
+function mergeSummaryFragments(
+  requestSummary: LlmContextSummary | undefined,
+  responseSummary: LlmContextSummary | undefined,
+): LlmContextSummary | undefined {
+  if (!requestSummary && !responseSummary) {
+    return undefined;
+  }
+
+  const summary = {
+    ...(requestSummary ?? responseSummary)!,
+  } as LlmContextSummary;
+
+  if (!requestSummary || !responseSummary) {
+    return summary;
+  }
+
+  for (const [key, value] of Object.entries(responseSummary) as [
+    keyof LlmContextSummary,
+    LlmContextSummary[keyof LlmContextSummary],
+  ][]) {
+    if (value !== undefined) {
+      summary[key] = value as never;
+    }
+  }
+
+  return summary;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- normalize request and response payloads independently when only one side is parseable
- preserve original formatting for normalized prompt and response text sections
- add assistant tests covering partial normalization and text-fidelity behavior

Part of plan: llm-context-inspector-redesign.md (remediation round 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
