### PR TITLE
Fix iOS fork navigation test concurrency

### DIFF
--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -39,7 +39,8 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         )
         store.conversations = [child]
 
-        let parentLocalId = try XCTUnwrap(await store.openForkParent(of: child.id))
+        let openedParentLocalId = await store.openForkParent(of: child.id)
+        let parentLocalId = try XCTUnwrap(openedParentLocalId)
 
         XCTAssertEqual(detailClient.requests, ["conv-parent"])
         XCTAssertEqual(store.selectionRequest?.conversationLocalId, parentLocalId)


### PR DESCRIPTION
## Summary
- move the async `openForkParent` call out of `XCTUnwrap` in the iOS navigation test
- preserve the existing assertion flow while satisfying newer Swift concurrency rules in CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23283537062/job/67701876925
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
