### PR TITLE
fix: enforce private conversation fork boundaries on Apple clients

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -249,7 +249,7 @@ class IOSConversationStore: ObservableObject {
     private func mergeConversationMetadata(from restored: IOSConversation, into conversation: inout IOSConversation) {
         conversation.conversationId = restored.conversationId ?? conversation.conversationId
         conversation.scheduleJobId = restored.scheduleJobId ?? conversation.scheduleJobId
-        conversation.forkParent = restored.forkParent ?? conversation.forkParent
+        conversation.forkParent = restored.forkParent
         let hasLocalPinEdit = conversation.conversationId.map { locallyEditedPinConversationIds.contains($0) } ?? false
         if !hasLocalPinEdit {
             conversation.isPinned = restored.isPinned
@@ -675,10 +675,6 @@ class IOSConversationStore: ObservableObject {
 
                 var merged: [IOSConversation] = []
                 for var restored in restoredConversations {
-                    if let conversationId = restored.conversationId,
-                       let cachedConversation = conversations.first(where: { $0.conversationId == conversationId }) {
-                        restored.forkParent = restored.forkParent ?? cachedConversation.forkParent
-                    }
                     if let local = localOverrides[restored.conversationId ?? ""] {
                         let sid = restored.conversationId ?? ""
                         let useLocalPin = locallyEditedPinConversationIds.contains(sid)
@@ -1223,17 +1219,19 @@ class IOSConversationStore: ObservableObject {
     func openForkParent(of conversationLocalId: UUID) async -> UUID? {
         guard isConnectedMode,
               let conversation = conversations.first(where: { $0.id == conversationLocalId }),
+              !conversation.isPrivate,
               let forkParent = conversation.forkParent else {
             return nil
         }
 
         let parentLocalId: UUID
         if let existingIndex = existingConversationIndex(forConversationId: forkParent.conversationId) {
+            guard !conversations[existingIndex].isPrivate else { return nil }
             parentLocalId = conversations[existingIndex].id
         } else {
             guard let parentConversation = await conversationDetailClient.fetchConversation(
                 conversationId: forkParent.conversationId
-            ) else {
+            ), parentConversation.conversationType != "private" else {
                 return nil
             }
             parentLocalId = upsertConversationListItem(parentConversation)

--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -99,6 +99,46 @@ final class ConversationForkIOSTests: XCTestCase {
         XCTAssertNil(restored.forkParent)
     }
 
+    func testConversationListRefreshClearsStaleForkParentFromCachedConversation() {
+        let (userDefaults, suiteName) = makeUserDefaults()
+        defer { clear(userDefaults, suiteName: suiteName) }
+
+        let daemonClient = DaemonClient()
+        let store = IOSConversationStore(
+            daemonClient: daemonClient,
+            connectedModeOverride: true,
+            userDefaults: userDefaults
+        )
+        store.isLoadingInitialConversations = false
+
+        let cachedConversation = IOSConversation(
+            title: "Cached thread",
+            conversationId: "conv-thread",
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: "msg-parent",
+                title: "Parent thread"
+            )
+        )
+        store.conversations = [cachedConversation]
+
+        let response = makeConversationListResponse(
+            conversations: [
+                ConversationListResponseItem(
+                    id: "conv-thread",
+                    title: "Cached thread",
+                    createdAt: 1_700_000_000,
+                    updatedAt: 1_700_000_100,
+                    conversationType: "standard"
+                )
+            ]
+        )
+        daemonClient.onConversationListResponse?(response)
+
+        let refreshed = store.conversations.first(where: { $0.conversationId == "conv-thread" })
+        XCTAssertNil(refreshed?.forkParent)
+    }
+
     func testExactForkCommandInterceptsCurrentPersistedTipWithoutAppendingUserBubble() async throws {
         let (userDefaults, suiteName) = makeUserDefaults()
         defer { clear(userDefaults, suiteName: suiteName) }
@@ -218,6 +258,44 @@ final class ConversationForkIOSTests: XCTestCase {
                 title: "Parent thread"
             )
         )
+    }
+
+    private func makeConversationListResponse(
+        conversations: [ConversationListResponseItem],
+        hasMore: Bool? = nil
+    ) -> ConversationListResponseMessage {
+        var payload: [String: Any] = [
+            "type": "conversation_list_response",
+            "conversations": conversations.map { item in
+                var dict: [String: Any] = [
+                    "id": item.id,
+                    "title": item.title,
+                    "updatedAt": item.updatedAt,
+                ]
+                if let createdAt = item.createdAt {
+                    dict["createdAt"] = createdAt
+                }
+                if let conversationType = item.conversationType {
+                    dict["conversationType"] = conversationType
+                }
+                if let forkParent = item.forkParent {
+                    var forkParentDict: [String: Any] = [
+                        "conversationId": forkParent.conversationId,
+                        "messageId": forkParent.messageId
+                    ]
+                    if let title = forkParent.title {
+                        forkParentDict["title"] = title
+                    }
+                    dict["forkParent"] = forkParentDict
+                }
+                return dict
+            }
+        ]
+        if let hasMore {
+            payload["hasMore"] = hasMore
+        }
+        let data = try! JSONSerialization.data(withJSONObject: payload)
+        return try! JSONDecoder().decode(ConversationListResponseMessage.self, from: data)
     }
 }
 

--- a/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
@@ -43,6 +43,22 @@ final class ConversationForkMessageActionIOSTests: XCTestCase {
         XCTAssertFalse(streamingView.canForkFromMessage)
     }
 
+    func testPrivateConversationDoesNotExposeMessageForkAction() {
+        let store = IOSConversationStore(daemonClient: MockDaemonClient(), connectedModeOverride: true)
+        let privateConversation = IOSConversation(
+            title: "Private",
+            conversationId: "conv-private",
+            isPrivate: true
+        )
+
+        XCTAssertNil(
+            makeConversationForkFromMessageAction(
+                store: store,
+                conversation: privateConversation
+            )
+        )
+    }
+
     func testMessageForkActionUsesStoreHelperAndPublishesSelectionForNewFork() async throws {
         let (userDefaults, suiteName) = makeUserDefaults()
         defer { clear(userDefaults, suiteName: suiteName) }

--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -140,6 +140,33 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         XCTAssertEqual(forkClient.requests.first?.throughMessageId, "msg-tip")
     }
 
+    func testForkActionsAreHiddenForPrivateConversations() {
+        let privateConversation = IOSConversation(
+            title: "Private",
+            conversationId: "conv-private",
+            isPrivate: true,
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: "msg-parent",
+                title: "Parent thread"
+            )
+        )
+
+        XCTAssertFalse(shouldShowCurrentTipForkAction(for: privateConversation))
+        XCTAssertNil(
+            makeCurrentTipForkToolbarAction(
+                store: IOSConversationStore(daemonClient: MockDaemonClient(), connectedModeOverride: true),
+                conversation: privateConversation
+            )
+        )
+        XCTAssertNil(
+            makeOpenForkParentAction(
+                store: IOSConversationStore(daemonClient: MockDaemonClient(), connectedModeOverride: true),
+                conversation: privateConversation
+            )
+        )
+    }
+
     private func makeUserDefaults() -> (UserDefaults, String) {
         let suiteName = "ConversationForkNavigationIOSTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -43,7 +43,7 @@ func applyConversationSelectionRequest(
 }
 
 func shouldShowCurrentTipForkAction(for conversation: IOSConversation) -> Bool {
-    conversation.conversationId != nil
+    conversation.conversationId != nil && !conversation.isPrivate
 }
 
 @MainActor
@@ -60,11 +60,28 @@ func makeCurrentTipForkToolbarAction(
 }
 
 @MainActor
+func makeConversationForkFromMessageAction(
+    store: IOSConversationStore,
+    conversation: IOSConversation
+) -> ((String) -> Void)? {
+    guard conversation.conversationId != nil, !conversation.isPrivate else { return nil }
+    return makeOnForkFromMessageAction(
+        conversationLocalId: conversation.id,
+        forkConversationFromMessage: { conversationLocalId, daemonMessageId in
+            await store.forkConversation(
+                conversationLocalId: conversationLocalId,
+                throughDaemonMessageId: daemonMessageId
+            )
+        }
+    )
+}
+
+@MainActor
 func makeOpenForkParentAction(
     store: IOSConversationStore,
     conversation: IOSConversation
 ) -> (() -> Void)? {
-    guard conversation.forkParent != nil else { return nil }
+    guard conversation.forkParent != nil, !conversation.isPrivate else { return nil }
     return {
         Task { @MainActor in
             _ = await store.openForkParent(of: conversation.id)
@@ -724,14 +741,9 @@ struct ConversationChatView: View {
                 onPendingAnchorHandled: { requestId in
                     store.consumePendingAnchorRequest(id: requestId)
                 },
-                onForkFromMessage: conversation.conversationId == nil ? nil : makeOnForkFromMessageAction(
-                    conversationLocalId: conversation.id,
-                    forkConversationFromMessage: { conversationLocalId, daemonMessageId in
-                        await store.forkConversation(
-                            conversationLocalId: conversationLocalId,
-                            throughDaemonMessageId: daemonMessageId
-                        )
-                    }
+                onForkFromMessage: makeConversationForkFromMessageAction(
+                    store: store,
+                    conversation: conversation
                 )
             )
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -51,8 +51,14 @@ struct ConversationHeaderPresentation {
         // Can copy when there's non-empty content
         self.canCopy = hasUserMessage
         self.showsForkConversationAction = conversation.conversationId != nil && !isPrivateConversation
-        self.forkParentTitle = conversation.forkParent?.title
-        self.forkParentConversationId = conversation.forkParent?.conversationId
-        self.forkParentMessageId = conversation.forkParent?.messageId
+        if isPrivateConversation {
+            self.forkParentTitle = nil
+            self.forkParentConversationId = nil
+            self.forkParentMessageId = nil
+        } else {
+            self.forkParentTitle = conversation.forkParent?.title
+            self.forkParentConversationId = conversation.forkParent?.conversationId
+            self.forkParentMessageId = conversation.forkParent?.messageId
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -837,9 +837,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     @discardableResult
     func openForkParentConversation(conversationId: String, sourceMessageId: String?) async -> Bool {
-        if selectConversationByConversationId(conversationId) {
-            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
-                unarchiveConversation(id: match.id)
+        if let existingConversation = conversations.first(where: { $0.conversationId == conversationId }) {
+            guard existingConversation.kind != .private else { return false }
+            selectConversation(id: existingConversation.id)
+            if existingConversation.isArchived {
+                unarchiveConversation(id: existingConversation.id)
             }
             applyPendingAnchorMessageIfPossible(
                 localConversationId: activeConversationId,
@@ -852,9 +854,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return false
         }
 
-        if selectConversationByConversationId(conversationId) {
-            if let match = conversations.first(where: { $0.conversationId == conversationId }), match.isArchived {
-                unarchiveConversation(id: match.id)
+        if let existingConversation = conversations.first(where: { $0.conversationId == conversationId }) {
+            guard existingConversation.kind != .private else { return false }
+            selectConversation(id: existingConversation.id)
+            if existingConversation.isArchived {
+                unarchiveConversation(id: existingConversation.id)
             }
             applyPendingAnchorMessageIfPossible(
                 localConversationId: activeConversationId,
@@ -862,6 +866,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             )
             return true
         }
+
+        guard conversation.conversationType != "private" else { return false }
 
         if isConversationArchived(conversation.id) {
             var archived = archivedConversationIds
@@ -939,25 +945,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         guard let detail = await conversationDetailClient.fetchConversation(conversationId: fallback.id) else {
             return fallback
         }
-        guard detail.forkParent == nil, let fallbackForkParent = fallback.forkParent else {
-            return detail
-        }
-        return ConversationListResponseItem(
-            id: detail.id,
-            title: detail.title,
-            createdAt: detail.createdAt,
-            updatedAt: detail.updatedAt,
-            conversationType: detail.conversationType,
-            source: detail.source,
-            scheduleJobId: detail.scheduleJobId,
-            channelBinding: detail.channelBinding,
-            conversationOriginChannel: detail.conversationOriginChannel,
-            conversationOriginInterface: detail.conversationOriginInterface,
-            assistantAttention: detail.assistantAttention,
-            displayOrder: detail.displayOrder,
-            isPinned: detail.isPinned,
-            forkParent: fallbackForkParent
-        )
+        return detail
     }
 
     @discardableResult
@@ -978,8 +966,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                 localId: existingConversation.id,
                 createdAt: existingConversation.createdAt,
                 isArchived: isArchived,
-                fallbackPinnedOrder: existingConversation.pinnedOrder,
-                fallbackForkParent: existingConversation.forkParent
+                fallbackPinnedOrder: existingConversation.pinnedOrder
             )
             mergeAssistantAttention(from: item, intoConversationAt: existingIdx)
             if let viewModel = chatViewModels[existingConversation.id] {
@@ -1010,8 +997,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         localId: UUID = UUID(),
         createdAt: Date? = nil,
         isArchived: Bool,
-        fallbackPinnedOrder: Int? = nil,
-        fallbackForkParent: ConversationForkParent? = nil
+        fallbackPinnedOrder: Int? = nil
     ) -> ConversationModel {
         let effectiveCreatedAtMillis = item.createdAt ?? item.updatedAt
         let isPinned = item.isPinned ?? false
@@ -1035,7 +1021,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             lastSeenAssistantMessageAt: item.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             },
-            forkParent: item.forkParent ?? fallbackForkParent
+            forkParent: item.forkParent
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -209,8 +209,7 @@ final class ConversationRestorer {
                 delegate.conversations[existingIdx].isPinned = isPinned
                 delegate.conversations[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
                 delegate.conversations[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
-                delegate.conversations[existingIdx].forkParent =
-                    session.forkParent ?? delegate.conversations[existingIdx].forkParent
+                delegate.conversations[existingIdx].forkParent = session.forkParent
                 delegate.mergeAssistantAttention(from: session, intoConversationAt: existingIdx)
                 if isPinned && session.displayOrder == nil { pinnedCount += 1 }
                 continue

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -64,6 +64,29 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertFalse(p.showsForkConversationAction)
     }
 
+    func testPrivateConversationSuppressesForkParentMetadata() {
+        let conversation = ConversationModel(
+            title: "Private Chat",
+            conversationId: "session-private",
+            kind: .private,
+            forkParent: ConversationForkParent(
+                conversationId: "session-parent",
+                messageId: "msg-parent",
+                title: "Original"
+            )
+        )
+        let p = ConversationHeaderPresentation(
+            activeConversation: conversation,
+            activeViewModel: nil,
+            isConversationVisible: true
+        )
+
+        XCTAssertFalse(p.showsForkParentLink)
+        XCTAssertNil(p.forkParentTitle)
+        XCTAssertNil(p.forkParentConversationId)
+        XCTAssertNil(p.forkParentMessageId)
+    }
+
     // MARK: - Not started (no conversationId, no messages)
 
     func testUnstartedConversationDoesNotShowActions() {

--- a/clients/macos/vellum-assistantTests/ConversationManagerForkTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerForkTests.swift
@@ -170,6 +170,29 @@ final class ConversationManagerForkTests: XCTestCase {
         XCTAssertTrue(conversationManager.conversations.isEmpty)
     }
 
+    func testOpenForkParentConversationRefusesPrivateParents() async {
+        let privateConversation = ConversationModel(
+            title: "Private",
+            conversationId: "conv-private",
+            kind: .private,
+            forkParent: ConversationForkParent(
+                conversationId: "conv-parent",
+                messageId: "msg-parent",
+                title: "Parent"
+            )
+        )
+        conversationManager.conversations = [privateConversation]
+
+        let opened = await conversationManager.openForkParentConversation(
+            conversationId: "conv-private",
+            sourceMessageId: "msg-parent"
+        )
+
+        XCTAssertFalse(opened)
+        XCTAssertNil(conversationManager.activeConversationId)
+        XCTAssertTrue(detailClient.fetchedConversationIds.isEmpty)
+    }
+
     @discardableResult
     private func makePersistedConversation(title: String, conversationId: String) -> ConversationModel {
         let conversation = ConversationModel(title: title, conversationId: conversationId)

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -296,6 +296,36 @@ struct ConversationRestorerTests {
         #expect(delegate.conversations[0].title == "Untitled")
     }
 
+    @Test @MainActor
+    func cachedForkParentIsClearedWhenServerOmitsIt() {
+        let dc = DaemonClient()
+        let restorer = ConversationRestorer(daemonClient: dc)
+        let delegate = MockConversationRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let conversation = ConversationModel(
+            title: "Cached thread",
+            conversationId: "session-1",
+            forkParent: ConversationForkParent(
+                conversationId: "session-parent",
+                messageId: "msg-parent",
+                title: "Parent"
+            )
+        )
+        let vm = delegate.makeViewModel()
+        vm.conversationId = "session-1"
+        delegate.conversations = [conversation]
+        delegate.viewModels[conversation.id] = vm
+
+        restorer.handleConversationListResponse(
+            makeConversationListResponse(conversations: [
+                (id: "session-1", title: "Cached thread", updatedAt: 1_700_000_100, conversationType: "standard")
+            ])
+        )
+
+        #expect(delegate.conversations[0].forkParent == nil)
+    }
+
     // MARK: - Conversation List Restoration
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- hide fork affordances for private conversations on Apple clients
- make fork parent metadata server-authoritative so stale private-parent links clear on refresh
- keep parent navigation from surfacing private conversations in the normal chat views

Fixes gap identified during plan review for conversation-forking.md.