### PR TITLE
Fix remaining normalization gaps in the LLM inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -16,7 +16,10 @@ describe("normalizeLlmContextPayloads", () => {
             role: "user",
             content: [
               { type: "text", text: "What's the weather in Boston?" },
-              { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,abc" },
+              },
             ],
           },
         ],
@@ -311,6 +314,126 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
+  test("normalizes plain-text OpenAI requests when the response identifies OpenAI", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_003,
+      requestPayload: {
+        model: "gpt-4.1",
+        messages: [
+          { role: "system", content: "Stay brief." },
+          { role: "user", content: "What should I pack for Boston?" },
+        ],
+      },
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Bring a warm coat and an umbrella.",
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 24,
+          completion_tokens: 11,
+        },
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-2026-03-01",
+      inputTokens: 24,
+      outputTokens: 11,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: "stop",
+      requestMessageCount: 2,
+      requestToolCount: 0,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "Bring a warm coat and an umbrella.",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "system",
+        label: "System prompt",
+        role: "system",
+        text: "Stay brief.",
+      },
+      {
+        kind: "message",
+        label: "User message 2",
+        role: "user",
+        text: "What should I pack for Boston?",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "Bring a warm coat and an umbrella.",
+      },
+    ]);
+  });
+
+  test("normalizes plain-text Anthropic requests when the response identifies Anthropic", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_004,
+      requestPayload: {
+        model: "claude-sonnet",
+        messages: [
+          { role: "user", content: "Find the latest changelog entry." },
+        ],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 19,
+          output_tokens: 9,
+        },
+        content: [{ type: "text", text: "I found one from this morning." }],
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      inputTokens: 19,
+      outputTokens: 9,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: "end_turn",
+      requestMessageCount: 1,
+      requestToolCount: 0,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "I found one from this morning.",
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "Find the latest changelog entry.",
+      },
+    ]);
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "I found one from this morning.",
+      },
+    ]);
+  });
+
   test("normalizes Anthropic web_search_tool_result blocks", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_004,
@@ -387,6 +510,17 @@ describe("normalizeLlmContextPayloads", () => {
         label: "User message 1 tool result",
         role: "user",
         toolName: "stu_req_1",
+        data: {
+          type: "web_search_tool_result",
+          tool_use_id: "stu_req_1",
+          content: [
+            {
+              type: "web_search_result",
+              url: "https://example.com",
+              title: "Example result",
+            },
+          ],
+        },
         text: "[Web search results]",
       },
     ]);
@@ -402,6 +536,17 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Assistant response tool result",
         role: "assistant",
         toolName: "stu_resp_1",
+        data: {
+          type: "web_search_tool_result",
+          tool_use_id: "stu_resp_1",
+          content: [
+            {
+              type: "web_search_result",
+              url: "https://example.org",
+              title: "Another result",
+            },
+          ],
+        },
         text: "[Web search results]",
       },
     ]);

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -58,14 +58,20 @@ export function normalizeLlmContextPayloads(
     normalizeOpenAiRequestPayload(input.requestPayload),
     normalizeAnthropicRequestPayload(input.requestPayload),
     normalizeGeminiRequestPayload(input.requestPayload),
-  ].filter((candidate): candidate is NormalizedPayloadCandidate => Boolean(candidate));
+  ].filter((candidate): candidate is NormalizedPayloadCandidate =>
+    Boolean(candidate),
+  );
   const responseCandidates = [
     normalizeOpenAiResponsePayload(input.responsePayload),
     normalizeAnthropicResponsePayload(input.responsePayload),
     normalizeGeminiResponsePayload(input.responsePayload),
-  ].filter((candidate): candidate is NormalizedPayloadCandidate => Boolean(candidate));
+  ].filter((candidate): candidate is NormalizedPayloadCandidate =>
+    Boolean(candidate),
+  );
 
-  const requestProviders = new Set(requestCandidates.map((candidate) => candidate.provider));
+  const requestProviders = new Set(
+    requestCandidates.map((candidate) => candidate.provider),
+  );
   const responseProviders = new Set(
     responseCandidates.map((candidate) => candidate.provider),
   );
