### PR TITLE
Fix macOS payload inspector initializer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadModel.swift
@@ -28,9 +28,7 @@ struct MessageInspectorPayloadModel: Equatable {
 
     init(payload: AnyCodable, preferredViewMode: MessageInspectorPayloadViewMode = .tree) {
         if let string = payload.value as? String {
-            source = string
-            isTreeAvailable = false
-            viewMode = .source
+            self.init(source: string, isTreeAvailable: false, viewMode: .source)
             return
         }
 
@@ -41,9 +39,12 @@ struct MessageInspectorPayloadModel: Equatable {
     }
 
     init(source: String, preferredViewMode: MessageInspectorPayloadViewMode = .tree) {
-        self.source = source
-        isTreeAvailable = Self.canRenderTree(source: source)
-        viewMode = isTreeAvailable ? preferredViewMode : .source
+        let isTreeAvailable = Self.canRenderTree(source: source)
+        self.init(
+            source: source,
+            isTreeAvailable: isTreeAvailable,
+            viewMode: isTreeAvailable ? preferredViewMode : .source
+        )
     }
 
     var availableViewModes: [MessageInspectorPayloadViewMode] {
@@ -56,6 +57,16 @@ struct MessageInspectorPayloadModel: Equatable {
 
     var showsExpandCollapseActions: Bool {
         isTreeAvailable && viewMode == .tree
+    }
+
+    private init(
+        source: String,
+        isTreeAvailable: Bool,
+        viewMode: MessageInspectorPayloadViewMode
+    ) {
+        self.source = source
+        self.isTreeAvailable = isTreeAvailable
+        self.viewMode = viewMode
     }
 
     static func canRenderTree(source: String) -> Bool {


### PR DESCRIPTION
## Summary
- fix the message inspector payload model initializer so Swift no longer rejects direct assignment to `let` properties
- preserve the existing behavior for raw string payloads by forcing source-only mode through a shared designated initializer

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23283744287/job/67702526682
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
