### PR TITLE
Fix response mode classification in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -243,15 +243,7 @@ struct MessageInspectorResponseTabModel: Equatable {
             return responseToolCallCount > 0 ? "Tool-calling response" : "Text-only response"
         }
 
-        if let stopReason = summary?.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-            if ["tool_calls", "tool_use", "function_call", "function_response"].contains(stopReason) {
-                return "Tool-calling response"
-            }
-
-            return "Text-only response"
-        }
-
-        if sections.contains(where: { $0.isToolCallLike }) {
+        if sections.contains(where: { $0.isToolCallSection }) {
             return "Tool-calling response"
         }
 
@@ -282,7 +274,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
     let toolName: String?
     let copyText: String
     let presentationKind: PresentationKind
-    let isToolCallLike: Bool
+    let isToolCallSection: Bool
 
     var showsRawPayloadHint: Bool {
         presentationKind == .toolCall
@@ -299,7 +291,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         switch section.kind {
         case .tool, .toolUse, .functionCall:
             presentationKind = .toolCall
-            isToolCallLike = true
+            isToolCallSection = true
             kindLabel = "Tool call"
             let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
@@ -307,21 +299,21 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
             copyText = copySource
         case .toolResult, .functionResponse:
             presentationKind = .other
-            isToolCallLike = true
+            isToolCallSection = false
             kindLabel = section.kind == .functionResponse ? "Function response" : "Tool result"
             let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
             copyText = preview ?? title
         case .assistant, .message, .text, .output, .completion, .reasoning, .markdown, .code, .json:
             presentationKind = .assistantText
-            isToolCallLike = false
+            isToolCallSection = false
             kindLabel = "Assistant text"
             bodyText = section.text ?? Self.previewText(for: section.data)
             copyText = bodyText ?? title
         default:
             let preview = section.text ?? Self.previewText(for: section.data)
             presentationKind = preview == nil ? .other : .assistantText
-            isToolCallLike = false
+            isToolCallSection = false
             kindLabel = section.kind.rawValue
             bodyText = preview
             copyText = bodyText ?? title

--- a/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
@@ -132,6 +132,84 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         XCTAssertEqual(model.sections.count, 1)
     }
 
+    func testResponseTabModelDoesNotTreatResultOnlySectionsAsToolCalling() {
+        let model = MessageInspectorResponseTabModel(
+            entry: makeEntry(
+                responsePayload: AnyCodable([
+                    "stop_reason": "function_response"
+                ]),
+                summary: LLMCallSummary(
+                    stopReason: "function_response"
+                ),
+                responseSections: [
+                    LLMContextSection(
+                        kind: .toolResult,
+                        label: "Tool result 1",
+                        role: "assistant",
+                        text: "result preview",
+                        toolName: "search_web",
+                        data: AnyCodable([
+                            "results": [
+                                "docs"
+                            ]
+                        ])
+                    ),
+                    LLMContextSection(
+                        kind: .functionResponse,
+                        label: "Function response 1",
+                        role: "assistant",
+                        text: "function response preview",
+                        toolName: "search_web",
+                        data: AnyCodable([
+                            "status": "ok"
+                        ])
+                    )
+                ]
+            )
+        )
+
+        XCTAssertTrue(model.hasNormalizedSections)
+        XCTAssertEqual(model.responseStopReason, "function_response")
+        XCTAssertEqual(model.responseModeLabel, "Text-only response")
+        XCTAssertEqual(model.sections.count, 2)
+        XCTAssertEqual(model.sections[0].presentationKind, .other)
+        XCTAssertEqual(model.sections[1].presentationKind, .other)
+    }
+
+    func testResponseTabModelUsesExplicitSummaryToolCallCountForToolCalling() {
+        let model = MessageInspectorResponseTabModel(
+            entry: makeEntry(
+                responsePayload: AnyCodable([
+                    "stop_reason": "function_response"
+                ]),
+                summary: LLMCallSummary(
+                    stopReason: "function_response",
+                    responseToolCallCount: 1
+                ),
+                responseSections: [
+                    LLMContextSection(
+                        kind: .toolResult,
+                        label: "Tool result 1",
+                        role: "assistant",
+                        text: "result preview",
+                        toolName: "search_web",
+                        data: AnyCodable([
+                            "results": [
+                                "docs"
+                            ]
+                        ])
+                    )
+                ]
+            )
+        )
+
+        XCTAssertTrue(model.hasNormalizedSections)
+        XCTAssertEqual(model.responseStopReason, "function_response")
+        XCTAssertEqual(model.responseModeLabel, "Tool-calling response")
+        XCTAssertEqual(model.sections.count, 1)
+        XCTAssertEqual(model.sections[0].presentationKind, .other)
+    }
+
     func testResponseTabModelFallsBackWithoutNormalizedSections() {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(


### PR DESCRIPTION
## Summary
- stop treating result-only sections as tool-calling response signals
- keep stop-reason metadata and raw fallback behavior intact
- add response-tab coverage for the corrected mode classification

Part of plan: llm-context-inspector-redesign.md (remediation round 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
