### PR TITLE
Fix shared defaults storage regression

### DIFF
--- a/clients/shared/Tests/SharedUserDefaultsTests.swift
+++ b/clients/shared/Tests/SharedUserDefaultsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class SharedUserDefaultsTests: XCTestCase {
+    private let key = "shared-defaults-regression-test"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        SharedUserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    func testSharedUserDefaultsSeesValuesWrittenThroughStandardDefaults() {
+        let expectedValue = "visible-through-shared-defaults"
+
+        UserDefaults.standard.set(expectedValue, forKey: key)
+
+        XCTAssertEqual(SharedUserDefaults.standard.string(forKey: key), expectedValue)
+    }
+}

--- a/clients/shared/Utilities/SharedUserDefaults.swift
+++ b/clients/shared/Utilities/SharedUserDefaults.swift
@@ -2,16 +2,6 @@ import Foundation
 
 enum SharedUserDefaults {
     static var standard: UserDefaults {
-        #if SWIFT_PACKAGE
-        return packageDefaults
-        #else
         return .standard
-        #endif
     }
-
-    #if SWIFT_PACKAGE
-    private static let packageDefaults: UserDefaults = {
-        UserDefaults(suiteName: "com.vellum.vellum-assistant.swiftpackage") ?? UserDefaults()
-    }()
-    #endif
 }


### PR DESCRIPTION
## Summary
- keep shared runtime defaults aligned with the app persisted store
- add regression coverage for shared conversation clients using the same defaults namespace
- Apple refs checked (2026-03-19): UserDefaults.standard is the shared defaults object for the current app

Part of plan: conversation-forking.md remediation round 4