### PR TITLE
Fix remaining normalization correctness in the LLM inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -493,18 +493,12 @@ describe("normalizeLlmContextPayloads", () => {
       stopReason: "end_turn",
       requestMessageCount: 1,
       requestToolCount: 0,
-      responseMessageCount: 1,
+      responseMessageCount: undefined,
       responseToolCallCount: undefined,
-      responsePreview: "[Web search results]",
+      responsePreview: undefined,
       toolCallNames: undefined,
     });
     expect(normalized.requestSections).toEqual([
-      {
-        kind: "message",
-        label: "User message 1",
-        role: "user",
-        text: "[Web search results]",
-      },
       {
         kind: "tool_result",
         label: "User message 1 tool result",
@@ -525,12 +519,6 @@ describe("normalizeLlmContextPayloads", () => {
       },
     ]);
     expect(normalized.responseSections).toEqual([
-      {
-        kind: "message",
-        label: "Assistant response",
-        role: "assistant",
-        text: "[Web search results]",
-      },
       {
         kind: "tool_result",
         label: "Assistant response tool result",
@@ -711,12 +699,15 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
-  test("normalizes an OpenAI request even when the response payload is malformed", () => {
+  test("normalizes an OpenAI request with object tool_choice even when the response payload is malformed", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_005,
       requestPayload: {
         model: "gpt-4.1",
-        tool_choice: "auto",
+        tool_choice: {
+          type: "function",
+          function: { name: "lookup" },
+        },
         messages: [
           {
             role: "system",
@@ -794,7 +785,10 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Request settings",
         data: {
           model: "gpt-4.1",
-          tool_choice: "auto",
+          tool_choice: {
+            type: "function",
+            function: { name: "lookup" },
+          },
         },
         language: "json",
       },

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -294,7 +294,7 @@ function normalizeAnthropicRequestPayload(
   const hasAnthropicSignal =
     request.system !== undefined ||
     requestToolNames.length > 0 ||
-    Boolean(asRecord(request.tool_choice)) ||
+    isAnthropicToolChoice(request.tool_choice) ||
     hasAnthropicContentSignal;
   if (!allowPlainText && !hasAnthropicSignal) {
     return null;
@@ -723,6 +723,18 @@ function extractAnthropicToolNames(tools: unknown): string[] {
     .filter((name): name is string => typeof name === "string");
 }
 
+function isAnthropicToolChoice(toolChoice: unknown): boolean {
+  const record = asRecord(toolChoice);
+  if (!record) {
+    return false;
+  }
+
+  const type = asString(record.type);
+  return (
+    type === "auto" || type === "any" || type === "tool" || type === "none"
+  );
+}
+
 function extractGeminiToolNames(tools: unknown): string[] {
   const toolGroups = asRecordArray(tools) ?? [];
   const names: string[] = [];
@@ -843,14 +855,6 @@ function collectAnthropicText(content: unknown): string | undefined {
 
     if (type === "image") {
       textParts.push("[image]");
-      continue;
-    }
-
-    if (isAnthropicToolResultType(type)) {
-      const resultText = collectAnthropicToolResultText(block);
-      if (resultText) {
-        textParts.push(resultText);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid false Anthropic matches for OpenAI request-only normalization
- stop duplicating Anthropic tool-result content into assistant text sections
- add assistant tests covering the corrected normalization behavior

Part of plan: llm-context-inspector-redesign.md (remediation round 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
