### PR TITLE
fix: rebuild disk view after assistant message consolidation

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -143,6 +143,14 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginChannel: () => null,
 }));
 
+const syncMessageToDiskMock = mock(() => {});
+const rebuildConversationDiskViewFromDbStateMock = mock(() => {});
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: syncMessageToDiskMock,
+  rebuildConversationDiskViewFromDbState:
+    rebuildConversationDiskViewFromDbStateMock,
+}));
+
 mock.module("../memory/retriever.js", () => ({
   buildMemoryRecall: async () => ({
     enabled: false,
@@ -213,8 +221,9 @@ mock.module("../daemon/history-repair.js", () => ({
   deepRepairHistory: (msgs: Message[]) => ({ messages: msgs, stats: {} }),
 }));
 
+const consolidateAssistantMessagesMock = mock(() => false);
 mock.module("../daemon/conversation-history.js", () => ({
-  consolidateAssistantMessages: () => {},
+  consolidateAssistantMessages: consolidateAssistantMessagesMock,
 }));
 
 const recordUsageMock = mock(() => {});
@@ -448,6 +457,10 @@ beforeEach(() => {
   mockOverflowAction = "fail_gracefully";
   mockApprovalResult = { approved: false };
   recordUsageMock.mockClear();
+  syncMessageToDiskMock.mockClear();
+  rebuildConversationDiskViewFromDbStateMock.mockClear();
+  consolidateAssistantMessagesMock.mockReset();
+  consolidateAssistantMessagesMock.mockImplementation(() => false);
 });
 
 describe("session-agent-loop", () => {
@@ -1688,6 +1701,49 @@ describe("session-agent-loop", () => {
       await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
 
       expect(drainReason).toBe("loop_complete");
+    });
+
+    test("rebuilds disk view after consolidation mutates persisted history", async () => {
+      consolidateAssistantMessagesMock.mockReturnValue(true);
+
+      const ctx = makeCtx({
+        agentLoopRun: async (
+          messages: Message[],
+          onEvent: (event: AgentEvent) => void,
+        ) => {
+          onEvent({
+            type: "message_complete",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+            },
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 10,
+            outputTokens: 5,
+            model: "test",
+            providerDurationMs: 50,
+          });
+          return [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [{ type: "text", text: "done" }] as ContentBlock[],
+            },
+          ];
+        },
+      });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-consolidate", () => {});
+
+      expect(consolidateAssistantMessagesMock).toHaveBeenCalledWith(
+        "test-conv",
+        "msg-consolidate",
+      );
+      expect(rebuildConversationDiskViewFromDbStateMock).toHaveBeenCalledWith(
+        "test-conv",
+      );
     });
   });
 

--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -58,12 +58,19 @@ import {
   linkAttachmentToMessage,
   uploadAttachment,
 } from "../memory/attachments-store.js";
-import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import {
+  addMessage,
+  createConversation,
+  deleteMessageById,
+  relinkAttachments,
+  updateMessageContent,
+} from "../memory/conversation-crud.js";
 import {
   flattenContentBlocks,
   getConversationDirName,
   getConversationDirPath,
   initConversationDir,
+  rebuildConversationDiskViewFromDbState,
   removeConversationDir,
   resolveUniqueFilename,
   syncMessageToDisk,
@@ -607,6 +614,93 @@ describe("syncMessageToDisk", () => {
     expect(existsSync(join(dirPath, "attachments", record.attachments[0]))).toBe(
       true,
     );
+
+    rmSync(dirPath, { recursive: true, force: true });
+  });
+});
+
+describe("rebuildConversationDiskViewFromDbState", () => {
+  beforeEach(resetTables);
+
+  test("rewrites stale pre-consolidation disk view with final DB state", async () => {
+    const conv = createConversation("Consolidation Repair");
+    initConversationDir({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.createdAt,
+      conversationType: conv.conversationType,
+      originChannel: null,
+    });
+
+    const userMsg = await addMessage(conv.id, "user", "find docs", undefined, {
+      skipIndexing: true,
+    });
+    const assistantPart1 = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "Searching..." }]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const internalToolResult = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tool-1", content: "done" },
+      ]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const assistantPart2 = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "Found it." }]),
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const att = uploadAttachment("result.txt", "text/plain", "ok");
+    linkAttachmentToMessage(assistantPart2.id, att.id, 0);
+
+    // Simulate stale disk view generated before consolidation.
+    syncMessageToDisk(conv.id, userMsg.id, conv.createdAt);
+    syncMessageToDisk(conv.id, assistantPart1.id, conv.createdAt);
+    syncMessageToDisk(conv.id, internalToolResult.id, conv.createdAt);
+    syncMessageToDisk(conv.id, assistantPart2.id, conv.createdAt);
+
+    // Simulate DB mutations performed by consolidation.
+    updateMessageContent(
+      assistantPart1.id,
+      JSON.stringify([
+        { type: "text", text: "Searching..." },
+        { type: "tool_result", tool_use_id: "tool-1", content: "done" },
+        { type: "text", text: "Found it." },
+      ]),
+    );
+    relinkAttachments([assistantPart2.id], assistantPart1.id);
+    deleteMessageById(internalToolResult.id);
+    deleteMessageById(assistantPart2.id);
+
+    rebuildConversationDiskViewFromDbState(conv.id);
+
+    const dirPath = getConversationDirPath(conv.id, conv.createdAt);
+    const lines = readFileSync(join(dirPath, "messages.jsonl"), "utf-8")
+      .trim()
+      .split("\n");
+
+    expect(lines).toHaveLength(2);
+
+    const rebuiltUser = JSON.parse(lines[0]);
+    const rebuiltAssistant = JSON.parse(lines[1]);
+
+    expect(rebuiltUser.role).toBe("user");
+    expect(rebuiltAssistant.role).toBe("assistant");
+    expect(rebuiltAssistant.content).toBe("Searching...\nFound it.");
+    expect(rebuiltAssistant.toolResults).toEqual([{ content: "done" }]);
+    expect(rebuiltAssistant.attachments).toHaveLength(1);
+    expect(
+      existsSync(join(dirPath, "attachments", rebuiltAssistant.attachments[0])),
+    ).toBe(true);
 
     rmSync(dirPath, { recursive: true, force: true });
   });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -43,7 +43,10 @@ import {
   updateConversationContextWindow,
   updateConversationTitle,
 } from "../memory/conversation-crud.js";
