### PR TITLE
fix: remove invalid optional binding on non-optional ForkParent.title in iOS test

### DIFF
--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -279,13 +279,11 @@ final class ConversationForkIOSTests: XCTestCase {
                     dict["conversationType"] = conversationType
                 }
                 if let forkParent = item.forkParent {
-                    var forkParentDict: [String: Any] = [
+                    let forkParentDict: [String: Any] = [
                         "conversationId": forkParent.conversationId,
-                        "messageId": forkParent.messageId
+                        "messageId": forkParent.messageId,
+                        "title": forkParent.title
                     ]
-                    if let title = forkParent.title {
-                        forkParentDict["title"] = title
-                    }
                     dict["forkParent"] = forkParentDict
                 }
                 return dict


### PR DESCRIPTION
## Summary
- `ConversationForkParent.title` is `String` (non-optional), but `ConversationForkIOSTests.swift:286` used `if let` optional binding on it, causing the iOS CI build to fail
- Changed to include `title` directly in the dictionary literal since it's always present

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23284044095/job/67703402442
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
