### PR TITLE
fix: paginate iOS fork parent anchors until found or exhausted

### DIFF
--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -97,6 +97,42 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         )
     }
 
+    func testPendingChatAnchorSearchKeepsLoadingOlderHistoryUntilExhausted() {
+        let oldest = makeMessage(text: "Oldest", daemonMessageId: "msg-oldest")
+        let newest = makeMessage(text: "Newest", daemonMessageId: "msg-newest")
+        let displayedMessages = [oldest, newest]
+
+        XCTAssertEqual(
+            nextPendingChatAnchorSearchStep(
+                daemonMessageId: "msg-newest",
+                displayedMessages: displayedMessages,
+                displayedMessageCount: 1,
+                hasMoreMessages: true
+            ),
+            .scroll(localMessageId: newest.id, requiresExpandedWindow: false)
+        )
+
+        XCTAssertEqual(
+            nextPendingChatAnchorSearchStep(
+                daemonMessageId: "msg-missing",
+                displayedMessages: displayedMessages,
+                displayedMessageCount: 1,
+                hasMoreMessages: true
+            ),
+            .loadOlderPage
+        )
+
+        XCTAssertEqual(
+            nextPendingChatAnchorSearchStep(
+                daemonMessageId: "msg-missing",
+                displayedMessages: displayedMessages,
+                displayedMessageCount: 1,
+                hasMoreMessages: false
+            ),
+            .consume
+        )
+    }
+
     func testCurrentTipForkToolbarActionOnlyExistsForPersistedConversationAndForksCurrentTip() async throws {
         let (userDefaults, suiteName) = makeUserDefaults()
         defer { clear(userDefaults, suiteName: suiteName) }

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -32,6 +32,12 @@ struct PendingChatAnchorResolution: Equatable {
     let requiresExpandedWindow: Bool
 }
 
+enum PendingChatAnchorSearchStep: Equatable {
+    case scroll(localMessageId: UUID, requiresExpandedWindow: Bool)
+    case loadOlderPage
+    case consume
+}
+
 func makeOnForkFromMessageAction(
     conversationLocalId: UUID?,
     forkConversationFromMessage: ((UUID, String) async -> UUID?)?
@@ -64,6 +70,26 @@ func resolvePendingChatAnchor(
     return PendingChatAnchorResolution(
         localMessageId: displayedMessages[messageIndex].id,
         requiresExpandedWindow: displayedMessageCount != Int.max && messageIndex < visibleStartIndex
+    )
+}
+
+func nextPendingChatAnchorSearchStep(
+    daemonMessageId: String,
+    displayedMessages: [ChatMessage],
+    displayedMessageCount: Int,
+    hasMoreMessages: Bool
+) -> PendingChatAnchorSearchStep {
+    guard let resolution = resolvePendingChatAnchor(
+        daemonMessageId: daemonMessageId,
+        displayedMessages: displayedMessages,
+        displayedMessageCount: displayedMessageCount
+    ) else {
+        return hasMoreMessages ? .loadOlderPage : .consume
+    }
+
+    return .scroll(
+        localMessageId: resolution.localMessageId,
+        requiresExpandedWindow: resolution.requiresExpandedWindow
     )
 }
 
@@ -221,6 +247,13 @@ struct ChatContentView: View {
             .onChange(of: viewModel.messages.count) { _, _ in
                 if !hasPendingAnchor && isNearBottom && !viewModel.isLoadingMoreMessages {
                     scrollToBottom(proxy: proxy, animated: true)
+                } else if hasPendingAnchor {
+                    attemptPendingAnchorScrollIfNeeded(proxy: proxy)
+                }
+            }
+            .onChange(of: viewModel.hasMoreHistory) { _, _ in
+                if hasPendingAnchor {
+                    attemptPendingAnchorScrollIfNeeded(proxy: proxy)
                 }
             }
             .onChange(of: viewModel.messages.last?.text) { _, _ in
@@ -710,34 +743,56 @@ struct ChatContentView: View {
     }
 
     private func attemptPendingAnchorScrollIfNeeded(proxy: ScrollViewProxy) {
-        guard let pendingAnchorRequestId,
-              let pendingAnchorDaemonMessageId,
-              viewModel.isHistoryLoaded else {
-            return
-        }
-
         scrollRestoreTask?.cancel()
-
-        guard let resolution = resolvePendingChatAnchor(
-            daemonMessageId: pendingAnchorDaemonMessageId,
-            displayedMessages: viewModel.displayedMessages,
-            displayedMessageCount: viewModel.displayedMessageCount
-        ) else {
-            onPendingAnchorHandled?(pendingAnchorRequestId)
-            return
-        }
-
         scrollRestoreTask = Task { @MainActor in
-            if resolution.requiresExpandedWindow {
-                viewModel.displayedMessageCount = Int.max
-                try? await Task.sleep(nanoseconds: 50_000_000)
-                guard !Task.isCancelled else { return }
-            }
+            while !Task.isCancelled {
+                guard let pendingAnchorRequestId,
+                      let pendingAnchorDaemonMessageId,
+                      viewModel.isHistoryLoaded else {
+                    return
+                }
 
-            withAnimation(.easeOut(duration: 0.3)) {
-                proxy.scrollTo(resolution.localMessageId, anchor: .center)
+                switch nextPendingChatAnchorSearchStep(
+                    daemonMessageId: pendingAnchorDaemonMessageId,
+                    displayedMessages: viewModel.displayedMessages,
+                    displayedMessageCount: viewModel.displayedMessageCount,
+                    hasMoreMessages: viewModel.hasMoreMessages
+                ) {
+                case let .scroll(localMessageId, requiresExpandedWindow):
+                    if requiresExpandedWindow {
+                        viewModel.displayedMessageCount = Int.max
+                        try? await Task.sleep(nanoseconds: 50_000_000)
+                        guard !Task.isCancelled else { return }
+                        continue
+                    }
+
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        proxy.scrollTo(localMessageId, anchor: .center)
+                    }
+                    onPendingAnchorHandled?(pendingAnchorRequestId)
+                    return
+
+                case .loadOlderPage:
+                    if viewModel.isLoadingMoreMessages {
+                        return
+                    }
+
+                    let startedLoading = await viewModel.loadPreviousMessagePage()
+                    guard startedLoading else {
+                        guard !viewModel.isLoadingMoreMessages else { return }
+                        onPendingAnchorHandled?(pendingAnchorRequestId)
+                        return
+                    }
+
+                    if viewModel.isLoadingMoreMessages {
+                        return
+                    }
+
+                case .consume:
+                    onPendingAnchorHandled?(pendingAnchorRequestId)
+                    return
+                }
             }
-            onPendingAnchorHandled?(pendingAnchorRequestId)
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep pending iOS fork-parent anchors alive while older history can still load
- drive additional history pagination from the anchor flow until the source message is found or history is exhausted
- add focused regression coverage for older branch-point navigation

Fixes gap identified during plan review for conversation-forking.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
