### PR TITLE
fix: converge resolved conversation directories in repair flows

### DIFF
--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
@@ -177,7 +180,7 @@ import { Conversation } from "../daemon/conversation.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeConversation(): Conversation {
+function makeConversation(workingDir = "/tmp"): Conversation {
   const provider = {
     name: "mock",
     async sendMessage(): Promise<ProviderResponse> {
@@ -195,7 +198,7 @@ function makeConversation(): Conversation {
     "system prompt",
     4096,
     () => {},
-    "/tmp",
+    workingDir,
   );
 }
 
@@ -271,5 +274,29 @@ describe("Conversation workspace cache state", () => {
       "<workspace_top_level>",
     );
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
+  });
+
+  test("workspace hints follow the resolved legacy directory when canonical is absent", () => {
+    const workspaceRoot = mkdtempSync(
+      join(tmpdir(), "conversation-workspace-cache-state-"),
+    );
+    const legacyDirName = `conv-1_2026-03-19T12-00-00.000Z`;
+    mkdirSync(join(workspaceRoot, "conversations", legacyDirName), {
+      recursive: true,
+    });
+
+    try {
+      const tempConversation = makeConversation(workspaceRoot);
+      tempConversation.refreshWorkspaceTopLevelContextIfNeeded();
+
+      expect(tempConversation.getWorkspaceTopLevelContext()!).toContain(
+        `Current conversation folder: conversations/${legacyDirName}/`,
+      );
+      expect(tempConversation.getWorkspaceTopLevelContext()!).toContain(
+        `Attachment files: conversations/${legacyDirName}/attachments/`,
+      );
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
@@ -270,4 +270,70 @@ describe("013-repair-conversation-disk-view migration", () => {
     expect(readFileSync(messagesPath, "utf-8")).toBe(firstRunMessages);
     expect(readdirSync(attachmentsDir).sort()).toEqual(["transcript.txt"]);
   });
+
+  test("converges duplicate legacy/canonical directories to canonical after repair rebuild", () => {
+    const { conversationId, conversationCreatedAt, conversationUpdatedAt } =
+      seedConversationRows();
+    const timestamp = toConversationTimestamp(conversationCreatedAt);
+    const canonicalDirName = `${timestamp}_${conversationId}`;
+    const canonicalDirPath = join(conversationsDir, canonicalDirName);
+    const legacyDirPath = join(
+      conversationsDir,
+      `${conversationId}_${timestamp}`,
+    );
+    const canonicalMessagesPath = join(canonicalDirPath, "messages.jsonl");
+    const canonicalAttachmentsDir = join(canonicalDirPath, "attachments");
+
+    mkdirSync(canonicalAttachmentsDir, { recursive: true });
+    writeFileSync(
+      join(canonicalDirPath, "meta.json"),
+      JSON.stringify(
+        {
+          id: conversationId,
+          title: "Repair Test",
+          type: "standard",
+          channel: "desktop",
+          createdAt: new Date(conversationCreatedAt).toISOString(),
+          updatedAt: new Date(conversationUpdatedAt - 1000).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    writeFileSync(canonicalMessagesPath, '{"role":"user","content":"stale"}\n');
+    writeFileSync(join(canonicalAttachmentsDir, "stale.txt"), "stale");
+
+    const legacyAttachmentsDir = join(legacyDirPath, "attachments");
+    mkdirSync(legacyAttachmentsDir, { recursive: true });
+    writeFileSync(join(legacyDirPath, "meta.json"), "{\"legacy\":true}\n");
+    writeFileSync(join(legacyDirPath, "messages.jsonl"), "{\"legacy\":true}\n");
+    writeFileSync(join(legacyAttachmentsDir, "legacy.txt"), "legacy");
+
+    repairConversationDiskViewMigration.run(workspaceDir);
+
+    expect(readdirSync(conversationsDir).sort()).toEqual([canonicalDirName]);
+    expect(existsSync(canonicalDirPath)).toBe(true);
+    expect(existsSync(legacyDirPath)).toBe(false);
+    expect(
+      JSON.parse(readFileSync(join(canonicalDirPath, "meta.json"), "utf-8"))
+        .updatedAt,
+    ).toBe(new Date(conversationUpdatedAt).toISOString());
+    expect(
+      readFileSync(canonicalMessagesPath, "utf-8").trim().split("\n"),
+    ).toHaveLength(1);
+    expect(JSON.parse(readFileSync(canonicalMessagesPath, "utf-8").trim())).toEqual(
+      {
+        role: "user",
+        ts: "2026-03-18T16:01:00.000Z",
+        content: "Repair missing disk view",
+        attachments: ["transcript.txt"],
+      },
+    );
+    expect(readdirSync(canonicalAttachmentsDir).sort()).toEqual([
+      "transcript.txt",
+    ]);
+    expect(
+      readFileSync(join(canonicalAttachmentsDir, "transcript.txt"), "utf-8"),
+    ).toBe("hello world");
+  });
 });

--- a/assistant/src/daemon/conversation-workspace.ts
+++ b/assistant/src/daemon/conversation-workspace.ts
@@ -1,5 +1,7 @@
+import { join } from "node:path";
+
 import { getConversation } from "../memory/conversation-crud.js";
-import { getConversationDirName } from "../memory/conversation-disk-view.js";
+import { resolveConversationDirectoryPaths } from "../memory/conversation-directories.js";
 import { renderWorkspaceTopLevelContext } from "../workspace/top-level-renderer.js";
 import { scanTopLevelDirectories } from "../workspace/top-level-scanner.js";
 
@@ -21,10 +23,15 @@ export function refreshWorkspaceTopLevelContextIfNeeded(
     return;
   const snapshot = scanTopLevelDirectories(ctx.workingDir);
   const conversation = getConversation(ctx.conversationId);
-  const currentConversationPath =
-    conversation && typeof conversation.createdAt === "number"
-      ? `conversations/${getConversationDirName(conversation.id, conversation.createdAt)}/`
-      : null;
+  let currentConversationPath: string | null = null;
+  if (conversation && typeof conversation.createdAt === "number") {
+    const { resolvedDirName } = resolveConversationDirectoryPaths(
+      conversation.id,
+      conversation.createdAt,
+      join(ctx.workingDir, "conversations"),
+    );
+    currentConversationPath = `conversations/${resolvedDirName}/`;
+  }
   ctx.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot, {
     currentConversationPath,
     currentConversationAttachmentsPath: currentConversationPath

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -47,6 +47,53 @@ export function getLegacyConversationDirPath(
   );
 }
 
+export interface ResolvedConversationDirectoryPaths {
+  canonicalDirPath: string;
+  canonicalDirName: string;
+  legacyDirPath: string;
+  legacyDirName: string;
+  resolvedDirPath: string;
+  resolvedDirName: string;
+  hasCanonicalDir: boolean;
+  hasLegacyDir: boolean;
+}
+
+export function resolveConversationDirectoryPaths(
+  id: string,
+  createdAtMs: number,
+  conversationsDir: string = getConversationsDir(),
+): ResolvedConversationDirectoryPaths {
+  const canonicalDirName = getConversationDirName(id, createdAtMs);
+  const canonicalDirPath = join(conversationsDir, canonicalDirName);
+  const hasCanonicalDir = existsSync(canonicalDirPath);
+
+  const legacyDirName = getLegacyConversationDirName(id, createdAtMs);
+  const legacyDirPath = join(conversationsDir, legacyDirName);
+  const hasLegacyDir = existsSync(legacyDirPath);
+
+  const resolvedDirPath = hasCanonicalDir
+    ? canonicalDirPath
+    : hasLegacyDir
+      ? legacyDirPath
+      : canonicalDirPath;
+  const resolvedDirName = hasCanonicalDir
+    ? canonicalDirName
+    : hasLegacyDir
+      ? legacyDirName
+      : canonicalDirName;
+
+  return {
+    canonicalDirPath,
+    canonicalDirName,
+    legacyDirPath,
+    legacyDirName,
+    resolvedDirPath,
+    resolvedDirName,
+    hasCanonicalDir,
+    hasLegacyDir,
+  };
+}
+
 /**
  * Resolve the active conversation directory path:
  * 1) prefer timestamp-first when it exists;
@@ -57,13 +104,14 @@ export function getResolvedConversationDirPath(
   id: string,
   createdAtMs: number,
 ): string {
-  const dirPath = getConversationDirPath(id, createdAtMs);
-  if (existsSync(dirPath)) return dirPath;
+  return resolveConversationDirectoryPaths(id, createdAtMs).resolvedDirPath;
+}
 
-  const legacyDirPath = getLegacyConversationDirPath(id, createdAtMs);
-  if (existsSync(legacyDirPath)) return legacyDirPath;
-
-  return dirPath;
+export function getResolvedConversationDirName(
+  id: string,
+  createdAtMs: number,
+): string {
+  return resolveConversationDirectoryPaths(id, createdAtMs).resolvedDirName;
 }
 
 export function getConversationAttachmentsDirPath(

--- a/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
@@ -4,16 +4,45 @@ import { join } from "node:path";
 import { asc, eq } from "drizzle-orm";
 
 import {
-  getResolvedConversationDirPath,
   initConversationDir,
   syncMessageToDisk,
   updateMetaFile,
 } from "../../memory/conversation-disk-view.js";
+import { resolveConversationDirectoryPaths } from "../../memory/conversation-directories.js";
 import { getDb } from "../../memory/db.js";
 import { conversations, messages } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("workspace-migrations");
+
+function hasExpectedDiskViewArtifacts(
+  conv: { updatedAt: number },
+  dirPath: string,
+): boolean {
+  const metaPath = join(dirPath, "meta.json");
+  const messagesPath = join(dirPath, "messages.jsonl");
+  const attachDir = join(dirPath, "attachments");
+  if (!existsSync(metaPath) || !existsSync(messagesPath) || !existsSync(attachDir))
+    return false;
+
+  try {
+    const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
+    const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
+    return existing.updatedAt === expectedUpdatedAt;
+  } catch {
+    return false;
+  }
+}
+
+function convergeDualConversationDirsToCanonical(
+  conv: { updatedAt: number },
+  canonicalDirPath: string,
+  legacyDirPath: string,
+): void {
+  if (!existsSync(canonicalDirPath) || !existsSync(legacyDirPath)) return;
+  if (!hasExpectedDiskViewArtifacts(conv, canonicalDirPath)) return;
+  rmSync(legacyDirPath, { recursive: true, force: true });
+}
 
 /**
  * Rebuild the conversation disk view for all persisted conversations.
@@ -34,28 +63,26 @@ export function rebuildConversationDiskViewFromDb(): void {
   let processed = 0;
 
   for (const conv of allConversations) {
-    const dirPath = getResolvedConversationDirPath(conv.id, conv.createdAt);
+    const { canonicalDirPath, legacyDirPath, resolvedDirPath: dirPath } =
+      resolveConversationDirectoryPaths(conv.id, conv.createdAt);
     const metaPath = join(dirPath, "meta.json");
     const messagesPath = join(dirPath, "messages.jsonl");
     const attachDir = join(dirPath, "attachments");
 
     // Check if already migrated (idempotent)
-    if (existsSync(metaPath)) {
-      try {
-        const existing = JSON.parse(readFileSync(metaPath, "utf-8"));
-        const expectedUpdatedAt = new Date(conv.updatedAt).toISOString();
-        const hasRequiredArtifacts =
-          existsSync(messagesPath) && existsSync(attachDir);
-        if (existing.updatedAt === expectedUpdatedAt && hasRequiredArtifacts) {
-          processed++;
-          if (processed % 50 === 0) {
-            log.info(`Backfilled ${processed}/${total} conversations to disk`);
-          }
-          continue;
-        }
-      } catch {
-        // meta.json exists but is unreadable/malformed — re-create it
+    if (existsSync(metaPath) && hasExpectedDiskViewArtifacts(conv, dirPath)) {
+      // Prefer the timestamp-first canonical directory whenever both sibling
+      // directories exist and the canonical projection is complete.
+      convergeDualConversationDirsToCanonical(
+        conv,
+        canonicalDirPath,
+        legacyDirPath,
+      );
+      processed++;
+      if (processed % 50 === 0) {
+        log.info(`Backfilled ${processed}/${total} conversations to disk`);
       }
+      continue;
     }
 
     // Create dir + meta.json (initConversationDir sets updatedAt = createdAt)
@@ -88,6 +115,7 @@ export function rebuildConversationDiskViewFromDb(): void {
     // idempotency check won't skip a conversation with incomplete messages
     // if the migration is interrupted mid-loop.
     updateMetaFile(conv);
+    convergeDualConversationDirsToCanonical(conv, canonicalDirPath, legacyDirPath);
 
     processed++;
     if (processed % 50 === 0) {


### PR DESCRIPTION
## Summary
- converge dual legacy/canonical conversation folders during rebuild and repair flows
- make workspace conversation-path hints follow the resolved active conversation folder
- add focused regression coverage for duplicate-folder repair and resolved workspace hints

Fixes gaps identified during plan review for repair-conversation-disk-view.md.

**Gap:** Resolved-directory convergence and workspace hints must match the active folder
**What was expected:** repair flows should converge to one authoritative folder and workspace hints should point at the real active folder.
**What was found:** stale sibling folders could remain after repair and workspace hints could still point at the timestamp-first name when the legacy folder was active.