### PR TITLE
fix: preserve compacted attachment files during disk-view repair

### DIFF
--- a/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
@@ -56,7 +56,7 @@ mock.module("../config/loader.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { getConversationDirPath } from "../memory/conversation-disk-view.js";
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, rawRun, resetDb } from "../memory/db.js";
 import {
   attachments,
   conversations,
@@ -90,6 +90,7 @@ function resetConversationsDir() {
 }
 
 function seedConversationRows(): {
+  attachmentId: string;
   conversationId: string;
   conversationCreatedAt: number;
   conversationUpdatedAt: number;
@@ -151,7 +152,12 @@ function seedConversationRows(): {
     })
     .run();
 
-  return { conversationId, conversationCreatedAt, conversationUpdatedAt };
+  return {
+    attachmentId,
+    conversationId,
+    conversationCreatedAt,
+    conversationUpdatedAt,
+  };
 }
 
 function toConversationTimestamp(createdAtMs: number): string {
@@ -305,8 +311,8 @@ describe("013-repair-conversation-disk-view migration", () => {
 
     const legacyAttachmentsDir = join(legacyDirPath, "attachments");
     mkdirSync(legacyAttachmentsDir, { recursive: true });
-    writeFileSync(join(legacyDirPath, "meta.json"), "{\"legacy\":true}\n");
-    writeFileSync(join(legacyDirPath, "messages.jsonl"), "{\"legacy\":true}\n");
+    writeFileSync(join(legacyDirPath, "meta.json"), '{"legacy":true}\n');
+    writeFileSync(join(legacyDirPath, "messages.jsonl"), '{"legacy":true}\n');
     writeFileSync(join(legacyAttachmentsDir, "legacy.txt"), "legacy");
 
     repairConversationDiskViewMigration.run(workspaceDir);
@@ -321,19 +327,75 @@ describe("013-repair-conversation-disk-view migration", () => {
     expect(
       readFileSync(canonicalMessagesPath, "utf-8").trim().split("\n"),
     ).toHaveLength(1);
-    expect(JSON.parse(readFileSync(canonicalMessagesPath, "utf-8").trim())).toEqual(
-      {
-        role: "user",
-        ts: "2026-03-18T16:01:00.000Z",
-        content: "Repair missing disk view",
-        attachments: ["transcript.txt"],
-      },
-    );
+    expect(
+      JSON.parse(readFileSync(canonicalMessagesPath, "utf-8").trim()),
+    ).toEqual({
+      role: "user",
+      ts: "2026-03-18T16:01:00.000Z",
+      content: "Repair missing disk view",
+      attachments: ["transcript.txt"],
+    });
     expect(readdirSync(canonicalAttachmentsDir).sort()).toEqual([
       "transcript.txt",
     ]);
     expect(
       readFileSync(join(canonicalAttachmentsDir, "transcript.txt"), "utf-8"),
     ).toBe("hello world");
+  });
+
+  test("preserves compacted attachment files while pruning stale projected files during repair", () => {
+    const {
+      attachmentId,
+      conversationId,
+      conversationCreatedAt,
+      conversationUpdatedAt,
+    } = seedConversationRows();
+    const conversationDir = getConversationDirPath(
+      conversationId,
+      conversationCreatedAt,
+    );
+    const messagesPath = join(conversationDir, "messages.jsonl");
+    const attachmentsDir = join(conversationDir, "attachments");
+    const transcriptPath = join(attachmentsDir, "transcript.txt");
+    const stalePath = join(attachmentsDir, "stale.txt");
+
+    mkdirSync(attachmentsDir, { recursive: true });
+    writeFileSync(
+      join(conversationDir, "meta.json"),
+      JSON.stringify(
+        {
+          id: conversationId,
+          title: "Repair Test",
+          type: "standard",
+          channel: "desktop",
+          createdAt: new Date(conversationCreatedAt).toISOString(),
+          updatedAt: new Date(conversationUpdatedAt - 1000).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    writeFileSync(messagesPath, '{"role":"user","content":"stale"}\n');
+    writeFileSync(transcriptPath, "hello world");
+    writeFileSync(stalePath, "stale");
+
+    rawRun(
+      `UPDATE attachments
+       SET data_base64 = '', file_path = ?, source_path = NULL
+       WHERE id = ?`,
+      transcriptPath,
+      attachmentId,
+    );
+
+    repairConversationDiskViewMigration.run(workspaceDir);
+
+    expect(readFileSync(transcriptPath, "utf-8")).toBe("hello world");
+    expect(existsSync(stalePath)).toBe(false);
+    expect(JSON.parse(readFileSync(messagesPath, "utf-8").trim())).toEqual({
+      role: "user",
+      ts: "2026-03-18T16:01:00.000Z",
+      content: "Repair missing disk view",
+      attachments: ["transcript.txt"],
+    });
   });
 });

--- a/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/rebuild-conversation-disk-view.ts
@@ -1,6 +1,7 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -52,6 +53,42 @@ function convergeDualConversationDirsToCanonical(
   if (!existsSync(canonicalDirPath) || !existsSync(legacyDirPath)) return;
   if (!hasExpectedDiskViewArtifacts(conv, canonicalDirPath)) return;
   rmSync(legacyDirPath, { recursive: true, force: true });
+}
+
+function getProjectedAttachmentFilenames(messagesPath: string): Set<string> {
+  const filenames = new Set<string>();
+  if (!existsSync(messagesPath)) return filenames;
+
+  const raw = readFileSync(messagesPath, "utf-8");
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as { attachments?: unknown };
+      if (!Array.isArray(parsed.attachments)) continue;
+      for (const attachment of parsed.attachments) {
+        if (typeof attachment === "string") {
+          filenames.add(attachment);
+        }
+      }
+    } catch {
+      // Ignore malformed lines. A later replay will rewrite them.
+    }
+  }
+
+  return filenames;
+}
+
+function pruneUnreferencedProjectedAttachments(
+  attachDir: string,
+  messagesPath: string,
+): void {
+  if (!existsSync(attachDir)) return;
+
+  const referenced = getProjectedAttachmentFilenames(messagesPath);
+  for (const entry of readdirSync(attachDir)) {
+    if (referenced.has(entry)) continue;
+    rmSync(join(attachDir, entry), { recursive: true, force: true });
+  }
 }
 
 /**
@@ -106,10 +143,12 @@ export function rebuildConversationDiskViewFromDb(): void {
     if (existsSync(messagesPath)) {
       rmSync(messagesPath, { force: true });
     }
-    if (existsSync(attachDir)) {
-      rmSync(attachDir, { recursive: true, force: true });
-    }
     writeFileSync(messagesPath, "");
+
+    // Preserve already materialized attachment files across repair replay.
+    // Some rows have data_base64 compacted away and only retain their
+    // conversation-scoped file_path, so removing attachments/ here would
+    // make the content unrecoverable.
     mkdirSync(attachDir, { recursive: true });
 
     // Query all messages for this conversation and sync each to disk
@@ -128,6 +167,7 @@ export function rebuildConversationDiskViewFromDb(): void {
     // idempotency check won't skip a conversation with incomplete messages
     // if the migration is interrupted mid-loop.
     updateMetaFile(conv);
+    pruneUnreferencedProjectedAttachments(attachDir, messagesPath);
     convergeDualConversationDirsToCanonical(
       conv,
       canonicalDirPath,


### PR DESCRIPTION
## Summary
- preserve already materialized attachment files while replaying repaired conversation disk views
- prune only attachment files that the rebuilt messages projection no longer references
- add a regression covering compacted file-backed attachments in the 013 repair migration

## Testing
- cd assistant && bun test src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
