### PR TITLE
fix: align attachment storage with resolved conversation directories

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,6 +16,7 @@ mock.module("../util/platform.js", () => ({
   ensureDataDir: () => {},
   getRootDir: () => testDir,
   getWorkspaceDir: () => join(testDir, "workspace"),
+  getConversationsDir: () => join(testDir, "workspace", "conversations"),
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -51,6 +52,7 @@ import {
   uploadAttachment,
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
+import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, rawGet, rawRun, resetDb } from "../memory/db.js";
 
@@ -71,6 +73,22 @@ function resetTables() {
   db.run("DELETE FROM attachments");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
+}
+
+function getConversationTimestamp(createdAt: number): string {
+  return new Date(createdAt).toISOString().replace(/:/g, "-");
+}
+
+function getLegacyConversationDirPath(
+  conversationId: string,
+  createdAt: number,
+): string {
+  return join(
+    testDir,
+    "workspace",
+    "conversations",
+    `${conversationId}_${getConversationTimestamp(createdAt)}`,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -411,6 +429,42 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     expect(linked[0].originalFilename).toBe("chart.png");
     expect(linked[0].dataBase64).toBe("iVBORw0K");
     expect(getFilePathForAttachment(stored.id)).toContain("/conversations/");
+  });
+
+  test("uses timestamp-first conversation directory and does not recreate a legacy sibling", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "assistant", "Disk view repaired");
+    const canonicalDir = getConversationDirPath(conv.id, conv.createdAt);
+    const legacyDir = getLegacyConversationDirPath(conv.id, conv.createdAt);
+    rmSync(legacyDir, { recursive: true, force: true });
+
+    const stored = uploadAttachment("repaired.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const filePath = getFilePathForAttachment(stored.id);
+    expect(filePath).not.toBeNull();
+    expect(filePath!).toContain(join(canonicalDir, "attachments"));
+    expect(existsSync(filePath!)).toBe(true);
+    expect(existsSync(legacyDir)).toBe(false);
+  });
+
+  test("reuses an existing legacy conversation directory when timestamp-first is absent", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "assistant", "Legacy path");
+    const canonicalDir = getConversationDirPath(conv.id, conv.createdAt);
+    const legacyDir = getLegacyConversationDirPath(conv.id, conv.createdAt);
+
+    rmSync(canonicalDir, { recursive: true, force: true });
+    mkdirSync(legacyDir, { recursive: true });
+
+    const stored = uploadAttachment("legacy.png", "image/png", "iVBORw0K");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const filePath = getFilePathForAttachment(stored.id);
+    expect(filePath).not.toBeNull();
+    expect(filePath!).toContain(join(legacyDir, "attachments"));
+    expect(existsSync(filePath!)).toBe(true);
+    expect(existsSync(canonicalDir)).toBe(false);
   });
 
   test("returns attachments in position order", async () => {

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -20,7 +20,8 @@ import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
-import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { getConversationAttachmentsDirPath } from "./conversation-directories.js";
 import { getDb, rawAll, rawGet, rawRun } from "./db.js";
 import { attachments, messageAttachments } from "./schema.js";
 
@@ -51,25 +52,6 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function getConversationDirName(
-  conversationId: string,
-  createdAtMs: number,
-): string {
-  const isoDate = new Date(createdAtMs).toISOString().replace(/:/g, "-");
-  return `${conversationId}_${isoDate}`;
-}
-
-function getConversationAttachmentsDirPath(
-  conversationId: string,
-  createdAtMs: number,
-): string {
-  return join(
-    getConversationsDir(),
-    getConversationDirName(conversationId, createdAtMs),
-    "attachments",
-  );
 }
 
 function resolveUniqueFilename(dir: string, filename: string): string {

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -1,0 +1,77 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { getConversationsDir } from "../util/platform.js";
+
+function getConversationDirTimestamp(createdAtMs: number): string {
+  return new Date(createdAtMs).toISOString().replace(/:/g, "-");
+}
+
+export function getLegacyConversationDirName(
+  id: string,
+  createdAtMs: number,
+): string {
+  return `${id}_${getConversationDirTimestamp(createdAtMs)}`;
+}
+
+/**
+ * Build a filesystem-safe directory name for a conversation.
+ * Format: `{isoDate}_{id}` where colons in the ISO date are replaced with
+ * hyphens so the name is valid on all platforms (Windows forbids colons).
+ */
+export function getConversationDirName(
+  id: string,
+  createdAtMs: number,
+): string {
+  return `${getConversationDirTimestamp(createdAtMs)}_${id}`;
+}
+
+/**
+ * Return the absolute path to a conversation's timestamp-first disk-view
+ * directory.
+ */
+export function getConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  return join(getConversationsDir(), getConversationDirName(id, createdAtMs));
+}
+
+export function getLegacyConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  return join(
+    getConversationsDir(),
+    getLegacyConversationDirName(id, createdAtMs),
+  );
+}
+
+/**
+ * Resolve the active conversation directory path:
+ * 1) prefer timestamp-first when it exists;
+ * 2) otherwise reuse legacy sibling when present;
+ * 3) otherwise fall back to timestamp-first as the creation target.
+ */
+export function getResolvedConversationDirPath(
+  id: string,
+  createdAtMs: number,
+): string {
+  const dirPath = getConversationDirPath(id, createdAtMs);
+  if (existsSync(dirPath)) return dirPath;
+
+  const legacyDirPath = getLegacyConversationDirPath(id, createdAtMs);
+  if (existsSync(legacyDirPath)) return legacyDirPath;
+
+  return dirPath;
+}
+
+export function getConversationAttachmentsDirPath(
+  conversationId: string,
+  createdAtMs: number,
+): string {
+  return join(
+    getResolvedConversationDirPath(conversationId, createdAtMs),
+    "attachments",
+  );
+}

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -20,12 +20,17 @@ import {
 import { basename, dirname, extname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getConversationsDir } from "../util/platform.js";
 import {
   getAttachmentContent,
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
 } from "./attachments-store.js";
+import {
+  getConversationDirName,
+  getConversationDirPath,
+  getLegacyConversationDirPath,
+  getResolvedConversationDirPath,
+} from "./conversation-directories.js";
 import { getMessageById } from "./conversation-crud.js";
 
 const log = getLogger("conversation-disk-view");
@@ -34,61 +39,11 @@ const log = getLogger("conversation-disk-view");
 // Directory helpers
 // ---------------------------------------------------------------------------
 
-function getConversationDirTimestamp(createdAtMs: number): string {
-  return new Date(createdAtMs).toISOString().replace(/:/g, "-");
-}
-
-function getLegacyConversationDirName(
-  id: string,
-  createdAtMs: number,
-): string {
-  return `${id}_${getConversationDirTimestamp(createdAtMs)}`;
-}
-
-/**
- * Build a filesystem-safe directory name for a conversation.
- * Format: `{isoDate}_{id}` where colons in the ISO date are replaced with
- * hyphens so the name is valid on all platforms (Windows forbids colons).
- */
-export function getConversationDirName(
-  id: string,
-  createdAtMs: number,
-): string {
-  return `${getConversationDirTimestamp(createdAtMs)}_${id}`;
-}
-
-/**
- * Return the absolute path to a conversation's disk-view directory.
- */
-export function getConversationDirPath(
-  id: string,
-  createdAtMs: number,
-): string {
-  return join(getConversationsDir(), getConversationDirName(id, createdAtMs));
-}
-
-function getLegacyConversationDirPath(
-  id: string,
-  createdAtMs: number,
-): string {
-  return join(
-    getConversationsDir(),
-    getLegacyConversationDirName(id, createdAtMs),
-  );
-}
-
-export function getResolvedConversationDirPath(
-  id: string,
-  createdAtMs: number,
-): string {
-  const dirPath = getConversationDirPath(id, createdAtMs);
-  if (existsSync(dirPath)) return dirPath;
-
-  const legacyDirPath = getLegacyConversationDirPath(id, createdAtMs);
-  if (existsSync(legacyDirPath)) return legacyDirPath;
-
-  return dirPath;
-}
+export {
+  getConversationDirName,
+  getConversationDirPath,
+  getResolvedConversationDirPath,
+};
 
 function ensureConversationDirPath(
   id: string,


### PR DESCRIPTION
## Summary
- make attachment materialization use the same resolved conversation directory as the disk view
- preserve intentional legacy-directory reuse without recreating legacy sibling folders unnecessarily
- add regression coverage for attachment writes after timestamp-first disk-view repair

Fixes gap identified during plan review for repair-conversation-disk-view.md.

**Gap:** Attachment storage must use the same resolved conversation directory as the repaired disk view
**What was expected:** Attachment materialization and disk-view repair should target the same active conversation folder.
**What was found:** attachments-store could still recreate legacy `{conversationId}_{timestamp}` directories after the timestamp-first repair path was in place.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
