### PR TITLE
fix: reject private conversation forks and preserve fork llm context

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -63,9 +63,11 @@ import {
   createConversation,
   forkConversation,
   getMessages,
+  PRIVATE_CONVERSATION_FORK_ERROR,
 } from "../memory/conversation-crud.js";
 import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getRequestLogsByMessageId } from "../memory/llm-request-log-store.js";
 import {
   channelInboundEvents,
   conversationAssistantAttentionState,
@@ -153,7 +155,12 @@ describe("forkConversation", () => {
       sourceMessages.map((message) => message.createdAt),
     );
     expect(forkMessages.map((message) => parseMetadata(message.metadata))).toEqual(
-      sourceMessages.map((message) => parseMetadata(message.metadata)),
+      sourceMessages.map((message) => {
+        const metadata = parseMetadata(message.metadata);
+        return metadata && typeof metadata === "object"
+          ? { ...(metadata as Record<string, unknown>), forkSourceMessageId: message.id }
+          : { forkSourceMessageId: message.id };
+      }),
     );
     expect(
       forkMessages.every(
@@ -242,7 +249,7 @@ describe("forkConversation", () => {
     );
   });
 
-  test("normalizes private source forks to standard conversations without external bindings", async () => {
+  test("rejects private source forks", async () => {
     const source = createConversation({
       title: "Private notes",
       conversationType: "private",
@@ -276,19 +283,9 @@ describe("forkConversation", () => {
       })
       .run();
 
-    const fork = forkConversation({ conversationId: source.id });
-    const binding = db
-      .select()
-      .from(externalConversationBindings)
-      .where(eq(externalConversationBindings.conversationId, fork.id))
-      .get();
-
-    expect(source.conversationType).toBe("private");
-    expect(fork.conversationType).toBe("standard");
-    expect(fork.memoryScopeId).toBe("default");
-    expect(fork.originChannel).toBeNull();
-    expect(fork.originInterface).toBeNull();
-    expect(binding).toBeUndefined();
+    expect(() => forkConversation({ conversationId: source.id })).toThrow(
+      PRIVATE_CONVERSATION_FORK_ERROR,
+    );
   });
 
   test("marks copied assistant history as seen and excludes request logs, queued work, and inbound events", async () => {
@@ -300,7 +297,7 @@ describe("forkConversation", () => {
       undefined,
       { skipIndexing: true },
     );
-    await addMessage(
+    const sourceAssistant = await addMessage(
       source.id,
       "assistant",
       "I found the failing migration.",
@@ -315,7 +312,7 @@ describe("forkConversation", () => {
       .values({
         id: "llm-log-1",
         conversationId: source.id,
-        messageId: sourceUser.id,
+        messageId: sourceAssistant.id,
         requestPayload: '{"prompt":"debug"}',
         responsePayload: '{"result":"ok"}',
         createdAt: now,
@@ -377,6 +374,14 @@ describe("forkConversation", () => {
     const forkAssistant = getMessages(fork.id).find(
       (message) => message.role === "assistant",
     );
+    const forkAssistantMetadata = forkAssistant?.metadata
+      ? (JSON.parse(forkAssistant.metadata) as {
+          forkSourceMessageId?: string;
+        })
+      : null;
+    const forkRequestLogs = forkAssistant
+      ? getRequestLogsByMessageId(forkAssistant.id)
+      : [];
     const forkState = getAttentionStateByConversationIds([fork.id]).get(fork.id);
     const forkRequestLogCount = db
       .select()
@@ -402,6 +407,10 @@ describe("forkConversation", () => {
     expect(sourceState).toBeDefined();
     expect(sourceState?.lastSeenAssistantMessageId).toBeNull();
     expect(forkAssistant).toBeDefined();
+    expect(forkAssistantMetadata?.forkSourceMessageId).toBe(sourceAssistant.id);
+    expect(forkRequestLogs).toHaveLength(1);
+    expect(forkRequestLogs[0]?.conversationId).toBe(source.id);
+    expect(forkRequestLogs[0]?.messageId).toBe(sourceAssistant.id);
     expect(forkState).toBeDefined();
     expect(forkState?.latestAssistantMessageId).toBe(forkAssistant?.id);
     expect(forkState?.lastSeenAssistantMessageId).toBe(forkAssistant?.id);

--- a/assistant/src/__tests__/conversation-fork-route.test.ts
+++ b/assistant/src/__tests__/conversation-fork-route.test.ts
@@ -66,7 +66,11 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import {
+  addMessage,
+  createConversation,
+  PRIVATE_CONVERSATION_FORK_ERROR,
+} from "../memory/conversation-crud.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { getPolicy } from "../runtime/auth/route-policy.js";
 import { mintToken } from "../runtime/auth/token-service.js";
@@ -195,6 +199,61 @@ describe("POST /v1/conversations/fork", () => {
       error: {
         code: "NOT_FOUND",
         message: "Conversation missing-conversation not found",
+      },
+    });
+  });
+
+  test("does not expose private parents in detail reads", async () => {
+    const parent = createConversation({
+      title: "Private parent",
+      conversationType: "private",
+    });
+    const parentMessage = await addMessage(
+      parent.id,
+      "assistant",
+      "Private parent message",
+      undefined,
+      { skipIndexing: true },
+    );
+    const child = createConversation("Child conversation");
+    getDb().run(
+      `UPDATE conversations
+       SET fork_parent_conversation_id = '${parent.id}',
+           fork_parent_message_id = '${parentMessage.id}'
+       WHERE id = '${child.id}'`,
+    );
+
+    await startServer();
+
+    const response = await fetch(url(`/conversations/${child.id}`), {
+      headers: AUTH_HEADERS,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      conversation: ConversationSummary;
+    };
+    expect(body.conversation).not.toHaveProperty("forkParent");
+  });
+
+  test("rejects private source conversations", async () => {
+    const source = createConversation({
+      title: "Private source",
+      conversationType: "private",
+    });
+
+    await startServer();
+
+    const response = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationId: source.id }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "FORBIDDEN",
+        message: PRIVATE_CONVERSATION_FORK_ERROR,
       },
     });
   });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -63,6 +63,9 @@ const subagentNotificationSchema = z.object({
   conversationId: z.string().optional(),
 });
 
+export const PRIVATE_CONVERSATION_FORK_ERROR =
+  "Private conversations cannot be forked";
+
 export const messageMetadataSchema = z
   .object({
     userMessageChannel: channelIdSchema.optional(),
@@ -83,12 +86,41 @@ export const messageMetadataSchema = z
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
     automated: z.boolean().optional(),
+    forkSourceMessageId: z.string().optional(),
     /** Image source paths from desktop attachments, keyed by filename. */
     imageSourcePaths: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
+function cloneForkMessageMetadata(
+  metadata: string | null,
+  sourceMessageId: string,
+): string {
+  if (!metadata) {
+    return JSON.stringify({ forkSourceMessageId: sourceMessageId });
+  }
+
+  try {
+    const parsed = JSON.parse(metadata);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const sourceRecord = parsed as Record<string, unknown>;
+      const forkSourceMessageId =
+        typeof sourceRecord.forkSourceMessageId === "string"
+          ? sourceRecord.forkSourceMessageId
+          : sourceMessageId;
+      return JSON.stringify({
+        ...sourceRecord,
+        forkSourceMessageId,
+      });
+    }
+  } catch {
+    // Fall through to source-only metadata.
+  }
+
+  return JSON.stringify({ forkSourceMessageId: sourceMessageId });
+}
 
 /**
  * Extract provenance metadata fields from a TrustContext.
@@ -293,6 +325,9 @@ export function forkConversation(params: {
   if (!sourceConversation) {
     throw new UserError(`Conversation ${conversationId} not found`);
   }
+  if (sourceConversation.conversationType === "private") {
+    throw new UserError(PRIVATE_CONVERSATION_FORK_ERROR);
+  }
 
   const sourceMessages = db
     .select()
@@ -346,7 +381,7 @@ export function forkConversation(params: {
         role: message.role,
         content: message.content,
         createdAt: message.createdAt,
-        metadata: message.metadata,
+        metadata: cloneForkMessageMetadata(message.metadata, message.id),
       })
       .run();
     forkedMessageIds.set(message.id, forkedMessageId);

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, isNull, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getMessageById, messageMetadataSchema } from "./conversation-crud.js";
 import { getDb } from "./db.js";
 import { llmRequestLogs } from "./schema.js";
 
@@ -74,17 +75,42 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
   createdAt: number;
 }> {
   const db = getDb();
-  return db
-    .select({
-      id: llmRequestLogs.id,
-      conversationId: llmRequestLogs.conversationId,
-      messageId: llmRequestLogs.messageId,
-      requestPayload: llmRequestLogs.requestPayload,
-      responsePayload: llmRequestLogs.responsePayload,
-      createdAt: llmRequestLogs.createdAt,
-    })
-    .from(llmRequestLogs)
-    .where(eq(llmRequestLogs.messageId, messageId))
-    .orderBy(llmRequestLogs.createdAt)
-    .all();
+  const selectLogs = (targetMessageId: string) =>
+    db
+      .select({
+        id: llmRequestLogs.id,
+        conversationId: llmRequestLogs.conversationId,
+        messageId: llmRequestLogs.messageId,
+        requestPayload: llmRequestLogs.requestPayload,
+        responsePayload: llmRequestLogs.responsePayload,
+        createdAt: llmRequestLogs.createdAt,
+      })
+      .from(llmRequestLogs)
+      .where(eq(llmRequestLogs.messageId, targetMessageId))
+      .orderBy(llmRequestLogs.createdAt)
+      .all();
+
+  const exactLogs = selectLogs(messageId);
+  if (exactLogs.length > 0) {
+    return exactLogs;
+  }
+
+  const message = getMessageById(messageId);
+  if (!message?.metadata) {
+    return exactLogs;
+  }
+
+  try {
+    const parsed = messageMetadataSchema.safeParse(JSON.parse(message.metadata));
+    const sourceMessageId =
+      parsed.success && typeof parsed.data.forkSourceMessageId === "string"
+        ? parsed.data.forkSourceMessageId
+        : null;
+    if (!sourceMessageId || sourceMessageId === messageId) {
+      return exactLogs;
+    }
+    return selectLogs(sourceMessageId);
+  } catch {
+    return exactLogs;
+  }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -774,7 +774,12 @@ export class RuntimeHttpServer {
       parentConversation = getConversation(parentConversationId);
       parentCache.set(parentConversationId, parentConversation);
     }
-    if (!parentConversation) return undefined;
+    if (
+      !parentConversation ||
+      parentConversation.conversationType === "private"
+    ) {
+      return undefined;
+    }
 
     return {
       conversationId: parentConversationId,

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -16,6 +16,7 @@
 import {
   batchSetDisplayOrders,
   deleteConversation,
+  PRIVATE_CONVERSATION_FORK_ERROR,
   wipeConversation,
 } from "../../memory/conversation-crud.js";
 import {
@@ -117,6 +118,9 @@ export function conversationManagementRouteDefinitions(
           return Response.json({ conversation });
         } catch (err) {
           if (err instanceof UserError) {
+            if (err.message === PRIVATE_CONVERSATION_FORK_ERROR) {
+              return httpError("FORBIDDEN", err.message, 403);
+            }
             return httpError("NOT_FOUND", err.message, 404);
           }
           throw err;


### PR DESCRIPTION
## Summary
- reject forking private conversations and stop exposing private fork parents in HTTP reads
- preserve source-message metadata so forked messages can resolve original LLM inspector context
- add regression coverage for the new fork safety and inspector behavior

Fixes gap identified during plan review for conversation-forking.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
