### PR TITLE
Fix lint violations in LLM context normalization

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -52,8 +52,8 @@ import {
   uploadAttachment,
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
-import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { getDb, initializeDb, rawGet, rawRun, resetDb } from "../memory/db.js";
 
 initializeDb();

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -25,13 +25,13 @@ import {
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
 } from "./attachments-store.js";
+import { getMessageById } from "./conversation-crud.js";
 import {
   getConversationDirName,
   getConversationDirPath,
   getLegacyConversationDirPath,
   getResolvedConversationDirPath,
 } from "./conversation-directories.js";
-import { getMessageById } from "./conversation-crud.js";
 
 const log = getLogger("conversation-disk-view");
 

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -58,12 +58,12 @@ export function normalizeLlmContextPayloads(
     normalizeOpenAiRequestPayload(input.requestPayload),
     normalizeAnthropicRequestPayload(input.requestPayload),
     normalizeGeminiRequestPayload(input.requestPayload),
-  ].filter((candidate): candidate is NormalizedPayloadCandidate => candidate !== null);
+  ].filter((candidate): candidate is NormalizedPayloadCandidate => Boolean(candidate));
   const responseCandidates = [
     normalizeOpenAiResponsePayload(input.responsePayload),
     normalizeAnthropicResponsePayload(input.responsePayload),
     normalizeGeminiResponsePayload(input.responsePayload),
-  ].filter((candidate): candidate is NormalizedPayloadCandidate => candidate !== null);
+  ].filter((candidate): candidate is NormalizedPayloadCandidate => Boolean(candidate));
 
   const requestProviders = new Set(requestCandidates.map((candidate) => candidate.provider));
   const responseProviders = new Set(
@@ -135,7 +135,7 @@ function normalizeOpenAiRequestPayload(
     asString(request.tool_choice) !== undefined ||
     (request.parallel_tool_calls !== undefined &&
       typeof request.parallel_tool_calls === "boolean") ||
-    messages.some((message) => asRecordArray(message.tool_calls) !== null);
+    messages.some((message) => Boolean(asRecordArray(message.tool_calls)));
   if (!hasOpenAiSignal) {
     return null;
   }
@@ -286,7 +286,7 @@ function normalizeAnthropicRequestPayload(
   const hasAnthropicSignal =
     request.system !== undefined ||
     requestToolNames.length > 0 ||
-    asRecord(request.tool_choice) !== null ||
+    Boolean(asRecord(request.tool_choice)) ||
     hasAnthropicContentSignal;
   if (!hasAnthropicSignal) {
     return null;


### PR DESCRIPTION
## Summary
- fix the import ordering errors reported by the failing lint job
- replace disallowed `!== null` checks in LLM context normalization with equivalent boolean guards

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23283744285/job/67702512180
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
