### PR TITLE
fix: gate current-tip forks on persisted tips

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -201,6 +201,14 @@ describe("forkConversation", () => {
     ]);
   });
 
+  test("rejects forks when the source conversation has no persisted messages", () => {
+    const source = createConversation("Empty thread");
+
+    expect(() => forkConversation({ conversationId: source.id })).toThrow(
+      `Conversation ${source.id} has no persisted messages to fork`,
+    );
+  });
+
   test("relinks copied attachments into the fork and syncs disk view", async () => {
     const source = createConversation("Attachment thread");
     await addMessage(source.id, "user", "Please review this image", undefined, {

--- a/assistant/src/__tests__/conversation-fork-route.test.ts
+++ b/assistant/src/__tests__/conversation-fork-route.test.ts
@@ -185,6 +185,26 @@ describe("POST /v1/conversations/fork", () => {
     expect(forkBody).toEqual(detailBody);
   });
 
+  test("rejects empty source conversations", async () => {
+    const source = createConversation("Empty source");
+
+    await startServer();
+
+    const response = await fetch(url("/conversations/fork"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ conversationId: source.id }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        code: "NOT_FOUND",
+        message: `Conversation ${source.id} has no persisted messages to fork`,
+      },
+    });
+  });
+
   test("returns NOT_FOUND when the source conversation does not exist", async () => {
     await startServer();
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -337,6 +337,12 @@ export function forkConversation(params: {
     .all()
     .map(parseMessage);
 
+  if (sourceMessages.length === 0) {
+    throw new UserError(
+      `Conversation ${conversationId} has no persisted messages to fork`,
+    );
+  }
+
   const copyBoundaryIndex =
     throughMessageId == null
       ? sourceMessages.length - 1

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -324,7 +324,7 @@ class IOSConversationStore: ObservableObject {
             || latestLoadedAssistantMessageTimestamp(for: conversations[index].id) != nil
     }
 
-    private func latestPersistedTipDaemonMessageId(for conversationLocalId: UUID) -> String? {
+    func latestPersistedTipDaemonMessageId(for conversationLocalId: UUID) -> String? {
         viewModels[conversationLocalId]?.messages.last(where: {
             $0.daemonMessageId != nil && !$0.isStreaming && !$0.isHidden
         })?.daemonMessageId
@@ -930,6 +930,7 @@ class IOSConversationStore: ObservableObject {
     private func updateForkCommandHandler(vm: ChatViewModel, conversationLocalId: UUID) {
         guard isConnectedMode,
               let conversation = conversations.first(where: { $0.id == conversationLocalId }),
+              !conversation.isPrivate,
               conversation.conversationId != nil,
               latestPersistedTipDaemonMessageId(for: conversationLocalId) != nil else {
             vm.onFork = nil
@@ -1265,7 +1266,9 @@ class IOSConversationStore: ObservableObject {
 
     @discardableResult
     func forkCurrentTip(conversationLocalId: UUID) async -> UUID? {
-        guard let daemonMessageId = latestPersistedTipDaemonMessageId(for: conversationLocalId) else {
+        guard let conversation = conversations.first(where: { $0.id == conversationLocalId }),
+              !conversation.isPrivate,
+              let daemonMessageId = latestPersistedTipDaemonMessageId(for: conversationLocalId) else {
             return nil
         }
         return await forkConversation(

--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -160,9 +160,18 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         XCTAssertNil(
             makeCurrentTipForkToolbarAction(store: store, conversation: localConversation)
         )
+        XCTAssertFalse(
+            shouldShowCurrentTipForkAction(store: store, for: persistedConversation)
+        )
 
         let viewModel = store.viewModel(for: persistedConversation.id)
+        XCTAssertNil(
+            makeCurrentTipForkToolbarAction(store: store, conversation: persistedConversation)
+        )
         viewModel.messages = [makeMessage(text: "Persisted assistant reply", daemonMessageId: "msg-tip")]
+        XCTAssertTrue(
+            shouldShowCurrentTipForkAction(store: store, for: persistedConversation)
+        )
 
         let action = try XCTUnwrap(
             makeCurrentTipForkToolbarAction(store: store, conversation: persistedConversation)
@@ -188,7 +197,7 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(shouldShowCurrentTipForkAction(for: privateConversation))
+        XCTAssertFalse(shouldShowCurrentTipForkAction(store: IOSConversationStore(daemonClient: MockDaemonClient(), connectedModeOverride: true), for: privateConversation))
         XCTAssertNil(
             makeCurrentTipForkToolbarAction(
                 store: IOSConversationStore(daemonClient: MockDaemonClient(), connectedModeOverride: true),

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -42,8 +42,13 @@ func applyConversationSelectionRequest(
     }
 }
 
-func shouldShowCurrentTipForkAction(for conversation: IOSConversation) -> Bool {
-    conversation.conversationId != nil && !conversation.isPrivate
+func shouldShowCurrentTipForkAction(
+    store: IOSConversationStore,
+    for conversation: IOSConversation
+) -> Bool {
+    conversation.conversationId != nil
+        && !conversation.isPrivate
+        && store.latestPersistedTipDaemonMessageId(for: conversation.id) != nil
 }
 
 @MainActor
@@ -51,7 +56,7 @@ func makeCurrentTipForkToolbarAction(
     store: IOSConversationStore,
     conversation: IOSConversation
 ) -> (() -> Void)? {
-    guard shouldShowCurrentTipForkAction(for: conversation) else { return nil }
+    guard shouldShowCurrentTipForkAction(store: store, for: conversation) else { return nil }
     return {
         Task { @MainActor in
             _ = await store.forkCurrentTip(conversationLocalId: conversation.id)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -50,7 +50,13 @@ struct ConversationHeaderPresentation {
 
         // Can copy when there's non-empty content
         self.canCopy = hasUserMessage
-        self.showsForkConversationAction = conversation.conversationId != nil && !isPrivateConversation
+        let latestPersistedTipDaemonMessageId = activeViewModel?.messages.last(where: {
+            $0.daemonMessageId != nil && !$0.isStreaming && !$0.isHidden
+        })?.daemonMessageId
+        self.showsForkConversationAction =
+            conversation.conversationId != nil
+            && !isPrivateConversation
+            && latestPersistedTipDaemonMessageId != nil
         if isPrivateConversation {
             self.forkParentTitle = nil
             self.forkParentConversationId = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -271,8 +271,24 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
+    private static let privateConversationForkErrorText =
+        "Forking is unavailable in private conversations."
+
     func forkActiveConversation() async {
-        await forkConversation(throughDaemonMessageId: nil)
+        guard let conversation = activeConversation else {
+            activeViewModel?.errorText = "Send a message before forking this conversation."
+            return
+        }
+        guard conversation.kind != .private else {
+            activeViewModel?.errorText = Self.privateConversationForkErrorText
+            return
+        }
+        guard let daemonMessageId = latestPersistedTipDaemonMessageId(for: conversation.id) else {
+            activeViewModel?.errorText = "Send a message before forking this conversation."
+            return
+        }
+
+        await forkConversation(throughDaemonMessageId: daemonMessageId)
     }
 
     func forkConversation(throughDaemonMessageId daemonMessageId: String?) async {
@@ -299,6 +315,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         selectConversation(id: localConversationId)
+    }
+
+    private func latestPersistedTipDaemonMessageId(for conversationLocalId: UUID) -> String? {
+        chatViewModels[conversationLocalId]?.messages.last(where: {
+            $0.daemonMessageId != nil && !$0.isStreaming && !$0.isHidden
+        })?.daemonMessageId
     }
 
     func createConversation() {

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -46,6 +46,21 @@ final class ConversationHeaderPresentationTests: XCTestCase {
         XCTAssertEqual(p.displayTitle, "Test Conversation")
         XCTAssertTrue(p.isStarted)
         XCTAssertTrue(p.showsActionsMenu)
+        XCTAssertFalse(p.showsForkConversationAction)
+    }
+
+    func testStartedStandardConversationWithPersistedTipShowsForkAction() {
+        let conversation = ConversationModel(title: "Test Conversation", conversationId: "session-1")
+        let vm = ChatViewModel(daemonClient: DaemonClient())
+        var message = ChatMessage(role: .assistant, text: "Persisted reply")
+        message.daemonMessageId = "msg-tip"
+        vm.messages = [message]
+        let p = ConversationHeaderPresentation(
+            activeConversation: conversation,
+            activeViewModel: vm,
+            isConversationVisible: true
+        )
+
         XCTAssertTrue(p.showsForkConversationAction)
     }
 

--- a/clients/macos/vellum-assistantTests/ConversationManagerForkTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerForkTests.swift
@@ -136,6 +136,7 @@ final class ConversationManagerForkTests: XCTestCase {
             XCTFail("Expected an active source view model")
             return
         }
+        sourceViewModel.messages = [makeMessage(daemonMessageId: "msg-root")]
 
         let forkTriggered = expectation(description: "fork routed through manager")
         forkClient.onFork = {
@@ -148,10 +149,31 @@ final class ConversationManagerForkTests: XCTestCase {
         await fulfillment(of: [forkTriggered], timeout: 1.0)
 
         XCTAssertEqual(forkClient.capturedConversationIds, ["conv-root"])
-        XCTAssertEqual(forkClient.capturedMessageIds, [nil])
-        XCTAssertTrue(sourceViewModel.messages.isEmpty)
+        XCTAssertEqual(forkClient.capturedMessageIds, ["msg-root"])
+        XCTAssertEqual(sourceViewModel.messages.count, 1)
+        XCTAssertEqual(sourceViewModel.messages.first?.daemonMessageId, "msg-root")
         XCTAssertEqual(sourceViewModel.inputText, "")
         XCTAssertEqual(conversationManager.activeConversation?.conversationId, "conv-fork")
+    }
+
+    func testExactForkCommandOnPrivateConversationShowsLocalErrorWithoutRouting() async {
+        conversationManager.createPrivateConversation()
+
+        guard let privateViewModel = conversationManager.activeViewModel else {
+            XCTFail("Expected an active private view model")
+            return
+        }
+
+        privateViewModel.inputText = "/fork"
+        privateViewModel.sendMessage()
+
+        XCTAssertTrue(forkClient.capturedConversationIds.isEmpty)
+        XCTAssertTrue(privateViewModel.messages.isEmpty)
+        XCTAssertEqual(privateViewModel.inputText, "")
+        XCTAssertEqual(
+            privateViewModel.errorText,
+            "Forking is unavailable in private conversations."
+        )
     }
 
     func testExactForkCommandOnUnsavedDraftShowsLocalErrorWithoutAppendingBubble() {
@@ -202,5 +224,11 @@ final class ConversationManagerForkTests: XCTestCase {
         conversationManager.setChatViewModel(viewModel, for: conversation.id)
         conversationManager.selectConversation(id: conversation.id)
         return conversation
+    }
+
+    private func makeMessage(daemonMessageId: String) -> ChatMessage {
+        var message = ChatMessage(role: .assistant, text: "Persisted assistant reply")
+        message.daemonMessageId = daemonMessageId
+        return message
     }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -584,6 +584,9 @@ public final class ChatViewModel: ObservableObject {
     /// by the client instead of being sent to the assistant.
     public var onFork: (() -> Void)?
 
+    private static let privateConversationForkErrorText =
+        "Forking is unavailable in private conversations."
+
     /// Whether this view model has had its history loaded from the daemon.
     public var isHistoryLoaded: Bool = false
 
@@ -1152,7 +1155,10 @@ public final class ChatViewModel: ObservableObject {
             suggestion = nil
             pendingSuggestionRequestId = nil
             flushCoalescedPublish()
-            if let onFork {
+            if conversationType == "private" {
+                errorText = Self.privateConversationForkErrorText
+                conversationError = nil
+            } else if let onFork {
                 errorText = nil
                 conversationError = nil
                 onFork()

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -180,6 +180,19 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.map(\.text), deprecatedCommands)
     }
 
+    func testExactForkCommandInPrivateConversationShowsLocalError() {
+        viewModel.conversationType = "private"
+        viewModel.inputText = "/fork"
+        viewModel.sendMessage()
+
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertEqual(
+            viewModel.errorText,
+            "Forking is unavailable in private conversations."
+        )
+        XCTAssertNil(viewModel.conversationError)
+    }
+
     func testPopulateFromHistoryRetagsCommandListAcrossPaginationBoundary() {
         let assistantReply = HistoryResponseMessage(
             id: UUID().uuidString,


### PR DESCRIPTION
## Summary
- reject empty conversation forks so current-tip branching always has a real persisted branch point
- require a persisted tip before exposing current-tip fork actions on Apple clients
- make private-chat /fork fail locally with an explanatory message instead of attempting the route

Fixes gap identified during plan review for conversation-forking.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