@@ -79,30 +85,12 @@ export function normalizeLlmContextPayloads(
 
   if (sharedProviders.length === 1) {
     const provider = sharedProviders[0] as LlmContextSummary["provider"];
-    const requestCandidate = requestCandidates.find(
-      (candidate) => candidate.provider === provider,
+    return mergeNormalizedCandidates(
+      requestCandidates.find((candidate) => candidate.provider === provider) ??
+        undefined,
+      responseCandidates.find((candidate) => candidate.provider === provider) ??
+        undefined,
     );
-    const responseCandidate = responseCandidates.find(
-      (candidate) => candidate.provider === provider,
-    );
-
-    const requestSections = [
-      ...(requestCandidate?.requestSections ?? []),
-      ...(responseCandidate?.requestSections ?? []),
-    ];
-    const responseSections = [
-      ...(requestCandidate?.responseSections ?? []),
-      ...(responseCandidate?.responseSections ?? []),
-    ];
-
-    return {
-      summary: mergeSummaryFragments(
-        requestCandidate?.summary,
-        responseCandidate?.summary,
-      ),
-      requestSections: requestSections.length > 0 ? requestSections : undefined,
-      responseSections: responseSections.length > 0 ? responseSections : undefined,
-    };
   }
 
   if (requestCandidates.length === 1 && responseCandidates.length === 0) {
@@ -110,7 +98,13 @@ export function normalizeLlmContextPayloads(
   }
 
   if (responseCandidates.length === 1 && requestCandidates.length === 0) {
-    return responseCandidates[0] as LlmContextNormalizationResult;
+    const responseCandidate =
+      responseCandidates[0] as NormalizedPayloadCandidate;
+    const requestCandidate = normalizeCompatibleRequestPayload(
+      input.requestPayload,
+      responseCandidate.provider,
+    );
+    return mergeNormalizedCandidates(requestCandidate, responseCandidate);
   }
 
   return {};
@@ -118,6 +112,7 @@ export function normalizeLlmContextPayloads(
 
 function normalizeOpenAiRequestPayload(
   requestPayload: unknown,
+  allowPlainText = false,
 ): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
   if (!request) {
@@ -136,7 +131,7 @@ function normalizeOpenAiRequestPayload(
     (request.parallel_tool_calls !== undefined &&
       typeof request.parallel_tool_calls === "boolean") ||
     messages.some((message) => Boolean(asRecordArray(message.tool_calls)));
-  if (!hasOpenAiSignal) {
+  if (!allowPlainText && !hasOpenAiSignal) {
     return null;
   }
 
@@ -146,7 +141,12 @@ function normalizeOpenAiRequestPayload(
     const messageText = extractOpenAiContentText(message.content);
     if (messageText !== undefined) {
       requestSections.push({
-        kind: role === "system" ? "system" : role === "tool" ? "tool_result" : "message",
+        kind:
+          role === "system"
+            ? "system"
+            : role === "tool"
+              ? "tool_result"
+              : "message",
         label: buildMessageLabel(role, index + 1),
         role,
         text: messageText,
@@ -174,7 +174,9 @@ function normalizeOpenAiRequestPayload(
 
   const requestSettings = omitRecordKeys(request, ["messages", "tools"]);
   if (hasMeaningfulRequestSettings(requestSettings)) {
-    requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
+    requestSections.push(
+      structuredJsonSection("settings", "Request settings", requestSettings),
+    );
   }
 
   return {
@@ -247,18 +249,24 @@ function normalizeOpenAiResponsePayload(
       requestMessageCount: undefined,
       requestToolCount: undefined,
       responseMessageCount:
-        responseText !== undefined || responseToolSections.length > 0 ? 1 : undefined,
+        responseText !== undefined || responseToolSections.length > 0
+          ? 1
+          : undefined,
       responseToolCallCount:
-        responseToolSections.length > 0 ? responseToolSections.length : undefined,
+        responseToolSections.length > 0
+          ? responseToolSections.length
+          : undefined,
       responsePreview: responseText ? truncateText(responseText) : undefined,
       toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
     },
-    responseSections: responseSections.length > 0 ? responseSections : undefined,
+    responseSections:
+      responseSections.length > 0 ? responseSections : undefined,
   };
 }
 
 function normalizeAnthropicRequestPayload(
   requestPayload: unknown,
+  allowPlainText = false,
 ): NormalizedPayloadCandidate | null {
   const request = asRecord(requestPayload);
   if (!request) {
@@ -288,7 +296,7 @@ function normalizeAnthropicRequestPayload(
     requestToolNames.length > 0 ||
     Boolean(asRecord(request.tool_choice)) ||
     hasAnthropicContentSignal;
-  if (!hasAnthropicSignal) {
+  if (!allowPlainText && !hasAnthropicSignal) {
     return null;
   }
 
@@ -316,9 +324,15 @@ function normalizeAnthropicRequestPayload(
     });
   }
 
-  const requestSettings = omitRecordKeys(request, ["system", "messages", "tools"]);
+  const requestSettings = omitRecordKeys(request, [
+    "system",
+    "messages",
+    "tools",
+  ]);
   if (hasMeaningfulRequestSettings(requestSettings)) {
-    requestSections.push(structuredJsonSection("settings", "Request settings", requestSettings));
+    requestSections.push(
+      structuredJsonSection("settings", "Request settings", requestSettings),
+    );
   }
 
   return {
@@ -355,10 +369,15 @@ function normalizeAnthropicResponsePayload(
     return null;
   }
 
-  const responseSections = anthropicContentSections(content, "Assistant response");
+  const responseSections = anthropicContentSections(
+    content,
+    "Assistant response",
+  );
   const responseText = collectAnthropicText(content);
   const responseToolNames = content
-    .map((block) => (asString(block.type) === "tool_use" ? asString(block.name) : undefined))
+    .map((block) =>
+      asString(block.type) === "tool_use" ? asString(block.name) : undefined,
+    )
     .filter((name): name is string => typeof name === "string");
 
   const usage = asRecord(response.usage);
@@ -375,13 +394,17 @@ function normalizeAnthropicResponsePayload(
       requestMessageCount: undefined,
       requestToolCount: undefined,
       responseMessageCount:
-        responseText !== undefined || responseToolNames.length > 0 ? 1 : undefined,
+        responseText !== undefined || responseToolNames.length > 0
+          ? 1
+          : undefined,
       responseToolCallCount:
         responseToolNames.length > 0 ? responseToolNames.length : undefined,
       responsePreview: responseText ? truncateText(responseText) : undefined,
-      toolCallNames: responseToolNames.length > 0 ? responseToolNames : undefined,
+      toolCallNames:
+        responseToolNames.length > 0 ? responseToolNames : undefined,
     },
-    responseSections: responseSections.length > 0 ? responseSections : undefined,
+    responseSections:
+      responseSections.length > 0 ? responseSections : undefined,
   };
 }
 
@@ -400,7 +423,9 @@ function normalizeGeminiRequestPayload(
 
   const requestSections: LlmContextSection[] = [];
   const config = asRecord(request.config);
-  const systemText = extractGeminiSystemInstructionText(config?.systemInstruction);
+  const systemText = extractGeminiSystemInstructionText(
+    config?.systemInstruction,
+  );
   if (systemText !== undefined) {
     requestSections.push({
       kind: "system",
@@ -510,7 +535,8 @@ function normalizeGeminiResponsePayload(
       responsePreview: responseText ? truncateText(responseText) : undefined,
       toolCallNames: toolCallNames.length > 0 ? toolCallNames : undefined,
     },
-    responseSections: responseSections.length > 0 ? responseSections : undefined,
+    responseSections:
+      responseSections.length > 0 ? responseSections : undefined,
   };
 }
 
@@ -566,6 +592,10 @@ function anthropicMessageSections(
         label: `${label} tool result`,
         role,
         toolName: asString(block.name) ?? asString(block.tool_use_id),
+        data:
+          type === "web_search_tool_result"
+            ? sanitizeAnthropicWebSearchToolResultData(block)
+            : undefined,
         text: collectAnthropicToolResultText(block),
       });
     }
@@ -605,7 +635,8 @@ function geminiContentSections(
 
     const inlineData = asRecord(part.inlineData);
     if (inlineData) {
-      const mimeType = asString(inlineData.mimeType) ?? "application/octet-stream";
+      const mimeType =
+        asString(inlineData.mimeType) ?? "application/octet-stream";
       textParts.push(`[inline data: ${mimeType}]`);
       continue;
     }
@@ -696,7 +727,8 @@ function extractGeminiToolNames(tools: unknown): string[] {
   const toolGroups = asRecordArray(tools) ?? [];
   const names: string[] = [];
   for (const toolGroup of toolGroups) {
-    for (const declaration of asRecordArray(toolGroup.functionDeclarations) ?? []) {
+    for (const declaration of asRecordArray(toolGroup.functionDeclarations) ??
+      []) {
       const name = asString(declaration.name);
       if (name) {
         names.push(name);
@@ -756,7 +788,9 @@ function extractAnthropicSystemText(system: unknown): string | undefined {
   return joinTextParts(textParts);
 }
 
-function extractGeminiSystemInstructionText(systemInstruction: unknown): string | undefined {
+function extractGeminiSystemInstructionText(
+  systemInstruction: unknown,
+): string | undefined {
   if (typeof systemInstruction === "string") {
     return hasMeaningfulText(systemInstruction) ? systemInstruction : undefined;
   }
@@ -834,6 +868,35 @@ function collectAnthropicToolResultText(
     return "[Web search results]";
   }
   return collectAnthropicText(block.content);
+}
+
+function sanitizeAnthropicWebSearchToolResultData(
+  block: Record<string, unknown>,
+): unknown {
+  return sanitizeAnthropicStructuredValue(block);
+}
+
+function sanitizeAnthropicStructuredValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeAnthropicStructuredValue(entry));
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter(
+        ([key, entryValue]) =>
+          key !== "encrypted_content" && entryValue !== undefined,
+      )
+      .map(([key, entryValue]) => [
+        key,
+        sanitizeAnthropicStructuredValue(entryValue),
+      ]),
+  );
 }
 
 function buildMessageLabel(role: string, index: number): string {
@@ -982,6 +1045,48 @@ function mergeSummaryFragments(
   return summary;
 }
 
+function mergeNormalizedCandidates(
+  requestCandidate: NormalizedPayloadCandidate | null | undefined,
+  responseCandidate: NormalizedPayloadCandidate | null | undefined,
+): LlmContextNormalizationResult {
+  if (!requestCandidate && !responseCandidate) {
+    return {};
+  }
+
+  const requestSections = [
+    ...(requestCandidate?.requestSections ?? []),
+    ...(responseCandidate?.requestSections ?? []),
+  ];
+  const responseSections = [
+    ...(requestCandidate?.responseSections ?? []),
+    ...(responseCandidate?.responseSections ?? []),
+  ];
+
+  return {
+    summary: mergeSummaryFragments(
+      requestCandidate?.summary,
+      responseCandidate?.summary,
+    ),
+    requestSections: requestSections.length > 0 ? requestSections : undefined,
+    responseSections:
+      responseSections.length > 0 ? responseSections : undefined,
+  };
+}
+
+function normalizeCompatibleRequestPayload(
+  requestPayload: unknown,
+  provider: LlmContextSummary["provider"],
+): NormalizedPayloadCandidate | null {
+  switch (provider) {
+    case "openai":
+      return normalizeOpenAiRequestPayload(requestPayload, true);
+    case "anthropic":
+      return normalizeAnthropicRequestPayload(requestPayload, true);
+    case "gemini":
+      return normalizeGeminiRequestPayload(requestPayload);
+  }
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== "object" || value == null || Array.isArray(value)) {
     return null;
@@ -1004,5 +1109,7 @@ function asString(value: unknown): string | undefined {
 }
 
 function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }


### PR DESCRIPTION
## Summary
- normalize compatible plain-text OpenAI and Anthropic requests when the paired response identifies the provider
- preserve sanitized structured data for Anthropic web search tool results
- add assistant tests covering the new normalization paths

Part of plan: llm-context-inspector-redesign.md (remediation round 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
