### PR TITLE
fix: keep exact /fork local and restore shared Swift compile

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1142,18 +1142,23 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
-        // Intercept the exact `/fork` command only when the platform has
-        // registered a local fork handler and there is no extra payload.
+        // Intercept the exact `/fork` command locally so it never falls
+        // through to the assistant as ordinary chat text.
         if text == "/fork",
            !hasAttachments,
-           !hasSkillInvocation,
-           let onFork
+           !hasSkillInvocation
         {
             inputText = ""
             suggestion = nil
             pendingSuggestionRequestId = nil
             flushCoalescedPublish()
-            onFork()
+            if let onFork {
+                errorText = nil
+                conversationError = nil
+                onFork()
+            } else {
+                errorText = "Send a message before forking this conversation."
+            }
             return
         }
 
@@ -3234,7 +3239,7 @@ public final class ChatViewModel: ObservableObject {
     /// platform. On non-macOS platforms, returns nil fields (PTT is desktop-only).
     static func currentPttMetadata() -> PttMetadata {
         #if os(macOS)
-        let key = UserDefaults.standard.string(forKey: "activationKey") ?? "fn"
+        let key = SharedUserDefaults.standard.string(forKey: "activationKey") ?? "fn"
         let micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         return PttMetadata(activationKey: key, microphonePermissionGranted: micGranted)
         #else

--- a/clients/shared/Tests/ChatViewModelForkCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelForkCommandTests.swift
@@ -37,6 +37,17 @@ final class ChatViewModelForkCommandTests: XCTestCase {
         XCTAssertTrue(daemonClient.sentMessages.isEmpty)
     }
 
+    func testExactForkWithoutHandlerShowsLocalErrorAndNeverSendsUpstream() {
+        viewModel.inputText = "/fork"
+
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.inputText, "")
+        XCTAssertEqual(viewModel.errorText, "Send a message before forking this conversation.")
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertTrue(daemonClient.sentMessages.isEmpty)
+    }
+
     func testForkWithArgumentsStaysOnNormalSendPath() {
         var forkCount = 0
         viewModel.onFork = { forkCount += 1 }

--- a/clients/shared/Tests/ConversationDetailClientTests.swift
+++ b/clients/shared/Tests/ConversationDetailClientTests.swift
@@ -46,7 +46,7 @@ final class ConversationDetailClientTests: XCTestCase {
         MockConversationDetailURLProtocol.requestHandler = nil
         URLProtocol.registerClass(MockConversationDetailURLProtocol.self)
 
-        originalConnectedAssistantId = UserDefaults.standard.object(forKey: "connectedAssistantId")
+        originalConnectedAssistantId = SharedUserDefaults.standard.object(forKey: "connectedAssistantId")
 
         let primaryLockfileURL = LockfilePaths.primary
         primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
@@ -68,9 +68,9 @@ final class ConversationDetailClientTests: XCTestCase {
         }
 
         if let originalConnectedAssistantId {
-            UserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
+            SharedUserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
         } else {
-            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+            SharedUserDefaults.standard.removeObject(forKey: "connectedAssistantId")
         }
 
         try super.tearDownWithError()
@@ -158,6 +158,6 @@ final class ConversationDetailClientTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
         try data.write(to: LockfilePaths.primary, options: .atomic)
-        UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+        SharedUserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
     }
 }

--- a/clients/shared/Tests/ConversationForkClientTests.swift
+++ b/clients/shared/Tests/ConversationForkClientTests.swift
@@ -46,7 +46,7 @@ final class ConversationForkClientTests: XCTestCase {
         MockConversationForkURLProtocol.requestHandler = nil
         URLProtocol.registerClass(MockConversationForkURLProtocol.self)
 
-        originalConnectedAssistantId = UserDefaults.standard.object(forKey: "connectedAssistantId")
+        originalConnectedAssistantId = SharedUserDefaults.standard.object(forKey: "connectedAssistantId")
 
         let primaryLockfileURL = LockfilePaths.primary
         primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
@@ -68,9 +68,9 @@ final class ConversationForkClientTests: XCTestCase {
         }
 
         if let originalConnectedAssistantId {
-            UserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
+            SharedUserDefaults.standard.set(originalConnectedAssistantId, forKey: "connectedAssistantId")
         } else {
-            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+            SharedUserDefaults.standard.removeObject(forKey: "connectedAssistantId")
         }
 
         try super.tearDownWithError()
@@ -196,7 +196,7 @@ final class ConversationForkClientTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
         try data.write(to: LockfilePaths.primary, options: .atomic)
-        UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+        SharedUserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
     }
 
     private func requestJSONBody(from request: URLRequest) throws -> [String: Any] {

--- a/clients/shared/Utilities/APIKeyManager.swift
+++ b/clients/shared/Utilities/APIKeyManager.swift
@@ -15,7 +15,7 @@ public class APIKeyManager {
 
     public func getAPIKey(provider: String = "anthropic") -> String? {
         #if os(macOS) || targetEnvironment(simulator)
-        return UserDefaults.standard.string(forKey: udKey(provider))
+        return SharedUserDefaults.standard.string(forKey: udKey(provider))
         #else
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -39,7 +39,7 @@ public class APIKeyManager {
 
     public func setAPIKey(_ key: String, provider: String = "anthropic") -> Bool {
         #if os(macOS) || targetEnvironment(simulator)
-        UserDefaults.standard.set(key, forKey: udKey(provider))
+        SharedUserDefaults.standard.set(key, forKey: udKey(provider))
         return true
         #else
         guard let data = key.data(using: .utf8) else { return false }
@@ -67,7 +67,7 @@ public class APIKeyManager {
 
     public func deleteAPIKey(provider: String = "anthropic") -> Bool {
         #if os(macOS) || targetEnvironment(simulator)
-        UserDefaults.standard.removeObject(forKey: udKey(provider))
+        SharedUserDefaults.standard.removeObject(forKey: udKey(provider))
         return true
         #else
         let query: [String: Any] = [

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -33,7 +33,7 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         // When an explicit environment is provided (e.g. tests/previews),
         // skip UserDefaults to maintain isolation and determinism.
         if !isExplicitEnvironment {
-            let defaults = UserDefaults.standard
+            let defaults = SharedUserDefaults.standard
             for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(userDefaultsPrefix) {
                 let name = String(key.dropFirst(userDefaultsPrefix.count))
                 guard !name.isEmpty else { continue }
@@ -99,7 +99,7 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         defer { lock.unlock() }
         let normalized = Self.normalize(key)
         overrides[normalized] = enabled
-        UserDefaults.standard.set(enabled, forKey: userDefaultsPrefix + normalized)
+        SharedUserDefaults.standard.set(enabled, forKey: userDefaultsPrefix + normalized)
     }
 
     public func removeOverride(_ key: String) {
@@ -107,7 +107,7 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         defer { lock.unlock() }
         let normalized = Self.normalize(key)
         overrides.removeValue(forKey: normalized)
-        UserDefaults.standard.removeObject(forKey: userDefaultsPrefix + normalized)
+        SharedUserDefaults.standard.removeObject(forKey: userDefaultsPrefix + normalized)
     }
 
     /// Load VELLUM_FLAG_* entries from a `.env` file and apply them as overrides.

--- a/clients/shared/Utilities/SharedUserDefaults.swift
+++ b/clients/shared/Utilities/SharedUserDefaults.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum SharedUserDefaults {
+    static var standard: UserDefaults {
+        #if SWIFT_PACKAGE
+        return packageDefaults
+        #else
+        return .standard
+        #endif
+    }
+
+    #if SWIFT_PACKAGE
+    private static let packageDefaults: UserDefaults = {
+        UserDefaults(suiteName: "com.vellum.vellum-assistant.swiftpackage") ?? UserDefaults()
+    }()
+    #endif
+}


### PR DESCRIPTION
## Summary
- keep exact /fork on the local app-command path even when the conversation is not forkable yet
- surface a deterministic local error instead of sending /fork upstream as a normal message
- repair the shared SwiftPM compile failure blocking fork-related client test runs

Fixes gap identified during plan review for conversation-forking.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