-import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
+import {
+  rebuildConversationDiskViewFromDbState,
+  syncMessageToDisk,
+} from "../memory/conversation-disk-view.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
@@ -1766,7 +1769,13 @@ export async function runAgentLoopImpl(
     ctx.commandIntent = undefined;
 
     if (userMessageId) {
-      consolidateAssistantMessages(ctx.conversationId, userMessageId);
+      const didMutateHistory = consolidateAssistantMessages(
+        ctx.conversationId,
+        userMessageId,
+      );
+      if (didMutateHistory) {
+        rebuildConversationDiskViewFromDbState(ctx.conversationId);
+      }
     }
 
     ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -142,10 +142,10 @@ export async function cleanupQdrantVectors(
 export function consolidateAssistantMessages(
   conversationId: string,
   userMessageId: string,
-): void {
+): boolean {
   const allMessages = getMessages(conversationId);
   const userMsgIndex = allMessages.findIndex((m) => m.id === userMessageId);
-  if (userMsgIndex === -1) return;
+  if (userMsgIndex === -1) return false;
 
   const messagesToConsolidate: typeof allMessages = [];
   const internalToolResultMessages: typeof allMessages = [];
@@ -182,12 +182,14 @@ export function consolidateAssistantMessages(
 
   // Only consolidate if there are multiple assistant messages
   if (messagesToConsolidate.length <= 1) {
+    let didMutate = false;
     // Still delete internal tool_result messages even if only one assistant message,
     // and collect IDs for vector cleanup
     const allSegmentIds: string[] = [];
     const allOrphanedItemIds: string[] = [];
     for (const id of messagesToDelete) {
       const deleted = deleteMessageById(id);
+      didMutate = true;
       allSegmentIds.push(...deleted.segmentIds);
       allOrphanedItemIds.push(...deleted.orphanedItemIds);
     }
@@ -205,7 +207,7 @@ export function consolidateAssistantMessages(
         );
       });
     }
-    return;
+    return didMutate;
   }
 
   log.info(
@@ -350,6 +352,7 @@ export function consolidateAssistantMessages(
     },
     "Assistant messages consolidated",
   );
+  return true;
 }
 
 // ── Undo ─────────────────────────────────────────────────────────────

--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -25,13 +25,17 @@ import {
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
 } from "./attachments-store.js";
-import { getMessageById } from "./conversation-crud.js";
 import {
   getConversationDirName,
   getConversationDirPath,
   getLegacyConversationDirPath,
   getResolvedConversationDirPath,
 } from "./conversation-directories.js";
+import {
+  getConversation,
+  getMessageById,
+  getMessages,
+} from "./conversation-crud.js";
 
 const log = getLogger("conversation-disk-view");
 
@@ -318,6 +322,51 @@ export function syncMessageToDisk(
     log.warn(
       { err, conversationId, messageId },
       "Failed to sync message to disk",
+    );
+  }
+}
+
+/**
+ * Rebuild a single conversation's disk view from current DB state.
+ *
+ * This rewrites append-only `messages.jsonl` and replays all persisted messages
+ * in DB order so disk data matches post-mutation state (e.g., after assistant-
+ * message consolidation). Existing attachment files are preserved to avoid
+ * losing file-backed rows where base64 payloads were already compacted out.
+ */
+export function rebuildConversationDiskViewFromDbState(
+  conversationId: string,
+): void {
+  try {
+    const conv = getConversation(conversationId);
+    if (!conv) {
+      log.warn(
+        { conversationId },
+        "rebuildConversationDiskViewFromDbState: conversation not found",
+      );
+      return;
+    }
+
+    const dirPath = ensureConversationDirPath(conversationId, conv.createdAt);
+    const messagesPath = join(dirPath, "messages.jsonl");
+
+    rmSync(messagesPath, { force: true });
+    writeFileSync(messagesPath, "");
+    // Preserve attachment files: many attachment rows are file-backed with
+    // data_base64 cleared, so deleting attachments/ can make content
+    // unrecoverable for replay.
+    mkdirSync(join(dirPath, "attachments"), { recursive: true });
+
+    const convMessages = getMessages(conversationId);
+    for (const msg of convMessages) {
+      syncMessageToDisk(conversationId, msg.id, conv.createdAt);
+    }
+
+    updateMetaFile(conv);
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to rebuild conversation disk view from DB state",
     );
   }
 }


### PR DESCRIPTION
## Summary
- refresh conversation disk-view state after assistant-message consolidation mutates the DB
- keep attachment ownership and JSONL content aligned with the final consolidated message
- add focused regression coverage for post-consolidation disk-view consistency

Fixes gap identified during plan review for repair-conversation-disk-view.md.

**Gap:** Post-consolidation assistant turns must refresh the disk view
**What was expected:** The disk view should reflect the final consolidated assistant state.
**What was found:** the disk view could remain stale because sync ran before consolidation rewrote DB state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
