### PR TITLE
fix: sort imports in conversation-disk-view.ts

### DIFF
--- a/assistant/src/memory/conversation-disk-view.ts
+++ b/assistant/src/memory/conversation-disk-view.ts
@@ -26,16 +26,16 @@ import {
   getFilePathForAttachment,
 } from "./attachments-store.js";
 import {
+  getConversation,
+  getMessageById,
+  getMessages,
+} from "./conversation-crud.js";
+import {
   getConversationDirName,
   getConversationDirPath,
   getLegacyConversationDirPath,
   getResolvedConversationDirPath,
 } from "./conversation-directories.js";
-import {
-  getConversation,
-  getMessageById,
-  getMessages,
-} from "./conversation-crud.js";
 
 const log = getLogger("conversation-disk-view");
 
@@ -49,10 +49,7 @@ export {
   getResolvedConversationDirPath,
 };
 
-function ensureConversationDirPath(
-  id: string,
-  createdAtMs: number,
-): string {
+function ensureConversationDirPath(id: string, createdAtMs: number): string {
   const dirPath = getResolvedConversationDirPath(id, createdAtMs);
   mkdirSync(dirPath, { recursive: true });
   return dirPath;


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-disk-view.ts` by sorting the `conversation-crud.js` import before `conversation-directories.js`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23284130746/job/67703659587
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
