### PR TITLE
Fix prompt text fidelity in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -194,15 +194,6 @@ struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
         }
 
         if let string = value as? String {
-            if preferredLanguage == .json, let parsedJSON = parseJSONString(string) {
-                return (
-                    prettyPrintedJSONString(for: parsedJSON) ?? string,
-                    .json,
-                    true,
-                    "JSON"
-                )
-            }
-
             return (
                 string,
                 preferredLanguage ?? .plain,
@@ -243,14 +234,6 @@ struct MessageInspectorPromptSectionModel: Identifiable, Equatable {
         }
 
         return String(data: data, encoding: .utf8)
-    }
-
-    private static func parseJSONString(_ string: String) -> Any? {
-        guard let data = string.data(using: .utf8) else {
-            return nil
-        }
-
-        return try? JSONSerialization.jsonObject(with: data)
     }
 
     private static func syntaxLanguage(for language: String?) -> SyntaxLanguage? {

--- a/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorPromptTabTests.swift
@@ -73,7 +73,7 @@ final class MessageInspectorPromptTabTests: XCTestCase {
         XCTAssertTrue(model.bannerText.contains("same order"))
     }
 
-    func testPromptTabModelUsesLanguageHintForJSONStringSections() {
+    func testPromptTabModelPreservesJSONStringSectionsVerbatim() {
         let entry = makeEntry(
             requestPayload: AnyCodable([:]),
             requestSections: [
@@ -88,9 +88,10 @@ final class MessageInspectorPromptTabTests: XCTestCase {
 
         let model = MessageInspectorPromptTabModel(entry: entry)
 
-        XCTAssertEqual(model.sections[0].presentationStyle, .structured)
+        XCTAssertEqual(model.sections[0].presentationStyle, .text)
         XCTAssertEqual(model.sections[0].syntaxLanguage, .json)
-        XCTAssertTrue(model.sections[0].displayText.contains("\"temperature\""))
+        XCTAssertEqual(model.sections[0].displayText, "{\"temperature\":0.4,\"top_p\":0.9}")
+        XCTAssertEqual(model.sections[0].copyText, "{\"temperature\":0.4,\"top_p\":0.9}")
         XCTAssertEqual(model.sections[0].formatLabel, "JSON")
     }
 


### PR DESCRIPTION
## Summary
- preserve original text for normalized JSON-string prompt sections
- keep pretty-printing for structured non-string prompt content only
- add prompt-tab coverage for verbatim JSON-string rendering

Part of plan: llm-context-inspector-redesign.md (remediation round 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
